### PR TITLE
Remove libbpf dependency from relocation tests

### DIFF
--- a/test/run.sh
+++ b/test/run.sh
@@ -187,8 +187,5 @@ cargo xtask build-integration-test --musl --libbpf-dir "$1"
 scp_vm ../target/x86_64-unknown-linux-musl/debug/integration-test
 exec_vm sudo ./integration-test --skip relocations
 
-# Relocation tests build the eBPF programs and require libbpf. We run them outside VM.
-export LIBBPF_INCLUDE="${AYA_TMPDIR}/libbpf/"
-mkdir -p "$LIBBPF_INCLUDE"
-(cd "$1/src" && make INCLUDEDIR="$LIBBPF_INCLUDE" install_headers)
+# Relocation tests build the eBPF programs themself. We run them outside VM.
 sudo -E ../target/x86_64-unknown-linux-musl/debug/integration-test relocations

--- a/xtask/src/build_ebpf.rs
+++ b/xtask/src/build_ebpf.rs
@@ -103,12 +103,6 @@ fn build_c_ebpf(opts: &BuildEbpfOptions) -> anyhow::Result<()> {
 
     let include_path = out_path.join("include");
     get_libbpf_headers(&opts.libbpf_dir, &include_path)?;
-    // Export libbpf location as an env variable since it's needed for building
-    // the relocation tests at test/integration-test/src/tests/relocations.rs
-    // We decided to make an exception and build its eBPF programs at run-time
-    // because of the many different permutations.
-    std::env::set_var("LIBBPF_INCLUDE", &include_path);
-
     let files = fs::read_dir(&src).unwrap();
     for file in files {
         let p = file.unwrap().path();


### PR DESCRIPTION
Simplifiy the relocation tests build process by removing the need for libbpf at runtime.
Its usage is replaced with local `__builtin_*` attributes.
This removes the need for the `LIBBPF_INCLUDE` env variable.

An alternative solution would be to create a `libbpf_polyfill.h` file with the needed definitions (and explain why the file is needed) and include just that from the relocation tests. Let me know if you'd prefer it that way.