### PR TITLE
upgrade clap to 4.x

### DIFF
--- a/aya-tool/Cargo.toml
+++ b/aya-tool/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 
 [dependencies]
 bindgen = "0.63"
-clap = { version = "3", features = ["derive"] }
+clap = { version = "4", features = ["derive"] }
 anyhow = "1"
 thiserror = "1"
 tempfile = "3"

--- a/aya/src/lib.rs
+++ b/aya/src/lib.rs
@@ -33,8 +33,8 @@
 //! [async-std]: https://docs.rs/async-std
 
 #![doc(
-    html_logo_url = "https://aya-rs.dev/assets/images/crabby_dev.svg",
-    html_favicon_url = "https://aya-rs.dev/assets/images/crabby_dev.svg"
+    html_logo_url = "https://aya-rs.dev/assets/images/crabby.svg",
+    html_favicon_url = "https://aya-rs.dev/assets/images/crabby.svg"
 )]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![deny(clippy::all, missing_docs)]

--- a/aya/src/lib.rs
+++ b/aya/src/lib.rs
@@ -33,8 +33,8 @@
 //! [async-std]: https://docs.rs/async-std
 
 #![doc(
-    html_logo_url = "https://aya-rs.dev/assets/images/crabby.svg",
-    html_favicon_url = "https://aya-rs.dev/assets/images/crabby.svg"
+    html_logo_url = "https://aya-rs.dev/assets/images/crabby_dev.svg",
+    html_favicon_url = "https://aya-rs.dev/assets/images/crabby_dev.svg"
 )]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![deny(clippy::all, missing_docs)]

--- a/bpf/aya-bpf-bindings/build.rs
+++ b/bpf/aya-bpf-bindings/build.rs
@@ -3,10 +3,10 @@ use std::env;
 fn main() {
     println!("cargo:rerun-if-env-changed=CARGO_CFG_BPF_TARGET_ARCH");
     if let Ok(arch) = env::var("CARGO_CFG_BPF_TARGET_ARCH") {
-        println!("cargo:rustc-cfg=bpf_target_arch=\"{}\"", arch);
+        println!("cargo:rustc-cfg=bpf_target_arch=\"{arch}\"");
     } else {
         let arch = env::var("HOST").unwrap();
         let arch = arch.split_once('-').map_or(&*arch, |x| x.0);
-        println!("cargo:rustc-cfg=bpf_target_arch=\"{}\"", arch);
+        println!("cargo:rustc-cfg=bpf_target_arch=\"{arch}\"");
     }
 }

--- a/bpf/aya-bpf-cty/build.rs
+++ b/bpf/aya-bpf-cty/build.rs
@@ -3,10 +3,10 @@ use std::env;
 fn main() {
     println!("cargo:rerun-if-env-changed=CARGO_CFG_BPF_TARGET_ARCH");
     if let Ok(arch) = env::var("CARGO_CFG_BPF_TARGET_ARCH") {
-        println!("cargo:rustc-cfg=bpf_target_arch=\"{}\"", arch);
+        println!("cargo:rustc-cfg=bpf_target_arch=\"{arch}\"");
     } else {
         let arch = env::var("HOST").unwrap();
         let arch = arch.split_once('-').map_or(&*arch, |x| x.0);
-        println!("cargo:rustc-cfg=bpf_target_arch=\"{}\"", arch);
+        println!("cargo:rustc-cfg=bpf_target_arch=\"{arch}\"");
     }
 }

--- a/test/integration-test/Cargo.toml
+++ b/test/integration-test/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 [dependencies]
 anyhow = "1"
 aya = { path = "../../aya" }
-clap = { version = "3", features = ["derive"] }
+clap = { version = "4", features = ["derive"] }
 env_logger = "0.10"
 inventory = "0.2"
 integration-test-macros = { path = "../integration-test-macros" }

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 
 [dependencies]
 aya-tool = { path = "../aya-tool" }
-clap = { version = "3", features = ["derive"] }
+clap = { version = "4", features = ["derive"] }
 anyhow = "1"
 syn = "1"
 quote = "1"

--- a/xtask/src/build_ebpf.rs
+++ b/xtask/src/build_ebpf.rs
@@ -37,7 +37,7 @@ impl std::fmt::Display for Architecture {
 }
 
 #[derive(Debug, Parser)]
-pub struct Options {
+pub struct BuildEbpfOptions {
     /// Set the endianness of the BPF target
     #[clap(default_value = "bpfel-unknown-none", long)]
     pub target: Architecture,
@@ -49,12 +49,12 @@ pub struct Options {
     pub libbpf_dir: PathBuf,
 }
 
-pub fn build_ebpf(opts: Options) -> anyhow::Result<()> {
+pub fn build_ebpf(opts: BuildEbpfOptions) -> anyhow::Result<()> {
     build_rust_ebpf(&opts)?;
     build_c_ebpf(&opts)
 }
 
-fn build_rust_ebpf(opts: &Options) -> anyhow::Result<()> {
+fn build_rust_ebpf(opts: &BuildEbpfOptions) -> anyhow::Result<()> {
     let mut dir = PathBuf::from(WORKSPACE_ROOT.to_string());
     dir.push("test/integration-ebpf");
 
@@ -92,7 +92,7 @@ fn get_libbpf_headers<P: AsRef<Path>>(libbpf_dir: P, include_path: P) -> anyhow:
     Ok(())
 }
 
-fn build_c_ebpf(opts: &Options) -> anyhow::Result<()> {
+fn build_c_ebpf(opts: &BuildEbpfOptions) -> anyhow::Result<()> {
     let mut src = PathBuf::from(WORKSPACE_ROOT.to_string());
     src.push("test/integration-ebpf/src/bpf");
 

--- a/xtask/src/build_test.rs
+++ b/xtask/src/build_test.rs
@@ -10,7 +10,7 @@ pub struct Options {
     pub musl: bool,
 
     #[clap(flatten)]
-    pub ebpf_options: build_ebpf::Options,
+    pub ebpf_options: build_ebpf::BuildEbpfOptions,
 }
 
 pub fn build_test(opts: Options) -> anyhow::Result<()> {

--- a/xtask/src/codegen/mod.rs
+++ b/xtask/src/codegen/mod.rs
@@ -54,32 +54,32 @@ impl std::fmt::Display for Architecture {
 
 #[derive(Parser)]
 pub struct Options {
-    #[clap(long, action)]
+    #[arg(long, action)]
     libbpf_dir: PathBuf,
 
     // sysroot options. Default to ubuntu headers installed by the
     // libc6-dev-{arm64,armel}-cross packages.
-    #[clap(long, default_value = "/usr/include/x86_64-linux-gnu", action)]
+    #[arg(long, default_value = "/usr/include/x86_64-linux-gnu", action)]
     x86_64_sysroot: PathBuf,
 
-    #[clap(long, default_value = "/usr/aarch64-linux-gnu/include", action)]
+    #[arg(long, default_value = "/usr/aarch64-linux-gnu/include", action)]
     aarch64_sysroot: PathBuf,
 
-    #[clap(long, default_value = "/usr/arm-linux-gnueabi/include", action)]
+    #[arg(long, default_value = "/usr/arm-linux-gnueabi/include", action)]
     armv7_sysroot: PathBuf,
 
-    #[clap(long, default_value = "/usr/riscv64-linux-gnu/include", action)]
+    #[arg(long, default_value = "/usr/riscv64-linux-gnu/include", action)]
     riscv64_sysroot: PathBuf,
 
-    #[clap(subcommand)]
+    #[command(subcommand)]
     command: Option<Command>,
 }
 
-#[derive(Parser)]
+#[derive(clap::Subcommand)]
 enum Command {
-    #[clap(name = "aya")]
+    #[command(name = "aya")]
     Aya,
-    #[clap(name = "aya-bpf-bindings")]
+    #[command(name = "aya-bpf-bindings")]
     AyaBpfBindings,
 }
 

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -9,7 +9,7 @@ use std::process::exit;
 
 use clap::Parser;
 #[derive(Parser)]
-pub struct Options {
+pub struct XtaskOptions {
     #[clap(subcommand)]
     command: Command,
 }
@@ -19,12 +19,12 @@ enum Command {
     Codegen(codegen::Options),
     Docs,
     BuildIntegrationTest(build_test::Options),
-    BuildIntegrationTestEbpf(build_ebpf::Options),
+    BuildIntegrationTestEbpf(build_ebpf::BuildEbpfOptions),
     IntegrationTest(run::Options),
 }
 
 fn main() {
-    let opts = Options::parse();
+    let opts = XtaskOptions::parse();
 
     use Command::*;
     let ret = match opts.command {

--- a/xtask/src/run.rs
+++ b/xtask/src/run.rs
@@ -3,7 +3,7 @@ use std::{os::unix::process::CommandExt, path::PathBuf, process::Command};
 use anyhow::Context as _;
 use clap::Parser;
 
-use crate::build_ebpf::{build_ebpf, Architecture, Options as BuildOptions};
+use crate::build_ebpf::{build_ebpf, Architecture, BuildEbpfOptions as BuildOptions};
 
 #[derive(Debug, Parser)]
 pub struct Options {


### PR DESCRIPTION
PR upgrades clap to version 4 to avoid clap-3.x being pulled in due to the aya dependency.