### PR TITLE
aya-log: Add format hints for MAC addresses

### DIFF
--- a/aya-log-common/src/lib.rs
+++ b/aya-log-common/src/lib.rs
@@ -44,6 +44,8 @@ pub enum RecordField {
     NumArgs,
 }
 
+/// Types which are supported by aya-log and can be safely sent from eBPF
+/// programs to userspace.
 #[repr(usize)]
 #[derive(Copy, Clone, Debug)]
 pub enum Argument {
@@ -64,7 +66,11 @@ pub enum Argument {
     F32,
     F64,
 
+    /// `[u8; 6]` array which represents a MAC address.
+    ArrU8Len6,
+    /// `[u8; 16]` array which represents an IPv6 address.
     ArrU8Len16,
+    /// `[u16; 8]` array which represents an IPv6 address.
     ArrU16Len8,
 
     Str,
@@ -84,6 +90,10 @@ pub enum DisplayHint {
     Ipv4,
     /// `:ipv6`
     Ipv6,
+    /// `:mac`
+    LowerMac,
+    /// `:MAC`
+    UpperMac,
 }
 
 #[cfg(feature = "userspace")]
@@ -175,6 +185,12 @@ impl WriteToBuf for [u16; 8] {
         let ptr = self.as_ptr().cast::<u8>();
         let bytes = unsafe { slice::from_raw_parts(ptr, 16) };
         TagLenValue::<Argument>::new(Argument::ArrU16Len8, bytes).write(buf)
+    }
+}
+
+impl WriteToBuf for [u8; 6] {
+    fn write(&self, buf: &mut [u8]) -> Result<usize, ()> {
+        TagLenValue::<Argument>::new(Argument::ArrU8Len6, self).write(buf)
     }
 }
 

--- a/aya-log-ebpf-macros/src/expand.rs
+++ b/aya-log-ebpf-macros/src/expand.rs
@@ -81,6 +81,8 @@ fn hint_to_expr(hint: DisplayHint) -> Result<Expr> {
         DisplayHint::UpperHex => parse_str("::aya_log_ebpf::macro_support::DisplayHint::UpperHex"),
         DisplayHint::Ipv4 => parse_str("::aya_log_ebpf::macro_support::DisplayHint::Ipv4"),
         DisplayHint::Ipv6 => parse_str("::aya_log_ebpf::macro_support::DisplayHint::Ipv6"),
+        DisplayHint::LowerMac => parse_str("::aya_log_ebpf::macro_support::DisplayHint::LowerMac"),
+        DisplayHint::UpperMac => parse_str("::aya_log_ebpf::macro_support::DisplayHint::UpperMac"),
     }
 }
 

--- a/aya-log-parser/src/lib.rs
+++ b/aya-log-parser/src/lib.rs
@@ -59,6 +59,8 @@ fn parse_display_hint(s: &str) -> Result<DisplayHint, String> {
         "X" => DisplayHint::UpperHex,
         "ipv4" => DisplayHint::Ipv4,
         "ipv6" => DisplayHint::Ipv6,
+        "mac" => DisplayHint::LowerMac,
+        "MAC" => DisplayHint::UpperMac,
         _ => return Err(format!("unknown display hint: {:?}", s)),
     })
 }


### PR DESCRIPTION
Add `{:mac}` (for lower-case hex representation) and `{:MAC}` (for upper-case hex representation) format hints for the `[u8; 6]` type, which is the standard one in Linux to store physical addresses in.

Tested with: https://github.com/vadorovsky/aya-examples/tree/main/xdp-mac

Signed-off-by: Michal Rostecki <vadorovsky@gmail.com>