### PR TITLE
Return non-error only when helper function returns `0` in queue map

### DIFF
--- a/bpf/aya-bpf/src/maps/queue.rs
+++ b/bpf/aya-bpf/src/maps/queue.rs
@@ -51,7 +51,7 @@ impl<T> Queue<T> {
                 flags,
             )
         };
-        (ret >= 0).then(|| ()).ok_or(ret)
+        (ret == 0).then(|| ()).ok_or(ret)
     }
 
     pub fn pop(&mut self) -> Option<T> {
@@ -61,7 +61,7 @@ impl<T> Queue<T> {
                 &mut self.def as *mut _ as *mut _,
                 value.as_mut_ptr() as *mut _,
             );
-            (ret >= 0).then(|| value.assume_init())
+            (ret == 0).then(|| value.assume_init())
         }
     }
 }


### PR DESCRIPTION
As described in https://github.com/aya-rs/aya/issues/288, queue does not return `error` even calling pop() from the empty queue.

This is because the helper functions (`bpf_map_pop_elem()`)
does not return negative value for rust/aya correctly.

The `bpf_map_pop_elem()` and `bpf_map_push_elem()`
returns `0` on success - https://man7.org/linux/man-pages/man7/bpf-helpers.7.html, so this patch
changes the condition as only `0` on success.

Fix https://github.com/aya-rs/aya/issues/288