### PR TITLE
aya: fix detaching links on drop

### DIFF
--- a/aya/src/programs/cgroup_device.rs
+++ b/aya/src/programs/cgroup_device.rs
@@ -72,9 +72,9 @@ impl CgroupDevice {
             )? as RawFd;
             self.data
                 .links
-                .insert(CgroupDeviceLink(CgroupDeviceLinkInner::Fd(FdLink::new(
-                    link_fd,
-                ))))
+                .insert(CgroupDeviceLink::new(CgroupDeviceLinkInner::Fd(
+                    FdLink::new(link_fd),
+                )))
         } else {
             bpf_prog_attach(prog_fd, cgroup_fd, BPF_CGROUP_DEVICE).map_err(|(_, io_error)| {
                 ProgramError::SyscallError {
@@ -84,7 +84,7 @@ impl CgroupDevice {
             })?;
             self.data
                 .links
-                .insert(CgroupDeviceLink(CgroupDeviceLinkInner::ProgAttach(
+                .insert(CgroupDeviceLink::new(CgroupDeviceLinkInner::ProgAttach(
                     ProgAttachLink::new(prog_fd, cgroup_fd, BPF_CGROUP_DEVICE),
                 )))
         }

--- a/aya/src/programs/cgroup_skb.rs
+++ b/aya/src/programs/cgroup_skb.rs
@@ -105,7 +105,9 @@ impl CgroupSkb {
             )? as RawFd;
             self.data
                 .links
-                .insert(CgroupSkbLink(CgroupSkbLinkInner::Fd(FdLink::new(link_fd))))
+                .insert(CgroupSkbLink::new(CgroupSkbLinkInner::Fd(FdLink::new(
+                    link_fd,
+                ))))
         } else {
             bpf_prog_attach(prog_fd, cgroup_fd, attach_type).map_err(|(_, io_error)| {
                 ProgramError::SyscallError {
@@ -116,7 +118,7 @@ impl CgroupSkb {
 
             self.data
                 .links
-                .insert(CgroupSkbLink(CgroupSkbLinkInner::ProgAttach(
+                .insert(CgroupSkbLink::new(CgroupSkbLinkInner::ProgAttach(
                     ProgAttachLink::new(prog_fd, cgroup_fd, attach_type),
                 )))
         }

--- a/aya/src/programs/cgroup_sock.rs
+++ b/aya/src/programs/cgroup_sock.rs
@@ -81,7 +81,7 @@ impl CgroupSock {
             )? as RawFd;
             self.data
                 .links
-                .insert(CgroupSockLink(CgroupSockLinkInner::Fd(FdLink::new(
+                .insert(CgroupSockLink::new(CgroupSockLinkInner::Fd(FdLink::new(
                     link_fd,
                 ))))
         } else {
@@ -94,7 +94,7 @@ impl CgroupSock {
 
             self.data
                 .links
-                .insert(CgroupSockLink(CgroupSockLinkInner::ProgAttach(
+                .insert(CgroupSockLink::new(CgroupSockLinkInner::ProgAttach(
                     ProgAttachLink::new(prog_fd, cgroup_fd, attach_type),
                 )))
         }

--- a/aya/src/programs/cgroup_sock_addr.rs
+++ b/aya/src/programs/cgroup_sock_addr.rs
@@ -82,7 +82,7 @@ impl CgroupSockAddr {
             )? as RawFd;
             self.data
                 .links
-                .insert(CgroupSockAddrLink(CgroupSockAddrLinkInner::Fd(
+                .insert(CgroupSockAddrLink::new(CgroupSockAddrLinkInner::Fd(
                     FdLink::new(link_fd),
                 )))
         } else {
@@ -93,11 +93,13 @@ impl CgroupSockAddr {
                 }
             })?;
 
-            self.data
-                .links
-                .insert(CgroupSockAddrLink(CgroupSockAddrLinkInner::ProgAttach(
-                    ProgAttachLink::new(prog_fd, cgroup_fd, attach_type),
-                )))
+            self.data.links.insert(CgroupSockAddrLink::new(
+                CgroupSockAddrLinkInner::ProgAttach(ProgAttachLink::new(
+                    prog_fd,
+                    cgroup_fd,
+                    attach_type,
+                )),
+            ))
         }
     }
 

--- a/aya/src/programs/cgroup_sockopt.rs
+++ b/aya/src/programs/cgroup_sockopt.rs
@@ -79,9 +79,9 @@ impl CgroupSockopt {
             )? as RawFd;
             self.data
                 .links
-                .insert(CgroupSockoptLink(CgroupSockoptLinkInner::Fd(FdLink::new(
-                    link_fd,
-                ))))
+                .insert(CgroupSockoptLink::new(CgroupSockoptLinkInner::Fd(
+                    FdLink::new(link_fd),
+                )))
         } else {
             bpf_prog_attach(prog_fd, cgroup_fd, attach_type).map_err(|(_, io_error)| {
                 ProgramError::SyscallError {
@@ -92,7 +92,7 @@ impl CgroupSockopt {
 
             self.data
                 .links
-                .insert(CgroupSockoptLink(CgroupSockoptLinkInner::ProgAttach(
+                .insert(CgroupSockoptLink::new(CgroupSockoptLinkInner::ProgAttach(
                     ProgAttachLink::new(prog_fd, cgroup_fd, attach_type),
                 )))
         }

--- a/aya/src/programs/cgroup_sysctl.rs
+++ b/aya/src/programs/cgroup_sysctl.rs
@@ -74,9 +74,9 @@ impl CgroupSysctl {
             )? as RawFd;
             self.data
                 .links
-                .insert(CgroupSysctlLink(CgroupSysctlLinkInner::Fd(FdLink::new(
-                    link_fd,
-                ))))
+                .insert(CgroupSysctlLink::new(CgroupSysctlLinkInner::Fd(
+                    FdLink::new(link_fd),
+                )))
         } else {
             bpf_prog_attach(prog_fd, cgroup_fd, BPF_CGROUP_SYSCTL).map_err(|(_, io_error)| {
                 ProgramError::SyscallError {
@@ -87,7 +87,7 @@ impl CgroupSysctl {
 
             self.data
                 .links
-                .insert(CgroupSysctlLink(CgroupSysctlLinkInner::ProgAttach(
+                .insert(CgroupSysctlLink::new(CgroupSysctlLinkInner::ProgAttach(
                     ProgAttachLink::new(prog_fd, cgroup_fd, BPF_CGROUP_SYSCTL),
                 )))
         }

--- a/aya/src/programs/extension.rs
+++ b/aya/src/programs/extension.rs
@@ -95,7 +95,9 @@ impl Extension {
                 call: "bpf_link_create".to_owned(),
                 io_error,
             })? as RawFd;
-        self.data.links.insert(ExtensionLink(FdLink::new(link_fd)))
+        self.data
+            .links
+            .insert(ExtensionLink::new(FdLink::new(link_fd)))
     }
 
     /// Attaches the extension to another program.
@@ -123,7 +125,9 @@ impl Extension {
                 call: "bpf_link_create".to_owned(),
                 io_error,
             })? as RawFd;
-        self.data.links.insert(ExtensionLink(FdLink::new(link_fd)))
+        self.data
+            .links
+            .insert(ExtensionLink::new(FdLink::new(link_fd)))
     }
 
     /// Detaches the extension.

--- a/aya/src/programs/sk_lookup.rs
+++ b/aya/src/programs/sk_lookup.rs
@@ -70,7 +70,9 @@ impl SkLookup {
                 io_error,
             },
         )? as RawFd;
-        self.data.links.insert(SkLookupLink(FdLink::new(link_fd)))
+        self.data
+            .links
+            .insert(SkLookupLink::new(FdLink::new(link_fd)))
     }
 
     /// Takes ownership of the link referenced by the provided link_id.

--- a/aya/src/programs/sk_msg.rs
+++ b/aya/src/programs/sk_msg.rs
@@ -88,7 +88,7 @@ impl SkMsg {
                 io_error,
             }
         })?;
-        self.data.links.insert(SkMsgLink(ProgAttachLink::new(
+        self.data.links.insert(SkMsgLink::new(ProgAttachLink::new(
             prog_fd,
             map_fd,
             BPF_SK_MSG_VERDICT,

--- a/aya/src/programs/sk_skb.rs
+++ b/aya/src/programs/sk_skb.rs
@@ -84,9 +84,11 @@ impl SkSkb {
                 io_error,
             }
         })?;
-        self.data
-            .links
-            .insert(SkSkbLink(ProgAttachLink::new(prog_fd, map_fd, attach_type)))
+        self.data.links.insert(SkSkbLink::new(ProgAttachLink::new(
+            prog_fd,
+            map_fd,
+            attach_type,
+        )))
     }
 
     /// Detaches the program.

--- a/aya/src/programs/sock_ops.rs
+++ b/aya/src/programs/sock_ops.rs
@@ -68,7 +68,7 @@ impl SockOps {
                 io_error,
             }
         })?;
-        self.data.links.insert(SockOpsLink(ProgAttachLink::new(
+        self.data.links.insert(SockOpsLink::new(ProgAttachLink::new(
             prog_fd,
             cgroup_fd,
             BPF_CGROUP_SOCK_OPS,

--- a/aya/src/programs/tc.rs
+++ b/aya/src/programs/tc.rs
@@ -165,7 +165,7 @@ impl SchedClassifier {
         }
         .map_err(|io_error| TcError::NetlinkError { io_error })?;
 
-        self.data.links.insert(SchedClassifierLink(TcLink {
+        self.data.links.insert(SchedClassifierLink::new(TcLink {
             if_index: if_index as i32,
             attach_type,
             priority,

--- a/test/integration-ebpf/src/test.rs
+++ b/test/integration-ebpf/src/test.rs
@@ -1,9 +1,13 @@
 #![no_std]
 #![no_main]
 
-use aya_bpf::{bindings::xdp_action, macros::xdp, programs::XdpContext};
+use aya_bpf::{
+    bindings::xdp_action,
+    macros::{kprobe, xdp},
+    programs::{ProbeContext, XdpContext},
+};
 
-#[xdp(name = "test_unload")]
+#[xdp(name = "test_unload_xdp")]
 pub fn pass(ctx: XdpContext) -> u32 {
     match unsafe { try_pass(ctx) } {
         Ok(ret) => ret,
@@ -13,6 +17,12 @@ pub fn pass(ctx: XdpContext) -> u32 {
 
 unsafe fn try_pass(_ctx: XdpContext) -> Result<u32, u32> {
     Ok(xdp_action::XDP_PASS)
+}
+
+#[kprobe]
+// truncated name to match bpftool output
+pub fn test_unload_kpr(_ctx: ProbeContext) -> u32 {
+    0
 }
 
 #[panic_handler]


### PR DESCRIPTION
https://github.com/aya-rs/aya/pull/366 broke detaching links on drop for everything but FdLink. This restores detach on drop for all links.