### PR TITLE
aya: Fix segfault in define_link_wrapper

### DIFF
--- a/aya/src/programs/links.rs
+++ b/aya/src/programs/links.rs
@@ -258,7 +258,7 @@ macro_rules! define_link_wrapper {
 
         impl From<$wrapper> for $base {
             fn from(w: $wrapper) -> $base {
-                w.into()
+                w.0
             }
         }
     };

--- a/test/integration-test/src/tests/load.rs
+++ b/test/integration-test/src/tests/load.rs
@@ -61,7 +61,7 @@ fn multiple_btf_maps() -> anyhow::Result<()> {
 }
 
 fn is_loaded() -> bool {
-    let output = Command::new("bpftool").args(&["prog"]).output().unwrap();
+    let output = Command::new("bpftool").args(["prog"]).output().unwrap();
     let stdout = String::from_utf8(output.stdout).unwrap();
     stdout.contains("test_unload")
 }


### PR DESCRIPTION
The From<$wrapper> for $base implemention is refers to itself,
eventually causing a segfault.

Signed-off-by: Dave Tucker <dave@dtucker.co.uk>