### PR TITLE
add tracefs mount point select function

### DIFF
--- a/aya/src/programs/mod.rs
+++ b/aya/src/programs/mod.rs
@@ -207,9 +207,9 @@ pub enum ProgramError {
         name: String,
     },
 
-    /// TraceFS not found.
-    #[error("tracefs non found")]
-    TraceFsNotFound,
+    /// An error occurred while working with IO.
+    #[error(transparent)]
+    IOError(#[from] io::Error),
 }
 
 /// A [`Program`] file descriptor.

--- a/aya/src/programs/mod.rs
+++ b/aya/src/programs/mod.rs
@@ -206,6 +206,10 @@ pub enum ProgramError {
         /// program name
         name: String,
     },
+
+    /// TraceFS not found.
+    #[error("tracefs non found")]
+    TraceFsNotFound,
 }
 
 /// A [`Program`] file descriptor.

--- a/aya/src/programs/probe.rs
+++ b/aya/src/programs/probe.rs
@@ -9,8 +9,8 @@ use std::{
 use crate::{
     programs::{
         kprobe::KProbeError, perf_attach, perf_attach::PerfLink, perf_attach_debugfs,
-        trace_point::read_sys_fs_trace_point_id, uprobe::UProbeError, utils::get_tracefs, Link,
-        ProgramData, ProgramError,
+        trace_point::read_sys_fs_trace_point_id, uprobe::UProbeError, utils::find_tracefs_path,
+        Link, ProgramData, ProgramError,
     },
     sys::{kernel_version, perf_event_open_probe, perf_event_open_trace_point},
 };
@@ -61,7 +61,7 @@ pub(crate) fn attach<T: Link + From<PerfLink>>(
 pub(crate) fn detach_debug_fs(kind: ProbeKind, event_alias: &str) -> Result<(), ProgramError> {
     use ProbeKind::*;
 
-    let tracefs = get_tracefs()?;
+    let tracefs = find_tracefs_path()?;
 
     match kind {
         KProbe | KRetProbe => delete_probe_event(tracefs, kind, event_alias)
@@ -118,7 +118,7 @@ fn create_as_trace_point(
 ) -> Result<(i32, String), ProgramError> {
     use ProbeKind::*;
 
-    let tracefs = get_tracefs()?;
+    let tracefs = find_tracefs_path()?;
 
     let event_alias = match kind {
         KProbe | KRetProbe => create_probe_event(tracefs, kind, name, offset)

--- a/aya/src/programs/trace_point.rs
+++ b/aya/src/programs/trace_point.rs
@@ -7,12 +7,11 @@ use crate::{
     programs::{
         define_link_wrapper, load_program,
         perf_attach::{perf_attach, PerfLink, PerfLinkId},
+        utils::find_tracefs_path,
         ProgramData, ProgramError,
     },
     sys::perf_event_open_trace_point,
 };
-
-use super::utils::get_tracefs;
 
 /// The type returned when attaching a [`TracePoint`] fails.
 #[derive(Debug, Error)]
@@ -79,7 +78,7 @@ impl TracePoint {
     ///
     /// The returned value can be used to detach, see [TracePoint::detach].
     pub fn attach(&mut self, category: &str, name: &str) -> Result<TracePointLinkId, ProgramError> {
-        let tracefs = get_tracefs()?;
+        let tracefs = find_tracefs_path()?;
         let id = read_sys_fs_trace_point_id(tracefs, category, name)?;
         let fd = perf_event_open_trace_point(id, None).map_err(|(_code, io_error)| {
             ProgramError::SyscallError {

--- a/aya/src/programs/utils.rs
+++ b/aya/src/programs/utils.rs
@@ -1,5 +1,5 @@
 //! Common functions shared between multiple eBPF program types.
-use std::{ffi::CStr, os::unix::io::RawFd};
+use std::{ffi::CStr, os::unix::io::RawFd, path::Path};
 
 use crate::{
     programs::{FdLink, Link, ProgramData, ProgramError},
@@ -21,4 +21,26 @@ pub(crate) fn attach_raw_tracepoint<T: Link + From<FdLink>>(
     })? as RawFd;
 
     program_data.links.insert(FdLink::new(pfd).into())
+}
+
+// Get tracefs filesystem 
+pub(crate) fn get_tracefs() -> Result<&'static Path, ProgramError> {
+    lazy_static::lazy_static! {
+        static ref TRACE_FS: Option<&'static Path> = {
+            let mounts = [
+                Path::new("/sys/kernel/tracing"),
+                Path::new("/sys/kernel/debug/tracing"),
+            ];
+
+            for mount in mounts {
+                if mount.exists() {
+                    return Some(mount);
+                }
+            }
+            None
+
+        };
+    }
+
+    TRACE_FS.as_deref().ok_or(ProgramError::TraceFsNotFound)
 }


### PR DESCRIPTION
This PR would to improve the access to `tracefs`.

This is implemented with a single check to determine if the `tracefs` is mounted or not. It checks in two known locations, in order of priority:

1. `/sys/kernel/tracing`
2. `/sys/kernel/debug/tracing`

Most of the systems have both `tracefs` and `debugfs` mounted, but in some hardened systems the kernel is compiled without `debugfs` or simply not mounted. Android documentation for example has a warning for debugfs in user builds.