### PR TITLE
aya: Remove unnecessary unsafe markers on map iteration.

### DIFF
--- a/aya/src/maps/array/array.rs
+++ b/aya/src/maps/array/array.rs
@@ -94,7 +94,7 @@ impl<T: Deref<Target = Map>, V: Pod> Array<T, V> {
 
     /// An iterator over the elements of the array. The iterator item type is `Result<V,
     /// MapError>`.
-    pub unsafe fn iter(&self) -> impl Iterator<Item = Result<V, MapError>> + '_ {
+    pub fn iter(&self) -> impl Iterator<Item = Result<V, MapError>> + '_ {
         (0..self.len()).map(move |i| self.get(&i, 0))
     }
 
@@ -134,7 +134,7 @@ impl<T: Deref<Target = Map>, V: Pod> IterableMap<u32, V> for Array<T, V> {
         &self.inner
     }
 
-    unsafe fn get(&self, index: &u32) -> Result<V, MapError> {
+    fn get(&self, index: &u32) -> Result<V, MapError> {
         self.get(index, 0)
     }
 }

--- a/aya/src/maps/array/per_cpu_array.rs
+++ b/aya/src/maps/array/per_cpu_array.rs
@@ -113,7 +113,7 @@ impl<T: Deref<Target = Map>, V: Pod> PerCpuArray<T, V> {
 
     /// An iterator over the elements of the array. The iterator item type is
     /// `Result<PerCpuValues<V>, MapError>`.
-    pub unsafe fn iter(&self) -> impl Iterator<Item = Result<PerCpuValues<V>, MapError>> + '_ {
+    pub fn iter(&self) -> impl Iterator<Item = Result<PerCpuValues<V>, MapError>> + '_ {
         (0..self.len()).map(move |i| self.get(&i, 0))
     }
 
@@ -153,7 +153,7 @@ impl<T: Deref<Target = Map>, V: Pod> IterableMap<u32, PerCpuValues<V>> for PerCp
         &self.inner
     }
 
-    unsafe fn get(&self, index: &u32) -> Result<PerCpuValues<V>, MapError> {
+    fn get(&self, index: &u32) -> Result<PerCpuValues<V>, MapError> {
         self.get(index, 0)
     }
 }

--- a/aya/src/maps/array/program_array.rs
+++ b/aya/src/maps/array/program_array.rs
@@ -79,7 +79,7 @@ impl<T: Deref<Target = Map>> ProgramArray<T> {
 
     /// An iterator over the indices of the array that point to a program. The iterator item type
     /// is `Result<u32, MapError>`.
-    pub unsafe fn indices(&self) -> MapKeys<'_, u32> {
+    pub fn indices(&self) -> MapKeys<'_, u32> {
         MapKeys::new(&self.inner)
     }
 

--- a/aya/src/maps/hash_map/per_cpu_hash_map.rs
+++ b/aya/src/maps/hash_map/per_cpu_hash_map.rs
@@ -73,7 +73,7 @@ impl<T: Deref<Target = Map>, K: Pod, V: Pod> PerCpuHashMap<T, K, V> {
     }
 
     /// Returns a slice of values - one for each CPU - associated with the key.
-    pub unsafe fn get(&self, key: &K, flags: u64) -> Result<PerCpuValues<V>, MapError> {
+    pub fn get(&self, key: &K, flags: u64) -> Result<PerCpuValues<V>, MapError> {
         let fd = self.inner.deref().fd_or_err()?;
         let values = bpf_map_lookup_elem_per_cpu(fd, key, flags).map_err(|(code, io_error)| {
             MapError::SyscallError {
@@ -87,13 +87,13 @@ impl<T: Deref<Target = Map>, K: Pod, V: Pod> PerCpuHashMap<T, K, V> {
 
     /// An iterator visiting all key-value pairs in arbitrary order. The
     /// iterator item type is `Result<(K, PerCpuValues<V>), MapError>`.
-    pub unsafe fn iter(&self) -> MapIter<'_, K, PerCpuValues<V>, Self> {
+    pub fn iter(&self) -> MapIter<'_, K, PerCpuValues<V>, Self> {
         MapIter::new(self)
     }
 
     /// An iterator visiting all keys in arbitrary order. The iterator element
     /// type is `Result<K, MapError>`.
-    pub unsafe fn keys(&self) -> MapKeys<'_, K> {
+    pub fn keys(&self) -> MapKeys<'_, K> {
         MapKeys::new(&self.inner)
     }
 }
@@ -154,7 +154,7 @@ impl<T: Deref<Target = Map>, K: Pod, V: Pod> IterableMap<K, PerCpuValues<V>>
         &self.inner
     }
 
-    unsafe fn get(&self, key: &K) -> Result<PerCpuValues<V>, MapError> {
+    fn get(&self, key: &K) -> Result<PerCpuValues<V>, MapError> {
         PerCpuHashMap::get(self, key, 0)
     }
 }

--- a/aya/src/maps/mod.rs
+++ b/aya/src/maps/mod.rs
@@ -237,7 +237,7 @@ impl Drop for Map {
 pub trait IterableMap<K: Pod, V> {
     fn map(&self) -> &Map;
 
-    unsafe fn get(&self, key: &K) -> Result<V, MapError>;
+    fn get(&self, key: &K) -> Result<V, MapError>;
 }
 
 /// Iterator returned by `map.keys()`.
@@ -317,14 +317,11 @@ impl<K: Pod, V, I: IterableMap<K, V>> Iterator for MapIter<'_, K, V, I> {
     fn next(&mut self) -> Option<Self::Item> {
         loop {
             match self.keys.next() {
-                Some(Ok(key)) => {
-                    let value = unsafe { self.map.get(&key) };
-                    match value {
-                        Ok(value) => return Some(Ok((key, value))),
-                        Err(MapError::KeyNotFound) => continue,
-                        Err(e) => return Some(Err(e)),
-                    }
-                }
+                Some(Ok(key)) => match self.map.get(&key) {
+                    Ok(value) => return Some(Ok((key, value))),
+                    Err(MapError::KeyNotFound) => continue,
+                    Err(e) => return Some(Err(e)),
+                },
                 Some(Err(e)) => return Some(Err(e)),
                 None => return None,
             }

--- a/aya/src/maps/sock/sock_hash.rs
+++ b/aya/src/maps/sock/sock_hash.rs
@@ -87,7 +87,7 @@ impl<T: Deref<Target = Map>, K: Pod> SockHash<T, K> {
     }
 
     /// Returns the fd of the socket stored at the given key.
-    pub unsafe fn get(&self, key: &K, flags: u64) -> Result<RawFd, MapError> {
+    pub fn get(&self, key: &K, flags: u64) -> Result<RawFd, MapError> {
         let fd = self.inner.deref().fd_or_err()?;
         let value = bpf_map_lookup_elem(fd, key, flags).map_err(|(code, io_error)| {
             MapError::SyscallError {
@@ -101,13 +101,13 @@ impl<T: Deref<Target = Map>, K: Pod> SockHash<T, K> {
 
     /// An iterator visiting all key-value pairs in arbitrary order. The
     /// iterator item type is `Result<(K, V), MapError>`.
-    pub unsafe fn iter(&self) -> MapIter<'_, K, RawFd, Self> {
+    pub fn iter(&self) -> MapIter<'_, K, RawFd, Self> {
         MapIter::new(self)
     }
 
     /// An iterator visiting all keys in arbitrary order. The iterator element
     /// type is `Result<K, MapError>`.
-    pub unsafe fn keys(&self) -> MapKeys<'_, K> {
+    pub fn keys(&self) -> MapKeys<'_, K> {
         MapKeys::new(&self.inner)
     }
 }
@@ -129,7 +129,7 @@ impl<T: Deref<Target = Map>, K: Pod> IterableMap<K, RawFd> for SockHash<T, K> {
         &self.inner
     }
 
-    unsafe fn get(&self, key: &K) -> Result<RawFd, MapError> {
+    fn get(&self, key: &K) -> Result<RawFd, MapError> {
         SockHash::get(self, key, 0)
     }
 }

--- a/aya/src/maps/sock/sock_map.rs
+++ b/aya/src/maps/sock/sock_map.rs
@@ -71,7 +71,7 @@ impl<T: Deref<Target = Map>> SockMap<T> {
 
     /// An iterator over the indices of the array that point to a program. The iterator item type
     /// is `Result<u32, MapError>`.
-    pub unsafe fn indices(&self) -> MapKeys<'_, u32> {
+    pub fn indices(&self) -> MapKeys<'_, u32> {
         MapKeys::new(&self.inner)
     }
 

--- a/aya/src/maps/stack_trace.rs
+++ b/aya/src/maps/stack_trace.rs
@@ -156,7 +156,7 @@ impl<T: Deref<Target = Map>> IterableMap<u32, StackTrace> for StackTraceMap<T> {
         &self.inner
     }
 
-    unsafe fn get(&self, index: &u32) -> Result<StackTrace, MapError> {
+    fn get(&self, index: &u32) -> Result<StackTrace, MapError> {
         self.get(index, 0)
     }
 }


### PR DESCRIPTION
Map iteration can yield stale keys and values by virtue of sharing a
data structure with BPF programs which can modify it. However, all
accesses remain perfectly safe and will not cause memory corruption or
data races.