### PR TITLE
xtask: generate userspace bindings for bpf_{cpu,dev}map_val

### DIFF
--- a/xtask/src/codegen/aya.rs
+++ b/xtask/src/codegen/aya.rs
@@ -72,6 +72,8 @@ fn codegen_bindings(opts: &Options) -> Result<(), anyhow::Error> {
         "bpf_func_info",
         "bpf_line_info",
         "bpf_lpm_trie_key",
+        "bpf_cpumap_val",
+        "bpf_devmap_val",
         // BTF
         "btf_header",
         "btf_ext_info",


### PR DESCRIPTION
This PR adds bindings for the two userspace structs `bpf_cpumap_val` and `bpf_devmap_val`. It will be needed by #527 for full support of chained programs in cpu/devmap.

Also, it will need a bors run after merge to actually generate the bindings.

Thanks!