### PR TITLE
Small Pinning API improvements

### DIFF
--- a/aya/src/lib.rs
+++ b/aya/src/lib.rs
@@ -48,6 +48,7 @@ mod bpf;
 mod generated;
 pub mod maps;
 mod obj;
+pub mod pin;
 pub mod programs;
 mod sys;
 pub mod util;

--- a/aya/src/pin.rs
+++ b/aya/src/pin.rs
@@ -1,0 +1,35 @@
+//! Pinning BPF objects to the BPF filesystem.
+use std::io;
+use thiserror::Error;
+
+/// An error ocurred working with a pinned BPF object.
+#[derive(Error, Debug)]
+pub enum PinError {
+    /// The object has already been pinned.
+    #[error("the BPF object `{name}` has already been pinned")]
+    AlreadyPinned {
+        /// Object name.
+        name: String,
+    },
+    /// The object FD is not known by Aya.
+    #[error("the BPF object `{name}`'s FD is not known")]
+    NoFd {
+        /// Object name.
+        name: String,
+    },
+    /// The path for the BPF object is not valid.
+    #[error("invalid pin path `{error}`")]
+    InvalidPinPath {
+        /// The error message.
+        error: String,
+    },
+    /// An error ocurred making a syscall.
+    #[error("{name} failed")]
+    SyscallError {
+        /// The syscall name.
+        name: String,
+        /// The [`io::Error`] returned by the syscall.
+        #[source]
+        io_error: io::Error,
+    },
+}

--- a/aya/src/programs/links.rs
+++ b/aya/src/programs/links.rs
@@ -1,12 +1,10 @@
 //! Program links.
 use libc::{close, dup};
-use thiserror::Error;
 
 use std::{
     borrow::Borrow,
     collections::{hash_map::Entry, HashMap},
     ffi::CString,
-    io,
     ops::Deref,
     os::unix::prelude::RawFd,
     path::Path,
@@ -14,27 +12,10 @@ use std::{
 
 use crate::{
     generated::bpf_attach_type,
+    pin::PinError,
     programs::ProgramError,
     sys::{bpf_pin_object, bpf_prog_detach},
 };
-
-/// An error ocurred working with a Link.
-#[derive(Error, Debug)]
-pub enum LinkError {
-    /// Invalid Pin Path.
-    #[error("invalid pin path `{error}`")]
-    InvalidPinPath {
-        /// The error message.
-        error: String,
-    },
-    /// Pinning error.
-    #[error("BPF_OBJ_PIN failed")]
-    PinError {
-        /// The [`io::Error`] returned by the syscall.
-        #[source]
-        io_error: io::Error,
-    },
-}
 
 /// A Link.
 pub trait Link: std::fmt::Debug + 'static {
@@ -142,17 +123,19 @@ impl FdLink {
     ///
     /// When a BPF object is pinned to a BPF filesystem it will remain attached after
     /// Aya has detached the link.
-    /// To remove the attachment, the file on the BPF filesystem must be remove.
+    /// To remove the attachment, the file on the BPF filesystem must be removed.
     /// Any directories in the the path provided should have been created by the caller.
-    pub fn pin<P: AsRef<Path>>(&self, path: P) -> Result<(), LinkError> {
+    pub fn pin<P: AsRef<Path>>(&self, path: P) -> Result<(), PinError> {
         let path_string =
             CString::new(path.as_ref().to_string_lossy().into_owned()).map_err(|e| {
-                LinkError::InvalidPinPath {
+                PinError::InvalidPinPath {
                     error: e.to_string(),
                 }
             })?;
-        bpf_pin_object(self.fd, &path_string)
-            .map_err(|(_code, io_error)| LinkError::PinError { io_error })?;
+        bpf_pin_object(self.fd, &path_string).map_err(|(_, io_error)| PinError::SyscallError {
+            name: "BPF_OBJ_PIN".to_string(),
+            io_error,
+        })?;
         Ok(())
     }
 }


### PR DESCRIPTION
1, Allow pinning from the program directly (e.g `TracePoint::pin("/path")`
2. Add `FdLink::pin("/path")`, which requires that you've called `take_link()` first, which actually isn't a bad thing at all :wink: 