### PR TITLE
aya: use impl Borrow<T> instead of T for maps

### DIFF
--- a/aya/src/maps/array/array.rs
+++ b/aya/src/maps/array/array.rs
@@ -1,6 +1,7 @@
 use std::{
+    borrow::Borrow,
     convert::{AsMut, AsRef},
-    marker::PhantomData, borrow::Borrow,
+    marker::PhantomData,
 };
 
 use crate::{

--- a/aya/src/maps/array/array.rs
+++ b/aya/src/maps/array/array.rs
@@ -89,7 +89,7 @@ impl<T: AsMut<MapData>, V: Pod> Array<T, V> {
     ///
     /// Returns [`MapError::OutOfBounds`] if `index` is out of bounds, [`MapError::SyscallError`]
     /// if `bpf_map_update_elem` fails.
-    pub fn set(&mut self, index: u32, value: impl Borrow<V>, flags: u64) -> Result<(), MapError> {
+    pub fn set(&mut self, index: u32, value: impl Borrow<V> + Pod, flags: u64) -> Result<(), MapError> {
         let data = self.inner.as_mut();
         check_bounds(data, index)?;
         let fd = data.fd_or_err()?;

--- a/aya/src/maps/array/array.rs
+++ b/aya/src/maps/array/array.rs
@@ -89,11 +89,11 @@ impl<T: AsMut<MapData>, V: Pod> Array<T, V> {
     ///
     /// Returns [`MapError::OutOfBounds`] if `index` is out of bounds, [`MapError::SyscallError`]
     /// if `bpf_map_update_elem` fails.
-    pub fn set(&mut self, index: u32, value: impl Borrow<V> + Pod, flags: u64) -> Result<(), MapError> {
+    pub fn set(&mut self, index: u32, value: impl Borrow<V>, flags: u64) -> Result<(), MapError> {
         let data = self.inner.as_mut();
         check_bounds(data, index)?;
         let fd = data.fd_or_err()?;
-        bpf_map_update_elem(fd, Some(&index), &value, flags).map_err(|(_, io_error)| {
+        bpf_map_update_elem(fd, Some(&index), value.borrow(), flags).map_err(|(_, io_error)| {
             MapError::SyscallError {
                 call: "bpf_map_update_elem".to_owned(),
                 io_error,

--- a/aya/src/maps/array/array.rs
+++ b/aya/src/maps/array/array.rs
@@ -1,6 +1,6 @@
 use std::{
     convert::{AsMut, AsRef},
-    marker::PhantomData,
+    marker::PhantomData, borrow::Borrow,
 };
 
 use crate::{
@@ -88,7 +88,7 @@ impl<T: AsMut<MapData>, V: Pod> Array<T, V> {
     ///
     /// Returns [`MapError::OutOfBounds`] if `index` is out of bounds, [`MapError::SyscallError`]
     /// if `bpf_map_update_elem` fails.
-    pub fn set(&mut self, index: u32, value: V, flags: u64) -> Result<(), MapError> {
+    pub fn set(&mut self, index: u32, value: impl Borrow<V>, flags: u64) -> Result<(), MapError> {
         let data = self.inner.as_mut();
         check_bounds(data, index)?;
         let fd = data.fd_or_err()?;

--- a/aya/src/maps/bloom_filter.rs
+++ b/aya/src/maps/bloom_filter.rs
@@ -1,5 +1,5 @@
 //! A Bloom Filter.
-use std::{convert::AsRef, marker::PhantomData};
+use std::{convert::AsRef, marker::PhantomData, borrow::Borrow};
 
 use crate::{
     maps::{check_v_size, MapData, MapError},
@@ -62,7 +62,7 @@ impl<T: AsRef<MapData>, V: Pod> BloomFilter<T, V> {
     }
 
     /// Inserts a value into the map.
-    pub fn insert(&self, value: V, flags: u64) -> Result<(), MapError> {
+    pub fn insert(&self, value: impl Borrow<V>, flags: u64) -> Result<(), MapError> {
         let fd = self.inner.as_ref().fd_or_err()?;
         bpf_map_push_elem(fd, &value, flags).map_err(|(_, io_error)| MapError::SyscallError {
             call: "bpf_map_push_elem".to_owned(),

--- a/aya/src/maps/bloom_filter.rs
+++ b/aya/src/maps/bloom_filter.rs
@@ -1,5 +1,5 @@
 //! A Bloom Filter.
-use std::{convert::AsRef, marker::PhantomData, borrow::Borrow};
+use std::{borrow::Borrow, convert::AsRef, marker::PhantomData};
 
 use crate::{
     maps::{check_v_size, MapData, MapError},

--- a/aya/src/maps/bloom_filter.rs
+++ b/aya/src/maps/bloom_filter.rs
@@ -64,9 +64,11 @@ impl<T: AsRef<MapData>, V: Pod> BloomFilter<T, V> {
     /// Inserts a value into the map.
     pub fn insert(&self, value: impl Borrow<V>, flags: u64) -> Result<(), MapError> {
         let fd = self.inner.as_ref().fd_or_err()?;
-        bpf_map_push_elem(fd, value.borrow(), flags).map_err(|(_, io_error)| MapError::SyscallError {
-            call: "bpf_map_push_elem".to_owned(),
-            io_error,
+        bpf_map_push_elem(fd, value.borrow(), flags).map_err(|(_, io_error)| {
+            MapError::SyscallError {
+                call: "bpf_map_push_elem".to_owned(),
+                io_error,
+            }
         })?;
         Ok(())
     }

--- a/aya/src/maps/bloom_filter.rs
+++ b/aya/src/maps/bloom_filter.rs
@@ -64,7 +64,7 @@ impl<T: AsRef<MapData>, V: Pod> BloomFilter<T, V> {
     /// Inserts a value into the map.
     pub fn insert(&self, value: impl Borrow<V>, flags: u64) -> Result<(), MapError> {
         let fd = self.inner.as_ref().fd_or_err()?;
-        bpf_map_push_elem(fd, &value, flags).map_err(|(_, io_error)| MapError::SyscallError {
+        bpf_map_push_elem(fd, value.borrow(), flags).map_err(|(_, io_error)| MapError::SyscallError {
             call: "bpf_map_push_elem".to_owned(),
             io_error,
         })?;

--- a/aya/src/maps/hash_map/hash_map.rs
+++ b/aya/src/maps/hash_map/hash_map.rs
@@ -1,6 +1,6 @@
 use std::{
     convert::{AsMut, AsRef},
-    marker::PhantomData,
+    marker::PhantomData, borrow::Borrow,
 };
 
 use crate::{
@@ -78,8 +78,8 @@ impl<T: AsRef<MapData>, K: Pod, V: Pod> HashMap<T, K, V> {
 
 impl<T: AsMut<MapData>, K: Pod, V: Pod> HashMap<T, K, V> {
     /// Inserts a key-value pair into the map.
-    pub fn insert(&mut self, key: K, value: V, flags: u64) -> Result<(), MapError> {
-        hash_map::insert(self.inner.as_mut(), key, value, flags)
+    pub fn insert(&mut self, key: impl Borrow<K>, value: impl Borrow<V>, flags: u64) -> Result<(), MapError> {
+        hash_map::insert(self.inner.as_mut(), key.borrow(), value.borrow(), flags)
     }
 
     /// Removes a key from the map.
@@ -285,7 +285,7 @@ mod tests {
         let mut hm = HashMap::<_, u32, u32>::new(&mut map).unwrap();
 
         assert!(matches!(
-            hm.insert(1, 42, 0),
+            hm.insert(1u32, 42u32, 0),
             Err(MapError::SyscallError { call, io_error }) if call == "bpf_map_update_elem" && io_error.raw_os_error() == Some(EFAULT)
         ));
     }

--- a/aya/src/maps/hash_map/hash_map.rs
+++ b/aya/src/maps/hash_map/hash_map.rs
@@ -1,6 +1,7 @@
 use std::{
+    borrow::Borrow,
     convert::{AsMut, AsRef},
-    marker::PhantomData, borrow::Borrow,
+    marker::PhantomData,
 };
 
 use crate::{
@@ -78,7 +79,12 @@ impl<T: AsRef<MapData>, K: Pod, V: Pod> HashMap<T, K, V> {
 
 impl<T: AsMut<MapData>, K: Pod, V: Pod> HashMap<T, K, V> {
     /// Inserts a key-value pair into the map.
-    pub fn insert(&mut self, key: impl Borrow<K>, value: impl Borrow<V>, flags: u64) -> Result<(), MapError> {
+    pub fn insert(
+        &mut self,
+        key: impl Borrow<K>,
+        value: impl Borrow<V>,
+        flags: u64,
+    ) -> Result<(), MapError> {
         hash_map::insert(self.inner.as_mut(), &key, &value, flags)
     }
 

--- a/aya/src/maps/hash_map/hash_map.rs
+++ b/aya/src/maps/hash_map/hash_map.rs
@@ -79,7 +79,7 @@ impl<T: AsRef<MapData>, K: Pod, V: Pod> HashMap<T, K, V> {
 impl<T: AsMut<MapData>, K: Pod, V: Pod> HashMap<T, K, V> {
     /// Inserts a key-value pair into the map.
     pub fn insert(&mut self, key: impl Borrow<K>, value: impl Borrow<V>, flags: u64) -> Result<(), MapError> {
-        hash_map::insert(self.inner.as_mut(), key.borrow(), value.borrow(), flags)
+        hash_map::insert(self.inner.as_mut(), &key, &value, flags)
     }
 
     /// Removes a key from the map.

--- a/aya/src/maps/hash_map/hash_map.rs
+++ b/aya/src/maps/hash_map/hash_map.rs
@@ -85,7 +85,7 @@ impl<T: AsMut<MapData>, K: Pod, V: Pod> HashMap<T, K, V> {
         value: impl Borrow<V>,
         flags: u64,
     ) -> Result<(), MapError> {
-        hash_map::insert(self.inner.as_mut(), &key, &value, flags)
+        hash_map::insert(self.inner.as_mut(), key.borrow(), value.borrow(), flags)
     }
 
     /// Removes a key from the map.

--- a/aya/src/maps/hash_map/mod.rs
+++ b/aya/src/maps/hash_map/mod.rs
@@ -1,4 +1,5 @@
 //! Hash map types.
+
 use crate::{
     maps::MapError,
     sys::{bpf_map_delete_elem, bpf_map_update_elem},
@@ -15,12 +16,12 @@ use super::MapData;
 
 pub(crate) fn insert<K, V>(
     map: &mut MapData,
-    key: K,
-    value: V,
+    key: &K,
+    value: &V,
     flags: u64,
 ) -> Result<(), MapError> {
     let fd = map.fd_or_err()?;
-    bpf_map_update_elem(fd, Some(&key), &value, flags).map_err(|(_, io_error)| {
+    bpf_map_update_elem(fd, Some(key), value, flags).map_err(|(_, io_error)| {
         MapError::SyscallError {
             call: "bpf_map_update_elem".to_owned(),
             io_error,

--- a/aya/src/maps/hash_map/mod.rs
+++ b/aya/src/maps/hash_map/mod.rs
@@ -30,7 +30,7 @@ pub(crate) fn insert<K: Pod, V: Pod>(
     Ok(())
 }
 
-pub(crate) fn remove<K>(map: &mut MapData, key: &K) -> Result<(), MapError> {
+pub(crate) fn remove<K: Pod>(map: &mut MapData, key: &K) -> Result<(), MapError> {
     let fd = map.fd_or_err()?;
     bpf_map_delete_elem(fd, key)
         .map(|_| ())

--- a/aya/src/maps/hash_map/mod.rs
+++ b/aya/src/maps/hash_map/mod.rs
@@ -1,7 +1,7 @@
 //! Hash map types.
 use crate::{
     maps::MapError,
-    sys::{bpf_map_delete_elem, bpf_map_update_elem},
+    sys::{bpf_map_delete_elem, bpf_map_update_elem}, Pod,
 };
 
 #[allow(clippy::module_inception)]
@@ -13,7 +13,7 @@ pub use per_cpu_hash_map::*;
 
 use super::MapData;
 
-pub(crate) fn insert<K, V>(
+pub(crate) fn insert<K: Pod, V: Pod>(
     map: &mut MapData,
     key: &K,
     value: &V,

--- a/aya/src/maps/hash_map/mod.rs
+++ b/aya/src/maps/hash_map/mod.rs
@@ -1,7 +1,8 @@
 //! Hash map types.
 use crate::{
     maps::MapError,
-    sys::{bpf_map_delete_elem, bpf_map_update_elem}, Pod,
+    sys::{bpf_map_delete_elem, bpf_map_update_elem},
+    Pod,
 };
 
 #[allow(clippy::module_inception)]

--- a/aya/src/maps/hash_map/mod.rs
+++ b/aya/src/maps/hash_map/mod.rs
@@ -1,5 +1,4 @@
 //! Hash map types.
-
 use crate::{
     maps::MapError,
     sys::{bpf_map_delete_elem, bpf_map_update_elem},

--- a/aya/src/maps/hash_map/per_cpu_hash_map.rs
+++ b/aya/src/maps/hash_map/per_cpu_hash_map.rs
@@ -1,7 +1,7 @@
 //! Per-CPU hash map.
 use std::{
     convert::{AsMut, AsRef},
-    marker::PhantomData,
+    marker::PhantomData, borrow::Borrow,
 };
 
 use crate::{
@@ -115,7 +115,7 @@ impl<T: AsMut<MapData>, K: Pod, V: Pod> PerCpuHashMap<T, K, V> {
     /// )?;
     /// # Ok::<(), Error>(())
     /// ```
-    pub fn insert(&mut self, key: K, values: PerCpuValues<V>, flags: u64) -> Result<(), MapError> {
+    pub fn insert(&mut self, key: impl Borrow<K>, values: PerCpuValues<V>, flags: u64) -> Result<(), MapError> {
         let fd = self.inner.as_mut().fd_or_err()?;
         bpf_map_update_elem_per_cpu(fd, &key, &values, flags).map_err(|(_, io_error)| {
             MapError::SyscallError {

--- a/aya/src/maps/hash_map/per_cpu_hash_map.rs
+++ b/aya/src/maps/hash_map/per_cpu_hash_map.rs
@@ -1,7 +1,8 @@
 //! Per-CPU hash map.
 use std::{
+    borrow::Borrow,
     convert::{AsMut, AsRef},
-    marker::PhantomData, borrow::Borrow,
+    marker::PhantomData,
 };
 
 use crate::{
@@ -115,7 +116,12 @@ impl<T: AsMut<MapData>, K: Pod, V: Pod> PerCpuHashMap<T, K, V> {
     /// )?;
     /// # Ok::<(), Error>(())
     /// ```
-    pub fn insert(&mut self, key: impl Borrow<K>, values: PerCpuValues<V>, flags: u64) -> Result<(), MapError> {
+    pub fn insert(
+        &mut self,
+        key: impl Borrow<K>,
+        values: PerCpuValues<V>,
+        flags: u64,
+    ) -> Result<(), MapError> {
         let fd = self.inner.as_mut().fd_or_err()?;
         bpf_map_update_elem_per_cpu(fd, &key, &values, flags).map_err(|(_, io_error)| {
             MapError::SyscallError {

--- a/aya/src/maps/hash_map/per_cpu_hash_map.rs
+++ b/aya/src/maps/hash_map/per_cpu_hash_map.rs
@@ -123,7 +123,7 @@ impl<T: AsMut<MapData>, K: Pod, V: Pod> PerCpuHashMap<T, K, V> {
         flags: u64,
     ) -> Result<(), MapError> {
         let fd = self.inner.as_mut().fd_or_err()?;
-        bpf_map_update_elem_per_cpu(fd, &key, &values, flags).map_err(|(_, io_error)| {
+        bpf_map_update_elem_per_cpu(fd, key.borrow(), &values, flags).map_err(|(_, io_error)| {
             MapError::SyscallError {
                 call: "bpf_map_update_elem".to_owned(),
                 io_error,

--- a/aya/src/maps/hash_map/per_cpu_hash_map.rs
+++ b/aya/src/maps/hash_map/per_cpu_hash_map.rs
@@ -123,12 +123,12 @@ impl<T: AsMut<MapData>, K: Pod, V: Pod> PerCpuHashMap<T, K, V> {
         flags: u64,
     ) -> Result<(), MapError> {
         let fd = self.inner.as_mut().fd_or_err()?;
-        bpf_map_update_elem_per_cpu(fd, key.borrow(), &values, flags).map_err(|(_, io_error)| {
-            MapError::SyscallError {
+        bpf_map_update_elem_per_cpu(fd, key.borrow(), &values, flags).map_err(
+            |(_, io_error)| MapError::SyscallError {
                 call: "bpf_map_update_elem".to_owned(),
                 io_error,
-            }
-        })?;
+            },
+        )?;
 
         Ok(())
     }

--- a/aya/src/maps/lpm_trie.rs
+++ b/aya/src/maps/lpm_trie.rs
@@ -136,7 +136,7 @@ impl<T: AsMut<MapData>, K: Pod, V: Pod> LpmTrie<T, K, V> {
         flags: u64,
     ) -> Result<(), MapError> {
         let fd = self.inner.as_mut().fd_or_err()?;
-        bpf_map_update_elem(fd, Some(key), &value, flags).map_err(|(_, io_error)| {
+        bpf_map_update_elem(fd, Some(key), value.borrow(), flags).map_err(|(_, io_error)| {
             MapError::SyscallError {
                 call: "bpf_map_update_elem".to_owned(),
                 io_error,

--- a/aya/src/maps/lpm_trie.rs
+++ b/aya/src/maps/lpm_trie.rs
@@ -2,7 +2,7 @@
 use std::{
     convert::{AsMut, AsRef},
     marker::PhantomData,
-    mem,
+    mem, borrow::Borrow,
 };
 
 use crate::{
@@ -128,7 +128,7 @@ impl<T: AsRef<MapData>, K: Pod, V: Pod> LpmTrie<T, K, V> {
 
 impl<T: AsMut<MapData>, K: Pod, V: Pod> LpmTrie<T, K, V> {
     /// Inserts a key value pair into the map.
-    pub fn insert(&mut self, key: &Key<K>, value: V, flags: u64) -> Result<(), MapError> {
+    pub fn insert(&mut self, key: &Key<K>, value: impl Borrow<V>, flags: u64) -> Result<(), MapError> {
         let fd = self.inner.as_mut().fd_or_err()?;
         bpf_map_update_elem(fd, Some(key), &value, flags).map_err(|(_, io_error)| {
             MapError::SyscallError {

--- a/aya/src/maps/lpm_trie.rs
+++ b/aya/src/maps/lpm_trie.rs
@@ -1,8 +1,9 @@
 //! A LPM Trie.
 use std::{
+    borrow::Borrow,
     convert::{AsMut, AsRef},
     marker::PhantomData,
-    mem, borrow::Borrow,
+    mem,
 };
 
 use crate::{
@@ -128,7 +129,12 @@ impl<T: AsRef<MapData>, K: Pod, V: Pod> LpmTrie<T, K, V> {
 
 impl<T: AsMut<MapData>, K: Pod, V: Pod> LpmTrie<T, K, V> {
     /// Inserts a key value pair into the map.
-    pub fn insert(&mut self, key: &Key<K>, value: impl Borrow<V>, flags: u64) -> Result<(), MapError> {
+    pub fn insert(
+        &mut self,
+        key: &Key<K>,
+        value: impl Borrow<V>,
+        flags: u64,
+    ) -> Result<(), MapError> {
         let fd = self.inner.as_mut().fd_or_err()?;
         bpf_map_update_elem(fd, Some(key), &value, flags).map_err(|(_, io_error)| {
             MapError::SyscallError {

--- a/aya/src/maps/queue.rs
+++ b/aya/src/maps/queue.rs
@@ -1,7 +1,8 @@
 //! A FIFO queue.
 use std::{
+    borrow::Borrow,
     convert::{AsMut, AsRef},
-    marker::PhantomData, borrow::Borrow,
+    marker::PhantomData,
 };
 
 use crate::{

--- a/aya/src/maps/queue.rs
+++ b/aya/src/maps/queue.rs
@@ -1,7 +1,7 @@
 //! A FIFO queue.
 use std::{
     convert::{AsMut, AsRef},
-    marker::PhantomData,
+    marker::PhantomData, borrow::Borrow,
 };
 
 use crate::{
@@ -78,7 +78,7 @@ impl<T: AsMut<MapData>, V: Pod> Queue<T, V> {
     /// # Errors
     ///
     /// [`MapError::SyscallError`] if `bpf_map_update_elem` fails.
-    pub fn push(&mut self, value: V, flags: u64) -> Result<(), MapError> {
+    pub fn push(&mut self, value: impl Borrow<V>, flags: u64) -> Result<(), MapError> {
         let fd = self.inner.as_mut().fd_or_err()?;
         bpf_map_push_elem(fd, &value, flags).map_err(|(_, io_error)| MapError::SyscallError {
             call: "bpf_map_push_elem".to_owned(),

--- a/aya/src/maps/queue.rs
+++ b/aya/src/maps/queue.rs
@@ -81,7 +81,7 @@ impl<T: AsMut<MapData>, V: Pod> Queue<T, V> {
     /// [`MapError::SyscallError`] if `bpf_map_update_elem` fails.
     pub fn push(&mut self, value: impl Borrow<V>, flags: u64) -> Result<(), MapError> {
         let fd = self.inner.as_mut().fd_or_err()?;
-        bpf_map_push_elem(fd, &value, flags).map_err(|(_, io_error)| MapError::SyscallError {
+        bpf_map_push_elem(fd, value.borrow(), flags).map_err(|(_, io_error)| MapError::SyscallError {
             call: "bpf_map_push_elem".to_owned(),
             io_error,
         })?;

--- a/aya/src/maps/queue.rs
+++ b/aya/src/maps/queue.rs
@@ -81,9 +81,11 @@ impl<T: AsMut<MapData>, V: Pod> Queue<T, V> {
     /// [`MapError::SyscallError`] if `bpf_map_update_elem` fails.
     pub fn push(&mut self, value: impl Borrow<V>, flags: u64) -> Result<(), MapError> {
         let fd = self.inner.as_mut().fd_or_err()?;
-        bpf_map_push_elem(fd, value.borrow(), flags).map_err(|(_, io_error)| MapError::SyscallError {
-            call: "bpf_map_push_elem".to_owned(),
-            io_error,
+        bpf_map_push_elem(fd, value.borrow(), flags).map_err(|(_, io_error)| {
+            MapError::SyscallError {
+                call: "bpf_map_push_elem".to_owned(),
+                io_error,
+            }
         })?;
         Ok(())
     }

--- a/aya/src/maps/sock/sock_hash.rs
+++ b/aya/src/maps/sock/sock_hash.rs
@@ -122,7 +122,7 @@ impl<T: AsMut<MapData>, K: Pod> SockHash<T, K> {
         value: I,
         flags: u64,
     ) -> Result<(), MapError> {
-        hash_map::insert(self.inner.as_mut(), &key, &value.as_raw_fd(), flags)
+        hash_map::insert(self.inner.as_mut(), key.borrow(), &value.as_raw_fd(), flags)
     }
 
     /// Removes a socket from the map.

--- a/aya/src/maps/sock/sock_hash.rs
+++ b/aya/src/maps/sock/sock_hash.rs
@@ -1,7 +1,7 @@
 use std::{
     convert::{AsMut, AsRef},
     marker::PhantomData,
-    os::unix::io::{AsRawFd, RawFd},
+    os::unix::io::{AsRawFd, RawFd}, borrow::Borrow,
 };
 
 use crate::{
@@ -115,7 +115,7 @@ impl<T: AsRef<MapData>, K: Pod> SockHash<T, K> {
 
 impl<T: AsMut<MapData>, K: Pod> SockHash<T, K> {
     /// Inserts a socket under the given key.
-    pub fn insert<I: AsRawFd>(&mut self, key: K, value: I, flags: u64) -> Result<(), MapError> {
+    pub fn insert<I: AsRawFd>(&mut self, key: impl Borrow<K>, value: I, flags: u64) -> Result<(), MapError> {
         hash_map::insert(self.inner.as_mut(), &key, &value.as_raw_fd(), flags)
     }
 

--- a/aya/src/maps/sock/sock_hash.rs
+++ b/aya/src/maps/sock/sock_hash.rs
@@ -116,7 +116,7 @@ impl<T: AsRef<MapData>, K: Pod> SockHash<T, K> {
 impl<T: AsMut<MapData>, K: Pod> SockHash<T, K> {
     /// Inserts a socket under the given key.
     pub fn insert<I: AsRawFd>(&mut self, key: K, value: I, flags: u64) -> Result<(), MapError> {
-        hash_map::insert(self.inner.as_mut(), key, value.as_raw_fd(), flags)
+        hash_map::insert(self.inner.as_mut(), &key, &value.as_raw_fd(), flags)
     }
 
     /// Removes a socket from the map.

--- a/aya/src/maps/sock/sock_hash.rs
+++ b/aya/src/maps/sock/sock_hash.rs
@@ -1,7 +1,8 @@
 use std::{
+    borrow::Borrow,
     convert::{AsMut, AsRef},
     marker::PhantomData,
-    os::unix::io::{AsRawFd, RawFd}, borrow::Borrow,
+    os::unix::io::{AsRawFd, RawFd},
 };
 
 use crate::{
@@ -115,7 +116,12 @@ impl<T: AsRef<MapData>, K: Pod> SockHash<T, K> {
 
 impl<T: AsMut<MapData>, K: Pod> SockHash<T, K> {
     /// Inserts a socket under the given key.
-    pub fn insert<I: AsRawFd>(&mut self, key: impl Borrow<K>, value: I, flags: u64) -> Result<(), MapError> {
+    pub fn insert<I: AsRawFd>(
+        &mut self,
+        key: impl Borrow<K>,
+        value: I,
+        flags: u64,
+    ) -> Result<(), MapError> {
         hash_map::insert(self.inner.as_mut(), &key, &value.as_raw_fd(), flags)
     }
 

--- a/aya/src/maps/stack.rs
+++ b/aya/src/maps/stack.rs
@@ -1,7 +1,8 @@
 //! A LIFO stack.
 use std::{
+    borrow::Borrow,
     convert::{AsMut, AsRef},
-    marker::PhantomData, borrow::Borrow,
+    marker::PhantomData,
 };
 
 use crate::{

--- a/aya/src/maps/stack.rs
+++ b/aya/src/maps/stack.rs
@@ -1,7 +1,7 @@
 //! A LIFO stack.
 use std::{
     convert::{AsMut, AsRef},
-    marker::PhantomData,
+    marker::PhantomData, borrow::Borrow,
 };
 
 use crate::{
@@ -78,7 +78,7 @@ impl<T: AsMut<MapData>, V: Pod> Stack<T, V> {
     /// # Errors
     ///
     /// [`MapError::SyscallError`] if `bpf_map_update_elem` fails.
-    pub fn push(&mut self, value: V, flags: u64) -> Result<(), MapError> {
+    pub fn push(&mut self, value: impl Borrow<V>, flags: u64) -> Result<(), MapError> {
         let fd = self.inner.as_mut().fd_or_err()?;
         bpf_map_update_elem(fd, None::<&u32>, &value, flags).map_err(|(_, io_error)| {
             MapError::SyscallError {

--- a/aya/src/maps/stack.rs
+++ b/aya/src/maps/stack.rs
@@ -81,7 +81,7 @@ impl<T: AsMut<MapData>, V: Pod> Stack<T, V> {
     /// [`MapError::SyscallError`] if `bpf_map_update_elem` fails.
     pub fn push(&mut self, value: impl Borrow<V>, flags: u64) -> Result<(), MapError> {
         let fd = self.inner.as_mut().fd_or_err()?;
-        bpf_map_update_elem(fd, None::<&u32>, &value, flags).map_err(|(_, io_error)| {
+        bpf_map_update_elem(fd, None::<&u32>, value.borrow(), flags).map_err(|(_, io_error)| {
             MapError::SyscallError {
                 call: "bpf_map_update_elem".to_owned(),
                 io_error,

--- a/aya/src/sys/bpf.rs
+++ b/aya/src/sys/bpf.rs
@@ -251,7 +251,7 @@ pub(crate) fn bpf_map_update_elem<K: Pod, V: Pod>(
     sys_bpf(bpf_cmd::BPF_MAP_UPDATE_ELEM, &attr)
 }
 
-pub(crate) fn bpf_map_push_elem<V>(fd: RawFd, value: &V, flags: u64) -> SysResult {
+pub(crate) fn bpf_map_push_elem<V: Pod>(fd: RawFd, value: &V, flags: u64) -> SysResult {
     let mut attr = unsafe { mem::zeroed::<bpf_attr>() };
 
     let u = unsafe { &mut attr.__bindgen_anon_2 };
@@ -279,7 +279,7 @@ pub(crate) fn bpf_map_update_elem_ptr<K, V>(
     sys_bpf(bpf_cmd::BPF_MAP_UPDATE_ELEM, &attr)
 }
 
-pub(crate) fn bpf_map_update_elem_per_cpu<K, V: Pod>(
+pub(crate) fn bpf_map_update_elem_per_cpu<K: Pod, V: Pod>(
     fd: RawFd,
     key: &K,
     values: &PerCpuValues<V>,
@@ -289,7 +289,7 @@ pub(crate) fn bpf_map_update_elem_per_cpu<K, V: Pod>(
     bpf_map_update_elem_ptr(fd, key, mem.as_mut_ptr(), flags)
 }
 
-pub(crate) fn bpf_map_delete_elem<K>(fd: RawFd, key: &K) -> SysResult {
+pub(crate) fn bpf_map_delete_elem<K: Pod>(fd: RawFd, key: &K) -> SysResult {
     let mut attr = unsafe { mem::zeroed::<bpf_attr>() };
 
     let u = unsafe { &mut attr.__bindgen_anon_2 };
@@ -299,7 +299,7 @@ pub(crate) fn bpf_map_delete_elem<K>(fd: RawFd, key: &K) -> SysResult {
     sys_bpf(bpf_cmd::BPF_MAP_DELETE_ELEM, &attr)
 }
 
-pub(crate) fn bpf_map_get_next_key<K>(
+pub(crate) fn bpf_map_get_next_key<K: Pod>(
     fd: RawFd,
     key: Option<&K>,
 ) -> Result<Option<K>, (c_long, io::Error)> {

--- a/aya/src/sys/bpf.rs
+++ b/aya/src/sys/bpf.rs
@@ -232,7 +232,7 @@ pub(crate) fn bpf_map_lookup_elem_ptr<K: Pod, V>(
     }
 }
 
-pub(crate) fn bpf_map_update_elem<K, V>(
+pub(crate) fn bpf_map_update_elem<K: Pod, V: Pod>(
     fd: RawFd,
     key: Option<&K>,
     value: &V,

--- a/bpf/aya-bpf/src/maps/sock_hash.rs
+++ b/bpf/aya-bpf/src/maps/sock_hash.rs
@@ -1,4 +1,4 @@
-use core::{cell::UnsafeCell, marker::PhantomData, mem, borrow::Borrow};
+use core::{borrow::Borrow, cell::UnsafeCell, marker::PhantomData, mem};
 
 use aya_bpf_cty::c_void;
 

--- a/bpf/aya-bpf/src/maps/sock_hash.rs
+++ b/bpf/aya-bpf/src/maps/sock_hash.rs
@@ -1,4 +1,4 @@
-use core::{cell::UnsafeCell, marker::PhantomData, mem};
+use core::{cell::UnsafeCell, marker::PhantomData, mem, borrow::Borrow};
 
 use aya_bpf_cty::c_void;
 
@@ -89,7 +89,7 @@ impl<K> SockHash<K> {
     pub fn redirect_sk_lookup(
         &mut self,
         ctx: &SkLookupContext,
-        key: K,
+        key: impl Borrow<K>,
         flags: u64,
     ) -> Result<(), u32> {
         unsafe {


### PR DESCRIPTION
This PR changes map related APIs to use reference to Pod instead of Pod. This should fix #427