### PR TITLE
Have bpf_map_update_elem take Option<&K> for key

### DIFF
--- a/aya/src/maps/array/array.rs
+++ b/aya/src/maps/array/array.rs
@@ -118,7 +118,7 @@ impl<T: Deref<Target = Map> + DerefMut<Target = Map>, V: Pod> Array<T, V> {
     pub fn set(&mut self, index: u32, value: V, flags: u64) -> Result<(), MapError> {
         let fd = self.inner.fd_or_err()?;
         self.check_bounds(index)?;
-        bpf_map_update_elem(fd, &index, &value, flags).map_err(|(code, io_error)| {
+        bpf_map_update_elem(fd, Some(&index), &value, flags).map_err(|(code, io_error)| {
             MapError::SyscallError {
                 call: "bpf_map_update_elem".to_owned(),
                 code,

--- a/aya/src/maps/array/program_array.rs
+++ b/aya/src/maps/array/program_array.rs
@@ -103,7 +103,7 @@ impl<T: Deref<Target = Map> + DerefMut<Target = Map>> ProgramArray<T> {
         self.check_bounds(index)?;
         let prog_fd = program.fd().ok_or(MapError::ProgramNotLoaded)?;
 
-        bpf_map_update_elem(fd, &index, &prog_fd, flags).map_err(|(code, io_error)| {
+        bpf_map_update_elem(fd, Some(&index), &prog_fd, flags).map_err(|(code, io_error)| {
             MapError::SyscallError {
                 call: "bpf_map_update_elem".to_owned(),
                 code,

--- a/aya/src/maps/hash_map/mod.rs
+++ b/aya/src/maps/hash_map/mod.rs
@@ -29,7 +29,7 @@ pub(crate) fn check_kv_size<K, V>(map: &Map) -> Result<(), MapError> {
 
 pub(crate) fn insert<K, V>(map: &mut Map, key: K, value: V, flags: u64) -> Result<(), MapError> {
     let fd = map.fd_or_err()?;
-    bpf_map_update_elem(fd, &key, &value, flags).map_err(|(code, io_error)| {
+    bpf_map_update_elem(fd, Some(&key), &value, flags).map_err(|(code, io_error)| {
         MapError::SyscallError {
             call: "bpf_map_update_elem".to_owned(),
             code,

--- a/aya/src/maps/lpm_trie.rs
+++ b/aya/src/maps/lpm_trie.rs
@@ -145,7 +145,7 @@ impl<T: Deref<Target = Map>, K: Pod, V: Pod> LpmTrie<T, K, V> {
     /// Inserts a key value pair into the map.
     pub fn insert(&self, key: &Key<K>, value: V, flags: u64) -> Result<(), MapError> {
         let fd = self.inner.deref().fd_or_err()?;
-        bpf_map_update_elem(fd, key, &value, flags).map_err(|(code, io_error)| {
+        bpf_map_update_elem(fd, Some(key), &value, flags).map_err(|(code, io_error)| {
             MapError::SyscallError {
                 call: "bpf_map_update_elem".to_owned(),
                 code,

--- a/aya/src/maps/perf/perf_event_array.rs
+++ b/aya/src/maps/perf/perf_event_array.rs
@@ -191,7 +191,7 @@ impl<T: DerefMut<Target = Map>> PerfEventArray<T> {
         // this cannot fail as new() checks that the fd is open
         let map_fd = self.map.fd_or_err().unwrap();
         let buf = PerfBuffer::open(index, self.page_size, page_count.unwrap_or(2))?;
-        bpf_map_update_elem(map_fd, &index, &buf.as_raw_fd(), 0)
+        bpf_map_update_elem(map_fd, Some(&index), &buf.as_raw_fd(), 0)
             .map_err(|(_, io_error)| io_error)?;
 
         Ok(PerfEventArrayBuffer {

--- a/aya/src/maps/sock/sock_map.rs
+++ b/aya/src/maps/sock/sock_map.rs
@@ -90,7 +90,7 @@ impl<T: Deref<Target = Map> + DerefMut<Target = Map>> SockMap<T> {
     pub fn set<I: AsRawFd>(&mut self, index: u32, socket: &I, flags: u64) -> Result<(), MapError> {
         let fd = self.inner.fd_or_err()?;
         self.check_bounds(index)?;
-        bpf_map_update_elem(fd, &index, &socket.as_raw_fd(), flags).map_err(
+        bpf_map_update_elem(fd, Some(&index), &socket.as_raw_fd(), flags).map_err(
             |(code, io_error)| MapError::SyscallError {
                 call: "bpf_map_update_elem".to_owned(),
                 code,

--- a/aya/src/maps/stack.rs
+++ b/aya/src/maps/stack.rs
@@ -99,7 +99,7 @@ impl<T: Deref<Target = Map> + DerefMut<Target = Map>, V: Pod> Stack<T, V> {
     /// [`MapError::SyscallError`] if `bpf_map_update_elem` fails.
     pub fn push(&mut self, value: V, flags: u64) -> Result<(), MapError> {
         let fd = self.inner.fd_or_err()?;
-        bpf_map_update_elem(fd, &0, &value, flags).map_err(|(code, io_error)| {
+        bpf_map_update_elem(fd, None::<&u32>, &value, flags).map_err(|(code, io_error)| {
             MapError::SyscallError {
                 call: "bpf_map_update_elem".to_owned(),
                 code,

--- a/aya/src/sys/bpf.rs
+++ b/aya/src/sys/bpf.rs
@@ -223,12 +223,19 @@ pub(crate) fn bpf_map_lookup_elem_ptr<K: Pod, V>(
     }
 }
 
-pub(crate) fn bpf_map_update_elem<K, V>(fd: RawFd, key: &K, value: &V, flags: u64) -> SysResult {
+pub(crate) fn bpf_map_update_elem<K, V>(
+    fd: RawFd,
+    key: Option<&K>,
+    value: &V,
+    flags: u64,
+) -> SysResult {
     let mut attr = unsafe { mem::zeroed::<bpf_attr>() };
 
     let u = unsafe { &mut attr.__bindgen_anon_2 };
     u.map_fd = fd as u32;
-    u.key = key as *const _ as u64;
+    if let Some(key) = key {
+        u.key = key as *const _ as u64;
+    }
     u.__bindgen_anon_1.value = value as *const _ as u64;
     u.flags = flags;
 


### PR DESCRIPTION
bpf_map_update_elem is used in lieu of bpf_map_push_elem to maintain support for kernel version < 4.20. The kernel expects a null pointer for the key for this use case. With this change, if you pass None as key to `bpf_map_update_elem`, it will pass null as key.
