### PR TITLE
Make Clippy Happy

### DIFF
--- a/aya/src/obj/btf/btf.rs
+++ b/aya/src/obj/btf/btf.rs
@@ -83,7 +83,7 @@ pub struct Btf {
     header: btf_header,
     strings: Vec<u8>,
     types: Vec<BtfType>,
-    endianness: Endianness,
+    _endianness: Endianness,
 }
 
 impl Btf {
@@ -125,7 +125,7 @@ impl Btf {
             header,
             strings,
             types,
-            endianness,
+            _endianness: endianness,
         })
     }
 
@@ -271,11 +271,11 @@ unsafe fn read_btf_header(data: &[u8]) -> btf_header {
 #[derive(Debug, Clone)]
 pub struct BtfExt {
     data: Vec<u8>,
-    endianness: Endianness,
+    _endianness: Endianness,
     relocations: Vec<(u32, Vec<Relocation>)>,
     header: btf_ext_header,
-    func_info_rec_size: usize,
-    line_info_rec_size: usize,
+    _func_info_rec_size: usize,
+    _line_info_rec_size: usize,
     core_relo_rec_size: usize,
 }
 
@@ -322,11 +322,11 @@ impl BtfExt {
         let mut ext = BtfExt {
             header,
             relocations: Vec::new(),
-            func_info_rec_size: rec_size(func_info_off, func_info_len)?,
-            line_info_rec_size: rec_size(line_info_off, line_info_len)?,
+            _func_info_rec_size: rec_size(func_info_off, func_info_len)?,
+            _line_info_rec_size: rec_size(line_info_off, line_info_len)?,
             core_relo_rec_size: rec_size(core_relo_off, core_relo_len)?,
             data: data.to_vec(),
-            endianness,
+            _endianness: endianness,
         };
 
         let rec_size = ext.core_relo_rec_size;
@@ -409,7 +409,7 @@ impl<'a> Iterator for SecInfoIter<'a> {
 
         Some(SecInfo {
             sec_name_off,
-            num_info,
+            _num_info: num_info,
             data,
         })
     }
@@ -418,7 +418,7 @@ impl<'a> Iterator for SecInfoIter<'a> {
 #[derive(Debug)]
 pub(crate) struct SecInfo<'a> {
     sec_name_off: u32,
-    num_info: u32,
+    _num_info: u32,
     data: &'a [u8],
 }
 

--- a/aya/src/obj/btf/relocation.rs
+++ b/aya/src/obj/btf/relocation.rs
@@ -281,7 +281,7 @@ fn relocate_btf_program<'target>(
 }
 
 fn flavorless_name(name: &str) -> &str {
-    name.splitn(2, "___").next().unwrap()
+    name.split_once("___").map_or(name, |x| x.0)
 }
 
 fn find_candidates<'target>(
@@ -303,7 +303,7 @@ fn find_candidates<'target>(
         candidates.push(Candidate {
             name: name.to_owned(),
             btf: target_btf,
-            ty,
+            _ty: ty,
             type_id: type_id as u32,
         });
     }
@@ -719,7 +719,7 @@ struct Accessor {
 struct Candidate<'a> {
     name: String,
     btf: &'a Btf,
-    ty: &'a BtfType,
+    _ty: &'a BtfType,
     type_id: u32,
 }
 

--- a/aya/src/obj/btf/types.rs
+++ b/aya/src/obj/btf/types.rs
@@ -342,7 +342,7 @@ pub(crate) fn fields_are_compatible(
         match local_ty {
             Fwd(_) | Enum(_, _) => {
                 let flavorless_name =
-                    |name: &str| name.splitn(2, "___").next().unwrap().to_string();
+                    |name: &str| name.split_once("___").map_or(name, |x| x.0).to_string();
 
                 let local_name = flavorless_name(&*local_btf.type_name(local_ty)?.unwrap());
                 let target_name = flavorless_name(&*target_btf.type_name(target_ty)?.unwrap());

--- a/aya/src/programs/uprobe.rs
+++ b/aya/src/programs/uprobe.rs
@@ -198,7 +198,7 @@ fn find_lib_in_proc_maps(pid: pid_t, lib: &str) -> Result<Option<String>, io::Er
 pub(crate) struct CacheEntry {
     key: String,
     value: String,
-    flags: i32,
+    _flags: i32,
 }
 
 #[derive(Debug)]
@@ -259,7 +259,11 @@ impl LdSoCache {
                 unsafe { CStr::from_ptr(cursor.get_ref()[v_pos..].as_ptr() as *const c_char) }
                     .to_string_lossy()
                     .into_owned();
-            entries.push(CacheEntry { key, value, flags });
+            entries.push(CacheEntry {
+                key,
+                value,
+                _flags: flags,
+            });
         }
 
         Ok(LdSoCache { entries })


### PR DESCRIPTION
Seems the nightly clippy has found some dead code and issues with `manual implementation of split once`
This PR:

1. Ignores fields that aren't read (prefix field name with underscore)
2. Replaces `splitn` with `split_once`