### PR TITLE
Set attach type during load for BPF_PROG_TYPE_CGROUP_SKB

### DIFF
--- a/aya/src/programs/cgroup_skb.rs
+++ b/aya/src/programs/cgroup_skb.rs
@@ -62,11 +62,12 @@ pub struct CgroupSkb {
 impl CgroupSkb {
     /// Loads the program inside the kernel.
     pub fn load(&mut self) -> Result<(), ProgramError> {
-        self.data.expected_attach_type = match self.expected_attach_type {
-            Some(CgroupSkbAttachType::Ingress) => Some(BPF_CGROUP_INET_INGRESS),
-            Some(CgroupSkbAttachType::Egress) => Some(BPF_CGROUP_INET_EGRESS),
-            None => None,
-        };
+        self.data.expected_attach_type =
+            self.expected_attach_type
+                .map(|attach_type| match attach_type {
+                    CgroupSkbAttachType::Ingress => BPF_CGROUP_INET_INGRESS,
+                    CgroupSkbAttachType::Egress => BPF_CGROUP_INET_EGRESS,
+                });
         load_program(BPF_PROG_TYPE_CGROUP_SKB, &mut self.data)
     }
 

--- a/aya/src/programs/cgroup_skb.rs
+++ b/aya/src/programs/cgroup_skb.rs
@@ -62,6 +62,11 @@ pub struct CgroupSkb {
 impl CgroupSkb {
     /// Loads the program inside the kernel.
     pub fn load(&mut self) -> Result<(), ProgramError> {
+        self.data.expected_attach_type = match self.expected_attach_type {
+            Some(CgroupSkbAttachType::Ingress) => Some(BPF_CGROUP_INET_INGRESS),
+            Some(CgroupSkbAttachType::Egress) => Some(BPF_CGROUP_INET_EGRESS),
+            None => None,
+        };
         load_program(BPF_PROG_TYPE_CGROUP_SKB, &mut self.data)
     }
 


### PR DESCRIPTION
As per title, this patch sets `expected_attach_type` during load.

Fix https://github.com/aya-rs/aya/issues/262