### PR TITLE
aya: netlink: use NETLINK_EXT_ACK from libc crate

### DIFF
--- a/aya/Cargo.toml
+++ b/aya/Cargo.toml
@@ -11,7 +11,7 @@ documentation = "https://docs.rs/aya"
 edition = "2018"
 
 [dependencies]
-libc = { version = "0.2" }
+libc = { version = "0.2.105" }
 thiserror = "1"
 object = { version = "0.27", default-features = false, features = ["std", "read_core", "elf"] }
 bitflags = "1.2.1"

--- a/aya/src/sys/netlink.rs
+++ b/aya/src/sys/netlink.rs
@@ -2,11 +2,11 @@ use std::{collections::HashMap, ffi::CStr, io, mem, os::unix::io::RawFd, ptr, sl
 use thiserror::Error;
 
 use libc::{
-    c_int, close, getsockname, nlattr, nlmsgerr, nlmsghdr, recv, send, setsockopt, sockaddr_nl,
-    socket, AF_NETLINK, AF_UNSPEC, ETH_P_ALL, IFLA_XDP, NETLINK_ROUTE, NLA_ALIGNTO, NLA_F_NESTED,
-    NLA_TYPE_MASK, NLMSG_DONE, NLMSG_ERROR, NLM_F_ACK, NLM_F_CREATE, NLM_F_DUMP, NLM_F_ECHO,
-    NLM_F_EXCL, NLM_F_MULTI, NLM_F_REQUEST, RTM_DELTFILTER, RTM_GETTFILTER, RTM_NEWQDISC,
-    RTM_NEWTFILTER, RTM_SETLINK, SOCK_RAW, SOL_NETLINK,
+    close, getsockname, nlattr, nlmsgerr, nlmsghdr, recv, send, setsockopt, sockaddr_nl, socket,
+    AF_NETLINK, AF_UNSPEC, ETH_P_ALL, IFLA_XDP, NETLINK_EXT_ACK, NETLINK_ROUTE, NLA_ALIGNTO,
+    NLA_F_NESTED, NLA_TYPE_MASK, NLMSG_DONE, NLMSG_ERROR, NLM_F_ACK, NLM_F_CREATE, NLM_F_DUMP,
+    NLM_F_ECHO, NLM_F_EXCL, NLM_F_MULTI, NLM_F_REQUEST, RTM_DELTFILTER, RTM_GETTFILTER,
+    RTM_NEWQDISC, RTM_NEWTFILTER, RTM_SETLINK, SOCK_RAW, SOL_NETLINK,
 };
 
 use crate::{
@@ -20,7 +20,6 @@ use crate::{
 };
 
 const NLA_HDR_LEN: usize = align_to(mem::size_of::<nlattr>(), NLA_ALIGNTO as usize);
-const NETLINK_EXT_ACK: c_int = 11;
 
 // Safety: marking this as unsafe overall because of all the pointer math required to comply with
 // netlink alignments


### PR DESCRIPTION
NETLINK_EXT_ACK is available since libc crate version 0.2.105, see
https://github.com/rust-lang/libc/releases/tag/0.2.105