### PR TITLE
aya: rework links

### DIFF
--- a/aya/Cargo.toml
+++ b/aya/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aya"
-version = "0.10.7"
+version = "0.11.0-dev.0"
 description = "An eBPF library with a focus on developer experience and operability."
 keywords = ["ebpf", "bpf", "linux", "kernel"]
 license = "MIT OR Apache-2.0"

--- a/aya/src/bpf.rs
+++ b/aya/src/bpf.rs
@@ -405,57 +405,58 @@ impl<'a> BpfLoader<'a> {
                 } else {
                     None
                 };
-                let data = ProgramData {
-                    name: prog_name,
-                    obj,
-                    fd: None,
-                    links: Vec::new(),
-                    expected_attach_type: None,
-                    attach_btf_obj_fd: None,
-                    attach_btf_id: None,
-                    attach_prog_fd: None,
-                    btf_fd,
-                };
+                let section = obj.section.clone();
+
                 let program = if self.extensions.contains(name.as_str()) {
-                    Program::Extension(Extension { data })
+                    Program::Extension(Extension {
+                        data: ProgramData::new(prog_name, obj, btf_fd),
+                    })
                 } else {
-                    match &data.obj.section {
+                    match &section {
                         ProgramSection::KProbe { .. } => Program::KProbe(KProbe {
-                            data,
+                            data: ProgramData::new(prog_name, obj, btf_fd),
                             kind: ProbeKind::KProbe,
                         }),
                         ProgramSection::KRetProbe { .. } => Program::KProbe(KProbe {
-                            data,
+                            data: ProgramData::new(prog_name, obj, btf_fd),
                             kind: ProbeKind::KRetProbe,
                         }),
                         ProgramSection::UProbe { .. } => Program::UProbe(UProbe {
-                            data,
+                            data: ProgramData::new(prog_name, obj, btf_fd),
                             kind: ProbeKind::UProbe,
                         }),
                         ProgramSection::URetProbe { .. } => Program::UProbe(UProbe {
-                            data,
+                            data: ProgramData::new(prog_name, obj, btf_fd),
                             kind: ProbeKind::URetProbe,
                         }),
-                        ProgramSection::TracePoint { .. } => {
-                            Program::TracePoint(TracePoint { data })
-                        }
+                        ProgramSection::TracePoint { .. } => Program::TracePoint(TracePoint {
+                            data: ProgramData::new(prog_name, obj, btf_fd),
+                        }),
                         ProgramSection::SocketFilter { .. } => {
-                            Program::SocketFilter(SocketFilter { data })
+                            Program::SocketFilter(SocketFilter {
+                                data: ProgramData::new(prog_name, obj, btf_fd),
+                            })
                         }
-                        ProgramSection::Xdp { .. } => Program::Xdp(Xdp { data }),
-                        ProgramSection::SkMsg { .. } => Program::SkMsg(SkMsg { data }),
+                        ProgramSection::Xdp { .. } => Program::Xdp(Xdp {
+                            data: ProgramData::new(prog_name, obj, btf_fd),
+                        }),
+                        ProgramSection::SkMsg { .. } => Program::SkMsg(SkMsg {
+                            data: ProgramData::new(prog_name, obj, btf_fd),
+                        }),
                         ProgramSection::SkSkbStreamParser { .. } => Program::SkSkb(SkSkb {
-                            data,
+                            data: ProgramData::new(prog_name, obj, btf_fd),
                             kind: SkSkbKind::StreamParser,
                         }),
                         ProgramSection::SkSkbStreamVerdict { .. } => Program::SkSkb(SkSkb {
-                            data,
+                            data: ProgramData::new(prog_name, obj, btf_fd),
                             kind: SkSkbKind::StreamVerdict,
                         }),
-                        ProgramSection::SockOps { .. } => Program::SockOps(SockOps { data }),
+                        ProgramSection::SockOps { .. } => Program::SockOps(SockOps {
+                            data: ProgramData::new(prog_name, obj, btf_fd),
+                        }),
                         ProgramSection::SchedClassifier { .. } => {
                             Program::SchedClassifier(SchedClassifier {
-                                data,
+                                data: ProgramData::new(prog_name, obj, btf_fd),
                                 name: unsafe {
                                     CString::from_vec_unchecked(Vec::from(name.clone()))
                                         .into_boxed_c_str()
@@ -463,29 +464,45 @@ impl<'a> BpfLoader<'a> {
                             })
                         }
                         ProgramSection::CgroupSkb { .. } => Program::CgroupSkb(CgroupSkb {
-                            data,
+                            data: ProgramData::new(prog_name, obj, btf_fd),
                             expected_attach_type: None,
                         }),
                         ProgramSection::CgroupSkbIngress { .. } => Program::CgroupSkb(CgroupSkb {
-                            data,
+                            data: ProgramData::new(prog_name, obj, btf_fd),
                             expected_attach_type: Some(CgroupSkbAttachType::Ingress),
                         }),
                         ProgramSection::CgroupSkbEgress { .. } => Program::CgroupSkb(CgroupSkb {
-                            data,
+                            data: ProgramData::new(prog_name, obj, btf_fd),
                             expected_attach_type: Some(CgroupSkbAttachType::Egress),
                         }),
-                        ProgramSection::LircMode2 { .. } => Program::LircMode2(LircMode2 { data }),
-                        ProgramSection::PerfEvent { .. } => Program::PerfEvent(PerfEvent { data }),
+                        ProgramSection::LircMode2 { .. } => Program::LircMode2(LircMode2 {
+                            data: ProgramData::new(prog_name, obj, btf_fd),
+                        }),
+                        ProgramSection::PerfEvent { .. } => Program::PerfEvent(PerfEvent {
+                            data: ProgramData::new(prog_name, obj, btf_fd),
+                        }),
                         ProgramSection::RawTracePoint { .. } => {
-                            Program::RawTracePoint(RawTracePoint { data })
+                            Program::RawTracePoint(RawTracePoint {
+                                data: ProgramData::new(prog_name, obj, btf_fd),
+                            })
                         }
-                        ProgramSection::Lsm { .. } => Program::Lsm(Lsm { data }),
+                        ProgramSection::Lsm { .. } => Program::Lsm(Lsm {
+                            data: ProgramData::new(prog_name, obj, btf_fd),
+                        }),
                         ProgramSection::BtfTracePoint { .. } => {
-                            Program::BtfTracePoint(BtfTracePoint { data })
+                            Program::BtfTracePoint(BtfTracePoint {
+                                data: ProgramData::new(prog_name, obj, btf_fd),
+                            })
                         }
-                        ProgramSection::FEntry { .. } => Program::FEntry(FEntry { data }),
-                        ProgramSection::FExit { .. } => Program::FExit(FExit { data }),
-                        ProgramSection::Extension { .. } => Program::Extension(Extension { data }),
+                        ProgramSection::FEntry { .. } => Program::FEntry(FEntry {
+                            data: ProgramData::new(prog_name, obj, btf_fd),
+                        }),
+                        ProgramSection::FExit { .. } => Program::FExit(FExit {
+                            data: ProgramData::new(prog_name, obj, btf_fd),
+                        }),
+                        ProgramSection::Extension { .. } => Program::Extension(Extension {
+                            data: ProgramData::new(prog_name, obj, btf_fd),
+                        }),
                     }
                 };
                 (name, program)

--- a/aya/src/programs/kprobe.rs
+++ b/aya/src/programs/kprobe.rs
@@ -5,9 +5,10 @@ use thiserror::Error;
 use crate::{
     generated::bpf_prog_type::BPF_PROG_TYPE_KPROBE,
     programs::{
-        load_program,
+        define_link_wrapper, load_program,
+        perf_attach::{PerfLink, PerfLinkId},
         probe::{attach, ProbeKind},
-        LinkRef, ProgramData, ProgramError,
+        ProgramData, ProgramError,
     },
 };
 
@@ -38,14 +39,12 @@ use crate::{
 #[derive(Debug)]
 #[doc(alias = "BPF_PROG_TYPE_KPROBE")]
 pub struct KProbe {
-    pub(crate) data: ProgramData,
+    pub(crate) data: ProgramData<KProbeLink>,
     pub(crate) kind: ProbeKind,
 }
 
 impl KProbe {
     /// Loads the program inside the kernel.
-    ///
-    /// See also [`Program::load`](crate::programs::Program::load).
     pub fn load(&mut self) -> Result<(), ProgramError> {
         load_program(BPF_PROG_TYPE_KPROBE, &mut self.data)
     }
@@ -65,10 +64,27 @@ impl KProbe {
     /// If the program is a `kprobe`, it is attached to the *start* address of the target function.
     /// Conversely if the program is a `kretprobe`, it is attached to the return address of the
     /// target function.
-    pub fn attach(&mut self, fn_name: &str, offset: u64) -> Result<LinkRef, ProgramError> {
+    ///
+    /// The returned value can be used to detach from the given function, see [KProbe::detach].
+    pub fn attach(&mut self, fn_name: &str, offset: u64) -> Result<KProbeLinkId, ProgramError> {
         attach(&mut self.data, self.kind, fn_name, offset, None)
     }
+
+    /// Detaches the program.
+    ///
+    /// See [KProbe::attach].
+    pub fn detach(&mut self, link_id: KProbeLinkId) -> Result<(), ProgramError> {
+        self.data.links.remove(link_id)
+    }
 }
+
+define_link_wrapper!(
+    KProbeLink,
+    /// The type returned by [KProbe::attach]. Can be passed to [KProbe::detach].
+    KProbeLinkId,
+    PerfLink,
+    PerfLinkId
+);
 
 /// The type returned when attaching a [`KProbe`] fails.
 #[derive(Debug, Error)]

--- a/aya/src/programs/links.rs
+++ b/aya/src/programs/links.rs
@@ -1,0 +1,260 @@
+use libc::{close, dup};
+use std::{
+    collections::{hash_map::Entry, HashMap},
+    os::unix::prelude::RawFd,
+};
+
+use crate::{generated::bpf_attach_type, programs::ProgramError, sys::bpf_prog_detach};
+
+pub(crate) trait Link: std::fmt::Debug + 'static {
+    type Id: std::fmt::Debug + std::hash::Hash + Eq + PartialEq;
+
+    fn id(&self) -> Self::Id;
+
+    fn detach(self) -> Result<(), ProgramError>;
+}
+
+#[derive(Debug)]
+pub(crate) struct LinkMap<T: Link> {
+    links: HashMap<T::Id, T>,
+}
+
+impl<T: Link> LinkMap<T> {
+    pub(crate) fn new() -> LinkMap<T> {
+        LinkMap {
+            links: HashMap::new(),
+        }
+    }
+
+    pub(crate) fn insert(&mut self, link: T) -> Result<T::Id, ProgramError> {
+        let id = link.id();
+
+        match self.links.entry(link.id()) {
+            Entry::Occupied(_) => return Err(ProgramError::AlreadyAttached),
+            Entry::Vacant(e) => e.insert(link),
+        };
+
+        Ok(id)
+    }
+
+    pub(crate) fn remove(&mut self, link_id: T::Id) -> Result<(), ProgramError> {
+        self.links
+            .remove(&link_id)
+            .ok_or(ProgramError::NotAttached)?
+            .detach()
+    }
+}
+
+impl<T: Link> Drop for LinkMap<T> {
+    fn drop(&mut self) {
+        for (_, link) in self.links.drain() {
+            let _ = link.detach();
+        }
+    }
+}
+
+#[derive(Debug, Hash, Eq, PartialEq)]
+pub(crate) struct FdLinkId(pub(crate) RawFd);
+
+#[derive(Debug)]
+pub(crate) struct FdLink {
+    fd: RawFd,
+}
+
+impl FdLink {
+    pub(crate) fn new(fd: RawFd) -> FdLink {
+        FdLink { fd }
+    }
+}
+
+impl Link for FdLink {
+    type Id = FdLinkId;
+
+    fn id(&self) -> Self::Id {
+        FdLinkId(self.fd)
+    }
+
+    fn detach(self) -> Result<(), ProgramError> {
+        unsafe { close(self.fd) };
+        Ok(())
+    }
+}
+
+#[derive(Debug, Hash, Eq, PartialEq)]
+pub(crate) struct ProgAttachLinkId(RawFd, RawFd, bpf_attach_type);
+
+#[derive(Debug)]
+pub(crate) struct ProgAttachLink {
+    prog_fd: RawFd,
+    target_fd: RawFd,
+    attach_type: bpf_attach_type,
+}
+
+impl ProgAttachLink {
+    pub(crate) fn new(
+        prog_fd: RawFd,
+        target_fd: RawFd,
+        attach_type: bpf_attach_type,
+    ) -> ProgAttachLink {
+        ProgAttachLink {
+            prog_fd,
+            target_fd: unsafe { dup(target_fd) },
+            attach_type,
+        }
+    }
+}
+
+impl Link for ProgAttachLink {
+    type Id = ProgAttachLinkId;
+
+    fn id(&self) -> Self::Id {
+        ProgAttachLinkId(self.prog_fd, self.target_fd, self.attach_type)
+    }
+
+    fn detach(self) -> Result<(), ProgramError> {
+        let _ = bpf_prog_detach(self.prog_fd, self.target_fd, self.attach_type);
+        unsafe { close(self.target_fd) };
+        Ok(())
+    }
+}
+
+macro_rules! define_link_wrapper {
+    ($wrapper:ident, #[$doc:meta] $wrapper_id:ident, $base:ident, $base_id:ident) => {
+        #[$doc]
+        #[derive(Debug, Hash, Eq, PartialEq)]
+        pub struct $wrapper_id($base_id);
+
+        #[derive(Debug)]
+        pub(crate) struct $wrapper($base);
+
+        impl crate::programs::Link for $wrapper {
+            type Id = $wrapper_id;
+
+            fn id(&self) -> Self::Id {
+                $wrapper_id(self.0.id())
+            }
+
+            fn detach(self) -> Result<(), ProgramError> {
+                self.0.detach()
+            }
+        }
+
+        impl From<$base> for $wrapper {
+            fn from(b: $base) -> $wrapper {
+                $wrapper(b)
+            }
+        }
+    };
+}
+
+pub(crate) use define_link_wrapper;
+
+#[cfg(test)]
+mod tests {
+    use std::{cell::RefCell, rc::Rc};
+
+    use crate::programs::ProgramError;
+
+    use super::{Link, LinkMap};
+
+    #[derive(Debug, Hash, Eq, PartialEq)]
+    struct TestLinkId(u8, u8);
+
+    #[derive(Debug)]
+    struct TestLink {
+        id: (u8, u8),
+        detached: Rc<RefCell<u8>>,
+    }
+
+    impl TestLink {
+        fn new(a: u8, b: u8) -> TestLink {
+            TestLink {
+                id: (a, b),
+                detached: Rc::new(RefCell::new(0)),
+            }
+        }
+    }
+
+    impl Link for TestLink {
+        type Id = TestLinkId;
+
+        fn id(&self) -> Self::Id {
+            TestLinkId(self.id.0, self.id.1)
+        }
+
+        fn detach(self) -> Result<(), ProgramError> {
+            *self.detached.borrow_mut() += 1;
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn test_link_map() {
+        let mut links = LinkMap::new();
+        let l1 = TestLink::new(1, 2);
+        let l1_detached = Rc::clone(&l1.detached);
+        let l2 = TestLink::new(1, 3);
+        let l2_detached = Rc::clone(&l2.detached);
+
+        let id1 = links.insert(l1).unwrap();
+        let id2 = links.insert(l2).unwrap();
+
+        assert!(*l1_detached.borrow() == 0);
+        assert!(*l2_detached.borrow() == 0);
+
+        assert!(links.remove(id1).is_ok());
+        assert!(*l1_detached.borrow() == 1);
+        assert!(*l2_detached.borrow() == 0);
+
+        assert!(links.remove(id2).is_ok());
+        assert!(*l1_detached.borrow() == 1);
+        assert!(*l2_detached.borrow() == 1);
+    }
+
+    #[test]
+    fn test_already_attached() {
+        let mut links = LinkMap::new();
+
+        links.insert(TestLink::new(1, 2)).unwrap();
+        assert!(matches!(
+            links.insert(TestLink::new(1, 2)),
+            Err(ProgramError::AlreadyAttached)
+        ));
+    }
+
+    #[test]
+    fn test_not_attached() {
+        let mut links = LinkMap::new();
+
+        let l1 = TestLink::new(1, 2);
+        let l1_id1 = l1.id();
+        let l1_id2 = l1.id();
+        links.insert(TestLink::new(1, 2)).unwrap();
+        links.remove(l1_id1).unwrap();
+        assert!(matches!(
+            links.remove(l1_id2),
+            Err(ProgramError::NotAttached)
+        ));
+    }
+
+    #[test]
+    fn test_drop_detach() {
+        let l1 = TestLink::new(1, 2);
+        let l1_detached = Rc::clone(&l1.detached);
+        let l2 = TestLink::new(1, 3);
+        let l2_detached = Rc::clone(&l2.detached);
+
+        {
+            let mut links = LinkMap::new();
+            let id1 = links.insert(l1).unwrap();
+            links.insert(l2).unwrap();
+            // manually remove one link
+            assert!(links.remove(id1).is_ok());
+            assert!(*l1_detached.borrow() == 1);
+            assert!(*l2_detached.borrow() == 0);
+        }
+        // remove the other on drop
+        assert!(*l1_detached.borrow() == 1);
+        assert!(*l2_detached.borrow() == 1);
+    }
+}

--- a/aya/src/programs/lirc_mode2.rs
+++ b/aya/src/programs/lirc_mode2.rs
@@ -2,7 +2,7 @@ use std::os::unix::prelude::{AsRawFd, RawFd};
 
 use crate::{
     generated::{bpf_attach_type::BPF_LIRC_MODE2, bpf_prog_type::BPF_PROG_TYPE_LIRC_MODE2},
-    programs::{load_program, query, Link, LinkRef, ProgramData, ProgramError, ProgramInfo},
+    programs::{load_program, query, Link, ProgramData, ProgramError, ProgramInfo},
     sys::{bpf_obj_get_info_by_fd, bpf_prog_attach, bpf_prog_detach, bpf_prog_get_fd_by_id},
 };
 
@@ -48,19 +48,19 @@ use libc::{close, dup};
 #[derive(Debug)]
 #[doc(alias = "BPF_PROG_TYPE_LIRC_MODE2")]
 pub struct LircMode2 {
-    pub(crate) data: ProgramData,
+    pub(crate) data: ProgramData<LircLink>,
 }
 
 impl LircMode2 {
     /// Loads the program inside the kernel.
-    ///
-    /// See also [`Program::load`](crate::programs::Program::load).
     pub fn load(&mut self) -> Result<(), ProgramError> {
         load_program(BPF_PROG_TYPE_LIRC_MODE2, &mut self.data)
     }
 
     /// Attaches the program to the given lirc device.
-    pub fn attach<T: AsRawFd>(&mut self, lircdev: T) -> Result<LinkRef, ProgramError> {
+    ///
+    /// The returned value can be used to detach, see [LircMode2::detach].
+    pub fn attach<T: AsRawFd>(&mut self, lircdev: T) -> Result<LircLinkId, ProgramError> {
         let prog_fd = self.data.fd_or_err()?;
         let lircdev_fd = lircdev.as_raw_fd();
 
@@ -71,7 +71,14 @@ impl LircMode2 {
             }
         })?;
 
-        Ok(self.data.link(LircLink::new(prog_fd, lircdev_fd)))
+        self.data.links.insert(LircLink::new(prog_fd, lircdev_fd))
+    }
+
+    /// Detaches the program.
+    ///
+    /// See [LircMode2::attach].
+    pub fn detach(&mut self, link_id: LircLinkId) -> Result<(), ProgramError> {
+        self.data.links.remove(link_id)
     }
 
     /// Queries the lirc device for attached programs.
@@ -91,60 +98,50 @@ impl LircMode2 {
 
         Ok(prog_fds
             .into_iter()
-            .map(|prog_fd| LircLink {
-                prog_fd: Some(prog_fd),
-                target_fd: Some(unsafe { dup(target_fd.as_raw_fd()) }),
-            })
+            .map(|prog_fd| LircLink::new(prog_fd, target_fd.as_raw_fd()))
             .collect())
     }
 }
 
+/// The type returned by [LircMode2::attach]. Can be passed to [LircMode2::detach].
+#[derive(Debug, Hash, Eq, PartialEq)]
+pub struct LircLinkId(RawFd, RawFd);
+
 #[derive(Debug)]
 pub struct LircLink {
-    prog_fd: Option<RawFd>,
-    target_fd: Option<RawFd>,
+    prog_fd: RawFd,
+    target_fd: RawFd,
 }
 
 impl LircLink {
     pub(crate) fn new(prog_fd: RawFd, target_fd: RawFd) -> LircLink {
         LircLink {
-            prog_fd: Some(prog_fd),
-            target_fd: Some(unsafe { dup(target_fd) }),
+            prog_fd,
+            target_fd: unsafe { dup(target_fd) },
         }
     }
 
     pub fn info(&self) -> Result<ProgramInfo, ProgramError> {
-        if let Some(fd) = self.prog_fd {
-            match bpf_obj_get_info_by_fd(fd) {
-                Ok(info) => Ok(ProgramInfo(info)),
-                Err(io_error) => Err(ProgramError::SyscallError {
-                    call: "bpf_obj_get_info_by_fd".to_owned(),
-                    io_error,
-                }),
-            }
-        } else {
-            Err(ProgramError::AlreadyDetached)
+        match bpf_obj_get_info_by_fd(self.prog_fd) {
+            Ok(info) => Ok(ProgramInfo(info)),
+            Err(io_error) => Err(ProgramError::SyscallError {
+                call: "bpf_obj_get_info_by_fd".to_owned(),
+                io_error,
+            }),
         }
     }
 }
 
 impl Link for LircLink {
-    fn detach(&mut self) -> Result<(), ProgramError> {
-        if let Some(prog_fd) = self.prog_fd.take() {
-            let target_fd = self.target_fd.take().unwrap();
-            let _ = bpf_prog_detach(prog_fd, target_fd, BPF_LIRC_MODE2);
-            unsafe { close(target_fd) };
-            Ok(())
-        } else {
-            Err(ProgramError::AlreadyDetached)
-        }
-    }
-}
+    type Id = LircLinkId;
 
-impl Drop for LircLink {
-    fn drop(&mut self) {
-        if let Some(target_fd) = self.target_fd.take() {
-            unsafe { close(target_fd) };
-        }
+    fn id(&self) -> Self::Id {
+        LircLinkId(self.prog_fd, self.target_fd)
+    }
+
+    fn detach(self) -> Result<(), ProgramError> {
+        let _ = bpf_prog_detach(self.prog_fd, self.target_fd, BPF_LIRC_MODE2);
+        unsafe { close(self.target_fd) };
+        Ok(())
     }
 }

--- a/aya/src/programs/perf_attach.rs
+++ b/aya/src/programs/perf_attach.rs
@@ -2,64 +2,64 @@ use libc::close;
 use std::os::unix::io::RawFd;
 
 use crate::{
-    programs::{probe::detach_debug_fs, ProbeKind},
+    programs::{probe::detach_debug_fs, Link, ProbeKind, ProgramData, ProgramError},
     sys::perf_event_ioctl,
     PERF_EVENT_IOC_DISABLE, PERF_EVENT_IOC_ENABLE, PERF_EVENT_IOC_SET_BPF,
 };
 
-use super::{Link, LinkRef, ProgramData, ProgramError};
+#[derive(Debug, Hash, Eq, PartialEq)]
+pub struct PerfLinkId(RawFd);
 
 #[derive(Debug)]
-struct PerfLink {
-    perf_fd: Option<RawFd>,
+pub(crate) struct PerfLink {
+    perf_fd: RawFd,
     probe_kind: Option<ProbeKind>,
     event_alias: Option<String>,
 }
 
 impl Link for PerfLink {
-    fn detach(&mut self) -> Result<(), ProgramError> {
-        if let Some(fd) = self.perf_fd.take() {
-            let _ = perf_event_ioctl(fd, PERF_EVENT_IOC_DISABLE, 0);
-            unsafe { close(fd) };
+    type Id = PerfLinkId;
 
-            if let Some(probe_kind) = self.probe_kind.take() {
-                if let Some(event_alias) = self.event_alias.take() {
-                    let _ = detach_debug_fs(probe_kind, &event_alias);
-                }
+    fn id(&self) -> Self::Id {
+        PerfLinkId(self.perf_fd)
+    }
+
+    fn detach(mut self) -> Result<(), ProgramError> {
+        let _ = perf_event_ioctl(self.perf_fd, PERF_EVENT_IOC_DISABLE, 0);
+        unsafe { close(self.perf_fd) };
+
+        if let Some(probe_kind) = self.probe_kind.take() {
+            if let Some(event_alias) = self.event_alias.take() {
+                let _ = detach_debug_fs(probe_kind, &event_alias);
             }
-
-            Ok(())
-        } else {
-            Err(ProgramError::AlreadyDetached)
         }
+
+        Ok(())
     }
 }
 
-impl Drop for PerfLink {
-    fn drop(&mut self) {
-        let _ = self.detach();
-    }
-}
-
-pub(crate) fn perf_attach(data: &mut ProgramData, fd: RawFd) -> Result<LinkRef, ProgramError> {
+pub(crate) fn perf_attach<T: Link + From<PerfLink>>(
+    data: &mut ProgramData<T>,
+    fd: RawFd,
+) -> Result<T::Id, ProgramError> {
     perf_attach_either(data, fd, None, None)
 }
 
-pub(crate) fn perf_attach_debugfs(
-    data: &mut ProgramData,
+pub(crate) fn perf_attach_debugfs<T: Link + From<PerfLink>>(
+    data: &mut ProgramData<T>,
     fd: RawFd,
     probe_kind: ProbeKind,
     event_alias: String,
-) -> Result<LinkRef, ProgramError> {
+) -> Result<T::Id, ProgramError> {
     perf_attach_either(data, fd, Some(probe_kind), Some(event_alias))
 }
 
-fn perf_attach_either(
-    data: &mut ProgramData,
+fn perf_attach_either<T: Link + From<PerfLink>>(
+    data: &mut ProgramData<T>,
     fd: RawFd,
     probe_kind: Option<ProbeKind>,
     event_alias: Option<String>,
-) -> Result<LinkRef, ProgramError> {
+) -> Result<T::Id, ProgramError> {
     let prog_fd = data.fd_or_err()?;
     perf_event_ioctl(fd, PERF_EVENT_IOC_SET_BPF, prog_fd).map_err(|(_, io_error)| {
         ProgramError::SyscallError {
@@ -74,9 +74,12 @@ fn perf_attach_either(
         }
     })?;
 
-    Ok(data.link(PerfLink {
-        perf_fd: Some(fd),
-        probe_kind,
-        event_alias,
-    }))
+    data.links.insert(
+        PerfLink {
+            perf_fd: fd,
+            probe_kind,
+            event_alias,
+        }
+        .into(),
+    )
 }

--- a/aya/src/programs/perf_event.rs
+++ b/aya/src/programs/perf_event.rs
@@ -1,16 +1,23 @@
 //! Perf event programs.
-use crate::{generated::bpf_prog_type::BPF_PROG_TYPE_PERF_EVENT, sys::perf_event_open};
-
-use crate::generated::perf_type_id::{
-    PERF_TYPE_BREAKPOINT, PERF_TYPE_HARDWARE, PERF_TYPE_HW_CACHE, PERF_TYPE_RAW,
-    PERF_TYPE_SOFTWARE, PERF_TYPE_TRACEPOINT,
-};
-
 pub use crate::generated::{
     perf_hw_cache_id, perf_hw_cache_op_id, perf_hw_cache_op_result_id, perf_hw_id, perf_sw_ids,
 };
 
-use super::{load_program, perf_attach, LinkRef, ProgramData, ProgramError};
+use crate::{
+    generated::{
+        bpf_prog_type::BPF_PROG_TYPE_PERF_EVENT,
+        perf_type_id::{
+            PERF_TYPE_BREAKPOINT, PERF_TYPE_HARDWARE, PERF_TYPE_HW_CACHE, PERF_TYPE_RAW,
+            PERF_TYPE_SOFTWARE, PERF_TYPE_TRACEPOINT,
+        },
+    },
+    programs::{
+        load_program, perf_attach,
+        perf_attach::{PerfLink, PerfLinkId},
+        ProgramData, ProgramError,
+    },
+    sys::perf_event_open,
+};
 
 /// The type of perf event
 #[repr(u32)]
@@ -112,13 +119,11 @@ pub enum PerfEventScope {
 #[derive(Debug)]
 #[doc(alias = "BPF_PROG_TYPE_PERF_EVENT")]
 pub struct PerfEvent {
-    pub(crate) data: ProgramData,
+    pub(crate) data: ProgramData<PerfLink>,
 }
 
 impl PerfEvent {
     /// Loads the program inside the kernel.
-    ///
-    /// See also [`Program::load`](crate::programs::Program::load).
     pub fn load(&mut self) -> Result<(), ProgramError> {
         load_program(BPF_PROG_TYPE_PERF_EVENT, &mut self.data)
     }
@@ -128,13 +133,15 @@ impl PerfEvent {
     /// The possible values and encoding of the `config` argument depends on the
     /// `perf_type`. See `perf_sw_ids`, `perf_hw_id`, `perf_hw_cache_id`,
     /// `perf_hw_cache_op_id` and `perf_hw_cache_op_result_id`.
+    ///
+    /// The returned value can be used to detach, see [PerfEvent::detach].
     pub fn attach(
         &mut self,
         perf_type: PerfTypeId,
         config: u64,
         scope: PerfEventScope,
         sample_policy: SamplePolicy,
-    ) -> Result<LinkRef, ProgramError> {
+    ) -> Result<PerfLinkId, ProgramError> {
         let (sample_period, sample_frequency) = match sample_policy {
             SamplePolicy::Period(period) => (period, None),
             SamplePolicy::Frequency(frequency) => (0, Some(frequency)),
@@ -162,5 +169,12 @@ impl PerfEvent {
         })? as i32;
 
         perf_attach(&mut self.data, fd)
+    }
+
+    /// Detaches the program.
+    ///
+    /// See [PerfEvent::attach].
+    pub fn detach(&mut self, link_id: PerfLinkId) -> Result<(), ProgramError> {
+        self.data.links.remove(link_id)
     }
 }

--- a/aya/src/programs/probe.rs
+++ b/aya/src/programs/probe.rs
@@ -7,8 +7,8 @@ use std::{
 
 use crate::{
     programs::{
-        kprobe::KProbeError, perf_attach, perf_attach_debugfs,
-        trace_point::read_sys_fs_trace_point_id, uprobe::UProbeError, LinkRef, ProgramData,
+        kprobe::KProbeError, perf_attach, perf_attach::PerfLink, perf_attach_debugfs,
+        trace_point::read_sys_fs_trace_point_id, uprobe::UProbeError, Link, ProgramData,
         ProgramError,
     },
     sys::{kernel_version, perf_event_open_probe, perf_event_open_trace_point},
@@ -36,13 +36,13 @@ impl ProbeKind {
     }
 }
 
-pub(crate) fn attach(
-    program_data: &mut ProgramData,
+pub(crate) fn attach<T: Link + From<PerfLink>>(
+    program_data: &mut ProgramData<T>,
     kind: ProbeKind,
     fn_name: &str,
     offset: u64,
     pid: Option<pid_t>,
-) -> Result<LinkRef, ProgramError> {
+) -> Result<T::Id, ProgramError> {
     // https://github.com/torvalds/linux/commit/e12f03d7031a977356e3d7b75a68c2185ff8d155
     // Use debugfs to create probe
     let k_ver = kernel_version().unwrap();

--- a/aya/src/programs/sk_msg.rs
+++ b/aya/src/programs/sk_msg.rs
@@ -1,7 +1,10 @@
 use crate::{
     generated::{bpf_attach_type::BPF_SK_MSG_VERDICT, bpf_prog_type::BPF_PROG_TYPE_SK_MSG},
     maps::sock::SocketMap,
-    programs::{load_program, LinkRef, ProgAttachLink, ProgramData, ProgramError},
+    programs::{
+        define_link_wrapper, load_program, ProgAttachLink, ProgAttachLinkId, ProgramData,
+        ProgramError,
+    },
     sys::bpf_prog_attach,
 };
 
@@ -56,19 +59,19 @@ use crate::{
 #[derive(Debug)]
 #[doc(alias = "BPF_PROG_TYPE_SK_MSG")]
 pub struct SkMsg {
-    pub(crate) data: ProgramData,
+    pub(crate) data: ProgramData<SkMsgLink>,
 }
 
 impl SkMsg {
     /// Loads the program inside the kernel.
-    ///
-    /// See also [`Program::load`](crate::programs::Program::load).
     pub fn load(&mut self) -> Result<(), ProgramError> {
         load_program(BPF_PROG_TYPE_SK_MSG, &mut self.data)
     }
 
     /// Attaches the program to the given sockmap.
-    pub fn attach(&mut self, map: &dyn SocketMap) -> Result<LinkRef, ProgramError> {
+    ///
+    /// The returned value can be used to detach, see [SkMsg::detach].
+    pub fn attach(&mut self, map: &dyn SocketMap) -> Result<SkMsgLinkId, ProgramError> {
         let prog_fd = self.data.fd_or_err()?;
         let map_fd = map.fd_or_err()?;
 
@@ -78,8 +81,25 @@ impl SkMsg {
                 io_error,
             }
         })?;
-        Ok(self
-            .data
-            .link(ProgAttachLink::new(prog_fd, map_fd, BPF_SK_MSG_VERDICT)))
+        self.data.links.insert(SkMsgLink(ProgAttachLink::new(
+            prog_fd,
+            map_fd,
+            BPF_SK_MSG_VERDICT,
+        )))
+    }
+
+    /// Detaches the program from a sockmap.
+    ///
+    /// See [SkMsg::attach].
+    pub fn detach(&mut self, link_id: SkMsgLinkId) -> Result<(), ProgramError> {
+        self.data.links.remove(link_id)
     }
 }
+
+define_link_wrapper!(
+    SkMsgLink,
+    /// The type returned by [SkMsg::attach]. Can be passed to [SkMsg::detach].
+    SkMsgLinkId,
+    ProgAttachLink,
+    ProgAttachLinkId
+);

--- a/aya/src/programs/xdp.rs
+++ b/aya/src/programs/xdp.rs
@@ -1,6 +1,6 @@
 use bitflags;
 use libc::if_nametoindex;
-use std::{ffi::CString, io, os::unix::io::RawFd};
+use std::{ffi::CString, hash::Hash, io, os::unix::io::RawFd};
 use thiserror::Error;
 
 use crate::{
@@ -10,7 +10,7 @@ use crate::{
         XDP_FLAGS_DRV_MODE, XDP_FLAGS_HW_MODE, XDP_FLAGS_REPLACE, XDP_FLAGS_SKB_MODE,
         XDP_FLAGS_UPDATE_IF_NOEXIST,
     },
-    programs::{load_program, FdLink, Link, LinkRef, ProgramData, ProgramError},
+    programs::{define_link_wrapper, load_program, FdLink, Link, ProgramData, ProgramError},
     sys::{bpf_link_create, kernel_version, netlink_set_xdp_fd},
 };
 
@@ -68,19 +68,19 @@ bitflags! {
 #[derive(Debug)]
 #[doc(alias = "BPF_PROG_TYPE_XDP")]
 pub struct Xdp {
-    pub(crate) data: ProgramData,
+    pub(crate) data: ProgramData<XdpLink>,
 }
 
 impl Xdp {
     /// Loads the program inside the kernel.
-    ///
-    /// See also [`Program::load`](crate::programs::Program::load).
     pub fn load(&mut self) -> Result<(), ProgramError> {
         self.data.expected_attach_type = Some(bpf_attach_type::BPF_XDP);
         load_program(BPF_PROG_TYPE_XDP, &mut self.data)
     }
 
     /// Attaches the program to the given `interface`.
+    ///
+    /// The returned value can be used to detach, see [Xdp::detach].
     ///
     /// # Errors
     ///
@@ -91,7 +91,7 @@ impl Xdp {
     /// kernels `>= 5.9.0`, and instead
     /// [`XdpError::NetlinkError`] is returned for older
     /// kernels.
-    pub fn attach(&mut self, interface: &str, flags: XdpFlags) -> Result<LinkRef, ProgramError> {
+    pub fn attach(&mut self, interface: &str, flags: XdpFlags) -> Result<XdpLinkId, ProgramError> {
         let prog_fd = self.data.fd_or_err()?;
         let c_interface = CString::new(interface).unwrap();
         let if_index = unsafe { if_nametoindex(c_interface.as_ptr()) } as RawFd;
@@ -109,63 +109,89 @@ impl Xdp {
                     io_error,
                 },
             )? as RawFd;
-            Ok(self
-                .data
-                .link(XdpLink::FdLink(FdLink { fd: Some(link_fd) })))
+            self.data
+                .links
+                .insert(XdpLink(XdpLinkInner::FdLink(FdLink::new(link_fd))))
         } else {
             unsafe { netlink_set_xdp_fd(if_index, prog_fd, None, flags.bits) }
                 .map_err(|io_error| XdpError::NetlinkError { io_error })?;
 
-            Ok(self.data.link(XdpLink::NlLink(NlLink {
+            self.data.links.insert(XdpLink(XdpLinkInner::NlLink(NlLink {
                 if_index,
-                prog_fd: Some(prog_fd),
+                prog_fd,
                 flags,
             })))
         }
     }
+
+    /// Detaches the program.
+    ///
+    /// See [Xdp::attach].
+    pub fn detach(&mut self, link_id: XdpLinkId) -> Result<(), ProgramError> {
+        self.data.links.remove(link_id)
+    }
 }
 
 #[derive(Debug)]
-struct NlLink {
+pub(crate) struct NlLink {
     if_index: i32,
-    prog_fd: Option<RawFd>,
+    prog_fd: RawFd,
     flags: XdpFlags,
 }
 
 impl Link for NlLink {
-    fn detach(&mut self) -> Result<(), ProgramError> {
-        if let Some(fd) = self.prog_fd.take() {
-            let k_ver = kernel_version().unwrap();
-            let flags = if k_ver >= (5, 7, 0) {
-                self.flags.bits | XDP_FLAGS_REPLACE
-            } else {
-                self.flags.bits
-            };
-            let _ = unsafe { netlink_set_xdp_fd(self.if_index, -1, Some(fd), flags) };
-            Ok(())
+    type Id = (i32, RawFd);
+
+    fn id(&self) -> Self::Id {
+        (self.if_index, self.prog_fd)
+    }
+
+    fn detach(self) -> Result<(), ProgramError> {
+        let k_ver = kernel_version().unwrap();
+        let flags = if k_ver >= (5, 7, 0) {
+            self.flags.bits | XDP_FLAGS_REPLACE
         } else {
-            Err(ProgramError::AlreadyDetached)
-        }
+            self.flags.bits
+        };
+        let _ = unsafe { netlink_set_xdp_fd(self.if_index, -1, Some(self.prog_fd), flags) };
+        Ok(())
     }
 }
 
-impl Drop for NlLink {
-    fn drop(&mut self) {
-        let _ = self.detach();
-    }
+#[derive(Debug, Hash, Eq, PartialEq)]
+enum XdpLinkIdInner {
+    FdLinkId(<FdLink as Link>::Id),
+    NlLinkId(<NlLink as Link>::Id),
 }
 
 #[derive(Debug)]
-enum XdpLink {
+enum XdpLinkInner {
     FdLink(FdLink),
     NlLink(NlLink),
 }
 
-impl Link for XdpLink {
-    fn detach(&mut self) -> Result<(), ProgramError> {
+impl Link for XdpLinkInner {
+    type Id = XdpLinkIdInner;
+
+    fn id(&self) -> Self::Id {
         match self {
-            XdpLink::FdLink(link) => link.detach(),
-            XdpLink::NlLink(link) => link.detach(),
+            XdpLinkInner::FdLink(link) => XdpLinkIdInner::FdLinkId(link.id()),
+            XdpLinkInner::NlLink(link) => XdpLinkIdInner::NlLinkId(link.id()),
+        }
+    }
+
+    fn detach(self) -> Result<(), ProgramError> {
+        match self {
+            XdpLinkInner::FdLink(link) => link.detach(),
+            XdpLinkInner::NlLink(link) => link.detach(),
         }
     }
 }
+
+define_link_wrapper!(
+    XdpLink,
+    /// The type returned by [Xdp::attach]. Can be passed to [Xdp::detach].
+    XdpLinkId,
+    XdpLinkInner,
+    XdpLinkIdInner
+);

--- a/aya/src/sys/bpf.rs
+++ b/aya/src/sys/bpf.rs
@@ -21,12 +21,10 @@ use crate::{
     },
     maps::PerCpuValues,
     obj::btf::{FuncSecInfo, LineSecInfo},
-    sys::{kernel_version, SysResult},
+    sys::{kernel_version, syscall, SysResult, Syscall},
     util::VerifierLog,
     Pod, BPF_OBJ_NAME_LEN,
 };
-
-use super::{syscall, Syscall};
 
 pub(crate) fn bpf_create_map(name: &CStr, def: &bpf_map_def) -> SysResult {
     let mut attr = unsafe { mem::zeroed::<bpf_attr>() };


### PR DESCRIPTION
Remove LinkRef and remove the Rc<RefCell<_>> that was used to store type-erased link values in ProgramData. Among other things, this allows `Bpf` to be `Send`, which makes it easier to use it with async runtimes.

Change the link API to:

    let link_id = prog.attach(...)?;
    ...
    prog.detach(link_id)?;

Link ids are strongly typed, so it's impossible to eg:

    let link_id = uprobe.attach(...)?;
    xdp.detach(link_id);

As it would result in a compile time error.

Links are still stored inside `ProgramData`, and unless detached explicitly, they are automatically detached when the parent program gets dropped.