### PR TITLE
workflows: Run clippy for user space and eBPF crates separately

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -31,9 +31,32 @@ jobs:
         run: |
           cargo fmt --all -- --check
 
-      - name: Run clippy
+      - name: Run clippy (for user space crates)
         run: |
-          cargo clippy --workspace --exclude integration-test -- --deny warnings
+          cargo clippy --workspace \
+          --exclude integration-test \
+          --exclude aya-bpf \
+          --exclude aya-bpf-bindings \
+          --exclude aya-log-ebpf \
+          --exclude integration-ebpf \
+          -- --deny warnings
+
+      - name: Run clippy (for eBPF crates)
+        run: |
+          cargo +nightly clippy \
+          --target bpfel-unknown-none -Zbuild-std=core \
+          --workspace \
+          --exclude aya \
+          --exclude aya-obj \
+          --exclude aya-tool \
+          --exclude aya-log \
+          --exclude aya-log-parser \
+          --exclude integration-test \
+          --exclude integration-test-macros \
+          --exclude xtask \
+          --exclude aya-bpf-macros \
+          --exclude aya-log-ebpf-macros \
+          -- --deny warnings
 
       - name: Run miri
         run: |


### PR DESCRIPTION
Clippy triggers builds for the checked crates. Without any additional arguments, it does so with the default toolchain for the default target. The default target for x86_64 hosts is x86_64-unknown-linux-gnu. Also, lack of additional arguments means using the std library.

To avoid issues coming from compiling eBPF crates for x86_64 target and with std (like [0]), this change ensures that they are checked with `--target bpfel-unknown-none` and `-Zbuild-std=core` options.

[0] https://github.com/aya-rs/aya/actions/runs/4669677849/jobs/8268452592