### PR TITLE
Update `VerifierLogLevel` to use bitflags

### DIFF
--- a/aya/src/bpf.rs
+++ b/aya/src/bpf.rs
@@ -205,7 +205,7 @@ bitflags! {
         const DEBUG = 1;
         /// Enables verbose verifier logging.
         const VERBOSE = 2 | Self::DEBUG.bits;
-        /// Enables verifier stats
+        /// Enables verifier stats.
         const STATS = 4;
     }
 }

--- a/aya/src/bpf.rs
+++ b/aya/src/bpf.rs
@@ -197,15 +197,15 @@ pub struct BpfLoader<'a> {
 }
 
 bitflags! {
-    /// Used to set the verifier log level in [BpfLoader](BpfLoader::verifier_log_level()).
+    /// Used to set the verifier log level flags in [BpfLoader](BpfLoader::verifier_log_level()).
     pub struct VerifierLogLevel: u32 {
-        /// Used to disable all logging.
+        /// Sets no verifier logging.
         const DISABLE = 0;
-        ///  Logs tracing with details level 1
-        const LEVEL1 = 1;
-        /// Log tracing with details level 2
-        const LEVEL2 = 2 | Self::LEVEL1.bits;
-        /// Logs eBPF verifier stats
+        /// Enables debug verifier logging.
+        const DEBUG = 1;
+        /// Enables verbose verifier logging.
+        const VERBOSE = 2 | Self::DEBUG.bits;
+        /// Enables verifier stats
         const STATS = 4;
     }
 }
@@ -213,7 +213,7 @@ bitflags! {
 impl Default for VerifierLogLevel {
     fn default() -> Self {
         Self {
-            bits: Self::LEVEL1.bits | Self::STATS.bits,
+            bits: Self::DEBUG.bits | Self::STATS.bits,
         }
     }
 }
@@ -345,7 +345,7 @@ impl<'a> BpfLoader<'a> {
     /// use aya::{BpfLoader, VerifierLogLevel};
     ///
     /// let bpf = BpfLoader::new()
-    ///     .verifier_log_level(VerifierLogLevel::LEVEL2 | VerifierLogLevel::STATS)
+    ///     .verifier_log_level(VerifierLogLevel::VERBOSE | VerifierLogLevel::STATS)
     ///     .load_file("file.o")?;
     /// # Ok::<(), aya::BpfError>(())
     /// ```


### PR DESCRIPTION
As talked with @alessandrod [here](https://discord.com/channels/855676609003651072/855676609003651075/1014213239762067486), using `bitflags!` to implement the `VerifierLogLevel`.

I think that using the `Default` trait might be better than having a `DEFAULT` value in the struct but not so sure on that.

Also setting `Level2` as `Level1 | 2` since in the kernel level 1 seems to imply level 2. Meaning, that when they check for log level they either check for [`BPF_LOG_LEVEL2`](https://github.com/torvalds/linux/blob/f16214c102f0f64b2f3546e989498525bd7b7708/include/linux/bpf_verifier.h#L419) (when it's exclusive to 2) or [`BPF_LOG_LEVEL`](https://github.com/torvalds/linux/blob/f16214c102f0f64b2f3546e989498525bd7b7708/include/linux/bpf_verifier.h#L422) when it also include level 1, So I didn't think being able to use 2 was very useful.