### PR TITLE
Add ability to iterate over LpmTrie keys and matches

### DIFF
--- a/aya/src/maps/lpm_trie.rs
+++ b/aya/src/maps/lpm_trie.rs
@@ -139,8 +139,8 @@ impl<T: AsRef<MapData>, K: Pod, V: Pod> LpmTrie<T, K, V> {
 
     /// An iterator visiting all keys matching key. The
     /// iterator item type is `Result<Key<K>, MapError>`.
-    pub fn iter_key(&self, key: Key<K>) -> LpnTrieKeys<'_, K> {
-        LpnTrieKeys::new(self.inner.as_ref(), key)
+    pub fn iter_key(&self, key: Key<K>) -> LpmTrieKeys<'_, K> {
+        LpmTrieKeys::new(self.inner.as_ref(), key)
     }
 }
 
@@ -188,15 +188,15 @@ impl<T: AsRef<MapData>, K: Pod, V: Pod> IterableMap<Key<K>, V> for LpmTrie<T, K,
 }
 
 /// Iterator returned by `LpmTrie::iter_key()`.
-pub struct LpnTrieKeys<'coll, K: Pod> {
+pub struct LpmTrieKeys<'coll, K: Pod> {
     map: &'coll MapData,
     err: bool,
     key: Key<K>,
 }
 
-impl<'coll, K: Pod> LpnTrieKeys<'coll, K> {
-    fn new(map: &'coll MapData, key: Key<K>) -> LpnTrieKeys<'coll, K> {
-        LpnTrieKeys {
+impl<'coll, K: Pod> LpmTrieKeys<'coll, K> {
+    fn new(map: &'coll MapData, key: Key<K>) -> LpmTrieKeys<'coll, K> {
+        LpmTrieKeys {
             map,
             err: false,
             key,
@@ -204,7 +204,7 @@ impl<'coll, K: Pod> LpnTrieKeys<'coll, K> {
     }
 }
 
-impl<K: Pod> Iterator for LpnTrieKeys<'_, K> {
+impl<K: Pod> Iterator for LpmTrieKeys<'_, K> {
     type Item = Result<Key<K>, MapError>;
 
     fn next(&mut self) -> Option<Result<Key<K>, MapError>> {

--- a/aya/src/maps/lpm_trie.rs
+++ b/aya/src/maps/lpm_trie.rs
@@ -128,7 +128,7 @@ impl<T: AsRef<MapData>, K: Pod, V: Pod> LpmTrie<T, K, V> {
 
     /// An iterator visiting all key-value pairs in arbitrary order. The
     /// iterator item type is `Result<(K, V), MapError>`.
-    pub fn iter(&self) -> MapIter<'_, K, V, Self> {
+    pub fn iter(&self) -> MapIter<'_, Key<K>, V, Self> {
         MapIter::new(self)
     }
 
@@ -172,14 +172,13 @@ impl<T: AsMut<MapData>, K: Pod, V: Pod> LpmTrie<T, K, V> {
     }
 }
 
-impl<T: AsRef<MapData>, K: Pod, V: Pod> IterableMap<K, V> for LpmTrie<T, K, V> {
+impl<T: AsRef<MapData>, K: Pod, V: Pod> IterableMap<Key<K>, V> for LpmTrie<T, K, V> {
     fn map(&self) -> &MapData {
         self.inner.as_ref()
     }
 
-    fn get(&self, key: &K) -> Result<V, MapError> {
-        let lookup = Key::new(mem::size_of::<K>() as u32, *key);
-        self.get(&lookup, 0)
+    fn get(&self, key: &Key<K>) -> Result<V, MapError> {
+        self.get(key, 0)
     }
 }
 

--- a/aya/src/maps/lpm_trie.rs
+++ b/aya/src/maps/lpm_trie.rs
@@ -499,32 +499,4 @@ mod tests {
 
         assert!(matches!(trie.get(&key, 0), Err(MapError::KeyNotFound)));
     }
-
-    // #[test]
-    // // Syscall overrides are performing integer-to-pointer conversions, which
-    // // should be done with `ptr::from_exposed_addr` in Rust nightly, but we have
-    // // to support stable as well.
-    // #[cfg_attr(miri, ignore)]
-    // fn test_iter() {
-    //     override_syscall(|call| match call {
-    //         Syscall::Bpf {
-    //             cmd: bpf_cmd::BPF_MAP_GET_NEXT_KEY,
-    //             attr,
-    //         } => get_next_key(attr),
-    //         Syscall::Bpf {
-    //             cmd: bpf_cmd::BPF_MAP_LOOKUP_ELEM,
-    //             attr,
-    //         } => lookup_elem(attr),
-    //         _ => sys_error(EFAULT),
-    //     });
-    //     let map = MapData {
-    //         obj: new_obj_map(),
-    //         fd: None,
-    //         pinned: false,
-    //         btf_fd: None,
-    //     };
-    //     let hm = LpmTrie::<_, u32, u32>::new(&map).unwrap();
-    //     let items = hm.iter().collect::<Result<Vec<_>, _>>().unwrap();
-    //     assert_eq!(&items, &[(10, 100), (20, 200), (30, 300)])
-    // }
 }

--- a/aya/src/maps/lpm_trie.rs
+++ b/aya/src/maps/lpm_trie.rs
@@ -7,7 +7,7 @@ use std::{
 
 use crate::{
     maps::{check_kv_size, IterableMap, MapData, MapError, MapIter, MapKeys},
-    sys::{bpf_map_delete_elem, bpf_map_lookup_elem, bpf_map_update_elem, bpf_map_get_next_key},
+    sys::{bpf_map_delete_elem, bpf_map_get_next_key, bpf_map_lookup_elem, bpf_map_update_elem},
     Pod,
 };
 
@@ -199,7 +199,7 @@ impl<'coll, K: Pod> LpnTrieKeys<'coll, K> {
         LpnTrieKeys {
             map,
             err: false,
-            key
+            key,
         }
     }
 }


### PR DESCRIPTION
I've done basic testing for `LpmTrie::iter()` and `LpmTrie::keys()` but have not tested `LpmTrie::iter_key()`.

This pull requests does not have any unit tests.