### PR TITLE
aya-bpf/helpers: expose raw bindings through helpers::gen

### DIFF
--- a/bpf/aya-bpf/src/helpers.rs
+++ b/bpf/aya-bpf/src/helpers.rs
@@ -1,6 +1,6 @@
 use core::mem::{self, MaybeUninit};
 
-use aya_bpf_bindings::helpers as gen;
+pub use aya_bpf_bindings::helpers as gen;
 pub use gen::*;
 
 use crate::cty::{c_char, c_long, c_void};


### PR DESCRIPTION
Until we add another set of bpf_probe_read_* wrappers for reading into a map pointer,
users need access to the underlying bpf_probe_read helper, which is clobbered by this
module. This patch enables direct access to the underlying helpers::gen module to support
such use cases.

In my view, it would also probably make sense to just not export helpers::gen::* and force
the user to opt into helpers::gen, but this can be decided on later.

Signed-off-by: William Findlay <william@williamfindlay.com>