### PR TITLE
Expose inner errors

### DIFF
--- a/aya/src/bpf.rs
+++ b/aya/src/bpf.rs
@@ -905,11 +905,11 @@ pub enum BpfError {
     },
 
     /// Error parsing BPF object
-    #[error("error parsing BPF object")]
+    #[error("error parsing BPF object: {0}")]
     ParseError(#[from] ParseError),
 
     /// Error parsing BTF object
-    #[error("BTF error")]
+    #[error("BTF error: {0}")]
     BtfError(#[from] BtfError),
 
     /// Error performing relocations
@@ -926,11 +926,11 @@ pub enum BpfError {
     #[error("no BTF parsed for object")]
     NoBTF,
 
-    #[error("map error")]
+    #[error("map error: {0}")]
     /// A map error
     MapError(#[from] MapError),
 
-    #[error("program error")]
+    #[error("program error: {0}")]
     /// A program error
     ProgramError(#[from] ProgramError),
 }


### PR DESCRIPTION
Currently aya will just report a standard outer level error on failure.  Ensure that we also report the inner error condition back to the user

Currently: 

```
[2023-01-19T15:53:14Z WARN  bpfd::rpc] BPFD load error: map error
```

With Patch: 

```
[2023-01-19T17:36:10Z WARN  bpfd::rpc] BPFD load error: map error: failed to create map `ingress_node_firewall_events_map` with code -1
```