### PR TITLE
Add missing inline macro to xdp methods

### DIFF
--- a/bpf/aya-bpf/src/programs/xdp.rs
+++ b/bpf/aya-bpf/src/programs/xdp.rs
@@ -11,10 +11,12 @@ impl XdpContext {
         XdpContext { ctx }
     }
 
+    #[inline]
     pub fn data(&self) -> usize {
         unsafe { (*self.ctx).data as usize }
     }
 
+    #[inline]
     pub fn data_end(&self) -> usize {
         unsafe { (*self.ctx).data_end as usize }
     }


### PR DESCRIPTION
I think these inline attributes are missing for XdpContext.