### PR TITLE
github: Set toolchain override

### DIFF
--- a/.github/workflows/build-aya-bpf.yml
+++ b/.github/workflows/build-aya-bpf.yml
@@ -23,11 +23,12 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: nightly
+          override: true
 
       - uses: Swatinem/rust-cache@v1
 
       - name: Build
-        run: cargo +nightly build --verbose
+        run: cargo build --verbose
 
       - name: Run tests
-        run: RUST_BACKTRACE=full cargo +nightly test --verbose
+        run: RUST_BACKTRACE=full cargo test --verbose


### PR DESCRIPTION
This ensures that the cache action uses the correct Rust version

Signed-off-by: Dave Tucker <dave@dtucker.co.uk>