### PR TITLE
Add Program::info()

### DIFF
--- a/aya/src/programs/mod.rs
+++ b/aya/src/programs/mod.rs
@@ -396,7 +396,9 @@ impl Program {
         }
     }
 
-    /// Returns ProgramInfo for a program.
+    /// Returns infomation about a program.
+    ///
+    /// Returns [None](`std::option::Option::None`) when the program does not have a file descriptor (most likely because it isn't loaded).
     pub fn info(&self) -> Option<Result<ProgramInfo, ProgramError>> {
         match self {
             Program::KProbe(p) => p.info(),
@@ -730,6 +732,8 @@ macro_rules! impl_info {
         $(
             impl $struct_name {
                 /// Returns a ProgramInfo for this Program.
+                ///
+                /// Returns [None](`std::option::Option::None`) when the program does not have a file descriptor (most likely because it isn't loaded).
                 pub fn info(&self) -> Option<Result<ProgramInfo, ProgramError>> {
                     self.data.fd.map(|fd| ProgramInfo::from_fd(&fd))
                 }

--- a/aya/src/programs/mod.rs
+++ b/aya/src/programs/mod.rs
@@ -395,6 +395,36 @@ impl Program {
             Program::CgroupDevice(p) => p.fd(),
         }
     }
+
+    /// Returns ProgramInfo for a program.
+    pub fn info(&self) -> Option<Result<ProgramInfo, ProgramError>> {
+        match self {
+            Program::KProbe(p) => p.info(),
+            Program::UProbe(p) => p.info(),
+            Program::TracePoint(p) => p.info(),
+            Program::SocketFilter(p) => p.info(),
+            Program::Xdp(p) => p.info(),
+            Program::SkMsg(p) => p.info(),
+            Program::SkSkb(p) => p.info(),
+            Program::SockOps(p) => p.info(),
+            Program::SchedClassifier(p) => p.info(),
+            Program::CgroupSkb(p) => p.info(),
+            Program::CgroupSysctl(p) => p.info(),
+            Program::CgroupSockopt(p) => p.info(),
+            Program::LircMode2(p) => p.info(),
+            Program::PerfEvent(p) => p.info(),
+            Program::RawTracePoint(p) => p.info(),
+            Program::Lsm(p) => p.info(),
+            Program::BtfTracePoint(p) => p.info(),
+            Program::FEntry(p) => p.info(),
+            Program::FExit(p) => p.info(),
+            Program::Extension(p) => p.info(),
+            Program::CgroupSockAddr(p) => p.info(),
+            Program::SkLookup(p) => p.info(),
+            Program::CgroupSock(p) => p.info(),
+            Program::CgroupDevice(p) => p.info(),
+        }
+    }
 }
 
 impl Drop for Program {
@@ -669,6 +699,46 @@ macro_rules! impl_fd {
 }
 
 impl_fd!(
+    KProbe,
+    UProbe,
+    TracePoint,
+    SocketFilter,
+    Xdp,
+    SkMsg,
+    SkSkb,
+    SchedClassifier,
+    CgroupSkb,
+    CgroupSysctl,
+    CgroupSockopt,
+    LircMode2,
+    PerfEvent,
+    Lsm,
+    RawTracePoint,
+    BtfTracePoint,
+    FEntry,
+    FExit,
+    Extension,
+    CgroupSockAddr,
+    SkLookup,
+    SockOps,
+    CgroupSock,
+    CgroupDevice,
+);
+
+macro_rules! impl_info {
+    ($($struct_name:ident),+ $(,)?) => {
+        $(
+            impl $struct_name {
+                /// Returns a ProgramInfo for this Program.
+                pub fn info(&self) -> Option<Result<ProgramInfo, ProgramError>> {
+                    self.data.fd.map(|fd| ProgramInfo::from_fd(&fd))
+                }
+            }
+        )+
+    }
+}
+
+impl_info!(
     KProbe,
     UProbe,
     TracePoint,

--- a/aya/src/sys/bpf.rs
+++ b/aya/src/sys/bpf.rs
@@ -425,6 +425,7 @@ pub(crate) fn bpf_prog_query(
     ret
 }
 
+// TODO: Replace RawFd with OwnedFd
 pub(crate) fn bpf_prog_get_fd_by_id(prog_id: u32) -> Result<RawFd, io::Error> {
     let mut attr = unsafe { mem::zeroed::<bpf_attr>() };
 


### PR DESCRIPTION
Adds the ability to get ProgramInfo directly from a Program without having to handle file descriptors.

Also fixed 2 locations I believe file descriptors would leak and added some `TODO` notes for switching over to OwnedFd in the future.

Note: `Program::info()` returns an unwieldy double nested value `Option<Result<ProgramInfo, ProgramError>>` because programs can have no fd (hence the Option) and getting program info from a file descriptor can fail (hence the Result).