### PR TITLE
btf: fix sanitization if BTF_FUNC_GLOBAL is not supported

### DIFF
--- a/aya/src/obj/btf/btf.rs
+++ b/aya/src/obj/btf/btf.rs
@@ -596,7 +596,8 @@ impl Btf {
                             "{}: BTF_FUNC_GLOBAL not supported. replacing with BTF_FUNC_STATIC",
                             kind
                         );
-                        ty.info |= (btf_func_linkage::BTF_FUNC_STATIC as u32) & 0xFFFF;
+                        ty.info = (ty.info & 0xFFFF0000)
+                            | (btf_func_linkage::BTF_FUNC_STATIC as u32) & 0xFFFF;
                         btf.add_type(BtfType::Func(ty));
                     } else {
                         btf.add_type(BtfType::Func(ty));


### PR DESCRIPTION
The lower 16 bits were not actually being cleared.