### PR TITLE
Fix #128: Add support for BPF_MAP_TYPE_LPM_TRIE map

### DIFF
--- a/aya/src/generated/linux_bindings_aarch64.rs
+++ b/aya/src/generated/linux_bindings_aarch64.rs
@@ -80,6 +80,36 @@ where
         }
     }
 }
+#[repr(C)]
+#[derive(Default)]
+pub struct __IncompleteArrayField<T>(::std::marker::PhantomData<T>, [T; 0]);
+impl<T> __IncompleteArrayField<T> {
+    #[inline]
+    pub const fn new() -> Self {
+        __IncompleteArrayField(::std::marker::PhantomData, [])
+    }
+    #[inline]
+    pub fn as_ptr(&self) -> *const T {
+        self as *const _ as *const T
+    }
+    #[inline]
+    pub fn as_mut_ptr(&mut self) -> *mut T {
+        self as *mut _ as *mut T
+    }
+    #[inline]
+    pub unsafe fn as_slice(&self, len: usize) -> &[T] {
+        ::std::slice::from_raw_parts(self.as_ptr(), len)
+    }
+    #[inline]
+    pub unsafe fn as_mut_slice(&mut self, len: usize) -> &mut [T] {
+        ::std::slice::from_raw_parts_mut(self.as_mut_ptr(), len)
+    }
+}
+impl<T> ::std::fmt::Debug for __IncompleteArrayField<T> {
+    fn fmt(&self, fmt: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+        fmt.write_str("__IncompleteArrayField")
+    }
+}
 pub const BPF_LD: u32 = 0;
 pub const BPF_LDX: u32 = 1;
 pub const BPF_ST: u32 = 2;
@@ -192,6 +222,12 @@ impl bpf_insn {
         });
         __bindgen_bitfield_unit
     }
+}
+#[repr(C)]
+#[derive(Debug)]
+pub struct bpf_lpm_trie_key {
+    pub prefixlen: __u32,
+    pub data: __IncompleteArrayField<__u8>,
 }
 impl bpf_cmd {
     pub const BPF_PROG_RUN: bpf_cmd = bpf_cmd::BPF_PROG_TEST_RUN;
@@ -932,7 +968,7 @@ pub enum perf_sw_ids {
     PERF_COUNT_SW_BPF_OUTPUT = 10,
     PERF_COUNT_SW_MAX = 11,
 }
-#[repr(u64)]
+#[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub enum perf_event_sample_format {
     PERF_SAMPLE_IP = 1,
@@ -956,7 +992,6 @@ pub enum perf_event_sample_format {
     PERF_SAMPLE_REGS_INTR = 262144,
     PERF_SAMPLE_PHYS_ADDR = 524288,
     PERF_SAMPLE_MAX = 1048576,
-    __PERF_SAMPLE_CALLCHAIN_EARLY = 9223372036854775808,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -967,7 +1002,7 @@ pub struct perf_event_attr {
     pub __bindgen_anon_1: perf_event_attr__bindgen_ty_1,
     pub sample_type: __u64,
     pub read_format: __u64,
-    pub _bitfield_align_1: [u32; 0],
+    pub _bitfield_align_1: [u64; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 8usize]>,
     pub __bindgen_anon_2: perf_event_attr__bindgen_ty_2,
     pub bp_type: __u32,
@@ -998,16 +1033,12 @@ pub union perf_event_attr__bindgen_ty_2 {
 #[derive(Copy, Clone)]
 pub union perf_event_attr__bindgen_ty_3 {
     pub bp_addr: __u64,
-    pub kprobe_func: __u64,
-    pub uprobe_path: __u64,
     pub config1: __u64,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub union perf_event_attr__bindgen_ty_4 {
     pub bp_len: __u64,
-    pub kprobe_addr: __u64,
-    pub probe_offset: __u64,
     pub config2: __u64,
 }
 impl perf_event_attr {
@@ -1320,47 +1351,14 @@ impl perf_event_attr {
         }
     }
     #[inline]
-    pub fn ksymbol(&self) -> __u64 {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(29usize, 1u8) as u64) }
-    }
-    #[inline]
-    pub fn set_ksymbol(&mut self, val: __u64) {
-        unsafe {
-            let val: u64 = ::std::mem::transmute(val);
-            self._bitfield_1.set(29usize, 1u8, val as u64)
-        }
-    }
-    #[inline]
-    pub fn bpf_event(&self) -> __u64 {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(30usize, 1u8) as u64) }
-    }
-    #[inline]
-    pub fn set_bpf_event(&mut self, val: __u64) {
-        unsafe {
-            let val: u64 = ::std::mem::transmute(val);
-            self._bitfield_1.set(30usize, 1u8, val as u64)
-        }
-    }
-    #[inline]
-    pub fn aux_output(&self) -> __u64 {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(31usize, 1u8) as u64) }
-    }
-    #[inline]
-    pub fn set_aux_output(&mut self, val: __u64) {
-        unsafe {
-            let val: u64 = ::std::mem::transmute(val);
-            self._bitfield_1.set(31usize, 1u8, val as u64)
-        }
-    }
-    #[inline]
     pub fn __reserved_1(&self) -> __u64 {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(32usize, 32u8) as u64) }
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(29usize, 35u8) as u64) }
     }
     #[inline]
     pub fn set___reserved_1(&mut self, val: __u64) {
         unsafe {
             let val: u64 = ::std::mem::transmute(val);
-            self._bitfield_1.set(32usize, 32u8, val as u64)
+            self._bitfield_1.set(29usize, 35u8, val as u64)
         }
     }
     #[inline]
@@ -1393,9 +1391,6 @@ impl perf_event_attr {
         context_switch: __u64,
         write_backward: __u64,
         namespaces: __u64,
-        ksymbol: __u64,
-        bpf_event: __u64,
-        aux_output: __u64,
         __reserved_1: __u64,
     ) -> __BindgenBitfieldUnit<[u8; 8usize]> {
         let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 8usize]> = Default::default();
@@ -1513,19 +1508,7 @@ impl perf_event_attr {
             let namespaces: u64 = unsafe { ::std::mem::transmute(namespaces) };
             namespaces as u64
         });
-        __bindgen_bitfield_unit.set(29usize, 1u8, {
-            let ksymbol: u64 = unsafe { ::std::mem::transmute(ksymbol) };
-            ksymbol as u64
-        });
-        __bindgen_bitfield_unit.set(30usize, 1u8, {
-            let bpf_event: u64 = unsafe { ::std::mem::transmute(bpf_event) };
-            bpf_event as u64
-        });
-        __bindgen_bitfield_unit.set(31usize, 1u8, {
-            let aux_output: u64 = unsafe { ::std::mem::transmute(aux_output) };
-            aux_output as u64
-        });
-        __bindgen_bitfield_unit.set(32usize, 32u8, {
+        __bindgen_bitfield_unit.set(29usize, 35u8, {
             let __reserved_1: u64 = unsafe { ::std::mem::transmute(__reserved_1) };
             __reserved_1 as u64
         });
@@ -1703,9 +1686,7 @@ pub enum perf_event_type {
     PERF_RECORD_SWITCH = 14,
     PERF_RECORD_SWITCH_CPU_WIDE = 15,
     PERF_RECORD_NAMESPACES = 16,
-    PERF_RECORD_KSYMBOL = 17,
-    PERF_RECORD_BPF_EVENT = 18,
-    PERF_RECORD_MAX = 19,
+    PERF_RECORD_MAX = 17,
 }
 pub const IFLA_XDP_UNSPEC: _bindgen_ty_84 = _bindgen_ty_84::IFLA_XDP_UNSPEC;
 pub const IFLA_XDP_FD: _bindgen_ty_84 = _bindgen_ty_84::IFLA_XDP_FD;
@@ -1784,9 +1765,7 @@ pub enum _bindgen_ty_97 {
     TCA_DUMP_INVISIBLE = 10,
     TCA_CHAIN = 11,
     TCA_HW_OFFLOAD = 12,
-    TCA_INGRESS_BLOCK = 13,
-    TCA_EGRESS_BLOCK = 14,
-    __TCA_MAX = 15,
+    __TCA_MAX = 13,
 }
 pub const TCA_BPF_UNSPEC: _bindgen_ty_153 = _bindgen_ty_153::TCA_BPF_UNSPEC;
 pub const TCA_BPF_ACT: _bindgen_ty_153 = _bindgen_ty_153::TCA_BPF_ACT;

--- a/aya/src/generated/linux_bindings_armv7.rs
+++ b/aya/src/generated/linux_bindings_armv7.rs
@@ -80,6 +80,36 @@ where
         }
     }
 }
+#[repr(C)]
+#[derive(Default)]
+pub struct __IncompleteArrayField<T>(::std::marker::PhantomData<T>, [T; 0]);
+impl<T> __IncompleteArrayField<T> {
+    #[inline]
+    pub const fn new() -> Self {
+        __IncompleteArrayField(::std::marker::PhantomData, [])
+    }
+    #[inline]
+    pub fn as_ptr(&self) -> *const T {
+        self as *const _ as *const T
+    }
+    #[inline]
+    pub fn as_mut_ptr(&mut self) -> *mut T {
+        self as *mut _ as *mut T
+    }
+    #[inline]
+    pub unsafe fn as_slice(&self, len: usize) -> &[T] {
+        ::std::slice::from_raw_parts(self.as_ptr(), len)
+    }
+    #[inline]
+    pub unsafe fn as_mut_slice(&mut self, len: usize) -> &mut [T] {
+        ::std::slice::from_raw_parts_mut(self.as_mut_ptr(), len)
+    }
+}
+impl<T> ::std::fmt::Debug for __IncompleteArrayField<T> {
+    fn fmt(&self, fmt: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+        fmt.write_str("__IncompleteArrayField")
+    }
+}
 pub const BPF_LD: u32 = 0;
 pub const BPF_LDX: u32 = 1;
 pub const BPF_ST: u32 = 2;
@@ -192,6 +222,12 @@ impl bpf_insn {
         });
         __bindgen_bitfield_unit
     }
+}
+#[repr(C)]
+#[derive(Debug)]
+pub struct bpf_lpm_trie_key {
+    pub prefixlen: __u32,
+    pub data: __IncompleteArrayField<__u8>,
 }
 impl bpf_cmd {
     pub const BPF_PROG_RUN: bpf_cmd = bpf_cmd::BPF_PROG_TEST_RUN;
@@ -932,7 +968,7 @@ pub enum perf_sw_ids {
     PERF_COUNT_SW_BPF_OUTPUT = 10,
     PERF_COUNT_SW_MAX = 11,
 }
-#[repr(u64)]
+#[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub enum perf_event_sample_format {
     PERF_SAMPLE_IP = 1,
@@ -956,7 +992,6 @@ pub enum perf_event_sample_format {
     PERF_SAMPLE_REGS_INTR = 262144,
     PERF_SAMPLE_PHYS_ADDR = 524288,
     PERF_SAMPLE_MAX = 1048576,
-    __PERF_SAMPLE_CALLCHAIN_EARLY = 9223372036854775808,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -967,7 +1002,7 @@ pub struct perf_event_attr {
     pub __bindgen_anon_1: perf_event_attr__bindgen_ty_1,
     pub sample_type: __u64,
     pub read_format: __u64,
-    pub _bitfield_align_1: [u32; 0],
+    pub _bitfield_align_1: [u64; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 8usize]>,
     pub __bindgen_anon_2: perf_event_attr__bindgen_ty_2,
     pub bp_type: __u32,
@@ -998,16 +1033,12 @@ pub union perf_event_attr__bindgen_ty_2 {
 #[derive(Copy, Clone)]
 pub union perf_event_attr__bindgen_ty_3 {
     pub bp_addr: __u64,
-    pub kprobe_func: __u64,
-    pub uprobe_path: __u64,
     pub config1: __u64,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub union perf_event_attr__bindgen_ty_4 {
     pub bp_len: __u64,
-    pub kprobe_addr: __u64,
-    pub probe_offset: __u64,
     pub config2: __u64,
 }
 impl perf_event_attr {
@@ -1320,47 +1351,14 @@ impl perf_event_attr {
         }
     }
     #[inline]
-    pub fn ksymbol(&self) -> __u64 {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(29usize, 1u8) as u64) }
-    }
-    #[inline]
-    pub fn set_ksymbol(&mut self, val: __u64) {
-        unsafe {
-            let val: u64 = ::std::mem::transmute(val);
-            self._bitfield_1.set(29usize, 1u8, val as u64)
-        }
-    }
-    #[inline]
-    pub fn bpf_event(&self) -> __u64 {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(30usize, 1u8) as u64) }
-    }
-    #[inline]
-    pub fn set_bpf_event(&mut self, val: __u64) {
-        unsafe {
-            let val: u64 = ::std::mem::transmute(val);
-            self._bitfield_1.set(30usize, 1u8, val as u64)
-        }
-    }
-    #[inline]
-    pub fn aux_output(&self) -> __u64 {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(31usize, 1u8) as u64) }
-    }
-    #[inline]
-    pub fn set_aux_output(&mut self, val: __u64) {
-        unsafe {
-            let val: u64 = ::std::mem::transmute(val);
-            self._bitfield_1.set(31usize, 1u8, val as u64)
-        }
-    }
-    #[inline]
     pub fn __reserved_1(&self) -> __u64 {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(32usize, 32u8) as u64) }
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(29usize, 35u8) as u64) }
     }
     #[inline]
     pub fn set___reserved_1(&mut self, val: __u64) {
         unsafe {
             let val: u64 = ::std::mem::transmute(val);
-            self._bitfield_1.set(32usize, 32u8, val as u64)
+            self._bitfield_1.set(29usize, 35u8, val as u64)
         }
     }
     #[inline]
@@ -1393,9 +1391,6 @@ impl perf_event_attr {
         context_switch: __u64,
         write_backward: __u64,
         namespaces: __u64,
-        ksymbol: __u64,
-        bpf_event: __u64,
-        aux_output: __u64,
         __reserved_1: __u64,
     ) -> __BindgenBitfieldUnit<[u8; 8usize]> {
         let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 8usize]> = Default::default();
@@ -1513,19 +1508,7 @@ impl perf_event_attr {
             let namespaces: u64 = unsafe { ::std::mem::transmute(namespaces) };
             namespaces as u64
         });
-        __bindgen_bitfield_unit.set(29usize, 1u8, {
-            let ksymbol: u64 = unsafe { ::std::mem::transmute(ksymbol) };
-            ksymbol as u64
-        });
-        __bindgen_bitfield_unit.set(30usize, 1u8, {
-            let bpf_event: u64 = unsafe { ::std::mem::transmute(bpf_event) };
-            bpf_event as u64
-        });
-        __bindgen_bitfield_unit.set(31usize, 1u8, {
-            let aux_output: u64 = unsafe { ::std::mem::transmute(aux_output) };
-            aux_output as u64
-        });
-        __bindgen_bitfield_unit.set(32usize, 32u8, {
+        __bindgen_bitfield_unit.set(29usize, 35u8, {
             let __reserved_1: u64 = unsafe { ::std::mem::transmute(__reserved_1) };
             __reserved_1 as u64
         });
@@ -1703,9 +1686,7 @@ pub enum perf_event_type {
     PERF_RECORD_SWITCH = 14,
     PERF_RECORD_SWITCH_CPU_WIDE = 15,
     PERF_RECORD_NAMESPACES = 16,
-    PERF_RECORD_KSYMBOL = 17,
-    PERF_RECORD_BPF_EVENT = 18,
-    PERF_RECORD_MAX = 19,
+    PERF_RECORD_MAX = 17,
 }
 pub const IFLA_XDP_UNSPEC: _bindgen_ty_84 = _bindgen_ty_84::IFLA_XDP_UNSPEC;
 pub const IFLA_XDP_FD: _bindgen_ty_84 = _bindgen_ty_84::IFLA_XDP_FD;
@@ -1784,9 +1765,7 @@ pub enum _bindgen_ty_97 {
     TCA_DUMP_INVISIBLE = 10,
     TCA_CHAIN = 11,
     TCA_HW_OFFLOAD = 12,
-    TCA_INGRESS_BLOCK = 13,
-    TCA_EGRESS_BLOCK = 14,
-    __TCA_MAX = 15,
+    __TCA_MAX = 13,
 }
 pub const TCA_BPF_UNSPEC: _bindgen_ty_153 = _bindgen_ty_153::TCA_BPF_UNSPEC;
 pub const TCA_BPF_ACT: _bindgen_ty_153 = _bindgen_ty_153::TCA_BPF_ACT;

--- a/aya/src/generated/linux_bindings_x86_64.rs
+++ b/aya/src/generated/linux_bindings_x86_64.rs
@@ -80,6 +80,36 @@ where
         }
     }
 }
+#[repr(C)]
+#[derive(Default, Clone, Copy)]
+pub struct __IncompleteArrayField<T>(::std::marker::PhantomData<T>, [T; 0]);
+impl<T> __IncompleteArrayField<T> {
+    #[inline]
+    pub const fn new() -> Self {
+        __IncompleteArrayField(::std::marker::PhantomData, [])
+    }
+    #[inline]
+    pub fn as_ptr(&self) -> *const T {
+        self as *const _ as *const T
+    }
+    #[inline]
+    pub fn as_mut_ptr(&mut self) -> *mut T {
+        self as *mut _ as *mut T
+    }
+    #[inline]
+    pub unsafe fn as_slice(&self, len: usize) -> &[T] {
+        ::std::slice::from_raw_parts(self.as_ptr(), len)
+    }
+    #[inline]
+    pub unsafe fn as_mut_slice(&mut self, len: usize) -> &mut [T] {
+        ::std::slice::from_raw_parts_mut(self.as_mut_ptr(), len)
+    }
+}
+impl<T> ::std::fmt::Debug for __IncompleteArrayField<T> {
+    fn fmt(&self, fmt: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+        fmt.write_str("__IncompleteArrayField")
+    }
+}
 pub const BPF_LD: u32 = 0;
 pub const BPF_LDX: u32 = 1;
 pub const BPF_ST: u32 = 2;
@@ -192,6 +222,12 @@ impl bpf_insn {
         });
         __bindgen_bitfield_unit
     }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct bpf_lpm_trie_key {
+    pub prefixlen: __u32,
+    pub data: __IncompleteArrayField<__u8>,
 }
 impl bpf_cmd {
     pub const BPF_PROG_RUN: bpf_cmd = bpf_cmd::BPF_PROG_TEST_RUN;
@@ -932,7 +968,7 @@ pub enum perf_sw_ids {
     PERF_COUNT_SW_BPF_OUTPUT = 10,
     PERF_COUNT_SW_MAX = 11,
 }
-#[repr(u64)]
+#[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub enum perf_event_sample_format {
     PERF_SAMPLE_IP = 1,
@@ -956,7 +992,6 @@ pub enum perf_event_sample_format {
     PERF_SAMPLE_REGS_INTR = 262144,
     PERF_SAMPLE_PHYS_ADDR = 524288,
     PERF_SAMPLE_MAX = 1048576,
-    __PERF_SAMPLE_CALLCHAIN_EARLY = 9223372036854775808,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -967,7 +1002,7 @@ pub struct perf_event_attr {
     pub __bindgen_anon_1: perf_event_attr__bindgen_ty_1,
     pub sample_type: __u64,
     pub read_format: __u64,
-    pub _bitfield_align_1: [u32; 0],
+    pub _bitfield_align_1: [u64; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 8usize]>,
     pub __bindgen_anon_2: perf_event_attr__bindgen_ty_2,
     pub bp_type: __u32,
@@ -998,16 +1033,12 @@ pub union perf_event_attr__bindgen_ty_2 {
 #[derive(Copy, Clone)]
 pub union perf_event_attr__bindgen_ty_3 {
     pub bp_addr: __u64,
-    pub kprobe_func: __u64,
-    pub uprobe_path: __u64,
     pub config1: __u64,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub union perf_event_attr__bindgen_ty_4 {
     pub bp_len: __u64,
-    pub kprobe_addr: __u64,
-    pub probe_offset: __u64,
     pub config2: __u64,
 }
 impl perf_event_attr {
@@ -1320,47 +1351,14 @@ impl perf_event_attr {
         }
     }
     #[inline]
-    pub fn ksymbol(&self) -> __u64 {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(29usize, 1u8) as u64) }
-    }
-    #[inline]
-    pub fn set_ksymbol(&mut self, val: __u64) {
-        unsafe {
-            let val: u64 = ::std::mem::transmute(val);
-            self._bitfield_1.set(29usize, 1u8, val as u64)
-        }
-    }
-    #[inline]
-    pub fn bpf_event(&self) -> __u64 {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(30usize, 1u8) as u64) }
-    }
-    #[inline]
-    pub fn set_bpf_event(&mut self, val: __u64) {
-        unsafe {
-            let val: u64 = ::std::mem::transmute(val);
-            self._bitfield_1.set(30usize, 1u8, val as u64)
-        }
-    }
-    #[inline]
-    pub fn aux_output(&self) -> __u64 {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(31usize, 1u8) as u64) }
-    }
-    #[inline]
-    pub fn set_aux_output(&mut self, val: __u64) {
-        unsafe {
-            let val: u64 = ::std::mem::transmute(val);
-            self._bitfield_1.set(31usize, 1u8, val as u64)
-        }
-    }
-    #[inline]
     pub fn __reserved_1(&self) -> __u64 {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(32usize, 32u8) as u64) }
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(29usize, 35u8) as u64) }
     }
     #[inline]
     pub fn set___reserved_1(&mut self, val: __u64) {
         unsafe {
             let val: u64 = ::std::mem::transmute(val);
-            self._bitfield_1.set(32usize, 32u8, val as u64)
+            self._bitfield_1.set(29usize, 35u8, val as u64)
         }
     }
     #[inline]
@@ -1393,9 +1391,6 @@ impl perf_event_attr {
         context_switch: __u64,
         write_backward: __u64,
         namespaces: __u64,
-        ksymbol: __u64,
-        bpf_event: __u64,
-        aux_output: __u64,
         __reserved_1: __u64,
     ) -> __BindgenBitfieldUnit<[u8; 8usize]> {
         let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 8usize]> = Default::default();
@@ -1513,19 +1508,7 @@ impl perf_event_attr {
             let namespaces: u64 = unsafe { ::std::mem::transmute(namespaces) };
             namespaces as u64
         });
-        __bindgen_bitfield_unit.set(29usize, 1u8, {
-            let ksymbol: u64 = unsafe { ::std::mem::transmute(ksymbol) };
-            ksymbol as u64
-        });
-        __bindgen_bitfield_unit.set(30usize, 1u8, {
-            let bpf_event: u64 = unsafe { ::std::mem::transmute(bpf_event) };
-            bpf_event as u64
-        });
-        __bindgen_bitfield_unit.set(31usize, 1u8, {
-            let aux_output: u64 = unsafe { ::std::mem::transmute(aux_output) };
-            aux_output as u64
-        });
-        __bindgen_bitfield_unit.set(32usize, 32u8, {
+        __bindgen_bitfield_unit.set(29usize, 35u8, {
             let __reserved_1: u64 = unsafe { ::std::mem::transmute(__reserved_1) };
             __reserved_1 as u64
         });
@@ -1703,9 +1686,7 @@ pub enum perf_event_type {
     PERF_RECORD_SWITCH = 14,
     PERF_RECORD_SWITCH_CPU_WIDE = 15,
     PERF_RECORD_NAMESPACES = 16,
-    PERF_RECORD_KSYMBOL = 17,
-    PERF_RECORD_BPF_EVENT = 18,
-    PERF_RECORD_MAX = 19,
+    PERF_RECORD_MAX = 17,
 }
 pub const IFLA_XDP_UNSPEC: _bindgen_ty_84 = _bindgen_ty_84::IFLA_XDP_UNSPEC;
 pub const IFLA_XDP_FD: _bindgen_ty_84 = _bindgen_ty_84::IFLA_XDP_FD;
@@ -1784,9 +1765,7 @@ pub enum _bindgen_ty_97 {
     TCA_DUMP_INVISIBLE = 10,
     TCA_CHAIN = 11,
     TCA_HW_OFFLOAD = 12,
-    TCA_INGRESS_BLOCK = 13,
-    TCA_EGRESS_BLOCK = 14,
-    __TCA_MAX = 15,
+    __TCA_MAX = 13,
 }
 pub const TCA_BPF_UNSPEC: _bindgen_ty_153 = _bindgen_ty_153::TCA_BPF_UNSPEC;
 pub const TCA_BPF_ACT: _bindgen_ty_153 = _bindgen_ty_153::TCA_BPF_ACT;

--- a/aya/src/maps/lpm_trie.rs
+++ b/aya/src/maps/lpm_trie.rs
@@ -1,0 +1,103 @@
+//! A LPM Trie.
+use std::{convert::TryFrom, marker::PhantomData, mem, ops::Deref};
+
+use crate::{
+    generated::bpf_map_type::BPF_MAP_TYPE_LPM_TRIE,
+    maps::{Map, MapError},
+    sys::{bpf_map_delete_elem, bpf_map_lookup_elem, bpf_map_update_elem},
+    Pod,
+};
+
+/// A Longest Prefix Match Trie.
+///
+/// # Minimum kernel version
+///
+/// The minimum kernel version required to use this feature is 4.20.
+///
+/// # Examples
+/// ```no_run
+/// # let bpf = aya::Bpf::load(&[])?;
+/// use aya::maps::LpmTrie;
+/// use std::convert::TryFrom;
+///
+/// let mut trie = LpmTrie::try_from(bpf.map_mut("LPM_TRIE")?)?;
+///
+/// # Ok::<(), aya::BpfError>(())
+/// ```
+
+#[doc(alias = "BPF_MAP_TYPE_LPM_TRIE")]
+pub struct LpmTrie<T: Deref<Target = Map>, K, V> {
+    inner: T,
+    _k: PhantomData<K>,
+    _v: PhantomData<V>,
+}
+
+impl<T: Deref<Target = Map>, K: Pod, V: Pod> LpmTrie<T, K, V> {
+    pub(crate) fn new(map: T) -> Result<LpmTrie<T, K, V>, MapError> {
+        let map_type = map.obj.def.map_type;
+
+        // validate the map definition
+        if map_type != BPF_MAP_TYPE_LPM_TRIE as u32 {
+            return Err(MapError::InvalidMapType {
+                map_type: map_type as u32,
+            });
+        }
+        let size = mem::size_of::<K>();
+        let expected = map.obj.def.key_size as usize;
+        if size != expected {
+            return Err(MapError::InvalidKeySize { size, expected });
+        }
+        let size = mem::size_of::<V>();
+        let expected = map.obj.def.value_size as usize;
+        if size != expected {
+            return Err(MapError::InvalidValueSize { size, expected });
+        };
+
+        let _ = map.fd_or_err()?;
+
+        Ok(LpmTrie {
+            inner: map,
+            _k: PhantomData,
+            _v: PhantomData,
+        })
+    }
+
+    /// Returns a copy of the value associated with the key.
+    pub unsafe fn get(&self, key: &K, flags: u64) -> Result<V, MapError> {
+        let fd = self.inner.deref().fd_or_err()?;
+        let value = bpf_map_lookup_elem(fd, key, flags).map_err(|(code, io_error)| {
+            MapError::SyscallError {
+                call: "bpf_map_lookup_elem".to_owned(),
+                code,
+                io_error,
+            }
+        })?;
+        value.ok_or(MapError::KeyNotFound)
+    }
+
+    /// Updates a key-value pair for the value associated with the key.
+    pub unsafe fn insert(&self, key: K, value: V, flags: u64) -> Result<(), MapError> {
+        let fd = self.inner.deref().fd_or_err()?;
+        bpf_map_update_elem(fd, &key, &value, flags).map_err(|(code, io_error)| {
+            MapError::SyscallError {
+                call: "bpf_map_update_elem".to_owned(),
+                code,
+                io_error,
+            }
+        })?;
+
+        Ok(())
+    }
+
+    /// Deletes elements from the map by key.
+    pub unsafe fn remove(&self, key: &K) -> Result<(), MapError> {
+        let fd = self.inner.deref().fd_or_err()?;
+        bpf_map_delete_elem(fd, key)
+            .map(|_| ())
+            .map_err(|(code, io_error)| MapError::SyscallError {
+                call: "bpf_map_delete_elem".to_owned(),
+                code,
+                io_error,
+            })
+    }
+}

--- a/aya/src/maps/lpm_trie.rs
+++ b/aya/src/maps/lpm_trie.rs
@@ -32,7 +32,6 @@ pub struct LpmTrie<T: Deref<Target = Map>, K, V> {
     _v: PhantomData<V>,
 }
 
-#[derive(Clone, Copy)]
 #[repr(packed)]
 pub struct Key<K: Pod> {
     pub key_base: bpf_lpm_trie_key,
@@ -48,6 +47,14 @@ impl<K: Pod> Key<K> {
             },
             data: data,
         }
+    }
+}
+
+impl<K:Pod> Copy for Key<K> { }
+
+impl<K:Pod> Clone for Key<K> {
+    fn clone(&self) -> Self {
+        *self
     }
 }
 

--- a/aya/src/maps/mod.rs
+++ b/aya/src/maps/mod.rs
@@ -50,6 +50,7 @@ mod map_lock;
 
 pub mod array;
 pub mod hash_map;
+pub mod lpm_trie;
 pub mod perf;
 pub mod queue;
 pub mod sock;

--- a/xtask/src/codegen/aya.rs
+++ b/xtask/src/codegen/aya.rs
@@ -68,6 +68,7 @@ fn codegen_bindings(opts: &Options) -> Result<(), anyhow::Error> {
         "bpf_btf_info",
         "bpf_func_info",
         "bpf_line_info",
+        "bpf_lpm_trie_key",
         // BTF
         "btf_header",
         "btf_ext_info",


### PR DESCRIPTION
## What this does?
Adds support for `BPF_MAP_TYPE_LPM_TRIE` map. 

Issue: #128 .

Some resources:
- https://www.ferrisellis.com/content/ebpf_syscall_and_maps/#bpf_map_type_lpm_trie
- https://blog.apnic.net/2020/10/23/journeying-into-xdp-augmenting-the-dns/
- https://www.lewuathe.com/longest-prefix-match-with-trie-tree.html

### TODO:

- [ ] Unit Tests
- [x] Support for keys with _specific_ struct as described [here](https://blog.apnic.net/2020/10/23/journeying-into-xdp-augmenting-the-dns/).

cc: @dave-tucker @alessandrod 