### PR TITLE
Support Parsing of BTF Maps

### DIFF
--- a/aya/src/maps/array/array.rs
+++ b/aya/src/maps/array/array.rs
@@ -40,20 +40,20 @@ pub struct Array<T: Deref<Target = Map>, V: Pod> {
 
 impl<T: Deref<Target = Map>, V: Pod> Array<T, V> {
     fn new(map: T) -> Result<Array<T, V>, MapError> {
-        let map_type = map.obj.def.map_type;
+        let map_type = map.obj.map_type();
         if map_type != BPF_MAP_TYPE_ARRAY as u32 {
             return Err(MapError::InvalidMapType {
                 map_type: map_type as u32,
             });
         }
         let expected = mem::size_of::<u32>();
-        let size = map.obj.def.key_size as usize;
+        let size = map.obj.key_size() as usize;
         if size != expected {
             return Err(MapError::InvalidKeySize { size, expected });
         }
 
         let expected = mem::size_of::<V>();
-        let size = map.obj.def.value_size as usize;
+        let size = map.obj.value_size() as usize;
         if size != expected {
             return Err(MapError::InvalidValueSize { size, expected });
         }
@@ -69,7 +69,7 @@ impl<T: Deref<Target = Map>, V: Pod> Array<T, V> {
     ///
     /// This corresponds to the value of `bpf_map_def::max_entries` on the eBPF side.
     pub fn len(&self) -> u32 {
-        self.inner.obj.def.max_entries
+        self.inner.obj.max_entries()
     }
 
     /// Returns the value stored at the given index.
@@ -99,8 +99,8 @@ impl<T: Deref<Target = Map>, V: Pod> Array<T, V> {
     }
 
     fn check_bounds(&self, index: u32) -> Result<(), MapError> {
-        let max_entries = self.inner.obj.def.max_entries;
-        if index >= self.inner.obj.def.max_entries {
+        let max_entries = self.inner.obj.max_entries();
+        if index >= self.inner.obj.max_entries() {
             Err(MapError::OutOfBounds { index, max_entries })
         } else {
             Ok(())

--- a/aya/src/maps/array/per_cpu_array.rs
+++ b/aya/src/maps/array/per_cpu_array.rs
@@ -59,20 +59,20 @@ pub struct PerCpuArray<T: Deref<Target = Map>, V: Pod> {
 
 impl<T: Deref<Target = Map>, V: Pod> PerCpuArray<T, V> {
     fn new(map: T) -> Result<PerCpuArray<T, V>, MapError> {
-        let map_type = map.obj.def.map_type;
+        let map_type = map.obj.map_type();
         if map_type != BPF_MAP_TYPE_PERCPU_ARRAY as u32 {
             return Err(MapError::InvalidMapType {
                 map_type: map_type as u32,
             });
         }
         let expected = mem::size_of::<u32>();
-        let size = map.obj.def.key_size as usize;
+        let size = map.obj.key_size() as usize;
         if size != expected {
             return Err(MapError::InvalidKeySize { size, expected });
         }
 
         let expected = mem::size_of::<V>();
-        let size = map.obj.def.value_size as usize;
+        let size = map.obj.value_size() as usize;
         if size != expected {
             return Err(MapError::InvalidValueSize { size, expected });
         }
@@ -88,7 +88,7 @@ impl<T: Deref<Target = Map>, V: Pod> PerCpuArray<T, V> {
     ///
     /// This corresponds to the value of `bpf_map_def::max_entries` on the eBPF side.
     pub fn len(&self) -> u32 {
-        self.inner.obj.def.max_entries
+        self.inner.obj.max_entries()
     }
 
     /// Returns a slice of values - one for each CPU - stored at the given index.
@@ -118,8 +118,8 @@ impl<T: Deref<Target = Map>, V: Pod> PerCpuArray<T, V> {
     }
 
     fn check_bounds(&self, index: u32) -> Result<(), MapError> {
-        let max_entries = self.inner.obj.def.max_entries;
-        if index >= self.inner.obj.def.max_entries {
+        let max_entries = self.inner.obj.max_entries();
+        if index >= self.inner.obj.max_entries() {
             Err(MapError::OutOfBounds { index, max_entries })
         } else {
             Ok(())

--- a/aya/src/maps/array/program_array.rs
+++ b/aya/src/maps/array/program_array.rs
@@ -57,20 +57,20 @@ pub struct ProgramArray<T: Deref<Target = Map>> {
 
 impl<T: Deref<Target = Map>> ProgramArray<T> {
     fn new(map: T) -> Result<ProgramArray<T>, MapError> {
-        let map_type = map.obj.def.map_type;
+        let map_type = map.obj.map_type();
         if map_type != BPF_MAP_TYPE_PROG_ARRAY as u32 {
             return Err(MapError::InvalidMapType {
                 map_type: map_type as u32,
             });
         }
         let expected = mem::size_of::<u32>();
-        let size = map.obj.def.key_size as usize;
+        let size = map.obj.key_size() as usize;
         if size != expected {
             return Err(MapError::InvalidKeySize { size, expected });
         }
 
         let expected = mem::size_of::<RawFd>();
-        let size = map.obj.def.value_size as usize;
+        let size = map.obj.value_size() as usize;
         if size != expected {
             return Err(MapError::InvalidValueSize { size, expected });
         }
@@ -86,8 +86,8 @@ impl<T: Deref<Target = Map>> ProgramArray<T> {
     }
 
     fn check_bounds(&self, index: u32) -> Result<(), MapError> {
-        let max_entries = self.inner.obj.def.max_entries;
-        if index >= self.inner.obj.def.max_entries {
+        let max_entries = self.inner.obj.max_entries();
+        if index >= self.inner.obj.max_entries() {
             Err(MapError::OutOfBounds { index, max_entries })
         } else {
             Ok(())

--- a/aya/src/maps/hash_map/mod.rs
+++ b/aya/src/maps/hash_map/mod.rs
@@ -15,12 +15,12 @@ pub use per_cpu_hash_map::*;
 
 pub(crate) fn check_kv_size<K, V>(map: &Map) -> Result<(), MapError> {
     let size = mem::size_of::<K>();
-    let expected = map.obj.def.key_size as usize;
+    let expected = map.obj.key_size() as usize;
     if size != expected {
         return Err(MapError::InvalidKeySize { size, expected });
     }
     let size = mem::size_of::<V>();
-    let expected = map.obj.def.value_size as usize;
+    let expected = map.obj.value_size() as usize;
     if size != expected {
         return Err(MapError::InvalidValueSize { size, expected });
     };

--- a/aya/src/maps/hash_map/per_cpu_hash_map.rs
+++ b/aya/src/maps/hash_map/per_cpu_hash_map.rs
@@ -52,7 +52,7 @@ pub struct PerCpuHashMap<T: Deref<Target = Map>, K: Pod, V: Pod> {
 
 impl<T: Deref<Target = Map>, K: Pod, V: Pod> PerCpuHashMap<T, K, V> {
     pub(crate) fn new(map: T) -> Result<PerCpuHashMap<T, K, V>, MapError> {
-        let map_type = map.obj.def.map_type;
+        let map_type = map.obj.map_type();
 
         // validate the map definition
         if map_type != BPF_MAP_TYPE_PERCPU_HASH as u32

--- a/aya/src/maps/perf/perf_event_array.rs
+++ b/aya/src/maps/perf/perf_event_array.rs
@@ -164,7 +164,7 @@ pub struct PerfEventArray<T: DerefMut<Target = Map>> {
 
 impl<T: DerefMut<Target = Map>> PerfEventArray<T> {
     pub(crate) fn new(map: T) -> Result<PerfEventArray<T>, MapError> {
-        let map_type = map.obj.def.map_type;
+        let map_type = map.obj.map_type();
         if map_type != BPF_MAP_TYPE_PERF_EVENT_ARRAY as u32 {
             return Err(MapError::InvalidMapType {
                 map_type: map_type as u32,

--- a/aya/src/maps/queue.rs
+++ b/aya/src/maps/queue.rs
@@ -39,20 +39,20 @@ pub struct Queue<T: Deref<Target = Map>, V: Pod> {
 
 impl<T: Deref<Target = Map>, V: Pod> Queue<T, V> {
     fn new(map: T) -> Result<Queue<T, V>, MapError> {
-        let map_type = map.obj.def.map_type;
+        let map_type = map.obj.map_type();
         if map_type != BPF_MAP_TYPE_QUEUE as u32 {
             return Err(MapError::InvalidMapType {
                 map_type: map_type as u32,
             });
         }
         let expected = 0;
-        let size = map.obj.def.key_size as usize;
+        let size = map.obj.key_size() as usize;
         if size != expected {
             return Err(MapError::InvalidKeySize { size, expected });
         }
 
         let expected = mem::size_of::<V>();
-        let size = map.obj.def.value_size as usize;
+        let size = map.obj.value_size() as usize;
         if size != expected {
             return Err(MapError::InvalidValueSize { size, expected });
         }
@@ -68,7 +68,7 @@ impl<T: Deref<Target = Map>, V: Pod> Queue<T, V> {
     ///
     /// This corresponds to the value of `bpf_map_def::max_entries` on the eBPF side.
     pub fn capacity(&self) -> u32 {
-        self.inner.obj.def.max_entries
+        self.inner.obj.max_entries()
     }
 }
 

--- a/aya/src/maps/sock/sock_hash.rs
+++ b/aya/src/maps/sock/sock_hash.rs
@@ -69,7 +69,7 @@ pub struct SockHash<T: Deref<Target = Map>, K> {
 
 impl<T: Deref<Target = Map>, K: Pod> SockHash<T, K> {
     pub(crate) fn new(map: T) -> Result<SockHash<T, K>, MapError> {
-        let map_type = map.obj.def.map_type;
+        let map_type = map.obj.map_type();
 
         // validate the map definition
         if map_type != BPF_MAP_TYPE_SOCKHASH as u32 {

--- a/aya/src/maps/sock/sock_map.rs
+++ b/aya/src/maps/sock/sock_map.rs
@@ -47,20 +47,20 @@ pub struct SockMap<T: Deref<Target = Map>> {
 
 impl<T: Deref<Target = Map>> SockMap<T> {
     fn new(map: T) -> Result<SockMap<T>, MapError> {
-        let map_type = map.obj.def.map_type;
+        let map_type = map.obj.map_type();
         if map_type != BPF_MAP_TYPE_SOCKMAP as u32 {
             return Err(MapError::InvalidMapType {
                 map_type: map_type as u32,
             });
         }
         let expected = mem::size_of::<u32>();
-        let size = map.obj.def.key_size as usize;
+        let size = map.obj.key_size() as usize;
         if size != expected {
             return Err(MapError::InvalidKeySize { size, expected });
         }
 
         let expected = mem::size_of::<RawFd>();
-        let size = map.obj.def.value_size as usize;
+        let size = map.obj.value_size() as usize;
         if size != expected {
             return Err(MapError::InvalidValueSize { size, expected });
         }
@@ -76,8 +76,8 @@ impl<T: Deref<Target = Map>> SockMap<T> {
     }
 
     fn check_bounds(&self, index: u32) -> Result<(), MapError> {
-        let max_entries = self.inner.obj.def.max_entries;
-        if index >= self.inner.obj.def.max_entries {
+        let max_entries = self.inner.obj.max_entries();
+        if index >= self.inner.obj.max_entries() {
             Err(MapError::OutOfBounds { index, max_entries })
         } else {
             Ok(())

--- a/aya/src/maps/stack.rs
+++ b/aya/src/maps/stack.rs
@@ -39,20 +39,20 @@ pub struct Stack<T: Deref<Target = Map>, V: Pod> {
 
 impl<T: Deref<Target = Map>, V: Pod> Stack<T, V> {
     fn new(map: T) -> Result<Stack<T, V>, MapError> {
-        let map_type = map.obj.def.map_type;
+        let map_type = map.obj.map_type();
         if map_type != BPF_MAP_TYPE_STACK as u32 {
             return Err(MapError::InvalidMapType {
                 map_type: map_type as u32,
             });
         }
         let expected = 0;
-        let size = map.obj.def.key_size as usize;
+        let size = map.obj.key_size() as usize;
         if size != expected {
             return Err(MapError::InvalidKeySize { size, expected });
         }
 
         let expected = mem::size_of::<V>();
-        let size = map.obj.def.value_size as usize;
+        let size = map.obj.value_size() as usize;
         if size != expected {
             return Err(MapError::InvalidValueSize { size, expected });
         }
@@ -68,7 +68,7 @@ impl<T: Deref<Target = Map>, V: Pod> Stack<T, V> {
     ///
     /// This corresponds to the value of `bpf_map_def::max_entries` on the eBPF side.
     pub fn capacity(&self) -> u32 {
-        self.inner.obj.def.max_entries
+        self.inner.obj.max_entries()
     }
 }
 

--- a/aya/src/maps/stack_trace.rs
+++ b/aya/src/maps/stack_trace.rs
@@ -73,14 +73,14 @@ pub struct StackTraceMap<T> {
 
 impl<T: Deref<Target = Map>> StackTraceMap<T> {
     fn new(map: T) -> Result<StackTraceMap<T>, MapError> {
-        let map_type = map.obj.def.map_type;
+        let map_type = map.obj.map_type();
         if map_type != BPF_MAP_TYPE_STACK_TRACE as u32 {
             return Err(MapError::InvalidMapType {
                 map_type: map_type as u32,
             });
         }
         let expected = mem::size_of::<u32>();
-        let size = map.obj.def.key_size as usize;
+        let size = map.obj.key_size() as usize;
         if size != expected {
             return Err(MapError::InvalidKeySize { size, expected });
         }
@@ -93,7 +93,7 @@ impl<T: Deref<Target = Map>> StackTraceMap<T> {
                     io_error,
                 }
             })?;
-        let size = map.obj.def.value_size as usize;
+        let size = map.obj.value_size() as usize;
         if size > max_stack_depth * mem::size_of::<u64>() {
             return Err(MapError::InvalidValueSize { size, expected });
         }

--- a/test/integration-ebpf/src/bpf/multimap-btf.bpf.c
+++ b/test/integration-ebpf/src/bpf/multimap-btf.bpf.c
@@ -1,0 +1,30 @@
+#include <linux/bpf.h>
+#include <bpf/bpf_helpers.h>
+
+struct {
+	__uint(type, BPF_MAP_TYPE_ARRAY);
+	__type(key, __u32);
+	__type(value, __u64);
+	__uint(max_entries, 1);
+} map_1 SEC(".maps");
+
+struct {
+	__uint(type, BPF_MAP_TYPE_ARRAY);
+	__type(key, __u32);
+	__type(value, __u64);
+	__uint(max_entries, 1);
+} map_2 SEC(".maps");
+
+
+SEC("tracepoint")
+int bpf_prog(void *ctx)
+{
+	__u32 key = 0;
+	__u64 twenty_four = 24;
+	__u64 forty_two = 42;
+    bpf_map_update_elem(&map_1, &key, &twenty_four, BPF_ANY);
+    bpf_map_update_elem(&map_2, &key, &forty_two, BPF_ANY);
+	return 0;
+}
+
+char _license[] SEC("license") = "GPL";


### PR DESCRIPTION
This PR allows for BTF maps in the .maps ELF section to be parsed.
It reads the necessary information from the BTF section of the ELF file.
It provides the BTF IDs to the `bpf_map_create` call.

This allows for `bpftool` to pretty print maps! For example:

```bash
$ sudo bpftool map dump id 224 
[{
        "key": 0,
        "value": {
            "rx_packets": 0
        }
    },{
        "key": 1,
        "value": {
            "rx_packets": 0
        }
    },{
        "key": 2,
        "value": {
            "rx_packets": 148
        }
    },{
        "key": 3,
        "value": {
            "rx_packets": 0
        }
    },{
        "key": 4,
        "value": {
            "rx_packets": 0
        }
    }
]
```