### PR TITLE
aya-bpf: Set skb_buff visbility to pub

### DIFF
--- a/bpf/aya-bpf/src/programs/sk_buff.rs
+++ b/bpf/aya-bpf/src/programs/sk_buff.rs
@@ -12,7 +12,7 @@ use aya_bpf_cty::c_long;
 use crate::{bindings::__sk_buff, BpfContext};
 
 pub struct SkBuffContext {
-    skb: *mut __sk_buff,
+    pub skb: *mut __sk_buff,
 }
 
 impl SkBuffContext {


### PR DESCRIPTION
It is possible to access the skb pointer with as_ptr method of BpfContext, but direct access to skb is better, because as_ptr requires a cast.
Accessing skb is necessary to write missing functions or to access skb_buff properties such as ifindex, data, data_end, hash, etc

You can implement missing methods directly into SkBuffContext implementation, but in the future a new method may suddenly appear.
So I think that solution is good.