### PR TITLE
Mark .rodata maps as readonly and freeze on load

### DIFF
--- a/aya/src/maps/hash_map/hash_map.rs
+++ b/aya/src/maps/hash_map/hash_map.rs
@@ -169,6 +169,7 @@ mod tests {
             },
             section_index: 0,
             data: Vec::new(),
+            kind: obj::MapKind::Other,
         }
     }
 
@@ -221,6 +222,7 @@ mod tests {
                 },
                 section_index: 0,
                 data: Vec::new(),
+                kind: obj::MapKind::Other,
             },
             fd: None,
             pinned: false,
@@ -280,6 +282,7 @@ mod tests {
                 },
                 section_index: 0,
                 data: Vec::new(),
+                kind: obj::MapKind::Other,
             },
             fd: Some(42),
             pinned: false,

--- a/aya/src/maps/mod.rs
+++ b/aya/src/maps/mod.rs
@@ -477,6 +477,7 @@ mod tests {
     use crate::{
         bpf_map_def,
         generated::{bpf_cmd, bpf_map_type::BPF_MAP_TYPE_HASH},
+        obj::MapKind,
         sys::{override_syscall, Syscall},
     };
 
@@ -493,6 +494,7 @@ mod tests {
             },
             section_index: 0,
             data: Vec::new(),
+            kind: MapKind::Other,
         }
     }
 

--- a/aya/src/maps/perf/perf_event_array.rs
+++ b/aya/src/maps/perf/perf_event_array.rs
@@ -9,7 +9,6 @@ use std::{
 };
 
 use bytes::BytesMut;
-use libc::{sysconf, _SC_PAGESIZE};
 
 use crate::{
     generated::bpf_map_type::BPF_MAP_TYPE_PERF_EVENT_ARRAY,
@@ -18,6 +17,7 @@ use crate::{
         Map, MapError, MapRefMut,
     },
     sys::bpf_map_update_elem,
+    util::page_size,
 };
 
 /// A ring buffer that can receive events from eBPF programs.
@@ -177,8 +177,7 @@ impl<T: DerefMut<Target = Map>> PerfEventArray<T> {
 
         Ok(PerfEventArray {
             map: Arc::new(map),
-            // Safety: libc
-            page_size: unsafe { sysconf(_SC_PAGESIZE) } as usize,
+            page_size: page_size(),
         })
     }
 

--- a/aya/src/sys/bpf.rs
+++ b/aya/src/sys/bpf.rs
@@ -253,6 +253,14 @@ pub(crate) fn bpf_map_get_next_key<K>(
     }
 }
 
+// since kernel 5.2
+pub(crate) fn bpf_map_freeze(fd: RawFd) -> SysResult {
+    let mut attr = unsafe { mem::zeroed::<bpf_attr>() };
+    let u = unsafe { &mut attr.__bindgen_anon_2 };
+    u.map_fd = fd as u32;
+    sys_bpf(bpf_cmd::BPF_MAP_FREEZE, &attr)
+}
+
 // since kernel 5.7
 pub(crate) fn bpf_link_create(
     prog_fd: RawFd,

--- a/aya/src/util.rs
+++ b/aya/src/util.rs
@@ -4,12 +4,13 @@ use std::{
     ffi::CString,
     fs::{self, File},
     io::{self, BufReader},
+    mem, slice,
     str::FromStr,
 };
 
 use crate::generated::{TC_H_MAJ_MASK, TC_H_MIN_MASK};
 
-use libc::if_nametoindex;
+use libc::{if_nametoindex, sysconf, _SC_PAGESIZE};
 
 use io::BufRead;
 
@@ -141,6 +142,17 @@ macro_rules! include_bytes_aligned {
 
         &ALIGNED.bytes
     }};
+}
+
+pub(crate) fn page_size() -> usize {
+    // Safety: libc
+    (unsafe { sysconf(_SC_PAGESIZE) }) as usize
+}
+
+// bytes_of converts a <T> to a byte slice
+pub(crate) unsafe fn bytes_of<T>(val: &T) -> &[u8] {
+    let size = mem::size_of::<T>();
+    slice::from_raw_parts(slice::from_ref(val).as_ptr().cast(), size)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
This commit marks .rodata maps as BPF_F_RDONLY_PROG when loaded to
prevent a BPF program mutating them.

Initial map data is populated by the loader using the new `BpfLoader::set_global()` API.
The loader will mark a map as frozen using bpf_map_freeze to prevent map data
being changed from userspace.

Related to #117 