### PR TITLE
aya: perf_buffer: call BytesMut::reserve() internally

### DIFF
--- a/aya/src/maps/perf/perf_event_array.rs
+++ b/aya/src/maps/perf/perf_event_array.rs
@@ -51,9 +51,6 @@ impl<T: DerefMut<Target = Map>> PerfEventArrayBuffer<T> {
     /// # Errors
     ///
     /// [`PerfBufferError::NoBuffers`] is returned when `out_bufs` is empty.
-    ///
-    /// [`PerfBufferError::MoreSpaceNeeded { size }`](PerfBufferError) is returned when the size of the events is
-    /// bigger than the size of the out_bufs provided.
     pub fn read_events(&mut self, out_bufs: &mut [BytesMut]) -> Result<Events, PerfBufferError> {
         self.buf.read_events(out_bufs)
     }


### PR DESCRIPTION
This changes PerfBuffer::read_events() to call BytesMut::reserve()
internally, and deprecates PerfBufferError::MoreSpaceNeeded.

This makes for a more ergonomic API, and allows for a more idiomatic
usage of BytesMut. For example consider:

    let mut buffers = vec![BytesMut::with_capacity(N), ...];
    loop {
        let events = oob_cpu_buf.read_events(&mut buffers).unwrap();
        for buf in &mut buffers[..events.read] {
            let sub: Bytes = buf.split_off(n).into();
            process_sub_buf(sub);
        }
        ...
    }

This is a common way to process perf bufs, where a sub buffer is split
off from the original buffer and then processed. In the next iteration
of the loop when it's time to read again, two things can happen:

- if processing of the sub buffer is complete and `sub` has been
dropped, read_events() will call buf.reserve(sample_size) and hit a fast
path in BytesMut that will just restore the original capacity of the
buffer (assuming sample_size <= N).

- if processing of the sub buffer hasn't ended (eg the buffer has been
stored or is being processed in another thread),
buf.reserve(sample_size) will actually allocate the new memory required
to read the sample.

In other words, calling buf.reserve(sample_size) inside read_events()
simplifies doing zero-copy processing of buffers in many cases.