### PR TITLE
aya: Add PinnedProgram

### DIFF
--- a/aya/src/bpf.rs
+++ b/aya/src/bpf.rs
@@ -630,7 +630,7 @@ impl<'a> BpfLoader<'a> {
                         ProgramSection::CgroupSock { attach_type, .. } => {
                             Program::CgroupSock(CgroupSock {
                                 data: ProgramData::new(prog_name, obj, btf_fd, verifier_log_level),
-                                attach_type: *attach_type,
+                                attach_type: Some(*attach_type),
                             })
                         }
                     }

--- a/aya/src/programs/cgroup_sock.rs
+++ b/aya/src/programs/cgroup_sock.rs
@@ -54,13 +54,18 @@ use crate::{
 #[doc(alias = "BPF_PROG_TYPE_CGROUP_SOCK")]
 pub struct CgroupSock {
     pub(crate) data: ProgramData<CgroupSockLink>,
-    pub(crate) attach_type: CgroupSockAttachType,
+    pub(crate) attach_type: Option<CgroupSockAttachType>,
 }
 
 impl CgroupSock {
     /// Loads the program inside the kernel.
     pub fn load(&mut self) -> Result<(), ProgramError> {
-        self.data.expected_attach_type = Some(self.attach_type.into());
+        if self.attach_type.is_none() {
+            return Err(ProgramError::IncompleteProgramDefinition(
+                "missing attach_type".to_string(),
+            ));
+        }
+        self.data.expected_attach_type = Some(self.attach_type.unwrap().into());
         load_program(BPF_PROG_TYPE_CGROUP_SOCK, &mut self.data)
     }
 


### PR DESCRIPTION
This commit adds PinnedProgram which allows the creation of a Program from a path on bpffs. This is useful to be able to call `attach` or other APIs for programs that are already loaded to the kernel. Unfortunately figuring out the concrete type of program is hard given the information in the kernel so this may not work for all program types.

Signed-off-by: Dave Tucker <dave@dtucker.co.uk>