### PR TITLE
make integration tests handle and display errors instead of returning anyhow::Result<()>

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,6 +30,8 @@ Make sure that your work is tracked by an issue or a (draft) pull request, this
 helps us avoid duplicating work. If your work includes publicly visible changes,
 make sure those are properly documented as explained in the section above.
 
+### Running tests
+Run the unit tests with `cargo test`. See [Aya Integration Tests](https://github.com/aya-rs/aya/blob/main/test/README.md) regarding running the integration tests.
 ### Commits
 
 It is a recommended best practice to keep your changes as logically grouped as

--- a/test/integration-test-macros/src/lib.rs
+++ b/test/integration-test-macros/src/lib.rs
@@ -17,3 +17,19 @@ pub fn integration_test(_attr: TokenStream, item: TokenStream) -> TokenStream {
     };
     TokenStream::from(expanded)
 }
+
+#[proc_macro_attribute]
+pub fn integration_test_new(_attr: TokenStream, item: TokenStream) -> TokenStream {
+    let item = parse_macro_input!(item as ItemFn);
+    let name = &item.sig.ident;
+    let name_str = &item.sig.ident.to_string();
+    let expanded = quote! {
+        #item
+
+        inventory::submit!(IntegrationTestNew {
+            name: concat!(module_path!(), "::", #name_str),
+            test_fn: #name,
+        });
+    };
+    TokenStream::from(expanded)
+}

--- a/test/integration-test/src/main.rs
+++ b/test/integration-test/src/main.rs
@@ -31,6 +31,7 @@ macro_rules! exec_test {
     ($test:expr) => {{
         info!("Running {}", $test.name);
         if let Err(e) = ($test.test_fn)() {
+            println!("Error in {}: {}", $test.name, e);
             panic!("{}", e)
         }
     }};

--- a/test/integration-test/src/tests/load.rs
+++ b/test/integration-test/src/tests/load.rs
@@ -56,7 +56,11 @@ fn multiple_btf_maps() -> anyhow::Result<()> {
 }
 
 fn is_loaded(name: &str) -> bool {
-    let output = Command::new("bpftool").args(["prog"]).output().unwrap();
+    let output = Command::new("bpftool").args(["prog"]).output();
+    let output = match output {
+        Err(e) => panic!("Failed to run 'bpftool prog': {e}"),
+        Ok(out) => out,
+    };
     let stdout = String::from_utf8(output.stdout).unwrap();
     stdout.contains(name)
 }

--- a/test/integration-test/src/tests/load.rs
+++ b/test/integration-test/src/tests/load.rs
@@ -10,24 +10,22 @@ use aya::{
     Bpf,
 };
 
-use super::{integration_test, IntegrationTest};
+use super::{integration_test, integration_test_new, IntegrationTest, IntegrationTestNew};
 
 const MAX_RETRIES: u32 = 100;
 const RETRY_DURATION_MS: u64 = 10;
 
-#[integration_test]
-fn long_name() -> anyhow::Result<()> {
+#[integration_test_new]
+fn long_name() {
     let bytes = include_bytes_aligned!("../../../../target/bpfel-unknown-none/debug/name_test");
-    let mut bpf = Bpf::load(bytes)?;
-    let name_prog: &mut Xdp = bpf.program_mut("ihaveaverylongname").unwrap().try_into()?;
+    let mut bpf = Bpf::load(bytes).unwrap();
+    let name_prog: &mut Xdp = bpf.program_mut("ihaveaverylongname").unwrap().try_into().unwrap();
     name_prog.load().unwrap();
-    name_prog.attach("lo", XdpFlags::default())?;
+    name_prog.attach("lo", XdpFlags::default()).unwrap();
 
     // We used to be able to assert with bpftool that the program name was short.
     // It seem though that it now uses the name from the ELF symbol table instead.
     // Therefore, as long as we were able to load the program, this is good enough.
-
-    Ok(())
 }
 
 #[integration_test]

--- a/test/integration-test/src/tests/mod.rs
+++ b/test/integration-test/src/tests/mod.rs
@@ -15,6 +15,13 @@ pub struct IntegrationTest {
     pub test_fn: fn() -> anyhow::Result<()>,
 }
 
+pub use integration_test_macros::integration_test_new;
+#[derive(Debug)]
+pub struct IntegrationTestNew {
+    pub name: &'static str,
+    pub test_fn: fn(),
+}
+
 pub(crate) fn kernel_version() -> anyhow::Result<(u8, u8, u8)> {
     lazy_static! {
         static ref RE: Regex = Regex::new(r"^([0-9]+)\.([0-9]+)\.([0-9]+)").unwrap();
@@ -35,3 +42,4 @@ pub(crate) fn kernel_version() -> anyhow::Result<(u8, u8, u8)> {
 }
 
 inventory::collect!(IntegrationTest);
+inventory::collect!(IntegrationTestNew);


### PR DESCRIPTION
Related to #421.  