### PR TITLE
aya-bpf: Add docs for the main lib and few map types

### DIFF
--- a/bpf/aya-bpf/src/maps/array.rs
+++ b/bpf/aya-bpf/src/maps/array.rs
@@ -8,6 +8,20 @@ use crate::{
     maps::PinningType,
 };
 
+/// A fixed-size array that can be shared between eBPF programs and user-space.
+///
+/// # Minimum kernel version
+///
+/// The minimum kernel version required to use this feature is 3.19.
+///
+/// # Examples
+///
+/// ```no_run
+/// use aya_bpf::{macros::map, maps::Array};
+///
+/// #[map]
+/// static MY_ARRAY: Array<u32> = Array::with_max_entries(1024, 0);
+/// ```
 #[repr(transparent)]
 pub struct Array<T> {
     def: UnsafeCell<bpf_map_def>,

--- a/bpf/aya-bpf/src/maps/lpm_trie.rs
+++ b/bpf/aya-bpf/src/maps/lpm_trie.rs
@@ -33,6 +33,7 @@ impl<K> Key<K> {
 }
 
 impl<K, V> LpmTrie<K, V> {
+    /// Creates an `LpmTrie` map with the maximum number of elements.
     pub const fn with_max_entries(max_entries: u32, flags: u32) -> LpmTrie<K, V> {
         let flags = flags | BPF_F_NO_PREALLOC;
         LpmTrie {
@@ -47,6 +48,8 @@ impl<K, V> LpmTrie<K, V> {
         }
     }
 
+    /// Creates an `LpmTrie` map pinned in the BPPFS filesystem, with the
+    /// maximum number of elements.
     pub const fn pinned(max_entries: u32, flags: u32) -> LpmTrie<K, V> {
         let flags = flags | BPF_F_NO_PREALLOC;
         LpmTrie {
@@ -61,6 +64,7 @@ impl<K, V> LpmTrie<K, V> {
         }
     }
 
+    /// Returns a copy of the value associated with the key.
     #[inline]
     pub fn get(&self, key: &Key<K>) -> Option<&V> {
         unsafe {
@@ -71,6 +75,7 @@ impl<K, V> LpmTrie<K, V> {
         }
     }
 
+    /// Inserts a key-value pair into the map.
     #[inline]
     pub fn insert(&self, key: &Key<K>, value: &V, flags: u64) -> Result<(), c_long> {
         let ret = unsafe {
@@ -84,6 +89,7 @@ impl<K, V> LpmTrie<K, V> {
         (ret == 0).then_some(()).ok_or(ret)
     }
 
+    /// Removes a key from the map.
     #[inline]
     pub fn remove(&self, key: &Key<K>) -> Result<(), c_long> {
         let ret = unsafe {

--- a/bpf/aya-bpf/src/maps/mod.rs
+++ b/bpf/aya-bpf/src/maps/mod.rs
@@ -1,3 +1,42 @@
+//! Data structures used to store eBPF programs data and share them with the
+//! user space.
+//!
+//! The eBPF platform provides data structures - maps in eBPF speak - that are
+//! used store data and share it with the user space. When you define a static
+//! variable of a map type (i.e. [`HashMap`](crate::maps::HashMap), that map gets
+//! initialized during the eBPF object load into the kernel and is ready to
+//! use by programs.
+//!
+
+//!
+//! # Typed maps
+//!
+//! The eBPF API includes many map types each supporting different operations.
+//!
+//! Each type of map provides methods to access and modify the data in the map
+//! (i.e. [`get`](crate::maps::HashMap::get), [`get_ptr_mut`](crate::maps::HashMap::get_ptr_mut),
+//! [`insert`](crate::maps::HashMap::insert) and, [`remove`](crate::maps::HashMap::remove)).
+//!
+//! For example:
+//!
+//! ```no_run
+//! # #![allow(dead_code)]
+//! use aya_bpf::{macros::map, maps::HashMap};
+//! # use aya_bpf::programs::TracePointContext;
+//!
+//! #[map]
+//! static PID_TO_TGID: HashMap<u32, u32> = HashMap::with_max_entries(1024, 0);
+//!
+//! # fn try_test(ctx: &TracePointContext) -> Result<i32, i32> {
+//! let pid: u32 = ctx.pid();
+//! let tgid: u32 = ctx.tgid();
+//! PID_TO_TGID.insert(&pid, &tgid, 0).map_err(|e| e as i32)?;
+//! # Ok(0)
+//! # }
+//! ```
+//!
+//! Please refer to documentation for each map type for more details.
+
 #[repr(u32)]
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub(crate) enum PinningType {

--- a/bpf/aya-bpf/src/maps/perf/perf_event_array.rs
+++ b/bpf/aya-bpf/src/maps/perf/perf_event_array.rs
@@ -7,6 +7,40 @@ use crate::{
     BpfContext,
 };
 
+/// An array for pushing out custom event data (as a struct defined by
+/// developer) to user space.
+///
+/// # Minimum kernel version
+///
+/// The minimum kernel version for this feature is 4.3.
+///
+/// # Examples
+///
+/// ```no_run
+/// use aya_bpf::{macros::map, maps::PerfEventArray};
+/// use aya_bpf::programs::XdpContext};
+///
+/// #[repr(C)]
+/// #[derive(Clone, Copy)]
+/// pub struct PacketLog {
+///     pub ipv4_address: u32,
+///     pub port: u32,
+/// }
+///
+/// #[map]
+/// static EVENTS: PerfEventArray<PacketLog> = PerfEventArray::with_max_entries(1024, 0);
+///
+/// # unsafe fn try_test(ctx: &XdpContext) -> Result<i32, i32> {
+/// let ipv4_address = parse_source_ipv4_address(&ctx.data);
+/// let port = parse_source_port(&ctx.data);
+/// let packet_log = Entry {
+///    ipv4_address,
+///    port,
+/// };
+/// EVENTS.output(ctx, &packet_log, 0);
+/// # Ok(0)
+/// # }
+/// ```
 #[repr(transparent)]
 pub struct PerfEventArray<T> {
     def: UnsafeCell<bpf_map_def>,
@@ -20,6 +54,7 @@ impl<T> PerfEventArray<T> {
         PerfEventArray::with_max_entries(0, flags)
     }
 
+    /// Creates an `PerfEventArray` with the maximum number of elements.
     pub const fn with_max_entries(max_entries: u32, flags: u32) -> PerfEventArray<T> {
         PerfEventArray {
             def: UnsafeCell::new(bpf_map_def {
@@ -35,6 +70,8 @@ impl<T> PerfEventArray<T> {
         }
     }
 
+    /// Creates an `PerfEventArray` pinned in the BPPFS filesystem, with the
+    /// maximum number of elements.
     pub const fn pinned(max_entries: u32, flags: u32) -> PerfEventArray<T> {
         PerfEventArray {
             def: UnsafeCell::new(bpf_map_def {
@@ -50,10 +87,31 @@ impl<T> PerfEventArray<T> {
         }
     }
 
+    /// Outputs the given event to the array.
+    ///
+    /// ```no_run
+    /// use aya_bpf::{macros::map, maps::PerfEventArray};
+    /// # use aya_bpf::programs::LsmContext;
+    ///
+    /// #[repr(C)]
+    /// pub struct Entry {
+    ///     pub some_field: u32,
+    /// }
+    ///
+    /// #[map]
+    /// static mut EVENTS: PerfEventArray<Entry> = PerfEventArray::<Entry>::with_max_entries(1024, 0);
+    ///
+    /// # unsafe fn try_test(ctx: &LsmContext) -> Result<i32, i32> {
+    /// let entry = Entry { some_field: 42 };
+    /// EVENTS.output(ctx, &entry, 0);
+    /// # Ok(0)
+    /// # }
+    /// ```
     pub fn output<C: BpfContext>(&self, ctx: &C, data: &T, flags: u32) {
         self.output_at_index(ctx, BPF_F_CURRENT_CPU as u32, data, flags)
     }
 
+    /// Outputs the given event to the array at the given index.
     pub fn output_at_index<C: BpfContext>(&self, ctx: &C, index: u32, data: &T, flags: u32) {
         let flags = (flags as u64) << 32 | index as u64;
         unsafe {


### PR DESCRIPTION
This change adds a summary of the aya-bpf lib and docs for:

* hash map
* lpm trie
* perf event arrays

Signed-off-by: Michal Rostecki <vadorovsky@gmail.com>