### PR TITLE
Fix bindings for archs other than x86

### DIFF
--- a/.github/workflows/gen.yml
+++ b/.github/workflows/gen.yml
@@ -20,6 +20,11 @@ jobs:
 
       - uses: Swatinem/rust-cache@v1
 
+      - name: Install headers
+        run: |
+          apt -y update
+          apt -y install libc6-dev libc6-dev-{aarch64,armel}-cross
+
       - name: Run codegen
         run: |
           cargo xtask codegen --libbpf-dir ./libbpf

--- a/xtask/src/codegen/mod.rs
+++ b/xtask/src/codegen/mod.rs
@@ -53,6 +53,17 @@ pub struct Options {
     #[structopt(long)]
     libbpf_dir: PathBuf,
 
+    // sysroot options. Default to ubuntu headers installed by the
+    // libc6-dev-{arm64,armel}-cross packages.
+    #[structopt(long, default_value = "/usr/include/x86_64-linux-gnu")]
+    x86_64_sysroot: PathBuf,
+
+    #[structopt(long, default_value = "/usr/aarch64-linux-gnu/include")]
+    aarch64_sysroot: PathBuf,
+
+    #[structopt(long, default_value = "/usr/arm-linux-gnueabi/include")]
+    armv7_sysroot: PathBuf,
+
     #[structopt(subcommand)]
     command: Option<Command>,
 }


### PR DESCRIPTION
This fixes binding generation for archs other than x86, and makes it possible to specify sysroot paths when running codegen on distros other than ubuntu.