### PR TITLE
Minor fix for `lpm_trie::key` docs

### DIFF
--- a/bpf/aya-bpf/src/maps/lpm_trie.rs
+++ b/bpf/aya-bpf/src/maps/lpm_trie.rs
@@ -19,7 +19,7 @@ unsafe impl<K: Sync, V: Sync> Sync for LpmTrie<K, V> {}
 
 #[repr(packed)]
 pub struct Key<K> {
-    /// Represents the number of bytes matched against.
+    /// Represents the number of bits matched against.
     pub prefix_len: u32,
     /// Represents arbitrary data stored in the LpmTrie.
     pub data: K,


### PR DESCRIPTION
Hi, this is a very minor fix to the docs of `lpm_trie::Key` I think the `prefix_len` represent the number of bits instead of the number of bytes to match against, this is needed to work with the whole range of CIDRs