### PR TITLE
codegen: add btf_decl_tag

### DIFF
--- a/xtask/src/codegen/aya.rs
+++ b/xtask/src/codegen/aya.rs
@@ -81,6 +81,7 @@ fn codegen_bindings(opts: &Options) -> Result<(), anyhow::Error> {
         "btf_var",
         "btf_var_secinfo",
         "btf_func_linkage",
+        "btf_decl_tag",
         // PERF
         "perf_event_attr",
         "perf_sw_ids",


### PR DESCRIPTION
This is required to add support for BTF_KIND_DECL_TAG

Signed-off-by: Dave Tucker <dave@dtucker.co.uk>