### PR TITLE
Implement Pinning For Maps and Programs

### DIFF
--- a/aya/src/maps/array/array.rs
+++ b/aya/src/maps/array/array.rs
@@ -23,7 +23,7 @@ use crate::{
 ///
 /// # Examples
 /// ```no_run
-/// # let bpf = aya::Bpf::load(&[], None)?;
+/// # let bpf = aya::Bpf::load(&[])?;
 /// use aya::maps::Array;
 /// use std::convert::TryFrom;
 ///

--- a/aya/src/maps/array/per_cpu_array.rs
+++ b/aya/src/maps/array/per_cpu_array.rs
@@ -32,7 +32,7 @@ use crate::{
 /// #     #[error(transparent)]
 /// #     Bpf(#[from] aya::BpfError)
 /// # }
-/// # let bpf = aya::Bpf::load(&[], None)?;
+/// # let bpf = aya::Bpf::load(&[])?;
 /// use aya::maps::{PerCpuArray, PerCpuValues};
 /// use aya::util::nr_cpus;
 /// use std::convert::TryFrom;

--- a/aya/src/maps/array/program_array.rs
+++ b/aya/src/maps/array/program_array.rs
@@ -26,7 +26,7 @@ use crate::{
 ///
 /// # Examples
 /// ```no_run
-/// # let bpf = aya::Bpf::load(&[], None)?;
+/// # let bpf = aya::Bpf::load(&[])?;
 /// use aya::maps::ProgramArray;
 /// use aya::programs::CgroupSkb;
 /// use std::convert::{TryFrom, TryInto};

--- a/aya/src/maps/hash_map/hash_map.rs
+++ b/aya/src/maps/hash_map/hash_map.rs
@@ -20,7 +20,7 @@ use crate::{
 /// # Examples
 ///
 /// ```no_run
-/// # let bpf = aya::Bpf::load(&[], None)?;
+/// # let bpf = aya::Bpf::load(&[])?;
 /// use aya::maps::HashMap;
 /// use std::convert::TryFrom;
 ///
@@ -182,6 +182,7 @@ mod tests {
         let map = Map {
             obj: new_obj_map("TEST"),
             fd: None,
+            pinned: false,
         };
         assert!(matches!(
             HashMap::<_, u8, u32>::new(&map),
@@ -197,6 +198,7 @@ mod tests {
         let map = Map {
             obj: new_obj_map("TEST"),
             fd: None,
+            pinned: false,
         };
         assert!(matches!(
             HashMap::<_, u32, u16>::new(&map),
@@ -223,6 +225,7 @@ mod tests {
                 data: Vec::new(),
             },
             fd: None,
+            pinned: false,
         };
 
         assert!(matches!(
@@ -236,6 +239,7 @@ mod tests {
         let mut map = Map {
             obj: new_obj_map("TEST"),
             fd: None,
+            pinned: false,
         };
 
         assert!(matches!(
@@ -249,6 +253,7 @@ mod tests {
         let mut map = Map {
             obj: new_obj_map("TEST"),
             fd: Some(42),
+            pinned: false,
         };
 
         assert!(HashMap::<_, u32, u32>::new(&mut map).is_ok());
@@ -259,6 +264,7 @@ mod tests {
         let map = Map {
             obj: new_obj_map("TEST"),
             fd: Some(42),
+            pinned: false,
         };
         assert!(HashMap::<_, u32, u32>::try_from(&map).is_ok())
     }
@@ -279,6 +285,7 @@ mod tests {
                 data: Vec::new(),
             },
             fd: Some(42),
+            pinned: false,
         };
 
         assert!(HashMap::<_, u32, u32>::try_from(&map).is_ok())
@@ -291,6 +298,7 @@ mod tests {
         let mut map = Map {
             obj: new_obj_map("TEST"),
             fd: Some(42),
+            pinned: false,
         };
         let mut hm = HashMap::<_, u32, u32>::new(&mut map).unwrap();
 
@@ -313,6 +321,7 @@ mod tests {
         let mut map = Map {
             obj: new_obj_map("TEST"),
             fd: Some(42),
+            pinned: false,
         };
         let mut hm = HashMap::<_, u32, u32>::new(&mut map).unwrap();
 
@@ -326,6 +335,7 @@ mod tests {
         let mut map = Map {
             obj: new_obj_map("TEST"),
             fd: Some(42),
+            pinned: false,
         };
         let mut hm = HashMap::<_, u32, u32>::new(&mut map).unwrap();
 
@@ -348,6 +358,7 @@ mod tests {
         let mut map = Map {
             obj: new_obj_map("TEST"),
             fd: Some(42),
+            pinned: false,
         };
         let mut hm = HashMap::<_, u32, u32>::new(&mut map).unwrap();
 
@@ -360,6 +371,7 @@ mod tests {
         let map = Map {
             obj: new_obj_map("TEST"),
             fd: Some(42),
+            pinned: false,
         };
         let hm = HashMap::<_, u32, u32>::new(&map).unwrap();
 
@@ -381,6 +393,7 @@ mod tests {
         let map = Map {
             obj: new_obj_map("TEST"),
             fd: Some(42),
+            pinned: false,
         };
         let hm = HashMap::<_, u32, u32>::new(&map).unwrap();
 
@@ -419,6 +432,7 @@ mod tests {
         let map = Map {
             obj: new_obj_map("TEST"),
             fd: Some(42),
+            pinned: false,
         };
         let hm = HashMap::<_, u32, u32>::new(&map).unwrap();
         let keys = unsafe { hm.keys() }.collect::<Result<Vec<_>, _>>();
@@ -462,6 +476,7 @@ mod tests {
         let map = Map {
             obj: new_obj_map("TEST"),
             fd: Some(42),
+            pinned: false,
         };
         let hm = HashMap::<_, u32, u32>::new(&map).unwrap();
 
@@ -489,6 +504,7 @@ mod tests {
         let map = Map {
             obj: new_obj_map("TEST"),
             fd: Some(42),
+            pinned: false,
         };
         let hm = HashMap::<_, u32, u32>::new(&map).unwrap();
 
@@ -518,6 +534,7 @@ mod tests {
         let map = Map {
             obj: new_obj_map("TEST"),
             fd: Some(42),
+            pinned: false,
         };
         let hm = HashMap::<_, u32, u32>::new(&map).unwrap();
         let items = unsafe { hm.iter() }.collect::<Result<Vec<_>, _>>().unwrap();
@@ -550,6 +567,7 @@ mod tests {
         let map = Map {
             obj: new_obj_map("TEST"),
             fd: Some(42),
+            pinned: false,
         };
         let hm = HashMap::<_, u32, u32>::new(&map).unwrap();
 
@@ -583,6 +601,7 @@ mod tests {
         let map = Map {
             obj: new_obj_map("TEST"),
             fd: Some(42),
+            pinned: false,
         };
         let hm = HashMap::<_, u32, u32>::new(&map).unwrap();
 
@@ -622,6 +641,7 @@ mod tests {
         let map = Map {
             obj: new_obj_map("TEST"),
             fd: Some(42),
+            pinned: false,
         };
         let hm = HashMap::<_, u32, u32>::new(&map).unwrap();
 

--- a/aya/src/maps/hash_map/per_cpu_hash_map.rs
+++ b/aya/src/maps/hash_map/per_cpu_hash_map.rs
@@ -27,7 +27,7 @@ use crate::{
 /// # Examples
 ///
 /// ```no_run
-/// # let bpf = aya::Bpf::load(&[], None)?;
+/// # let bpf = aya::Bpf::load(&[])?;
 /// use aya::maps::PerCpuHashMap;
 /// use std::convert::TryFrom;
 ///
@@ -113,7 +113,7 @@ impl<T: DerefMut<Target = Map>, K: Pod, V: Pod> PerCpuHashMap<T, K, V> {
     /// #     #[error(transparent)]
     /// #     Bpf(#[from] aya::BpfError)
     /// # }
-    /// # let bpf = aya::Bpf::load(&[], None)?;
+    /// # let bpf = aya::Bpf::load(&[])?;
     /// use aya::maps::{PerCpuHashMap, PerCpuValues};
     /// use aya::util::nr_cpus;
     /// use std::convert::TryFrom;

--- a/aya/src/maps/perf/async_perf_event_array.rs
+++ b/aya/src/maps/perf/async_perf_event_array.rs
@@ -46,7 +46,7 @@ use crate::maps::{
 /// # }
 /// # #[cfg(feature = "async_tokio")]
 /// # async fn try_main() -> Result<(), Error> {
-/// # let bpf = aya::Bpf::load(&[], None)?;
+/// # let bpf = aya::Bpf::load(&[])?;
 /// use aya::maps::perf::{AsyncPerfEventArray, PerfBufferError};
 /// use aya::util::online_cpus;
 /// use std::convert::TryFrom;

--- a/aya/src/maps/perf/perf_event_array.rs
+++ b/aya/src/maps/perf/perf_event_array.rs
@@ -109,7 +109,7 @@ impl<T: DerefMut<Target = Map>> AsRawFd for PerfEventArrayBuffer<T> {
 /// #    #[error(transparent)]
 /// #    PerfBuf(#[from] aya::maps::perf::PerfBufferError),
 /// # }
-/// # let bpf = aya::Bpf::load(&[], None)?;
+/// # let bpf = aya::Bpf::load(&[])?;
 /// use aya::maps::PerfEventArray;
 /// use aya::util::online_cpus;
 /// use std::convert::{TryFrom, TryInto};

--- a/aya/src/maps/queue.rs
+++ b/aya/src/maps/queue.rs
@@ -21,7 +21,7 @@ use crate::{
 ///
 /// # Examples
 /// ```no_run
-/// # let bpf = aya::Bpf::load(&[], None)?;
+/// # let bpf = aya::Bpf::load(&[])?;
 /// use aya::maps::Queue;
 /// use std::convert::TryFrom;
 ///

--- a/aya/src/maps/sock/sock_hash.rs
+++ b/aya/src/maps/sock/sock_hash.rs
@@ -41,7 +41,7 @@ use crate::{
 /// #     #[error(transparent)]
 /// #     Bpf(#[from] aya::BpfError)
 /// # }
-/// # let mut bpf = aya::Bpf::load(&[], None)?;
+/// # let mut bpf = aya::Bpf::load(&[])?;
 /// use std::convert::{TryFrom, TryInto};
 /// use std::io::Write;
 /// use std::net::TcpStream;

--- a/aya/src/maps/sock/sock_map.rs
+++ b/aya/src/maps/sock/sock_map.rs
@@ -29,7 +29,7 @@ use crate::{
 /// # Examples
 ///
 /// ```no_run
-/// # let mut bpf = aya::Bpf::load(&[], None)?;
+/// # let mut bpf = aya::Bpf::load(&[])?;
 /// use std::convert::{TryFrom, TryInto};
 /// use aya::maps::SockMap;
 /// use aya::programs::SkSkb;

--- a/aya/src/maps/stack.rs
+++ b/aya/src/maps/stack.rs
@@ -21,7 +21,7 @@ use crate::{
 ///
 /// # Examples
 /// ```no_run
-/// # let bpf = aya::Bpf::load(&[], None)?;
+/// # let bpf = aya::Bpf::load(&[])?;
 /// use aya::maps::Stack;
 /// use std::convert::TryFrom;
 ///

--- a/aya/src/maps/stack_trace.rs
+++ b/aya/src/maps/stack_trace.rs
@@ -34,7 +34,7 @@ use crate::{
 /// #     #[error(transparent)]
 /// #     Bpf(#[from] aya::BpfError)
 /// # }
-/// # let bpf = aya::Bpf::load(&[], None)?;
+/// # let bpf = aya::Bpf::load(&[])?;
 /// use aya::maps::StackTraceMap;
 /// use aya::util::kernel_symbols;
 /// use std::convert::TryFrom;

--- a/aya/src/obj/mod.rs
+++ b/aya/src/obj/mod.rs
@@ -586,6 +586,7 @@ mod tests {
     use std::slice;
 
     use super::*;
+    use crate::PinningType;
 
     fn fake_section<'a>(name: &'a str, data: &'a [u8]) -> Section<'a> {
         Section {
@@ -688,7 +689,7 @@ mod tests {
             max_entries: 4,
             map_flags: 5,
             id: 0,
-            pinning: 0,
+            pinning: PinningType::None,
         };
 
         assert_eq!(
@@ -706,7 +707,7 @@ mod tests {
             max_entries: 4,
             map_flags: 5,
             id: 6,
-            pinning: 7,
+            pinning: PinningType::ByName,
         };
 
         assert_eq!(parse_map_def("foo", bytes_of(&def)).unwrap(), def);
@@ -721,7 +722,7 @@ mod tests {
             max_entries: 4,
             map_flags: 5,
             id: 6,
-            pinning: 7,
+            pinning: PinningType::ByName,
         };
         let mut buf = [0u8; 128];
         unsafe { ptr::write_unaligned(buf.as_mut_ptr() as *mut _, def) };
@@ -750,7 +751,7 @@ mod tests {
                         max_entries: 4,
                         map_flags: 5,
                         id: 0,
-                        pinning: 0
+                        pinning: PinningType::None,
                     })
                 ),
                 "foo"
@@ -765,7 +766,7 @@ mod tests {
                     max_entries: 4,
                     map_flags: 5,
                     id: 0,
-                    pinning: 0
+                    pinning: PinningType::None,
                 },
                 data
             }) if name == "foo" && data.is_empty()
@@ -793,7 +794,7 @@ mod tests {
                     max_entries: 1,
                     map_flags: 0,
                     id: 0,
-                    pinning: 0,
+                    pinning: PinningType::None,
                 },
                 data
             }) if name == ".bss" && data == map_data && value_size == map_data.len() as u32

--- a/aya/src/programs/cgroup_skb.rs
+++ b/aya/src/programs/cgroup_skb.rs
@@ -37,7 +37,7 @@ use super::FdLink;
 /// #     #[error(transparent)]
 /// #     Bpf(#[from] aya::BpfError)
 /// # }
-/// # let mut bpf = aya::Bpf::load(&[], None)?;
+/// # let mut bpf = aya::Bpf::load(&[])?;
 /// use std::fs::File;
 /// use std::convert::TryInto;
 /// use aya::programs::{CgroupSkb, CgroupSkbAttachType};

--- a/aya/src/programs/lirc_mode2.rs
+++ b/aya/src/programs/lirc_mode2.rs
@@ -33,7 +33,7 @@ use libc::{close, dup};
 /// #     #[error(transparent)]
 /// #     Bpf(#[from] aya::BpfError)
 /// # }
-/// # let mut bpf = aya::Bpf::load(&[], None)?;
+/// # let mut bpf = aya::Bpf::load(&[])?;
 /// use std::fs::File;
 /// use std::convert::TryInto;
 /// use aya::programs::LircMode2;

--- a/aya/src/programs/perf_event.rs
+++ b/aya/src/programs/perf_event.rs
@@ -59,7 +59,7 @@ pub enum PerfEventScope {
 /// #     #[error(transparent)]
 /// #     Bpf(#[from] aya::BpfError)
 /// # }
-/// # let mut bpf = aya::Bpf::load(&[], None)?;
+/// # let mut bpf = aya::Bpf::load(&[])?;
 /// use std::convert::TryInto;
 /// use aya::util::online_cpus;
 /// use aya::programs::perf_event::{

--- a/aya/src/programs/sk_msg.rs
+++ b/aya/src/programs/sk_msg.rs
@@ -29,7 +29,7 @@ use crate::{
 /// #     #[error(transparent)]
 /// #     Bpf(#[from] aya::BpfError)
 /// # }
-/// # let mut bpf = aya::Bpf::load(&[], None)?;
+/// # let mut bpf = aya::Bpf::load(&[])?;
 /// use std::convert::{TryFrom, TryInto};
 /// use std::io::Write;
 /// use std::net::TcpStream;

--- a/aya/src/programs/sk_skb.rs
+++ b/aya/src/programs/sk_skb.rs
@@ -28,7 +28,7 @@ pub enum SkSkbKind {
 /// # Examples
 ///
 /// ```no_run
-/// # let mut bpf = aya::Bpf::load(&[], None)?;
+/// # let mut bpf = aya::Bpf::load(&[])?;
 /// use std::convert::{TryFrom, TryInto};
 /// use aya::maps::SockMap;
 /// use aya::programs::SkSkb;

--- a/aya/src/programs/sock_ops.rs
+++ b/aya/src/programs/sock_ops.rs
@@ -30,7 +30,7 @@ use crate::{
 /// #     #[error(transparent)]
 /// #     Bpf(#[from] aya::BpfError)
 /// # }
-/// # let mut bpf = aya::Bpf::load(&[], None)?;
+/// # let mut bpf = aya::Bpf::load(&[])?;
 /// use std::fs::File;
 /// use std::convert::TryInto;
 /// use aya::programs::SockOps;

--- a/aya/src/programs/socket_filter.rs
+++ b/aya/src/programs/socket_filter.rs
@@ -44,7 +44,7 @@ pub enum SocketFilterError {
 /// #     #[error(transparent)]
 /// #     Bpf(#[from] aya::BpfError)
 /// # }
-/// # let mut bpf = aya::Bpf::load(&[], None)?;
+/// # let mut bpf = aya::Bpf::load(&[])?;
 /// use std::convert::TryInto;
 /// use std::net::TcpStream;
 /// use std::os::unix::io::AsRawFd;

--- a/aya/src/programs/tc.rs
+++ b/aya/src/programs/tc.rs
@@ -51,7 +51,7 @@ pub enum TcAttachType {
 /// #     #[error(transparent)]
 /// #     Bpf(#[from] aya::BpfError)
 /// # }
-/// # let mut bpf = aya::Bpf::load(&[], None)?;
+/// # let mut bpf = aya::Bpf::load(&[])?;
 /// use std::convert::TryInto;
 /// use aya::programs::{tc, SchedClassifier, TcAttachType};
 ///

--- a/aya/src/programs/trace_point.rs
+++ b/aya/src/programs/trace_point.rs
@@ -40,7 +40,7 @@ pub enum TracePointError {
 /// #     #[error(transparent)]
 /// #     Bpf(#[from] aya::BpfError)
 /// # }
-/// # let mut bpf = aya::Bpf::load(&[], None)?;
+/// # let mut bpf = aya::Bpf::load(&[])?;
 /// use std::convert::TryInto;
 /// use aya::programs::TracePoint;
 ///

--- a/aya/src/sys/bpf.rs
+++ b/aya/src/sys/bpf.rs
@@ -38,6 +38,21 @@ pub(crate) fn bpf_create_map(name: &CStr, def: &bpf_map_def) -> SysResult {
     sys_bpf(bpf_cmd::BPF_MAP_CREATE, &attr)
 }
 
+pub(crate) fn bpf_pin_object(fd: RawFd, path: &CStr) -> SysResult {
+    let mut attr = unsafe { mem::zeroed::<bpf_attr>() };
+    let u = unsafe { &mut attr.__bindgen_anon_4 };
+    u.bpf_fd = fd as u32;
+    u.pathname = path.as_ptr() as u64;
+    sys_bpf(bpf_cmd::BPF_OBJ_PIN, &attr)
+}
+
+pub(crate) fn bpf_get_object(path: &CStr) -> SysResult {
+    let mut attr = unsafe { mem::zeroed::<bpf_attr>() };
+    let u = unsafe { &mut attr.__bindgen_anon_4 };
+    u.pathname = path.as_ptr() as u64;
+    sys_bpf(bpf_cmd::BPF_OBJ_GET, &attr)
+}
+
 pub(crate) fn bpf_load_program(
     ty: bpf_prog_type,
     insns: &[bpf_insn],

--- a/bpf/aya-bpf/src/maps/array.rs
+++ b/bpf/aya-bpf/src/maps/array.rs
@@ -5,6 +5,7 @@ use aya_bpf_cty::c_void;
 use crate::{
     bindings::{bpf_map_def, bpf_map_type::BPF_MAP_TYPE_ARRAY},
     helpers::bpf_map_lookup_elem,
+    maps::PinningType,
 };
 
 #[repr(transparent)]
@@ -23,7 +24,22 @@ impl<T> Array<T> {
                 max_entries,
                 map_flags: flags,
                 id: 0,
-                pinning: 0,
+                pinning: PinningType::None as u32,
+            },
+            _t: PhantomData,
+        }
+    }
+
+    pub const fn pinned(max_entries: u32, flags: u32) -> Array<T> {
+        Array {
+            def: bpf_map_def {
+                type_: BPF_MAP_TYPE_ARRAY,
+                key_size: mem::size_of::<u32>() as u32,
+                value_size: mem::size_of::<T>() as u32,
+                max_entries,
+                map_flags: flags,
+                id: 0,
+                pinning: PinningType::ByName as u32,
             },
             _t: PhantomData,
         }

--- a/bpf/aya-bpf/src/maps/hash_map.rs
+++ b/bpf/aya-bpf/src/maps/hash_map.rs
@@ -5,6 +5,7 @@ use aya_bpf_cty::{c_long, c_void};
 use crate::{
     bindings::{bpf_map_def, bpf_map_type::BPF_MAP_TYPE_HASH},
     helpers::{bpf_map_delete_elem, bpf_map_lookup_elem, bpf_map_update_elem},
+    maps::PinningType,
 };
 
 #[repr(transparent)]
@@ -24,14 +25,14 @@ impl<K, V> HashMap<K, V> {
                 max_entries,
                 map_flags: flags,
                 id: 0,
-                pinning: 0,
+                pinning: PinningType::None as u32,
             },
             _k: PhantomData,
             _v: PhantomData,
         }
     }
 
-    pub const fn pinned(max_entries: u32, flags: u32, pinning: u32) -> HashMap<K, V> {
+    pub const fn pinned(max_entries: u32, flags: u32) -> HashMap<K, V> {
         HashMap {
             def: bpf_map_def {
                 type_: BPF_MAP_TYPE_HASH,
@@ -40,7 +41,7 @@ impl<K, V> HashMap<K, V> {
                 max_entries,
                 map_flags: flags,
                 id: 0,
-                pinning,
+                pinning: PinningType::ByName as u32,
             },
             _k: PhantomData,
             _v: PhantomData,

--- a/bpf/aya-bpf/src/maps/mod.rs
+++ b/bpf/aya-bpf/src/maps/mod.rs
@@ -1,3 +1,10 @@
+#[repr(u32)]
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub(crate) enum PinningType {
+    None = 0,
+    ByName = 1,
+}
+
 pub mod array;
 pub mod hash_map;
 pub mod per_cpu_array;

--- a/bpf/aya-bpf/src/maps/per_cpu_array.rs
+++ b/bpf/aya-bpf/src/maps/per_cpu_array.rs
@@ -5,6 +5,7 @@ use aya_bpf_cty::c_void;
 use crate::{
     bindings::{bpf_map_def, bpf_map_type::BPF_MAP_TYPE_PERCPU_ARRAY},
     helpers::bpf_map_lookup_elem,
+    maps::PinningType,
 };
 
 #[repr(transparent)]
@@ -23,7 +24,22 @@ impl<T> PerCpuArray<T> {
                 max_entries,
                 map_flags: flags,
                 id: 0,
-                pinning: 0,
+                pinning: PinningType::None as u32,
+            },
+            _t: PhantomData,
+        }
+    }
+
+    pub const fn pinned(max_entries: u32, flags: u32) -> PerCpuArray<T> {
+        PerCpuArray {
+            def: bpf_map_def {
+                type_: BPF_MAP_TYPE_PERCPU_ARRAY,
+                key_size: mem::size_of::<u32>() as u32,
+                value_size: mem::size_of::<T>() as u32,
+                max_entries,
+                map_flags: flags,
+                id: 0,
+                pinning: PinningType::ByName as u32,
             },
             _t: PhantomData,
         }

--- a/bpf/aya-bpf/src/maps/perf_map.rs
+++ b/bpf/aya-bpf/src/maps/perf_map.rs
@@ -3,6 +3,7 @@ use core::{marker::PhantomData, mem};
 use crate::{
     bindings::{bpf_map_def, bpf_map_type::BPF_MAP_TYPE_PERF_EVENT_ARRAY, BPF_F_CURRENT_CPU},
     helpers::bpf_perf_event_output,
+    maps::PinningType,
     BpfContext,
 };
 
@@ -26,7 +27,22 @@ impl<T> PerfMap<T> {
                 max_entries,
                 map_flags: flags,
                 id: 0,
-                pinning: 0,
+                pinning: PinningType::None as u32,
+            },
+            _t: PhantomData,
+        }
+    }
+
+    pub const fn pinned(max_entries: u32, flags: u32) -> PerfMap<T> {
+        PerfMap {
+            def: bpf_map_def {
+                type_: BPF_MAP_TYPE_PERF_EVENT_ARRAY,
+                key_size: mem::size_of::<u32>() as u32,
+                value_size: mem::size_of::<u32>() as u32,
+                max_entries,
+                map_flags: flags,
+                id: 0,
+                pinning: PinningType::ByName as u32,
             },
             _t: PhantomData,
         }

--- a/bpf/aya-bpf/src/maps/queue.rs
+++ b/bpf/aya-bpf/src/maps/queue.rs
@@ -3,6 +3,7 @@ use core::{marker::PhantomData, mem};
 use crate::{
     bindings::{bpf_map_def, bpf_map_type::BPF_MAP_TYPE_QUEUE},
     helpers::{bpf_map_pop_elem, bpf_map_push_elem},
+    maps::PinningType,
 };
 
 #[repr(transparent)]
@@ -21,7 +22,22 @@ impl<T> Queue<T> {
                 max_entries,
                 map_flags: flags,
                 id: 0,
-                pinning: 0,
+                pinning: PinningType::None as u32,
+            },
+            _t: PhantomData,
+        }
+    }
+
+    pub const fn pinned(max_entries: u32, flags: u32) -> Queue<T> {
+        Queue {
+            def: bpf_map_def {
+                type_: BPF_MAP_TYPE_QUEUE,
+                key_size: 0,
+                value_size: mem::size_of::<T>() as u32,
+                max_entries,
+                map_flags: flags,
+                id: 0,
+                pinning: PinningType::ByName as u32,
             },
             _t: PhantomData,
         }

--- a/bpf/aya-bpf/src/maps/sock_hash.rs
+++ b/bpf/aya-bpf/src/maps/sock_hash.rs
@@ -5,6 +5,7 @@ use aya_bpf_cty::c_void;
 use crate::{
     bindings::{bpf_map_def, bpf_map_type::BPF_MAP_TYPE_SOCKHASH, bpf_sock_ops},
     helpers::{bpf_msg_redirect_hash, bpf_sock_hash_update},
+    maps::PinningType,
     programs::SkMsgContext,
     BpfContext,
 };
@@ -25,7 +26,22 @@ impl<K> SockHash<K> {
                 max_entries,
                 map_flags: flags,
                 id: 0,
-                pinning: 0,
+                pinning: PinningType::None as u32,
+            },
+            _k: PhantomData,
+        }
+    }
+
+    pub const fn pinned(max_entries: u32, flags: u32) -> SockHash<K> {
+        SockHash {
+            def: bpf_map_def {
+                type_: BPF_MAP_TYPE_SOCKHASH,
+                key_size: mem::size_of::<K>() as u32,
+                value_size: mem::size_of::<u32>() as u32,
+                max_entries,
+                map_flags: flags,
+                id: 0,
+                pinning: PinningType::ByName as u32,
             },
             _k: PhantomData,
         }

--- a/bpf/aya-bpf/src/maps/sock_map.rs
+++ b/bpf/aya-bpf/src/maps/sock_map.rs
@@ -5,6 +5,7 @@ use aya_bpf_cty::c_void;
 use crate::{
     bindings::{bpf_map_def, bpf_map_type::BPF_MAP_TYPE_SOCKMAP, bpf_sock_ops},
     helpers::{bpf_msg_redirect_map, bpf_sock_map_update},
+    maps::PinningType,
     programs::SkMsgContext,
     BpfContext,
 };
@@ -24,7 +25,21 @@ impl SockMap {
                 max_entries,
                 map_flags: flags,
                 id: 0,
-                pinning: 0,
+                pinning: PinningType::None as u32,
+            },
+        }
+    }
+
+    pub const fn pinned(max_entries: u32, flags: u32) -> SockMap {
+        SockMap {
+            def: bpf_map_def {
+                type_: BPF_MAP_TYPE_SOCKMAP,
+                key_size: mem::size_of::<u32>() as u32,
+                value_size: mem::size_of::<u32>() as u32,
+                max_entries,
+                map_flags: flags,
+                id: 0,
+                pinning: PinningType::ByName as u32,
             },
         }
     }

--- a/bpf/aya-bpf/src/maps/stack_trace.rs
+++ b/bpf/aya-bpf/src/maps/stack_trace.rs
@@ -2,42 +2,53 @@ use core::mem;
 
 use crate::{
     bindings::{bpf_map_def, bpf_map_type::BPF_MAP_TYPE_STACK_TRACE},
-    helpers::{bpf_get_stackid},
+    helpers::bpf_get_stackid,
+    maps::PinningType,
     BpfContext,
 };
 
 #[repr(transparent)]
 pub struct StackTrace {
-	def: bpf_map_def,
+    def: bpf_map_def,
 }
 
 const PERF_MAX_STACK_DEPTH: u32 = 127;
 
 impl StackTrace {
-	pub const fn with_max_entries(max_entries: u32, flags: u32) -> StackTrace {
-		StackTrace {
-			def: bpf_map_def {
-				type_: BPF_MAP_TYPE_STACK_TRACE,
-				key_size: mem::size_of::<u32>() as u32,
-				value_size: mem::size_of::<u64>() as u32 * PERF_MAX_STACK_DEPTH,
-				max_entries,
-				map_flags: flags,
-				id: 0,
-				pinning: 0,
-			},
-		}
-	}
+    pub const fn with_max_entries(max_entries: u32, flags: u32) -> StackTrace {
+        StackTrace {
+            def: bpf_map_def {
+                type_: BPF_MAP_TYPE_STACK_TRACE,
+                key_size: mem::size_of::<u32>() as u32,
+                value_size: mem::size_of::<u64>() as u32 * PERF_MAX_STACK_DEPTH,
+                max_entries,
+                map_flags: flags,
+                id: 0,
+                pinning: PinningType::None as u32,
+            },
+        }
+    }
 
-	pub unsafe fn get_stackid<C: BpfContext>(&mut self, ctx: &C, flags: u64) -> Result<i64, i64> {
-		let ret = bpf_get_stackid(
-			ctx.as_ptr(),
-			&mut self.def as *mut _ as *mut _,
-			flags,
-		);
-		if ret < 0 {
-			Err(ret)
-		} else {
-			Ok(ret)
-		}
-	}
+    pub const fn pinned(max_entries: u32, flags: u32) -> StackTrace {
+        StackTrace {
+            def: bpf_map_def {
+                type_: BPF_MAP_TYPE_STACK_TRACE,
+                key_size: mem::size_of::<u32>() as u32,
+                value_size: mem::size_of::<u64>() as u32 * PERF_MAX_STACK_DEPTH,
+                max_entries,
+                map_flags: flags,
+                id: 0,
+                pinning: PinningType::ByName as u32,
+            },
+        }
+    }
+
+    pub unsafe fn get_stackid<C: BpfContext>(&mut self, ctx: &C, flags: u64) -> Result<i64, i64> {
+        let ret = bpf_get_stackid(ctx.as_ptr(), &mut self.def as *mut _ as *mut _, flags);
+        if ret < 0 {
+            Err(ret)
+        } else {
+            Ok(ret)
+        }
+    }
 }


### PR DESCRIPTION
This commit adds 2 new methods to aya::sys
- bpf_pin_object
- bpf_get_object

Which allow the pinning and retrieval of programs/maps to bpffs.

For map pinning, the user must ensure the `pinning u32` in the
`bpf_map_def` is set to 1, maps will be pinned using a new builder API.

```rust
BpfLoader::new().map_pin_path("/sys/fs/bpf/myapp").load_file("myapp.o")
```

This will pin all maps whose definition requests pinning to path + name.

Closes #45 