### PR TITLE
aya: Improved BTF Type API

### DIFF
--- a/aya/src/obj/btf/types.rs
+++ b/aya/src/obj/btf/types.rs
@@ -2,63 +2,822 @@ use std::{fmt::Display, mem, ptr};
 
 use object::Endianness;
 
-use crate::{
-    generated::{
-        btf_array, btf_decl_tag, btf_enum, btf_func_linkage, btf_member, btf_param, btf_type,
-        btf_type__bindgen_ty_1, btf_var, btf_var_secinfo, BTF_KIND_ARRAY, BTF_KIND_CONST,
-        BTF_KIND_DATASEC, BTF_KIND_DECL_TAG, BTF_KIND_ENUM, BTF_KIND_FLOAT, BTF_KIND_FUNC,
-        BTF_KIND_FUNC_PROTO, BTF_KIND_FWD, BTF_KIND_INT, BTF_KIND_PTR, BTF_KIND_RESTRICT,
-        BTF_KIND_STRUCT, BTF_KIND_TYPEDEF, BTF_KIND_TYPE_TAG, BTF_KIND_UNION, BTF_KIND_UNKN,
-        BTF_KIND_VAR, BTF_KIND_VOLATILE,
-    },
-    obj::btf::{Btf, BtfError, MAX_RESOLVE_DEPTH},
-};
+use crate::obj::btf::{Btf, BtfError, MAX_RESOLVE_DEPTH};
 
 #[derive(Clone, Debug)]
 pub(crate) enum BtfType {
     Unknown,
-    Fwd(btf_type),
-    Const(btf_type),
-    Volatile(btf_type),
-    Restrict(btf_type),
-    Ptr(btf_type),
-    Typedef(btf_type),
-    Func(btf_type),
-    Int(btf_type, u32),
-    Float(btf_type),
-    Enum(btf_type, Vec<btf_enum>),
-    Array(btf_type, btf_array),
-    Struct(btf_type, Vec<btf_member>),
-    Union(btf_type, Vec<btf_member>),
-    FuncProto(btf_type, Vec<btf_param>),
-    Var(btf_type, btf_var),
-    DataSec(btf_type, Vec<btf_var_secinfo>),
-    DeclTag(btf_type, btf_decl_tag),
-    TypeTag(btf_type),
+    Fwd(Fwd),
+    Const(Const),
+    Volatile(Volatile),
+    Restrict(Restrict),
+    Ptr(Ptr),
+    Typedef(Typedef),
+    Func(Func),
+    Int(Int),
+    Float(Float),
+    Enum(Enum),
+    Array(Array),
+    Struct(Struct),
+    Union(Union),
+    FuncProto(FuncProto),
+    Var(Var),
+    DataSec(DataSec),
+    DeclTag(DeclTag),
+    TypeTag(TypeTag),
+}
+
+#[repr(C)]
+#[derive(Clone, Debug)]
+pub(crate) struct Fwd {
+    pub(crate) name_offset: u32,
+    info: u32,
+    _unused: u32,
+}
+
+impl Fwd {
+    pub(crate) fn to_bytes(&self) -> Vec<u8> {
+        bytes_of::<Fwd>(self).to_vec()
+    }
+
+    pub(crate) fn kind(&self) -> BtfKind {
+        BtfKind::Fwd
+    }
+
+    pub(crate) fn type_info_size(&self) -> usize {
+        mem::size_of::<Self>()
+    }
+}
+
+#[repr(C)]
+#[derive(Clone, Debug)]
+pub(crate) struct Const {
+    pub(crate) name_offset: u32,
+    info: u32,
+    pub(crate) btf_type: u32,
+}
+
+impl Const {
+    pub(crate) fn to_bytes(&self) -> Vec<u8> {
+        bytes_of::<Const>(self).to_vec()
+    }
+
+    pub(crate) fn kind(&self) -> BtfKind {
+        BtfKind::Const
+    }
+
+    pub(crate) fn type_info_size(&self) -> usize {
+        mem::size_of::<Self>()
+    }
+
+    pub(crate) fn new(btf_type: u32) -> Self {
+        let info = (BtfKind::Const as u32) << 24;
+        Const {
+            name_offset: 0,
+            info,
+            btf_type,
+        }
+    }
+}
+
+#[repr(C)]
+#[derive(Clone, Debug)]
+pub(crate) struct Volatile {
+    pub(crate) name_offset: u32,
+    info: u32,
+    pub(crate) btf_type: u32,
+}
+
+impl Volatile {
+    pub(crate) fn to_bytes(&self) -> Vec<u8> {
+        bytes_of::<Volatile>(self).to_vec()
+    }
+
+    pub(crate) fn kind(&self) -> BtfKind {
+        BtfKind::Volatile
+    }
+
+    pub(crate) fn type_info_size(&self) -> usize {
+        mem::size_of::<Self>()
+    }
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct Restrict {
+    pub(crate) name_offset: u32,
+    _info: u32,
+    pub(crate) btf_type: u32,
+}
+
+impl Restrict {
+    pub(crate) fn to_bytes(&self) -> Vec<u8> {
+        bytes_of::<Restrict>(self).to_vec()
+    }
+
+    pub(crate) fn kind(&self) -> BtfKind {
+        BtfKind::Restrict
+    }
+
+    pub(crate) fn type_info_size(&self) -> usize {
+        mem::size_of::<Self>()
+    }
+}
+
+#[repr(C)]
+#[derive(Clone, Debug)]
+pub(crate) struct Ptr {
+    pub(crate) name_offset: u32,
+    info: u32,
+    pub(crate) btf_type: u32,
+}
+
+impl Ptr {
+    pub(crate) fn to_bytes(&self) -> Vec<u8> {
+        bytes_of::<Self>(self).to_vec()
+    }
+
+    pub(crate) fn kind(&self) -> BtfKind {
+        BtfKind::Ptr
+    }
+
+    pub(crate) fn type_info_size(&self) -> usize {
+        mem::size_of::<Self>()
+    }
+
+    pub(crate) fn new(name_offset: u32, btf_type: u32) -> Self {
+        let info = (BtfKind::Ptr as u32) << 24;
+        Ptr {
+            name_offset,
+            info,
+            btf_type,
+        }
+    }
+}
+
+#[repr(C)]
+#[derive(Clone, Debug)]
+pub(crate) struct Typedef {
+    pub(crate) name_offset: u32,
+    info: u32,
+    pub(crate) btf_type: u32,
+}
+
+impl Typedef {
+    pub(crate) fn to_bytes(&self) -> Vec<u8> {
+        bytes_of::<Self>(self).to_vec()
+    }
+
+    pub(crate) fn kind(&self) -> BtfKind {
+        BtfKind::Typedef
+    }
+
+    pub(crate) fn type_info_size(&self) -> usize {
+        mem::size_of::<Self>()
+    }
+
+    pub(crate) fn new(name_offset: u32, btf_type: u32) -> Self {
+        let info = (BtfKind::Typedef as u32) << 24;
+        Typedef {
+            name_offset,
+            info,
+            btf_type,
+        }
+    }
+}
+
+#[repr(C)]
+#[derive(Clone, Debug)]
+pub(crate) struct Float {
+    pub(crate) name_offset: u32,
+    info: u32,
+    pub(crate) size: u32,
+}
+
+impl Float {
+    pub(crate) fn to_bytes(&self) -> Vec<u8> {
+        bytes_of::<Self>(self).to_vec()
+    }
+
+    pub(crate) fn kind(&self) -> BtfKind {
+        BtfKind::Float
+    }
+    pub(crate) fn type_info_size(&self) -> usize {
+        mem::size_of::<Self>()
+    }
+
+    pub(crate) fn new(name_offset: u32, size: u32) -> Self {
+        let info = (BtfKind::Float as u32) << 24;
+        Float {
+            name_offset,
+            info,
+            size,
+        }
+    }
+}
+
+#[repr(C)]
+#[derive(Clone, Debug)]
+pub(crate) struct Func {
+    pub(crate) name_offset: u32,
+    info: u32,
+    pub(crate) btf_type: u32,
+}
+
+#[repr(u32)]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) enum FuncLinkage {
+    Static = 0,
+    Global = 1,
+    Extern = 2,
+    Unknown,
+}
+
+impl From<u32> for FuncLinkage {
+    fn from(v: u32) -> Self {
+        match v {
+            0 => FuncLinkage::Static,
+            1 => FuncLinkage::Global,
+            2 => FuncLinkage::Extern,
+            _ => FuncLinkage::Unknown,
+        }
+    }
+}
+
+impl Func {
+    pub(crate) fn to_bytes(&self) -> Vec<u8> {
+        bytes_of::<Self>(self).to_vec()
+    }
+
+    pub(crate) fn kind(&self) -> BtfKind {
+        BtfKind::Func
+    }
+    pub(crate) fn type_info_size(&self) -> usize {
+        mem::size_of::<Self>()
+    }
+
+    pub(crate) fn new(name_offset: u32, proto: u32, linkage: FuncLinkage) -> Self {
+        let mut info = (BtfKind::Func as u32) << 24;
+        info |= (linkage as u32) & 0xFFFF;
+        Func {
+            name_offset,
+            info,
+            btf_type: proto,
+        }
+    }
+
+    pub(crate) fn linkage(&self) -> FuncLinkage {
+        (self.info & 0xFFF).into()
+    }
+
+    pub(crate) fn set_linkage(&mut self, linkage: FuncLinkage) {
+        self.info = (self.info & 0xFFFF0000) | (linkage as u32) & 0xFFFF;
+    }
+}
+
+#[repr(C)]
+#[derive(Clone, Debug)]
+pub(crate) struct TypeTag {
+    pub(crate) name_offset: u32,
+    info: u32,
+    pub(crate) btf_type: u32,
+}
+
+impl TypeTag {
+    pub(crate) fn to_bytes(&self) -> Vec<u8> {
+        bytes_of::<Self>(self).to_vec()
+    }
+
+    pub(crate) fn kind(&self) -> BtfKind {
+        BtfKind::TypeTag
+    }
+
+    pub(crate) fn type_info_size(&self) -> usize {
+        mem::size_of::<Self>()
+    }
+
+    pub(crate) fn new(name_offset: u32, btf_type: u32) -> Self {
+        let info = (BtfKind::TypeTag as u32) << 24;
+        TypeTag {
+            name_offset,
+            info,
+            btf_type,
+        }
+    }
+}
+
+#[repr(u32)]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) enum IntEncoding {
+    None,
+    Signed = 1,
+    Char = 2,
+    Bool = 4,
+    Unknown,
+}
+
+impl From<u32> for IntEncoding {
+    fn from(v: u32) -> Self {
+        match v {
+            0 => IntEncoding::None,
+            1 => IntEncoding::Signed,
+            2 => IntEncoding::Char,
+            4 => IntEncoding::Bool,
+            _ => IntEncoding::Unknown,
+        }
+    }
+}
+
+#[repr(C)]
+#[derive(Clone, Debug)]
+pub(crate) struct Int {
+    pub(crate) name_offset: u32,
+    info: u32,
+    pub(crate) size: u32,
+    pub(crate) data: u32,
+}
+
+impl Int {
+    pub(crate) fn to_bytes(&self) -> Vec<u8> {
+        let mut buf = vec![];
+        buf.extend(bytes_of::<u32>(&self.name_offset));
+        buf.extend(bytes_of::<u32>(&self.info));
+        buf.extend(bytes_of::<u32>(&self.size));
+        buf.extend(bytes_of::<u32>(&self.data));
+        buf
+    }
+
+    pub(crate) fn kind(&self) -> BtfKind {
+        BtfKind::Int
+    }
+    pub(crate) fn type_info_size(&self) -> usize {
+        mem::size_of::<Self>()
+    }
+
+    pub(crate) fn new(name_offset: u32, size: u32, encoding: IntEncoding, offset: u32) -> Self {
+        let info = (BtfKind::Int as u32) << 24;
+        let mut data = 0u32;
+        data |= (encoding as u32 & 0x0f) << 24;
+        data |= (offset & 0xff) << 16;
+        data |= (size * 8) & 0xff;
+        Int {
+            name_offset,
+            info,
+            size,
+            data,
+        }
+    }
+
+    pub(crate) fn encoding(&self) -> IntEncoding {
+        ((self.data & 0x0f000000) >> 24).into()
+    }
+
+    pub(crate) fn offset(&self) -> u32 {
+        (self.data & 0x00ff0000) >> 16
+    }
+
+    // TODO: Remove directive this when this crate is pub
+    #[cfg(test)]
+    pub(crate) fn bits(&self) -> u32 {
+        self.data & 0x000000ff
+    }
+}
+
+#[repr(C)]
+#[derive(Debug, Clone)]
+pub(crate) struct BtfEnum {
+    pub(crate) name_offset: u32,
+    pub(crate) value: i32,
+}
+
+#[repr(C)]
+#[derive(Clone, Debug)]
+pub(crate) struct Enum {
+    pub(crate) name_offset: u32,
+    info: u32,
+    pub(crate) size: u32,
+    pub(crate) variants: Vec<BtfEnum>,
+}
+
+impl Enum {
+    pub(crate) fn to_bytes(&self) -> Vec<u8> {
+        let mut buf = vec![];
+        buf.extend(bytes_of::<u32>(&self.name_offset));
+        buf.extend(bytes_of::<u32>(&self.info));
+        buf.extend(bytes_of::<u32>(&self.size));
+        for v in &self.variants {
+            buf.extend(bytes_of::<u32>(&v.name_offset));
+            buf.extend(bytes_of::<i32>(&v.value));
+        }
+        buf
+    }
+
+    pub(crate) fn kind(&self) -> BtfKind {
+        BtfKind::Enum
+    }
+
+    pub(crate) fn type_info_size(&self) -> usize {
+        mem::size_of::<Fwd>() + mem::size_of::<BtfEnum>() * self.variants.len()
+    }
+
+    pub(crate) fn new(name_offset: u32, variants: Vec<BtfEnum>) -> Self {
+        let mut info = (BtfKind::Enum as u32) << 24;
+        info |= (variants.len() as u32) & 0xFFFF;
+        Enum {
+            name_offset,
+            info,
+            size: 4,
+            variants,
+        }
+    }
+}
+
+#[repr(C)]
+#[derive(Clone, Debug)]
+pub(crate) struct BtfMember {
+    pub(crate) name_offset: u32,
+    pub(crate) btf_type: u32,
+    pub(crate) offset: u32,
+}
+
+#[repr(C)]
+#[derive(Clone, Debug)]
+pub(crate) struct Struct {
+    pub(crate) name_offset: u32,
+    info: u32,
+    pub(crate) size: u32,
+    pub(crate) members: Vec<BtfMember>,
+}
+
+impl Struct {
+    pub(crate) fn to_bytes(&self) -> Vec<u8> {
+        let mut buf = vec![];
+        buf.extend(bytes_of::<u32>(&self.name_offset));
+        buf.extend(bytes_of::<u32>(&self.info));
+        buf.extend(bytes_of::<u32>(&self.size));
+        for v in &self.members {
+            buf.extend(bytes_of::<u32>(&v.name_offset));
+            buf.extend(bytes_of::<u32>(&v.btf_type));
+            buf.extend(bytes_of::<u32>(&v.offset));
+        }
+        buf
+    }
+
+    pub(crate) fn kind(&self) -> BtfKind {
+        BtfKind::Struct
+    }
+
+    pub(crate) fn type_info_size(&self) -> usize {
+        mem::size_of::<Fwd>() + mem::size_of::<BtfMember>() * self.members.len()
+    }
+
+    pub(crate) fn new(name_offset: u32, members: Vec<BtfMember>, size: u32) -> Self {
+        let mut info = (BtfKind::Struct as u32) << 24;
+        info |= (members.len() as u32) & 0xFFFF;
+        Struct {
+            name_offset,
+            info,
+            size,
+            members,
+        }
+    }
+
+    pub(crate) fn member_bit_offset(&self, member: &BtfMember) -> usize {
+        let k_flag = self.info >> 31 == 1;
+        let bit_offset = if k_flag {
+            member.offset & 0xFFFFFF
+        } else {
+            member.offset
+        };
+
+        bit_offset as usize
+    }
+
+    pub(crate) fn member_bit_field_size(&self, member: &BtfMember) -> usize {
+        let k_flag = (self.info >> 31) == 1;
+        let size = if k_flag { member.offset >> 24 } else { 0 };
+
+        size as usize
+    }
+}
+
+#[repr(C)]
+#[derive(Clone, Debug)]
+pub(crate) struct Union {
+    pub(crate) name_offset: u32,
+    info: u32,
+    pub(crate) size: u32,
+    pub(crate) members: Vec<BtfMember>,
+}
+
+impl Union {
+    pub(crate) fn to_bytes(&self) -> Vec<u8> {
+        let mut buf = vec![];
+        buf.extend(bytes_of::<u32>(&self.name_offset));
+        buf.extend(bytes_of::<u32>(&self.info));
+        buf.extend(bytes_of::<u32>(&self.size));
+        for v in &self.members {
+            buf.extend(bytes_of::<u32>(&v.name_offset));
+            buf.extend(bytes_of::<u32>(&v.btf_type));
+            buf.extend(bytes_of::<u32>(&v.offset));
+        }
+        buf
+    }
+
+    pub(crate) fn kind(&self) -> BtfKind {
+        BtfKind::Union
+    }
+
+    pub(crate) fn type_info_size(&self) -> usize {
+        mem::size_of::<Fwd>() + mem::size_of::<BtfMember>() * self.members.len()
+    }
+
+    pub(crate) fn member_bit_offset(&self, member: &BtfMember) -> usize {
+        let k_flag = self.info >> 31 == 1;
+        let bit_offset = if k_flag {
+            member.offset & 0xFFFFFF
+        } else {
+            member.offset
+        };
+
+        bit_offset as usize
+    }
+
+    pub(crate) fn member_bit_field_size(&self, member: &BtfMember) -> usize {
+        let k_flag = (self.info >> 31) == 1;
+        let size = if k_flag { member.offset >> 24 } else { 0 };
+
+        size as usize
+    }
+}
+
+#[repr(C)]
+#[derive(Clone, Debug)]
+pub(crate) struct BtfArray {
+    pub(crate) element_type: u32,
+    pub(crate) index_type: u32,
+    pub(crate) len: u32,
+}
+#[repr(C)]
+#[derive(Clone, Debug)]
+pub(crate) struct Array {
+    pub(crate) name_offset: u32,
+    info: u32,
+    _unused: u32,
+    pub(crate) array: BtfArray,
+}
+
+impl Array {
+    pub(crate) fn to_bytes(&self) -> Vec<u8> {
+        let mut buf = vec![];
+        buf.extend(bytes_of::<u32>(&self.name_offset));
+        buf.extend(bytes_of::<u32>(&self.info));
+        buf.extend(bytes_of::<u32>(&self._unused));
+        buf.extend(bytes_of::<BtfArray>(&self.array));
+        buf
+    }
+
+    pub(crate) fn kind(&self) -> BtfKind {
+        BtfKind::Array
+    }
+
+    pub(crate) fn type_info_size(&self) -> usize {
+        mem::size_of::<Self>()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn new(name_offset: u32, element_type: u32, index_type: u32, len: u32) -> Self {
+        let info = (BtfKind::Array as u32) << 24;
+        Array {
+            name_offset,
+            info,
+            _unused: 0,
+            array: BtfArray {
+                element_type,
+                index_type,
+                len,
+            },
+        }
+    }
+}
+
+#[repr(C)]
+#[derive(Clone, Debug)]
+pub(crate) struct BtfParam {
+    pub(crate) name_offset: u32,
+    pub(crate) btf_type: u32,
+}
+
+#[repr(C)]
+#[derive(Clone, Debug)]
+pub(crate) struct FuncProto {
+    pub(crate) name_offset: u32,
+    info: u32,
+    pub(crate) return_type: u32,
+    pub(crate) params: Vec<BtfParam>,
+}
+
+impl FuncProto {
+    pub(crate) fn to_bytes(&self) -> Vec<u8> {
+        let mut buf = vec![];
+        buf.extend(bytes_of::<u32>(&self.name_offset));
+        buf.extend(bytes_of::<u32>(&self.info));
+        buf.extend(bytes_of::<u32>(&self.return_type));
+        for p in &self.params {
+            buf.extend(bytes_of::<u32>(&p.name_offset));
+            buf.extend(bytes_of::<u32>(&p.btf_type));
+        }
+        buf
+    }
+
+    pub(crate) fn kind(&self) -> BtfKind {
+        BtfKind::FuncProto
+    }
+
+    pub(crate) fn type_info_size(&self) -> usize {
+        mem::size_of::<Fwd>() + mem::size_of::<BtfParam>() * self.params.len()
+    }
+
+    pub(crate) fn new(params: Vec<BtfParam>, return_type: u32) -> Self {
+        let mut info = (BtfKind::FuncProto as u32) << 24;
+        info |= (params.len() as u32) & 0xFFFF;
+        FuncProto {
+            name_offset: 0,
+            info,
+            return_type,
+            params,
+        }
+    }
+}
+
+#[repr(u32)]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) enum VarLinkage {
+    Static,
+    Global,
+    Extern,
+    Unknown,
+}
+
+impl From<u32> for VarLinkage {
+    fn from(v: u32) -> Self {
+        match v {
+            0 => VarLinkage::Static,
+            1 => VarLinkage::Global,
+            2 => VarLinkage::Extern,
+            _ => VarLinkage::Unknown,
+        }
+    }
+}
+
+#[repr(C)]
+#[derive(Clone, Debug)]
+pub(crate) struct Var {
+    pub(crate) name_offset: u32,
+    info: u32,
+    pub(crate) btf_type: u32,
+    pub(crate) linkage: VarLinkage,
+}
+
+impl Var {
+    pub(crate) fn to_bytes(&self) -> Vec<u8> {
+        let mut buf = vec![];
+        buf.extend(bytes_of::<u32>(&self.name_offset));
+        buf.extend(bytes_of::<u32>(&self.info));
+        buf.extend(bytes_of::<u32>(&self.btf_type));
+        buf.extend(bytes_of::<VarLinkage>(&self.linkage));
+        buf
+    }
+
+    pub(crate) fn kind(&self) -> BtfKind {
+        BtfKind::Var
+    }
+
+    pub(crate) fn type_info_size(&self) -> usize {
+        mem::size_of::<Self>()
+    }
+
+    pub(crate) fn new(name_offset: u32, btf_type: u32, linkage: VarLinkage) -> Self {
+        let info = (BtfKind::Var as u32) << 24;
+        Var {
+            name_offset,
+            info,
+            btf_type,
+            linkage,
+        }
+    }
+}
+
+#[repr(C)]
+#[derive(Clone, Debug)]
+pub(crate) struct DataSecEntry {
+    pub(crate) btf_type: u32,
+    pub(crate) offset: u32,
+    pub(crate) size: u32,
+}
+
+#[repr(C)]
+#[derive(Clone, Debug)]
+pub(crate) struct DataSec {
+    pub(crate) name_offset: u32,
+    info: u32,
+    pub(crate) size: u32,
+    pub(crate) entries: Vec<DataSecEntry>,
+}
+
+impl DataSec {
+    pub(crate) fn to_bytes(&self) -> Vec<u8> {
+        let mut buf = vec![];
+        buf.extend(bytes_of::<u32>(&self.name_offset));
+        buf.extend(bytes_of::<u32>(&self.info));
+        buf.extend(bytes_of::<u32>(&self.size));
+        for e in &self.entries {
+            buf.extend(bytes_of::<u32>(&e.btf_type));
+            buf.extend(bytes_of::<u32>(&e.offset));
+            buf.extend(bytes_of::<u32>(&e.size));
+        }
+        buf
+    }
+
+    pub(crate) fn kind(&self) -> BtfKind {
+        BtfKind::DataSec
+    }
+
+    pub(crate) fn type_info_size(&self) -> usize {
+        mem::size_of::<Fwd>() + mem::size_of::<DataSecEntry>() * self.entries.len()
+    }
+
+    pub(crate) fn new(name_offset: u32, entries: Vec<DataSecEntry>, size: u32) -> Self {
+        let mut info = (BtfKind::DataSec as u32) << 24;
+        info |= (entries.len() as u32) & 0xFFFF;
+        DataSec {
+            name_offset,
+            info,
+            size,
+            entries,
+        }
+    }
+}
+
+#[repr(C)]
+#[derive(Clone, Debug)]
+pub(crate) struct DeclTag {
+    pub(crate) name_offset: u32,
+    info: u32,
+    pub(crate) btf_type: u32,
+    pub(crate) component_index: i32,
+}
+
+impl DeclTag {
+    pub(crate) fn to_bytes(&self) -> Vec<u8> {
+        let mut buf = vec![];
+        buf.extend(bytes_of::<u32>(&self.name_offset));
+        buf.extend(bytes_of::<u32>(&self.info));
+        buf.extend(bytes_of::<u32>(&self.btf_type));
+        buf.extend(bytes_of::<i32>(&self.component_index));
+        buf
+    }
+
+    pub(crate) fn kind(&self) -> BtfKind {
+        BtfKind::DeclTag
+    }
+
+    pub(crate) fn type_info_size(&self) -> usize {
+        mem::size_of::<Self>()
+    }
+
+    pub(crate) fn new(name_offset: u32, btf_type: u32, component_index: i32) -> Self {
+        let info = (BtfKind::DeclTag as u32) << 24;
+        DeclTag {
+            name_offset,
+            info,
+            btf_type,
+            component_index,
+        }
+    }
 }
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 #[repr(u32)]
 pub(crate) enum BtfKind {
-    Unknown = BTF_KIND_UNKN,
-    Int = BTF_KIND_INT,
-    Float = BTF_KIND_FLOAT,
-    Ptr = BTF_KIND_PTR,
-    Array = BTF_KIND_ARRAY,
-    Struct = BTF_KIND_STRUCT,
-    Union = BTF_KIND_UNION,
-    Enum = BTF_KIND_ENUM,
-    Fwd = BTF_KIND_FWD,
-    Typedef = BTF_KIND_TYPEDEF,
-    Volatile = BTF_KIND_VOLATILE,
-    Const = BTF_KIND_CONST,
-    Restrict = BTF_KIND_RESTRICT,
-    Func = BTF_KIND_FUNC,
-    FuncProto = BTF_KIND_FUNC_PROTO,
-    Var = BTF_KIND_VAR,
-    DataSec = BTF_KIND_DATASEC,
-    DeclTag = BTF_KIND_DECL_TAG,
-    TypeTag = BTF_KIND_TYPE_TAG,
+    Unknown = 0,
+    Int = 1,
+    Ptr = 2,
+    Array = 3,
+    Struct = 4,
+    Union = 5,
+    Enum = 6,
+    Fwd = 7,
+    Typedef = 8,
+    Volatile = 9,
+    Const = 10,
+    Restrict = 11,
+    Func = 12,
+    FuncProto = 13,
+    Var = 14,
+    DataSec = 15,
+    Float = 16,
+    DeclTag = 17,
+    TypeTag = 18,
 }
 
 impl TryFrom<u32> for BtfKind {
@@ -67,25 +826,25 @@ impl TryFrom<u32> for BtfKind {
     fn try_from(v: u32) -> Result<Self, Self::Error> {
         use BtfKind::*;
         Ok(match v {
-            BTF_KIND_UNKN => Unknown,
-            BTF_KIND_INT => Int,
-            BTF_KIND_FLOAT => Float,
-            BTF_KIND_PTR => Ptr,
-            BTF_KIND_ARRAY => Array,
-            BTF_KIND_STRUCT => Struct,
-            BTF_KIND_UNION => Union,
-            BTF_KIND_ENUM => Enum,
-            BTF_KIND_FWD => Fwd,
-            BTF_KIND_TYPEDEF => Typedef,
-            BTF_KIND_VOLATILE => Volatile,
-            BTF_KIND_CONST => Const,
-            BTF_KIND_RESTRICT => Restrict,
-            BTF_KIND_FUNC => Func,
-            BTF_KIND_FUNC_PROTO => FuncProto,
-            BTF_KIND_VAR => Var,
-            BTF_KIND_DATASEC => DataSec,
-            BTF_KIND_DECL_TAG => DeclTag,
-            BTF_KIND_TYPE_TAG => TypeTag,
+            0 => Unknown,
+            1 => Int,
+            2 => Ptr,
+            3 => Array,
+            4 => Struct,
+            5 => Union,
+            6 => Enum,
+            7 => Fwd,
+            8 => Typedef,
+            9 => Volatile,
+            10 => Const,
+            11 => Restrict,
+            12 => Func,
+            13 => FuncProto,
+            14 => Var,
+            15 => DataSec,
+            16 => Float,
+            17 => DeclTag,
+            18 => TypeTag,
             kind => return Err(BtfError::InvalidTypeKind { kind }),
         })
     }
@@ -146,20 +905,46 @@ unsafe fn read_array<T>(data: &[u8], len: usize) -> Result<Vec<T>, BtfError> {
 impl BtfType {
     #[allow(unused_unsafe)]
     pub(crate) unsafe fn read(data: &[u8], endianness: Endianness) -> Result<BtfType, BtfError> {
-        let ty = unsafe { read::<btf_type>(data)? };
-        let data = &data[mem::size_of::<btf_type>()..];
-
-        let vlen = type_vlen(&ty) as usize;
-        use BtfType::*;
-        Ok(match type_kind(&ty)? {
-            BtfKind::Unknown => Unknown,
-            BtfKind::Fwd => Fwd(ty),
-            BtfKind::Const => Const(ty),
-            BtfKind::Volatile => Volatile(ty),
-            BtfKind::Restrict => Restrict(ty),
-            BtfKind::Ptr => Ptr(ty),
-            BtfKind::Typedef => Typedef(ty),
-            BtfKind::Func => Func(ty),
+        let ty = unsafe { read_array::<u32>(data, 3)? };
+        let data = &data[mem::size_of::<u32>() * 3..];
+        let vlen = type_vlen(ty[1]) as usize;
+        Ok(match type_kind(ty[1])? {
+            BtfKind::Unknown => BtfType::Unknown,
+            BtfKind::Fwd => BtfType::Fwd(Fwd {
+                name_offset: ty[0],
+                info: ty[1],
+                _unused: 0,
+            }),
+            BtfKind::Const => BtfType::Const(Const {
+                name_offset: ty[0],
+                info: ty[1],
+                btf_type: ty[2],
+            }),
+            BtfKind::Volatile => BtfType::Volatile(Volatile {
+                name_offset: ty[0],
+                info: ty[1],
+                btf_type: ty[2],
+            }),
+            BtfKind::Restrict => BtfType::Restrict(Restrict {
+                name_offset: ty[0],
+                _info: ty[1],
+                btf_type: ty[2],
+            }),
+            BtfKind::Ptr => BtfType::Ptr(Ptr {
+                name_offset: ty[0],
+                info: ty[1],
+                btf_type: ty[2],
+            }),
+            BtfKind::Typedef => BtfType::Typedef(Typedef {
+                name_offset: ty[0],
+                info: ty[1],
+                btf_type: ty[2],
+            }),
+            BtfKind::Func => BtfType::Func(Func {
+                name_offset: ty[0],
+                info: ty[1],
+                btf_type: ty[2],
+            }),
             BtfKind::Int => {
                 if mem::size_of::<u32>() > data.len() {
                     return Err(BtfError::InvalidTypeInfo);
@@ -169,324 +954,233 @@ impl BtfType {
                 } else {
                     u32::from_be_bytes
                 };
-                Int(
-                    ty,
-                    read_u32(data[..mem::size_of::<u32>()].try_into().unwrap()),
-                )
+                BtfType::Int(Int {
+                    name_offset: ty[0],
+                    info: ty[1],
+                    size: ty[2],
+                    data: read_u32(data[..mem::size_of::<u32>()].try_into().unwrap()),
+                })
             }
-            BtfKind::Float => Float(ty),
-            BtfKind::Enum => Enum(ty, unsafe { read_array(data, vlen)? }),
-            BtfKind::Array => Array(ty, unsafe { read(data)? }),
-            BtfKind::Struct => Struct(ty, unsafe { read_array(data, vlen)? }),
-            BtfKind::Union => Union(ty, unsafe { read_array(data, vlen)? }),
-            BtfKind::FuncProto => FuncProto(ty, unsafe { read_array(data, vlen)? }),
-            BtfKind::Var => Var(ty, unsafe { read(data)? }),
-            BtfKind::DataSec => DataSec(ty, unsafe { read_array(data, vlen)? }),
-            BtfKind::DeclTag => DeclTag(ty, unsafe { read(data)? }),
-            BtfKind::TypeTag => TypeTag(ty),
+            BtfKind::Float => BtfType::Float(Float {
+                name_offset: ty[0],
+                info: ty[1],
+                size: ty[2],
+            }),
+            BtfKind::Enum => BtfType::Enum(Enum {
+                name_offset: ty[0],
+                info: ty[1],
+                size: ty[2],
+                variants: unsafe { read_array::<BtfEnum>(data, vlen)? },
+            }),
+            BtfKind::Array => BtfType::Array(Array {
+                name_offset: ty[0],
+                info: ty[1],
+                _unused: 0,
+                array: unsafe { read(data)? },
+            }),
+            BtfKind::Struct => BtfType::Struct(Struct {
+                name_offset: ty[0],
+                info: ty[1],
+                size: ty[2],
+                members: unsafe { read_array::<BtfMember>(data, vlen)? },
+            }),
+            BtfKind::Union => BtfType::Union(Union {
+                name_offset: ty[0],
+                info: ty[1],
+                size: ty[2],
+                members: unsafe { read_array::<BtfMember>(data, vlen)? },
+            }),
+            BtfKind::FuncProto => BtfType::FuncProto(FuncProto {
+                name_offset: ty[0],
+                info: ty[1],
+                return_type: ty[2],
+                params: unsafe { read_array::<BtfParam>(data, vlen)? },
+            }),
+            BtfKind::Var => BtfType::Var(Var {
+                name_offset: ty[0],
+                info: ty[1],
+                btf_type: ty[2],
+                linkage: unsafe { read(data)? },
+            }),
+            BtfKind::DataSec => BtfType::DataSec(DataSec {
+                name_offset: ty[0],
+                info: ty[1],
+                size: ty[2],
+                entries: unsafe { read_array::<DataSecEntry>(data, vlen)? },
+            }),
+            BtfKind::DeclTag => BtfType::DeclTag(DeclTag {
+                name_offset: ty[0],
+                info: ty[1],
+                btf_type: ty[2],
+                component_index: unsafe { read(data)? },
+            }),
+            BtfKind::TypeTag => BtfType::TypeTag(TypeTag {
+                name_offset: ty[0],
+                info: ty[1],
+                btf_type: ty[2],
+            }),
         })
     }
 
     pub(crate) fn to_bytes(&self) -> Vec<u8> {
-        fn bytes_of<T>(val: &T) -> &[u8] {
-            // Safety: all btf types are POD
-            unsafe { crate::util::bytes_of(val) }
-        }
         match self {
-            BtfType::Fwd(btf_type)
-            | BtfType::Const(btf_type)
-            | BtfType::Volatile(btf_type)
-            | BtfType::Restrict(btf_type)
-            | BtfType::Ptr(btf_type)
-            | BtfType::Typedef(btf_type)
-            | BtfType::Func(btf_type)
-            | BtfType::Float(btf_type)
-            | BtfType::TypeTag(btf_type) => bytes_of::<btf_type>(btf_type).to_vec(),
-            BtfType::Int(btf_type, len) => {
-                let mut buf = bytes_of::<btf_type>(btf_type).to_vec();
-                buf.append(&mut len.to_ne_bytes().to_vec());
-                buf
-            }
-            BtfType::Enum(btf_type, enums) => {
-                let mut buf = bytes_of::<btf_type>(btf_type).to_vec();
-                for en in enums {
-                    buf.append(&mut bytes_of::<btf_enum>(en).to_vec());
-                }
-                buf
-            }
-            BtfType::Array(btf_type, btf_array) => {
-                let mut buf = bytes_of::<btf_type>(btf_type).to_vec();
-                buf.append(&mut bytes_of::<btf_array>(btf_array).to_vec());
-                buf
-            }
-            BtfType::Struct(btf_type, btf_members) | BtfType::Union(btf_type, btf_members) => {
-                let mut buf = bytes_of::<btf_type>(btf_type).to_vec();
-                for m in btf_members {
-                    buf.append(&mut bytes_of::<btf_member>(m).to_vec());
-                }
-                buf
-            }
-            BtfType::FuncProto(btf_type, btf_params) => {
-                let mut buf = bytes_of::<btf_type>(btf_type).to_vec();
-                for p in btf_params {
-                    buf.append(&mut bytes_of::<btf_param>(p).to_vec());
-                }
-                buf
-            }
-            BtfType::Var(btf_type, btf_var) => {
-                let mut buf = bytes_of::<btf_type>(btf_type).to_vec();
-                buf.append(&mut bytes_of::<btf_var>(btf_var).to_vec());
-                buf
-            }
-            BtfType::DataSec(btf_type, btf_var_secinfo) => {
-                let mut buf = bytes_of::<btf_type>(btf_type).to_vec();
-                for s in btf_var_secinfo {
-                    buf.append(&mut bytes_of::<btf_var_secinfo>(s).to_vec());
-                }
-                buf
-            }
             BtfType::Unknown => vec![],
-            BtfType::DeclTag(btf_type, btf_decl_tag) => {
-                let mut buf = bytes_of::<btf_type>(btf_type).to_vec();
-                buf.append(&mut bytes_of::<btf_decl_tag>(btf_decl_tag).to_vec());
-                buf
-            }
+            BtfType::Fwd(t) => t.to_bytes(),
+            BtfType::Const(t) => t.to_bytes(),
+            BtfType::Volatile(t) => t.to_bytes(),
+            BtfType::Restrict(t) => t.to_bytes(),
+            BtfType::Ptr(t) => t.to_bytes(),
+            BtfType::Typedef(t) => t.to_bytes(),
+            BtfType::Func(t) => t.to_bytes(),
+            BtfType::Int(t) => t.to_bytes(),
+            BtfType::Float(t) => t.to_bytes(),
+            BtfType::Enum(t) => t.to_bytes(),
+            BtfType::Array(t) => t.to_bytes(),
+            BtfType::Struct(t) => t.to_bytes(),
+            BtfType::Union(t) => t.to_bytes(),
+            BtfType::FuncProto(t) => t.to_bytes(),
+            BtfType::Var(t) => t.to_bytes(),
+            BtfType::DataSec(t) => t.to_bytes(),
+            BtfType::DeclTag(t) => t.to_bytes(),
+            BtfType::TypeTag(t) => t.to_bytes(),
+        }
+    }
+
+    pub(crate) fn size(&self) -> Option<u32> {
+        match self {
+            BtfType::Int(t) => Some(t.size),
+            BtfType::Float(t) => Some(t.size),
+            BtfType::Enum(t) => Some(t.size),
+            BtfType::Struct(t) => Some(t.size),
+            BtfType::Union(t) => Some(t.size),
+            BtfType::DataSec(t) => Some(t.size),
+            _ => None,
+        }
+    }
+
+    pub(crate) fn btf_type(&self) -> Option<u32> {
+        match self {
+            BtfType::Const(t) => Some(t.btf_type),
+            BtfType::Volatile(t) => Some(t.btf_type),
+            BtfType::Restrict(t) => Some(t.btf_type),
+            BtfType::Ptr(t) => Some(t.btf_type),
+            BtfType::Typedef(t) => Some(t.btf_type),
+            // FuncProto contains the return type here, and doesn't directly reference another type
+            BtfType::FuncProto(t) => Some(t.return_type),
+            BtfType::Var(t) => Some(t.btf_type),
+            BtfType::DeclTag(t) => Some(t.btf_type),
+            BtfType::TypeTag(t) => Some(t.btf_type),
+            _ => None,
         }
     }
 
     pub(crate) fn type_info_size(&self) -> usize {
-        let ty_size = mem::size_of::<btf_type>();
-
-        use BtfType::*;
         match self {
-            Unknown => ty_size,
-            Fwd(_) | Const(_) | Volatile(_) | Restrict(_) | Ptr(_) | Typedef(_) | Func(_)
-            | Float(_) | TypeTag(_) => ty_size,
-            Int(_, _) => ty_size + mem::size_of::<u32>(),
-            Enum(ty, _) => ty_size + type_vlen(ty) * mem::size_of::<btf_enum>(),
-            Array(_, _) => ty_size + mem::size_of::<btf_array>(),
-            Struct(ty, _) => ty_size + type_vlen(ty) * mem::size_of::<btf_member>(),
-            Union(ty, _) => ty_size + type_vlen(ty) * mem::size_of::<btf_member>(),
-            FuncProto(ty, _) => ty_size + type_vlen(ty) * mem::size_of::<btf_param>(),
-            Var(_, _) => ty_size + mem::size_of::<btf_var>(),
-            DataSec(ty, _) => ty_size + type_vlen(ty) * mem::size_of::<btf_var_secinfo>(),
-            DeclTag(_, _) => ty_size + mem::size_of::<btf_decl_tag>(),
+            BtfType::Unknown => mem::size_of::<Fwd>(),
+            BtfType::Fwd(t) => t.type_info_size(),
+            BtfType::Const(t) => t.type_info_size(),
+            BtfType::Volatile(t) => t.type_info_size(),
+            BtfType::Restrict(t) => t.type_info_size(),
+            BtfType::Ptr(t) => t.type_info_size(),
+            BtfType::Typedef(t) => t.type_info_size(),
+            BtfType::Func(t) => t.type_info_size(),
+            BtfType::Int(t) => t.type_info_size(),
+            BtfType::Float(t) => t.type_info_size(),
+            BtfType::Enum(t) => t.type_info_size(),
+            BtfType::Array(t) => t.type_info_size(),
+            BtfType::Struct(t) => t.type_info_size(),
+            BtfType::Union(t) => t.type_info_size(),
+            BtfType::FuncProto(t) => t.type_info_size(),
+            BtfType::Var(t) => t.type_info_size(),
+            BtfType::DataSec(t) => t.type_info_size(),
+            BtfType::DeclTag(t) => t.type_info_size(),
+            BtfType::TypeTag(t) => t.type_info_size(),
         }
     }
 
-    pub(crate) fn btf_type(&self) -> Option<&btf_type> {
-        use BtfType::*;
-        Some(match self {
-            Unknown => return None,
-            Fwd(ty) => ty,
-            Const(ty) => ty,
-            Volatile(ty) => ty,
-            Restrict(ty) => ty,
-            Ptr(ty) => ty,
-            Typedef(ty) => ty,
-            Func(ty) => ty,
-            Int(ty, _) => ty,
-            Float(ty) => ty,
-            Enum(ty, _) => ty,
-            Array(ty, _) => ty,
-            Struct(ty, _) => ty,
-            Union(ty, _) => ty,
-            FuncProto(ty, _) => ty,
-            Var(ty, _) => ty,
-            DataSec(ty, _) => ty,
-            DeclTag(ty, _) => ty,
-            TypeTag(ty) => ty,
-        })
+    pub(crate) fn name_offset(&self) -> u32 {
+        match self {
+            BtfType::Unknown => 0,
+            BtfType::Fwd(t) => t.name_offset,
+            BtfType::Const(t) => t.name_offset,
+            BtfType::Volatile(t) => t.name_offset,
+            BtfType::Restrict(t) => t.name_offset,
+            BtfType::Ptr(t) => t.name_offset,
+            BtfType::Typedef(t) => t.name_offset,
+            BtfType::Func(t) => t.name_offset,
+            BtfType::Int(t) => t.name_offset,
+            BtfType::Float(t) => t.name_offset,
+            BtfType::Enum(t) => t.name_offset,
+            BtfType::Array(t) => t.name_offset,
+            BtfType::Struct(t) => t.name_offset,
+            BtfType::Union(t) => t.name_offset,
+            BtfType::FuncProto(t) => t.name_offset,
+            BtfType::Var(t) => t.name_offset,
+            BtfType::DataSec(t) => t.name_offset,
+            BtfType::DeclTag(t) => t.name_offset,
+            BtfType::TypeTag(t) => t.name_offset,
+        }
     }
 
-    pub(crate) fn info(&self) -> Option<u32> {
-        self.btf_type().map(|ty| ty.info)
-    }
-
-    pub(crate) fn name_offset(&self) -> Option<u32> {
-        self.btf_type().map(|ty| ty.name_off)
-    }
-
-    pub(crate) fn kind(&self) -> Result<Option<BtfKind>, BtfError> {
-        self.btf_type().map(type_kind).transpose()
+    pub(crate) fn kind(&self) -> BtfKind {
+        match self {
+            BtfType::Unknown => BtfKind::Unknown,
+            BtfType::Fwd(t) => t.kind(),
+            BtfType::Const(t) => t.kind(),
+            BtfType::Volatile(t) => t.kind(),
+            BtfType::Restrict(t) => t.kind(),
+            BtfType::Ptr(t) => t.kind(),
+            BtfType::Typedef(t) => t.kind(),
+            BtfType::Func(t) => t.kind(),
+            BtfType::Int(t) => t.kind(),
+            BtfType::Float(t) => t.kind(),
+            BtfType::Enum(t) => t.kind(),
+            BtfType::Array(t) => t.kind(),
+            BtfType::Struct(t) => t.kind(),
+            BtfType::Union(t) => t.kind(),
+            BtfType::FuncProto(t) => t.kind(),
+            BtfType::Var(t) => t.kind(),
+            BtfType::DataSec(t) => t.kind(),
+            BtfType::DeclTag(t) => t.kind(),
+            BtfType::TypeTag(t) => t.kind(),
+        }
     }
 
     pub(crate) fn is_composite(&self) -> bool {
-        matches!(self, BtfType::Struct(_, _) | BtfType::Union(_, _))
+        matches!(self, BtfType::Struct(_) | BtfType::Union(_))
     }
 
-    pub(crate) fn new_int(name_off: u32, size: u32, encoding: u32, offset: u32) -> BtfType {
-        let info = (BTF_KIND_INT) << 24;
-        let mut btf_type = unsafe { std::mem::zeroed::<btf_type>() };
-        btf_type.name_off = name_off;
-        btf_type.info = info;
-        btf_type.__bindgen_anon_1.size = size;
-
-        let mut data = 0u32;
-        data |= (encoding & 0x0f) << 24;
-        data |= (offset & 0xff) << 16;
-        data |= (size * 8) & 0xff;
-        BtfType::Int(btf_type, data)
+    pub(crate) fn members(&self) -> Option<impl Iterator<Item = &BtfMember>> {
+        match self {
+            BtfType::Struct(t) => Some(t.members.iter()),
+            BtfType::Union(t) => Some(t.members.iter()),
+            _ => None,
+        }
     }
 
-    pub(crate) fn new_func(name_off: u32, proto: u32, linkage: btf_func_linkage) -> BtfType {
-        let mut info = (BTF_KIND_FUNC) << 24;
-        info |= (linkage as u32) & 0xFFFF;
-        let mut btf_type = unsafe { std::mem::zeroed::<btf_type>() };
-        btf_type.name_off = name_off;
-        btf_type.info = info;
-        btf_type.__bindgen_anon_1.type_ = proto;
-        BtfType::Func(btf_type)
+    pub(crate) fn member_bit_field_size(&self, member: &BtfMember) -> Option<usize> {
+        match self {
+            BtfType::Struct(t) => Some(t.member_bit_field_size(member)),
+            BtfType::Union(t) => Some(t.member_bit_field_size(member)),
+            _ => None,
+        }
     }
 
-    pub(crate) fn new_func_proto(params: Vec<btf_param>, return_type: u32) -> BtfType {
-        let mut info = (BTF_KIND_FUNC_PROTO) << 24;
-        info |= (params.len() as u32) & 0xFFFF;
-        let mut btf_type = unsafe { std::mem::zeroed::<btf_type>() };
-        btf_type.name_off = 0;
-        btf_type.info = info;
-        btf_type.__bindgen_anon_1.type_ = return_type;
-        BtfType::FuncProto(btf_type, params)
-    }
-
-    pub(crate) fn new_var(name_off: u32, type_: u32, linkage: u32) -> BtfType {
-        let info = (BTF_KIND_VAR) << 24;
-        let mut btf_type = unsafe { std::mem::zeroed::<btf_type>() };
-        btf_type.name_off = name_off;
-        btf_type.info = info;
-        btf_type.__bindgen_anon_1.type_ = type_;
-        let var = btf_var { linkage };
-        BtfType::Var(btf_type, var)
-    }
-
-    pub(crate) fn new_datasec(
-        name_off: u32,
-        variables: Vec<btf_var_secinfo>,
-        size: u32,
-    ) -> BtfType {
-        let mut info = (BTF_KIND_DATASEC) << 24;
-        info |= (variables.len() as u32) & 0xFFFF;
-        let mut btf_type = unsafe { std::mem::zeroed::<btf_type>() };
-        btf_type.name_off = name_off;
-        btf_type.info = info;
-        btf_type.__bindgen_anon_1.size = size;
-        BtfType::DataSec(btf_type, variables)
-    }
-
-    pub(crate) fn new_float(name_off: u32, size: u32) -> BtfType {
-        let info = (BTF_KIND_FLOAT) << 24;
-        let mut btf_type = unsafe { std::mem::zeroed::<btf_type>() };
-        btf_type.name_off = name_off;
-        btf_type.info = info;
-        btf_type.__bindgen_anon_1.size = size;
-        BtfType::Float(btf_type)
-    }
-
-    pub(crate) fn new_struct(name_off: u32, members: Vec<btf_member>, size: u32) -> BtfType {
-        let mut info = (BTF_KIND_STRUCT) << 24;
-        info |= (members.len() as u32) & 0xFFFF;
-        let mut btf_type = unsafe { std::mem::zeroed::<btf_type>() };
-        btf_type.name_off = name_off;
-        btf_type.info = info;
-        btf_type.__bindgen_anon_1.size = size;
-        BtfType::Struct(btf_type, members)
-    }
-
-    pub(crate) fn new_enum(name_off: u32, members: Vec<btf_enum>) -> BtfType {
-        let mut info = (BTF_KIND_ENUM) << 24;
-        info |= (members.len() as u32) & 0xFFFF;
-        let mut btf_type = unsafe { std::mem::zeroed::<btf_type>() };
-        btf_type.name_off = name_off;
-        btf_type.info = info;
-        btf_type.__bindgen_anon_1.size = 4;
-        BtfType::Enum(btf_type, members)
-    }
-
-    pub(crate) fn new_typedef(name_off: u32, type_: u32) -> BtfType {
-        let info = (BTF_KIND_TYPEDEF) << 24;
-        let mut btf_type = unsafe { std::mem::zeroed::<btf_type>() };
-        btf_type.name_off = name_off;
-        btf_type.info = info;
-        btf_type.__bindgen_anon_1.type_ = type_;
-        BtfType::Typedef(btf_type)
-    }
-
-    #[cfg(test)]
-    pub(crate) fn new_array(name_off: u32, type_: u32, index_type: u32, nelems: u32) -> BtfType {
-        let info = (BTF_KIND_ARRAY) << 24;
-        let mut btf_type = unsafe { std::mem::zeroed::<btf_type>() };
-        btf_type.name_off = name_off;
-        btf_type.info = info;
-        let btf_array = btf_array {
-            type_,
-            index_type,
-            nelems,
-        };
-        BtfType::Array(btf_type, btf_array)
-    }
-
-    pub(crate) fn new_decl_tag(name_off: u32, type_: u32, component_idx: i32) -> BtfType {
-        let info = (BTF_KIND_DECL_TAG) << 24;
-        let mut btf_type = unsafe { std::mem::zeroed::<btf_type>() };
-        btf_type.name_off = name_off;
-        btf_type.info = info;
-        btf_type.__bindgen_anon_1.type_ = type_;
-        let btf_decl_tag = btf_decl_tag { component_idx };
-        BtfType::DeclTag(btf_type, btf_decl_tag)
-    }
-
-    pub(crate) fn new_type_tag(name_off: u32, type_: u32) -> BtfType {
-        let info = (BTF_KIND_TYPE_TAG) << 24;
-        let mut btf_type = unsafe { std::mem::zeroed::<btf_type>() };
-        btf_type.name_off = name_off;
-        btf_type.info = info;
-        btf_type.__bindgen_anon_1.type_ = type_;
-        BtfType::TypeTag(btf_type)
-    }
-
-    pub(crate) fn new_ptr(name_off: u32, type_: u32) -> BtfType {
-        let info = (BTF_KIND_PTR) << 24;
-        let mut btf_type = unsafe { std::mem::zeroed::<btf_type>() };
-        btf_type.name_off = name_off;
-        btf_type.info = info;
-        btf_type.__bindgen_anon_1.type_ = type_;
-        BtfType::Ptr(btf_type)
-    }
-
-    pub(crate) fn new_const(type_: u32) -> BtfType {
-        let info = (BTF_KIND_CONST) << 24;
-        let mut btf_type = unsafe { std::mem::zeroed::<btf_type>() };
-        btf_type.name_off = 0;
-        btf_type.info = info;
-        btf_type.__bindgen_anon_1.type_ = type_;
-        BtfType::Const(btf_type)
+    pub(crate) fn member_bit_offset(&self, member: &BtfMember) -> Option<usize> {
+        match self {
+            BtfType::Struct(t) => Some(t.member_bit_offset(member)),
+            BtfType::Union(t) => Some(t.member_bit_offset(member)),
+            _ => None,
+        }
     }
 }
 
-fn type_kind(ty: &btf_type) -> Result<BtfKind, BtfError> {
-    ((ty.info >> 24) & 0x1F).try_into()
+fn type_kind(info: u32) -> Result<BtfKind, BtfError> {
+    ((info >> 24) & 0x1F).try_into()
 }
 
-pub(crate) fn type_vlen(ty: &btf_type) -> usize {
-    (ty.info & 0xFFFF) as usize
-}
-
-pub(crate) fn member_bit_offset(info: u32, member: &btf_member) -> usize {
-    let k_flag = info >> 31 == 1;
-    let bit_offset = if k_flag {
-        member.offset & 0xFFFFFF
-    } else {
-        member.offset
-    };
-
-    bit_offset as usize
-}
-
-pub(crate) fn member_bit_field_size(ty: &btf_type, member: &btf_member) -> usize {
-    let k_flag = (ty.info >> 31) == 1;
-    let size = if k_flag { member.offset >> 24 } else { 0 };
-
-    size as usize
+fn type_vlen(info: u32) -> usize {
+    (info & 0xFFFF) as usize
 }
 
 pub(crate) fn types_are_compatible(
@@ -500,7 +1194,7 @@ pub(crate) fn types_are_compatible(
     let local_ty = local_btf.type_by_id(local_id)?;
     let target_ty = target_btf.type_by_id(target_id)?;
 
-    if local_ty.kind()? != target_ty.kind()? {
+    if local_ty.kind() != target_ty.kind() {
         return Ok(false);
     }
 
@@ -510,58 +1204,52 @@ pub(crate) fn types_are_compatible(
         let local_ty = local_btf.type_by_id(local_id)?;
         let target_ty = target_btf.type_by_id(target_id)?;
 
-        if local_ty.kind()? != target_ty.kind()? {
+        if local_ty.kind() != target_ty.kind() {
             return Ok(false);
         }
 
-        use BtfType::*;
         match local_ty {
-            Unknown | Struct(_, _) | Union(_, _) | Enum(_, _) | Fwd(_) | Float(_) => {
-                return Ok(true)
-            }
-            Int(_, local_off) => {
-                let local_off = (local_off >> 16) & 0xFF;
-                if let Int(_, target_off) = target_ty {
-                    let target_off = (target_off >> 16) & 0xFF;
-                    return Ok(local_off == 0 && target_off == 0);
+            BtfType::Unknown
+            | BtfType::Struct(_)
+            | BtfType::Union(_)
+            | BtfType::Enum(_)
+            | BtfType::Fwd(_)
+            | BtfType::Float(_) => return Ok(true),
+            BtfType::Int(local) => {
+                if let BtfType::Int(target) = target_ty {
+                    return Ok(local.offset() == 0 && target.offset() == 0);
                 }
             }
-            Ptr(l_ty) => {
-                if let Ptr(t_ty) = target_ty {
-                    // Safety: union
-                    unsafe {
-                        local_id = l_ty.__bindgen_anon_1.type_;
-                        target_id = t_ty.__bindgen_anon_1.type_;
-                    }
+            BtfType::Ptr(local) => {
+                if let BtfType::Ptr(target) = target_ty {
+                    local_id = local.btf_type;
+                    target_id = target.btf_type;
                     continue;
                 }
             }
-            Array(_, l_ty) => {
-                if let Array(_, t_ty) = target_ty {
-                    local_id = l_ty.type_;
-                    target_id = t_ty.type_;
+            BtfType::Array(Array { array: local, .. }) => {
+                if let BtfType::Array(Array { array: target, .. }) = target_ty {
+                    local_id = local.element_type;
+                    target_id = target.element_type;
                     continue;
                 }
             }
-            FuncProto(l_ty, l_params) => {
-                if let FuncProto(t_ty, t_params) = target_ty {
-                    if l_params.len() != t_params.len() {
+            BtfType::FuncProto(local) => {
+                if let BtfType::FuncProto(target) = target_ty {
+                    if local.params.len() != target.params.len() {
                         return Ok(false);
                     }
 
-                    for (l_param, t_param) in l_params.iter().zip(t_params.iter()) {
-                        let local_id = local_btf.resolve_type(l_param.type_)?;
-                        let target_id = target_btf.resolve_type(t_param.type_)?;
+                    for (l_param, t_param) in local.params.iter().zip(target.params.iter()) {
+                        let local_id = local_btf.resolve_type(l_param.btf_type)?;
+                        let target_id = target_btf.resolve_type(t_param.btf_type)?;
                         if !types_are_compatible(local_btf, local_id, target_btf, target_id)? {
                             return Ok(false);
                         }
                     }
 
-                    // Safety: union
-                    unsafe {
-                        local_id = l_ty.__bindgen_anon_1.type_;
-                        target_id = t_ty.__bindgen_anon_1.type_;
-                    }
+                    local_id = local.return_type;
+                    target_id = target.return_type;
                     continue;
                 }
             }
@@ -588,35 +1276,31 @@ pub(crate) fn fields_are_compatible(
             return Ok(true);
         }
 
-        if local_ty.kind()? != target_ty.kind()? {
+        if local_ty.kind() != target_ty.kind() {
             return Ok(false);
         }
 
-        use BtfType::*;
         match local_ty {
-            Fwd(_) | Enum(_, _) => {
+            BtfType::Fwd(_) | BtfType::Enum(_) => {
                 let flavorless_name =
                     |name: &str| name.split_once("___").map_or(name, |x| x.0).to_string();
 
-                let local_name = flavorless_name(&local_btf.type_name(local_ty)?.unwrap());
-                let target_name = flavorless_name(&target_btf.type_name(target_ty)?.unwrap());
+                let local_name = flavorless_name(&local_btf.type_name(local_ty)?);
+                let target_name = flavorless_name(&target_btf.type_name(target_ty)?);
 
                 return Ok(local_name == target_name);
             }
-            Int(_, local_off) => {
-                let local_off = (local_off >> 16) & 0xFF;
-                if let Int(_, target_off) = target_ty {
-                    let target_off = (target_off >> 16) & 0xFF;
-                    return Ok(local_off == 0 && target_off == 0);
+            BtfType::Int(local) => {
+                if let BtfType::Int(target) = target_ty {
+                    return Ok(local.offset() == 0 && target.offset() == 0);
                 }
             }
-            Float(_) => return Ok(true),
-            Ptr(_) => return Ok(true),
-            Array(_, l_ty) => {
-                if let Array(_, t_ty) = target_ty {
-                    local_id = l_ty.type_;
-                    target_id = t_ty.type_;
-
+            BtfType::Float(_) => return Ok(true),
+            BtfType::Ptr(_) => return Ok(true),
+            BtfType::Array(Array { array: local, .. }) => {
+                if let BtfType::Array(Array { array: target, .. }) = target_ty {
+                    local_id = local.element_type;
+                    target_id = target.element_type;
                     continue;
                 }
             }
@@ -627,30 +1311,12 @@ pub(crate) fn fields_are_compatible(
     Err(BtfError::MaximumTypeDepthReached { type_id: local_id })
 }
 
-impl std::fmt::Debug for btf_type {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("btf_type")
-            .field("name_off", &self.name_off)
-            .field("info", &self.info)
-            .field("__bindgen_anon_1", &self.__bindgen_anon_1)
-            .finish()
-    }
+fn bytes_of<T>(val: &T) -> &[u8] {
+    // Safety: all btf types are POD
+    unsafe { crate::util::bytes_of(val) }
 }
-
-impl std::fmt::Debug for btf_type__bindgen_ty_1 {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        // Safety: union
-        f.debug_struct("btf_type__bindgen_ty_1")
-            .field("size", unsafe { &self.size })
-            .field("type_", unsafe { &self.type_ })
-            .finish()
-    }
-}
-
 #[cfg(test)]
 mod tests {
-    use crate::generated::BTF_INT_SIGNED;
-
     use super::*;
 
     #[test]
@@ -662,16 +1328,16 @@ mod tests {
         ];
         let got = unsafe { BtfType::read(data, endianness) };
         match got {
-            Ok(BtfType::Int(ty, nr_bits)) => {
-                assert_eq!(ty.name_off, 1);
-                assert_eq!(unsafe { ty.__bindgen_anon_1.size }, 8);
-                assert_eq!(nr_bits, 64);
+            Ok(BtfType::Int(new)) => {
+                assert_eq!(new.name_offset, 1);
+                assert_eq!(new.size, 8);
+                assert_eq!(new.bits(), 64);
+                let data2 = new.to_bytes();
+                assert_eq!(data, data2);
             }
             Ok(t) => panic!("expected int type, got {:#?}", t),
             Err(_) => panic!("unexpected error"),
         }
-        let data2 = got.unwrap().to_bytes();
-        assert_eq!(data, data2.as_slice());
     }
 
     #[test]
@@ -680,7 +1346,7 @@ mod tests {
             0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x08, 0x00, 0x00, 0x00, 0x40, 0x00,
             0x00, 0x00,
         ];
-        let int = BtfType::new_int(1, 8, 0, 0);
+        let int = Int::new(1, 8, IntEncoding::None, 0);
         assert_eq!(int.to_bytes(), data);
     }
 
@@ -690,7 +1356,7 @@ mod tests {
             0x13, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x01, 0x00, 0x00, 0x00, 0x08, 0x00,
             0x00, 0x00,
         ];
-        let int = BtfType::new_int(0x13, 1, 0, 0);
+        let int = Int::new(0x13, 1, IntEncoding::None, 0);
         assert_eq!(int.to_bytes(), data);
     }
 
@@ -700,7 +1366,7 @@ mod tests {
             0x4a, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x02, 0x00, 0x00, 0x00, 0x10, 0x00,
             0x00, 0x01,
         ];
-        let int = BtfType::new_int(0x4a, 2, BTF_INT_SIGNED, 0);
+        let int = Int::new(0x4a, 2, IntEncoding::Signed, 0);
         assert_eq!(int.to_bytes(), data);
     }
 
@@ -717,7 +1383,7 @@ mod tests {
             Err(_) => panic!("unexpected error"),
         }
         let data2 = got.unwrap().to_bytes();
-        assert_eq!(data, data2.as_slice())
+        assert_eq!(data, data2)
     }
 
     #[test]
@@ -729,12 +1395,12 @@ mod tests {
         ];
         let got = unsafe { BtfType::read(data, endianness) };
         match got {
-            Ok(BtfType::Array(_, _)) => {}
+            Ok(BtfType::Array(_)) => {}
             Ok(t) => panic!("expected array type, got {:#?}", t),
             Err(_) => panic!("unexpected error"),
         }
         let data2 = got.unwrap().to_bytes();
-        assert_eq!(data, data2.as_slice())
+        assert_eq!(data, data2)
     }
 
     #[test]
@@ -746,12 +1412,12 @@ mod tests {
         ];
         let got = unsafe { BtfType::read(data, endianness) };
         match got {
-            Ok(BtfType::Struct(_, _)) => {}
+            Ok(BtfType::Struct(_)) => {}
             Ok(t) => panic!("expected struct type, got {:#?}", t),
             Err(_) => panic!("unexpected error"),
         }
         let data2 = got.unwrap().to_bytes();
-        assert_eq!(data, data2.as_slice())
+        assert_eq!(data, data2)
     }
 
     #[test]
@@ -763,12 +1429,12 @@ mod tests {
         ];
         let got = unsafe { BtfType::read(data, endianness) };
         match got {
-            Ok(BtfType::Union(_, _)) => {}
+            Ok(BtfType::Union(_)) => {}
             Ok(t) => panic!("expected union type, got {:#?}", t),
             Err(_) => panic!("unexpected error"),
         }
         let data2 = got.unwrap().to_bytes();
-        assert_eq!(data, data2.as_slice())
+        assert_eq!(data, data2)
     }
 
     #[test]
@@ -780,12 +1446,12 @@ mod tests {
         ];
         let got = unsafe { BtfType::read(data, endianness) };
         match got {
-            Ok(BtfType::Enum(_, _)) => {}
+            Ok(BtfType::Enum(_)) => {}
             Ok(t) => panic!("expected enum type, got {:#?}", t),
             Err(_) => panic!("unexpected error"),
         }
         let data2 = got.unwrap().to_bytes();
-        assert_eq!(data, data2.as_slice())
+        assert_eq!(data, data2)
     }
 
     #[test]
@@ -801,7 +1467,7 @@ mod tests {
             Err(_) => panic!("unexpected error"),
         }
         let data2 = got.unwrap().to_bytes();
-        assert_eq!(data, data2.as_slice())
+        assert_eq!(data, data2)
     }
 
     #[test]
@@ -817,7 +1483,7 @@ mod tests {
             Err(_) => panic!("unexpected error"),
         }
         let data2 = got.unwrap().to_bytes();
-        assert_eq!(data, data2.as_slice())
+        assert_eq!(data, data2)
     }
 
     #[test]
@@ -833,7 +1499,7 @@ mod tests {
             Err(_) => panic!("unexpected error"),
         }
         let data2 = got.unwrap().to_bytes();
-        assert_eq!(data, data2.as_slice())
+        assert_eq!(data, data2)
     }
 
     #[test]
@@ -849,7 +1515,7 @@ mod tests {
             Err(_) => panic!("unexpected error"),
         }
         let data2 = got.unwrap().to_bytes();
-        assert_eq!(data, data2.as_slice())
+        assert_eq!(data, data2)
     }
 
     #[test]
@@ -865,7 +1531,7 @@ mod tests {
             Err(_) => panic!("unexpected error"),
         }
         let data2 = got.unwrap().to_bytes();
-        assert_eq!(data, data2.as_slice())
+        assert_eq!(data, data2)
     }
 
     #[test]
@@ -881,7 +1547,7 @@ mod tests {
             Err(_) => panic!("unexpected error"),
         }
         let data2 = got.unwrap().to_bytes();
-        assert_eq!(data, data2.as_slice())
+        assert_eq!(data, data2)
     }
 
     #[test]
@@ -893,12 +1559,12 @@ mod tests {
         ];
         let got = unsafe { BtfType::read(data, endianness) };
         match got {
-            Ok(BtfType::FuncProto(_, _)) => {}
+            Ok(BtfType::FuncProto(_)) => {}
             Ok(t) => panic!("expected func_proto type, got {:#?}", t),
             Err(_) => panic!("unexpected error"),
         }
         let data2 = got.unwrap().to_bytes();
-        assert_eq!(data, data2.as_slice())
+        assert_eq!(data, data2)
     }
 
     #[test]
@@ -911,12 +1577,12 @@ mod tests {
         ];
         let got = unsafe { BtfType::read(data, endianness) };
         match got {
-            Ok(BtfType::Var(_, _)) => {}
+            Ok(BtfType::Var(_)) => {}
             Ok(t) => panic!("expected var type, got {:#?}", t),
             Err(_) => panic!("unexpected error"),
         };
         let data2 = got.unwrap().to_bytes();
-        assert_eq!(data, data2.as_slice())
+        assert_eq!(data, data2)
     }
 
     #[test]
@@ -928,19 +1594,17 @@ mod tests {
         ];
         let got = unsafe { BtfType::read(data, endianness) };
         match &got {
-            Ok(BtfType::DataSec(ty, info)) => {
-                assert_eq!(0, unsafe { ty.__bindgen_anon_1.size } as usize);
-                assert_eq!(1, type_vlen(ty) as usize);
-                assert_eq!(1, info.len());
-                assert_eq!(11, info[0].type_);
-                assert_eq!(0, info[0].offset);
-                assert_eq!(4, info[0].size);
+            Ok(BtfType::DataSec(ty)) => {
+                assert_eq!(0, ty.size);
+                assert_eq!(11, ty.entries[0].btf_type);
+                assert_eq!(0, ty.entries[0].offset);
+                assert_eq!(4, ty.entries[0].size);
             }
             Ok(t) => panic!("expected datasec type, got {:#?}", t),
             Err(_) => panic!("unexpected error"),
         }
         let data2 = got.unwrap().to_bytes();
-        assert_eq!(data, data2.as_slice())
+        assert_eq!(data, data2)
     }
 
     #[test]
@@ -956,27 +1620,27 @@ mod tests {
             Err(_) => panic!("unexpected error"),
         }
         let data2 = got.unwrap().to_bytes();
-        assert_eq!(data, data2.as_slice())
+        assert_eq!(data, data2)
     }
 
     #[test]
     fn test_write_btf_func_proto() {
         let params = vec![
-            btf_param {
-                name_off: 1,
-                type_: 1,
+            BtfParam {
+                name_offset: 1,
+                btf_type: 1,
             },
-            btf_param {
-                name_off: 3,
-                type_: 1,
+            BtfParam {
+                name_offset: 3,
+                btf_type: 1,
             },
         ];
-        let func_proto = BtfType::new_func_proto(params, 2);
+        let func_proto = FuncProto::new(params, 2);
         let data = func_proto.to_bytes();
         let got = unsafe { BtfType::read(&data, Endianness::default()) };
         match got {
-            Ok(BtfType::FuncProto(btf_type, _params)) => {
-                assert_eq!(type_vlen(&btf_type), 2);
+            Ok(BtfType::FuncProto(fp)) => {
+                assert_eq!(fp.params.len(), 2);
             }
             Ok(t) => panic!("expected func proto type, got {:#?}", t),
             Err(_) => panic!("unexpected error"),
@@ -987,11 +1651,11 @@ mod tests {
     fn test_types_are_compatible() {
         let mut btf = Btf::new();
         let name_offset = btf.add_string("u32".to_string());
-        let u32t = btf.add_type(BtfType::new_int(name_offset, 4, 0, 0));
+        let u32t = btf.add_type(BtfType::Int(Int::new(name_offset, 4, IntEncoding::None, 0)));
         let name_offset = btf.add_string("u64".to_string());
-        let u64t = btf.add_type(BtfType::new_int(name_offset, 8, 0, 0));
+        let u64t = btf.add_type(BtfType::Int(Int::new(name_offset, 8, IntEncoding::None, 0)));
         let name_offset = btf.add_string("widgets".to_string());
-        let array_type = btf.add_type(BtfType::new_array(name_offset, u64t, u32t, 16));
+        let array_type = btf.add_type(BtfType::Array(Array::new(name_offset, u64t, u32t, 16)));
 
         assert!(types_are_compatible(&btf, u32t, &btf, u32t).unwrap());
         // int types are compatible if offsets match. size and encoding aren't compared


### PR DESCRIPTION
This commit removes reliance on generated BtfType structs, as
well as adding a dedicated struct for each BTF type. As such,
we can now add nice accessors like `bits()` and `encoding()`
for Int vs. inlined shift/mask operations.

Signed-off-by: Dave Tucker <dave@dtucker.co.uk>