### PR TITLE
autofix clippy uninlined_format_args issues

### DIFF
--- a/aya-bpf-macros/src/expand.rs
+++ b/aya-bpf-macros/src/expand.rs
@@ -148,7 +148,7 @@ impl SockOps {
 
     pub fn expand(&self) -> Result<TokenStream> {
         let section_name = if let Some(name) = &self.name {
-            format!("sockops/{}", name)
+            format!("sockops/{name}")
         } else {
             "sockops".to_owned()
         };
@@ -208,7 +208,7 @@ impl Xdp {
 
     pub fn expand(&self) -> Result<TokenStream> {
         let section_name = if let Some(name) = &self.name {
-            format!("xdp/{}", name)
+            format!("xdp/{name}")
         } else {
             "xdp".to_owned()
         };
@@ -240,7 +240,7 @@ impl SchedClassifier {
 
     pub fn expand(&self) -> Result<TokenStream> {
         let section_name = if let Some(name) = &self.name {
-            format!("classifier/{}", name)
+            format!("classifier/{name}")
         } else {
             "classifier".to_owned()
         };
@@ -272,7 +272,7 @@ impl CgroupSysctl {
 
     pub fn expand(&self) -> Result<TokenStream> {
         let section_name = if let Some(name) = &self.name {
-            format!("cgroup/sysctl/{}", name)
+            format!("cgroup/sysctl/{name}")
         } else {
             ("cgroup/sysctl").to_owned()
         };
@@ -349,12 +349,12 @@ impl CgroupSkb {
     pub fn expand(&self) -> Result<TokenStream> {
         let section_name = if let Some(attach) = &self.expected_attach_type {
             if let Some(name) = &self.name {
-                format!("cgroup_skb/{}/{}", attach, name)
+                format!("cgroup_skb/{attach}/{name}")
             } else {
-                format!("cgroup_skb/{}", attach)
+                format!("cgroup_skb/{attach}")
             }
         } else if let Some(name) = &self.name {
-            format!("cgroup/skb/{}", name)
+            format!("cgroup/skb/{name}")
         } else {
             ("cgroup/skb").to_owned()
         };
@@ -432,12 +432,12 @@ impl CgroupSock {
     pub fn expand(&self) -> Result<TokenStream> {
         let section_name = if let Some(name) = &self.name {
             if let Some(attach_type) = &self.attach_type {
-                format!("cgroup/{}/{}", attach_type, name)
+                format!("cgroup/{attach_type}/{name}")
             } else {
-                format!("cgroup/sock/{}", name)
+                format!("cgroup/sock/{name}")
             }
         } else if let Some(attach_type) = &self.attach_type {
-            format!("cgroup/{}", attach_type)
+            format!("cgroup/{attach_type}")
         } else {
             "cgroup/sock".to_string()
         };
@@ -679,9 +679,9 @@ impl SkSkb {
     pub fn expand(&self) -> Result<TokenStream> {
         let kind = &self.kind;
         let section_name = if let Some(name) = &self.name {
-            format!("sk_skb/{}/{}", kind, name)
+            format!("sk_skb/{kind}/{name}")
         } else {
-            format!("sk_skb/{}", kind)
+            format!("sk_skb/{kind}")
         };
         let fn_name = &self.item.sig.ident;
         let item = &self.item;
@@ -712,7 +712,7 @@ impl SocketFilter {
 
     pub fn expand(&self) -> Result<TokenStream> {
         let section_name = if let Some(name) = &self.name {
-            format!("socket/{}", name)
+            format!("socket/{name}")
         } else {
             "socket".to_owned()
         };
@@ -802,7 +802,7 @@ impl SkLookup {
 
     pub fn expand(&self) -> Result<TokenStream> {
         let section_name = if let Some(name) = &self.name {
-            format!("sk_lookup/{}", name)
+            format!("sk_lookup/{name}")
         } else {
             "sk_lookup".to_owned()
         };

--- a/aya-log-ebpf-macros/src/expand.rs
+++ b/aya-log-ebpf-macros/src/expand.rs
@@ -71,7 +71,7 @@ impl Parse for LogArgs {
 }
 
 fn string_to_expr(s: String) -> Result<Expr> {
-    parse_str(&format!("\"{}\"", s))
+    parse_str(&format!("\"{s}\""))
 }
 
 fn hint_to_expr(hint: DisplayHint) -> Result<Expr> {
@@ -108,7 +108,7 @@ pub(crate) fn log(args: LogArgs, level: Option<TokenStream>) -> Result<TokenStre
     let fragments = parse(&format_string_val).map_err(|e| {
         Error::new(
             format_string.span(),
-            format!("could not parse the format string: {}", e),
+            format!("could not parse the format string: {e}"),
         )
     })?;
 

--- a/aya-log-parser/src/lib.rs
+++ b/aya-log-parser/src/lib.rs
@@ -61,7 +61,7 @@ fn parse_display_hint(s: &str) -> Result<DisplayHint, String> {
         "ipv6" => DisplayHint::Ipv6,
         "mac" => DisplayHint::LowerMac,
         "MAC" => DisplayHint::UpperMac,
-        _ => return Err(format!("unknown display hint: {:?}", s)),
+        _ => return Err(format!("unknown display hint: {s:?}")),
     })
 }
 
@@ -83,7 +83,7 @@ fn parse_param(mut input: &str) -> Result<Parameter, String> {
 
         hint = parse_display_hint(input)?;
     } else if !input.is_empty() {
-        return Err(format!("unexpected content {:?} in format string", input));
+        return Err(format!("unexpected content {input:?} in format string"));
     }
 
     Ok(Parameter { hint })

--- a/aya-log/src/lib.rs
+++ b/aya-log/src/lib.rs
@@ -137,7 +137,7 @@ where
     T: LowerHex,
 {
     fn format(v: T) -> String {
-        format!("{:x}", v)
+        format!("{v:x}")
     }
 }
 
@@ -147,7 +147,7 @@ where
     T: UpperHex,
 {
     fn format(v: T) -> String {
-        format!("{:X}", v)
+        format!("{v:X}")
     }
 }
 
@@ -481,7 +481,7 @@ fn log_buf(mut buf: &[u8], logger: &dyn Log) -> Result<(), ()> {
 
     logger.log(
         &Record::builder()
-            .args(format_args!("{}", full_log_msg))
+            .args(format_args!("{full_log_msg}"))
             .target(target.ok_or(())?)
             .level(level)
             .module_path(module)
@@ -529,7 +529,6 @@ mod test {
     use super::*;
     use aya_log_common::{write_record_header, WriteToBuf};
     use log::logger;
-    use testing_logger;
 
     fn new_log(args: usize) -> Result<(usize, Vec<u8>), ()> {
         let mut buf = vec![0; 8192];

--- a/aya-tool/Cargo.toml
+++ b/aya-tool/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 
 [dependencies]
 bindgen = "0.63"
-clap = { version = "3", features = ["derive"] }
+clap = { version = "4", features = ["derive"] }
 anyhow = "1"
 thiserror = "1"
 tempfile = "3"

--- a/aya-tool/src/bin/aya-tool.rs
+++ b/aya-tool/src/bin/aya-tool.rs
@@ -28,7 +28,7 @@ enum Command {
 
 fn main() {
     if let Err(e) = try_main() {
-        eprintln!("{:#}", e);
+        eprintln!("{e:#}");
         exit(1);
     }
 }
@@ -47,7 +47,7 @@ fn try_main() -> Result<(), anyhow::Error> {
             } else {
                 generate(InputFile::Btf(btf), &names, &bindgen_args)?
             };
-            println!("{}", bindings);
+            println!("{bindings}");
         }
     };
 

--- a/aya/src/obj/btf/btf.rs
+++ b/aya/src/obj/btf/btf.rs
@@ -490,7 +490,7 @@ impl Btf {
                     let mut ty = ty.clone();
                     for (i, mut param) in ty.params.iter_mut().enumerate() {
                         if param.name_offset == 0 && param.btf_type != 0 {
-                            param.name_offset = self.add_string(format!("param{}", i));
+                            param.name_offset = self.add_string(format!("param{i}"));
                         }
                     }
                     types.types[i] = BtfType::FuncProto(ty);

--- a/aya/src/obj/btf/relocation.rs
+++ b/aya/src/obj/btf/relocation.rs
@@ -682,7 +682,7 @@ impl<'a> AccessSpec<'a> {
                         rel_kind => {
                             return Err(RelocationError::InvalidRelocationKindForType {
                                 relocation_number: relocation.number,
-                                relocation_kind: format!("{:?}", rel_kind),
+                                relocation_kind: format!("{rel_kind:?}"),
                                 type_kind: format!("{:?}", ty.kind()),
                                 error: "field relocation on a type that doesn't have fields"
                                     .to_string(),
@@ -791,7 +791,7 @@ impl ComputedRelocation {
                     return Err(RelocationError::InvalidInstruction {
                         relocation_number: rel.number,
                         index: ins_index,
-                        error: format!("invalid src_reg={:x} expected {:x}", src_reg, BPF_K),
+                        error: format!("invalid src_reg={src_reg:x} expected {BPF_K:x}"),
                     }
                     .into());
                 }
@@ -803,7 +803,7 @@ impl ComputedRelocation {
                     return Err(RelocationError::InvalidInstruction {
                         relocation_number: rel.number,
                         index: ins_index,
-                        error: format!("value `{}` overflows 16 bits offset field", target_value),
+                        error: format!("value `{target_value}` overflows 16 bits offset field"),
                     }
                     .into());
                 }
@@ -844,7 +844,7 @@ impl ComputedRelocation {
                             return Err(RelocationError::InvalidInstruction {
                                 relocation_number: rel.number,
                                 index: ins_index,
-                                error: format!("invalid target size {}", size),
+                                error: format!("invalid target size {size}"),
                             }
                             .into())
                         }
@@ -868,7 +868,7 @@ impl ComputedRelocation {
                 return Err(RelocationError::InvalidInstruction {
                     relocation_number: rel.number,
                     index: ins_index,
-                    error: format!("invalid instruction class {:x}", class),
+                    error: format!("invalid instruction class {class:x}"),
                 }
                 .into())
             }
@@ -938,7 +938,7 @@ impl ComputedRelocation {
                     let ty = spec.btf.type_by_id(accessor.type_id)?;
                     return Err(RelocationError::InvalidRelocationKindForType {
                         relocation_number: rel.number,
-                        relocation_kind: format!("{:?}", rel_kind),
+                        relocation_kind: format!("{rel_kind:?}"),
                         type_kind: format!("{:?}", ty.kind()),
                         error: "invalid relocation kind for array type".to_string(),
                     }

--- a/aya/src/obj/btf/types.rs
+++ b/aya/src/obj/btf/types.rs
@@ -1335,7 +1335,7 @@ mod tests {
                 let data2 = new.to_bytes();
                 assert_eq!(data, data2);
             }
-            Ok(t) => panic!("expected int type, got {:#?}", t),
+            Ok(t) => panic!("expected int type, got {t:#?}"),
             Err(_) => panic!("unexpected error"),
         }
     }
@@ -1379,7 +1379,7 @@ mod tests {
         let got = unsafe { BtfType::read(data, endianness) };
         match got {
             Ok(BtfType::Ptr(_)) => {}
-            Ok(t) => panic!("expected ptr type, got {:#?}", t),
+            Ok(t) => panic!("expected ptr type, got {t:#?}"),
             Err(_) => panic!("unexpected error"),
         }
         let data2 = got.unwrap().to_bytes();
@@ -1396,7 +1396,7 @@ mod tests {
         let got = unsafe { BtfType::read(data, endianness) };
         match got {
             Ok(BtfType::Array(_)) => {}
-            Ok(t) => panic!("expected array type, got {:#?}", t),
+            Ok(t) => panic!("expected array type, got {t:#?}"),
             Err(_) => panic!("unexpected error"),
         }
         let data2 = got.unwrap().to_bytes();
@@ -1413,7 +1413,7 @@ mod tests {
         let got = unsafe { BtfType::read(data, endianness) };
         match got {
             Ok(BtfType::Struct(_)) => {}
-            Ok(t) => panic!("expected struct type, got {:#?}", t),
+            Ok(t) => panic!("expected struct type, got {t:#?}"),
             Err(_) => panic!("unexpected error"),
         }
         let data2 = got.unwrap().to_bytes();
@@ -1430,7 +1430,7 @@ mod tests {
         let got = unsafe { BtfType::read(data, endianness) };
         match got {
             Ok(BtfType::Union(_)) => {}
-            Ok(t) => panic!("expected union type, got {:#?}", t),
+            Ok(t) => panic!("expected union type, got {t:#?}"),
             Err(_) => panic!("unexpected error"),
         }
         let data2 = got.unwrap().to_bytes();
@@ -1447,7 +1447,7 @@ mod tests {
         let got = unsafe { BtfType::read(data, endianness) };
         match got {
             Ok(BtfType::Enum(_)) => {}
-            Ok(t) => panic!("expected enum type, got {:#?}", t),
+            Ok(t) => panic!("expected enum type, got {t:#?}"),
             Err(_) => panic!("unexpected error"),
         }
         let data2 = got.unwrap().to_bytes();
@@ -1463,7 +1463,7 @@ mod tests {
         let got = unsafe { BtfType::read(data, endianness) };
         match got {
             Ok(BtfType::Fwd(_)) => {}
-            Ok(t) => panic!("expected fwd type, got {:#?}", t),
+            Ok(t) => panic!("expected fwd type, got {t:#?}"),
             Err(_) => panic!("unexpected error"),
         }
         let data2 = got.unwrap().to_bytes();
@@ -1479,7 +1479,7 @@ mod tests {
         let got = unsafe { BtfType::read(data, endianness) };
         match got {
             Ok(BtfType::Typedef(_)) => {}
-            Ok(t) => panic!("expected typedef type, got {:#?}", t),
+            Ok(t) => panic!("expected typedef type, got {t:#?}"),
             Err(_) => panic!("unexpected error"),
         }
         let data2 = got.unwrap().to_bytes();
@@ -1495,7 +1495,7 @@ mod tests {
         let got = unsafe { BtfType::read(data, endianness) };
         match got {
             Ok(BtfType::Volatile(_)) => {}
-            Ok(t) => panic!("expected volatile type, got {:#?}", t),
+            Ok(t) => panic!("expected volatile type, got {t:#?}"),
             Err(_) => panic!("unexpected error"),
         }
         let data2 = got.unwrap().to_bytes();
@@ -1511,7 +1511,7 @@ mod tests {
         let got = unsafe { BtfType::read(data, endianness) };
         match got {
             Ok(BtfType::Const(_)) => {}
-            Ok(t) => panic!("expected const type, got {:#?}", t),
+            Ok(t) => panic!("expected const type, got {t:#?}"),
             Err(_) => panic!("unexpected error"),
         }
         let data2 = got.unwrap().to_bytes();
@@ -1527,7 +1527,7 @@ mod tests {
         let got = unsafe { BtfType::read(data, endianness) };
         match got {
             Ok(BtfType::Restrict(_)) => {}
-            Ok(t) => panic!("expected restrict type gpt {:#?}", t),
+            Ok(t) => panic!("expected restrict type gpt {t:#?}"),
             Err(_) => panic!("unexpected error"),
         }
         let data2 = got.unwrap().to_bytes();
@@ -1543,7 +1543,7 @@ mod tests {
         let got = unsafe { BtfType::read(data, endianness) };
         match got {
             Ok(BtfType::Func(_)) => {}
-            Ok(t) => panic!("expected func type gpt {:#?}", t),
+            Ok(t) => panic!("expected func type gpt {t:#?}"),
             Err(_) => panic!("unexpected error"),
         }
         let data2 = got.unwrap().to_bytes();
@@ -1560,7 +1560,7 @@ mod tests {
         let got = unsafe { BtfType::read(data, endianness) };
         match got {
             Ok(BtfType::FuncProto(_)) => {}
-            Ok(t) => panic!("expected func_proto type, got {:#?}", t),
+            Ok(t) => panic!("expected func_proto type, got {t:#?}"),
             Err(_) => panic!("unexpected error"),
         }
         let data2 = got.unwrap().to_bytes();
@@ -1578,7 +1578,7 @@ mod tests {
         let got = unsafe { BtfType::read(data, endianness) };
         match got {
             Ok(BtfType::Var(_)) => {}
-            Ok(t) => panic!("expected var type, got {:#?}", t),
+            Ok(t) => panic!("expected var type, got {t:#?}"),
             Err(_) => panic!("unexpected error"),
         };
         let data2 = got.unwrap().to_bytes();
@@ -1600,7 +1600,7 @@ mod tests {
                 assert_eq!(0, ty.entries[0].offset);
                 assert_eq!(4, ty.entries[0].size);
             }
-            Ok(t) => panic!("expected datasec type, got {:#?}", t),
+            Ok(t) => panic!("expected datasec type, got {t:#?}"),
             Err(_) => panic!("unexpected error"),
         }
         let data2 = got.unwrap().to_bytes();
@@ -1616,7 +1616,7 @@ mod tests {
         let got = unsafe { BtfType::read(data, endianness) };
         match got {
             Ok(BtfType::Float(_)) => {}
-            Ok(t) => panic!("expected float type, got {:#?}", t),
+            Ok(t) => panic!("expected float type, got {t:#?}"),
             Err(_) => panic!("unexpected error"),
         }
         let data2 = got.unwrap().to_bytes();
@@ -1642,7 +1642,7 @@ mod tests {
             Ok(BtfType::FuncProto(fp)) => {
                 assert_eq!(fp.params.len(), 2);
             }
-            Ok(t) => panic!("expected func proto type, got {:#?}", t),
+            Ok(t) => panic!("expected func proto type, got {t:#?}"),
             Err(_) => panic!("unexpected error"),
         }
     }

--- a/aya/src/programs/lsm.rs
+++ b/aya/src/programs/lsm.rs
@@ -60,7 +60,7 @@ impl Lsm {
     ///   be attached to
     pub fn load(&mut self, lsm_hook_name: &str, btf: &Btf) -> Result<(), ProgramError> {
         self.data.expected_attach_type = Some(BPF_LSM_MAC);
-        let type_name = format!("bpf_lsm_{}", lsm_hook_name);
+        let type_name = format!("bpf_lsm_{lsm_hook_name}");
         self.data.attach_btf_id =
             Some(btf.id_by_type_name_kind(type_name.as_str(), BtfKind::Func)?);
         load_program(BPF_PROG_TYPE_LSM, &mut self.data)

--- a/aya/src/programs/probe.rs
+++ b/aya/src/programs/probe.rs
@@ -154,8 +154,8 @@ fn create_probe_event(
         offset
     );
     let offset_suffix = match kind {
-        KProbe => format!("+{}", offset),
-        UProbe => format!(":{:#x}", offset),
+        KProbe => format!("+{offset}"),
+        UProbe => format!(":{offset:#x}"),
         _ => "".to_string(),
     };
     let probe = format!(
@@ -193,7 +193,7 @@ fn delete_probe_event(kind: ProbeKind, event_alias: &str) -> Result<(), (String,
             .open(&events_file_name)
             .map_err(|e| (events_file_name.to_string(), e))?;
 
-        let rm = format!("-:{}\n", event_alias);
+        let rm = format!("-:{event_alias}\n");
 
         events_file
             .write_all(rm.as_bytes())
@@ -204,7 +204,7 @@ fn delete_probe_event(kind: ProbeKind, event_alias: &str) -> Result<(), (String,
 }
 
 fn read_sys_fs_perf_type(pmu: &str) -> Result<u32, (String, io::Error)> {
-    let file = format!("/sys/bus/event_source/devices/{}/type", pmu);
+    let file = format!("/sys/bus/event_source/devices/{pmu}/type");
 
     let perf_ty = fs::read_to_string(&file).map_err(|e| (file.clone(), e))?;
     let perf_ty = perf_ty
@@ -216,7 +216,7 @@ fn read_sys_fs_perf_type(pmu: &str) -> Result<u32, (String, io::Error)> {
 }
 
 fn read_sys_fs_perf_ret_probe(pmu: &str) -> Result<u32, (String, io::Error)> {
-    let file = format!("/sys/bus/event_source/devices/{}/format/retprobe", pmu);
+    let file = format!("/sys/bus/event_source/devices/{pmu}/format/retprobe");
 
     let data = fs::read_to_string(&file).map_err(|e| (file.clone(), e))?;
 

--- a/aya/src/programs/tp_btf.rs
+++ b/aya/src/programs/tp_btf.rs
@@ -58,7 +58,7 @@ impl BtfTracePoint {
     /// * `btf` - btf information for the target system
     pub fn load(&mut self, tracepoint: &str, btf: &Btf) -> Result<(), ProgramError> {
         self.data.expected_attach_type = Some(BPF_TRACE_RAW_TP);
-        let type_name = format!("btf_trace_{}", tracepoint);
+        let type_name = format!("btf_trace_{tracepoint}");
         self.data.attach_btf_id =
             Some(btf.id_by_type_name_kind(type_name.as_str(), BtfKind::Typedef)?);
         load_program(BPF_PROG_TYPE_TRACING, &mut self.data)

--- a/aya/src/programs/trace_point.rs
+++ b/aya/src/programs/trace_point.rs
@@ -117,7 +117,7 @@ pub(crate) fn read_sys_fs_trace_point_id(
     category: &str,
     name: &str,
 ) -> Result<u32, TracePointError> {
-    let file = format!("/sys/kernel/debug/tracing/events/{}/{}/id", category, name);
+    let file = format!("/sys/kernel/debug/tracing/events/{category}/{name}/id");
 
     let id = fs::read_to_string(&file).map_err(|io_error| TracePointError::FileError {
         filename: file.clone(),

--- a/aya/src/programs/uprobe.rs
+++ b/aya/src/programs/uprobe.rs
@@ -84,7 +84,7 @@ impl UProbe {
 
         let mut path = if let Some(pid) = pid {
             find_lib_in_proc_maps(pid, target_str).map_err(|io_error| UProbeError::FileError {
-                filename: format!("/proc/{}/maps", pid),
+                filename: format!("/proc/{pid}/maps"),
                 io_error,
             })?
         } else {
@@ -187,7 +187,7 @@ pub enum UProbeError {
 }
 
 fn proc_maps_libs(pid: pid_t) -> Result<Vec<(String, String)>, io::Error> {
-    let maps_file = format!("/proc/{}/maps", pid);
+    let maps_file = format!("/proc/{pid}/maps");
     let data = fs::read_to_string(maps_file)?;
 
     Ok(data

--- a/aya/src/util.rs
+++ b/aya/src/util.rs
@@ -23,7 +23,7 @@ pub fn online_cpus() -> Result<Vec<u32>, io::Error> {
     parse_cpu_ranges(data.trim()).map_err(|_| {
         io::Error::new(
             io::ErrorKind::Other,
-            format!("unexpected {} format", ONLINE_CPUS),
+            format!("unexpected {ONLINE_CPUS} format"),
         )
     })
 }
@@ -43,7 +43,7 @@ pub(crate) fn possible_cpus() -> Result<Vec<u32>, io::Error> {
     parse_cpu_ranges(data.trim()).map_err(|_| {
         io::Error::new(
             io::ErrorKind::Other,
-            format!("unexpected {} format", POSSIBLE_CPUS),
+            format!("unexpected {POSSIBLE_CPUS} format"),
         )
     })
 }

--- a/bpf/aya-bpf-bindings/build.rs
+++ b/bpf/aya-bpf-bindings/build.rs
@@ -3,10 +3,10 @@ use std::env;
 fn main() {
     println!("cargo:rerun-if-env-changed=CARGO_CFG_BPF_TARGET_ARCH");
     if let Ok(arch) = env::var("CARGO_CFG_BPF_TARGET_ARCH") {
-        println!("cargo:rustc-cfg=bpf_target_arch=\"{}\"", arch);
+        println!("cargo:rustc-cfg=bpf_target_arch=\"{arch}\"");
     } else {
         let arch = env::var("HOST").unwrap();
         let arch = arch.split_once('-').map_or(&*arch, |x| x.0);
-        println!("cargo:rustc-cfg=bpf_target_arch=\"{}\"", arch);
+        println!("cargo:rustc-cfg=bpf_target_arch=\"{arch}\"");
     }
 }

--- a/bpf/aya-bpf-cty/build.rs
+++ b/bpf/aya-bpf-cty/build.rs
@@ -3,10 +3,10 @@ use std::env;
 fn main() {
     println!("cargo:rerun-if-env-changed=CARGO_CFG_BPF_TARGET_ARCH");
     if let Ok(arch) = env::var("CARGO_CFG_BPF_TARGET_ARCH") {
-        println!("cargo:rustc-cfg=bpf_target_arch=\"{}\"", arch);
+        println!("cargo:rustc-cfg=bpf_target_arch=\"{arch}\"");
     } else {
         let arch = env::var("HOST").unwrap();
         let arch = arch.split_once('-').map_or(&*arch, |x| x.0);
-        println!("cargo:rustc-cfg=bpf_target_arch=\"{}\"", arch);
+        println!("cargo:rustc-cfg=bpf_target_arch=\"{arch}\"");
     }
 }

--- a/bpf/aya-bpf/build.rs
+++ b/bpf/aya-bpf/build.rs
@@ -4,11 +4,11 @@ fn main() {
     check_rust_version();
     println!("cargo:rerun-if-env-changed=CARGO_CFG_BPF_TARGET_ARCH");
     if let Ok(arch) = env::var("CARGO_CFG_BPF_TARGET_ARCH") {
-        println!("cargo:rustc-cfg=bpf_target_arch=\"{}\"", arch);
+        println!("cargo:rustc-cfg=bpf_target_arch=\"{arch}\"");
     } else {
         let arch = env::var("HOST").unwrap();
         let arch = arch.split_once('-').map_or(&*arch, |x| x.0);
-        println!("cargo:rustc-cfg=bpf_target_arch=\"{}\"", arch);
+        println!("cargo:rustc-cfg=bpf_target_arch=\"{arch}\"");
     }
 }
 

--- a/test/integration-test/Cargo.toml
+++ b/test/integration-test/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 [dependencies]
 anyhow = "1"
 aya = { path = "../../aya" }
-clap = { version = "3", features = ["derive"] }
+clap = { version = "4", features = ["derive"] }
 env_logger = "0.10"
 inventory = "0.2"
 integration-test-macros = { path = "../integration-test-macros" }

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 
 [dependencies]
 aya-tool = { path = "../aya-tool" }
-clap = { version = "3", features = ["derive"] }
+clap = { version = "4", features = ["derive"] }
 anyhow = "1"
 syn = "1"
 quote = "1"

--- a/xtask/src/build_ebpf.rs
+++ b/xtask/src/build_ebpf.rs
@@ -37,7 +37,7 @@ impl std::fmt::Display for Architecture {
 }
 
 #[derive(Debug, Parser)]
-pub struct Options {
+pub struct BuildEbpfOptions {
     /// Set the endianness of the BPF target
     #[clap(default_value = "bpfel-unknown-none", long)]
     pub target: Architecture,
@@ -49,12 +49,12 @@ pub struct Options {
     pub libbpf_dir: PathBuf,
 }
 
-pub fn build_ebpf(opts: Options) -> anyhow::Result<()> {
+pub fn build_ebpf(opts: BuildEbpfOptions) -> anyhow::Result<()> {
     build_rust_ebpf(&opts)?;
     build_c_ebpf(&opts)
 }
 
-fn build_rust_ebpf(opts: &Options) -> anyhow::Result<()> {
+fn build_rust_ebpf(opts: &BuildEbpfOptions) -> anyhow::Result<()> {
     let mut dir = PathBuf::from(WORKSPACE_ROOT.to_string());
     dir.push("test/integration-ebpf");
 
@@ -92,7 +92,7 @@ fn get_libbpf_headers<P: AsRef<Path>>(libbpf_dir: P, include_path: P) -> anyhow:
     Ok(())
 }
 
-fn build_c_ebpf(opts: &Options) -> anyhow::Result<()> {
+fn build_c_ebpf(opts: &BuildEbpfOptions) -> anyhow::Result<()> {
     let mut src = PathBuf::from(WORKSPACE_ROOT.to_string());
     src.push("test/integration-ebpf/src/bpf");
 

--- a/xtask/src/build_ebpf.rs
+++ b/xtask/src/build_ebpf.rs
@@ -140,7 +140,7 @@ fn compile_with_clang<P: Clone + AsRef<Path>>(
         .arg("-target")
         .arg("bpf")
         .arg("-c")
-        .arg(format!("-D__TARGET_ARCH_{}", arch))
+        .arg(format!("-D__TARGET_ARCH_{arch}"))
         .arg(src.as_ref().as_os_str())
         .arg("-o")
         .arg(out.as_ref().as_os_str());

--- a/xtask/src/build_test.rs
+++ b/xtask/src/build_test.rs
@@ -10,7 +10,7 @@ pub struct Options {
     pub musl: bool,
 
     #[clap(flatten)]
-    pub ebpf_options: build_ebpf::Options,
+    pub ebpf_options: build_ebpf::BuildEbpfOptions,
 }
 
 pub fn build_test(opts: Options) -> anyhow::Result<()> {

--- a/xtask/src/codegen/aya.rs
+++ b/xtask/src/codegen/aya.rs
@@ -219,7 +219,7 @@ fn codegen_bindings(opts: &Options) -> Result<(), anyhow::Error> {
 
         // write the bindings, with the original helpers removed
         write_to_file(
-            generated.join(format!("linux_bindings_{}.rs", arch)),
+            generated.join(format!("linux_bindings_{arch}.rs")),
             &bindings.to_string(),
         )?;
     }

--- a/xtask/src/codegen/aya_bpf_bindings.rs
+++ b/xtask/src/codegen/aya_bpf_bindings.rs
@@ -110,7 +110,7 @@ pub fn codegen(opts: &Options) -> Result<(), anyhow::Error> {
         // write the new helpers as expanded by expand_helpers()
         write_to_file_fmt(
             generated.join("helpers.rs"),
-            &format!("use super::bindings::*; {}", helpers),
+            &format!("use super::bindings::*; {helpers}"),
         )?;
     }
 

--- a/xtask/src/codegen/mod.rs
+++ b/xtask/src/codegen/mod.rs
@@ -54,32 +54,32 @@ impl std::fmt::Display for Architecture {
 
 #[derive(Parser)]
 pub struct Options {
-    #[clap(long, action)]
+    #[arg(long, action)]
     libbpf_dir: PathBuf,
 
     // sysroot options. Default to ubuntu headers installed by the
     // libc6-dev-{arm64,armel}-cross packages.
-    #[clap(long, default_value = "/usr/include/x86_64-linux-gnu", action)]
+    #[arg(long, default_value = "/usr/include/x86_64-linux-gnu", action)]
     x86_64_sysroot: PathBuf,
 
-    #[clap(long, default_value = "/usr/aarch64-linux-gnu/include", action)]
+    #[arg(long, default_value = "/usr/aarch64-linux-gnu/include", action)]
     aarch64_sysroot: PathBuf,
 
-    #[clap(long, default_value = "/usr/arm-linux-gnueabi/include", action)]
+    #[arg(long, default_value = "/usr/arm-linux-gnueabi/include", action)]
     armv7_sysroot: PathBuf,
 
-    #[clap(long, default_value = "/usr/riscv64-linux-gnu/include", action)]
+    #[arg(long, default_value = "/usr/riscv64-linux-gnu/include", action)]
     riscv64_sysroot: PathBuf,
 
-    #[clap(subcommand)]
+    #[command(subcommand)]
     command: Option<Command>,
 }
 
-#[derive(Parser)]
+#[derive(clap::Subcommand)]
 enum Command {
-    #[clap(name = "aya")]
+    #[command(name = "aya")]
     Aya,
-    #[clap(name = "aya-bpf-bindings")]
+    #[command(name = "aya-bpf-bindings")]
     AyaBpfBindings,
 }
 

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -9,7 +9,7 @@ use std::process::exit;
 
 use clap::Parser;
 #[derive(Parser)]
-pub struct Options {
+pub struct XtaskOptions {
     #[clap(subcommand)]
     command: Command,
 }
@@ -19,12 +19,12 @@ enum Command {
     Codegen(codegen::Options),
     Docs,
     BuildIntegrationTest(build_test::Options),
-    BuildIntegrationTestEbpf(build_ebpf::Options),
+    BuildIntegrationTestEbpf(build_ebpf::BuildEbpfOptions),
     IntegrationTest(run::Options),
 }
 
 fn main() {
-    let opts = Options::parse();
+    let opts = XtaskOptions::parse();
 
     use Command::*;
     let ret = match opts.command {

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -36,7 +36,7 @@ fn main() {
     };
 
     if let Err(e) = ret {
-        eprintln!("{:#}", e);
+        eprintln!("{e:#}");
         exit(1);
     }
 }

--- a/xtask/src/run.rs
+++ b/xtask/src/run.rs
@@ -52,7 +52,7 @@ pub fn run(opts: Options) -> Result<(), anyhow::Error> {
     build(&opts).context("Error while building userspace application")?;
     // profile we are building (release or debug)
     let profile = if opts.release { "release" } else { "debug" };
-    let bin_path = format!("target/{}/integration-test", profile);
+    let bin_path = format!("target/{profile}/integration-test");
 
     // arguments to pass to the application
     let mut run_args: Vec<_> = opts.run_args.iter().map(String::as_str).collect();

--- a/xtask/src/run.rs
+++ b/xtask/src/run.rs
@@ -3,7 +3,7 @@ use std::{os::unix::process::CommandExt, path::PathBuf, process::Command};
 use anyhow::Context as _;
 use clap::Parser;
 
-use crate::build_ebpf::{build_ebpf, Architecture, Options as BuildOptions};
+use crate::build_ebpf::{build_ebpf, Architecture, BuildEbpfOptions as BuildOptions};
 
 #[derive(Debug, Parser)]
 pub struct Options {


### PR DESCRIPTION
PR contains the results of applying `cargo +nightly clippy --fix` to fix
clippy's uninlined_format_args issues https://rust-lang.github.io/rust-clippy/master/index.html#uninlined_format_args.

Cumulative with https://github.com/aya-rs/aya/pull/454