### PR TITLE
aya: remove unnecessary usage of &dyn trait in favor of impl trait.

### DIFF
--- a/aya/src/maps/array/program_array.rs
+++ b/aya/src/maps/array/program_array.rs
@@ -28,7 +28,7 @@ use crate::{
 /// ```no_run
 /// # let bpf = aya::Bpf::load(&[])?;
 /// use aya::maps::ProgramArray;
-/// use aya::programs::CgroupSkb;
+/// use aya::programs::{CgroupSkb, ProgramFd};
 /// use std::convert::{TryFrom, TryInto};
 ///
 /// let mut prog_array = ProgramArray::try_from(bpf.map_mut("JUMP_TABLE")?)?;
@@ -98,7 +98,7 @@ impl<T: Deref<Target = Map> + DerefMut<Target = Map>> ProgramArray<T> {
     ///
     /// When an eBPF program calls `bpf_tail_call(ctx, prog_array, index)`, control
     /// flow will jump to `program`.
-    pub fn set(&mut self, index: u32, program: &dyn ProgramFd, flags: u64) -> Result<(), MapError> {
+    pub fn set(&mut self, index: u32, program: impl ProgramFd, flags: u64) -> Result<(), MapError> {
         let fd = self.inner.fd_or_err()?;
         self.check_bounds(index)?;
         let prog_fd = program.fd().ok_or(MapError::ProgramNotLoaded)?;

--- a/aya/src/maps/hash_map/hash_map.rs
+++ b/aya/src/maps/hash_map/hash_map.rs
@@ -75,7 +75,7 @@ impl<T: Deref<Target = Map>, K: Pod, V: Pod> HashMap<T, K, V> {
 
     /// An iterator visiting all key-value pairs in arbitrary order. The
     /// iterator item type is `Result<(K, V), MapError>`.
-    pub unsafe fn iter(&self) -> MapIter<'_, K, V> {
+    pub unsafe fn iter(&self) -> MapIter<'_, K, V, Self> {
         MapIter::new(self)
     }
 

--- a/aya/src/maps/hash_map/per_cpu_hash_map.rs
+++ b/aya/src/maps/hash_map/per_cpu_hash_map.rs
@@ -87,7 +87,7 @@ impl<T: Deref<Target = Map>, K: Pod, V: Pod> PerCpuHashMap<T, K, V> {
 
     /// An iterator visiting all key-value pairs in arbitrary order. The
     /// iterator item type is `Result<(K, PerCpuValues<V>), MapError>`.
-    pub unsafe fn iter(&self) -> MapIter<'_, K, PerCpuValues<V>> {
+    pub unsafe fn iter(&self) -> MapIter<'_, K, PerCpuValues<V>, Self> {
         MapIter::new(self)
     }
 

--- a/aya/src/maps/sock/sock_hash.rs
+++ b/aya/src/maps/sock/sock_hash.rs
@@ -101,7 +101,7 @@ impl<T: Deref<Target = Map>, K: Pod> SockHash<T, K> {
 
     /// An iterator visiting all key-value pairs in arbitrary order. The
     /// iterator item type is `Result<(K, V), MapError>`.
-    pub unsafe fn iter(&self) -> MapIter<'_, K, RawFd> {
+    pub unsafe fn iter(&self) -> MapIter<'_, K, RawFd, Self> {
         MapIter::new(self)
     }
 

--- a/aya/src/maps/stack_trace.rs
+++ b/aya/src/maps/stack_trace.rs
@@ -140,7 +140,7 @@ impl<T: Deref<Target = Map>> StackTraceMap<T> {
 
     /// An iterator visiting all (`stack_id`, `stack_trace`) pairs in arbitrary order. The
     /// iterator item type is `Result<(u32, StackTrace), MapError>`.
-    pub fn iter(&self) -> MapIter<'_, u32, StackTrace> {
+    pub fn iter(&self) -> MapIter<'_, u32, StackTrace, Self> {
         MapIter::new(self)
     }
 
@@ -179,7 +179,7 @@ impl TryFrom<MapRefMut> for StackTraceMap<MapRefMut> {
 
 impl<'a, T: Deref<Target = Map>> IntoIterator for &'a StackTraceMap<T> {
     type Item = Result<(u32, StackTrace), MapError>;
-    type IntoIter = MapIter<'a, u32, StackTrace>;
+    type IntoIter = MapIter<'a, u32, StackTrace, StackTraceMap<T>>;
 
     fn into_iter(self) -> Self::IntoIter {
         self.iter()

--- a/aya/src/programs/mod.rs
+++ b/aya/src/programs/mod.rs
@@ -582,6 +582,12 @@ impl ProgramFd for Program {
     }
 }
 
+impl<'a, P: ProgramFd> ProgramFd for &'a P {
+    fn fd(&self) -> Option<RawFd> {
+        (*self).fd()
+    }
+}
+
 macro_rules! impl_program_fd {
     ($($struct_name:ident),+ $(,)?) => {
         $(

--- a/aya/src/util.rs
+++ b/aya/src/util.rs
@@ -76,7 +76,7 @@ pub fn kernel_symbols() -> Result<BTreeMap<u64, String>, io::Error> {
     parse_kernel_symbols(&mut reader)
 }
 
-fn parse_kernel_symbols(reader: &mut dyn BufRead) -> Result<BTreeMap<u64, String>, io::Error> {
+fn parse_kernel_symbols(reader: impl BufRead) -> Result<BTreeMap<u64, String>, io::Error> {
     let mut syms = BTreeMap::new();
 
     for line in reader.lines() {


### PR DESCRIPTION
This should improve performance in most situations by eliminating
unnecessary fat pointer indirection.