### PR TITLE
aya-bpf: expose sk_msg_md of SkMsgContext

### DIFF
--- a/bpf/aya-bpf/src/programs/sk_msg.rs
+++ b/bpf/aya-bpf/src/programs/sk_msg.rs
@@ -7,7 +7,7 @@ use crate::{
 };
 
 pub struct SkMsgContext {
-    msg: *mut sk_msg_md,
+    pub msg: *mut sk_msg_md,
 }
 
 impl SkMsgContext {


### PR DESCRIPTION
This patch expose sk_msg_md of SkMsgContext, it is similar change with https://github.com/aya-rs/aya/pull/239.