### PR TITLE
aya: fix Lru and LruPerCpu hash maps

### DIFF
--- a/aya/src/bpf.rs
+++ b/aya/src/bpf.rs
@@ -608,10 +608,10 @@ fn parse_map(data: (String, MapData)) -> Result<(String, Map), BpfError> {
         BPF_MAP_TYPE_PERCPU_ARRAY => Ok(Map::PerCpuArray(map)),
         BPF_MAP_TYPE_PROG_ARRAY => Ok(Map::ProgramArray(map)),
         BPF_MAP_TYPE_HASH => Ok(Map::HashMap(map)),
+        BPF_MAP_TYPE_LRU_HASH => Ok(Map::LruHashMap(map)),
         BPF_MAP_TYPE_PERCPU_HASH => Ok(Map::PerCpuHashMap(map)),
-        BPF_MAP_TYPE_PERF_EVENT_ARRAY | BPF_MAP_TYPE_LRU_PERCPU_HASH => {
-            Ok(Map::PerfEventArray(map))
-        }
+        BPF_MAP_TYPE_LRU_PERCPU_HASH => Ok(Map::PerCpuLruHashMap(map)),
+        BPF_MAP_TYPE_PERF_EVENT_ARRAY => Ok(Map::PerfEventArray(map)),
         BPF_MAP_TYPE_SOCKHASH => Ok(Map::SockHash(map)),
         BPF_MAP_TYPE_SOCKMAP => Ok(Map::SockMap(map)),
         BPF_MAP_TYPE_BLOOM_FILTER => Ok(Map::BloomFilter(map)),

--- a/aya/src/maps/mod.rs
+++ b/aya/src/maps/mod.rs
@@ -242,6 +242,10 @@ pub enum Map {
     HashMap(MapData),
     /// A [`PerCpuHashMap`] map
     PerCpuHashMap(MapData),
+    /// A [`HashMap`] map that uses a LRU eviction policy.
+    LruHashMap(MapData),
+    /// A [`PerCpuHashMap`] map that uses a LRU eviction policy.
+    PerCpuLruHashMap(MapData),
     /// A [`PerfEventArray`] map
     PerfEventArray(MapData),
     /// A [`SockMap`] map
@@ -268,7 +272,9 @@ impl Map {
             Map::PerCpuArray(map) => map.obj.map_type(),
             Map::ProgramArray(map) => map.obj.map_type(),
             Map::HashMap(map) => map.obj.map_type(),
+            Map::LruHashMap(map) => map.obj.map_type(),
             Map::PerCpuHashMap(map) => map.obj.map_type(),
+            Map::PerCpuLruHashMap(map) => map.obj.map_type(),
             Map::PerfEventArray(map) => map.obj.map_type(),
             Map::SockHash(map) => map.obj.map_type(),
             Map::SockMap(map) => map.obj.map_type(),


### PR DESCRIPTION
They were broken by https://github.com/aya-rs/aya/pull/397