### PR TITLE
aya-bpf/maps: Add skb_output/xdp_output to PerfEventArray

### DIFF
--- a/bpf/aya-bpf/src/maps/perf/perf_event_array.rs
+++ b/bpf/aya-bpf/src/maps/perf/perf_event_array.rs
@@ -66,4 +66,12 @@ impl<T> PerfEventArray<T> {
             );
         }
     }
+
+    pub fn skb_output<C: BpfContext>(&self, ctx: &C, skb_len: u32, data: &T) {
+        self.output_at_index(ctx, BPF_F_CURRENT_CPU as u32, data, skb_len)
+    }
+
+    pub fn xdp_output<C: BpfContext>(&self, ctx: &C, xdp_len: u32, data: &T) {
+        self.output_at_index(ctx, BPF_F_CURRENT_CPU as u32, data, xdp_len)
+    }
 }

--- a/bpf/aya-bpf/src/maps/perf/perf_event_byte_array.rs
+++ b/bpf/aya-bpf/src/maps/perf/perf_event_byte_array.rs
@@ -63,4 +63,12 @@ impl PerfEventByteArray {
             );
         }
     }
+
+    pub fn skb_output<C: BpfContext>(&self, ctx: &C, skb_len: u32, data: &[u8]) {
+        self.output_at_index(ctx, BPF_F_CURRENT_CPU as u32, data, skb_len)
+    }
+
+    pub fn xdp_output<C: BpfContext>(&self, ctx: &C, xdp_len: u32, data: &[u8]) {
+        self.output_at_index(ctx, BPF_F_CURRENT_CPU as u32, data, xdp_len)
+    }
 }


### PR DESCRIPTION
`skb_output` and `xdp_output` are simple wrappers around the existing
`output_at_index` method. With these wrappers, we can easily submit
the raw data blob held by `struct __sk_buff *`/`struct xdp_md *`
to a PerfEventArray.

Signed-off-by: Hengqi Chen <chenhengqi@outlook.com>