### PR TITLE
integration-test-macros: Use absolute path to `IntegrationTest`

### DIFF
--- a/test/integration-test-macros/src/lib.rs
+++ b/test/integration-test-macros/src/lib.rs
@@ -10,7 +10,7 @@ pub fn integration_test(_attr: TokenStream, item: TokenStream) -> TokenStream {
     let expanded = quote! {
         #item
 
-        inventory::submit!(IntegrationTest {
+        inventory::submit!(crate::tests::IntegrationTest {
             name: concat!(module_path!(), "::", #name_str),
             test_fn: #name,
         });

--- a/test/integration-test/src/tests/elf.rs
+++ b/test/integration-test/src/tests/elf.rs
@@ -1,4 +1,4 @@
-use super::{integration_test, IntegrationTest};
+use super::integration_test;
 
 use aya::include_bytes_aligned;
 use object::{Object, ObjectSymbol};

--- a/test/integration-test/src/tests/load.rs
+++ b/test/integration-test/src/tests/load.rs
@@ -13,7 +13,7 @@ use log::warn;
 
 use crate::tests::kernel_version;
 
-use super::{integration_test, IntegrationTest};
+use super::integration_test;
 
 const MAX_RETRIES: u32 = 100;
 const RETRY_DURATION_MS: u64 = 10;

--- a/test/integration-test/src/tests/rbpf.rs
+++ b/test/integration-test/src/tests/rbpf.rs
@@ -4,7 +4,7 @@ use std::collections::HashMap;
 use aya::include_bytes_aligned;
 use aya_obj::{generated::bpf_insn, Object, ProgramSection};
 
-use super::{integration_test, IntegrationTest};
+use super::integration_test;
 
 #[integration_test]
 fn run_with_rbpf() {

--- a/test/integration-test/src/tests/relocations.rs
+++ b/test/integration-test/src/tests/relocations.rs
@@ -4,7 +4,7 @@ use tempfile::TempDir;
 
 use aya::{maps::Array, programs::TracePoint, BpfLoader, Btf, Endianness};
 
-use super::{integration_test, IntegrationTest};
+use super::integration_test;
 
 // In the tests below we often use values like 0xAAAAAAAA or -0x7AAAAAAA. Those values have no
 // special meaning, they just have "nice" bit patterns that can be helpful while debugging.

--- a/test/integration-test/src/tests/smoke.rs
+++ b/test/integration-test/src/tests/smoke.rs
@@ -5,7 +5,7 @@ use aya::{
 };
 use log::info;
 
-use super::{integration_test, kernel_version, IntegrationTest};
+use super::{integration_test, kernel_version};
 
 #[integration_test]
 fn xdp() {


### PR DESCRIPTION
Macros shouldn't require importing additional symbols which are used in their generated code. They should use the absolute paths instead.