### PR TITLE
aya: More pinning fixes

### DIFF
--- a/aya-tool/src/generate.rs
+++ b/aya-tool/src/generate.rs
@@ -62,7 +62,7 @@ pub fn generate<T: AsRef<str>>(
     let (c_header, name) = match &input_file {
         InputFile::Btf(path) => (c_header_from_btf(path)?, "kernel_types.h"),
         InputFile::Header(header) => (
-            fs::read_to_string(&header).map_err(Error::ReadHeaderFile)?,
+            fs::read_to_string(header).map_err(Error::ReadHeaderFile)?,
             header.file_name().unwrap().to_str().unwrap(),
         ),
     };
@@ -92,9 +92,9 @@ pub fn generate<T: AsRef<str>>(
 
 fn c_header_from_btf(path: &Path) -> Result<String, Error> {
     let output = Command::new("bpftool")
-        .args(&["btf", "dump", "file"])
+        .args(["btf", "dump", "file"])
         .arg(path)
-        .args(&["format", "c"])
+        .args(["format", "c"])
         .output()
         .map_err(Error::BpfTool)?;
 

--- a/aya/src/programs/extension.rs
+++ b/aya/src/programs/extension.rs
@@ -148,8 +148,8 @@ impl Extension {
 fn get_btf_info(prog_fd: i32, func_name: &str) -> Result<(RawFd, u32), ProgramError> {
     // retrieve program information
     let info =
-        sys::bpf_obj_get_info_by_fd(prog_fd).map_err(|io_error| ProgramError::SyscallError {
-            call: "bpf_obj_get_info_by_fd".to_owned(),
+        sys::bpf_prog_get_info_by_fd(prog_fd).map_err(|io_error| ProgramError::SyscallError {
+            call: "bpf_prog_get_info_by_fd".to_owned(),
             io_error,
         })?;
 
@@ -175,7 +175,7 @@ fn get_btf_info(prog_fd: i32, func_name: &str) -> Result<(RawFd, u32), ProgramEr
                 let btf_info =
                     sys::btf_obj_get_info_by_fd(btf_fd, &mut buf).map_err(|io_error| {
                         ProgramError::SyscallError {
-                            call: "bpf_obj_get_info_by_fd".to_owned(),
+                            call: "btf_obj_get_info_by_fd".to_owned(),
                             io_error,
                         }
                     })?;
@@ -185,7 +185,7 @@ fn get_btf_info(prog_fd: i32, func_name: &str) -> Result<(RawFd, u32), ProgramEr
             }
         }
         Err(io_error) => Err(ProgramError::SyscallError {
-            call: "bpf_obj_get_info_by_fd".to_owned(),
+            call: "btf_obj_get_info_by_fd".to_owned(),
             io_error,
         }),
     }?;

--- a/aya/src/programs/links.rs
+++ b/aya/src/programs/links.rs
@@ -187,7 +187,7 @@ impl PinnedLink {
         }
     }
 
-    /// Creates a [`PinnedLink`] from a valid path on bpffs
+    /// Creates a [`PinnedLink`] from a valid path on bpffs.
     pub fn from_path<P: AsRef<Path>>(path: P) -> Result<Self, LinkError> {
         let path_string = CString::new(path.as_ref().to_string_lossy().to_string()).unwrap();
         let fd =

--- a/aya/src/programs/lirc_mode2.rs
+++ b/aya/src/programs/lirc_mode2.rs
@@ -4,7 +4,7 @@ use std::os::unix::prelude::{AsRawFd, RawFd};
 use crate::{
     generated::{bpf_attach_type::BPF_LIRC_MODE2, bpf_prog_type::BPF_PROG_TYPE_LIRC_MODE2},
     programs::{load_program, query, Link, ProgramData, ProgramError, ProgramInfo},
-    sys::{bpf_obj_get_info_by_fd, bpf_prog_attach, bpf_prog_detach, bpf_prog_get_fd_by_id},
+    sys::{bpf_prog_attach, bpf_prog_detach, bpf_prog_get_fd_by_id, bpf_prog_get_info_by_fd},
 };
 
 use libc::{close, dup};
@@ -132,10 +132,10 @@ impl LircLink {
 
     /// Get ProgramInfo from this link
     pub fn info(&self) -> Result<ProgramInfo, ProgramError> {
-        match bpf_obj_get_info_by_fd(self.prog_fd) {
+        match bpf_prog_get_info_by_fd(self.prog_fd) {
             Ok(info) => Ok(ProgramInfo(info)),
             Err(io_error) => Err(ProgramError::SyscallError {
-                call: "bpf_obj_get_info_by_fd".to_owned(),
+                call: "bpf_prog_get_info_by_fd".to_owned(),
                 io_error,
             }),
         }

--- a/aya/src/programs/mod.rs
+++ b/aya/src/programs/mod.rs
@@ -106,8 +106,8 @@ use crate::{
     obj::{self, btf::BtfError, Function, KernelVersion},
     pin::PinError,
     sys::{
-        bpf_get_object, bpf_load_program, bpf_obj_get_info_by_fd, bpf_pin_object,
-        bpf_prog_get_fd_by_id, bpf_prog_query, retry_with_verifier_logs, BpfLoadProgramAttrs,
+        bpf_get_object, bpf_load_program, bpf_pin_object, bpf_prog_get_fd_by_id,
+        bpf_prog_get_info_by_fd, bpf_prog_query, retry_with_verifier_logs, BpfLoadProgramAttrs,
     },
     util::VerifierLog,
 };
@@ -826,8 +826,8 @@ impl ProgramInfo {
                 io_error,
             })? as RawFd;
 
-        let info = bpf_obj_get_info_by_fd(fd).map_err(|io_error| ProgramError::SyscallError {
-            call: "bpf_obj_get_info_by_fd".to_owned(),
+        let info = bpf_prog_get_info_by_fd(fd).map_err(|io_error| ProgramError::SyscallError {
+            call: "bpf_prog_get_info_by_fd".to_owned(),
             io_error,
         })?;
         unsafe {

--- a/aya/src/programs/xdp.rs
+++ b/aya/src/programs/xdp.rs
@@ -250,6 +250,12 @@ impl TryFrom<XdpLink> for FdLink {
     }
 }
 
+impl From<FdLink> for XdpLink {
+    fn from(fd_link: FdLink) -> Self {
+        XdpLink(XdpLinkInner::FdLink(fd_link))
+    }
+}
+
 define_link_wrapper!(
     /// The link used by [Xdp] programs.
     XdpLink,

--- a/aya/src/sys/bpf.rs
+++ b/aya/src/sys/bpf.rs
@@ -442,7 +442,7 @@ pub(crate) fn bpf_prog_get_fd_by_id(prog_id: u32) -> Result<RawFd, io::Error> {
     }
 }
 
-pub(crate) fn bpf_obj_get_info_by_fd(prog_fd: RawFd) -> Result<bpf_prog_info, io::Error> {
+pub(crate) fn bpf_prog_get_info_by_fd(prog_fd: RawFd) -> Result<bpf_prog_info, io::Error> {
     let mut attr = unsafe { mem::zeroed::<bpf_attr>() };
     // info gets entirely populated by the kernel
     let info = unsafe { MaybeUninit::zeroed().assume_init() };

--- a/test/integration-test/src/tests/load.rs
+++ b/test/integration-test/src/tests/load.rs
@@ -3,7 +3,10 @@ use std::{process::Command, thread, time};
 use aya::{
     include_bytes_aligned,
     maps::{Array, MapRefMut},
-    programs::{links::FdLink, TracePoint, Xdp, XdpFlags},
+    programs::{
+        links::{FdLink, PinnedLink},
+        TracePoint, Xdp, XdpFlags,
+    },
     Bpf,
 };
 
@@ -60,14 +63,14 @@ fn multiple_btf_maps() -> anyhow::Result<()> {
     Ok(())
 }
 
-fn is_loaded() -> bool {
+fn is_loaded(name: &str) -> bool {
     let output = Command::new("bpftool").args(["prog"]).output().unwrap();
     let stdout = String::from_utf8(output.stdout).unwrap();
-    stdout.contains("test_unload")
+    stdout.contains(name)
 }
 
-fn assert_loaded(loaded: bool) {
-    let state = is_loaded();
+fn assert_loaded(name: &str, loaded: bool) {
+    let state = is_loaded(name);
     if state == loaded {
         return;
     }
@@ -84,19 +87,19 @@ fn unload() -> anyhow::Result<()> {
     {
         let _link_owned = prog.take_link(link);
         prog.unload().unwrap();
-        assert_loaded(true);
+        assert_loaded("test_unload", true);
     };
 
-    assert_loaded(false);
+    assert_loaded("test_unload", false);
     prog.load().unwrap();
 
-    assert_loaded(true);
+    assert_loaded("test_unload", true);
     prog.attach("lo", XdpFlags::default()).unwrap();
 
-    assert_loaded(true);
+    assert_loaded("test_unload", true);
     prog.unload().unwrap();
 
-    assert_loaded(false);
+    assert_loaded("test_unload", false);
     Ok(())
 }
 
@@ -108,24 +111,57 @@ fn pin_link() -> anyhow::Result<()> {
     prog.load().unwrap();
     let link_id = prog.attach("lo", XdpFlags::default()).unwrap();
     let link = prog.take_link(link_id)?;
-    assert_loaded(true);
+    assert_loaded("test_unload", true);
 
     let fd_link: FdLink = link.try_into()?;
     let pinned = fd_link.pin("/sys/fs/bpf/aya-xdp-test-lo")?;
 
     // because of the pin, the program is still attached
     prog.unload()?;
-    assert_loaded(true);
+    assert_loaded("test_unload", true);
 
     // delete the pin, but the program is still attached
     let new_link = pinned.unpin()?;
-    println!("third assert");
-    assert_loaded(true);
+    assert_loaded("test_unload", true);
 
     // finally when new_link is dropped we're detached
     drop(new_link);
-    println!("final assert");
-    assert_loaded(false);
+    assert_loaded("test_unload", false);
+
+    Ok(())
+}
+
+#[integration_test]
+fn pin_lifecycle() -> anyhow::Result<()> {
+    let bytes = include_bytes_aligned!("../../../../target/bpfel-unknown-none/debug/pass");
+
+    // 1. Load Program and Pin
+    {
+        let mut bpf = Bpf::load(bytes)?;
+        let prog: &mut Xdp = bpf.program_mut("pass").unwrap().try_into().unwrap();
+        prog.load().unwrap();
+        let link_id = prog.attach("lo", XdpFlags::default()).unwrap();
+        let link = prog.take_link(link_id)?;
+        let fd_link: FdLink = link.try_into()?;
+        fd_link.pin("/sys/fs/bpf/aya-xdp-test-lo")?;
+    }
+
+    // should still be loaded since link was pinned
+    assert_loaded("pass", true);
+
+    // 2. Load a new version of the program, unpin link, and atomically replace old program
+    {
+        let mut bpf = Bpf::load(bytes)?;
+        let prog: &mut Xdp = bpf.program_mut("pass").unwrap().try_into().unwrap();
+        prog.load().unwrap();
+
+        let link = PinnedLink::from_path("/sys/fs/bpf/aya-xdp-test-lo")?.unpin()?;
+        prog.attach_to_link(link.try_into()?)?;
+        assert_loaded("pass", true);
+    }
+
+    // program should be unloaded
+    assert_loaded("pass", false);
 
     Ok(())
 }


### PR DESCRIPTION
This PR adds some missing lifecycle APIs required for working with pins.

1. Adds PinnedLink::from_path to create a pinned link from bpffs
1. Adds From<PinnedLink> for FdLink to allow for ^ to be converted
1. Adds TryFrom<FdLink> for XdpLink

Signed-off-by: Dave Tucker <dave@dtucker.co.uk>