### PR TITLE
aya: eliminate name duplication in maps and programs.

### DIFF
--- a/aya/src/maps/array/program_array.rs
+++ b/aya/src/maps/array/program_array.rs
@@ -32,9 +32,9 @@ use crate::{
 /// use std::convert::{TryFrom, TryInto};
 ///
 /// let mut prog_array = ProgramArray::try_from(bpf.map_mut("JUMP_TABLE")?)?;
-/// let prog_0: &CgroupSkb = bpf.program("example_prog_0")?.try_into()?;
-/// let prog_1: &CgroupSkb = bpf.program("example_prog_1")?.try_into()?;
-/// let prog_2: &CgroupSkb = bpf.program("example_prog_2")?.try_into()?;
+/// let prog_0: &CgroupSkb = bpf.program("example_prog_0").unwrap().try_into()?;
+/// let prog_1: &CgroupSkb = bpf.program("example_prog_1").unwrap().try_into()?;
+/// let prog_2: &CgroupSkb = bpf.program("example_prog_2").unwrap().try_into()?;
 ///
 /// let flags = 0;
 ///

--- a/aya/src/maps/hash_map/hash_map.rs
+++ b/aya/src/maps/hash_map/hash_map.rs
@@ -158,9 +158,8 @@ mod tests {
 
     use super::*;
 
-    fn new_obj_map(name: &str) -> obj::Map {
+    fn new_obj_map() -> obj::Map {
         obj::Map {
-            name: name.to_string(),
             def: bpf_map_def {
                 map_type: BPF_MAP_TYPE_HASH as u32,
                 key_size: 4,
@@ -180,7 +179,7 @@ mod tests {
     #[test]
     fn test_wrong_key_size() {
         let map = Map {
-            obj: new_obj_map("TEST"),
+            obj: new_obj_map(),
             fd: None,
             pinned: false,
         };
@@ -196,7 +195,7 @@ mod tests {
     #[test]
     fn test_wrong_value_size() {
         let map = Map {
-            obj: new_obj_map("TEST"),
+            obj: new_obj_map(),
             fd: None,
             pinned: false,
         };
@@ -213,7 +212,6 @@ mod tests {
     fn test_try_from_wrong_map() {
         let map = Map {
             obj: obj::Map {
-                name: "TEST".to_string(),
                 def: bpf_map_def {
                     map_type: BPF_MAP_TYPE_PERF_EVENT_ARRAY as u32,
                     key_size: 4,
@@ -237,7 +235,7 @@ mod tests {
     #[test]
     fn test_new_not_created() {
         let mut map = Map {
-            obj: new_obj_map("TEST"),
+            obj: new_obj_map(),
             fd: None,
             pinned: false,
         };
@@ -251,7 +249,7 @@ mod tests {
     #[test]
     fn test_new_ok() {
         let mut map = Map {
-            obj: new_obj_map("TEST"),
+            obj: new_obj_map(),
             fd: Some(42),
             pinned: false,
         };
@@ -262,7 +260,7 @@ mod tests {
     #[test]
     fn test_try_from_ok() {
         let map = Map {
-            obj: new_obj_map("TEST"),
+            obj: new_obj_map(),
             fd: Some(42),
             pinned: false,
         };
@@ -273,7 +271,6 @@ mod tests {
     fn test_try_from_ok_lru() {
         let map = Map {
             obj: obj::Map {
-                name: "TEST".to_string(),
                 def: bpf_map_def {
                     map_type: BPF_MAP_TYPE_LRU_HASH as u32,
                     key_size: 4,
@@ -296,7 +293,7 @@ mod tests {
         override_syscall(|_| sys_error(EFAULT));
 
         let mut map = Map {
-            obj: new_obj_map("TEST"),
+            obj: new_obj_map(),
             fd: Some(42),
             pinned: false,
         };
@@ -319,7 +316,7 @@ mod tests {
         });
 
         let mut map = Map {
-            obj: new_obj_map("TEST"),
+            obj: new_obj_map(),
             fd: Some(42),
             pinned: false,
         };
@@ -333,7 +330,7 @@ mod tests {
         override_syscall(|_| sys_error(EFAULT));
 
         let mut map = Map {
-            obj: new_obj_map("TEST"),
+            obj: new_obj_map(),
             fd: Some(42),
             pinned: false,
         };
@@ -356,7 +353,7 @@ mod tests {
         });
 
         let mut map = Map {
-            obj: new_obj_map("TEST"),
+            obj: new_obj_map(),
             fd: Some(42),
             pinned: false,
         };
@@ -369,7 +366,7 @@ mod tests {
     fn test_get_syscall_error() {
         override_syscall(|_| sys_error(EFAULT));
         let map = Map {
-            obj: new_obj_map("TEST"),
+            obj: new_obj_map(),
             fd: Some(42),
             pinned: false,
         };
@@ -391,7 +388,7 @@ mod tests {
             _ => sys_error(EFAULT),
         });
         let map = Map {
-            obj: new_obj_map("TEST"),
+            obj: new_obj_map(),
             fd: Some(42),
             pinned: false,
         };
@@ -430,7 +427,7 @@ mod tests {
             _ => sys_error(EFAULT),
         });
         let map = Map {
-            obj: new_obj_map("TEST"),
+            obj: new_obj_map(),
             fd: Some(42),
             pinned: false,
         };
@@ -474,7 +471,7 @@ mod tests {
         });
 
         let map = Map {
-            obj: new_obj_map("TEST"),
+            obj: new_obj_map(),
             fd: Some(42),
             pinned: false,
         };
@@ -502,7 +499,7 @@ mod tests {
             _ => sys_error(EFAULT),
         });
         let map = Map {
-            obj: new_obj_map("TEST"),
+            obj: new_obj_map(),
             fd: Some(42),
             pinned: false,
         };
@@ -532,7 +529,7 @@ mod tests {
             _ => sys_error(EFAULT),
         });
         let map = Map {
-            obj: new_obj_map("TEST"),
+            obj: new_obj_map(),
             fd: Some(42),
             pinned: false,
         };
@@ -565,7 +562,7 @@ mod tests {
             _ => sys_error(EFAULT),
         });
         let map = Map {
-            obj: new_obj_map("TEST"),
+            obj: new_obj_map(),
             fd: Some(42),
             pinned: false,
         };
@@ -599,7 +596,7 @@ mod tests {
             _ => sys_error(EFAULT),
         });
         let map = Map {
-            obj: new_obj_map("TEST"),
+            obj: new_obj_map(),
             fd: Some(42),
             pinned: false,
         };
@@ -639,7 +636,7 @@ mod tests {
             _ => sys_error(EFAULT),
         });
         let map = Map {
-            obj: new_obj_map("TEST"),
+            obj: new_obj_map(),
             fd: Some(42),
             pinned: false,
         };

--- a/aya/src/maps/sock/sock_hash.rs
+++ b/aya/src/maps/sock/sock_hash.rs
@@ -50,7 +50,7 @@ use crate::{
 /// use aya::programs::SkMsg;
 ///
 /// let mut intercept_egress = SockHash::try_from(bpf.map_mut("INTERCEPT_EGRESS")?)?;
-/// let prog: &mut SkMsg = bpf.program_mut("intercept_egress_packet")?.try_into()?;
+/// let prog: &mut SkMsg = bpf.program_mut("intercept_egress_packet").unwrap().try_into()?;
 /// prog.load()?;
 /// prog.attach(&intercept_egress)?;
 ///

--- a/aya/src/maps/sock/sock_map.rs
+++ b/aya/src/maps/sock/sock_map.rs
@@ -35,7 +35,7 @@ use crate::{
 /// use aya::programs::SkSkb;
 ///
 /// let intercept_ingress = SockMap::try_from(bpf.map_mut("INTERCEPT_INGRESS")?)?;
-/// let prog: &mut SkSkb = bpf.program_mut("intercept_ingress_packet")?.try_into()?;
+/// let prog: &mut SkSkb = bpf.program_mut("intercept_ingress_packet").unwrap().try_into()?;
 /// prog.load()?;
 /// prog.attach(&intercept_ingress)?;
 /// # Ok::<(), aya::BpfError>(())

--- a/aya/src/obj/mod.rs
+++ b/aya/src/obj/mod.rs
@@ -44,7 +44,6 @@ pub struct Object {
 
 #[derive(Debug, Clone)]
 pub struct Map {
-    pub(crate) name: String,
     pub(crate) def: bpf_map_def,
     pub(crate) section_index: usize,
     pub(crate) data: Vec<u8>,
@@ -530,7 +529,6 @@ fn parse_map(section: &Section, name: &str) -> Result<Map, ParseError> {
 
     Ok(Map {
         section_index: section.index.0,
-        name: name.to_string(),
         def,
         data,
     })
@@ -785,7 +783,6 @@ mod tests {
             ),
             Ok(Map {
                 section_index: 0,
-                name,
                 def: bpf_map_def {
                     map_type: 1,
                     key_size: 2,
@@ -796,7 +793,7 @@ mod tests {
                     pinning: PinningType::None,
                 },
                 data
-            }) if name == "foo" && data.is_empty()
+            }) if data.is_empty()
         ))
     }
 
@@ -813,7 +810,6 @@ mod tests {
             ),
             Ok(Map {
                 section_index: 0,
-                name,
                 def: bpf_map_def {
                     map_type: _map_type,
                     key_size: 4,
@@ -824,7 +820,7 @@ mod tests {
                     pinning: PinningType::None,
                 },
                 data
-            }) if name == ".bss" && data == map_data && value_size == map_data.len() as u32
+            }) if data == map_data && value_size == map_data.len() as u32
         ))
     }
 

--- a/aya/src/programs/cgroup_skb.rs
+++ b/aya/src/programs/cgroup_skb.rs
@@ -43,7 +43,7 @@ use super::FdLink;
 /// use aya::programs::{CgroupSkb, CgroupSkbAttachType};
 ///
 /// let file = File::open("/sys/fs/cgroup/unified")?;
-/// let egress: &mut CgroupSkb = bpf.program_mut("egress_filter")?.try_into()?;
+/// let egress: &mut CgroupSkb = bpf.program_mut("egress_filter").unwrap().try_into()?;
 /// egress.load()?;
 /// egress.attach(file, CgroupSkbAttachType::Egress)?;
 /// # Ok::<(), Error>(())
@@ -61,11 +61,6 @@ impl CgroupSkb {
     /// See also [`Program::load`](crate::programs::Program::load).
     pub fn load(&mut self) -> Result<(), ProgramError> {
         load_program(BPF_PROG_TYPE_CGROUP_SKB, &mut self.data)
-    }
-
-    /// Returns the name of the program.
-    pub fn name(&self) -> String {
-        self.data.name.to_string()
     }
 
     /// Returns the expected attach type of the program.

--- a/aya/src/programs/kprobe.rs
+++ b/aya/src/programs/kprobe.rs
@@ -30,7 +30,7 @@ use crate::{
 /// use aya::{Bpf, programs::KProbe};
 /// use std::convert::TryInto;
 ///
-/// let program: &mut KProbe = bpf.program_mut("intercept_wakeups")?.try_into()?;
+/// let program: &mut KProbe = bpf.program_mut("intercept_wakeups").unwrap().try_into()?;
 /// program.load()?;
 /// program.attach("try_to_wake_up", 0)?;
 /// # Ok::<(), aya::BpfError>(())
@@ -48,11 +48,6 @@ impl KProbe {
     /// See also [`Program::load`](crate::programs::Program::load).
     pub fn load(&mut self) -> Result<(), ProgramError> {
         load_program(BPF_PROG_TYPE_KPROBE, &mut self.data)
-    }
-
-    /// Returns the name of the program.
-    pub fn name(&self) -> String {
-        self.data.name.to_string()
     }
 
     /// Returns `KProbe` if the program is a `kprobe`, or `KRetProbe` if the

--- a/aya/src/programs/lirc_mode2.rs
+++ b/aya/src/programs/lirc_mode2.rs
@@ -40,7 +40,7 @@ use libc::{close, dup};
 ///
 /// let file = File::open("/dev/lirc0")?;
 /// let mut bpf = aya::Bpf::load_file("imon_rsc.o")?;
-/// let decoder: &mut LircMode2 = bpf.program_mut("imon_rsc")?.try_into().unwrap();
+/// let decoder: &mut LircMode2 = bpf.program_mut("imon_rsc").unwrap().try_into().unwrap();
 /// decoder.load()?;
 /// decoder.attach(file)?;
 /// # Ok::<(), Error>(())
@@ -57,11 +57,6 @@ impl LircMode2 {
     /// See also [`Program::load`](crate::programs::Program::load).
     pub fn load(&mut self) -> Result<(), ProgramError> {
         load_program(BPF_PROG_TYPE_LIRC_MODE2, &mut self.data)
-    }
-
-    /// Returns the name of the program.
-    pub fn name(&self) -> String {
-        self.data.name.to_string()
     }
 
     /// Attaches the program to the given lirc device.

--- a/aya/src/programs/lsm.rs
+++ b/aya/src/programs/lsm.rs
@@ -43,7 +43,7 @@ use crate::{
 /// use std::convert::TryInto;
 ///
 /// let btf = Btf::from_sys_fs()?;
-/// let program: &mut Lsm = bpf.program_mut("lsm_prog")?.try_into()?;
+/// let program: &mut Lsm = bpf.program_mut("lsm_prog").unwrap().try_into()?;
 /// program.load("security_bprm_exec", &btf)?;
 /// program.attach()?;
 /// # Ok::<(), LsmError>(())
@@ -81,11 +81,6 @@ impl Lsm {
         self.data.attach_btf_id =
             Some(btf.id_by_type_name_kind(type_name.as_str(), BtfKind::Func)?);
         load_program(BPF_PROG_TYPE_LSM, &mut self.data).map_err(LsmLoadError::from)
-    }
-
-    /// Returns the name of the program.
-    pub fn name(&self) -> String {
-        self.data.name.to_string()
     }
 
     /// Attaches the program.

--- a/aya/src/programs/mod.rs
+++ b/aya/src/programs/mod.rs
@@ -19,7 +19,7 @@
 //!
 //! let mut bpf = Bpf::load_file("ebpf_programs.o")?;
 //! // intercept_wakeups is the name of the program we want to load
-//! let program: &mut KProbe = bpf.program_mut("intercept_wakeups")?.try_into()?;
+//! let program: &mut KProbe = bpf.program_mut("intercept_wakeups").unwrap().try_into()?;
 //! program.load()?;
 //! // intercept_wakeups will be called every time try_to_wake_up() is called
 //! // inside the kernel
@@ -95,10 +95,6 @@ use crate::{
 /// Error type returned when working with programs.
 #[derive(Debug, Error)]
 pub enum ProgramError {
-    /// The program could not be found in the object code.
-    #[error("program `{name}` not found")]
-    NotFound { name: String },
-
     /// The program is already loaded.
     #[error("the program is already loaded")]
     AlreadyLoaded,
@@ -240,11 +236,6 @@ impl Program {
         }
     }
 
-    /// Returns the name of the program.
-    pub fn name(&self) -> &str {
-        &self.data().name
-    }
-
     /// Pin the program to the provided path
     pub fn pin<P: AsRef<Path>>(&mut self, path: P) -> Result<(), ProgramError> {
         self.data_mut().pin(path)
@@ -293,7 +284,6 @@ impl Program {
 
 #[derive(Debug)]
 pub(crate) struct ProgramData {
-    pub(crate) name: String,
     pub(crate) obj: obj::Program,
     pub(crate) fd: Option<RawFd>,
     pub(crate) links: Vec<Rc<RefCell<dyn Link>>>,

--- a/aya/src/programs/perf_event.rs
+++ b/aya/src/programs/perf_event.rs
@@ -66,7 +66,7 @@ pub enum PerfEventScope {
 ///     perf_sw_ids::PERF_COUNT_SW_CPU_CLOCK, PerfEvent, PerfEventScope, PerfTypeId, SamplePolicy,
 /// };
 ///
-/// let prog: &mut PerfEvent = bpf.program_mut("observe_cpu_clock")?.try_into()?;
+/// let prog: &mut PerfEvent = bpf.program_mut("observe_cpu_clock").unwrap().try_into()?;
 /// prog.load()?;
 ///
 /// for cpu in online_cpus()? {

--- a/aya/src/programs/raw_trace_point.rs
+++ b/aya/src/programs/raw_trace_point.rs
@@ -26,7 +26,7 @@ use crate::{
 /// use aya::{Bpf, programs::RawTracePoint};
 /// use std::convert::TryInto;
 ///
-/// let program: &mut RawTracePoint = bpf.program_mut("sys_enter")?.try_into()?;
+/// let program: &mut RawTracePoint = bpf.program_mut("sys_enter").unwrap().try_into()?;
 /// program.load()?;
 /// program.attach("sys_enter")?;
 /// # Ok::<(), aya::BpfError>(())
@@ -43,11 +43,6 @@ impl RawTracePoint {
     /// See also [`Program::load`](crate::programs::Program::load).
     pub fn load(&mut self) -> Result<(), ProgramError> {
         load_program(BPF_PROG_TYPE_RAW_TRACEPOINT, &mut self.data)
-    }
-
-    /// Returns the name of the program.
-    pub fn name(&self) -> String {
-        self.data.name.to_string()
     }
 
     /// Attaches the program to the given tracepoint.

--- a/aya/src/programs/sk_msg.rs
+++ b/aya/src/programs/sk_msg.rs
@@ -38,7 +38,7 @@ use crate::{
 /// use aya::programs::SkMsg;
 ///
 /// let mut intercept_egress = SockHash::try_from(bpf.map_mut("INTERCEPT_EGRESS")?)?;
-/// let prog: &mut SkMsg = bpf.program_mut("intercept_egress_packet")?.try_into()?;
+/// let prog: &mut SkMsg = bpf.program_mut("intercept_egress_packet").unwrap().try_into()?;
 /// prog.load()?;
 /// prog.attach(&intercept_egress)?;
 ///
@@ -65,11 +65,6 @@ impl SkMsg {
     /// See also [`Program::load`](crate::programs::Program::load).
     pub fn load(&mut self) -> Result<(), ProgramError> {
         load_program(BPF_PROG_TYPE_SK_MSG, &mut self.data)
-    }
-
-    /// Returns the name of the program.
-    pub fn name(&self) -> String {
-        self.data.name.to_string()
     }
 
     /// Attaches the program to the given sockmap.

--- a/aya/src/programs/sk_skb.rs
+++ b/aya/src/programs/sk_skb.rs
@@ -34,7 +34,7 @@ pub enum SkSkbKind {
 /// use aya::programs::SkSkb;
 ///
 /// let intercept_ingress = SockMap::try_from(bpf.map_mut("INTERCEPT_INGRESS")?)?;
-/// let prog: &mut SkSkb = bpf.program_mut("intercept_ingress_packet")?.try_into()?;
+/// let prog: &mut SkSkb = bpf.program_mut("intercept_ingress_packet").unwrap().try_into()?;
 /// prog.load()?;
 /// prog.attach(&intercept_ingress)?;
 /// # Ok::<(), aya::BpfError>(())
@@ -56,11 +56,6 @@ impl SkSkb {
     /// See also [`Program::load`](crate::programs::Program::load).
     pub fn load(&mut self) -> Result<(), ProgramError> {
         load_program(BPF_PROG_TYPE_SK_SKB, &mut self.data)
-    }
-
-    /// Returns the name of the program.
-    pub fn name(&self) -> String {
-        self.data.name.to_string()
     }
 
     /// Attaches the program to the given socket map.

--- a/aya/src/programs/sock_ops.rs
+++ b/aya/src/programs/sock_ops.rs
@@ -36,7 +36,7 @@ use crate::{
 /// use aya::programs::SockOps;
 ///
 /// let file = File::open("/sys/fs/cgroup/unified")?;
-/// let prog: &mut SockOps = bpf.program_mut("intercept_active_sockets")?.try_into()?;
+/// let prog: &mut SockOps = bpf.program_mut("intercept_active_sockets").unwrap().try_into()?;
 /// prog.load()?;
 /// prog.attach(file)?;
 /// # Ok::<(), Error>(())
@@ -52,11 +52,6 @@ impl SockOps {
     /// See also [`Program::load`](crate::programs::Program::load).
     pub fn load(&mut self) -> Result<(), ProgramError> {
         load_program(BPF_PROG_TYPE_SOCK_OPS, &mut self.data)
-    }
-
-    /// Returns the name of the program.
-    pub fn name(&self) -> String {
-        self.data.name.to_string()
     }
 
     /// Attaches the program to the given cgroup.

--- a/aya/src/programs/socket_filter.rs
+++ b/aya/src/programs/socket_filter.rs
@@ -51,7 +51,7 @@ pub enum SocketFilterError {
 /// use aya::programs::SocketFilter;
 ///
 /// let mut client = TcpStream::connect("127.0.0.1:1234")?;
-/// let prog: &mut SocketFilter = bpf.program_mut("filter_packets")?.try_into()?;
+/// let prog: &mut SocketFilter = bpf.program_mut("filter_packets").unwrap().try_into()?;
 /// prog.load()?;
 /// prog.attach(client.as_raw_fd())?;
 /// # Ok::<(), Error>(())

--- a/aya/src/programs/tp_btf.rs
+++ b/aya/src/programs/tp_btf.rs
@@ -40,7 +40,7 @@ use crate::{
 /// use std::convert::TryInto;
 ///
 /// let btf = Btf::from_sys_fs()?;
-/// let program: &mut BtfTracePoint = bpf.program_mut("sched_process_fork")?.try_into()?;
+/// let program: &mut BtfTracePoint = bpf.program_mut("sched_process_fork").unwrap().try_into()?;
 /// program.load("sched_process_fork", &btf)?;
 /// program.attach()?;
 /// # Ok::<(), Error>(())
@@ -79,11 +79,6 @@ impl BtfTracePoint {
                 .map_err(BtfTracePointError::from)?,
         );
         load_program(BPF_PROG_TYPE_TRACING, &mut self.data)
-    }
-
-    /// Returns the name of the program.
-    pub fn name(&self) -> String {
-        self.data.name.to_string()
     }
 
     /// Attaches the program.

--- a/aya/src/programs/trace_point.rs
+++ b/aya/src/programs/trace_point.rs
@@ -44,7 +44,7 @@ pub enum TracePointError {
 /// use std::convert::TryInto;
 /// use aya::programs::TracePoint;
 ///
-/// let prog: &mut TracePoint = bpf.program_mut("trace_context_switch")?.try_into()?;
+/// let prog: &mut TracePoint = bpf.program_mut("trace_context_switch").unwrap().try_into()?;
 /// prog.load()?;
 /// prog.attach("sched", "sched_switch")?;
 /// # Ok::<(), Error>(())

--- a/aya/src/programs/uprobe.rs
+++ b/aya/src/programs/uprobe.rs
@@ -52,11 +52,6 @@ impl UProbe {
         load_program(BPF_PROG_TYPE_KPROBE, &mut self.data)
     }
 
-    /// Returns the name of the program.
-    pub fn name(&self) -> String {
-        self.data.name.to_string()
-    }
-
     /// Returns `UProbe` if the program is a `uprobe`, or `URetProbe` if the
     /// program is a `uretprobe`.
     pub fn kind(&self) -> ProbeKind {

--- a/aya/src/programs/xdp.rs
+++ b/aya/src/programs/xdp.rs
@@ -57,7 +57,7 @@ bitflags! {
 /// use aya::{Bpf, programs::{Xdp, XdpFlags}};
 /// use std::convert::TryInto;
 ///
-/// let program: &mut Xdp = bpf.program_mut("intercept_packets")?.try_into()?;
+/// let program: &mut Xdp = bpf.program_mut("intercept_packets").unwrap().try_into()?;
 /// program.attach("eth0", XdpFlags::default())?;
 /// # Ok::<(), aya::BpfError>(())
 /// ```
@@ -73,11 +73,6 @@ impl Xdp {
     /// See also [`Program::load`](crate::programs::Program::load).
     pub fn load(&mut self) -> Result<(), ProgramError> {
         load_program(BPF_PROG_TYPE_XDP, &mut self.data)
-    }
-
-    /// Returns the name of the program.
-    pub fn name(&self) -> String {
-        self.data.name.to_string()
     }
 
     /// Attaches the program to the given `interface`.


### PR DESCRIPTION
Map and ProgramData objects had unnecessarily cloned strings for their
names, despite them being just as easily available to external users via
bpf.maps() and bpf.programs().