### PR TITLE
aya-tool: remove outdated workaround

### DIFF
--- a/aya-tool/Cargo.toml
+++ b/aya-tool/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Alessandro Decina <alessandro.d@gmail.com>"]
 edition = "2021"
 
 [dependencies]
-bindgen = "0.63"
+bindgen = "0.64"
 clap = { version = "4", features = ["derive"] }
 anyhow = "1"
 thiserror = "1"

--- a/aya-tool/src/bindgen.rs
+++ b/aya-tool/src/bindgen.rs
@@ -20,11 +20,4 @@ pub fn bpf_builder() -> Builder {
         .clang_arg("-Wno-unknown-attributes")
         .default_enum_style(EnumVariation::ModuleConsts)
         .prepend_enum_name(false)
-        // NOTE(vadorovsky): It's a workaround for the upstream bindgen issue:
-        // https://github.com/rust-lang/rust-bindgen/issues/2083
-        // tl;dr: Rust nightly complains about #[repr(packed)] structs deriving
-        // Debug without Copy.
-        // It needs to be fixed properly upstream, but for now we have to
-        // disable Debug derive here.
-        .derive_debug(false)
 }


### PR DESCRIPTION
The comment says that `.derive_debug` was needed as a workaround for https://github.com/rust-lang/rust-bindgen/issues/2083. This issue is now closed, and aya-tool compiles without derive_debug.

Additionally, update bindgen dependency to 1.64.

Signed-off-by: Dmitry Savintsev <dsavints@gmail.com>