### PR TITLE
aya: Make FEATURES public

### DIFF
--- a/aya-obj/src/btf/btf.rs
+++ b/aya-obj/src/btf/btf.rs
@@ -166,12 +166,68 @@ pub enum BtfError {
 #[derive(Default, Debug)]
 #[allow(missing_docs)]
 pub struct BtfFeatures {
-    pub btf_func: bool,
-    pub btf_func_global: bool,
-    pub btf_datasec: bool,
-    pub btf_float: bool,
-    pub btf_decl_tag: bool,
-    pub btf_type_tag: bool,
+    btf_func: bool,
+    btf_func_global: bool,
+    btf_datasec: bool,
+    btf_float: bool,
+    btf_decl_tag: bool,
+    btf_type_tag: bool,
+}
+
+impl BtfFeatures {
+    #[doc(hidden)]
+    pub fn new(
+        btf_func: bool,
+        btf_func_global: bool,
+        btf_datasec: bool,
+        btf_float: bool,
+        btf_decl_tag: bool,
+        btf_type_tag: bool,
+    ) -> Self {
+        BtfFeatures {
+            btf_func,
+            btf_func_global,
+            btf_datasec,
+            btf_float,
+            btf_decl_tag,
+            btf_type_tag,
+        }
+    }
+
+    /// Returns true if the BTF_TYPE_FUNC is supported.
+    pub fn btf_func(&self) -> bool {
+        self.btf_func
+    }
+
+    /// Returns true if the BTF_TYPE_FUNC_GLOBAL is supported.
+    pub fn btf_func_global(&self) -> bool {
+        self.btf_func_global
+    }
+
+    /// Returns true if the BTF_TYPE_DATASEC is supported.
+    pub fn btf_datasec(&self) -> bool {
+        self.btf_datasec
+    }
+
+    /// Returns true if the BTF_FLOAT is supported.
+    pub fn btf_float(&self) -> bool {
+        self.btf_float
+    }
+
+    /// Returns true if the BTF_DECL_TAG is supported.
+    pub fn btf_decl_tag(&self) -> bool {
+        self.btf_decl_tag
+    }
+
+    /// Returns true if the BTF_TYPE_TAG is supported.
+    pub fn btf_type_tag(&self) -> bool {
+        self.btf_type_tag
+    }
+
+    /// Returns true if the BTF_KIND_FUNC_PROTO is supported.
+    pub fn btf_kind_func_proto(&self) -> bool {
+        self.btf_func && self.btf_decl_tag
+    }
 }
 
 /// Bpf Type Format metadata.

--- a/aya-obj/src/obj.rs
+++ b/aya-obj/src/obj.rs
@@ -42,11 +42,63 @@ const KERNEL_VERSION_ANY: u32 = 0xFFFF_FFFE;
 #[derive(Default, Debug)]
 #[allow(missing_docs)]
 pub struct Features {
-    pub bpf_name: bool,
-    pub bpf_probe_read_kernel: bool,
-    pub bpf_perf_link: bool,
-    pub bpf_global_data: bool,
-    pub btf: Option<BtfFeatures>,
+    bpf_name: bool,
+    bpf_probe_read_kernel: bool,
+    bpf_perf_link: bool,
+    bpf_global_data: bool,
+    bpf_cookie: bool,
+    btf: Option<BtfFeatures>,
+}
+
+impl Features {
+    #[doc(hidden)]
+    pub fn new(
+        bpf_name: bool,
+        bpf_probe_read_kernel: bool,
+        bpf_perf_link: bool,
+        bpf_global_data: bool,
+        bpf_cookie: bool,
+        btf: Option<BtfFeatures>,
+    ) -> Self {
+        Self {
+            bpf_name,
+            bpf_probe_read_kernel,
+            bpf_perf_link,
+            bpf_global_data,
+            bpf_cookie,
+            btf,
+        }
+    }
+
+    /// Returns whether BPF program names are supported.
+    pub fn bpf_name(&self) -> bool {
+        self.bpf_name
+    }
+
+    /// Returns whether the bpf_probe_read_kernel helper is supported.
+    pub fn bpf_probe_read_kernel(&self) -> bool {
+        self.bpf_probe_read_kernel
+    }
+
+    /// Returns whether bpf_links are supported for Kprobes/Uprobes/Tracepoints.
+    pub fn bpf_perf_link(&self) -> bool {
+        self.bpf_perf_link
+    }
+
+    /// Returns whether BPF program global data is supported.
+    pub fn bpf_global_data(&self) -> bool {
+        self.bpf_global_data
+    }
+
+    /// Returns whether BPF program cookie is supported.
+    pub fn bpf_cookie(&self) -> bool {
+        self.bpf_cookie
+    }
+
+    /// If BTF is supported, returns which BTF features are supported.
+    pub fn btf(&self) -> Option<&BtfFeatures> {
+        self.btf.as_ref()
+    }
 }
 
 /// The loaded object file representation

--- a/aya-obj/src/relocation.rs
+++ b/aya-obj/src/relocation.rs
@@ -242,10 +242,7 @@ fn relocate_maps<'a, I: Iterator<Item = &'a Relocation>>(
             m
         } else {
             let Some(m) = maps_by_section.get(&section_index) else {
-                debug!(
-                    "failed relocating map by section index {}",
-                    section_index
-                );
+                debug!("failed relocating map by section index {}", section_index);
                 return Err(RelocationError::SectionNotFound {
                     symbol_index: rel.symbol_index,
                     symbol_name: sym.name.clone(),

--- a/aya/src/programs/perf_attach.rs
+++ b/aya/src/programs/perf_attach.rs
@@ -73,7 +73,7 @@ impl Link for PerfLink {
 }
 
 pub(crate) fn perf_attach(prog_fd: RawFd, fd: RawFd) -> Result<PerfLinkInner, ProgramError> {
-    if FEATURES.bpf_perf_link {
+    if FEATURES.bpf_perf_link() {
         let link_fd =
             bpf_link_create(prog_fd, fd, BPF_PERF_EVENT, None, 0).map_err(|(_, io_error)| {
                 ProgramError::SyscallError {


### PR DESCRIPTION
This commit adds a new probe for bpf_attach_cookie, which would be used to implement USDT probes. Since USDT probes aren't currently supported, this triggers a dead_code warning in clippy.

There are cases where exposing FEATURES - our lazy static - is actually helpful to users of the library. For example, they may wish to choose to load a different version of their bytecode based on current features. Or, in the case of an orchestrator like bpfd, we might want to allow users to describe which features their program needs and return nice error message is one or more nodes in their cluster doesn't support the necessary feature set.