### PR TITLE
ci: Add action for xtask codegen

### DIFF
--- a/.github/workflows/gen.yml
+++ b/.github/workflows/gen.yml
@@ -1,0 +1,51 @@
+name: codegen
+
+on: workflow_dispatch
+
+jobs:
+  codegen:
+    runs-on: ubuntu-20.04
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions/checkout@v2
+        with:
+          repository: libbpf/libbpf
+          path: libbpf
+
+      - name: libbpf-version
+        working-directory: libbpf
+        run: echo "LIBBPF_SHA=$(git rev-parse HEAD)" >> $GITHUB_ENV
+
+      - uses: Swatinem/rust-cache@v1
+
+      - name: Run codegen
+        run: |
+          cargo xtask codegen --libbpf-dir ./libbpf
+
+      - name: Check for changes
+        run: |
+          git diff --quiet || echo "COMMIT_CHANGES=1" >> $GITHUB_ENV
+
+      - name: Commit Changes
+        id: commit
+        if: env.COMMIT_CHANGES == 1
+        uses: devops-infra/action-commit-push@master
+        with:
+          github_token: "${{ secrets.GITHUB_TOKEN }}"
+          commit_prefix: "[codegen] Update libbpf to ${{ env.LIBBPF_SHA }}"
+          commit_message: "Created using GitHub Actions"
+          target_branch: codegen
+
+
+      - name: Create pull request
+        if: steps.commit.outputs.files_changed != ''
+        uses: devops-infra/action-pull-request@master
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          body: "**Automated pull request**<br><br>Update libbpf to ${{ env.LIBBPF_SHA }}"
+          title: Update libbpf to ${{ env.LIBBPF_SHA }}
+          source_branch: codegen
+          target_branch: main
+          get_diff: true

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 Cargo.lock
 target/
 .vscode
+libbpf/


### PR DESCRIPTION
This commit adds a github action that will
- check out aya and libbpf
- run xtask codegen
- if there is a diff, commit changes to the codegen branch
- if changes were comitted, open a pull-request

Triggering is currently manual (via the `Actions`) tab or by REST API
Here's an example PR from this action: https://github.com/dave-tucker/aya/pull/2

Closes #59 