### PR TITLE
BTF fixes

### DIFF
--- a/aya-obj/src/btf/btf.rs
+++ b/aya-obj/src/btf/btf.rs
@@ -425,6 +425,18 @@ impl Btf {
                     fixed_ty.name_offset = 0;
                     types.types[i] = BtfType::Ptr(fixed_ty)
                 }
+                // Fixup STRUCT for Rust
+                // LLVM emits names that include characters that aren't valid C idents.
+                // Rather than replace all unsupported characters, just omit the name entirely.
+                BtfType::Struct(s) => {
+                    let name = self.string_at(s.name_offset)?.to_string();
+                    if name.contains(['<', '>', ' ', ':', ',']) {
+                        debug!("STRUCT name {} not supported. Omitted from BTF", name);
+                        let mut fixed_ty = s.clone();
+                        fixed_ty.name_offset = 0;
+                        types.types[i] = BtfType::Struct(fixed_ty)
+                    }
+                }
                 // Sanitize VAR if they are not supported
                 BtfType::Var(v) if !features.btf_datasec => {
                     types.types[i] = BtfType::Int(Int::new(v.name_offset, 1, IntEncoding::None, 0));


### PR DESCRIPTION
1. Make sure we support LLVM generated names which aren't valid C idents. 

2. Also, fix a bug which resulted in failure to load maps->  

```
bpf(BPF_MAP_CREATE, {map_type=BPF_MAP_TYPE_PERF_EVENT_ARRAY, key_size=4, value_size=4, max_entries=24, map_flags=0, inner_map_fd=0, map_name="ingress_node_fi", map_ifindex=0, btf_fd=11, btf_key_type_id=6, btf_value_type_id=6, btf_vmlinux_value_type_id=0, map_extra=0}, 144) = -1 ENOTSUPP (Unknown error 524)
```
Specifically it is the same fix deployed by libbpf, more information can be found here https://github.com/libbpf/libbpf/issues/355