### PR TITLE
aya: Add as_bytes() to Pod trait

### DIFF
--- a/aya-obj/src/obj.rs
+++ b/aya-obj/src/obj.rs
@@ -572,7 +572,7 @@ impl Object {
     }
 
     /// Patches map data
-    pub fn patch_map_data(&mut self, globals: HashMap<&str, &[u8]>) -> Result<(), ParseError> {
+    pub fn patch_map_data(&mut self, globals: HashMap<&str, Vec<u8>>) -> Result<(), ParseError> {
         let symbols: HashMap<String, &Symbol> = self
             .symbols_by_index
             .iter()
@@ -2245,12 +2245,12 @@ mod tests {
             },
         );
 
-        let test_data: &[u8] = &[1, 2, 3];
+        let test_data: Vec<u8> = vec![1, 2, 3];
         obj.patch_map_data(HashMap::from([("my_config", test_data)]))
             .unwrap();
 
         let map = obj.maps.get(".rodata").unwrap();
-        assert_eq!(test_data, map.data());
+        assert_eq!(vec![1, 2, 3], map.data());
     }
 
     #[test]


### PR DESCRIPTION
This adds as_bytes() to the Pod trait with a default implementation. The set_global API changes to use a Vec<u8> (and the hashmap it inserts into is also a Vec<u8>).
As such, users may either pass raw bytes they have constructed themselves - i.e `vec![1u8, 2u8, 3u8]`
Or any `Pod` type by calling `.as_bytes` on it.

```rust
use aya::BpfLoader;
use aya::{BpfLoader, Pod};

#[repr(C)]
#[derive(Copy,Clone)]
struct MyThing {
    foo: u64
}

impl Pod for MyThing {}

let thing1 = MyThing{foo:42};
let bpf = BpfLoader::new()
    .set_global("VERSION", unsafe { 2.as_bytes() })
    .set_global("MY_THING", unsafe { thing1.as_bytes() })
    .set_global("REVISION", vec![1u8])
    .load_file("file.o")?;
```