### PR TITLE
Fix linting issues

### DIFF
--- a/aya-gen/src/bin/aya-gen.rs
+++ b/aya-gen/src/bin/aya-gen.rs
@@ -12,14 +12,15 @@ pub struct Options {
 
 #[derive(Parser)]
 enum Command {
-    #[clap(name = "generate")]
+    #[clap(name = "generate", action)]
     Generate {
-        #[clap(long, default_value = "/sys/kernel/btf/vmlinux")]
+        #[clap(long, default_value = "/sys/kernel/btf/vmlinux", action)]
         btf: PathBuf,
-        #[clap(long, conflicts_with = "btf")]
+        #[clap(long, conflicts_with = "btf", action)]
         header: Option<PathBuf>,
+        #[clap(action)]
         names: Vec<String>,
-        #[clap(last = true)]
+        #[clap(last = true, action)]
         bindgen_args: Vec<String>,
     },
 }
@@ -40,12 +41,11 @@ fn try_main() -> Result<(), anyhow::Error> {
             names,
             bindgen_args,
         } => {
-            let bindings: String;
-            if let Some(header) = header {
-                bindings = generate(InputFile::Header(header), &names, &bindgen_args)?;
+            let bindings: String = if let Some(header) = header {
+                generate(InputFile::Header(header), &names, &bindgen_args)?
             } else {
-                bindings = generate(InputFile::Btf(btf), &names, &bindgen_args)?;
-            }
+                generate(InputFile::Btf(btf), &names, &bindgen_args)?
+            };
             println!("{}", bindings);
         }
     };

--- a/xtask/src/codegen/mod.rs
+++ b/xtask/src/codegen/mod.rs
@@ -54,21 +54,21 @@ impl std::fmt::Display for Architecture {
 
 #[derive(Parser)]
 pub struct Options {
-    #[clap(long)]
+    #[clap(long, action)]
     libbpf_dir: PathBuf,
 
     // sysroot options. Default to ubuntu headers installed by the
     // libc6-dev-{arm64,armel}-cross packages.
-    #[clap(long, default_value = "/usr/include/x86_64-linux-gnu")]
+    #[clap(long, default_value = "/usr/include/x86_64-linux-gnu", action)]
     x86_64_sysroot: PathBuf,
 
-    #[clap(long, default_value = "/usr/aarch64-linux-gnu/include")]
+    #[clap(long, default_value = "/usr/aarch64-linux-gnu/include", action)]
     aarch64_sysroot: PathBuf,
 
-    #[clap(long, default_value = "/usr/arm-linux-gnueabi/include")]
+    #[clap(long, default_value = "/usr/arm-linux-gnueabi/include", action)]
     armv7_sysroot: PathBuf,
 
-    #[clap(long, default_value = "/usr/riscv64-linux-gnu/include")]
+    #[clap(long, default_value = "/usr/riscv64-linux-gnu/include", action)]
     riscv64_sysroot: PathBuf,
 
     #[clap(subcommand)]

--- a/xtask/src/docs/mod.rs
+++ b/xtask/src/docs/mod.rs
@@ -25,7 +25,7 @@ pub fn docs() -> Result<(), anyhow::Error> {
     header_path.push("header.html");
     let mut header = fs::File::create(&header_path).expect("can't create header.html");
     header
-        .write(r#"<meta name="robots" content="noindex">"#.as_bytes())
+        .write_all(r#"<meta name="robots" content="noindex">"#.as_bytes())
         .expect("can't write header.html contents");
     header.flush().expect("couldn't flush contents");
 
@@ -78,7 +78,7 @@ pub fn docs() -> Result<(), anyhow::Error> {
 
     let mut robots = fs::File::create("site/robots.txt").expect("can't create robots.txt");
     robots
-        .write(
+        .write_all(
             indoc! {r#"
     User-Agent:*
     Disallow: /
@@ -89,7 +89,7 @@ pub fn docs() -> Result<(), anyhow::Error> {
 
     let mut index = fs::File::create("site/index.html").expect("can't create index.html");
     index
-        .write(
+        .write_all(
             indoc! {r#"
         <html>
             <meta name="robots" content="noindex">


### PR DESCRIPTION
Fixes [linting errors](https://github.com/aya-rs/aya/runs/6871782093?check_suite_focus=true) on `main`
A good part of those were caused by [clap changes in 3.2](https://epage.github.io/blog/2022/06/clap-32-last-call-before-40/)