### PR TITLE
aya: Fix Loading from cgroup/skb sections

### DIFF
--- a/aya/src/bpf.rs
+++ b/aya/src/bpf.rs
@@ -450,6 +450,10 @@ impl<'a> BpfLoader<'a> {
                                 },
                             })
                         }
+                        ProgramSection::CgroupSkb { .. } => Program::CgroupSkb(CgroupSkb {
+                            data,
+                            expected_attach_type: None,
+                        }),
                         ProgramSection::CgroupSkbIngress { .. } => Program::CgroupSkb(CgroupSkb {
                             data,
                             expected_attach_type: Some(CgroupSkbAttachType::Ingress),


### PR DESCRIPTION
fa037a88e2f0820d2a64bbaae12464bf5dce083d allowed for cgroup skb programs
that did not specify an attach direction to use the cgroup/skb section
name per the convention established in libbpf. It did not add the
necessary code to load programs from those sections which is added in
this commit

Fixes: #225 

Signed-off-by: Dave Tucker <dave@dtucker.co.uk>