### PR TITLE
bpf: fix `set_mark` by not copying `__sk_buff`

### DIFF
--- a/bpf/aya-bpf/src/programs/sk_buff.rs
+++ b/bpf/aya-bpf/src/programs/sk_buff.rs
@@ -25,7 +25,7 @@ impl SkBuff {
     #[allow(clippy::len_without_is_empty)]
     #[inline]
     pub fn len(&self) -> u32 {
-        unsafe { *self.skb }.len
+        unsafe { (*self.skb).len }
     }
 
     #[inline]
@@ -40,7 +40,7 @@ impl SkBuff {
 
     #[inline]
     pub fn set_mark(&mut self, mark: u32) {
-        unsafe { *self.skb }.mark = mark;
+        unsafe { (*self.skb).mark = mark }
     }
 
     #[inline]


### PR DESCRIPTION
Such an assignment in two parts (first deref in `unsafe`, then field access outside of `unsafe`) is bogus: the deref "returned" by the `unsafe` block actually creates a copy of the `__sk_buff` struct because it implements `Copy`. The mark value is written to the `mark` field of the copy, and not the real `__sk_buff`.

Change it to do it all in the `unsafe` block.

The same is done for the `.len()` getter to avoid copying the whole `__sk_buff` struct for a 32 bit field. Although such a copy should be optimized out by the compiler, it's better to help it do so.