### PR TITLE
Change from Rust edition 2018 to 2021

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,6 @@ Aya supports a large chunk of the eBPF API. The following example shows how to u
 
 ```rust
 use std::fs::File;
-use std::convert::TryInto;
 use aya::Bpf;
 use aya::programs::{CgroupSkb, CgroupSkbAttachType};
 

--- a/aya-bpf-macros/Cargo.toml
+++ b/aya-bpf-macros/Cargo.toml
@@ -2,7 +2,7 @@
 name = "aya-bpf-macros"
 version = "0.1.0"
 authors = ["Alessandro Decina <alessandro.d@gmail.com>"]
-edition = "2018"
+edition = "2021"
 
 [lib]
 proc-macro = true

--- a/aya-gen/Cargo.toml
+++ b/aya-gen/Cargo.toml
@@ -2,7 +2,7 @@
 name = "aya-gen"
 version = "0.1.0"
 authors = ["Alessandro Decina <alessandro.d@gmail.com>"]
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 bindgen = "0.60"

--- a/aya-log-common/Cargo.toml
+++ b/aya-log-common/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT OR Apache-2.0"
 authors = ["The Aya Contributors"]
 repository = "https://github.com/aya-rs/aya-log"
 documentation = "https://docs.rs/aya-log"
-edition = "2018"
+edition = "2021"
 
 [features]
 default = []

--- a/aya-log-ebpf-macros/Cargo.toml
+++ b/aya-log-ebpf-macros/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "aya-log-ebpf-macros"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 proc-macro2 = "1.0"

--- a/aya-log/Cargo.toml
+++ b/aya-log/Cargo.toml
@@ -8,7 +8,7 @@ authors = ["The Aya Contributors"]
 repository = "https://github.com/aya-rs/aya-log"
 readme = "README.md"
 documentation = "https://docs.rs/aya-log"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 aya = { path = "../aya", version = "0.11.0", features=["async_tokio"] }

--- a/aya-log/src/lib.rs
+++ b/aya-log/src/lib.rs
@@ -49,7 +49,7 @@
 //! [Log]: https://docs.rs/log/0.4.14/log/trait.Log.html
 //! [log]: https://docs.rs/log
 //!
-use std::{convert::TryInto, io, mem, ptr, str, sync::Arc};
+use std::{io, mem, ptr, str, sync::Arc};
 
 use aya_log_common::{ArgType, RecordField, LOG_BUF_CAPACITY, LOG_FIELDS};
 use bytes::BytesMut;

--- a/aya/Cargo.toml
+++ b/aya/Cargo.toml
@@ -8,7 +8,7 @@ authors = ["The Aya Contributors"]
 repository = "https://github.com/aya-rs/aya"
 readme = "README.md"
 documentation = "https://docs.rs/aya"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 libc = { version = "0.2.105" }

--- a/aya/README.md
+++ b/aya/README.md
@@ -75,7 +75,6 @@ Aya supports a large chunk of the eBPF API. The following example shows how to u
 
 ```rust
 use std::fs::File;
-use std::convert::TryInto;
 use aya::Bpf;
 use aya::programs::{CgroupSkb, CgroupSkbAttachType};
 

--- a/aya/src/bpf.rs
+++ b/aya/src/bpf.rs
@@ -1,7 +1,6 @@
 use std::{
     borrow::Cow,
     collections::{HashMap, HashSet},
-    convert::TryFrom,
     error::Error,
     ffi::CString,
     fs, io,
@@ -743,7 +742,6 @@ impl Bpf {
     /// ```no_run
     /// # let mut bpf = aya::Bpf::load(&[])?;
     /// use aya::programs::UProbe;
-    /// use std::convert::TryInto;
     ///
     /// let program: &mut UProbe = bpf.program_mut("SSL_read").unwrap().try_into()?;
     /// program.load()?;

--- a/aya/src/maps/array/array.rs
+++ b/aya/src/maps/array/array.rs
@@ -1,5 +1,4 @@
 use std::{
-    convert::TryFrom,
     marker::PhantomData,
     mem,
     ops::{Deref, DerefMut},
@@ -25,7 +24,6 @@ use crate::{
 /// ```no_run
 /// # let bpf = aya::Bpf::load(&[])?;
 /// use aya::maps::Array;
-/// use std::convert::TryFrom;
 ///
 /// let mut array = Array::try_from(bpf.map_mut("ARRAY")?)?;
 /// array.set(1, 42, 0)?;

--- a/aya/src/maps/array/per_cpu_array.rs
+++ b/aya/src/maps/array/per_cpu_array.rs
@@ -1,5 +1,4 @@
 use std::{
-    convert::TryFrom,
     marker::PhantomData,
     mem,
     ops::{Deref, DerefMut},
@@ -35,7 +34,6 @@ use crate::{
 /// # let bpf = aya::Bpf::load(&[])?;
 /// use aya::maps::{PerCpuArray, PerCpuValues};
 /// use aya::util::nr_cpus;
-/// use std::convert::TryFrom;
 ///
 /// let mut array = PerCpuArray::try_from(bpf.map_mut("ARRAY")?)?;
 ///

--- a/aya/src/maps/array/program_array.rs
+++ b/aya/src/maps/array/program_array.rs
@@ -1,7 +1,6 @@
 //! An array of eBPF program file descriptors used as a jump table.
 
 use std::{
-    convert::TryFrom,
     mem,
     ops::{Deref, DerefMut},
     os::unix::prelude::{AsRawFd, RawFd},
@@ -29,7 +28,6 @@ use crate::{
 /// # let mut bpf = aya::Bpf::load(&[])?;
 /// use aya::maps::ProgramArray;
 /// use aya::programs::CgroupSkb;
-/// use std::convert::{TryFrom, TryInto};
 ///
 /// let mut prog_array = ProgramArray::try_from(bpf.map_mut("JUMP_TABLE")?)?;
 /// let prog_0: &CgroupSkb = bpf.program("example_prog_0").unwrap().try_into()?;

--- a/aya/src/maps/bloom_filter.rs
+++ b/aya/src/maps/bloom_filter.rs
@@ -1,5 +1,5 @@
 //! A Bloom Filter.
-use std::{convert::TryFrom, marker::PhantomData, ops::Deref};
+use std::{marker::PhantomData, ops::Deref};
 
 use core::mem;
 
@@ -21,7 +21,6 @@ use crate::{
 /// ```no_run
 /// # let bpf = aya::Bpf::load(&[])?;
 /// use aya::maps::bloom_filter::BloomFilter;
-/// use std::convert::TryFrom;
 ///
 /// let mut bloom_filter = BloomFilter::try_from(bpf.map_mut("BLOOM_FILTER")?)?;
 ///

--- a/aya/src/maps/hash_map/hash_map.rs
+++ b/aya/src/maps/hash_map/hash_map.rs
@@ -1,5 +1,4 @@
 use std::{
-    convert::TryFrom,
     marker::PhantomData,
     ops::{Deref, DerefMut},
 };
@@ -22,7 +21,6 @@ use crate::{
 /// ```no_run
 /// # let bpf = aya::Bpf::load(&[])?;
 /// use aya::maps::HashMap;
-/// use std::convert::TryFrom;
 ///
 /// let mut redirect_ports = HashMap::try_from(bpf.map_mut("REDIRECT_PORTS")?)?;
 ///

--- a/aya/src/maps/hash_map/per_cpu_hash_map.rs
+++ b/aya/src/maps/hash_map/per_cpu_hash_map.rs
@@ -1,6 +1,5 @@
 //! Per-CPU hash map.
 use std::{
-    convert::TryFrom,
     marker::PhantomData,
     ops::{Deref, DerefMut},
 };
@@ -29,7 +28,6 @@ use crate::{
 /// ```no_run
 /// # let bpf = aya::Bpf::load(&[])?;
 /// use aya::maps::PerCpuHashMap;
-/// use std::convert::TryFrom;
 ///
 /// const CPU_IDS: u8 = 1;
 /// const WAKEUPS: u8 = 2;
@@ -116,7 +114,6 @@ impl<T: DerefMut<Target = Map>, K: Pod, V: Pod> PerCpuHashMap<T, K, V> {
     /// # let bpf = aya::Bpf::load(&[])?;
     /// use aya::maps::{PerCpuHashMap, PerCpuValues};
     /// use aya::util::nr_cpus;
-    /// use std::convert::TryFrom;
     ///
     /// const RETRIES: u8 = 1;
     ///

--- a/aya/src/maps/lpm_trie.rs
+++ b/aya/src/maps/lpm_trie.rs
@@ -1,5 +1,5 @@
 //! A LPM Trie.
-use std::{convert::TryFrom, marker::PhantomData, mem, ops::Deref};
+use std::{marker::PhantomData, mem, ops::Deref};
 
 use crate::{
     generated::bpf_map_type::BPF_MAP_TYPE_LPM_TRIE,
@@ -19,7 +19,6 @@ use crate::{
 /// ```no_run
 /// # let bpf = aya::Bpf::load(&[])?;
 /// use aya::maps::lpm_trie::{LpmTrie, Key};
-/// use std::convert::TryFrom;
 /// use std::net::Ipv4Addr;
 ///
 /// let mut trie = LpmTrie::try_from(bpf.map_mut("LPM_TRIE")?)?;
@@ -56,7 +55,6 @@ pub struct LpmTrie<T: Deref<Target = Map>, K, V> {
 ///
 /// ```no_run
 /// use aya::maps::lpm_trie::{LpmTrie, Key};
-/// use std::convert::TryFrom;
 /// use std::net::Ipv4Addr;
 ///
 /// let ipaddr = Ipv4Addr::new(8,8,8,8);
@@ -77,7 +75,6 @@ impl<K: Pod> Key<K> {
     ///
     /// ```no_run
     /// use aya::maps::lpm_trie::{LpmTrie, Key};
-    /// use std::convert::TryFrom;
     /// use std::net::Ipv4Addr;
     ///
     /// let ipaddr = Ipv4Addr::new(8, 8, 8, 8);

--- a/aya/src/maps/mod.rs
+++ b/aya/src/maps/mod.rs
@@ -16,7 +16,6 @@
 //!
 //! ```no_run
 //! # let mut bpf = aya::Bpf::load(&[])?;
-//! use std::convert::{TryFrom, TryInto};
 //! use aya::maps::SockMap;
 //! use aya::programs::SkMsg;
 //!
@@ -33,7 +32,6 @@
 //! versa. Because of that, all map values must be plain old data and therefore
 //! implement the [Pod] trait.
 use std::{
-    convert::{TryFrom, TryInto},
     ffi::CString,
     fmt, io,
     marker::PhantomData,
@@ -523,7 +521,6 @@ impl PerCpuKernelMem {
 /// # let bpf = aya::Bpf::load(&[])?;
 /// use aya::maps::PerCpuValues;
 /// use aya::util::nr_cpus;
-/// use std::convert::TryFrom;
 ///
 /// let values = PerCpuValues::try_from(vec![42u32; nr_cpus()?])?;
 /// # Ok::<(), Error>(())

--- a/aya/src/maps/perf/async_perf_event_array.rs
+++ b/aya/src/maps/perf/async_perf_event_array.rs
@@ -1,6 +1,5 @@
 use bytes::BytesMut;
 use std::{
-    convert::TryFrom,
     ops::DerefMut,
     os::unix::prelude::{AsRawFd, RawFd},
 };
@@ -49,7 +48,6 @@ use crate::maps::{
 /// # let bpf = aya::Bpf::load(&[])?;
 /// use aya::maps::perf::{AsyncPerfEventArray, PerfBufferError};
 /// use aya::util::online_cpus;
-/// use std::convert::TryFrom;
 /// use futures::future;
 /// use bytes::BytesMut;
 /// use tokio::task; // or async_std::task

--- a/aya/src/maps/perf/perf_buffer.rs
+++ b/aya/src/maps/perf/perf_buffer.rs
@@ -318,7 +318,7 @@ mod tests {
         generated::perf_event_mmap_page,
         sys::{override_syscall, Syscall, TEST_MMAP_RET},
     };
-    use std::{convert::TryInto, fmt::Debug, mem};
+    use std::{fmt::Debug, mem};
 
     const PAGE_SIZE: usize = 4096;
     union MMappedBuf {

--- a/aya/src/maps/perf/perf_event_array.rs
+++ b/aya/src/maps/perf/perf_event_array.rs
@@ -2,7 +2,6 @@
 //!
 //! [`perf`]: https://perf.wiki.kernel.org/index.php/Main_Page.
 use std::{
-    convert::TryFrom,
     ops::DerefMut,
     os::unix::io::{AsRawFd, RawFd},
     sync::Arc,
@@ -109,7 +108,6 @@ impl<T: DerefMut<Target = Map>> AsRawFd for PerfEventArrayBuffer<T> {
 /// # let bpf = aya::Bpf::load(&[])?;
 /// use aya::maps::PerfEventArray;
 /// use aya::util::online_cpus;
-/// use std::convert::{TryFrom, TryInto};
 /// use bytes::BytesMut;
 ///
 /// let mut perf_array = PerfEventArray::try_from(bpf.map_mut("EVENTS")?)?;

--- a/aya/src/maps/queue.rs
+++ b/aya/src/maps/queue.rs
@@ -1,6 +1,5 @@
 //! A FIFO queue.
 use std::{
-    convert::TryFrom,
     marker::PhantomData,
     mem,
     ops::{Deref, DerefMut},
@@ -23,7 +22,6 @@ use crate::{
 /// ```no_run
 /// # let bpf = aya::Bpf::load(&[])?;
 /// use aya::maps::Queue;
-/// use std::convert::TryFrom;
 ///
 /// let mut queue = Queue::try_from(bpf.map_mut("ARRAY")?)?;
 /// queue.push(42, 0)?;

--- a/aya/src/maps/sock/sock_hash.rs
+++ b/aya/src/maps/sock/sock_hash.rs
@@ -1,5 +1,4 @@
 use std::{
-    convert::TryFrom,
     marker::PhantomData,
     ops::{Deref, DerefMut},
     os::unix::io::{AsRawFd, RawFd},
@@ -42,7 +41,6 @@ use crate::{
 /// #     Bpf(#[from] aya::BpfError)
 /// # }
 /// # let mut bpf = aya::Bpf::load(&[])?;
-/// use std::convert::{TryFrom, TryInto};
 /// use std::io::Write;
 /// use std::net::TcpStream;
 /// use std::os::unix::io::AsRawFd;

--- a/aya/src/maps/sock/sock_map.rs
+++ b/aya/src/maps/sock/sock_map.rs
@@ -1,7 +1,6 @@
 //! An array of eBPF program file descriptors used as a jump table.
 
 use std::{
-    convert::TryFrom,
     mem,
     ops::{Deref, DerefMut},
     os::unix::{io::AsRawFd, prelude::RawFd},
@@ -30,7 +29,6 @@ use crate::{
 ///
 /// ```no_run
 /// # let mut bpf = aya::Bpf::load(&[])?;
-/// use std::convert::{TryFrom, TryInto};
 /// use aya::maps::SockMap;
 /// use aya::programs::SkSkb;
 ///

--- a/aya/src/maps/stack.rs
+++ b/aya/src/maps/stack.rs
@@ -1,6 +1,5 @@
 //! A LIFO stack.
 use std::{
-    convert::TryFrom,
     marker::PhantomData,
     mem,
     ops::{Deref, DerefMut},
@@ -23,7 +22,6 @@ use crate::{
 /// ```no_run
 /// # let bpf = aya::Bpf::load(&[])?;
 /// use aya::maps::Stack;
-/// use std::convert::TryFrom;
 ///
 /// let mut stack = Stack::try_from(bpf.map_mut("STACK")?)?;
 /// stack.push(42, 0)?;

--- a/aya/src/maps/stack_trace.rs
+++ b/aya/src/maps/stack_trace.rs
@@ -1,9 +1,7 @@
 //! A hash map of kernel or user space stack traces.
 //!
 //! See [`StackTraceMap`] for documentation and examples.
-use std::{
-    collections::BTreeMap, convert::TryFrom, fs, io, mem, ops::Deref, path::Path, str::FromStr,
-};
+use std::{collections::BTreeMap, fs, io, mem, ops::Deref, path::Path, str::FromStr};
 
 use crate::{
     generated::bpf_map_type::BPF_MAP_TYPE_STACK_TRACE,
@@ -37,7 +35,6 @@ use crate::{
 /// # let bpf = aya::Bpf::load(&[])?;
 /// use aya::maps::StackTraceMap;
 /// use aya::util::kernel_symbols;
-/// use std::convert::TryFrom;
 ///
 /// let mut stack_traces = StackTraceMap::try_from(bpf.map("STACK_TRACES")?)?;
 /// // load kernel symbols from /proc/kallsyms

--- a/aya/src/obj/btf/btf.rs
+++ b/aya/src/obj/btf/btf.rs
@@ -1,7 +1,6 @@
 use std::{
     borrow::Cow,
     collections::HashMap,
-    convert::TryInto,
     ffi::{c_void, CStr, CString},
     fs, io, mem,
     path::{Path, PathBuf},

--- a/aya/src/obj/btf/info.rs
+++ b/aya/src/obj/btf/info.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, convert::TryInto};
+use std::collections::HashMap;
 
 use bytes::BufMut;
 use object::Endianness;

--- a/aya/src/obj/btf/relocation.rs
+++ b/aya/src/obj/btf/relocation.rs
@@ -1,9 +1,4 @@
-use std::{
-    collections::HashMap,
-    convert::{TryFrom, TryInto},
-    io, mem, ptr,
-    str::FromStr,
-};
+use std::{collections::HashMap, io, mem, ptr, str::FromStr};
 
 use thiserror::Error;
 

--- a/aya/src/obj/btf/types.rs
+++ b/aya/src/obj/btf/types.rs
@@ -1,8 +1,4 @@
-use std::{
-    convert::{TryFrom, TryInto},
-    fmt::Display,
-    mem, ptr,
-};
+use std::{fmt::Display, mem, ptr};
 
 use object::Endianness;
 

--- a/aya/src/obj/mod.rs
+++ b/aya/src/obj/mod.rs
@@ -9,7 +9,6 @@ use object::{
 };
 use std::{
     collections::HashMap,
-    convert::{TryFrom, TryInto},
     ffi::{CStr, CString},
     mem, ptr,
     str::FromStr,

--- a/aya/src/programs/cgroup_skb.rs
+++ b/aya/src/programs/cgroup_skb.rs
@@ -44,7 +44,6 @@ use crate::{
 /// # }
 /// # let mut bpf = aya::Bpf::load(&[])?;
 /// use std::fs::File;
-/// use std::convert::TryInto;
 /// use aya::programs::{CgroupSkb, CgroupSkbAttachType};
 ///
 /// let file = File::open("/sys/fs/cgroup/unified")?;

--- a/aya/src/programs/cgroup_sock.rs
+++ b/aya/src/programs/cgroup_sock.rs
@@ -43,7 +43,6 @@ use crate::{
 /// # }
 /// # let mut bpf = aya::Bpf::load(&[])?;
 /// use std::fs::File;
-/// use std::convert::TryInto;
 /// use aya::programs::{CgroupSock, CgroupSockAttachType};
 ///
 /// let file = File::open("/sys/fs/cgroup/unified")?;

--- a/aya/src/programs/cgroup_sock_addr.rs
+++ b/aya/src/programs/cgroup_sock_addr.rs
@@ -44,7 +44,6 @@ use crate::{
 /// # }
 /// # let mut bpf = aya::Bpf::load(&[])?;
 /// use std::fs::File;
-/// use std::convert::TryInto;
 /// use aya::programs::{CgroupSockAddr, CgroupSockAddrAttachType};
 ///
 /// let file = File::open("/sys/fs/cgroup/unified")?;

--- a/aya/src/programs/cgroup_sockopt.rs
+++ b/aya/src/programs/cgroup_sockopt.rs
@@ -40,7 +40,6 @@ use crate::{
 /// # }
 /// # let mut bpf = aya::Bpf::load(&[])?;
 /// use std::fs::File;
-/// use std::convert::TryInto;
 /// use aya::programs::CgroupSockopt;
 ///
 /// let file = File::open("/sys/fs/cgroup/unified")?;

--- a/aya/src/programs/cgroup_sysctl.rs
+++ b/aya/src/programs/cgroup_sysctl.rs
@@ -38,7 +38,6 @@ use crate::{
 /// # }
 /// # let mut bpf = aya::Bpf::load(&[])?;
 /// use std::fs::File;
-/// use std::convert::TryInto;
 /// use aya::programs::CgroupSysctl;
 ///
 /// let file = File::open("/sys/fs/cgroup/unified")?;

--- a/aya/src/programs/extension.rs
+++ b/aya/src/programs/extension.rs
@@ -36,7 +36,6 @@ pub enum ExtensionError {
 ///
 /// ```no_run
 /// use aya::{BpfLoader, programs::{Xdp, XdpFlags, Extension}};
-/// use std::convert::TryInto;
 ///
 /// let mut bpf = BpfLoader::new().extension("extension").load_file("app.o")?;
 /// let prog: &mut Xdp = bpf.program_mut("main").unwrap().try_into()?;

--- a/aya/src/programs/fentry.rs
+++ b/aya/src/programs/fentry.rs
@@ -35,7 +35,6 @@ use crate::{
 /// # }
 /// # let mut bpf = Bpf::load_file("ebpf_programs.o")?;
 /// use aya::{Bpf, programs::FEntry, BtfError, Btf};
-/// use std::convert::TryInto;
 ///
 /// let btf = Btf::from_sys_fs()?;
 /// let program: &mut FEntry = bpf.program_mut("filename_lookup").unwrap().try_into()?;

--- a/aya/src/programs/fexit.rs
+++ b/aya/src/programs/fexit.rs
@@ -35,7 +35,6 @@ use crate::{
 /// # }
 /// # let mut bpf = Bpf::load_file("ebpf_programs.o")?;
 /// use aya::{Bpf, programs::FExit, BtfError, Btf};
-/// use std::convert::TryInto;
 ///
 /// let btf = Btf::from_sys_fs()?;
 /// let program: &mut FExit = bpf.program_mut("filename_lookup").unwrap().try_into()?;

--- a/aya/src/programs/kprobe.rs
+++ b/aya/src/programs/kprobe.rs
@@ -29,7 +29,6 @@ use crate::{
 /// ```no_run
 /// # let mut bpf = Bpf::load_file("ebpf_programs.o")?;
 /// use aya::{Bpf, programs::KProbe};
-/// use std::convert::TryInto;
 ///
 /// let program: &mut KProbe = bpf.program_mut("intercept_wakeups").unwrap().try_into()?;
 /// program.load()?;

--- a/aya/src/programs/lirc_mode2.rs
+++ b/aya/src/programs/lirc_mode2.rs
@@ -36,7 +36,6 @@ use libc::{close, dup};
 /// # }
 /// # let mut bpf = aya::Bpf::load(&[])?;
 /// use std::fs::File;
-/// use std::convert::TryInto;
 /// use aya::programs::LircMode2;
 ///
 /// let file = File::open("/dev/lirc0")?;

--- a/aya/src/programs/lsm.rs
+++ b/aya/src/programs/lsm.rs
@@ -36,7 +36,6 @@ use crate::{
 /// # }
 /// # let mut bpf = Bpf::load_file("ebpf_programs.o")?;
 /// use aya::{Bpf, programs::Lsm, BtfError, Btf};
-/// use std::convert::TryInto;
 ///
 /// let btf = Btf::from_sys_fs()?;
 /// let program: &mut Lsm = bpf.program_mut("lsm_prog").unwrap().try_into()?;

--- a/aya/src/programs/mod.rs
+++ b/aya/src/programs/mod.rs
@@ -15,7 +15,6 @@
 //!
 //! ```no_run
 //! use aya::{Bpf, programs::KProbe};
-//! use std::convert::TryInto;
 //!
 //! let mut bpf = Bpf::load_file("ebpf_programs.o")?;
 //! // intercept_wakeups is the name of the program we want to load
@@ -66,7 +65,6 @@ pub mod xdp;
 
 use libc::ENOSPC;
 use std::{
-    convert::TryFrom,
     ffi::CString,
     io,
     os::unix::io::{AsRawFd, RawFd},

--- a/aya/src/programs/perf_event.rs
+++ b/aya/src/programs/perf_event.rs
@@ -97,7 +97,6 @@ pub enum PerfEventScope {
 /// #     Bpf(#[from] aya::BpfError)
 /// # }
 /// # let mut bpf = aya::Bpf::load(&[])?;
-/// use std::convert::TryInto;
 /// use aya::util::online_cpus;
 /// use aya::programs::perf_event::{
 ///     perf_sw_ids::PERF_COUNT_SW_CPU_CLOCK, PerfEvent, PerfEventScope, PerfTypeId, SamplePolicy,

--- a/aya/src/programs/raw_trace_point.rs
+++ b/aya/src/programs/raw_trace_point.rs
@@ -26,7 +26,6 @@ use crate::{
 /// ```no_run
 /// # let mut bpf = Bpf::load_file("ebpf_programs.o")?;
 /// use aya::{Bpf, programs::RawTracePoint};
-/// use std::convert::TryInto;
 ///
 /// let program: &mut RawTracePoint = bpf.program_mut("sys_enter").unwrap().try_into()?;
 /// program.load()?;

--- a/aya/src/programs/sk_lookup.rs
+++ b/aya/src/programs/sk_lookup.rs
@@ -36,7 +36,6 @@ use super::links::FdLink;
 /// # }
 /// # let mut bpf = aya::Bpf::load(&[])?;
 /// use std::fs::File;
-/// use std::convert::TryInto;
 /// use aya::programs::SkLookup;
 ///
 /// let file = File::open("/var/run/netns/test")?;

--- a/aya/src/programs/sk_msg.rs
+++ b/aya/src/programs/sk_msg.rs
@@ -34,7 +34,6 @@ use crate::{
 /// #     Bpf(#[from] aya::BpfError)
 /// # }
 /// # let mut bpf = aya::Bpf::load(&[])?;
-/// use std::convert::{TryFrom, TryInto};
 /// use std::io::Write;
 /// use std::net::TcpStream;
 /// use std::os::unix::io::AsRawFd;

--- a/aya/src/programs/sk_skb.rs
+++ b/aya/src/programs/sk_skb.rs
@@ -35,7 +35,6 @@ pub enum SkSkbKind {
 ///
 /// ```no_run
 /// # let mut bpf = aya::Bpf::load(&[])?;
-/// use std::convert::{TryFrom, TryInto};
 /// use aya::maps::SockMap;
 /// use aya::programs::SkSkb;
 ///

--- a/aya/src/programs/sock_ops.rs
+++ b/aya/src/programs/sock_ops.rs
@@ -36,7 +36,6 @@ use crate::{
 /// # }
 /// # let mut bpf = aya::Bpf::load(&[])?;
 /// use std::fs::File;
-/// use std::convert::TryInto;
 /// use aya::programs::SockOps;
 ///
 /// let file = File::open("/sys/fs/cgroup/unified")?;

--- a/aya/src/programs/socket_filter.rs
+++ b/aya/src/programs/socket_filter.rs
@@ -47,7 +47,6 @@ pub enum SocketFilterError {
 /// #     Bpf(#[from] aya::BpfError)
 /// # }
 /// # let mut bpf = aya::Bpf::load(&[])?;
-/// use std::convert::TryInto;
 /// use std::net::TcpStream;
 /// use std::os::unix::io::AsRawFd;
 /// use aya::programs::SocketFilter;

--- a/aya/src/programs/tc.rs
+++ b/aya/src/programs/tc.rs
@@ -55,7 +55,6 @@ pub enum TcAttachType {
 /// #     Bpf(#[from] aya::BpfError)
 /// # }
 /// # let mut bpf = aya::Bpf::load(&[])?;
-/// use std::convert::TryInto;
 /// use aya::programs::{tc, SchedClassifier, TcAttachType};
 ///
 /// // the clsact qdisc needs to be added before SchedClassifier programs can be

--- a/aya/src/programs/tp_btf.rs
+++ b/aya/src/programs/tp_btf.rs
@@ -33,7 +33,6 @@ use crate::{
 /// # }
 /// # let mut bpf = Bpf::load_file("ebpf_programs.o")?;
 /// use aya::{Bpf, programs::BtfTracePoint, BtfError, Btf};
-/// use std::convert::TryInto;
 ///
 /// let btf = Btf::from_sys_fs()?;
 /// let program: &mut BtfTracePoint = bpf.program_mut("sched_process_fork").unwrap().try_into()?;

--- a/aya/src/programs/trace_point.rs
+++ b/aya/src/programs/trace_point.rs
@@ -51,7 +51,6 @@ pub enum TracePointError {
 /// #     Bpf(#[from] aya::BpfError)
 /// # }
 /// # let mut bpf = aya::Bpf::load(&[])?;
-/// use std::convert::TryInto;
 /// use aya::programs::TracePoint;
 ///
 /// let prog: &mut TracePoint = bpf.program_mut("trace_context_switch").unwrap().try_into()?;

--- a/aya/src/programs/xdp.rs
+++ b/aya/src/programs/xdp.rs
@@ -62,7 +62,6 @@ bitflags! {
 /// ```no_run
 /// # let mut bpf = Bpf::load_file("ebpf_programs.o")?;
 /// use aya::{Bpf, programs::{Xdp, XdpFlags}};
-/// use std::convert::TryInto;
 ///
 /// let program: &mut Xdp = bpf.program_mut("intercept_packets").unwrap().try_into()?;
 /// program.attach("eth0", XdpFlags::default())?;

--- a/aya/src/sys/mod.rs
+++ b/aya/src/sys/mod.rs
@@ -7,7 +7,7 @@ mod fake;
 
 use std::io;
 #[cfg(not(test))]
-use std::{convert::TryInto, ffi::CString, mem};
+use std::{ffi::CString, mem};
 
 #[cfg(not(test))]
 use libc::utsname;

--- a/aya/src/sys/netlink.rs
+++ b/aya/src/sys/netlink.rs
@@ -590,7 +590,7 @@ fn bytes_of<T>(val: &T) -> &[u8] {
 
 #[cfg(test)]
 mod tests {
-    use std::{convert::TryInto, ffi::CString};
+    use std::ffi::CString;
 
     use super::*;
 

--- a/bpf/aya-bpf-bindings/Cargo.toml
+++ b/bpf/aya-bpf-bindings/Cargo.toml
@@ -2,7 +2,7 @@
 name = "aya-bpf-bindings"
 version = "0.1.0"
 authors = ["Alessandro Decina <alessandro.d@gmail.com>"]
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 aya-bpf-cty = { path = "../aya-bpf-cty" }

--- a/bpf/aya-bpf/Cargo.toml
+++ b/bpf/aya-bpf/Cargo.toml
@@ -2,7 +2,7 @@
 name = "aya-bpf"
 version = "0.1.0"
 authors = ["Alessandro Decina <alessandro.d@gmail.com>"]
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 aya-bpf-cty = { path = "../aya-bpf-cty" }

--- a/bpf/aya-log-ebpf/Cargo.toml
+++ b/bpf/aya-log-ebpf/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "aya-log-ebpf"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 aya-bpf = { path = "../aya-bpf" }

--- a/test/integration-ebpf/Cargo.toml
+++ b/test/integration-ebpf/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "integration-ebpf"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 publish = false
 
 [dependencies]

--- a/test/integration-test-macros/Cargo.toml
+++ b/test/integration-test-macros/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "integration-test-macros"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 publish = false
 
 [dependencies]

--- a/test/integration-test/Cargo.toml
+++ b/test/integration-test/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "integration-test"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 publish = false
 
 [dependencies]

--- a/test/integration-test/src/tests/load.rs
+++ b/test/integration-test/src/tests/load.rs
@@ -1,8 +1,4 @@
-use std::{
-    convert::{TryFrom, TryInto},
-    process::Command,
-    thread, time,
-};
+use std::{process::Command, thread, time};
 
 use aya::{
     include_bytes_aligned,

--- a/test/integration-test/src/tests/smoke.rs
+++ b/test/integration-test/src/tests/smoke.rs
@@ -1,5 +1,3 @@
-use std::convert::TryInto;
-
 use aya::{
     include_bytes_aligned,
     programs::{Extension, Xdp, XdpFlags},

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -2,7 +2,7 @@
 name = "xtask"
 version = "0.1.0"
 authors = ["Alessandro Decina <alessandro.d@gmail.com>"]
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 aya-gen = { path = "../aya-gen" }


### PR DESCRIPTION
Rust 2021 adds more core prelude imports, including `TryFrom` and
`TryInto`.

Signed-off-by: Michal Rostecki <vadorovsky@gmail.com>