### PR TITLE
Fixes: #184 by removing aya_bpf dependency on common bindings.

### DIFF
--- a/aya-gen/src/bindgen.rs
+++ b/aya-gen/src/bindgen.rs
@@ -13,7 +13,7 @@ pub fn user_builder() -> Builder {
 pub fn bpf_builder() -> Builder {
     bindgen::builder()
         .use_core()
-        .ctypes_prefix("::aya_bpf::cty")
+        .ctypes_prefix("aya_bpf_cty")
         .layout_tests(false)
         .generate_comments(false)
         .clang_arg("-Wno-unknown-attributes")


### PR DESCRIPTION
@alessandrod https://github.com/aya-rs/aya/commit/ca14306860cbbb28563137c042fd0249d780bbb9 may also need to be reviewed.

### How to use?
Update `Cargo.toml` of `myapp-common` to use `aya-bpf-cty` instead of `aya-bpf`

> [dependencies]
>...
>aya-bpf-cty = { git = "https://github.com/aya-rs/aya", branch="main” }
>...