### PR TITLE
bpf(doc): Hide docs of bindings

### DIFF
--- a/bpf/aya-bpf/src/helpers.rs
+++ b/bpf/aya-bpf/src/helpers.rs
@@ -10,6 +10,7 @@
 use core::mem::{self, MaybeUninit};
 
 pub use aya_bpf_bindings::helpers as gen;
+#[doc(hidden)]
 pub use gen::*;
 
 use crate::cty::{c_char, c_long, c_void};


### PR DESCRIPTION
Before this change, documentation of helper functions (defined by us,
not bindings) were not visible, because `use gen::*` was overriding them
with helpers coming from aya-bpf-bindings, which have the same names and
no docs.

Signed-off-by: Michal Rostecki <vadorovsky@gmail.com>