### PR TITLE
Add `BPF_F_SLEEPABLE` flag support to LSM

### DIFF
--- a/aya-bpf-macros/src/expand.rs
+++ b/aya-bpf-macros/src/expand.rs
@@ -212,7 +212,7 @@ impl Xdp {
                 frags = m
             } else {
                 return Err(Error::new_spanned(
-                    "mutlibuffer",
+                    s,
                     "invalid value. should be 'true' or 'false'",
                 ));
             }
@@ -626,7 +626,7 @@ impl Lsm {
                 sleepable = m
             } else {
                 return Err(Error::new_spanned(
-                    "mutlibuffer",
+                    s,
                     "invalid value. should be 'true' or 'false'",
                 ));
             }

--- a/aya-obj/src/obj.rs
+++ b/aya-obj/src/obj.rs
@@ -148,7 +148,7 @@ pub struct Function {
 /// - `uprobe.s+` or `uretprobe.s+`
 /// - `usdt+`
 /// - `kprobe.multi+` or `kretprobe.multi+`: `BPF_TRACE_KPROBE_MULTI`
-/// - `lsm_cgroup+` or `lsm.s+`
+/// - `lsm_cgroup+`
 /// - `lwt_in`, `lwt_out`, `lwt_seg6local`, `lwt_xmit`
 /// - `raw_tp.w+`, `raw_tracepoint.w+`
 /// - `action`
@@ -477,7 +477,7 @@ impl FromStr for ProgramSection {
                 name,
                 sleepable_supported: false,
             },
-            "lsm.s+" => Lsm {
+            "lsm.s" => Lsm {
                 name,
                 sleepable_supported: true,
             },
@@ -1941,7 +1941,7 @@ mod tests {
         assert_matches!(
             obj.parse_section(fake_section(
                 BpfSectionKind::Program,
-                "lsm.s+/foo",
+                "lsm.s/foo",
                 bytes_of(&fake_ins())
             )),
             Ok(())

--- a/aya-obj/src/obj.rs
+++ b/aya-obj/src/obj.rs
@@ -183,7 +183,7 @@ pub enum ProgramSection {
     },
     Xdp {
         name: String,
-        frags_supported: bool,
+        frags: bool,
     },
     SkMsg {
         name: String,
@@ -231,7 +231,7 @@ pub enum ProgramSection {
     },
     Lsm {
         name: String,
-        sleepable_supported: bool,
+        sleepable: bool,
     },
     BtfTracePoint {
         name: String,
@@ -314,14 +314,8 @@ impl FromStr for ProgramSection {
             "kretprobe" => KRetProbe { name },
             "uprobe" => UProbe { name },
             "uretprobe" => URetProbe { name },
-            "xdp" => Xdp {
-                name,
-                frags_supported: false,
-            },
-            "xdp.frags" => Xdp {
-                name,
-                frags_supported: true,
-            },
+            "xdp" => Xdp { name, frags: false },
+            "xdp.frags" => Xdp { name, frags: true },
             "tp_btf" => BtfTracePoint { name },
             _ if kind.starts_with("tracepoint") || kind.starts_with("tp") => {
                 // tracepoint sections are named `tracepoint/category/event_name`,
@@ -475,11 +469,11 @@ impl FromStr for ProgramSection {
             "raw_tp" | "raw_tracepoint" => RawTracePoint { name },
             "lsm" => Lsm {
                 name,
-                sleepable_supported: false,
+                sleepable: false,
             },
             "lsm.s" => Lsm {
                 name,
-                sleepable_supported: true,
+                sleepable: true,
             },
             "fentry" => FEntry { name },
             "fexit" => FExit { name },
@@ -1846,7 +1840,7 @@ mod tests {
         assert_matches!(
             obj.programs.get("foo"),
             Some(Program {
-                section: ProgramSection::Xdp { .. },
+                section: ProgramSection::Xdp { frags: false, .. },
                 ..
             })
         );
@@ -1867,10 +1861,7 @@ mod tests {
         assert_matches!(
             obj.programs.get("foo"),
             Some(Program {
-                section: ProgramSection::Xdp {
-                    frags_supported: true,
-                    ..
-                },
+                section: ProgramSection::Xdp { frags: true, .. },
                 ..
             })
         );
@@ -1928,7 +1919,10 @@ mod tests {
         assert_matches!(
             obj.programs.get("foo"),
             Some(Program {
-                section: ProgramSection::Lsm { .. },
+                section: ProgramSection::Lsm {
+                    sleepable: false,
+                    ..
+                },
                 ..
             })
         );
@@ -1950,7 +1944,7 @@ mod tests {
             obj.programs.get("foo"),
             Some(Program {
                 section: ProgramSection::Lsm {
-                    sleepable_supported: true,
+                    sleepable: true,
                     ..
                 },
                 ..

--- a/aya/src/bpf.rs
+++ b/aya/src/bpf.rs
@@ -9,7 +9,7 @@ use std::{
 
 use aya_obj::{
     btf::{BtfFeatures, BtfRelocationError},
-    generated::BPF_F_XDP_HAS_FRAGS,
+    generated::{BPF_F_SLEEPABLE, BPF_F_XDP_HAS_FRAGS},
     relocation::BpfRelocationError,
 };
 use log::debug;
@@ -551,9 +551,17 @@ impl<'a> BpfLoader<'a> {
                                 data: ProgramData::new(prog_name, obj, btf_fd, verifier_log_level),
                             })
                         }
-                        ProgramSection::Lsm { .. } => Program::Lsm(Lsm {
-                            data: ProgramData::new(prog_name, obj, btf_fd, verifier_log_level),
-                        }),
+                        ProgramSection::Lsm {
+                            sleepable_supported,
+                            ..
+                        } => {
+                            let mut data =
+                                ProgramData::new(prog_name, obj, btf_fd, verifier_log_level);
+                            if *sleepable_supported {
+                                data.flags = BPF_F_SLEEPABLE;
+                            }
+                            Program::Lsm(Lsm { data })
+                        }
                         ProgramSection::BtfTracePoint { .. } => {
                             Program::BtfTracePoint(BtfTracePoint {
                                 data: ProgramData::new(prog_name, obj, btf_fd, verifier_log_level),

--- a/aya/src/bpf.rs
+++ b/aya/src/bpf.rs
@@ -478,12 +478,10 @@ impl<'a> BpfLoader<'a> {
                                 data: ProgramData::new(prog_name, obj, btf_fd, verifier_log_level),
                             })
                         }
-                        ProgramSection::Xdp {
-                            frags_supported, ..
-                        } => {
+                        ProgramSection::Xdp { frags, .. } => {
                             let mut data =
                                 ProgramData::new(prog_name, obj, btf_fd, verifier_log_level);
-                            if *frags_supported {
+                            if *frags {
                                 data.flags = BPF_F_XDP_HAS_FRAGS;
                             }
                             Program::Xdp(Xdp { data })
@@ -551,13 +549,10 @@ impl<'a> BpfLoader<'a> {
                                 data: ProgramData::new(prog_name, obj, btf_fd, verifier_log_level),
                             })
                         }
-                        ProgramSection::Lsm {
-                            sleepable_supported,
-                            ..
-                        } => {
+                        ProgramSection::Lsm { sleepable, .. } => {
                             let mut data =
                                 ProgramData::new(prog_name, obj, btf_fd, verifier_log_level);
-                            if *sleepable_supported {
+                            if *sleepable {
                                 data.flags = BPF_F_SLEEPABLE;
                             }
                             Program::Lsm(Lsm { data })


### PR DESCRIPTION
This adds support for the `BPF_F_SLEEPABLE` flag for LSM : https://lore.kernel.org/netdev/20200827220114.69225-3-alexei.starovoitov@gmail.com/

It follows the same tack as XDP multi-buffer support: https://github.com/aya-rs/aya/pull/519

Internally, this option follows the `libbpf` convention and is represented as `lsm.s`: https://elixir.bootlin.com/linux/latest/source/tools/lib/bpf/libbpf.c#L8560

In the public API, this is exposed via the eBPF `lsm` macro as an optional `sleepable = "bool"` argument.

```
#[lsm(name = "lsm_bprm_check_security", sleepable = "true")]
pub fn bprm_check_security(ctx: LsmContext) -> i32 {
    match try_bprm_check_security(ctx) {
        Ok(ret) => ret,
        Err(ret) => ret,
    }
}
```