### PR TITLE
ebpf, tool: Don't use aya-bpf-cty

### DIFF
--- a/aya-tool/src/bindgen.rs
+++ b/aya-tool/src/bindgen.rs
@@ -14,7 +14,7 @@ pub fn user_builder() -> Builder {
 pub fn bpf_builder() -> Builder {
     bindgen::builder()
         .use_core()
-        .ctypes_prefix("::aya_bpf::cty")
+        .ctypes_prefix("::core::ffi")
         .layout_tests(false)
         .generate_comments(false)
         .clang_arg("-Wno-unknown-attributes")

--- a/bpf/aya-bpf/Cargo.toml
+++ b/bpf/aya-bpf/Cargo.toml
@@ -5,7 +5,6 @@ authors = ["Alessandro Decina <alessandro.d@gmail.com>"]
 edition = "2021"
 
 [dependencies]
-aya-bpf-cty = { path = "../aya-bpf-cty" }
 aya-bpf-macros = { path = "../../aya-bpf-macros" }
 aya-bpf-bindings = { path = "../aya-bpf-bindings" }
 

--- a/bpf/aya-bpf/src/args.rs
+++ b/bpf/aya-bpf/src/args.rs
@@ -1,4 +1,6 @@
-use crate::{cty::c_void, helpers::bpf_probe_read};
+use core::ffi::c_void;
+
+use crate::helpers::bpf_probe_read;
 
 // aarch64 uses user_pt_regs instead of pt_regs
 #[cfg(not(bpf_target_arch = "aarch64"))]

--- a/bpf/aya-bpf/src/helpers.rs
+++ b/bpf/aya-bpf/src/helpers.rs
@@ -7,13 +7,14 @@
 //! also expose bindings to the underlying helpers as a fall-back in case of a missing
 //! implementation.
 
-use core::mem::{self, MaybeUninit};
+use core::{
+    ffi::{c_char, c_long, c_void},
+    mem::{self, MaybeUninit},
+};
 
 pub use aya_bpf_bindings::helpers as gen;
 #[doc(hidden)]
 pub use gen::*;
-
-use crate::cty::{c_char, c_long, c_void};
 
 /// Read bytes stored at `src` and store them as a `T`.
 ///
@@ -27,7 +28,8 @@ use crate::cty::{c_char, c_long, c_void};
 ///
 /// ```no_run
 /// # #![allow(dead_code)]
-/// # use aya_bpf::{cty::{c_int, c_long}, helpers::bpf_probe_read};
+/// # use core::ffi::{c_int, c_long};
+/// # use aya_bpf::helpers::bpf_probe_read;
 /// # fn try_test() -> Result<(), c_long> {
 /// # let kernel_ptr: *const c_int = 0 as _;
 /// let my_int: c_int = unsafe { bpf_probe_read(kernel_ptr)? };
@@ -64,7 +66,8 @@ pub unsafe fn bpf_probe_read<T>(src: *const T) -> Result<T, c_long> {
 ///
 /// ```no_run
 /// # #![allow(dead_code)]
-/// # use aya_bpf::{cty::{c_int, c_long}, helpers::bpf_probe_read_buf};
+/// # use core::ffi::{c_int, c_long};
+/// # use aya_bpf::helpers::bpf_probe_read_buf;
 /// # fn try_test() -> Result<(), c_long> {
 /// # let ptr: *const u8 = 0 as _;
 /// let mut buf = [0u8; 16];
@@ -100,7 +103,8 @@ pub unsafe fn bpf_probe_read_buf(src: *const u8, dst: &mut [u8]) -> Result<(), c
 ///
 /// ```no_run
 /// # #![allow(dead_code)]
-/// # use aya_bpf::{cty::{c_int, c_long}, helpers::bpf_probe_read_user};
+/// # use core::ffi::{c_int, c_long};
+/// # use aya_bpf::helpers::bpf_probe_read_user;
 /// # fn try_test() -> Result<(), c_long> {
 /// # let user_ptr: *const c_int = 0 as _;
 /// let my_int: c_int = unsafe { bpf_probe_read_user(user_ptr)? };
@@ -135,7 +139,8 @@ pub unsafe fn bpf_probe_read_user<T>(src: *const T) -> Result<T, c_long> {
 ///
 /// ```no_run
 /// # #![allow(dead_code)]
-/// # use aya_bpf::{cty::{c_int, c_long}, helpers::bpf_probe_read_user_buf};
+/// # use core::ffi::{c_int, c_long};
+/// # use aya_bpf::helpers::bpf_probe_read_user_buf;
 /// # fn try_test() -> Result<(), c_long> {
 /// # let user_ptr: *const u8 = 0 as _;
 /// let mut buf = [0u8; 16];
@@ -171,7 +176,8 @@ pub unsafe fn bpf_probe_read_user_buf(src: *const u8, dst: &mut [u8]) -> Result<
 ///
 /// ```no_run
 /// # #![allow(dead_code)]
-/// # use aya_bpf::{cty::{c_int, c_long}, helpers::bpf_probe_read_kernel};
+/// # use core::ffi::{c_int, c_long};
+/// # use aya_bpf::helpers::bpf_probe_read_kernel;
 /// # fn try_test() -> Result<(), c_long> {
 /// # let kernel_ptr: *const c_int = 0 as _;
 /// let my_int: c_int = unsafe { bpf_probe_read_kernel(kernel_ptr)? };
@@ -206,7 +212,8 @@ pub unsafe fn bpf_probe_read_kernel<T>(src: *const T) -> Result<T, c_long> {
 ///
 /// ```no_run
 /// # #![allow(dead_code)]
-/// # use aya_bpf::{cty::{c_int, c_long}, helpers::bpf_probe_read_kernel_buf};
+/// # use core::ffi::{c_int, c_long};
+/// # use aya_bpf::helpers::bpf_probe_read_kernel_buf;
 /// # fn try_test() -> Result<(), c_long> {
 /// # let kernel_ptr: *const u8 = 0 as _;
 /// let mut buf = [0u8; 16];
@@ -245,7 +252,8 @@ pub unsafe fn bpf_probe_read_kernel_buf(src: *const u8, dst: &mut [u8]) -> Resul
 ///
 /// ```no_run
 /// # #![allow(dead_code)]
-/// # use aya_bpf::{cty::c_long, helpers::bpf_probe_read_str};
+/// # use core::ffi::c_long;
+/// # use aya_bpf::helpers::bpf_probe_read_str;
 /// # fn try_test() -> Result<(), c_long> {
 /// # let kernel_ptr: *const u8 = 0 as _;
 /// let mut my_str = [0u8; 16];
@@ -291,7 +299,8 @@ pub unsafe fn bpf_probe_read_str(src: *const u8, dest: &mut [u8]) -> Result<usiz
 ///
 /// ```no_run
 /// # #![allow(dead_code)]
-/// # use aya_bpf::{cty::c_long, helpers::bpf_probe_read_user_str};
+/// # use core::ffi::c_long;
+/// # use aya_bpf::helpers::bpf_probe_read_user_str;
 /// # fn try_test() -> Result<(), c_long> {
 /// # let user_ptr: *const u8 = 0 as _;
 /// let mut my_str = [0u8; 16];
@@ -340,7 +349,8 @@ pub unsafe fn bpf_probe_read_user_str(src: *const u8, dest: &mut [u8]) -> Result
 ///
 /// ```no_run
 /// # #![allow(dead_code)]
-/// # use aya_bpf::{cty::c_long, helpers::bpf_probe_read_user_str_bytes};
+/// # use core::ffi::c_long;
+/// # use aya_bpf::helpers::bpf_probe_read_user_str_bytes;
 /// # fn try_test() -> Result<(), c_long> {
 /// # let user_ptr: *const u8 = 0 as _;
 /// let mut buf = [0u8; 16];
@@ -354,7 +364,8 @@ pub unsafe fn bpf_probe_read_user_str(src: *const u8, dest: &mut [u8]) -> Result
 /// With a `PerCpuArray` (with size defined by us):
 ///
 /// ```no_run
-/// # use aya_bpf::{cty::c_long, helpers::bpf_probe_read_user_str_bytes};
+/// # use core::ffi::c_long;
+/// # use aya_bpf::helpers::bpf_probe_read_user_str_bytes;
 /// use aya_bpf::{macros::map, maps::PerCpuArray};
 ///
 /// #[repr(C)]
@@ -383,8 +394,8 @@ pub unsafe fn bpf_probe_read_user_str(src: *const u8, dest: &mut [u8]) -> Result
 ///
 /// ```no_run
 /// # #![allow(dead_code)]
-/// # use aya_bpf::{cty::c_long, helpers::bpf_probe_read_user_str_bytes};
-/// # use aya_bpf::{macros::map, maps::PerCpuArray};
+/// # use core::ffi::c_long;
+/// # use aya_bpf::{helpers::bpf_probe_read_user_str_bytes, macros::map, maps::PerCpuArray};
 /// # #[repr(C)]
 /// # pub struct Buf {
 /// #     pub buf: [u8; 4096],
@@ -442,7 +453,8 @@ pub unsafe fn bpf_probe_read_user_str_bytes(
 ///
 /// ```no_run
 /// # #![allow(dead_code)]
-/// # use aya_bpf::{cty::c_long, helpers::bpf_probe_read_kernel_str};
+/// # use core::ffi::c_long;
+/// # use aya_bpf::helpers::bpf_probe_read_kernel_str;
 /// # fn try_test() -> Result<(), c_long> {
 /// # let kernel_ptr: *const u8 = 0 as _;
 /// let mut my_str = [0u8; 16];
@@ -491,7 +503,8 @@ pub unsafe fn bpf_probe_read_kernel_str(src: *const u8, dest: &mut [u8]) -> Resu
 ///
 /// ```no_run
 /// # #![allow(dead_code)]
-/// # use aya_bpf::{cty::c_long, helpers::bpf_probe_read_kernel_str_bytes};
+/// # use core::ffi::c_long;
+/// # use aya_bpf::helpers::bpf_probe_read_kernel_str_bytes;
 /// # fn try_test() -> Result<(), c_long> {
 /// # let kernel_ptr: *const u8 = 0 as _;
 /// let mut buf = [0u8; 16];
@@ -506,7 +519,8 @@ pub unsafe fn bpf_probe_read_kernel_str(src: *const u8, dest: &mut [u8]) -> Resu
 ///
 /// ```no_run
 /// # #![allow(dead_code)]
-/// # use aya_bpf::{cty::c_long, helpers::bpf_probe_read_kernel_str_bytes};
+/// # use core::ffi::c_long;
+/// # use aya_bpf::helpers::bpf_probe_read_kernel_str_bytes;
 /// use aya_bpf::{macros::map, maps::PerCpuArray};
 ///
 /// #[repr(C)]
@@ -535,8 +549,8 @@ pub unsafe fn bpf_probe_read_kernel_str(src: *const u8, dest: &mut [u8]) -> Resu
 ///
 /// ```no_run
 /// # #![allow(dead_code)]
-/// # use aya_bpf::{cty::c_long, helpers::bpf_probe_read_kernel_str_bytes};
-/// # use aya_bpf::{macros::map, maps::PerCpuArray};
+/// # use core::ffi::c_long;
+/// # use aya_bpf::{helpers::bpf_probe_read_kernel_str_bytes, macros::map, maps::PerCpuArray};
 /// # #[repr(C)]
 /// # pub struct Buf {
 /// #     pub buf: [u8; 4096],
@@ -591,8 +605,8 @@ pub unsafe fn bpf_probe_read_kernel_str_bytes(
 ///
 /// ```no_run
 /// # #![allow(dead_code)]
+/// # use core::ffi::{c_int, c_long}
 /// # use aya_bpf::{
-/// #     cty::{c_int, c_long},
 /// #     helpers::bpf_probe_write_user,
 /// #     programs::ProbeContext,
 /// # };

--- a/bpf/aya-bpf/src/lib.rs
+++ b/bpf/aya-bpf/src/lib.rs
@@ -21,10 +21,7 @@ pub mod helpers;
 pub mod maps;
 pub mod programs;
 
-pub use aya_bpf_cty as cty;
-
-use core::ffi::c_void;
-use cty::{c_int, c_long};
+use core::ffi::{c_int, c_long, c_void};
 use helpers::{bpf_get_current_comm, bpf_get_current_pid_tgid, bpf_get_current_uid_gid};
 
 pub use aya_bpf_macros as macros;

--- a/bpf/aya-bpf/src/maps/array.rs
+++ b/bpf/aya-bpf/src/maps/array.rs
@@ -1,6 +1,4 @@
-use core::{cell::UnsafeCell, marker::PhantomData, mem, ptr::NonNull};
-
-use aya_bpf_cty::c_void;
+use core::{cell::UnsafeCell, ffi::c_void, marker::PhantomData, mem, ptr::NonNull};
 
 use crate::{
     bindings::{bpf_map_def, bpf_map_type::BPF_MAP_TYPE_ARRAY},

--- a/bpf/aya-bpf/src/maps/bloom_filter.rs
+++ b/bpf/aya-bpf/src/maps/bloom_filter.rs
@@ -1,6 +1,4 @@
-use core::{marker::PhantomData, mem};
-
-use aya_bpf_cty::c_void;
+use core::{ffi::c_void, marker::PhantomData, mem};
 
 use crate::{
     bindings::{bpf_map_def, bpf_map_type::BPF_MAP_TYPE_BLOOM_FILTER},

--- a/bpf/aya-bpf/src/maps/hash_map.rs
+++ b/bpf/aya-bpf/src/maps/hash_map.rs
@@ -1,9 +1,14 @@
-use core::{cell::UnsafeCell, marker::PhantomData, mem, ptr::NonNull};
+use core::{
+    cell::UnsafeCell,
+    ffi::{c_long, c_void},
+    marker::PhantomData,
+    mem,
+    ptr::NonNull,
+};
 
 use aya_bpf_bindings::bindings::bpf_map_type::{
     BPF_MAP_TYPE_LRU_HASH, BPF_MAP_TYPE_LRU_PERCPU_HASH, BPF_MAP_TYPE_PERCPU_HASH,
 };
-use aya_bpf_cty::{c_long, c_void};
 
 use crate::{
     bindings::{bpf_map_def, bpf_map_type::BPF_MAP_TYPE_HASH},

--- a/bpf/aya-bpf/src/maps/lpm_trie.rs
+++ b/bpf/aya-bpf/src/maps/lpm_trie.rs
@@ -1,7 +1,12 @@
-use core::{cell::UnsafeCell, marker::PhantomData, mem, ptr::NonNull};
+use core::{
+    cell::UnsafeCell,
+    ffi::{c_long, c_void},
+    marker::PhantomData,
+    mem,
+    ptr::NonNull,
+};
 
 use aya_bpf_bindings::bindings::BPF_F_NO_PREALLOC;
-use aya_bpf_cty::{c_long, c_void};
 
 use crate::{
     bindings::{bpf_map_def, bpf_map_type::BPF_MAP_TYPE_LPM_TRIE},

--- a/bpf/aya-bpf/src/maps/per_cpu_array.rs
+++ b/bpf/aya-bpf/src/maps/per_cpu_array.rs
@@ -1,6 +1,4 @@
-use core::{cell::UnsafeCell, marker::PhantomData, mem, ptr::NonNull};
-
-use aya_bpf_cty::c_void;
+use core::{cell::UnsafeCell, ffi::c_void, marker::PhantomData, mem, ptr::NonNull};
 
 use crate::{
     bindings::{bpf_map_def, bpf_map_type::BPF_MAP_TYPE_PERCPU_ARRAY},

--- a/bpf/aya-bpf/src/maps/program_array.rs
+++ b/bpf/aya-bpf/src/maps/program_array.rs
@@ -1,6 +1,4 @@
-use core::{cell::UnsafeCell, hint::unreachable_unchecked, mem};
-
-use aya_bpf_cty::c_long;
+use core::{cell::UnsafeCell, ffi::c_long, hint::unreachable_unchecked, mem};
 
 use crate::{
     bindings::{bpf_map_def, bpf_map_type::BPF_MAP_TYPE_PROG_ARRAY},
@@ -15,7 +13,8 @@ use crate::{
 ///
 /// ```no_run
 /// # #![allow(dead_code)]
-/// use aya_bpf::{macros::map, maps::ProgramArray, cty::c_long};
+/// # use core::ffi::c_long;
+/// use aya_bpf::{macros::map, maps::ProgramArray};
 /// # use aya_bpf::{programs::LsmContext};
 ///
 /// #[map]

--- a/bpf/aya-bpf/src/maps/sock_hash.rs
+++ b/bpf/aya-bpf/src/maps/sock_hash.rs
@@ -1,6 +1,4 @@
-use core::{borrow::Borrow, cell::UnsafeCell, marker::PhantomData, mem};
-
-use aya_bpf_cty::c_void;
+use core::{borrow::Borrow, cell::UnsafeCell, ffi::c_void, marker::PhantomData, mem};
 
 use crate::{
     bindings::{bpf_map_def, bpf_map_type::BPF_MAP_TYPE_SOCKHASH, bpf_sock_ops},

--- a/bpf/aya-bpf/src/maps/sock_map.rs
+++ b/bpf/aya-bpf/src/maps/sock_map.rs
@@ -1,6 +1,4 @@
-use core::{cell::UnsafeCell, mem};
-
-use aya_bpf_cty::c_void;
+use core::{cell::UnsafeCell, ffi::c_void, mem};
 
 use crate::{
     bindings::{bpf_map_def, bpf_map_type::BPF_MAP_TYPE_SOCKMAP, bpf_sock_ops},

--- a/bpf/aya-bpf/src/programs/fentry.rs
+++ b/bpf/aya-bpf/src/programs/fentry.rs
@@ -18,7 +18,8 @@ impl FEntryContext {
     /// ```no_run
     /// # #![allow(non_camel_case_types)]
     /// # #![allow(dead_code)]
-    /// # use aya_bpf::{cty::c_int, programs::FEntryContext};
+    /// # use core::ffi::c_int;
+    /// # use aya_bpf::programs::FEntryContext;
     /// # type pid_t = c_int;
     /// # struct task_struct {
     /// #     pid: pid_t,

--- a/bpf/aya-bpf/src/programs/fexit.rs
+++ b/bpf/aya-bpf/src/programs/fexit.rs
@@ -18,7 +18,8 @@ impl FExitContext {
     /// ```no_run
     /// # #![allow(non_camel_case_types)]
     /// # #![allow(dead_code)]
-    /// # use aya_bpf::{cty::c_int, programs::FExitContext};
+    /// # use core::ffi::c_int;
+    /// # use aya_bpf::programs::FExitContext;
     /// # type pid_t = c_int;
     /// # struct task_struct {
     /// #     pid: pid_t,

--- a/bpf/aya-bpf/src/programs/lsm.rs
+++ b/bpf/aya-bpf/src/programs/lsm.rs
@@ -30,7 +30,8 @@ impl LsmContext {
     ///
     /// ```no_run
     /// # #![allow(dead_code)]
-    /// # use aya_bpf::{programs::LsmContext, cty::{c_int, c_ulong}};
+    /// # use core::ffi::{c_int, c_ulong};
+    /// # use aya_bpf::{programs::LsmContext};
     /// unsafe fn try_lsm_mmap_addr(ctx: LsmContext) -> Result<i32, i32> {
     ///     // In the kernel, this hook is defined as:
     ///     //   LSM_HOOK(int, 0, mmap_addr, unsigned long addr)

--- a/bpf/aya-bpf/src/programs/probe.rs
+++ b/bpf/aya-bpf/src/programs/probe.rs
@@ -26,7 +26,8 @@ impl ProbeContext {
     /// ```no_run
     /// # #![allow(non_camel_case_types)]
     /// # #![allow(dead_code)]
-    /// # use aya_bpf::{programs::ProbeContext, cty::c_int, helpers::bpf_probe_read};
+    /// # use core::ffi::c_int;
+    /// # use aya_bpf::{programs::ProbeContext, helpers::bpf_probe_read};
     /// # type pid_t = c_int;
     /// # struct task_struct {
     /// #     pid: pid_t,
@@ -50,7 +51,8 @@ impl ProbeContext {
     ///
     /// ```no_run
     /// # #![allow(dead_code)]
-    /// # use aya_bpf::{programs::ProbeContext, cty::c_int};
+    /// # use core::ffi::c_int;
+    /// # use aya_bpf::{programs::ProbeContext};
     /// unsafe fn try_kretprobe_try_to_wake_up(ctx: ProbeContext) -> Result<u32, u32> {
     ///     let retval: c_int = ctx.ret().ok_or(1u32)?;
     ///

--- a/bpf/aya-bpf/src/programs/sk_buff.rs
+++ b/bpf/aya-bpf/src/programs/sk_buff.rs
@@ -1,6 +1,6 @@
 use core::{
     cmp,
-    ffi::c_void,
+    ffi::{c_long, c_void},
     mem::{self, MaybeUninit},
 };
 
@@ -9,7 +9,6 @@ use aya_bpf_bindings::helpers::{
     bpf_skb_adjust_room, bpf_skb_change_type, bpf_skb_load_bytes, bpf_skb_pull_data,
     bpf_skb_store_bytes,
 };
-use aya_bpf_cty::c_long;
 
 use crate::{bindings::__sk_buff, BpfContext};
 

--- a/bpf/aya-bpf/src/programs/tc.rs
+++ b/bpf/aya-bpf/src/programs/tc.rs
@@ -1,4 +1,4 @@
-use aya_bpf_cty::{c_long, c_void};
+use core::ffi::{c_long, c_void};
 
 use crate::{bindings::__sk_buff, programs::sk_buff::SkBuff, BpfContext};
 

--- a/bpf/aya-bpf/src/programs/tp_btf.rs
+++ b/bpf/aya-bpf/src/programs/tp_btf.rs
@@ -24,7 +24,8 @@ impl BtfTracePointContext {
     ///
     /// ```no_run
     /// # #![allow(dead_code)]
-    /// # use aya_bpf::{programs::BtfTracePointContext, cty::{c_int, c_ulong, c_char}};
+    /// # use core::ffi::{c_char, c_int, c_ulong};
+    /// # use aya_bpf::programs::BtfTracePointContext;
     /// unsafe fn try_tp_btf_sched_process_fork(ctx: BtfTracePointContext) -> Result<u32, u32> {
     ///     // Grab arguments
     ///     let parent_comm: *const c_char = ctx.arg(0);

--- a/xtask/src/codegen/aya_bpf_bindings.rs
+++ b/xtask/src/codegen/aya_bpf_bindings.rs
@@ -17,9 +17,7 @@ pub fn codegen(opts: &Options) -> Result<(), anyhow::Error> {
     let builder = || {
         let mut bindgen = bindgen::bpf_builder()
             .header(&*dir.join("include/bindings.h").to_string_lossy())
-            // aya-tool uses aya_bpf::cty. We can't use that here since aya-bpf
-            // depends on aya-bpf-bindings so it would create a circular dep.
-            .ctypes_prefix("::aya_bpf_cty")
+            .ctypes_prefix("::core::ffi")
             .clang_args(&[
                 "-I",
                 &*opts.libbpf_dir.join("include/uapi").to_string_lossy(),


### PR DESCRIPTION
It's not needed anymore, all C types we need are in `core::ffi`.

Signed-off-by: Michal Rostecki <vadorovsky@gmail.com>