### PR TITLE
aya: Relocate maps using symbol_index

### DIFF
--- a/aya/src/bpf.rs
+++ b/aya/src/bpf.rs
@@ -393,7 +393,7 @@ impl<'a> BpfLoader<'a> {
             maps.insert(name, map);
         }
 
-        obj.relocate_maps(maps.iter().map(|(name, map)| (name.as_str(), map)))?;
+        obj.relocate_maps(&maps)?;
         obj.relocate_calls()?;
 
         let programs = obj

--- a/aya/src/maps/hash_map/hash_map.rs
+++ b/aya/src/maps/hash_map/hash_map.rs
@@ -170,6 +170,7 @@ mod tests {
             section_index: 0,
             data: Vec::new(),
             kind: obj::MapKind::Other,
+            symbol_index: 0,
         }
     }
 
@@ -221,6 +222,7 @@ mod tests {
                     ..Default::default()
                 },
                 section_index: 0,
+                symbol_index: 0,
                 data: Vec::new(),
                 kind: obj::MapKind::Other,
             },
@@ -281,6 +283,7 @@ mod tests {
                     ..Default::default()
                 },
                 section_index: 0,
+                symbol_index: 0,
                 data: Vec::new(),
                 kind: obj::MapKind::Other,
             },

--- a/aya/src/maps/lpm_trie.rs
+++ b/aya/src/maps/lpm_trie.rs
@@ -239,6 +239,7 @@ mod tests {
                 ..Default::default()
             },
             section_index: 0,
+            symbol_index: 0,
             data: Vec::new(),
             kind: obj::MapKind::Other,
         }
@@ -292,6 +293,7 @@ mod tests {
                     ..Default::default()
                 },
                 section_index: 0,
+                symbol_index: 0,
                 data: Vec::new(),
                 kind: obj::MapKind::Other,
             },

--- a/aya/src/maps/mod.rs
+++ b/aya/src/maps/mod.rs
@@ -567,6 +567,7 @@ mod tests {
                 ..Default::default()
             },
             section_index: 0,
+            symbol_index: 0,
             data: Vec::new(),
             kind: MapKind::Other,
         }

--- a/aya/src/obj/mod.rs
+++ b/aya/src/obj/mod.rs
@@ -76,6 +76,7 @@ impl From<&str> for MapKind {
 pub struct Map {
     pub(crate) def: bpf_map_def,
     pub(crate) section_index: usize,
+    pub(crate) symbol_index: usize,
     pub(crate) data: Vec<u8>,
     pub(crate) kind: MapKind,
 }
@@ -540,6 +541,7 @@ impl Object {
                 name.to_string(),
                 Map {
                     section_index: section.index.0,
+                    symbol_index: sym.index,
                     def,
                     data: Vec::new(),
                     kind: MapKind::Other,
@@ -847,6 +849,7 @@ fn parse_map(section: &Section, name: &str) -> Result<Map, ParseError> {
     };
     Ok(Map {
         section_index: section.index.0,
+        symbol_index: 0,
         def,
         data,
         kind,
@@ -1115,6 +1118,7 @@ mod tests {
             ),
             Ok(Map {
                 section_index: 0,
+                symbol_index: 0,
                 def: bpf_map_def {
                     map_type: _map_type,
                     key_size: 4,
@@ -1649,6 +1653,7 @@ mod tests {
                     pinning: PinningType::None,
                 },
                 section_index: 1,
+                symbol_index: 1,
                 data: vec![0, 0, 0],
                 kind: MapKind::Rodata,
             },


### PR DESCRIPTION
Since we support multiple maps in the same section, the section_index is
no longer a unique way to identify maps. This commit uses the symbol
index as the identifier, but falls back to section_index for rodata
and bss maps since we don't retrieve the symbol_index during parsing.

Signed-off-by: Dave Tucker <dave@dtucker.co.uk>