### PR TITLE
Add Unsupported Map type

### DIFF
--- a/aya/src/maps/mod.rs
+++ b/aya/src/maps/mod.rs
@@ -182,6 +182,13 @@ pub enum MapError {
         #[source]
         error: PinError,
     },
+
+    /// Unsupported Map type
+    #[error("Unsupported map type found {map_type}")]
+    Unsupported {
+        /// The map type
+        map_type: u32,
+    },
 }
 
 /// A map file descriptor.

--- a/aya/src/maps/mod.rs
+++ b/aya/src/maps/mod.rs
@@ -261,6 +261,8 @@ pub enum Map {
     StackTraceMap(MapData),
     /// A [`Queue`] map
     Queue(MapData),
+    /// An unsupported map type
+    Unsupported(MapData),
 }
 
 impl Map {
@@ -282,6 +284,7 @@ impl Map {
             Map::Stack(map) => map.obj.map_type(),
             Map::StackTraceMap(map) => map.obj.map_type(),
             Map::Queue(map) => map.obj.map_type(),
+            Map::Unsupported(map) => map.obj.map_type(),
         }
     }
 }


### PR DESCRIPTION
Just because aya doesn't support working with some map types doesn't mean we should't allow them to be loaded.

Add a new `Unsupported` map type to facilitate this, also add a debug log to let the user know we just loaded and unsupported map type.

