### PR TITLE
aya: MapData should be Borrow, not AsRef

### DIFF
--- a/aya/src/maps/bloom_filter.rs
+++ b/aya/src/maps/bloom_filter.rs
@@ -1,5 +1,5 @@
 //! A Bloom Filter.
-use std::{borrow::Borrow, convert::AsRef, marker::PhantomData};
+use std::{borrow::Borrow, marker::PhantomData};
 
 use crate::{
     maps::{check_v_size, MapData, MapError},
@@ -35,9 +35,9 @@ pub struct BloomFilter<T, V: Pod> {
     _v: PhantomData<V>,
 }
 
-impl<T: AsRef<MapData>, V: Pod> BloomFilter<T, V> {
+impl<T: Borrow<MapData>, V: Pod> BloomFilter<T, V> {
     pub(crate) fn new(map: T) -> Result<BloomFilter<T, V>, MapError> {
-        let data = map.as_ref();
+        let data = map.borrow();
         check_v_size::<V>(data)?;
 
         let _ = data.fd_or_err()?;
@@ -50,7 +50,7 @@ impl<T: AsRef<MapData>, V: Pod> BloomFilter<T, V> {
 
     /// Query the existence of the element.
     pub fn contains(&self, mut value: &V, flags: u64) -> Result<(), MapError> {
-        let fd = self.inner.as_ref().fd_or_err()?;
+        let fd = self.inner.borrow().fd_or_err()?;
 
         bpf_map_lookup_elem_ptr::<u32, _>(fd, None, &mut value, flags)
             .map_err(|(_, io_error)| MapError::SyscallError {
@@ -63,7 +63,7 @@ impl<T: AsRef<MapData>, V: Pod> BloomFilter<T, V> {
 
     /// Inserts a value into the map.
     pub fn insert(&self, value: impl Borrow<V>, flags: u64) -> Result<(), MapError> {
-        let fd = self.inner.as_ref().fd_or_err()?;
+        let fd = self.inner.borrow().fd_or_err()?;
         bpf_map_push_elem(fd, value.borrow(), flags).map_err(|(_, io_error)| {
             MapError::SyscallError {
                 call: "bpf_map_push_elem".to_owned(),

--- a/aya/src/maps/lpm_trie.rs
+++ b/aya/src/maps/lpm_trie.rs
@@ -1,7 +1,6 @@
 //! A LPM Trie.
 use std::{
-    borrow::Borrow,
-    convert::{AsMut, AsRef},
+    borrow::{Borrow, BorrowMut},
     marker::PhantomData,
 };
 
@@ -99,9 +98,9 @@ impl<K: Pod> Clone for Key<K> {
 // A Pod impl is required as Key struct is a key for a map.
 unsafe impl<K: Pod> Pod for Key<K> {}
 
-impl<T: AsRef<MapData>, K: Pod, V: Pod> LpmTrie<T, K, V> {
+impl<T: Borrow<MapData>, K: Pod, V: Pod> LpmTrie<T, K, V> {
     pub(crate) fn new(map: T) -> Result<LpmTrie<T, K, V>, MapError> {
-        let data = map.as_ref();
+        let data = map.borrow();
         check_kv_size::<Key<K>, V>(data)?;
 
         let _ = data.fd_or_err()?;
@@ -115,7 +114,7 @@ impl<T: AsRef<MapData>, K: Pod, V: Pod> LpmTrie<T, K, V> {
 
     /// Returns a copy of the value associated with the longest prefix matching key in the LpmTrie.
     pub fn get(&self, key: &Key<K>, flags: u64) -> Result<V, MapError> {
-        let fd = self.inner.as_ref().fd_or_err()?;
+        let fd = self.inner.borrow().fd_or_err()?;
         let value = bpf_map_lookup_elem(fd, key, flags).map_err(|(_, io_error)| {
             MapError::SyscallError {
                 call: "bpf_map_lookup_elem".to_owned(),
@@ -134,17 +133,17 @@ impl<T: AsRef<MapData>, K: Pod, V: Pod> LpmTrie<T, K, V> {
     /// An iterator visiting all keys in arbitrary order. The iterator element
     /// type is `Result<Key<K>, MapError>`.
     pub fn keys(&self) -> MapKeys<'_, Key<K>> {
-        MapKeys::new(self.inner.as_ref())
+        MapKeys::new(self.inner.borrow())
     }
 
     /// An iterator visiting all keys matching key. The
     /// iterator item type is `Result<Key<K>, MapError>`.
     pub fn iter_key(&self, key: Key<K>) -> LpmTrieKeys<'_, K> {
-        LpmTrieKeys::new(self.inner.as_ref(), key)
+        LpmTrieKeys::new(self.inner.borrow(), key)
     }
 }
 
-impl<T: AsMut<MapData>, K: Pod, V: Pod> LpmTrie<T, K, V> {
+impl<T: BorrowMut<MapData>, K: Pod, V: Pod> LpmTrie<T, K, V> {
     /// Inserts a key value pair into the map.
     pub fn insert(
         &mut self,
@@ -152,7 +151,7 @@ impl<T: AsMut<MapData>, K: Pod, V: Pod> LpmTrie<T, K, V> {
         value: impl Borrow<V>,
         flags: u64,
     ) -> Result<(), MapError> {
-        let fd = self.inner.as_mut().fd_or_err()?;
+        let fd = self.inner.borrow().fd_or_err()?;
         bpf_map_update_elem(fd, Some(key), value.borrow(), flags).map_err(|(_, io_error)| {
             MapError::SyscallError {
                 call: "bpf_map_update_elem".to_owned(),
@@ -167,7 +166,7 @@ impl<T: AsMut<MapData>, K: Pod, V: Pod> LpmTrie<T, K, V> {
     ///
     /// Both the prefix and data must match exactly - this method does not do a longest prefix match.
     pub fn remove(&mut self, key: &Key<K>) -> Result<(), MapError> {
-        let fd = self.inner.as_mut().fd_or_err()?;
+        let fd = self.inner.borrow().fd_or_err()?;
         bpf_map_delete_elem(fd, key)
             .map(|_| ())
             .map_err(|(_, io_error)| MapError::SyscallError {
@@ -177,9 +176,9 @@ impl<T: AsMut<MapData>, K: Pod, V: Pod> LpmTrie<T, K, V> {
     }
 }
 
-impl<T: AsRef<MapData>, K: Pod, V: Pod> IterableMap<Key<K>, V> for LpmTrie<T, K, V> {
+impl<T: Borrow<MapData>, K: Pod, V: Pod> IterableMap<Key<K>, V> for LpmTrie<T, K, V> {
     fn map(&self) -> &MapData {
-        self.inner.as_ref()
+        self.inner.borrow()
     }
 
     fn get(&self, key: &Key<K>) -> Result<V, MapError> {

--- a/aya/src/maps/mod.rs
+++ b/aya/src/maps/mod.rs
@@ -37,7 +37,6 @@
 //! versa. Because of that, all map values must be plain old data and therefore
 //! implement the [Pod] trait.
 use std::{
-    convert::{AsMut, AsRef},
     ffi::CString,
     fmt, io,
     marker::PhantomData,
@@ -479,18 +478,6 @@ pub struct MapData {
     pub(crate) btf_fd: Option<RawFd>,
     /// Indicates if this map has been pinned to bpffs
     pub pinned: bool,
-}
-
-impl AsRef<MapData> for MapData {
-    fn as_ref(&self) -> &MapData {
-        self
-    }
-}
-
-impl AsMut<MapData> for MapData {
-    fn as_mut(&mut self) -> &mut MapData {
-        self
-    }
 }
 
 impl MapData {

--- a/aya/src/maps/perf/async_perf_event_array.rs
+++ b/aya/src/maps/perf/async_perf_event_array.rs
@@ -1,6 +1,6 @@
 use bytes::BytesMut;
 use std::{
-    convert::AsMut,
+    borrow::{Borrow, BorrowMut},
     os::unix::prelude::{AsRawFd, RawFd},
 };
 
@@ -89,7 +89,7 @@ pub struct AsyncPerfEventArray<T> {
     perf_map: PerfEventArray<T>,
 }
 
-impl<T: AsMut<MapData> + AsRef<MapData>> AsyncPerfEventArray<T> {
+impl<T: BorrowMut<MapData> + Borrow<MapData>> AsyncPerfEventArray<T> {
     /// Opens the perf buffer at the given index.
     ///
     /// The returned buffer will receive all the events eBPF programs send at the given index.
@@ -112,7 +112,7 @@ impl<T: AsMut<MapData> + AsRef<MapData>> AsyncPerfEventArray<T> {
     }
 }
 
-impl<T: AsRef<MapData>> AsyncPerfEventArray<T> {
+impl<T: Borrow<MapData>> AsyncPerfEventArray<T> {
     pub(crate) fn new(map: T) -> Result<AsyncPerfEventArray<T>, MapError> {
         Ok(AsyncPerfEventArray {
             perf_map: PerfEventArray::new(map)?,
@@ -138,7 +138,7 @@ pub struct AsyncPerfEventArrayBuffer<T> {
 }
 
 #[cfg(any(feature = "async_tokio"))]
-impl<T: AsMut<MapData> + AsRef<MapData>> AsyncPerfEventArrayBuffer<T> {
+impl<T: BorrowMut<MapData> + Borrow<MapData>> AsyncPerfEventArrayBuffer<T> {
     /// Reads events from the buffer.
     ///
     /// This method reads events into the provided slice of buffers, filling
@@ -168,7 +168,7 @@ impl<T: AsMut<MapData> + AsRef<MapData>> AsyncPerfEventArrayBuffer<T> {
 }
 
 #[cfg(all(not(feature = "async_tokio"), feature = "async_std"))]
-impl<T: AsMut<MapData> + AsRef<MapData>> AsyncPerfEventArrayBuffer<T> {
+impl<T: BorrowMut<MapData> + Borrow<MapData>> AsyncPerfEventArrayBuffer<T> {
     /// Reads events from the buffer.
     ///
     /// This method reads events into the provided slice of buffers, filling

--- a/aya/src/maps/queue.rs
+++ b/aya/src/maps/queue.rs
@@ -1,7 +1,6 @@
 //! A FIFO queue.
 use std::{
-    borrow::Borrow,
-    convert::{AsMut, AsRef},
+    borrow::{Borrow, BorrowMut},
     marker::PhantomData,
 };
 
@@ -34,9 +33,9 @@ pub struct Queue<T, V: Pod> {
     _v: PhantomData<V>,
 }
 
-impl<T: AsRef<MapData>, V: Pod> Queue<T, V> {
+impl<T: Borrow<MapData>, V: Pod> Queue<T, V> {
     pub(crate) fn new(map: T) -> Result<Queue<T, V>, MapError> {
-        let data = map.as_ref();
+        let data = map.borrow();
         check_kv_size::<(), V>(data)?;
 
         let _fd = data.fd_or_err()?;
@@ -51,11 +50,11 @@ impl<T: AsRef<MapData>, V: Pod> Queue<T, V> {
     ///
     /// This corresponds to the value of `bpf_map_def::max_entries` on the eBPF side.
     pub fn capacity(&self) -> u32 {
-        self.inner.as_ref().obj.max_entries()
+        self.inner.borrow().obj.max_entries()
     }
 }
 
-impl<T: AsMut<MapData>, V: Pod> Queue<T, V> {
+impl<T: BorrowMut<MapData>, V: Pod> Queue<T, V> {
     /// Removes the first element and returns it.
     ///
     /// # Errors
@@ -63,7 +62,7 @@ impl<T: AsMut<MapData>, V: Pod> Queue<T, V> {
     /// Returns [`MapError::ElementNotFound`] if the queue is empty, [`MapError::SyscallError`]
     /// if `bpf_map_lookup_and_delete_elem` fails.
     pub fn pop(&mut self, flags: u64) -> Result<V, MapError> {
-        let fd = self.inner.as_mut().fd_or_err()?;
+        let fd = self.inner.borrow().fd_or_err()?;
 
         let value = bpf_map_lookup_and_delete_elem::<u32, _>(fd, None, flags).map_err(
             |(_, io_error)| MapError::SyscallError {
@@ -80,7 +79,7 @@ impl<T: AsMut<MapData>, V: Pod> Queue<T, V> {
     ///
     /// [`MapError::SyscallError`] if `bpf_map_update_elem` fails.
     pub fn push(&mut self, value: impl Borrow<V>, flags: u64) -> Result<(), MapError> {
-        let fd = self.inner.as_mut().fd_or_err()?;
+        let fd = self.inner.borrow().fd_or_err()?;
         bpf_map_push_elem(fd, value.borrow(), flags).map_err(|(_, io_error)| {
             MapError::SyscallError {
                 call: "bpf_map_push_elem".to_owned(),

--- a/aya/src/maps/stack.rs
+++ b/aya/src/maps/stack.rs
@@ -1,7 +1,6 @@
 //! A LIFO stack.
 use std::{
-    borrow::Borrow,
-    convert::{AsMut, AsRef},
+    borrow::{Borrow, BorrowMut},
     marker::PhantomData,
 };
 
@@ -34,9 +33,9 @@ pub struct Stack<T, V: Pod> {
     _v: PhantomData<V>,
 }
 
-impl<T: AsRef<MapData>, V: Pod> Stack<T, V> {
+impl<T: Borrow<MapData>, V: Pod> Stack<T, V> {
     pub(crate) fn new(map: T) -> Result<Stack<T, V>, MapError> {
-        let data = map.as_ref();
+        let data = map.borrow();
         check_kv_size::<(), V>(data)?;
 
         let _fd = data.fd_or_err()?;
@@ -51,11 +50,11 @@ impl<T: AsRef<MapData>, V: Pod> Stack<T, V> {
     ///
     /// This corresponds to the value of `bpf_map_def::max_entries` on the eBPF side.
     pub fn capacity(&self) -> u32 {
-        self.inner.as_ref().obj.max_entries()
+        self.inner.borrow().obj.max_entries()
     }
 }
 
-impl<T: AsMut<MapData>, V: Pod> Stack<T, V> {
+impl<T: BorrowMut<MapData>, V: Pod> Stack<T, V> {
     /// Removes the last element and returns it.
     ///
     /// # Errors
@@ -63,7 +62,7 @@ impl<T: AsMut<MapData>, V: Pod> Stack<T, V> {
     /// Returns [`MapError::ElementNotFound`] if the stack is empty, [`MapError::SyscallError`]
     /// if `bpf_map_lookup_and_delete_elem` fails.
     pub fn pop(&mut self, flags: u64) -> Result<V, MapError> {
-        let fd = self.inner.as_mut().fd_or_err()?;
+        let fd = self.inner.borrow().fd_or_err()?;
 
         let value = bpf_map_lookup_and_delete_elem::<u32, _>(fd, None, flags).map_err(
             |(_, io_error)| MapError::SyscallError {
@@ -80,7 +79,7 @@ impl<T: AsMut<MapData>, V: Pod> Stack<T, V> {
     ///
     /// [`MapError::SyscallError`] if `bpf_map_update_elem` fails.
     pub fn push(&mut self, value: impl Borrow<V>, flags: u64) -> Result<(), MapError> {
-        let fd = self.inner.as_mut().fd_or_err()?;
+        let fd = self.inner.borrow().fd_or_err()?;
         bpf_map_update_elem(fd, None::<&u32>, value.borrow(), flags).map_err(|(_, io_error)| {
             MapError::SyscallError {
                 call: "bpf_map_update_elem".to_owned(),


### PR DESCRIPTION
We don't ever do ref-to-ref conversion for MapData so Borrow should suffice.

Signed-off-by: Dave Tucker <dave@dtucker.co.uk>