### PR TITLE
improve handling of bpftool not found error

### DIFF
--- a/test/integration-test/src/tests/load.rs
+++ b/test/integration-test/src/tests/load.rs
@@ -56,7 +56,11 @@ fn multiple_btf_maps() -> anyhow::Result<()> {
 }
 
 fn is_loaded(name: &str) -> bool {
-    let output = Command::new("bpftool").args(["prog"]).output().unwrap();
+    let output = Command::new("bpftool").args(["prog"]).output();
+    let output = match output {
+        Err(e) => panic!("Failed to run 'bpftool prog': {e}"),
+        Ok(out) => out,
+    };
     let stdout = String::from_utf8(output.stdout).unwrap();
     stdout.contains(name)
 }


### PR DESCRIPTION
PR make its easier - in conjunction with the upcoming fix for #421 - to detect when integration tests fail due to `bpftool` not being found.
```
[vagrant@mybox aya]$ sudo mv /usr/sbin/bpftool /usr/sbin/bpftool.bk
[vagrant@mybox aya]$ cargo xtask integration-test --libbpf-dir /gh/libbpf/libbpf
[...]
thread 'main' panicked at 'Failed to run 'bpftool prog': No such file or directory (os error 2)', test/integration-test/src/tests/load.rs:57:19
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
Aborted
```