### PR TITLE
integration-tests: Build eBPF programs always with release profile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,9 +14,6 @@ panic = "abort"
 [profile.release]
 panic = "abort"
 
-[profile.dev.package.integration-ebpf]
-opt-level = 2
-overflow-checks = false
-
 [profile.release.package.integration-ebpf]
 debug = 2
+codegen-units = 1

--- a/test/integration-test/src/tests/elf.rs
+++ b/test/integration-test/src/tests/elf.rs
@@ -5,7 +5,7 @@ use object::{Object, ObjectSymbol};
 
 #[integration_test]
 fn test_maps() {
-    let bytes = include_bytes_aligned!("../../../../target/bpfel-unknown-none/debug/map_test");
+    let bytes = include_bytes_aligned!("../../../../target/bpfel-unknown-none/release/map_test");
     let obj_file = object::File::parse(bytes).unwrap();
     if obj_file.section_by_name("maps").is_none() {
         panic!("No 'maps' ELF section");

--- a/test/integration-test/src/tests/load.rs
+++ b/test/integration-test/src/tests/load.rs
@@ -20,7 +20,7 @@ const RETRY_DURATION_MS: u64 = 10;
 
 #[integration_test]
 fn long_name() {
-    let bytes = include_bytes_aligned!("../../../../target/bpfel-unknown-none/debug/name_test");
+    let bytes = include_bytes_aligned!("../../../../target/bpfel-unknown-none/release/name_test");
     let mut bpf = Bpf::load(bytes).unwrap();
     let name_prog: &mut Xdp = bpf
         .program_mut("ihaveaverylongname")
@@ -38,7 +38,7 @@ fn long_name() {
 #[integration_test]
 fn multiple_btf_maps() {
     let bytes =
-        include_bytes_aligned!("../../../../target/bpfel-unknown-none/debug/multimap-btf.bpf.o");
+        include_bytes_aligned!("../../../../target/bpfel-unknown-none/release/multimap-btf.bpf.o");
     let mut bpf = Bpf::load(bytes).unwrap();
 
     let map_1: Array<_, u64> = bpf.take_map("map_1").unwrap().try_into().unwrap();
@@ -85,7 +85,7 @@ macro_rules! assert_loaded {
 
 #[integration_test]
 fn unload_xdp() {
-    let bytes = include_bytes_aligned!("../../../../target/bpfel-unknown-none/debug/test");
+    let bytes = include_bytes_aligned!("../../../../target/bpfel-unknown-none/release/test");
     let mut bpf = Bpf::load(bytes).unwrap();
     let prog: &mut Xdp = bpf
         .program_mut("test_unload_xdp")
@@ -115,7 +115,7 @@ fn unload_xdp() {
 
 #[integration_test]
 fn unload_kprobe() {
-    let bytes = include_bytes_aligned!("../../../../target/bpfel-unknown-none/debug/test");
+    let bytes = include_bytes_aligned!("../../../../target/bpfel-unknown-none/release/test");
     let mut bpf = Bpf::load(bytes).unwrap();
     let prog: &mut KProbe = bpf
         .program_mut("test_unload_kpr")
@@ -150,7 +150,7 @@ fn pin_link() {
         return;
     }
 
-    let bytes = include_bytes_aligned!("../../../../target/bpfel-unknown-none/debug/test");
+    let bytes = include_bytes_aligned!("../../../../target/bpfel-unknown-none/release/test");
     let mut bpf = Bpf::load(bytes).unwrap();
     let prog: &mut Xdp = bpf
         .program_mut("test_unload_xdp")
@@ -185,7 +185,7 @@ fn pin_lifecycle() {
         return;
     }
 
-    let bytes = include_bytes_aligned!("../../../../target/bpfel-unknown-none/debug/pass");
+    let bytes = include_bytes_aligned!("../../../../target/bpfel-unknown-none/release/pass");
 
     // 1. Load Program and Pin
     {

--- a/test/integration-test/src/tests/rbpf.rs
+++ b/test/integration-test/src/tests/rbpf.rs
@@ -8,7 +8,7 @@ use super::{integration_test, IntegrationTest};
 
 #[integration_test]
 fn run_with_rbpf() {
-    let bytes = include_bytes_aligned!("../../../../target/bpfel-unknown-none/debug/pass");
+    let bytes = include_bytes_aligned!("../../../../target/bpfel-unknown-none/release/pass");
     let object = Object::parse(bytes).unwrap();
 
     assert_eq!(object.programs.len(), 1);
@@ -36,7 +36,7 @@ static mut MULTIMAP_MAPS: [*mut Vec<u64>; 2] = [null_mut(), null_mut()];
 #[integration_test]
 fn use_map_with_rbpf() {
     let bytes =
-        include_bytes_aligned!("../../../../target/bpfel-unknown-none/debug/multimap-btf.bpf.o");
+        include_bytes_aligned!("../../../../target/bpfel-unknown-none/release/multimap-btf.bpf.o");
     let mut object = Object::parse(bytes).unwrap();
 
     assert_eq!(object.programs.len(), 1);

--- a/test/integration-test/src/tests/smoke.rs
+++ b/test/integration-test/src/tests/smoke.rs
@@ -9,7 +9,7 @@ use super::{integration_test, kernel_version, IntegrationTest};
 
 #[integration_test]
 fn xdp() {
-    let bytes = include_bytes_aligned!("../../../../target/bpfel-unknown-none/debug/pass");
+    let bytes = include_bytes_aligned!("../../../../target/bpfel-unknown-none/release/pass");
     let mut bpf = Bpf::load(bytes).unwrap();
     let dispatcher: &mut Xdp = bpf.program_mut("pass").unwrap().try_into().unwrap();
     dispatcher.load().unwrap();
@@ -28,13 +28,14 @@ fn extension() {
     }
     // TODO: Check kernel version == 5.9 or later
     let main_bytes =
-        include_bytes_aligned!("../../../../target/bpfel-unknown-none/debug/main.bpf.o");
+        include_bytes_aligned!("../../../../target/bpfel-unknown-none/release/main.bpf.o");
     let mut bpf = Bpf::load(main_bytes).unwrap();
     let pass: &mut Xdp = bpf.program_mut("pass").unwrap().try_into().unwrap();
     pass.load().unwrap();
     pass.attach("lo", XdpFlags::default()).unwrap();
 
-    let ext_bytes = include_bytes_aligned!("../../../../target/bpfel-unknown-none/debug/ext.bpf.o");
+    let ext_bytes =
+        include_bytes_aligned!("../../../../target/bpfel-unknown-none/release/ext.bpf.o");
     let mut bpf = BpfLoader::new().extension("drop").load(ext_bytes).unwrap();
     let drop_: &mut Extension = bpf.program_mut("drop").unwrap().try_into().unwrap();
     drop_.load(pass.fd().unwrap(), "xdp_pass").unwrap();

--- a/xtask/src/build_ebpf.rs
+++ b/xtask/src/build_ebpf.rs
@@ -41,9 +41,6 @@ pub struct BuildEbpfOptions {
     /// Set the endianness of the BPF target
     #[clap(default_value = "bpfel-unknown-none", long)]
     pub target: Architecture,
-    /// Build the release target
-    #[clap(long)]
-    pub release: bool,
     /// Libbpf dir, required for compiling C code
     #[clap(long, action)]
     pub libbpf_dir: PathBuf,
@@ -59,17 +56,15 @@ fn build_rust_ebpf(opts: &BuildEbpfOptions) -> anyhow::Result<()> {
     dir.push("test/integration-ebpf");
 
     let target = format!("--target={}", opts.target);
-    let mut args = vec![
+    let args = vec![
         "+nightly",
         "build",
+        "--release",
         "--verbose",
         target.as_str(),
         "-Z",
         "build-std=core",
     ];
-    if opts.release {
-        args.push("--release")
-    }
     let status = Command::new("cargo")
         .current_dir(&dir)
         .args(&args)
@@ -99,7 +94,7 @@ fn build_c_ebpf(opts: &BuildEbpfOptions) -> anyhow::Result<()> {
     let mut out_path = PathBuf::from(WORKSPACE_ROOT.to_string());
     out_path.push("target");
     out_path.push(opts.target.to_string());
-    out_path.push(if opts.release { "release " } else { "debug" });
+    out_path.push("release");
 
     let include_path = out_path.join("include");
     get_libbpf_headers(&opts.libbpf_dir, &include_path)?;

--- a/xtask/src/run.rs
+++ b/xtask/src/run.rs
@@ -45,7 +45,6 @@ pub fn run(opts: Options) -> Result<(), anyhow::Error> {
     // build our ebpf program followed by our application
     build_ebpf(BuildOptions {
         target: opts.bpf_target,
-        release: opts.release,
         libbpf_dir: PathBuf::from(&opts.libbpf_dir),
     })
     .context("Error while building eBPF program")?;


### PR DESCRIPTION
Also, add the `codegen-unit` option to the profile.