### PR TITLE
Fix socket_filter section match

### DIFF
--- a/aya/src/obj/mod.rs
+++ b/aya/src/obj/mod.rs
@@ -1236,7 +1236,7 @@ mod tests {
         assert_matches!(
             obj.parse_section(fake_section(
                 BpfSectionKind::Program,
-                "socket_filter/foo",
+                "socket/foo",
                 bytes_of(&fake_ins())
             )),
             Ok(())

--- a/aya/src/obj/mod.rs
+++ b/aya/src/obj/mod.rs
@@ -184,7 +184,7 @@ impl FromStr for ProgramSection {
                 let name = section.splitn(2, '/').last().unwrap().to_owned();
                 TracePoint { name }
             }
-            "socket_filter" => SocketFilter { name },
+            "socket" => SocketFilter { name },
             "sk_msg" => SkMsg { name },
             "sk_skb" => match &*name {
                 "stream_parser" => SkSkbStreamParser { name },


### PR DESCRIPTION
`BPF_PROG_TYPE_SOCKET_FILTER` program expands the sectionname's kind with `socket` not `socket_filter`.
So current eBPF program with socket filter always fails. (Please refer to  https://github.com/aya-rs/aya/issues/227.)

This patch fixes it.

Fix https://github.com/aya-rs/aya/issues/227