### PR TITLE
maps: Fix the error message in `MapData::pin()`

### DIFF
--- a/aya/src/maps/mod.rs
+++ b/aya/src/maps/mod.rs
@@ -591,7 +591,7 @@ impl MapData {
             }
         })?;
         bpf_pin_object(fd, &path_string).map_err(|(_, io_error)| PinError::SyscallError {
-            name: "BPF_OBJ_GET".to_string(),
+            name: "BPF_OBJ_PIN".to_string(),
             io_error,
         })?;
         self.pinned = true;


### PR DESCRIPTION
The syscall name is `BPF_OBJ_PIN`, not `BPF_OBJ_GET`.

Signed-off-by: Michal Rostecki <vadorovsky@gmail.com>