### PR TITLE
bpf: Change the result type of bpf_get_current_comm helper

### DIFF
--- a/bpf/aya-bpf/src/helpers.rs
+++ b/bpf/aya-bpf/src/helpers.rs
@@ -13,7 +13,7 @@ pub use aya_bpf_bindings::helpers as gen;
 #[doc(hidden)]
 pub use gen::*;
 
-use crate::cty::{c_char, c_long, c_void};
+use crate::cty::{c_long, c_void};
 
 /// Read bytes stored at `src` and store them as a `T`.
 ///
@@ -625,7 +625,7 @@ pub unsafe fn bpf_probe_write_user<T>(dst: *mut T, src: *const T) -> Result<(), 
 }
 
 /// Read the `comm` field associated with the current task struct
-/// as a `[c_char; 16]`.
+/// as a `[u8; 16]`.
 ///
 /// # Examples
 ///
@@ -641,8 +641,8 @@ pub unsafe fn bpf_probe_write_user<T>(dst: *mut T, src: *const T) -> Result<(), 
 ///
 /// On failure, this function returns a negative value wrapped in an `Err`.
 #[inline]
-pub fn bpf_get_current_comm() -> Result<[c_char; 16], c_long> {
-    let mut comm: [c_char; 16usize] = [0; 16];
+pub fn bpf_get_current_comm() -> Result<[u8; 16], c_long> {
+    let mut comm: [u8; 16usize] = [0; 16];
     let ret = unsafe { gen::bpf_get_current_comm(&mut comm as *mut _ as *mut c_void, 16u32) };
     if ret == 0 {
         Ok(comm)

--- a/bpf/aya-bpf/src/lib.rs
+++ b/bpf/aya-bpf/src/lib.rs
@@ -24,7 +24,7 @@ pub mod programs;
 pub use aya_bpf_cty as cty;
 
 use core::ffi::c_void;
-use cty::{c_char, c_int, c_long};
+use cty::{c_int, c_long};
 use helpers::{bpf_get_current_comm, bpf_get_current_pid_tgid};
 
 pub use aya_bpf_macros as macros;
@@ -35,7 +35,7 @@ pub trait BpfContext {
     fn as_ptr(&self) -> *mut c_void;
 
     #[inline]
-    fn command(&self) -> Result<[c_char; TASK_COMM_LEN], c_long> {
+    fn command(&self) -> Result<[u8; TASK_COMM_LEN], c_long> {
         bpf_get_current_comm()
     }
 


### PR DESCRIPTION
Change it from `[i8; 16]` to `[u8; 18]`. `i8` arrays cannot be easily used in
Rust for converting to string (i.e. with `core::str::from_utf8_unchecked`)
and developers have to convert them themselves with unsafe code.

Using u8 arrays lets developers to just convert it with
`core::str::from_utf8_unchecked` without any limitations.

Example:

https://github.com/vadorovsky/aya-examples/blob/main/clone/clone-ebpf/src/main.rs

Signed-off-by: Michal Rostecki <vadorovsky@gmail.com>