### PR TITLE
Consistently name Pin APIs as from_pin

### DIFF
--- a/aya/src/maps/mod.rs
+++ b/aya/src/maps/mod.rs
@@ -48,14 +48,14 @@ use thiserror::Error;
 
 use crate::{
     generated::bpf_map_type,
-    obj,
+    obj::{self, parse_map_info},
     pin::PinError,
     sys::{
         bpf_create_map, bpf_get_object, bpf_map_get_info_by_fd, bpf_map_get_next_key,
         bpf_pin_object, kernel_version,
     },
     util::nr_cpus,
-    Pod,
+    PinningType, Pod,
 };
 
 mod map_lock;
@@ -325,7 +325,7 @@ impl Map {
         })?;
 
         Ok(Map {
-            obj: obj::parse_map_info(info, crate::PinningType::ByName),
+            obj: parse_map_info(info, PinningType::ByName),
             fd: Some(fd),
             btf_fd: None,
             pinned: true,
@@ -344,7 +344,7 @@ impl Map {
         })?;
 
         Ok(Map {
-            obj: obj::parse_map_info(info, crate::PinningType::None),
+            obj: parse_map_info(info, PinningType::None),
             fd: Some(fd),
             btf_fd: None,
             pinned: false,

--- a/aya/src/maps/mod.rs
+++ b/aya/src/maps/mod.rs
@@ -303,7 +303,7 @@ impl Map {
     }
 
     /// Loads a map from a pinned path in bpffs.
-    pub fn from_pinned<P: AsRef<Path>>(path: P) -> Result<Map, MapError> {
+    pub fn from_pin<P: AsRef<Path>>(path: P) -> Result<Map, MapError> {
         let path_string =
             CString::new(path.as_ref().to_string_lossy().into_owned()).map_err(|e| {
                 MapError::PinError {
@@ -334,7 +334,7 @@ impl Map {
 
     /// Loads a map from a [`RawFd`].
     ///
-    /// If loading from a BPF Filesystem (bpffs) you should use [`Map::from_pinned`].
+    /// If loading from a BPF Filesystem (bpffs) you should use [`Map::from_pin`].
     /// This API is intended for cases where you have received a valid BPF FD from some other means.
     /// For example, you received an FD over Unix Domain Socket.
     pub fn from_fd(fd: RawFd) -> Result<Map, MapError> {

--- a/aya/src/programs/links.rs
+++ b/aya/src/programs/links.rs
@@ -188,7 +188,7 @@ impl PinnedLink {
     }
 
     /// Creates a [`PinnedLink`] from a valid path on bpffs.
-    pub fn from_path<P: AsRef<Path>>(path: P) -> Result<Self, LinkError> {
+    pub fn from_pin<P: AsRef<Path>>(path: P) -> Result<Self, LinkError> {
         let path_string = CString::new(path.as_ref().to_string_lossy().to_string()).unwrap();
         let fd =
             bpf_get_object(&path_string).map_err(|(code, io_error)| LinkError::SyscallError {

--- a/aya/src/programs/mod.rs
+++ b/aya/src/programs/mod.rs
@@ -818,7 +818,7 @@ impl ProgramInfo {
     }
 
     /// Loads a program from a pinned path in bpffs.
-    pub fn from_pinned<P: AsRef<Path>>(path: P) -> Result<ProgramInfo, ProgramError> {
+    pub fn from_pin<P: AsRef<Path>>(path: P) -> Result<ProgramInfo, ProgramError> {
         let path_string = CString::new(path.as_ref().to_str().unwrap()).unwrap();
         let fd =
             bpf_get_object(&path_string).map_err(|(_, io_error)| ProgramError::SyscallError {

--- a/test/integration-test/src/tests/load.rs
+++ b/test/integration-test/src/tests/load.rs
@@ -155,7 +155,7 @@ fn pin_lifecycle() -> anyhow::Result<()> {
         let prog: &mut Xdp = bpf.program_mut("pass").unwrap().try_into().unwrap();
         prog.load().unwrap();
 
-        let link = PinnedLink::from_path("/sys/fs/bpf/aya-xdp-test-lo")?.unpin()?;
+        let link = PinnedLink::from_pin("/sys/fs/bpf/aya-xdp-test-lo")?.unpin()?;
         prog.attach_to_link(link.try_into()?)?;
         assert_loaded("pass", true);
     }


### PR DESCRIPTION
As discussed in #387, we should settle on one name for these APIs.
`from_pinned` - stutters when used with a type like `PinnedLink`
`from_path` - implies that any path could be used.
`from_pin` - seems like the best compromise.