### PR TITLE
fix clippy needless_borrow warnings

### DIFF
--- a/xtask/src/codegen/aya.rs
+++ b/xtask/src/codegen/aya.rs
@@ -49,7 +49,7 @@ fn codegen_internal_btf_bindings(opts: &Options) -> Result<(), anyhow::Error> {
         .to_string();
 
     // write the bindings, with the original helpers removed
-    write_to_file(&generated.join("btf_internal_bindings.rs"), &bindings)?;
+    write_to_file(generated.join("btf_internal_bindings.rs"), &bindings)?;
 
     Ok(())
 }
@@ -219,7 +219,7 @@ fn codegen_bindings(opts: &Options) -> Result<(), anyhow::Error> {
 
         // write the bindings, with the original helpers removed
         write_to_file(
-            &generated.join(format!("linux_bindings_{}.rs", arch)),
+            generated.join(format!("linux_bindings_{}.rs", arch)),
             &bindings.to_string(),
         )?;
     }

--- a/xtask/src/codegen/aya_bpf_bindings.rs
+++ b/xtask/src/codegen/aya_bpf_bindings.rs
@@ -103,13 +103,13 @@ pub fn codegen(opts: &Options) -> Result<(), anyhow::Error> {
         let generated = dir.join("src").join(arch.to_string());
         // write the bindings, with the original helpers removed
         write_to_file_fmt(
-            &generated.join("bindings.rs"),
+            generated.join("bindings.rs"),
             &tree.to_token_stream().to_string(),
         )?;
 
         // write the new helpers as expanded by expand_helpers()
         write_to_file_fmt(
-            &generated.join("helpers.rs"),
+            generated.join("helpers.rs"),
             &format!("use super::bindings::*; {}", helpers),
         )?;
     }


### PR DESCRIPTION
Fix the clippy warning on needless_borrow https://rust-lang.github.io/rust-clippy/master/index.html#needless_borrow which leads to the red CI lint builds.