### PR TITLE
Allow SkBuffContext .store() without a mutable reference

### DIFF
--- a/bpf/aya-bpf/src/programs/sk_buff.rs
+++ b/bpf/aya-bpf/src/programs/sk_buff.rs
@@ -142,7 +142,7 @@ impl SkBuffContext {
     }
 
     #[inline]
-    pub fn store<T>(&mut self, offset: usize, v: &T, flags: u64) -> Result<(), c_long> {
+    pub fn store<T>(&self, offset: usize, v: &T, flags: u64) -> Result<(), c_long> {
         unsafe {
             let ret = bpf_skb_store_bytes(
                 self.skb as *mut _,


### PR DESCRIPTION
- there's no mutable reference to SkBuffContext
- there's interior mutability since skb is stored as a mutable reference