### PR TITLE
Added MIPS bindings

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -15,3 +15,6 @@ linker = "powerpc64le-linux-gnu-gcc"
 
 [target.s390x-unknown-linux-gnu]
 linker = "s390x-linux-gnu-gcc"
+
+[target.mips-unknown-linux-gnu]
+linker = "mips-linux-gnu-gcc"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,6 +83,7 @@ jobs:
           - riscv64gc-unknown-linux-gnu
           - powerpc64le-unknown-linux-gnu
           - s390x-unknown-linux-gnu
+          - mips-unknown-linux-gnu
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -141,6 +142,7 @@ jobs:
           - riscv64
           - powerpc64
           - s390x
+          - mips
         target:
           - bpfel-unknown-none
           - bpfeb-unknown-none

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ default-members = [
 
     # ebpf crates are omitted; they must be built with:
     # --target bpfe{b,l}-unknown-none
-    # CARGO_CFG_BPF_TARGET_ARCH={x86_64,aarch64,arm,riscv64,powerpc64,s390x}
+    # CARGO_CFG_BPF_TARGET_ARCH={x86_64,aarch64,arm,riscv64,powerpc64,s390x,mips}
 ]
 
 [workspace.package]

--- a/aya-obj/src/generated/mod.rs
+++ b/aya-obj/src/generated/mod.rs
@@ -13,6 +13,8 @@ mod btf_internal_bindings;
 mod linux_bindings_aarch64;
 #[cfg(target_arch = "arm")]
 mod linux_bindings_armv7;
+#[cfg(target_arch = "mips")]
+mod linux_bindings_mips;
 #[cfg(target_arch = "powerpc64")]
 mod linux_bindings_powerpc64;
 #[cfg(target_arch = "riscv64")]
@@ -29,6 +31,8 @@ pub use btf_internal_bindings::{bpf_core_relo, bpf_core_relo_kind, btf_ext_heade
 pub use linux_bindings_aarch64::*;
 #[cfg(target_arch = "arm")]
 pub use linux_bindings_armv7::*;
+#[cfg(target_arch = "mips")]
+pub use linux_bindings_mips::*;
 #[cfg(target_arch = "powerpc64")]
 pub use linux_bindings_powerpc64::*;
 #[cfg(target_arch = "riscv64")]

--- a/ebpf/aya-ebpf-bindings/build.rs
+++ b/ebpf/aya-ebpf-bindings/build.rs
@@ -12,5 +12,5 @@ fn main() {
         }
         println!("cargo:rustc-cfg=bpf_target_arch=\"{arch}\"");
     }
-    println!("cargo::rustc-check-cfg=cfg(bpf_target_arch, values(\"x86_64\",\"arm\",\"aarch64\",\"riscv64\",\"powerpc64\",\"s390x\"))");
+    println!("cargo::rustc-check-cfg=cfg(bpf_target_arch, values(\"x86_64\",\"arm\",\"aarch64\",\"riscv64\",\"powerpc64\",\"s390x\",\"mips\"))");
 }

--- a/ebpf/aya-ebpf-bindings/src/lib.rs
+++ b/ebpf/aya-ebpf-bindings/src/lib.rs
@@ -20,11 +20,16 @@ mod powerpc64;
 #[cfg(bpf_target_arch = "s390x")]
 mod s390x;
 
+#[cfg(bpf_target_arch = "mips")]
+mod mips;
+
 mod gen {
     #[cfg(bpf_target_arch = "aarch64")]
     pub use super::aarch64::*;
     #[cfg(bpf_target_arch = "arm")]
     pub use super::armv7::*;
+    #[cfg(bpf_target_arch = "mips")]
+    pub use super::mips::*;
     #[cfg(bpf_target_arch = "powerpc64")]
     pub use super::powerpc64::*;
     #[cfg(bpf_target_arch = "riscv64")]

--- a/ebpf/aya-ebpf-bindings/src/mips/mod.rs
+++ b/ebpf/aya-ebpf-bindings/src/mips/mod.rs
@@ -1,0 +1,3 @@
+#![allow(clippy::all, dead_code)]
+pub mod bindings;
+pub mod helpers;

--- a/ebpf/aya-ebpf-cty/build.rs
+++ b/ebpf/aya-ebpf-cty/build.rs
@@ -12,6 +12,6 @@ fn main() {
         }
         println!("cargo:rustc-cfg=bpf_target_arch=\"{arch}\"");
     }
-    println!("cargo::rustc-check-cfg=cfg(bpf_target_arch, values(\"x86_64\",\"arm\",\"aarch64\",\"riscv64\",\"powerpc64\",\"s390x\"))");
+    println!("cargo::rustc-check-cfg=cfg(bpf_target_arch, values(\"x86_64\",\"arm\",\"aarch64\",\"riscv64\",\"powerpc64\",\"s390x\",\"mips\"))");
     println!("cargo::rustc-check-cfg=cfg(target_arch, values(\"asmjs\",\"nvptx\",\"xtensa\"))");
 }

--- a/ebpf/aya-ebpf-cty/src/lib.rs
+++ b/ebpf/aya-ebpf-cty/src/lib.rs
@@ -33,6 +33,9 @@ mod ad {
     #[cfg(bpf_target_arch = "s390x")]
     pub type c_char = super::c_uchar;
 
+    #[cfg(bpf_target_arch = "mips")]
+    pub type c_char = super::c_uchar;
+
     #[cfg(bpf_target_arch = "x86_64")]
     pub type c_char = super::c_schar;
 }

--- a/ebpf/aya-ebpf/build.rs
+++ b/ebpf/aya-ebpf/build.rs
@@ -13,7 +13,7 @@ fn main() {
         }
         println!("cargo:rustc-cfg=bpf_target_arch=\"{arch}\"");
     }
-    println!("cargo::rustc-check-cfg=cfg(bpf_target_arch, values(\"x86_64\",\"arm\",\"aarch64\",\"riscv64\",\"powerpc64\",\"s390x\"))");
+    println!("cargo::rustc-check-cfg=cfg(bpf_target_arch, values(\"x86_64\",\"arm\",\"aarch64\",\"riscv64\",\"powerpc64\",\"s390x\",\"mips\"))");
     println!("cargo::rustc-check-cfg=cfg(unstable)");
 }
 

--- a/ebpf/aya-ebpf/src/programs/probe.rs
+++ b/ebpf/aya-ebpf/src/programs/probe.rs
@@ -3,7 +3,8 @@ use core::ffi::c_void;
 #[cfg(any(
     bpf_target_arch = "x86_64",
     bpf_target_arch = "arm",
-    bpf_target_arch = "powerpc64"
+    bpf_target_arch = "powerpc64",
+    bpf_target_arch = "mips"
 ))]
 use crate::bindings::pt_regs;
 // aarch64 uses user_pt_regs instead of pt_regs

--- a/ebpf/aya-ebpf/src/programs/retprobe.rs
+++ b/ebpf/aya-ebpf/src/programs/retprobe.rs
@@ -3,7 +3,8 @@ use core::ffi::c_void;
 #[cfg(any(
     bpf_target_arch = "x86_64",
     bpf_target_arch = "arm",
-    bpf_target_arch = "powerpc64"
+    bpf_target_arch = "powerpc64",
+    bpf_target_arch = "mips"
 ))]
 use crate::bindings::pt_regs;
 // aarch64 uses user_pt_regs instead of pt_regs


### PR DESCRIPTION
This commit updates xtask scripts to generated bindings for MIPS alongside other architectures. It also updates
`aya-obj/src/generated/mod.rs` and `bpf/aya-bpf-bindings/src/lib.rs` to use the mips bindings.


<details>
<summary> Integration Tests using libbpf v1.1.0</summary>

```rust
emerald :: hobby/dhcp_aya/aya 130 » RUST_LOG=trace cargo xtask integration-test --libbpf-dir ./libbpf/
    Finished dev [unoptimized + debuginfo] target(s) in 0.16s
     Running `target/debug/xtask integration-test --libbpf-dir ./libbpf/`
       Fresh unicode-ident v1.0.6
       Fresh core v0.0.0 (/home/ishan/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core)
       Fresh proc-macro2 v1.0.49
       Fresh rustc-std-workspace-core v1.99.0 (/home/ishan/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/rustc-std-workspace-core)
       Fresh compiler_builtins v0.1.85
       Fresh quote v1.0.23
       Fresh rustversion v1.0.11
       Fresh aya-bpf-cty v0.2.1 (/home/ishan/hobby/dhcp_aya/aya/bpf/aya-bpf-cty)
       Fresh syn v1.0.107
       Fresh aya-bpf-bindings v0.1.0 (/home/ishan/hobby/dhcp_aya/aya/bpf/aya-bpf-bindings)
       Fresh aya-bpf-macros v0.1.0 (/home/ishan/hobby/dhcp_aya/aya/aya-bpf-macros)
       Fresh aya-bpf v0.1.0 (/home/ishan/hobby/dhcp_aya/aya/bpf/aya-bpf)
       Fresh integration-ebpf v0.1.0 (/home/ishan/hobby/dhcp_aya/aya/test/integration-ebpf)
    Finished dev [unoptimized + debuginfo] target(s) in 0.11s
  INSTALL  bpf.h libbpf.h btf.h libbpf_common.h libbpf_legacy.h bpf_helpers.h bpf_helper_defs.h bpf_tracing.h bpf_endian.h bpf_core_read.h skel_internal.h libbpf_version.h usdt.bpf.h
   Compiling aya-obj v0.1.0 (/home/ishan/hobby/dhcp_aya/aya/aya-obj)
   Compiling aya v0.11.0 (/home/ishan/hobby/dhcp_aya/aya/aya)
   Compiling integration-test v0.1.0 (/home/ishan/hobby/dhcp_aya/aya/test/integration-test)
    Finished dev [unoptimized + debuginfo] target(s) in 1.50s
[sudo] password for ishan:

running 14 tests
test integration_test::tests::elf::test_maps                ... ok
test integration_test::tests::load::pin_lifecycle           ... [2023-01-07T20:44:59Z DEBUG aya::bpf] [FEAT PROBE] BPF program name support: true
[2023-01-07T20:44:59Z DEBUG aya::bpf] [FEAT PROBE] BTF support: true
[2023-01-07T20:44:59Z DEBUG aya::bpf] [FEAT PROBE] BTF func support: true
[2023-01-07T20:44:59Z DEBUG aya::bpf] [FEAT PROBE] BTF global func support: true
[2023-01-07T20:44:59Z DEBUG aya::bpf] [FEAT PROBE] BTF var and datasec support: true
[2023-01-07T20:44:59Z DEBUG aya::bpf] [FEAT PROBE] BTF float support: true
[2023-01-07T20:44:59Z DEBUG aya::bpf] [FEAT PROBE] BTF decl_tag support: true
[2023-01-07T20:44:59Z DEBUG aya::bpf] [FEAT PROBE] BTF type_tag support: true
[2023-01-07T20:44:59Z DEBUG aya_obj::relocation] relocating program pass function pass
[2023-01-07T20:44:59Z DEBUG aya_obj::relocation] finished relocating program pass function pass
[2023-01-07T20:44:59Z DEBUG aya::bpf] [FEAT PROBE] BPF program name support: true
[2023-01-07T20:44:59Z DEBUG aya::bpf] [FEAT PROBE] BTF support: true
[2023-01-07T20:44:59Z DEBUG aya::bpf] [FEAT PROBE] BTF func support: true
[2023-01-07T20:44:59Z DEBUG aya::bpf] [FEAT PROBE] BTF global func support: true
[2023-01-07T20:44:59Z DEBUG aya::bpf] [FEAT PROBE] BTF var and datasec support: true
[2023-01-07T20:44:59Z DEBUG aya::bpf] [FEAT PROBE] BTF float support: true
[2023-01-07T20:44:59Z DEBUG aya::bpf] [FEAT PROBE] BTF decl_tag support: true
[2023-01-07T20:44:59Z DEBUG aya::bpf] [FEAT PROBE] BTF type_tag support: true
[2023-01-07T20:44:59Z DEBUG aya_obj::relocation] relocating program pass function pass
[2023-01-07T20:44:59Z DEBUG aya_obj::relocation] finished relocating program pass function pass
ok
test integration_test::tests::load::pin_link                ... [2023-01-07T20:44:59Z DEBUG aya::bpf] [FEAT PROBE] BPF program name support: true
[2023-01-07T20:44:59Z DEBUG aya::bpf] [FEAT PROBE] BTF support: true
[2023-01-07T20:44:59Z DEBUG aya::bpf] [FEAT PROBE] BTF func support: true
[2023-01-07T20:44:59Z DEBUG aya::bpf] [FEAT PROBE] BTF global func support: true
[2023-01-07T20:44:59Z DEBUG aya::bpf] [FEAT PROBE] BTF var and datasec support: true
[2023-01-07T20:44:59Z DEBUG aya::bpf] [FEAT PROBE] BTF float support: true
[2023-01-07T20:44:59Z DEBUG aya::bpf] [FEAT PROBE] BTF decl_tag support: true
[2023-01-07T20:44:59Z DEBUG aya::bpf] [FEAT PROBE] BTF type_tag support: true
[2023-01-07T20:44:59Z DEBUG aya_obj::relocation] relocating program test_unload_xdp function test_unload_xdp
[2023-01-07T20:44:59Z DEBUG aya_obj::relocation] finished relocating program test_unload_xdp function test_unload_xdp
[2023-01-07T20:44:59Z DEBUG aya_obj::relocation] relocating program test_unload_kpr function test_unload_kpr
[2023-01-07T20:44:59Z DEBUG aya_obj::relocation] finished relocating program test_unload_kpr function test_unload_kpr
ok
test integration_test::tests::load::unload_kprobe           ... [2023-01-07T20:44:59Z DEBUG aya::bpf] [FEAT PROBE] BPF program name support: true
[2023-01-07T20:44:59Z DEBUG aya::bpf] [FEAT PROBE] BTF support: true
[2023-01-07T20:44:59Z DEBUG aya::bpf] [FEAT PROBE] BTF func support: true
[2023-01-07T20:44:59Z DEBUG aya::bpf] [FEAT PROBE] BTF global func support: true
[2023-01-07T20:44:59Z DEBUG aya::bpf] [FEAT PROBE] BTF var and datasec support: true
[2023-01-07T20:44:59Z DEBUG aya::bpf] [FEAT PROBE] BTF float support: true
[2023-01-07T20:44:59Z DEBUG aya::bpf] [FEAT PROBE] BTF decl_tag support: true
[2023-01-07T20:44:59Z DEBUG aya::bpf] [FEAT PROBE] BTF type_tag support: true
[2023-01-07T20:44:59Z DEBUG aya_obj::relocation] relocating program test_unload_kpr function test_unload_kpr
[2023-01-07T20:44:59Z DEBUG aya_obj::relocation] finished relocating program test_unload_kpr function test_unload_kpr
[2023-01-07T20:44:59Z DEBUG aya_obj::relocation] relocating program test_unload_xdp function test_unload_xdp
[2023-01-07T20:44:59Z DEBUG aya_obj::relocation] finished relocating program test_unload_xdp function test_unload_xdp
ok
test integration_test::tests::load::unload_xdp              ... [2023-01-07T20:44:59Z DEBUG aya::bpf] [FEAT PROBE] BPF program name support: true
[2023-01-07T20:44:59Z DEBUG aya::bpf] [FEAT PROBE] BTF support: true
[2023-01-07T20:44:59Z DEBUG aya::bpf] [FEAT PROBE] BTF func support: true
[2023-01-07T20:44:59Z DEBUG aya::bpf] [FEAT PROBE] BTF global func support: true
[2023-01-07T20:44:59Z DEBUG aya::bpf] [FEAT PROBE] BTF var and datasec support: true
[2023-01-07T20:44:59Z DEBUG aya::bpf] [FEAT PROBE] BTF float support: true
[2023-01-07T20:44:59Z DEBUG aya::bpf] [FEAT PROBE] BTF decl_tag support: true
[2023-01-07T20:44:59Z DEBUG aya::bpf] [FEAT PROBE] BTF type_tag support: true
[2023-01-07T20:44:59Z DEBUG aya_obj::relocation] relocating program test_unload_kpr function test_unload_kpr
[2023-01-07T20:44:59Z DEBUG aya_obj::relocation] finished relocating program test_unload_kpr function test_unload_kpr
[2023-01-07T20:44:59Z DEBUG aya_obj::relocation] relocating program test_unload_xdp function test_unload_xdp
[2023-01-07T20:44:59Z DEBUG aya_obj::relocation] finished relocating program test_unload_xdp function test_unload_xdp
ok
test integration_test::tests::load::multiple_btf_maps       ... [2023-01-07T20:44:59Z DEBUG aya::bpf] [FEAT PROBE] BPF program name support: true
[2023-01-07T20:44:59Z DEBUG aya::bpf] [FEAT PROBE] BTF support: true
[2023-01-07T20:44:59Z DEBUG aya::bpf] [FEAT PROBE] BTF func support: true
[2023-01-07T20:44:59Z DEBUG aya::bpf] [FEAT PROBE] BTF global func support: true
[2023-01-07T20:44:59Z DEBUG aya::bpf] [FEAT PROBE] BTF var and datasec support: true
[2023-01-07T20:44:59Z DEBUG aya::bpf] [FEAT PROBE] BTF float support: true
[2023-01-07T20:44:59Z DEBUG aya::bpf] [FEAT PROBE] BTF decl_tag support: true
[2023-01-07T20:44:59Z DEBUG aya::bpf] [FEAT PROBE] BTF type_tag support: true
[2023-01-07T20:44:59Z DEBUG aya_obj::btf::btf] [DATASEC] .maps: fixup size to 64
[2023-01-07T20:44:59Z DEBUG aya_obj::btf::btf] [DATASEC] .maps: [VAR] map_1: fixup offset 0
[2023-01-07T20:44:59Z DEBUG aya_obj::btf::btf] [DATASEC] .maps: [VAR] map_2: fixup offset 32
[2023-01-07T20:44:59Z DEBUG aya_obj::btf::btf] [DATASEC] license: fixup size to 4
[2023-01-07T20:44:59Z DEBUG aya_obj::btf::btf] [DATASEC] license: [VAR] _license: fixup offset 0
[2023-01-07T20:44:59Z DEBUG aya_obj::relocation] relocating program tracepoint function tracepoint
[2023-01-07T20:44:59Z DEBUG aya_obj::relocation] finished relocating program tracepoint function tracepoint
ok
test integration_test::tests::load::long_name               ... [2023-01-07T20:45:02Z DEBUG aya::bpf] [FEAT PROBE] BPF program name support: true
[2023-01-07T20:45:02Z DEBUG aya::bpf] [FEAT PROBE] BTF support: true
[2023-01-07T20:45:02Z DEBUG aya::bpf] [FEAT PROBE] BTF func support: true
[2023-01-07T20:45:02Z DEBUG aya::bpf] [FEAT PROBE] BTF global func support: true
[2023-01-07T20:45:02Z DEBUG aya::bpf] [FEAT PROBE] BTF var and datasec support: true
[2023-01-07T20:45:02Z DEBUG aya::bpf] [FEAT PROBE] BTF float support: true
[2023-01-07T20:45:02Z DEBUG aya::bpf] [FEAT PROBE] BTF decl_tag support: true
[2023-01-07T20:45:02Z DEBUG aya::bpf] [FEAT PROBE] BTF type_tag support: true
[2023-01-07T20:45:02Z DEBUG aya_obj::relocation] relocating program ihaveaverylongname function ihaveaverylongname
[2023-01-07T20:45:02Z DEBUG aya_obj::relocation] finished relocating program ihaveaverylongname function ihaveaverylongname
ok
test integration_test::tests::smoke::extension              ... [2023-01-07T20:45:02Z INFO  integration_test::tests::smoke] skipping as 6.1 does not meet version requirement of 5.9
ok
test integration_test::tests::smoke::xdp                    ... [2023-01-07T20:45:02Z DEBUG aya::bpf] [FEAT PROBE] BPF program name support: true
[2023-01-07T20:45:02Z DEBUG aya::bpf] [FEAT PROBE] BTF support: true
[2023-01-07T20:45:02Z DEBUG aya::bpf] [FEAT PROBE] BTF func support: true
[2023-01-07T20:45:02Z DEBUG aya::bpf] [FEAT PROBE] BTF global func support: true
[2023-01-07T20:45:02Z DEBUG aya::bpf] [FEAT PROBE] BTF var and datasec support: true
[2023-01-07T20:45:02Z DEBUG aya::bpf] [FEAT PROBE] BTF float support: true
[2023-01-07T20:45:02Z DEBUG aya::bpf] [FEAT PROBE] BTF decl_tag support: true
[2023-01-07T20:45:02Z DEBUG aya::bpf] [FEAT PROBE] BTF type_tag support: true
[2023-01-07T20:45:02Z DEBUG aya_obj::relocation] relocating program pass function pass
[2023-01-07T20:45:02Z DEBUG aya_obj::relocation] finished relocating program pass function pass
ok
test integration_test::tests::rbpf::use_map_with_rbpf       ... [2023-01-07T20:45:02Z DEBUG aya_obj::relocation] relocating program tracepoint function tracepoint
[2023-01-07T20:45:02Z DEBUG aya_obj::relocation] finished relocating program tracepoint function tracepoint
ok
test integration_test::tests::rbpf::run_with_rbpf           ... ok
test integration_test::tests::relocations::relocate_pointer ... [2023-01-07T20:45:02Z DEBUG aya::bpf] [FEAT PROBE] BPF program name support: true
[2023-01-07T20:45:02Z DEBUG aya::bpf] [FEAT PROBE] BTF support: true
[2023-01-07T20:45:02Z DEBUG aya::bpf] [FEAT PROBE] BTF func support: true
[2023-01-07T20:45:02Z DEBUG aya::bpf] [FEAT PROBE] BTF global func support: true
[2023-01-07T20:45:02Z DEBUG aya::bpf] [FEAT PROBE] BTF var and datasec support: true
[2023-01-07T20:45:02Z DEBUG aya::bpf] [FEAT PROBE] BTF float support: true
[2023-01-07T20:45:02Z DEBUG aya::bpf] [FEAT PROBE] BTF decl_tag support: true
[2023-01-07T20:45:02Z DEBUG aya::bpf] [FEAT PROBE] BTF type_tag support: true
[2023-01-07T20:45:02Z DEBUG aya_obj::btf::btf] [DATASEC] .maps: fixup size to 32
[2023-01-07T20:45:02Z DEBUG aya_obj::btf::btf] [DATASEC] .maps: [VAR] output_map: fixup offset 0
[2023-01-07T20:45:02Z DEBUG aya_obj::btf::btf] [DATASEC] license: fixup size to 4
[2023-01-07T20:45:02Z DEBUG aya_obj::btf::btf] [DATASEC] license: [VAR] _license: fixup offset 0
[2023-01-07T20:45:02Z DEBUG aya_obj::relocation] relocating program bpf_prog function bpf_prog
[2023-01-07T20:45:02Z DEBUG aya_obj::relocation] finished relocating program bpf_prog function bpf_prog
[2023-01-07T20:45:03Z DEBUG aya::bpf] [FEAT PROBE] BPF program name support: true
[2023-01-07T20:45:03Z DEBUG aya::bpf] [FEAT PROBE] BTF support: true
[2023-01-07T20:45:03Z DEBUG aya::bpf] [FEAT PROBE] BTF func support: true
[2023-01-07T20:45:03Z DEBUG aya::bpf] [FEAT PROBE] BTF global func support: true
[2023-01-07T20:45:03Z DEBUG aya::bpf] [FEAT PROBE] BTF var and datasec support: true
[2023-01-07T20:45:03Z DEBUG aya::bpf] [FEAT PROBE] BTF float support: true
[2023-01-07T20:45:03Z DEBUG aya::bpf] [FEAT PROBE] BTF decl_tag support: true
[2023-01-07T20:45:03Z DEBUG aya::bpf] [FEAT PROBE] BTF type_tag support: true
[2023-01-07T20:45:03Z DEBUG aya_obj::btf::btf] [DATASEC] .maps: fixup size to 32
[2023-01-07T20:45:03Z DEBUG aya_obj::btf::btf] [DATASEC] .maps: [VAR] output_map: fixup offset 0
[2023-01-07T20:45:03Z DEBUG aya_obj::btf::btf] [DATASEC] license: fixup size to 4
[2023-01-07T20:45:03Z DEBUG aya_obj::btf::btf] [DATASEC] license: [VAR] _license: fixup offset 0
[2023-01-07T20:45:03Z DEBUG aya_obj::relocation] relocating program bpf_prog function bpf_prog
[2023-01-07T20:45:03Z DEBUG aya_obj::relocation] finished relocating program bpf_prog function bpf_prog
ok
test integration_test::tests::relocations::relocate_enum    ... [2023-01-07T20:45:04Z DEBUG aya::bpf] [FEAT PROBE] BPF program name support: true
[2023-01-07T20:45:04Z DEBUG aya::bpf] [FEAT PROBE] BTF support: true
[2023-01-07T20:45:04Z DEBUG aya::bpf] [FEAT PROBE] BTF func support: true
[2023-01-07T20:45:04Z DEBUG aya::bpf] [FEAT PROBE] BTF global func support: true
[2023-01-07T20:45:04Z DEBUG aya::bpf] [FEAT PROBE] BTF var and datasec support: true
[2023-01-07T20:45:04Z DEBUG aya::bpf] [FEAT PROBE] BTF float support: true
[2023-01-07T20:45:04Z DEBUG aya::bpf] [FEAT PROBE] BTF decl_tag support: true
[2023-01-07T20:45:04Z DEBUG aya::bpf] [FEAT PROBE] BTF type_tag support: true
[2023-01-07T20:45:04Z DEBUG aya_obj::btf::btf] [DATASEC] .maps: fixup size to 32
[2023-01-07T20:45:04Z DEBUG aya_obj::btf::btf] [DATASEC] .maps: [VAR] output_map: fixup offset 0
[2023-01-07T20:45:04Z DEBUG aya_obj::btf::btf] [DATASEC] license: fixup size to 4
[2023-01-07T20:45:04Z DEBUG aya_obj::btf::btf] [DATASEC] license: [VAR] _license: fixup offset 0
[2023-01-07T20:45:04Z DEBUG aya_obj::relocation] relocating program bpf_prog function bpf_prog
[2023-01-07T20:45:04Z DEBUG aya_obj::relocation] finished relocating program bpf_prog function bpf_prog
[2023-01-07T20:45:05Z DEBUG aya::bpf] [FEAT PROBE] BPF program name support: true
[2023-01-07T20:45:05Z DEBUG aya::bpf] [FEAT PROBE] BTF support: true
[2023-01-07T20:45:05Z DEBUG aya::bpf] [FEAT PROBE] BTF func support: true
[2023-01-07T20:45:05Z DEBUG aya::bpf] [FEAT PROBE] BTF global func support: true
[2023-01-07T20:45:05Z DEBUG aya::bpf] [FEAT PROBE] BTF var and datasec support: true
[2023-01-07T20:45:05Z DEBUG aya::bpf] [FEAT PROBE] BTF float support: true
[2023-01-07T20:45:05Z DEBUG aya::bpf] [FEAT PROBE] BTF decl_tag support: true
[2023-01-07T20:45:05Z DEBUG aya::bpf] [FEAT PROBE] BTF type_tag support: true
[2023-01-07T20:45:05Z DEBUG aya_obj::btf::btf] [DATASEC] .maps: fixup size to 32
[2023-01-07T20:45:05Z DEBUG aya_obj::btf::btf] [DATASEC] .maps: [VAR] output_map: fixup offset 0
[2023-01-07T20:45:05Z DEBUG aya_obj::btf::btf] [DATASEC] license: fixup size to 4
[2023-01-07T20:45:05Z DEBUG aya_obj::btf::btf] [DATASEC] license: [VAR] _license: fixup offset 0
[2023-01-07T20:45:05Z DEBUG aya_obj::relocation] relocating program bpf_prog function bpf_prog
[2023-01-07T20:45:05Z DEBUG aya_obj::relocation] finished relocating program bpf_prog function bpf_prog
ok
test integration_test::tests::relocations::relocate_field   ... [2023-01-07T20:45:06Z DEBUG aya::bpf] [FEAT PROBE] BPF program name support: true
[2023-01-07T20:45:06Z DEBUG aya::bpf] [FEAT PROBE] BTF support: true
[2023-01-07T20:45:06Z DEBUG aya::bpf] [FEAT PROBE] BTF func support: true
[2023-01-07T20:45:06Z DEBUG aya::bpf] [FEAT PROBE] BTF global func support: true
[2023-01-07T20:45:06Z DEBUG aya::bpf] [FEAT PROBE] BTF var and datasec support: true
[2023-01-07T20:45:06Z DEBUG aya::bpf] [FEAT PROBE] BTF float support: true
[2023-01-07T20:45:06Z DEBUG aya::bpf] [FEAT PROBE] BTF decl_tag support: true
[2023-01-07T20:45:06Z DEBUG aya::bpf] [FEAT PROBE] BTF type_tag support: true
[2023-01-07T20:45:06Z DEBUG aya_obj::btf::btf] [DATASEC] .maps: fixup size to 32
[2023-01-07T20:45:06Z DEBUG aya_obj::btf::btf] [DATASEC] .maps: [VAR] output_map: fixup offset 0
[2023-01-07T20:45:06Z DEBUG aya_obj::btf::btf] [DATASEC] license: fixup size to 4
[2023-01-07T20:45:06Z DEBUG aya_obj::btf::btf] [DATASEC] license: [VAR] _license: fixup offset 0
[2023-01-07T20:45:06Z DEBUG aya_obj::relocation] relocating program bpf_prog function bpf_prog
[2023-01-07T20:45:06Z DEBUG aya_obj::relocation] finished relocating program bpf_prog function bpf_prog
[2023-01-07T20:45:07Z DEBUG aya::bpf] [FEAT PROBE] BPF program name support: true
[2023-01-07T20:45:07Z DEBUG aya::bpf] [FEAT PROBE] BTF support: true
[2023-01-07T20:45:07Z DEBUG aya::bpf] [FEAT PROBE] BTF func support: true
[2023-01-07T20:45:07Z DEBUG aya::bpf] [FEAT PROBE] BTF global func support: true
[2023-01-07T20:45:07Z DEBUG aya::bpf] [FEAT PROBE] BTF var and datasec support: true
[2023-01-07T20:45:07Z DEBUG aya::bpf] [FEAT PROBE] BTF float support: true
[2023-01-07T20:45:07Z DEBUG aya::bpf] [FEAT PROBE] BTF decl_tag support: true
[2023-01-07T20:45:07Z DEBUG aya::bpf] [FEAT PROBE] BTF type_tag support: true
[2023-01-07T20:45:07Z DEBUG aya_obj::btf::btf] [DATASEC] .maps: fixup size to 32
[2023-01-07T20:45:07Z DEBUG aya_obj::btf::btf] [DATASEC] .maps: [VAR] output_map: fixup offset 0
[2023-01-07T20:45:07Z DEBUG aya_obj::btf::btf] [DATASEC] license: fixup size to 4
[2023-01-07T20:45:07Z DEBUG aya_obj::btf::btf] [DATASEC] license: [VAR] _license: fixup offset 0
[2023-01-07T20:45:07Z DEBUG aya_obj::relocation] relocating program bpf_prog function bpf_prog
[2023-01-07T20:45:07Z DEBUG aya_obj::relocation] finished relocating program bpf_prog function bpf_prog
ok

test result: ok. 14 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 9.68s
```

</details>


In `cargo test`, 1 test is failing. 

```rust
test btf::btf::tests::test_read_btf_from_sys_fs ... FAILED

failures:

---- btf::btf::tests::test_read_btf_from_sys_fs stdout ----
thread 'btf::btf::tests::test_read_btf_from_sys_fs' panicked at 'called `Result::unwrap()` on an `Err` value: InvalidTypeKind { kind: 19 }', aya-obj/src/btf/btf.rs:1450:85
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace


failures:
    btf::btf::tests::test_read_btf_from_sys_fs

test result: FAILED. 75 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.01s
```

From the documentation here, https://docs.kernel.org/bpf/btf.html
Type 19 is the new(?) `ENUM64` type. 

Should I try to fix that in this PR or create another PR to fix that issue? Or should I do some thing else? Please advise, thanks

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aya-rs/aya/482)
<!-- Reviewable:end -->
