### PR TITLE
Don't panic on failed BTF relocations

### DIFF
--- a/aya/src/obj/btf/mod.rs
+++ b/aya/src/obj/btf/mod.rs
@@ -6,5 +6,4 @@ mod types;
 
 pub use btf::*;
 pub(crate) use info::*;
-pub use relocation::RelocationError;
 pub(crate) use types::*;

--- a/aya/src/obj/btf/relocation.rs
+++ b/aya/src/obj/btf/relocation.rs
@@ -18,7 +18,7 @@ use crate::{
 };
 
 #[derive(Error, Debug)]
-pub enum RelocationError {
+enum RelocationError {
     #[error(transparent)]
     IOError(#[from] io::Error),
 


### PR DESCRIPTION
Error out instead of panicing when we can't find a compatible target candidate for a BTF relocation.

This can commonly happen if the loader is configured to not load BTF at all, or if the loaded BTF is older than the one used to generate the object file, so it doesn't have some newer type definitions.