### PR TITLE
aya: Add PinnedProgram

### DIFF
--- a/aya/src/bpf.rs
+++ b/aya/src/bpf.rs
@@ -601,7 +601,7 @@ impl<'a> BpfLoader<'a> {
                         ProgramSection::CgroupSock { attach_type, .. } => {
                             Program::CgroupSock(CgroupSock {
                                 data: ProgramData::new(prog_name, obj, btf_fd, verifier_log_level),
-                                attach_type: *attach_type,
+                                attach_type: Some(*attach_type),
                             })
                         }
                     }

--- a/aya/src/obj/relocation.rs
+++ b/aya/src/obj/relocation.rs
@@ -22,7 +22,7 @@ enum RelocationError {
     UnknownSymbol { index: usize },
 
     #[error("section `{section_index}` not found, referenced by symbol `{}` #{symbol_index}",
-            .symbol_name.clone().unwrap_or_else(|| "".to_string()))]
+            .symbol_name.clone().unwrap_or_default())]
     SectionNotFound {
         section_index: usize,
         symbol_index: usize,

--- a/aya/src/programs/cgroup_sock.rs
+++ b/aya/src/programs/cgroup_sock.rs
@@ -54,13 +54,18 @@ use crate::{
 #[doc(alias = "BPF_PROG_TYPE_CGROUP_SOCK")]
 pub struct CgroupSock {
     pub(crate) data: ProgramData<CgroupSockLink>,
-    pub(crate) attach_type: CgroupSockAttachType,
+    pub(crate) attach_type: Option<CgroupSockAttachType>,
 }
 
 impl CgroupSock {
     /// Loads the program inside the kernel.
     pub fn load(&mut self) -> Result<(), ProgramError> {
-        self.data.expected_attach_type = Some(self.attach_type.into());
+        if self.attach_type.is_none() {
+            return Err(ProgramError::IncompleteProgramDefinition(
+                "missing attach_type".to_string(),
+            ));
+        }
+        self.data.expected_attach_type = Some(self.attach_type.unwrap().into());
         load_program(BPF_PROG_TYPE_CGROUP_SOCK, &mut self.data)
     }
 

--- a/aya/src/sys/perf_event.rs
+++ b/aya/src/sys/perf_event.rs
@@ -30,7 +30,7 @@ pub(crate) fn perf_event_open(
     attr.type_ = perf_type;
     attr.sample_type = PERF_SAMPLE_RAW as u64;
     // attr.inherits = if pid > 0 { 1 } else { 0 };
-    attr.__bindgen_anon_2.wakeup_events = if wakeup { 1 } else { 0 };
+    attr.__bindgen_anon_2.wakeup_events = u32::from(wakeup);
 
     if let Some(frequency) = sample_frequency {
         attr.set_freq(1);


### PR DESCRIPTION
This commit adds PinnedProgram which allows the creation of a Program from a path on bpffs. This is useful to be able to call `attach` or other APIs for programs that are already loaded to the kernel. Unfortunately figuring out the concrete type of program is hard given the information in the kernel so this may not work for all program types.

Signed-off-by: Dave Tucker <dave@dtucker.co.uk>