### PR TITLE
Load static maps

### DIFF
--- a/aya/src/bpf.rs
+++ b/aya/src/bpf.rs
@@ -443,7 +443,7 @@ impl<'a> BpfLoader<'a> {
                         Err(_) => {
                             let fd = map.create(&name)?;
                             map.pin(&name, path).map_err(|error| MapError::PinError {
-                                name: name.to_string(),
+                                name: Some(name.to_string()),
                                 error,
                             })?;
                             fd
@@ -454,16 +454,14 @@ impl<'a> BpfLoader<'a> {
             };
             if !map.obj.data().is_empty() && map.obj.kind() != MapKind::Bss {
                 bpf_map_update_elem_ptr(fd, &0 as *const _, map.obj.data_mut().as_mut_ptr(), 0)
-                    .map_err(|(code, io_error)| MapError::SyscallError {
+                    .map_err(|(_, io_error)| MapError::SyscallError {
                         call: "bpf_map_update_elem".to_owned(),
-                        code,
                         io_error,
                     })?;
             }
             if map.obj.kind() == MapKind::Rodata {
-                bpf_map_freeze(fd).map_err(|(code, io_error)| MapError::SyscallError {
+                bpf_map_freeze(fd).map_err(|(_, io_error)| MapError::SyscallError {
                     call: "bpf_map_freeze".to_owned(),
-                    code,
                     io_error,
                 })?;
             }

--- a/aya/src/maps/array/array.rs
+++ b/aya/src/maps/array/array.rs
@@ -80,10 +80,9 @@ impl<T: Deref<Target = Map>, V: Pod> Array<T, V> {
         self.check_bounds(*index)?;
         let fd = self.inner.fd_or_err()?;
 
-        let value = bpf_map_lookup_elem(fd, index, flags).map_err(|(code, io_error)| {
+        let value = bpf_map_lookup_elem(fd, index, flags).map_err(|(_, io_error)| {
             MapError::SyscallError {
                 call: "bpf_map_lookup_elem".to_owned(),
-                code,
                 io_error,
             }
         })?;
@@ -116,10 +115,9 @@ impl<T: Deref<Target = Map> + DerefMut<Target = Map>, V: Pod> Array<T, V> {
     pub fn set(&mut self, index: u32, value: V, flags: u64) -> Result<(), MapError> {
         let fd = self.inner.fd_or_err()?;
         self.check_bounds(index)?;
-        bpf_map_update_elem(fd, Some(&index), &value, flags).map_err(|(code, io_error)| {
+        bpf_map_update_elem(fd, Some(&index), &value, flags).map_err(|(_, io_error)| {
             MapError::SyscallError {
                 call: "bpf_map_update_elem".to_owned(),
-                code,
                 io_error,
             }
         })?;

--- a/aya/src/maps/array/per_cpu_array.rs
+++ b/aya/src/maps/array/per_cpu_array.rs
@@ -99,10 +99,9 @@ impl<T: Deref<Target = Map>, V: Pod> PerCpuArray<T, V> {
         self.check_bounds(*index)?;
         let fd = self.inner.fd_or_err()?;
 
-        let value = bpf_map_lookup_elem_per_cpu(fd, index, flags).map_err(|(code, io_error)| {
+        let value = bpf_map_lookup_elem_per_cpu(fd, index, flags).map_err(|(_, io_error)| {
             MapError::SyscallError {
                 call: "bpf_map_lookup_elem".to_owned(),
-                code,
                 io_error,
             }
         })?;
@@ -135,10 +134,9 @@ impl<T: Deref<Target = Map> + DerefMut<Target = Map>, V: Pod> PerCpuArray<T, V> 
     pub fn set(&mut self, index: u32, values: PerCpuValues<V>, flags: u64) -> Result<(), MapError> {
         let fd = self.inner.fd_or_err()?;
         self.check_bounds(index)?;
-        bpf_map_update_elem_per_cpu(fd, &index, &values, flags).map_err(|(code, io_error)| {
+        bpf_map_update_elem_per_cpu(fd, &index, &values, flags).map_err(|(_, io_error)| {
             MapError::SyscallError {
                 call: "bpf_map_update_elem".to_owned(),
-                code,
                 io_error,
             }
         })?;

--- a/aya/src/maps/array/program_array.rs
+++ b/aya/src/maps/array/program_array.rs
@@ -103,10 +103,9 @@ impl<T: Deref<Target = Map> + DerefMut<Target = Map>> ProgramArray<T> {
         self.check_bounds(index)?;
         let prog_fd = program.as_raw_fd();
 
-        bpf_map_update_elem(fd, Some(&index), &prog_fd, flags).map_err(|(code, io_error)| {
+        bpf_map_update_elem(fd, Some(&index), &prog_fd, flags).map_err(|(_, io_error)| {
             MapError::SyscallError {
                 call: "bpf_map_update_elem".to_owned(),
-                code,
                 io_error,
             }
         })?;
@@ -122,9 +121,8 @@ impl<T: Deref<Target = Map> + DerefMut<Target = Map>> ProgramArray<T> {
         self.check_bounds(*index)?;
         bpf_map_delete_elem(fd, index)
             .map(|_| ())
-            .map_err(|(code, io_error)| MapError::SyscallError {
+            .map_err(|(_, io_error)| MapError::SyscallError {
                 call: "bpf_map_delete_elem".to_owned(),
-                code,
                 io_error,
             })
     }

--- a/aya/src/maps/hash_map/hash_map.rs
+++ b/aya/src/maps/hash_map/hash_map.rs
@@ -61,10 +61,9 @@ impl<T: Deref<Target = Map>, K: Pod, V: Pod> HashMap<T, K, V> {
     /// Returns a copy of the value associated with the key.
     pub fn get(&self, key: &K, flags: u64) -> Result<V, MapError> {
         let fd = self.inner.deref().fd_or_err()?;
-        let value = bpf_map_lookup_elem(fd, key, flags).map_err(|(code, io_error)| {
+        let value = bpf_map_lookup_elem(fd, key, flags).map_err(|(_, io_error)| {
             MapError::SyscallError {
                 call: "bpf_map_lookup_elem".to_owned(),
-                code,
                 io_error,
             }
         })?;
@@ -313,7 +312,7 @@ mod tests {
 
         assert!(matches!(
             hm.insert(1, 42, 0),
-            Err(MapError::SyscallError { call, code: -1, io_error }) if call == "bpf_map_update_elem" && io_error.raw_os_error() == Some(EFAULT)
+            Err(MapError::SyscallError { call, io_error }) if call == "bpf_map_update_elem" && io_error.raw_os_error() == Some(EFAULT)
         ));
     }
 
@@ -352,7 +351,7 @@ mod tests {
 
         assert!(matches!(
             hm.remove(&1),
-            Err(MapError::SyscallError { call, code: -1, io_error }) if call == "bpf_map_delete_elem" && io_error.raw_os_error() == Some(EFAULT)
+            Err(MapError::SyscallError { call, io_error }) if call == "bpf_map_delete_elem" && io_error.raw_os_error() == Some(EFAULT)
         ));
     }
 
@@ -390,7 +389,7 @@ mod tests {
 
         assert!(matches!(
             hm.get(&1, 0),
-            Err(MapError::SyscallError { call, code: -1, io_error }) if call == "bpf_map_lookup_elem" && io_error.raw_os_error() == Some(EFAULT)
+            Err(MapError::SyscallError { call, io_error }) if call == "bpf_map_lookup_elem" && io_error.raw_os_error() == Some(EFAULT)
         ));
     }
 

--- a/aya/src/maps/hash_map/mod.rs
+++ b/aya/src/maps/hash_map/mod.rs
@@ -29,10 +29,9 @@ pub(crate) fn check_kv_size<K, V>(map: &Map) -> Result<(), MapError> {
 
 pub(crate) fn insert<K, V>(map: &mut Map, key: K, value: V, flags: u64) -> Result<(), MapError> {
     let fd = map.fd_or_err()?;
-    bpf_map_update_elem(fd, Some(&key), &value, flags).map_err(|(code, io_error)| {
+    bpf_map_update_elem(fd, Some(&key), &value, flags).map_err(|(_, io_error)| {
         MapError::SyscallError {
             call: "bpf_map_update_elem".to_owned(),
-            code,
             io_error,
         }
     })?;
@@ -44,9 +43,8 @@ pub(crate) fn remove<K>(map: &mut Map, key: &K) -> Result<(), MapError> {
     let fd = map.fd_or_err()?;
     bpf_map_delete_elem(fd, key)
         .map(|_| ())
-        .map_err(|(code, io_error)| MapError::SyscallError {
+        .map_err(|(_, io_error)| MapError::SyscallError {
             call: "bpf_map_delete_elem".to_owned(),
-            code,
             io_error,
         })
 }

--- a/aya/src/maps/hash_map/per_cpu_hash_map.rs
+++ b/aya/src/maps/hash_map/per_cpu_hash_map.rs
@@ -73,10 +73,9 @@ impl<T: Deref<Target = Map>, K: Pod, V: Pod> PerCpuHashMap<T, K, V> {
     /// Returns a slice of values - one for each CPU - associated with the key.
     pub fn get(&self, key: &K, flags: u64) -> Result<PerCpuValues<V>, MapError> {
         let fd = self.inner.deref().fd_or_err()?;
-        let values = bpf_map_lookup_elem_per_cpu(fd, key, flags).map_err(|(code, io_error)| {
+        let values = bpf_map_lookup_elem_per_cpu(fd, key, flags).map_err(|(_, io_error)| {
             MapError::SyscallError {
                 call: "bpf_map_lookup_elem".to_owned(),
-                code,
                 io_error,
             }
         })?;
@@ -127,10 +126,9 @@ impl<T: DerefMut<Target = Map>, K: Pod, V: Pod> PerCpuHashMap<T, K, V> {
     /// ```
     pub fn insert(&mut self, key: K, values: PerCpuValues<V>, flags: u64) -> Result<(), MapError> {
         let fd = self.inner.fd_or_err()?;
-        bpf_map_update_elem_per_cpu(fd, &key, &values, flags).map_err(|(code, io_error)| {
+        bpf_map_update_elem_per_cpu(fd, &key, &values, flags).map_err(|(_, io_error)| {
             MapError::SyscallError {
                 call: "bpf_map_update_elem".to_owned(),
-                code,
                 io_error,
             }
         })?;

--- a/aya/src/maps/queue.rs
+++ b/aya/src/maps/queue.rs
@@ -81,9 +81,8 @@ impl<T: Deref<Target = Map> + DerefMut<Target = Map>, V: Pod> Queue<T, V> {
         let fd = self.inner.fd_or_err()?;
 
         let value = bpf_map_lookup_and_delete_elem::<u32, _>(fd, None, flags).map_err(
-            |(code, io_error)| MapError::SyscallError {
+            |(_, io_error)| MapError::SyscallError {
                 call: "bpf_map_lookup_and_delete_elem".to_owned(),
-                code,
                 io_error,
             },
         )?;
@@ -97,12 +96,9 @@ impl<T: Deref<Target = Map> + DerefMut<Target = Map>, V: Pod> Queue<T, V> {
     /// [`MapError::SyscallError`] if `bpf_map_update_elem` fails.
     pub fn push(&mut self, value: V, flags: u64) -> Result<(), MapError> {
         let fd = self.inner.fd_or_err()?;
-        bpf_map_push_elem(fd, &value, flags).map_err(|(code, io_error)| {
-            MapError::SyscallError {
-                call: "bpf_map_push_elem".to_owned(),
-                code,
-                io_error,
-            }
+        bpf_map_push_elem(fd, &value, flags).map_err(|(_, io_error)| MapError::SyscallError {
+            call: "bpf_map_push_elem".to_owned(),
+            io_error,
         })?;
         Ok(())
     }

--- a/aya/src/maps/sock/sock_hash.rs
+++ b/aya/src/maps/sock/sock_hash.rs
@@ -87,10 +87,9 @@ impl<T: Deref<Target = Map>, K: Pod> SockHash<T, K> {
     /// Returns the fd of the socket stored at the given key.
     pub fn get(&self, key: &K, flags: u64) -> Result<RawFd, MapError> {
         let fd = self.inner.deref().fd_or_err()?;
-        let value = bpf_map_lookup_elem(fd, key, flags).map_err(|(code, io_error)| {
+        let value = bpf_map_lookup_elem(fd, key, flags).map_err(|(_, io_error)| {
             MapError::SyscallError {
                 call: "bpf_map_lookup_elem".to_owned(),
-                code,
                 io_error,
             }
         })?;

--- a/aya/src/maps/sock/sock_map.rs
+++ b/aya/src/maps/sock/sock_map.rs
@@ -89,9 +89,8 @@ impl<T: Deref<Target = Map> + DerefMut<Target = Map>> SockMap<T> {
         let fd = self.inner.fd_or_err()?;
         self.check_bounds(index)?;
         bpf_map_update_elem(fd, Some(&index), &socket.as_raw_fd(), flags).map_err(
-            |(code, io_error)| MapError::SyscallError {
+            |(_, io_error)| MapError::SyscallError {
                 call: "bpf_map_update_elem".to_owned(),
-                code,
                 io_error,
             },
         )?;
@@ -104,9 +103,8 @@ impl<T: Deref<Target = Map> + DerefMut<Target = Map>> SockMap<T> {
         self.check_bounds(*index)?;
         bpf_map_delete_elem(fd, index)
             .map(|_| ())
-            .map_err(|(code, io_error)| MapError::SyscallError {
+            .map_err(|(_, io_error)| MapError::SyscallError {
                 call: "bpf_map_delete_elem".to_owned(),
-                code,
                 io_error,
             })
     }

--- a/aya/src/maps/stack.rs
+++ b/aya/src/maps/stack.rs
@@ -81,9 +81,8 @@ impl<T: Deref<Target = Map> + DerefMut<Target = Map>, V: Pod> Stack<T, V> {
         let fd = self.inner.fd_or_err()?;
 
         let value = bpf_map_lookup_and_delete_elem::<u32, _>(fd, None, flags).map_err(
-            |(code, io_error)| MapError::SyscallError {
+            |(_, io_error)| MapError::SyscallError {
                 call: "bpf_map_lookup_and_delete_elem".to_owned(),
-                code,
                 io_error,
             },
         )?;
@@ -97,10 +96,9 @@ impl<T: Deref<Target = Map> + DerefMut<Target = Map>, V: Pod> Stack<T, V> {
     /// [`MapError::SyscallError`] if `bpf_map_update_elem` fails.
     pub fn push(&mut self, value: V, flags: u64) -> Result<(), MapError> {
         let fd = self.inner.fd_or_err()?;
-        bpf_map_update_elem(fd, None::<&u32>, &value, flags).map_err(|(code, io_error)| {
+        bpf_map_update_elem(fd, None::<&u32>, &value, flags).map_err(|(_, io_error)| {
             MapError::SyscallError {
                 call: "bpf_map_update_elem".to_owned(),
-                code,
                 io_error,
             }
         })?;

--- a/aya/src/maps/stack_trace.rs
+++ b/aya/src/maps/stack_trace.rs
@@ -86,7 +86,6 @@ impl<T: Deref<Target = Map>> StackTraceMap<T> {
             sysctl::<usize>("kernel/perf_event_max_stack").map_err(|io_error| {
                 MapError::SyscallError {
                     call: "sysctl".to_owned(),
-                    code: -1,
                     io_error,
                 }
             })?;
@@ -113,9 +112,8 @@ impl<T: Deref<Target = Map>> StackTraceMap<T> {
 
         let mut frames = vec![0; self.max_stack_depth];
         bpf_map_lookup_elem_ptr(fd, Some(stack_id), frames.as_mut_ptr(), flags)
-            .map_err(|(code, io_error)| MapError::SyscallError {
+            .map_err(|(_, io_error)| MapError::SyscallError {
                 call: "bpf_map_lookup_elem".to_owned(),
-                code,
                 io_error,
             })?
             .ok_or(MapError::KeyNotFound)?;

--- a/aya/src/programs/extension.rs
+++ b/aya/src/programs/extension.rs
@@ -175,7 +175,7 @@ fn get_btf_info(prog_fd: i32, func_name: &str) -> Result<(RawFd, u32), ProgramEr
                 let btf_info =
                     sys::btf_obj_get_info_by_fd(btf_fd, &mut buf).map_err(|io_error| {
                         ProgramError::SyscallError {
-                            call: "btf_obj_get_info_by_fd".to_owned(),
+                            call: "bpf_prog_get_info_by_fd".to_owned(),
                             io_error,
                         }
                     })?;
@@ -185,7 +185,7 @@ fn get_btf_info(prog_fd: i32, func_name: &str) -> Result<(RawFd, u32), ProgramEr
             }
         }
         Err(io_error) => Err(ProgramError::SyscallError {
-            call: "btf_obj_get_info_by_fd".to_owned(),
+            call: "bpf_prog_get_info_by_fd".to_owned(),
             io_error,
         }),
     }?;

--- a/aya/src/sys/bpf.rs
+++ b/aya/src/sys/bpf.rs
@@ -11,8 +11,8 @@ use libc::{c_char, c_long, close, ENOENT, ENOSPC};
 
 use crate::{
     generated::{
-        bpf_attach_type, bpf_attr, bpf_btf_info, bpf_cmd, bpf_insn, bpf_link_info, bpf_prog_info,
-        bpf_prog_type, BPF_F_REPLACE,
+        bpf_attach_type, bpf_attr, bpf_btf_info, bpf_cmd, bpf_insn, bpf_link_info, bpf_map_info,
+        bpf_prog_info, bpf_prog_type, BPF_F_REPLACE,
     },
     maps::PerCpuValues,
     obj::{
@@ -439,14 +439,29 @@ pub(crate) fn bpf_prog_get_fd_by_id(prog_id: u32) -> Result<RawFd, io::Error> {
 pub(crate) fn bpf_prog_get_info_by_fd(prog_fd: RawFd) -> Result<bpf_prog_info, io::Error> {
     let mut attr = unsafe { mem::zeroed::<bpf_attr>() };
     // info gets entirely populated by the kernel
-    let info = unsafe { MaybeUninit::zeroed().assume_init() };
+    let info = MaybeUninit::zeroed();
 
     attr.info.bpf_fd = prog_fd as u32;
     attr.info.info = &info as *const _ as u64;
     attr.info.info_len = mem::size_of::<bpf_prog_info>() as u32;
 
     match sys_bpf(bpf_cmd::BPF_OBJ_GET_INFO_BY_FD, &attr) {
-        Ok(_) => Ok(info),
+        Ok(_) => Ok(unsafe { info.assume_init() }),
+        Err((_, err)) => Err(err),
+    }
+}
+
+pub(crate) fn bpf_map_get_info_by_fd(prog_fd: RawFd) -> Result<bpf_map_info, io::Error> {
+    let mut attr = unsafe { mem::zeroed::<bpf_attr>() };
+    // info gets entirely populated by the kernel
+    let info = MaybeUninit::zeroed();
+
+    attr.info.bpf_fd = prog_fd as u32;
+    attr.info.info = info.as_ptr() as *const _ as u64;
+    attr.info.info_len = mem::size_of::<bpf_map_info>() as u32;
+
+    match sys_bpf(bpf_cmd::BPF_OBJ_GET_INFO_BY_FD, &attr) {
+        Ok(_) => Ok(unsafe { info.assume_init() }),
         Err((_, err)) => Err(err),
     }
 }


### PR DESCRIPTION
fixes #385 

This PR adds the new `aya::maps::{from_pinned, from_fd}` APIs. Which will allow users to load in and interact with BPF maps from either a raw file descriptor or map pin point. 

The user can get a concrete aya map type to interact with like so 

```rust
    let map_pin_path = Path::new("/sys/fs/bpf/basic-node-firewall/BLOCKLIST");

    let mut block_map = Map::from_pinned(map_pin_path)?; 

    let mut blocklist: HashMap<_, PacketFiveTuple, u32> =
    HashMap::try_from(&mut block_map)?;
```

I tested this locally with a pinned map, but was unsure exactly how to add unit tests....and would appreciate any feedback on that :) 


