### PR TITLE
aya: Add loaded_programs() API to list all loaded programs

### DIFF
--- a/aya/src/lib.rs
+++ b/aya/src/lib.rs
@@ -51,6 +51,7 @@ pub mod maps;
 use aya_obj as obj;
 pub mod pin;
 pub mod programs;
+pub use programs::loaded_programs;
 mod sys;
 pub mod util;
 


### PR DESCRIPTION
This uses a Programs iterator to yield all loaded bpf programs using bpf_prog_get_next_id.

Example program [here](https://github.com/dave-tucker/prog-lister)

Signed-off-by: Dave Tucker <dave@dtucker.co.uk>