### PR TITLE
aya: remove Rc<RefCell<T>> usage in BPF program links.

### DIFF
--- a/aya/src/bpf.rs
+++ b/aya/src/bpf.rs
@@ -251,7 +251,6 @@ impl<'a> BpfLoader<'a> {
                 let data = ProgramData {
                     obj,
                     fd: None,
-                    links: Vec::new(),
                     expected_attach_type: None,
                     attach_btf_obj_fd: None,
                     attach_btf_id: None,

--- a/aya/src/maps/sock/mod.rs
+++ b/aya/src/maps/sock/mod.rs
@@ -11,3 +11,9 @@ pub use sock_map::SockMap;
 pub trait SocketMap {
     fn fd_or_err(&self) -> Result<RawFd, MapError>;
 }
+
+impl<'a, S: SocketMap> SocketMap for &'a S {
+    fn fd_or_err(&self) -> Result<RawFd, MapError> {
+        (*self).fd_or_err()
+    }
+}

--- a/aya/src/programs/kprobe.rs
+++ b/aya/src/programs/kprobe.rs
@@ -7,7 +7,7 @@ use crate::{
     programs::{
         load_program,
         probe::{attach, ProbeKind},
-        LinkRef, ProgramData, ProgramError,
+        OwnedLink, ProgramData, ProgramError,
     },
 };
 
@@ -65,7 +65,7 @@ impl KProbe {
     /// If the program is a `kprobe`, it is attached to the *start* address of the target function.
     /// Conversely if the program is a `kretprobe`, it is attached to the return address of the
     /// target function.
-    pub fn attach(&mut self, fn_name: &str, offset: u64) -> Result<LinkRef, ProgramError> {
+    pub fn attach(&mut self, fn_name: &str, offset: u64) -> Result<OwnedLink, ProgramError> {
         attach(&mut self.data, self.kind, fn_name, offset, None)
     }
 }

--- a/aya/src/programs/lirc_mode2.rs
+++ b/aya/src/programs/lirc_mode2.rs
@@ -2,7 +2,7 @@ use std::os::unix::prelude::{AsRawFd, RawFd};
 
 use crate::{
     generated::{bpf_attach_type::BPF_LIRC_MODE2, bpf_prog_type::BPF_PROG_TYPE_LIRC_MODE2},
-    programs::{load_program, query, Link, LinkRef, ProgramData, ProgramError, ProgramInfo},
+    programs::{load_program, query, Link, OwnedLink, ProgramData, ProgramError, ProgramInfo},
     sys::{bpf_obj_get_info_by_fd, bpf_prog_attach, bpf_prog_detach, bpf_prog_get_fd_by_id},
 };
 
@@ -60,7 +60,7 @@ impl LircMode2 {
     }
 
     /// Attaches the program to the given lirc device.
-    pub fn attach<T: AsRawFd>(&mut self, lircdev: T) -> Result<LinkRef, ProgramError> {
+    pub fn attach<T: AsRawFd>(&mut self, lircdev: T) -> Result<OwnedLink, ProgramError> {
         let prog_fd = self.data.fd_or_err()?;
         let lircdev_fd = lircdev.as_raw_fd();
 
@@ -71,7 +71,7 @@ impl LircMode2 {
             }
         })?;
 
-        Ok(self.data.link(LircLink::new(prog_fd, lircdev_fd)))
+        Ok(LircLink::new(prog_fd, lircdev_fd).into())
     }
 
     /// Queries the lirc device for attached programs.

--- a/aya/src/programs/lsm.rs
+++ b/aya/src/programs/lsm.rs
@@ -6,7 +6,7 @@ use thiserror::Error;
 use crate::{
     generated::{bpf_attach_type::BPF_LSM_MAC, bpf_prog_type::BPF_PROG_TYPE_LSM},
     obj::btf::{Btf, BtfError, BtfKind},
-    programs::{load_program, FdLink, LinkRef, ProgramData, ProgramError},
+    programs::{load_program, FdLink, OwnedLink, ProgramData, ProgramError},
     sys::bpf_raw_tracepoint_open,
 };
 
@@ -84,13 +84,13 @@ impl Lsm {
     }
 
     /// Attaches the program.
-    pub fn attach(&mut self) -> Result<LinkRef, ProgramError> {
+    pub fn attach(&mut self) -> Result<OwnedLink, ProgramError> {
         attach_btf_id(&mut self.data)
     }
 }
 
 /// Common logic for all BPF program types that attach to a BTF id.
-pub(crate) fn attach_btf_id(program_data: &mut ProgramData) -> Result<LinkRef, ProgramError> {
+pub(crate) fn attach_btf_id(program_data: &mut ProgramData) -> Result<OwnedLink, ProgramError> {
     let prog_fd = program_data.fd_or_err()?;
 
     // Attaching LSM programs doesn't require providing attach name. LSM
@@ -102,5 +102,5 @@ pub(crate) fn attach_btf_id(program_data: &mut ProgramData) -> Result<LinkRef, P
         }
     })? as RawFd;
 
-    Ok(program_data.link(FdLink { fd: Some(pfd) }))
+    Ok(FdLink { fd: Some(pfd) }.into())
 }

--- a/aya/src/programs/perf_event.rs
+++ b/aya/src/programs/perf_event.rs
@@ -10,7 +10,7 @@ pub use crate::generated::{
     perf_hw_cache_id, perf_hw_cache_op_id, perf_hw_cache_op_result_id, perf_hw_id, perf_sw_ids,
 };
 
-use super::{load_program, perf_attach, LinkRef, ProgramData, ProgramError};
+use super::{load_program, perf_attach, OwnedLink, ProgramData, ProgramError};
 
 #[repr(u32)]
 #[derive(Debug, Clone)]
@@ -104,7 +104,7 @@ impl PerfEvent {
         config: u64,
         scope: PerfEventScope,
         sample_policy: SamplePolicy,
-    ) -> Result<LinkRef, ProgramError> {
+    ) -> Result<OwnedLink, ProgramError> {
         let (sample_period, sample_frequency) = match sample_policy {
             SamplePolicy::Period(period) => (period, None),
             SamplePolicy::Frequency(frequency) => (0, Some(frequency)),

--- a/aya/src/programs/probe.rs
+++ b/aya/src/programs/probe.rs
@@ -8,7 +8,7 @@ use std::{
 use crate::{
     programs::{
         kprobe::KProbeError, perf_attach, perf_attach_debugfs,
-        trace_point::read_sys_fs_trace_point_id, uprobe::UProbeError, LinkRef, ProgramData,
+        trace_point::read_sys_fs_trace_point_id, uprobe::UProbeError, OwnedLink, ProgramData,
         ProgramError,
     },
     sys::{kernel_version, perf_event_open_probe, perf_event_open_trace_point},
@@ -41,7 +41,7 @@ pub(crate) fn attach(
     fn_name: &str,
     offset: u64,
     pid: Option<pid_t>,
-) -> Result<LinkRef, ProgramError> {
+) -> Result<OwnedLink, ProgramError> {
     // https://github.com/torvalds/linux/commit/e12f03d7031a977356e3d7b75a68c2185ff8d155
     // Use debugfs to create probe
     let k_ver = kernel_version().unwrap();

--- a/aya/src/programs/raw_trace_point.rs
+++ b/aya/src/programs/raw_trace_point.rs
@@ -3,7 +3,7 @@ use std::{ffi::CString, os::unix::io::RawFd};
 
 use crate::{
     generated::bpf_prog_type::BPF_PROG_TYPE_RAW_TRACEPOINT,
-    programs::{load_program, FdLink, LinkRef, ProgramData, ProgramError},
+    programs::{load_program, FdLink, OwnedLink, ProgramData, ProgramError},
     sys::bpf_raw_tracepoint_open,
 };
 
@@ -46,7 +46,7 @@ impl RawTracePoint {
     }
 
     /// Attaches the program to the given tracepoint.
-    pub fn attach(&mut self, tp_name: &str) -> Result<LinkRef, ProgramError> {
+    pub fn attach(&mut self, tp_name: &str) -> Result<OwnedLink, ProgramError> {
         let prog_fd = self.data.fd_or_err()?;
         let name = CString::new(tp_name).unwrap();
 
@@ -57,6 +57,6 @@ impl RawTracePoint {
             }
         })? as RawFd;
 
-        Ok(self.data.link(FdLink { fd: Some(pfd) }))
+        Ok(FdLink { fd: Some(pfd) }.into())
     }
 }

--- a/aya/src/programs/sk_msg.rs
+++ b/aya/src/programs/sk_msg.rs
@@ -1,7 +1,7 @@
 use crate::{
     generated::{bpf_attach_type::BPF_SK_MSG_VERDICT, bpf_prog_type::BPF_PROG_TYPE_SK_MSG},
     maps::sock::SocketMap,
-    programs::{load_program, LinkRef, ProgAttachLink, ProgramData, ProgramError},
+    programs::{load_program, OwnedLink, ProgAttachLink, ProgramData, ProgramError},
     sys::bpf_prog_attach,
 };
 
@@ -68,7 +68,7 @@ impl SkMsg {
     }
 
     /// Attaches the program to the given sockmap.
-    pub fn attach(&mut self, map: &dyn SocketMap) -> Result<LinkRef, ProgramError> {
+    pub fn attach(&mut self, map: impl SocketMap) -> Result<OwnedLink, ProgramError> {
         let prog_fd = self.data.fd_or_err()?;
         let map_fd = map.fd_or_err()?;
 
@@ -78,8 +78,6 @@ impl SkMsg {
                 io_error,
             }
         })?;
-        Ok(self
-            .data
-            .link(ProgAttachLink::new(prog_fd, map_fd, BPF_SK_MSG_VERDICT)))
+        Ok(ProgAttachLink::new(prog_fd, map_fd, BPF_SK_MSG_VERDICT).into())
     }
 }

--- a/aya/src/programs/sk_skb.rs
+++ b/aya/src/programs/sk_skb.rs
@@ -4,7 +4,7 @@ use crate::{
         bpf_prog_type::BPF_PROG_TYPE_SK_SKB,
     },
     maps::sock::SocketMap,
-    programs::{load_program, LinkRef, ProgAttachLink, ProgramData, ProgramError},
+    programs::{load_program, OwnedLink, ProgAttachLink, ProgramData, ProgramError},
     sys::bpf_prog_attach,
 };
 
@@ -59,7 +59,7 @@ impl SkSkb {
     }
 
     /// Attaches the program to the given socket map.
-    pub fn attach(&mut self, map: &dyn SocketMap) -> Result<LinkRef, ProgramError> {
+    pub fn attach(&mut self, map: impl SocketMap) -> Result<OwnedLink, ProgramError> {
         let prog_fd = self.data.fd_or_err()?;
         let map_fd = map.fd_or_err()?;
 
@@ -73,8 +73,6 @@ impl SkSkb {
                 io_error,
             }
         })?;
-        Ok(self
-            .data
-            .link(ProgAttachLink::new(prog_fd, map_fd, attach_type)))
+        Ok(ProgAttachLink::new(prog_fd, map_fd, attach_type).into())
     }
 }

--- a/aya/src/programs/sock_ops.rs
+++ b/aya/src/programs/sock_ops.rs
@@ -2,7 +2,7 @@ use std::os::unix::io::AsRawFd;
 
 use crate::{
     generated::{bpf_attach_type::BPF_CGROUP_SOCK_OPS, bpf_prog_type::BPF_PROG_TYPE_SOCK_OPS},
-    programs::{load_program, LinkRef, ProgAttachLink, ProgramData, ProgramError},
+    programs::{load_program, OwnedLink, ProgAttachLink, ProgramData, ProgramError},
     sys::bpf_prog_attach,
 };
 
@@ -55,7 +55,7 @@ impl SockOps {
     }
 
     /// Attaches the program to the given cgroup.
-    pub fn attach<T: AsRawFd>(&mut self, cgroup: T) -> Result<LinkRef, ProgramError> {
+    pub fn attach<T: AsRawFd>(&mut self, cgroup: T) -> Result<OwnedLink, ProgramError> {
         let prog_fd = self.data.fd_or_err()?;
         let cgroup_fd = cgroup.as_raw_fd();
 
@@ -65,8 +65,6 @@ impl SockOps {
                 io_error,
             }
         })?;
-        Ok(self
-            .data
-            .link(ProgAttachLink::new(prog_fd, cgroup_fd, BPF_CGROUP_SOCK_OPS)))
+        Ok(ProgAttachLink::new(prog_fd, cgroup_fd, BPF_CGROUP_SOCK_OPS).into())
     }
 }

--- a/aya/src/programs/tp_btf.rs
+++ b/aya/src/programs/tp_btf.rs
@@ -6,7 +6,7 @@ use thiserror::Error;
 use crate::{
     generated::{bpf_attach_type::BPF_TRACE_RAW_TP, bpf_prog_type::BPF_PROG_TYPE_TRACING},
     obj::btf::{Btf, BtfError, BtfKind},
-    programs::{load_program, FdLink, LinkRef, ProgramData, ProgramError},
+    programs::{load_program, FdLink, OwnedLink, ProgramData, ProgramError},
     sys::bpf_raw_tracepoint_open,
 };
 
@@ -82,7 +82,7 @@ impl BtfTracePoint {
     }
 
     /// Attaches the program.
-    pub fn attach(&mut self) -> Result<LinkRef, ProgramError> {
+    pub fn attach(&mut self) -> Result<OwnedLink, ProgramError> {
         let prog_fd = self.data.fd_or_err()?;
 
         // BTF programs specify their attach name at program load time
@@ -93,6 +93,6 @@ impl BtfTracePoint {
             }
         })? as RawFd;
 
-        Ok(self.data.link(FdLink { fd: Some(pfd) }))
+        Ok(FdLink { fd: Some(pfd) }.into())
     }
 }

--- a/aya/src/programs/trace_point.rs
+++ b/aya/src/programs/trace_point.rs
@@ -3,7 +3,7 @@ use thiserror::Error;
 
 use crate::{generated::bpf_prog_type::BPF_PROG_TYPE_TRACEPOINT, sys::perf_event_open_trace_point};
 
-use super::{load_program, perf_attach, LinkRef, ProgramData, ProgramError};
+use super::{load_program, perf_attach, OwnedLink, ProgramData, ProgramError};
 
 /// The type returned when attaching a [`TracePoint`] fails.
 #[derive(Debug, Error)]
@@ -67,7 +67,7 @@ impl TracePoint {
     ///
     /// For a list of the available event categories and names, see
     /// `/sys/kernel/debug/tracing/events`.
-    pub fn attach(&mut self, category: &str, name: &str) -> Result<LinkRef, ProgramError> {
+    pub fn attach(&mut self, category: &str, name: &str) -> Result<OwnedLink, ProgramError> {
         let id = read_sys_fs_trace_point_id(category, name)?;
         let fd = perf_event_open_trace_point(id, None).map_err(|(_code, io_error)| {
             ProgramError::SyscallError {

--- a/aya/src/programs/uprobe.rs
+++ b/aya/src/programs/uprobe.rs
@@ -18,7 +18,7 @@ use crate::{
     programs::{
         load_program,
         probe::{attach, ProbeKind},
-        LinkRef, ProgramData, ProgramError,
+        OwnedLink, ProgramData, ProgramError,
     },
 };
 
@@ -78,7 +78,7 @@ impl UProbe {
         offset: u64,
         target: T,
         pid: Option<pid_t>,
-    ) -> Result<LinkRef, ProgramError> {
+    ) -> Result<OwnedLink, ProgramError> {
         let target = target.as_ref();
         let target_str = &*target.as_os_str().to_string_lossy();
 


### PR DESCRIPTION
This is a breaking change which transfers all ownership of a link to an
eBPF program to the caller return value of the "attach" functions. This
eliminates the overhead of Rc<RefCell<T>>, as well as prevents the
links section of ProgramData from growing without bound as programs are
attached and detached.