### PR TITLE
Implement `Pod` for `bool`

### DIFF
--- a/aya/src/bpf.rs
+++ b/aya/src/bpf.rs
@@ -57,7 +57,7 @@ macro_rules! unsafe_impl_pod {
     }
 }
 
-unsafe_impl_pod!(i8, u8, i16, u16, i32, u32, i64, u64, u128, i128);
+unsafe_impl_pod!(i8, u8, i16, u16, i32, u32, i64, u64, u128, i128, bool);
 
 // It only makes sense that an array of POD types is itself POD
 unsafe impl<T: Pod, const N: usize> Pod for [T; N] {}


### PR DESCRIPTION
Without this change, it's impossible to use `bool` as a map element type or overriding `bool` global variables.

Signed-off-by: Michal Rostecki <vadorovsky@gmail.com>