### PR TITLE
bpf: Use `then_some` instead of `then(|| [...])`

### DIFF
--- a/bpf/aya-bpf/src/maps/bloom_filter.rs
+++ b/bpf/aya-bpf/src/maps/bloom_filter.rs
@@ -47,7 +47,7 @@ impl<T> BloomFilter<T> {
                 value as *const _ as *mut c_void,
             )
         };
-        (ret == 0).then(|| ()).ok_or(ret)
+        (ret == 0).then_some(()).ok_or(ret)
     }
 
     #[inline]
@@ -59,7 +59,7 @@ impl<T> BloomFilter<T> {
                 flags,
             )
         };
-        (ret == 0).then(|| ()).ok_or(ret)
+        (ret == 0).then_some(()).ok_or(ret)
     }
 }
 

--- a/bpf/aya-bpf/src/maps/hash_map.rs
+++ b/bpf/aya-bpf/src/maps/hash_map.rs
@@ -348,11 +348,11 @@ fn insert<K, V>(def: *mut bpf_map_def, key: &K, value: &V, flags: u64) -> Result
             flags,
         )
     };
-    (ret == 0).then(|| ()).ok_or(ret)
+    (ret == 0).then_some(()).ok_or(ret)
 }
 
 #[inline]
 fn remove<K>(def: *mut bpf_map_def, key: &K) -> Result<(), c_long> {
     let ret = unsafe { bpf_map_delete_elem(def as *mut _, key as *const _ as *const c_void) };
-    (ret == 0).then(|| ()).ok_or(ret)
+    (ret == 0).then_some(()).ok_or(ret)
 }

--- a/bpf/aya-bpf/src/maps/lpm_trie.rs
+++ b/bpf/aya-bpf/src/maps/lpm_trie.rs
@@ -78,7 +78,7 @@ impl<K, V> LpmTrie<K, V> {
                 flags,
             )
         };
-        (ret == 0).then(|| ()).ok_or(ret)
+        (ret == 0).then_some(()).ok_or(ret)
     }
 
     #[inline]
@@ -86,7 +86,7 @@ impl<K, V> LpmTrie<K, V> {
         let ret = unsafe {
             bpf_map_delete_elem(self.def.get() as *mut _, key as *const _ as *const c_void)
         };
-        (ret == 0).then(|| ()).ok_or(ret)
+        (ret == 0).then_some(()).ok_or(ret)
     }
 }
 

--- a/bpf/aya-bpf/src/maps/queue.rs
+++ b/bpf/aya-bpf/src/maps/queue.rs
@@ -53,14 +53,14 @@ impl<T> Queue<T> {
                 flags,
             )
         };
-        (ret == 0).then(|| ()).ok_or(ret)
+        (ret == 0).then_some(()).ok_or(ret)
     }
 
     pub fn pop(&self) -> Option<T> {
         unsafe {
             let mut value = mem::MaybeUninit::uninit();
             let ret = bpf_map_pop_elem(self.def.get() as *mut _, value.as_mut_ptr() as *mut _);
-            (ret == 0).then(|| value.assume_init())
+            (ret == 0).then_some(value.assume_init())
         }
     }
 }

--- a/bpf/aya-bpf/src/maps/sock_hash.rs
+++ b/bpf/aya-bpf/src/maps/sock_hash.rs
@@ -61,7 +61,7 @@ impl<K> SockHash<K> {
                 flags,
             )
         };
-        (ret == 0).then(|| ()).ok_or(ret)
+        (ret == 0).then_some(()).ok_or(ret)
     }
 
     pub fn redirect_msg(&self, ctx: &SkMsgContext, key: &mut K, flags: u64) -> i64 {
@@ -102,7 +102,7 @@ impl<K> SockHash<K> {
             }
             let ret = bpf_sk_assign(ctx.as_ptr() as *mut _, sk, flags);
             bpf_sk_release(sk);
-            (ret == 0).then(|| ()).ok_or(1)
+            (ret == 0).then_some(()).ok_or(1)
         }
     }
 }

--- a/bpf/aya-bpf/src/maps/sock_map.rs
+++ b/bpf/aya-bpf/src/maps/sock_map.rs
@@ -102,7 +102,7 @@ impl SockMap {
             }
             let ret = bpf_sk_assign(ctx.as_ptr() as *mut _, sk, flags);
             bpf_sk_release(sk);
-            (ret == 0).then(|| ()).ok_or(1)
+            (ret == 0).then_some(()).ok_or(1)
         }
     }
 }

--- a/bpf/aya-bpf/src/maps/stack.rs
+++ b/bpf/aya-bpf/src/maps/stack.rs
@@ -51,7 +51,7 @@ impl<T> Stack<T> {
                 flags,
             )
         };
-        (ret == 0).then(|| ()).ok_or(ret)
+        (ret == 0).then_some(()).ok_or(ret)
     }
 
     pub fn pop(&mut self) -> Option<T> {
@@ -61,7 +61,7 @@ impl<T> Stack<T> {
                 &mut self.def as *mut _ as *mut _,
                 value.as_mut_ptr() as *mut _,
             );
-            (ret == 0).then(|| value.assume_init())
+            (ret == 0).then_some(value.assume_init())
         }
     }
 }


### PR DESCRIPTION
This change fixes the `unnecessary_lazy_evaluations` clippy warning.

Signed-off-by: Michal Rostecki <vadorovsky@gmail.com>