### PR TITLE
aya: fix include_bytes_aligned! macro to work in some corner cases

### DIFF
--- a/aya/src/util.rs
+++ b/aya/src/util.rs
@@ -125,9 +125,12 @@ pub(crate) fn tc_handler_make(major: u32, minor: u32) -> u32 {
 #[macro_export]
 macro_rules! include_bytes_aligned {
     ($path:literal) => {{
+        #[repr(align(32))]
+        pub struct Aligned32;
+
         #[repr(C)]
         pub struct Aligned<Bytes: ?Sized> {
-            pub _align: [u32; 0],
+            pub _align: [Aligned32; 0],
             pub bytes: Bytes,
         }
 


### PR DESCRIPTION
I found a corner case in my own development workflow that caused the existing macro to not work properly. The following changes appear to fix things.

Ideally, we could add some test cases to CI to prevent regressions. This would require creating a dedicated directory to
hold test BPF programs so that we can "include" them at compile time.

Kind of off-topic but still relevant: A nice side effect of having such a directory of test programs is that it would allow us to potentially unit test aya's program loading/attaching functionality in the future, independently of the underlying aya-bpf implementation. We are doing something similar with libbpf-rs. @alessandrod WDYT?