### PR TITLE
aya: Fix MapData Clone implementation

### DIFF
--- a/aya/src/maps/mod.rs
+++ b/aya/src/maps/mod.rs
@@ -635,12 +635,7 @@ impl Clone for MapData {
     fn clone(&self) -> MapData {
         MapData {
             obj: self.obj.clone(),
-            fd: {
-                if let Some(fd) = self.fd {
-                    unsafe { Some(libc::dup(fd)) };
-                }
-                None
-            },
+            fd: self.fd.map(|fd| unsafe { libc::dup(fd) }),
             btf_fd: self.btf_fd,
             pinned: self.pinned,
         }


### PR DESCRIPTION
The Clone implementation of MapData was previously not storing the result of the dup operation.