### PR TITLE
xtask: Add `bpf_.*` instead of `bpf_map_.*` to allowed type

### DIFF
--- a/xtask/src/codegen/aya_bpf_bindings.rs
+++ b/xtask/src/codegen/aya_bpf_bindings.rs
@@ -51,7 +51,6 @@ pub fn codegen(opts: &Options) -> Result<(), anyhow::Error> {
             "pt_regs",
             "user_pt_regs",
             "xdp_action",
-            "bpf_adj_room_mode",
         ];
         let vars = ["BPF_.*", "bpf_.*", "TC_ACT_.*", "SOL_SOCKET", "SO_.*"];
 

--- a/xtask/src/codegen/aya_bpf_bindings.rs
+++ b/xtask/src/codegen/aya_bpf_bindings.rs
@@ -46,7 +46,7 @@ pub fn codegen(opts: &Options) -> Result<(), anyhow::Error> {
             .constified_enum("BPF_FLOW_.*");
 
         let types = [
-            "bpf_map_.*",
+            "bpf_.*",
             "sk_action",
             "pt_regs",
             "user_pt_regs",


### PR DESCRIPTION
This patch replaces `bpf_map_.*` with `bpf_.*`.

Currently some types that are not used in helper functions are not generated for bindings - e.g. `bpf_sk_lookup`, `bpf_sockopt` and etc.

Part of https://github.com/aya-rs/aya/issues/219

Note, this PR does not include bindings files as it would be better to be created by auto script.
The bindings can be updated by `cargo xtask codegen --libbpf-dir /<PATH_TO>/libbp`.