### PR TITLE
ci: lint: aya: Skip doctests with miri

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -47,7 +47,7 @@ jobs:
         env:
           MIRIFLAGS: -Zmiri-disable-stacked-borrows
         run: |
-          cargo miri test
+          cargo miri test --all-targets
           pushd bpf
           cargo miri test
           popd


### PR DESCRIPTION
Signed-off-by: Dave Tucker <dave@dtucker.co.uk>