### PR TITLE
aya-bpf: Add bpf_probe_write_user helper

### DIFF
--- a/bpf/aya-bpf-macros/src/lib.rs
+++ b/bpf/aya-bpf-macros/src/lib.rs
@@ -168,7 +168,7 @@ pub fn raw_tracepoint(attrs: TokenStream, item: TokenStream) -> TokenStream {
 /// Marks a function as an LSM program that can be attached to Linux LSM hooks.
 /// Used to implement security policy and audit logging.
 ///
-/// LSM probes can be attached to the kernel's [security hooks][1] to implement mandatory
+/// LSM probes can be attached to the kernel's security hooks to implement mandatory
 /// access control policy and security auditing.
 ///
 /// LSM probes require a kernel compiled with `CONFIG_BPF_LSM=y` and `CONFIG_DEBUG_INFO_BTF=y`.


### PR DESCRIPTION
This helper allows to write to mutable pointers in the userspace, which
come from userspace functions that uprobes attach to.

Signed-off-by: Michal Rostecki <mrostecki@opensuse.org>