### PR TITLE
aya: Support multiple maps in map sections

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -7,7 +7,7 @@ common usage behaviours work on real Linux distros
 
 This assumes you have a working Rust and Go toolchain on the host machine
 
-1. `rustup toolchain add x86_64-unknown-linux-musl`
+1. `rustup target add x86_64-unknown-linux-musl`
 1. Install [`rtf`](https://github.com/linuxkit/rtf): `go install github.com/linuxkit/rtf@latest`
 1. Install rust-script: `cargo install rust-script`
 1. Install `qemu` and `cloud-init-utils` package - or any package that provides `cloud-localds`

--- a/test/cases/010_load/010_multiple_maps/multimap.bpf.c
+++ b/test/cases/010_load/010_multiple_maps/multimap.bpf.c
@@ -1,0 +1,47 @@
+#include <linux/bpf.h>
+#include <bpf/bpf_helpers.h>
+
+const int XDP_ACTION_MAX = (XDP_TX + 1);
+
+struct datarec {
+	__u64 rx_packets;
+};
+
+// stats keyed by XDP Action
+struct bpf_map_def SEC("maps") xdp_stats_map = {
+	.type        = BPF_MAP_TYPE_ARRAY,
+	.key_size    = sizeof(__u32),
+	.value_size  = sizeof(struct datarec),
+	.max_entries = XDP_ACTION_MAX,
+};
+
+// tracks number of times called
+struct bpf_map_def SEC("maps") prog_stats_map = {
+	.type        = BPF_MAP_TYPE_ARRAY,
+	.key_size    = sizeof(__u32),
+	.value_size  = sizeof(__u64),
+	.max_entries = 1,
+};
+
+SEC("xdp/stats")
+int  xdp_stats(struct xdp_md *ctx)
+{
+    __u64 *stats;
+	struct datarec *rec;
+	__u32 key = XDP_PASS;
+	__u32 k1 = 0;
+
+    stats = bpf_map_lookup_elem(&prog_stats_map, &k1);
+    if (!stats)
+        return XDP_ABORTED;
+    __sync_fetch_and_add(stats, 1);
+
+	rec = bpf_map_lookup_elem(&xdp_stats_map, &key);
+	if (!rec)
+		return XDP_ABORTED;
+	__sync_fetch_and_add(&rec->rx_packets, 1);
+	
+	return XDP_PASS;
+}
+
+char _license[] SEC("license") = "GPL";

--- a/test/cases/010_load/010_multiple_maps/multimap.rs
+++ b/test/cases/010_load/010_multiple_maps/multimap.rs
@@ -1,0 +1,33 @@
+//! ```cargo
+//! [dependencies]
+//! log = "0.4"
+//! simplelog = "0.11"
+//! aya = { path = "../../../../aya" }
+//! ```
+
+use aya::{
+    Bpf,
+    programs::{Xdp, XdpFlags},
+};
+use log::info;
+use std::convert::TryInto;
+
+use simplelog::{ColorChoice, ConfigBuilder, LevelFilter, TermLogger, TerminalMode};
+
+fn main() {
+    TermLogger::init(
+        LevelFilter::Debug,
+        ConfigBuilder::new()
+            .set_target_level(LevelFilter::Error)
+            .set_location_level(LevelFilter::Error)
+            .build(),
+        TerminalMode::Mixed,
+        ColorChoice::Auto,
+    ).unwrap();
+    info!("Loading XDP program");
+    let mut bpf = Bpf::load_file("multimap.o").unwrap();
+    let pass: &mut Xdp = bpf.program_mut("stats").unwrap().try_into().unwrap();
+    pass.load().unwrap();
+    pass.attach("eth0", XdpFlags::default()).unwrap();
+    info!("Success...");
+}

--- a/test/cases/010_load/010_multiple_maps/test.sh
+++ b/test/cases/010_load/010_multiple_maps/test.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+# SUMMARY: Check that a program with multiple maps in the maps section loads
+# LABELS:
+
+set -e
+
+# Source libraries. Uncomment if needed/defined
+#. "${RT_LIB}"
+. "${RT_PROJECT_ROOT}/_lib/lib.sh"
+
+NAME=multimap
+
+clean_up() {
+    rm -rf ${NAME}.o ${NAME}
+    exec_vm rm -f ${NAME}.o ${NAME}
+}
+
+trap clean_up EXIT
+
+# Test code goes here
+compile_c_ebpf "$(pwd)/${NAME}.bpf.c"
+compile_user "$(pwd)/${NAME}.rs"
+
+scp_vm ${NAME}.o
+scp_vm ${NAME}
+
+exec_vm sudo ./${NAME}
+
+exit 0


### PR DESCRIPTION
This commit uses the symbol table to discover all maps inside an ELF
section. We then divide the data in to equal sized chunks and parse them
using parse_map_def

Signed-off-by: Dave Tucker <dave@dtucker.co.uk>