### PR TITLE
bpf: Add PtRegs wrapper

### DIFF
--- a/bpf/aya-bpf/src/args.rs
+++ b/bpf/aya-bpf/src/args.rs
@@ -56,6 +56,26 @@ unsafe_impl_from_btf_argument!(i64);
 unsafe_impl_from_btf_argument!(usize);
 unsafe_impl_from_btf_argument!(isize);
 
+pub struct PtRegs {
+    regs: *mut pt_regs,
+}
+
+/// PtRegs is a portable wrapper around
+/// pt_regs and user_pt_regs
+impl PtRegs {
+
+    pub fn new(ctx: *mut c_void) -> Self {
+        PtRegs {
+            regs: ctx as *mut _,
+        }
+    }
+
+    /// Returns the `n`th argument to passed to the probe function, starting from 0.
+    pub fn arg<T: FromPtRegs>(&self, n: usize) -> Option<T> {
+        T::from_argument( unsafe { &*self.regs } , n)
+    }
+}
+
 /// A trait that indicates a valid type for an argument which can be coerced from
 /// a pt_regs context.
 ///

--- a/bpf/aya-bpf/src/lib.rs
+++ b/bpf/aya-bpf/src/lib.rs
@@ -5,6 +5,7 @@
 pub use aya_bpf_bindings::bindings;
 
 mod args;
+pub use args::PtRegs;
 pub mod helpers;
 pub mod maps;
 pub mod programs;


### PR DESCRIPTION
This adds a portable wrapper around pt_regs and user_pt_regs.
It makes writing Raw Tracepoint or KProbe programs easier when the
arguments are one of these types while also ensuring code is portable
across architectures

# Example

```rust
unsafe fn try_log_syscall(ctx: RawTracePointContext) -> Result<u32, u32> {
    let pt_regs = PtRegs::new(ctx.as_ptr());
    let syscall_addr = pt_regs.arg(0).unwrap();
    let syscall: c_int = bpf_probe_read_user(syscall_addr).map_err(|e| e as u32)?;
    let pid = ctx.pid();
    let log_entry = SyscallLog {
        pid,
        syscall: syscall as u32,
    };
    EVENTS.output(&ctx, &log_entry, 0);
    Ok(0)
}
```