### PR TITLE
programs: uprobe: Support attaching within own address space

### DIFF
--- a/aya/Cargo.toml
+++ b/aya/Cargo.toml
@@ -22,6 +22,7 @@ futures = { version = "0.3.12", optional = true, default-features = false, featu
 tokio = { version = "1.2.0", features = ["macros", "rt", "rt-multi-thread", "net"], optional = true }
 async-std = { version = "1.9.0", optional = true }
 async-io = { version = "1.3", optional = true }
+procfs = "0.12"
 
 [dev-dependencies]
 matches = "0.1.8"


### PR DESCRIPTION
This change adds the method `attach_own_addr` to `UProbe` which allows
to attach uprobe/uretprobe programs to functions in the address space of
the userspace process loading the program.

The userspace function (written in Rust) to be attached by uprobe has to
be:

* `extern "C"`
* `#[no_mangle]`
* not inlined (`#[inline(never)]`)
* in a separate crate in lib.rs

Signed-off-by: Michal Rostecki <mrostecki@opensuse.org>