### PR TITLE
integration-test: Fix the kernel version chceck for smoke test

### DIFF
--- a/test/integration-test/src/tests/smoke.rs
+++ b/test/integration-test/src/tests/smoke.rs
@@ -19,7 +19,7 @@ fn xdp() {
 #[integration_test]
 fn extension() {
     let (major, minor, _) = kernel_version().unwrap();
-    if major < 5 || minor < 9 {
+    if major < 5 || (minor == 5 && minor < 9) {
         info!(
             "skipping as {}.{} does not meet version requirement of 5.9",
             major, minor


### PR DESCRIPTION
Before this chane, the check was always negative if the minor version was less then 9. So, for example, the smoke test was skipped for kernel 6.1:

```
skipping as 6.1 does not meet version requirement of 5.9
```

Signed-off-by: Michal Rostecki <vadorovsky@gmail.com>