### PR TITLE
aya: expand include_bytes_aligned to accept expressions.

### DIFF
--- a/aya/src/util.rs
+++ b/aya/src/util.rs
@@ -124,7 +124,7 @@ pub(crate) fn tc_handler_make(major: u32, minor: u32) -> u32 {
 /// ```
 #[macro_export]
 macro_rules! include_bytes_aligned {
-    ($path:literal) => {{
+    ($path:expr) => {{
         #[repr(align(32))]
         pub struct Aligned32;
 


### PR DESCRIPTION
This allows one to this macro with literal expressions involving macros
such as concat! and env!.