### PR TITLE
Don't use #[no_mangle] (clashes with `#[export_name]`)

### DIFF
--- a/bpf/aya-bpf-macros/src/expand.rs
+++ b/bpf/aya-bpf-macros/src/expand.rs
@@ -97,7 +97,6 @@ impl Map {
         let name = &self.name;
         let item = &self.item;
         Ok(quote! {
-            #[no_mangle]
             #[link_section = #section_name]
             #[export_name = #name]
             #item


### PR DESCRIPTION
This closes #270.

With this, the symbol name is correct in the intermediate LLVM bitcode
object file (`.rcgu.o`) and in the final BPF program.

---

`llvm-nm` on the intermediate object file:

![image](https://user-images.githubusercontent.com/7998310/169556319-595116bb-41c1-4361-a894-8efadee43b0b.png)

`readelf -a` on the final BPF program:

![image](https://user-images.githubusercontent.com/7998310/169556379-348cd578-34f6-4a4d-8ad8-cf3d82a6b006.png)
