### PR TITLE
aya-log-ebpf-macros: Fix the DisplayHint expression names

### DIFF
--- a/aya-log-ebpf-macros/src/expand.rs
+++ b/aya-log-ebpf-macros/src/expand.rs
@@ -79,8 +79,8 @@ fn hint_to_expr(hint: DisplayHint) -> Result<Expr> {
         DisplayHint::Default => parse_str("::aya_log_ebpf::macro_support::DisplayHint::Default"),
         DisplayHint::LowerHex => parse_str("::aya_log_ebpf::macro_support::DisplayHint::LowerHex"),
         DisplayHint::UpperHex => parse_str("::aya_log_ebpf::macro_support::DisplayHint::UpperHex"),
-        DisplayHint::Ipv4 => parse_str("::aya_log_ebpf::macro_support::DisplayHint::IPv4"),
-        DisplayHint::Ipv6 => parse_str("::aya_log_ebpf::macro_support::DisplayHint::IPv6"),
+        DisplayHint::Ipv4 => parse_str("::aya_log_ebpf::macro_support::DisplayHint::Ipv4"),
+        DisplayHint::Ipv6 => parse_str("::aya_log_ebpf::macro_support::DisplayHint::Ipv6"),
     }
 }
 


### PR DESCRIPTION
Signed-off-by: Michal Rostecki <vadorovsky@gmail.com>