### PR TITLE
aya: Do not use unwrap with btf_fd in bpf_create_map

### DIFF
--- a/aya/src/sys/bpf.rs
+++ b/aya/src/sys/bpf.rs
@@ -66,7 +66,7 @@ pub(crate) fn bpf_create_map(name: &CStr, def: &obj::Map, btf_fd: Option<RawFd>)
             _ => {
                 u.btf_key_type_id = m.def.btf_key_type_id;
                 u.btf_value_type_id = m.def.btf_value_type_id;
-                u.btf_fd = btf_fd.unwrap() as u32;
+                u.btf_fd = btf_fd.unwrap_or_default() as u32;
             }
         }
     }


### PR DESCRIPTION
Fixes a crash when trying to create a map of type `BPF_MAP_TYPE_PERCPU_ARRAY` when `btf_fd` is `None`.

Tested on Ubuntu 18.04 (4.15.0-202-generic)