### PR TITLE
fix: make maps compatible with kernel <= 4.14

### DIFF
--- a/aya/src/sys/bpf.rs
+++ b/aya/src/sys/bpf.rs
@@ -32,7 +32,7 @@ pub(crate) fn bpf_create_map(name: &CStr, def: &bpf_map_def) -> SysResult {
 
     // https://github.com/torvalds/linux/commit/ad5b177bd73f5107d97c36f56395c4281fb6f089
     // The map name was added as a parameter in kernel 4.15+ so we skip adding it on
-    // older kernels for compatibility 
+    // older kernels for compatibility
     let k_ver = kernel_version().unwrap();
     if k_ver >= (4, 15, 0) {
         // u.map_name is 16 bytes max and must be NULL terminated

--- a/aya/src/sys/bpf.rs
+++ b/aya/src/sys/bpf.rs
@@ -14,7 +14,7 @@ use crate::{
     generated::{bpf_attach_type, bpf_attr, bpf_cmd, bpf_insn, bpf_prog_info, bpf_prog_type},
     maps::PerCpuValues,
     programs::VerifierLog,
-    sys::SysResult,
+    sys::{kernel_version, SysResult},
     Pod, BPF_OBJ_NAME_LEN,
 };
 
@@ -30,10 +30,16 @@ pub(crate) fn bpf_create_map(name: &CStr, def: &bpf_map_def) -> SysResult {
     u.max_entries = def.max_entries;
     u.map_flags = def.map_flags;
 
-    // u.map_name is 16 bytes max and must be NULL terminated
-    let name_len = cmp::min(name.to_bytes().len(), BPF_OBJ_NAME_LEN - 1);
-    u.map_name[..name_len]
-        .copy_from_slice(unsafe { slice::from_raw_parts(name.as_ptr(), name_len) });
+    // https://github.com/torvalds/linux/commit/ad5b177bd73f5107d97c36f56395c4281fb6f089
+    // The map name was added as a parameter in kernel 4.15+ so we skip adding it on
+    // older kernels for compatibility 
+    let k_ver = kernel_version().unwrap();
+    if k_ver >= (4, 15, 0) {
+        // u.map_name is 16 bytes max and must be NULL terminated
+        let name_len = cmp::min(name.to_bytes().len(), BPF_OBJ_NAME_LEN - 1);
+        u.map_name[..name_len]
+            .copy_from_slice(unsafe { slice::from_raw_parts(name.as_ptr(), name_len) });
+    }
 
     sys_bpf(bpf_cmd::BPF_MAP_CREATE, &attr)
 }

--- a/aya/src/sys/mod.rs
+++ b/aya/src/sys/mod.rs
@@ -77,7 +77,7 @@ unsafe fn syscall_impl(call: Syscall) -> SysResult {
 
 #[cfg(test)]
 pub(crate) fn kernel_version() -> Result<(u32, u32, u32), ()> {
-    return Ok((0xff, 0xff, 0xff))
+    Ok((0xff, 0xff, 0xff))
 }
 
 #[cfg(not(test))]

--- a/aya/src/sys/mod.rs
+++ b/aya/src/sys/mod.rs
@@ -75,6 +75,12 @@ unsafe fn syscall_impl(call: Syscall) -> SysResult {
     Ok(ret)
 }
 
+#[cfg(test)]
+pub(crate) fn kernel_version() -> Result<(u32, u32, u32), ()> {
+    return Ok((0xff, 0xff, 0xff))
+}
+
+#[cfg(not(test))]
 pub(crate) fn kernel_version() -> Result<(u32, u32, u32), ()> {
     unsafe {
         let mut v = mem::zeroed::<utsname>();


### PR DESCRIPTION
In kernel 4.15 and additional parameter was added to allow maps to have names but using this breaks on older kernels. This change makes it so the name is only added on kernels 4.15 and newer.

Symptoms of the problem would show up like

```
error: map error: failed to create map `IPV4_EVENTS` with code -1: Invalid argument (os error 22)`
```

and in `strace` output would look like

```
bpf(BPF_MAP_CREATE, {map_type=BPF_MAP_TYPE_PERF_EVENT_ARRAY, key_size=4, value_size=4, max_entries=8, map_flags=0, inner_map_fd=0, map_name="IPV4_EVENTS", map_ifindex=0}, 128) = -1 EINVAL (Invalid argument)
```

After this patch the `strace` output looks like 

```
bpf(BPF_MAP_CREATE, {map_type=BPF_MAP_TYPE_PERF_EVENT_ARRAY, key_size=4, value_size=4, max_entries=2, map_flags=0, inner_map_fd=0, map_name="", map_ifindex=0}, 128) = 9
```