### PR TITLE
meta: fix rust-analyzer support for aya-bpf

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 Cargo.lock
 target/
-.vscode
 libbpf/

--- a/.vim/coc-settings.json
+++ b/.vim/coc-settings.json
@@ -1,0 +1,3 @@
+{
+  "rust-analyzer.linkedProjects": ["Cargo.toml", "bpf/Cargo.toml"]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "rust-analyzer.linkedProjects": ["Cargo.toml", "bpf/Cargo.toml"]
+}


### PR DESCRIPTION
Ironically, we have the same issue here as in https://github.com/aya-rs/aya-template/pull/13/.
This patch fixes this by explicitly defining the project layout for both vscode and neovim.