### PR TITLE
aya: Export program modules

### DIFF
--- a/aya/src/programs/cgroup_skb.rs
+++ b/aya/src/programs/cgroup_skb.rs
@@ -1,3 +1,4 @@
+//! Cgroup skb programs.
 use std::{
     hash::Hash,
     os::unix::prelude::{AsRawFd, RawFd},

--- a/aya/src/programs/cgroup_sock_addr.rs
+++ b/aya/src/programs/cgroup_sock_addr.rs
@@ -1,3 +1,4 @@
+//! Cgroup socket address programs.
 use thiserror::Error;
 
 use crate::generated::bpf_attach_type;

--- a/aya/src/programs/cgroup_sockopt.rs
+++ b/aya/src/programs/cgroup_sockopt.rs
@@ -1,3 +1,4 @@
+//! Cgroup socket option programs.
 use thiserror::Error;
 
 use std::{

--- a/aya/src/programs/cgroup_sysctl.rs
+++ b/aya/src/programs/cgroup_sysctl.rs
@@ -1,3 +1,4 @@
+//! Cgroup sysctl programs.
 use std::{
     hash::Hash,
     os::unix::prelude::{AsRawFd, RawFd},

--- a/aya/src/programs/extension.rs
+++ b/aya/src/programs/extension.rs
@@ -1,3 +1,4 @@
+//! Extension programs.
 use std::os::unix::prelude::{AsRawFd, RawFd};
 use thiserror::Error;
 

--- a/aya/src/programs/fentry.rs
+++ b/aya/src/programs/fentry.rs
@@ -1,4 +1,4 @@
-//! fentry programs.
+//! Fentry programs.
 
 use crate::{
     generated::{bpf_attach_type::BPF_TRACE_FENTRY, bpf_prog_type::BPF_PROG_TYPE_TRACING},

--- a/aya/src/programs/fexit.rs
+++ b/aya/src/programs/fexit.rs
@@ -1,4 +1,4 @@
-//! fexit programs.
+//! Fexit programs.
 
 use crate::{
     generated::{bpf_attach_type::BPF_TRACE_FEXIT, bpf_prog_type::BPF_PROG_TYPE_TRACING},

--- a/aya/src/programs/links.rs
+++ b/aya/src/programs/links.rs
@@ -1,3 +1,4 @@
+//! Program links.
 use libc::{close, dup};
 
 use std::{
@@ -9,7 +10,7 @@ use std::{
 
 use crate::{generated::bpf_attach_type, programs::ProgramError, sys::bpf_prog_detach};
 
-/// A Link
+/// A Link.
 pub trait Link: std::fmt::Debug + 'static {
     /// Unique Id
     type Id: std::fmt::Debug + std::hash::Hash + Eq + PartialEq;
@@ -91,11 +92,13 @@ impl<T: Link> Drop for LinkMap<T> {
     }
 }
 
+/// The identifier of an `FdLink`.
 #[derive(Debug, Hash, Eq, PartialEq)]
-pub(crate) struct FdLinkId(pub(crate) RawFd);
+pub struct FdLinkId(pub(crate) RawFd);
 
+/// A file descriptor link.
 #[derive(Debug)]
-pub(crate) struct FdLink {
+pub struct FdLink {
     pub(crate) fd: RawFd,
 }
 
@@ -118,11 +121,13 @@ impl Link for FdLink {
     }
 }
 
+/// The identifier of a `ProgAttachLink`.
 #[derive(Debug, Hash, Eq, PartialEq)]
-pub(crate) struct ProgAttachLinkId(RawFd, RawFd, bpf_attach_type);
+pub struct ProgAttachLinkId(RawFd, RawFd, bpf_attach_type);
 
+/// The Link type used by programs that are attached with `bpf_prog_attach`.
 #[derive(Debug)]
-pub(crate) struct ProgAttachLink {
+pub struct ProgAttachLink {
     prog_fd: RawFd,
     target_fd: RawFd,
     attach_type: bpf_attach_type,

--- a/aya/src/programs/lirc_mode2.rs
+++ b/aya/src/programs/lirc_mode2.rs
@@ -1,3 +1,4 @@
+//! Lirc programs.
 use std::os::unix::prelude::{AsRawFd, RawFd};
 
 use crate::{

--- a/aya/src/programs/mod.rs
+++ b/aya/src/programs/mod.rs
@@ -36,31 +36,31 @@
 //! [`Bpf::program`]: crate::Bpf::program
 //! [`Bpf::program_mut`]: crate::Bpf::program_mut
 //! [`maps`]: crate::maps
-mod cgroup_skb;
-mod cgroup_sock_addr;
-mod cgroup_sockopt;
-mod cgroup_sysctl;
-mod extension;
-mod fentry;
-mod fexit;
-mod kprobe;
-mod links;
-mod lirc_mode2;
-mod lsm;
-mod perf_attach;
+pub mod cgroup_skb;
+pub mod cgroup_sock_addr;
+pub mod cgroup_sockopt;
+pub mod cgroup_sysctl;
+pub mod extension;
+pub mod fentry;
+pub mod fexit;
+pub mod kprobe;
+pub mod links;
+pub mod lirc_mode2;
+pub mod lsm;
+pub mod perf_attach;
 pub mod perf_event;
 mod probe;
-mod raw_trace_point;
-mod sk_msg;
-mod sk_skb;
-mod sock_ops;
-mod socket_filter;
+pub mod raw_trace_point;
+pub mod sk_msg;
+pub mod sk_skb;
+pub mod sock_ops;
+pub mod socket_filter;
 pub mod tc;
-mod tp_btf;
-mod trace_point;
-mod uprobe;
+pub mod tp_btf;
+pub mod trace_point;
+pub mod uprobe;
 mod utils;
-mod xdp;
+pub mod xdp;
 
 use libc::ENOSPC;
 use std::{

--- a/aya/src/programs/perf_attach.rs
+++ b/aya/src/programs/perf_attach.rs
@@ -1,3 +1,4 @@
+//! Perf attach links.
 use libc::close;
 use std::os::unix::io::RawFd;
 
@@ -7,9 +8,11 @@ use crate::{
     PERF_EVENT_IOC_DISABLE, PERF_EVENT_IOC_ENABLE, PERF_EVENT_IOC_SET_BPF,
 };
 
+/// The identifer of a PerfLink.
 #[derive(Debug, Hash, Eq, PartialEq)]
 pub struct PerfLinkId(RawFd);
 
+/// The attachment type of PerfEvent programs.
 #[derive(Debug)]
 pub struct PerfLink {
     perf_fd: RawFd,

--- a/aya/src/programs/sk_msg.rs
+++ b/aya/src/programs/sk_msg.rs
@@ -1,3 +1,4 @@
+//! Skmsg programs.
 use crate::{
     generated::{bpf_attach_type::BPF_SK_MSG_VERDICT, bpf_prog_type::BPF_PROG_TYPE_SK_MSG},
     maps::sock::SocketMap,

--- a/aya/src/programs/sk_skb.rs
+++ b/aya/src/programs/sk_skb.rs
@@ -1,3 +1,4 @@
+//! Skskb programs.
 use crate::{
     generated::{
         bpf_attach_type::{BPF_SK_SKB_STREAM_PARSER, BPF_SK_SKB_STREAM_VERDICT},

--- a/aya/src/programs/sock_ops.rs
+++ b/aya/src/programs/sock_ops.rs
@@ -1,3 +1,4 @@
+//! Socket option programs.
 use std::os::unix::io::AsRawFd;
 
 use crate::{

--- a/aya/src/programs/socket_filter.rs
+++ b/aya/src/programs/socket_filter.rs
@@ -1,3 +1,4 @@
+//! Socket filter programs.
 use libc::{setsockopt, SOL_SOCKET};
 use std::{
     io, mem,

--- a/aya/src/programs/trace_point.rs
+++ b/aya/src/programs/trace_point.rs
@@ -1,3 +1,4 @@
+//! Tracepoint programs.
 use std::{fs, io};
 use thiserror::Error;
 

--- a/aya/src/programs/xdp.rs
+++ b/aya/src/programs/xdp.rs
@@ -1,3 +1,4 @@
+//! eXpress Data Path (XDP) programs.
 use bitflags;
 use libc::if_nametoindex;
 use std::{ffi::CString, hash::Hash, io, os::unix::io::RawFd};


### PR DESCRIPTION
This allows access to XdpLink, XdpLinkId etc... which is currently
unavailable since these modules are private

Signed-off-by: Dave Tucker <dave@dtucker.co.uk>