### PR TITLE
aya: Merge BTF Sanitize and Fixup

### DIFF
--- a/aya/src/bpf.rs
+++ b/aya/src/bpf.rs
@@ -309,8 +309,8 @@ impl<'a> BpfLoader<'a> {
                 // fixup btf
                 let section_data = obj.section_sizes.clone();
                 let symbol_offsets = obj.symbol_offset_by_name.clone();
-                obj_btf.fixup(&section_data, &symbol_offsets)?;
-                let btf = obj_btf.sanitize(&self.features)?;
+                let btf =
+                    obj_btf.fixup_and_sanitize(&section_data, &symbol_offsets, &self.features)?;
 
                 // load btf to the kernel
                 let raw_btf = btf.to_bytes();


### PR DESCRIPTION
This combines both in to one iteration.
It effectively copies the ELF BTF and applies sanitizations and fixups
and the original is retained. The original may still be used for
relocations.

It's an alternative to #175, which I couldn't get to pass the borrow checker.
Even so, keeping the original, unaltered BTF as read from ELF around isn't such a bad idea....