### PR TITLE
aya/maps: improve map errors to be more descriptive

### DIFF
--- a/aya/src/maps/mod.rs
+++ b/aya/src/maps/mod.rs
@@ -88,17 +88,19 @@ pub enum MapError {
     #[error("the map `{name}` has already been pinned")]
     AlreadyPinned { name: String },
 
-    #[error("failed to create map `{name}`: {code}")]
+    #[error("failed to create map `{name}` with code {code}")]
     CreateError {
         name: String,
         code: libc::c_long,
+        #[source]
         io_error: io::Error,
     },
 
-    #[error("failed to pin map `{name}`: {code}")]
+    #[error("failed to pin map `{name}` with code {code}")]
     PinError {
         name: String,
         code: libc::c_long,
+        #[source]
         io_error: io::Error,
     },
 
@@ -120,10 +122,11 @@ pub enum MapError {
     #[error("the program is not loaded")]
     ProgramNotLoaded,
 
-    #[error("the `{call}` syscall failed with code {code} io_error {io_error}")]
+    #[error("the `{call}` syscall failed with code {code}")]
     SyscallError {
         call: String,
         code: libc::c_long,
+        #[source]
         io_error: io::Error,
     },
 


### PR DESCRIPTION
While I was debugging #88, I noticed that generic map errors don't report the underlying `io_error` that caused the issue. Since the `bpf(2)` syscall always fails with -1 and sets errno, this effectively results in zero useful information being conveyed to the caller. This patch fixes `MapError` to report the io_error as the source, consistent with the way we already handle `ProgramError`.