### PR TITLE
aya: expose BPF verifier log level configuration

### DIFF
--- a/aya/src/bpf.rs
+++ b/aya/src/bpf.rs
@@ -194,6 +194,7 @@ pub struct BpfLoader<'a> {
     globals: HashMap<&'a str, &'a [u8]>,
     features: Features,
     extensions: HashSet<&'a str>,
+    verifier_log_level: u32,
 }
 
 impl<'a> BpfLoader<'a> {
@@ -207,6 +208,7 @@ impl<'a> BpfLoader<'a> {
             globals: HashMap::new(),
             features,
             extensions: HashSet::new(),
+            verifier_log_level: 7,
         }
     }
 
@@ -314,6 +316,24 @@ impl<'a> BpfLoader<'a> {
         self
     }
 
+    /// Sets BPF verifier log level.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use aya::BpfLoader;
+    ///
+    /// let bpf = BpfLoader::new()
+    ///     .verifier_log_level(3)
+    ///     .load_file("file.o")?;
+    /// # Ok::<(), aya::BpfError>(())
+    /// ```
+    ///
+    pub fn verifier_log_level(&mut self, level: u32) -> &mut BpfLoader<'a> {
+        self.verifier_log_level = level;
+        self
+    }
+
     /// Loads eBPF bytecode from a file.
     ///
     /// # Examples
@@ -345,6 +365,7 @@ impl<'a> BpfLoader<'a> {
     /// # Ok::<(), aya::BpfError>(())
     /// ```
     pub fn load(&mut self, data: &[u8]) -> Result<Bpf, BpfError> {
+        let verifier_log_level = self.verifier_log_level;
         let mut obj = Object::parse(data)?;
         obj.patch_map_data(self.globals.clone())?;
 
@@ -444,65 +465,65 @@ impl<'a> BpfLoader<'a> {
 
                 let program = if self.extensions.contains(name.as_str()) {
                     Program::Extension(Extension {
-                        data: ProgramData::new(prog_name, obj, btf_fd),
+                        data: ProgramData::new(prog_name, obj, btf_fd, verifier_log_level),
                     })
                 } else {
                     match &section {
                         ProgramSection::KProbe { .. } => Program::KProbe(KProbe {
-                            data: ProgramData::new(prog_name, obj, btf_fd),
+                            data: ProgramData::new(prog_name, obj, btf_fd, verifier_log_level),
                             kind: ProbeKind::KProbe,
                         }),
                         ProgramSection::KRetProbe { .. } => Program::KProbe(KProbe {
-                            data: ProgramData::new(prog_name, obj, btf_fd),
+                            data: ProgramData::new(prog_name, obj, btf_fd, verifier_log_level),
                             kind: ProbeKind::KRetProbe,
                         }),
                         ProgramSection::UProbe { .. } => Program::UProbe(UProbe {
-                            data: ProgramData::new(prog_name, obj, btf_fd),
+                            data: ProgramData::new(prog_name, obj, btf_fd, verifier_log_level),
                             kind: ProbeKind::UProbe,
                         }),
                         ProgramSection::URetProbe { .. } => Program::UProbe(UProbe {
-                            data: ProgramData::new(prog_name, obj, btf_fd),
+                            data: ProgramData::new(prog_name, obj, btf_fd, verifier_log_level),
                             kind: ProbeKind::URetProbe,
                         }),
                         ProgramSection::TracePoint { .. } => Program::TracePoint(TracePoint {
-                            data: ProgramData::new(prog_name, obj, btf_fd),
+                            data: ProgramData::new(prog_name, obj, btf_fd, verifier_log_level),
                         }),
                         ProgramSection::SocketFilter { .. } => {
                             Program::SocketFilter(SocketFilter {
-                                data: ProgramData::new(prog_name, obj, btf_fd),
+                                data: ProgramData::new(prog_name, obj, btf_fd, verifier_log_level),
                             })
                         }
                         ProgramSection::Xdp { .. } => Program::Xdp(Xdp {
-                            data: ProgramData::new(prog_name, obj, btf_fd),
+                            data: ProgramData::new(prog_name, obj, btf_fd, verifier_log_level),
                         }),
                         ProgramSection::SkMsg { .. } => Program::SkMsg(SkMsg {
-                            data: ProgramData::new(prog_name, obj, btf_fd),
+                            data: ProgramData::new(prog_name, obj, btf_fd, verifier_log_level),
                         }),
                         ProgramSection::CgroupSysctl { .. } => {
                             Program::CgroupSysctl(CgroupSysctl {
-                                data: ProgramData::new(prog_name, obj, btf_fd),
+                                data: ProgramData::new(prog_name, obj, btf_fd, verifier_log_level),
                             })
                         }
                         ProgramSection::CgroupSockopt { attach_type, .. } => {
                             Program::CgroupSockopt(CgroupSockopt {
-                                data: ProgramData::new(prog_name, obj, btf_fd),
+                                data: ProgramData::new(prog_name, obj, btf_fd, verifier_log_level),
                                 attach_type: *attach_type,
                             })
                         }
                         ProgramSection::SkSkbStreamParser { .. } => Program::SkSkb(SkSkb {
-                            data: ProgramData::new(prog_name, obj, btf_fd),
+                            data: ProgramData::new(prog_name, obj, btf_fd, verifier_log_level),
                             kind: SkSkbKind::StreamParser,
                         }),
                         ProgramSection::SkSkbStreamVerdict { .. } => Program::SkSkb(SkSkb {
-                            data: ProgramData::new(prog_name, obj, btf_fd),
+                            data: ProgramData::new(prog_name, obj, btf_fd, verifier_log_level),
                             kind: SkSkbKind::StreamVerdict,
                         }),
                         ProgramSection::SockOps { .. } => Program::SockOps(SockOps {
-                            data: ProgramData::new(prog_name, obj, btf_fd),
+                            data: ProgramData::new(prog_name, obj, btf_fd, verifier_log_level),
                         }),
                         ProgramSection::SchedClassifier { .. } => {
                             Program::SchedClassifier(SchedClassifier {
-                                data: ProgramData::new(prog_name, obj, btf_fd),
+                                data: ProgramData::new(prog_name, obj, btf_fd, verifier_log_level),
                                 name: unsafe {
                                     CString::from_vec_unchecked(Vec::from(name.clone()))
                                         .into_boxed_c_str()
@@ -510,57 +531,57 @@ impl<'a> BpfLoader<'a> {
                             })
                         }
                         ProgramSection::CgroupSkb { .. } => Program::CgroupSkb(CgroupSkb {
-                            data: ProgramData::new(prog_name, obj, btf_fd),
+                            data: ProgramData::new(prog_name, obj, btf_fd, verifier_log_level),
                             expected_attach_type: None,
                         }),
                         ProgramSection::CgroupSkbIngress { .. } => Program::CgroupSkb(CgroupSkb {
-                            data: ProgramData::new(prog_name, obj, btf_fd),
+                            data: ProgramData::new(prog_name, obj, btf_fd, verifier_log_level),
                             expected_attach_type: Some(CgroupSkbAttachType::Ingress),
                         }),
                         ProgramSection::CgroupSkbEgress { .. } => Program::CgroupSkb(CgroupSkb {
-                            data: ProgramData::new(prog_name, obj, btf_fd),
+                            data: ProgramData::new(prog_name, obj, btf_fd, verifier_log_level),
                             expected_attach_type: Some(CgroupSkbAttachType::Egress),
                         }),
                         ProgramSection::CgroupSockAddr { attach_type, .. } => {
                             Program::CgroupSockAddr(CgroupSockAddr {
-                                data: ProgramData::new(prog_name, obj, btf_fd),
+                                data: ProgramData::new(prog_name, obj, btf_fd, verifier_log_level),
                                 attach_type: *attach_type,
                             })
                         }
                         ProgramSection::LircMode2 { .. } => Program::LircMode2(LircMode2 {
-                            data: ProgramData::new(prog_name, obj, btf_fd),
+                            data: ProgramData::new(prog_name, obj, btf_fd, verifier_log_level),
                         }),
                         ProgramSection::PerfEvent { .. } => Program::PerfEvent(PerfEvent {
-                            data: ProgramData::new(prog_name, obj, btf_fd),
+                            data: ProgramData::new(prog_name, obj, btf_fd, verifier_log_level),
                         }),
                         ProgramSection::RawTracePoint { .. } => {
                             Program::RawTracePoint(RawTracePoint {
-                                data: ProgramData::new(prog_name, obj, btf_fd),
+                                data: ProgramData::new(prog_name, obj, btf_fd, verifier_log_level),
                             })
                         }
                         ProgramSection::Lsm { .. } => Program::Lsm(Lsm {
-                            data: ProgramData::new(prog_name, obj, btf_fd),
+                            data: ProgramData::new(prog_name, obj, btf_fd, verifier_log_level),
                         }),
                         ProgramSection::BtfTracePoint { .. } => {
                             Program::BtfTracePoint(BtfTracePoint {
-                                data: ProgramData::new(prog_name, obj, btf_fd),
+                                data: ProgramData::new(prog_name, obj, btf_fd, verifier_log_level),
                             })
                         }
                         ProgramSection::FEntry { .. } => Program::FEntry(FEntry {
-                            data: ProgramData::new(prog_name, obj, btf_fd),
+                            data: ProgramData::new(prog_name, obj, btf_fd, verifier_log_level),
                         }),
                         ProgramSection::FExit { .. } => Program::FExit(FExit {
-                            data: ProgramData::new(prog_name, obj, btf_fd),
+                            data: ProgramData::new(prog_name, obj, btf_fd, verifier_log_level),
                         }),
                         ProgramSection::Extension { .. } => Program::Extension(Extension {
-                            data: ProgramData::new(prog_name, obj, btf_fd),
+                            data: ProgramData::new(prog_name, obj, btf_fd, verifier_log_level),
                         }),
                         ProgramSection::SkLookup { .. } => Program::SkLookup(SkLookup {
-                            data: ProgramData::new(prog_name, obj, btf_fd),
+                            data: ProgramData::new(prog_name, obj, btf_fd, verifier_log_level),
                         }),
                         ProgramSection::CgroupSock { attach_type, .. } => {
                             Program::CgroupSock(CgroupSock {
-                                data: ProgramData::new(prog_name, obj, btf_fd),
+                                data: ProgramData::new(prog_name, obj, btf_fd, verifier_log_level),
                                 attach_type: *attach_type,
                             })
                         }

--- a/aya/src/programs/mod.rs
+++ b/aya/src/programs/mod.rs
@@ -408,6 +408,7 @@ pub(crate) struct ProgramData<T: Link> {
     pub(crate) attach_btf_id: Option<u32>,
     pub(crate) attach_prog_fd: Option<RawFd>,
     pub(crate) btf_fd: Option<RawFd>,
+    pub(crate) verifier_log_level: u32,
 }
 
 impl<T: Link> ProgramData<T> {
@@ -415,6 +416,7 @@ impl<T: Link> ProgramData<T> {
         name: Option<String>,
         obj: obj::Program,
         btf_fd: Option<RawFd>,
+        verifier_log_level: u32,
     ) -> ProgramData<T> {
         ProgramData {
             name,
@@ -426,6 +428,7 @@ impl<T: Link> ProgramData<T> {
             attach_btf_id: None,
             attach_prog_fd: None,
             btf_fd,
+            verifier_log_level,
         }
     }
 }
@@ -533,7 +536,11 @@ fn load_program<T: Link>(
         line_info_rec_size: *line_info_rec_size,
         line_info: line_info.clone(),
     };
-    let ret = retry_with_verifier_logs(10, &mut logger, |logger| bpf_load_program(&attr, logger));
+
+    let verifier_log_level = data.verifier_log_level;
+    let ret = retry_with_verifier_logs(10, &mut logger, |logger| {
+        bpf_load_program(&attr, logger, verifier_log_level)
+    });
 
     match ret {
         Ok(prog_fd) => {

--- a/aya/src/sys/bpf.rs
+++ b/aya/src/sys/bpf.rs
@@ -95,6 +95,7 @@ pub(crate) struct BpfLoadProgramAttrs<'a> {
 pub(crate) fn bpf_load_program(
     aya_attr: &BpfLoadProgramAttrs,
     logger: &mut VerifierLog,
+    verifier_log_level: u32,
 ) -> SysResult {
     let mut attr = unsafe { mem::zeroed::<bpf_attr>() };
 
@@ -139,7 +140,7 @@ pub(crate) fn bpf_load_program(
     }
     let log_buf = logger.buf();
     if log_buf.capacity() > 0 {
-        u.log_level = 7;
+        u.log_level = verifier_log_level;
         u.log_buf = log_buf.as_mut_ptr() as u64;
         u.log_size = log_buf.capacity() as u32;
     }


### PR DESCRIPTION
Hi!

Simple change that allows configuring verifier log level using `BpfLoader`.

Reducing the log level is very useful when debugging since the last line of the verifier error is its cause, so when the buffer is out of space you can't see the cause.

For reference: change discussed [here](https://discord.com/channels/855676609003651072/855676609003651075/1012486817087500389)