### PR TITLE
aya: Add fuzz targets

### DIFF
--- a/aya/fuzz/.gitignore
+++ b/aya/fuzz/.gitignore
@@ -1,0 +1,3 @@
+target
+corpus
+artifacts

--- a/aya/fuzz/Cargo.toml
+++ b/aya/fuzz/Cargo.toml
@@ -1,0 +1,31 @@
+[package]
+name = "aya-fuzz"
+version = "0.0.0"
+authors = ["Automatically generated"]
+publish = false
+edition = "2018"
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies]
+libfuzzer-sys = "0.4"
+
+[dependencies.aya]
+path = ".."
+
+# Prevent this from interfering with workspaces
+[workspace]
+members = ["."]
+
+[[bin]]
+name = "fuzz_bpf_load"
+path = "fuzz_targets/fuzz_bpf_load.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "fuzz_btf_parse"
+path = "fuzz_targets/fuzz_btf_parse.rs"
+test = false
+doc = false

--- a/aya/fuzz/fuzz_targets/fuzz_bpf_load.rs
+++ b/aya/fuzz/fuzz_targets/fuzz_bpf_load.rs
@@ -1,0 +1,7 @@
+#![no_main]
+use aya::Bpf;
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|data: &[u8]| {
+    let _ = Bpf::load(data);
+});

--- a/aya/fuzz/fuzz_targets/fuzz_btf_parse.rs
+++ b/aya/fuzz/fuzz_targets/fuzz_btf_parse.rs
@@ -1,0 +1,13 @@
+#![no_main]
+use aya::{Btf, Endianness};
+use libfuzzer_sys::fuzz_target;
+use std::{env::temp_dir, fs::File, io::Write};
+
+fuzz_target!(|data: &[u8]| {
+    let mut path = temp_dir();
+    path.push("btf");
+    let mut file = File::create(&path).unwrap();
+    file.write_all(data).unwrap();
+    file.flush().unwrap();
+    let _ = Btf::parse_file(path, Endianness::default());
+});


### PR DESCRIPTION
This is an initial attempt to add fuzzing with cargo-fuzz.
2 targets seemed simple enough to add which are Bpf::load and
Btf::parse_file since these are both public APIs which take byte
streams. Other more structured fuzzing can be added later

Signed-off-by: Dave Tucker <dave@dtucker.co.uk>