### PR TITLE
aya-log-common: support logging byte slices

### DIFF
--- a/.github/workflows/build-aya.yml
+++ b/.github/workflows/build-aya.yml
@@ -32,7 +32,7 @@ jobs:
 
       - uses: taiki-e/install-action@cargo-hack
       - name: Check
-        run: cargo hack check --feature-powerset --ignore-private
+        run: cargo hack check --all-targets --feature-powerset --ignore-private
 
       - uses: Swatinem/rust-cache@v1
       - name: Prereqs

--- a/aya-log-common/src/lib.rs
+++ b/aya-log-common/src/lib.rs
@@ -1,6 +1,6 @@
 #![no_std]
 
-use core::{mem, num, ptr, slice};
+use core::{mem, num, ptr};
 
 use num_enum::IntoPrimitive;
 
@@ -98,58 +98,65 @@ pub enum DisplayHint {
     UpperMac,
 }
 
-struct TagLenValue<'a, T> {
-    tag: T,
-    value: &'a [u8],
+struct TagLenValue<T, V> {
+    pub tag: T,
+    pub value: V,
 }
 
-impl<'a, T> TagLenValue<'a, T>
+impl<T, V> TagLenValue<T, V>
 where
-    T: Copy,
+    V: IntoIterator<Item = u8>,
+    <V as IntoIterator>::IntoIter: ExactSizeIterator,
 {
-    #[inline(always)]
-    pub(crate) fn new(tag: T, value: &'a [u8]) -> TagLenValue<'a, T> {
-        TagLenValue { tag, value }
-    }
-
-    pub(crate) fn write(&self, mut buf: &mut [u8]) -> Result<usize, ()> {
+    pub(crate) fn write(self, mut buf: &mut [u8]) -> Result<usize, ()> {
         // Break the abstraction to please the verifier.
         if buf.len() > LOG_BUF_CAPACITY {
             buf = &mut buf[..LOG_BUF_CAPACITY];
         }
         let Self { tag, value } = self;
+        let value = value.into_iter();
         let len = value.len();
         let wire_len: LogValueLength = value
             .len()
             .try_into()
             .map_err(|num::TryFromIntError { .. }| ())?;
-        let size = mem::size_of_val(tag) + mem::size_of_val(&wire_len) + len;
+        let size = mem::size_of_val(&tag) + mem::size_of_val(&wire_len) + len;
         if size > buf.len() {
             return Err(());
         }
 
-        unsafe { ptr::write_unaligned(buf.as_mut_ptr() as *mut _, *tag) };
-        buf = &mut buf[mem::size_of_val(tag)..];
+        let tag_size = mem::size_of_val(&tag);
+        unsafe { ptr::write_unaligned(buf.as_mut_ptr() as *mut _, tag) };
+        buf = &mut buf[tag_size..];
 
         unsafe { ptr::write_unaligned(buf.as_mut_ptr() as *mut _, wire_len) };
         buf = &mut buf[mem::size_of_val(&wire_len)..];
 
-        unsafe { ptr::copy_nonoverlapping(value.as_ptr(), buf.as_mut_ptr(), len) };
+        buf.iter_mut().zip(value).for_each(|(dst, src)| {
+            *dst = src;
+        });
 
         Ok(size)
     }
 }
 
+impl<T, V> TagLenValue<T, V> {
+    #[inline(always)]
+    pub(crate) fn new(tag: T, value: V) -> TagLenValue<T, V> {
+        TagLenValue { tag, value }
+    }
+}
+
 pub trait WriteToBuf {
     #[allow(clippy::result_unit_err)]
-    fn write(&self, buf: &mut [u8]) -> Result<usize, ()>;
+    fn write(self, buf: &mut [u8]) -> Result<usize, ()>;
 }
 
 macro_rules! impl_write_to_buf {
     ($type:ident, $arg_type:expr) => {
         impl WriteToBuf for $type {
-            fn write(&self, buf: &mut [u8]) -> Result<usize, ()> {
-                TagLenValue::<Argument>::new($arg_type, &self.to_ne_bytes()).write(buf)
+            fn write(self, buf: &mut [u8]) -> Result<usize, ()> {
+                TagLenValue::new($arg_type, self.to_ne_bytes()).write(buf)
             }
         }
     };
@@ -171,35 +178,34 @@ impl_write_to_buf!(f32, Argument::F32);
 impl_write_to_buf!(f64, Argument::F64);
 
 impl WriteToBuf for [u8; 16] {
-    fn write(&self, buf: &mut [u8]) -> Result<usize, ()> {
-        TagLenValue::<Argument>::new(Argument::ArrU8Len16, self).write(buf)
+    fn write(self, buf: &mut [u8]) -> Result<usize, ()> {
+        TagLenValue::new(Argument::ArrU8Len16, self).write(buf)
     }
 }
 
 impl WriteToBuf for [u16; 8] {
-    fn write(&self, buf: &mut [u8]) -> Result<usize, ()> {
-        let ptr = self.as_ptr().cast::<u8>();
-        let bytes = unsafe { slice::from_raw_parts(ptr, 16) };
-        TagLenValue::<Argument>::new(Argument::ArrU16Len8, bytes).write(buf)
+    fn write(self, buf: &mut [u8]) -> Result<usize, ()> {
+        let bytes = unsafe { core::mem::transmute::<_, [u8; 16]>(self) };
+        TagLenValue::new(Argument::ArrU16Len8, bytes).write(buf)
     }
 }
 
 impl WriteToBuf for [u8; 6] {
-    fn write(&self, buf: &mut [u8]) -> Result<usize, ()> {
-        TagLenValue::<Argument>::new(Argument::ArrU8Len6, self).write(buf)
+    fn write(self, buf: &mut [u8]) -> Result<usize, ()> {
+        TagLenValue::new(Argument::ArrU8Len6, self).write(buf)
     }
 }
 
-impl WriteToBuf for str {
-    fn write(&self, buf: &mut [u8]) -> Result<usize, ()> {
-        TagLenValue::<Argument>::new(Argument::Str, self.as_bytes()).write(buf)
+impl WriteToBuf for &str {
+    fn write(self, buf: &mut [u8]) -> Result<usize, ()> {
+        TagLenValue::new(Argument::Str, self.as_bytes().iter().copied()).write(buf)
     }
 }
 
 impl WriteToBuf for DisplayHint {
-    fn write(&self, buf: &mut [u8]) -> Result<usize, ()> {
-        let v: u8 = (*self).into();
-        TagLenValue::<Argument>::new(Argument::DisplayHint, &v.to_ne_bytes()).write(buf)
+    fn write(self, buf: &mut [u8]) -> Result<usize, ()> {
+        let v: u8 = self.into();
+        TagLenValue::new(Argument::DisplayHint, v.to_ne_bytes()).write(buf)
     }
 }
 
@@ -217,17 +223,16 @@ pub fn write_record_header(
 ) -> Result<usize, ()> {
     let level: u8 = level.into();
     let mut size = 0;
-    for attr in [
-        TagLenValue::<RecordField>::new(RecordField::Target, target.as_bytes()),
-        TagLenValue::<RecordField>::new(RecordField::Level, &level.to_ne_bytes()),
-        TagLenValue::<RecordField>::new(RecordField::Module, module.as_bytes()),
-        TagLenValue::<RecordField>::new(RecordField::File, file.as_bytes()),
-        TagLenValue::<RecordField>::new(RecordField::Line, &line.to_ne_bytes()),
-        TagLenValue::<RecordField>::new(RecordField::NumArgs, &num_args.to_ne_bytes()),
-    ] {
-        size += attr.write(&mut buf[size..])?;
-    }
-
+    size += TagLenValue::new(RecordField::Target, target.as_bytes().iter().copied())
+        .write(&mut buf[size..])?;
+    size += TagLenValue::new(RecordField::Level, level.to_ne_bytes()).write(&mut buf[size..])?;
+    size += TagLenValue::new(RecordField::Module, module.as_bytes().iter().copied())
+        .write(&mut buf[size..])?;
+    size += TagLenValue::new(RecordField::File, file.as_bytes().iter().copied())
+        .write(&mut buf[size..])?;
+    size += TagLenValue::new(RecordField::Line, line.to_ne_bytes()).write(&mut buf[size..])?;
+    size +=
+        TagLenValue::new(RecordField::NumArgs, num_args.to_ne_bytes()).write(&mut buf[size..])?;
     Ok(size)
 }
 

--- a/aya-log-common/src/lib.rs
+++ b/aya-log-common/src/lib.rs
@@ -75,6 +75,7 @@ pub enum Argument {
     /// `[u16; 8]` array which represents an IPv6 address.
     ArrU16Len8,
 
+    Bytes,
     Str,
 }
 
@@ -193,6 +194,12 @@ impl WriteToBuf for [u16; 8] {
 impl WriteToBuf for [u8; 6] {
     fn write(self, buf: &mut [u8]) -> Result<usize, ()> {
         TagLenValue::new(Argument::ArrU8Len6, self).write(buf)
+    }
+}
+
+impl WriteToBuf for &[u8] {
+    fn write(self, buf: &mut [u8]) -> Result<usize, ()> {
+        TagLenValue::new(Argument::Bytes, self.iter().copied()).write(buf)
     }
 }
 

--- a/aya-log-ebpf-macros/src/expand.rs
+++ b/aya-log-ebpf-macros/src/expand.rs
@@ -151,12 +151,11 @@ pub(crate) fn log(args: LogArgs, level: Option<TokenStream>) -> Result<TokenStre
                     let record_len = header_len;
 
                     if let Ok(record_len) = {
-                        use ::aya_log_ebpf::WriteToBuf;
                         Ok::<_, ()>(record_len) #( .and_then(|record_len| {
                             if record_len >= buf.buf.len() {
                                 return Err(());
                             }
-                            { #values_iter }.write(&mut buf.buf[record_len..]).map(|len| record_len + len)
+                            aya_log_ebpf::WriteToBuf::write({ #values_iter }, &mut buf.buf[record_len..]).map(|len| record_len + len)
                         }) )*
                     } {
                         unsafe { ::aya_log_ebpf::AYA_LOGS.output(

--- a/aya-log/src/lib.rs
+++ b/aya-log/src/lib.rs
@@ -564,7 +564,7 @@ mod test {
             .expect("could not write to the buffer");
 
         let logger = logger();
-        let _ = log_buf(&input, logger);
+        let () = log_buf(&input, logger).unwrap();
         testing_logger::validate(|captured_logs| {
             assert_eq!(captured_logs.len(), 1);
             assert_eq!(captured_logs[0].body, "test");
@@ -583,7 +583,7 @@ mod test {
         "test".write(&mut input[len..]).unwrap();
 
         let logger = logger();
-        let _ = log_buf(&input, logger);
+        let () = log_buf(&input, logger).unwrap();
         testing_logger::validate(|captured_logs| {
             assert_eq!(captured_logs.len(), 1);
             assert_eq!(captured_logs[0].body, "hello test");
@@ -601,7 +601,7 @@ mod test {
         14.write(&mut input[len..]).unwrap();
 
         let logger = logger();
-        let _ = log_buf(&input, logger);
+        let () = log_buf(&input, logger).unwrap();
         testing_logger::validate(|captured_logs| {
             assert_eq!(captured_logs.len(), 1);
             assert_eq!(captured_logs[0].body, "default hint: 14");
@@ -619,7 +619,7 @@ mod test {
         200.write(&mut input[len..]).unwrap();
 
         let logger = logger();
-        let _ = log_buf(&input, logger);
+        let () = log_buf(&input, logger).unwrap();
         testing_logger::validate(|captured_logs| {
             assert_eq!(captured_logs.len(), 1);
             assert_eq!(captured_logs[0].body, "lower hex: c8");
@@ -637,7 +637,7 @@ mod test {
         200.write(&mut input[len..]).unwrap();
 
         let logger = logger();
-        let _ = log_buf(&input, logger);
+        let () = log_buf(&input, logger).unwrap();
         testing_logger::validate(|captured_logs| {
             assert_eq!(captured_logs.len(), 1);
             assert_eq!(captured_logs[0].body, "upper hex: C8");
@@ -656,7 +656,7 @@ mod test {
         167772161u32.write(&mut input[len..]).unwrap();
 
         let logger = logger();
-        let _ = log_buf(&input, logger);
+        let () = log_buf(&input, logger).unwrap();
         testing_logger::validate(|captured_logs| {
             assert_eq!(captured_logs.len(), 1);
             assert_eq!(captured_logs[0].body, "ipv4: 10.0.0.1");
@@ -679,7 +679,7 @@ mod test {
         ipv6_arr.write(&mut input[len..]).unwrap();
 
         let logger = logger();
-        let _ = log_buf(&input, logger);
+        let () = log_buf(&input, logger).unwrap();
         testing_logger::validate(|captured_logs| {
             assert_eq!(captured_logs.len(), 1);
             assert_eq!(captured_logs[0].body, "ipv6: 2001:db8::1:1");
@@ -701,7 +701,7 @@ mod test {
         ipv6_arr.write(&mut input[len..]).unwrap();
 
         let logger = logger();
-        let _ = log_buf(&input, logger);
+        let () = log_buf(&input, logger).unwrap();
         testing_logger::validate(|captured_logs| {
             assert_eq!(captured_logs.len(), 1);
             assert_eq!(captured_logs[0].body, "ipv6: 2001:db8::1:1");
@@ -721,7 +721,7 @@ mod test {
         mac_arr.write(&mut input[len..]).unwrap();
 
         let logger = logger();
-        let _ = log_buf(&input, logger);
+        let () = log_buf(&input, logger).unwrap();
         testing_logger::validate(|captured_logs| {
             assert_eq!(captured_logs.len(), 1);
             assert_eq!(captured_logs[0].body, "mac: 00:00:5e:00:53:af");
@@ -741,7 +741,7 @@ mod test {
         mac_arr.write(&mut input[len..]).unwrap();
 
         let logger = logger();
-        let _ = log_buf(&input, logger);
+        let () = log_buf(&input, logger).unwrap();
         testing_logger::validate(|captured_logs| {
             assert_eq!(captured_logs.len(), 1);
             assert_eq!(captured_logs[0].body, "mac: 00:00:5E:00:53:AF");

--- a/aya-obj/src/relocation.rs
+++ b/aya-obj/src/relocation.rs
@@ -590,8 +590,6 @@ mod test {
 
         assert_eq!(fun.instructions[0].src_reg(), BPF_PSEUDO_MAP_FD as u8);
         assert_eq!(fun.instructions[0].imm, 1);
-
-        mem::forget(map);
     }
 
     #[test]
@@ -651,9 +649,6 @@ mod test {
 
         assert_eq!(fun.instructions[1].src_reg(), BPF_PSEUDO_MAP_FD as u8);
         assert_eq!(fun.instructions[1].imm, 2);
-
-        mem::forget(map_1);
-        mem::forget(map_2);
     }
 
     #[test]
@@ -690,8 +685,6 @@ mod test {
 
         assert_eq!(fun.instructions[0].src_reg(), BPF_PSEUDO_MAP_FD as u8);
         assert_eq!(fun.instructions[0].imm, 1);
-
-        mem::forget(map);
     }
 
     #[test]
@@ -751,8 +744,5 @@ mod test {
 
         assert_eq!(fun.instructions[1].src_reg(), BPF_PSEUDO_MAP_FD as u8);
         assert_eq!(fun.instructions[1].imm, 2);
-
-        mem::forget(map_1);
-        mem::forget(map_2);
     }
 }

--- a/test/integration-ebpf/src/log.rs
+++ b/test/integration-ebpf/src/log.rs
@@ -17,6 +17,8 @@ pub fn test_log(ctx: ProbeContext) {
     trace!(&ctx, "mac lc: {:mac}, mac uc: {:MAC}", mac, mac);
     let hex = 0x2f;
     warn!(&ctx, "hex lc: {:x}, hex uc: {:X}", hex, hex);
+    let hex = [0xde, 0xad, 0xbe, 0xef].as_slice();
+    debug!(&ctx, "hex lc: {:x}, hex uc: {:X}", hex, hex);
 }
 
 #[panic_handler]

--- a/test/integration-test/src/tests/log.rs
+++ b/test/integration-test/src/tests/log.rs
@@ -104,12 +104,12 @@ async fn log() {
 
     // Call the function that the uprobe is attached to, so it starts logging.
     trigger_ebpf_program();
-    captured_logs.wait_expected_len(5).await;
+    captured_logs.wait_expected_len(6).await;
 
     let records = captured_logs
         .lock()
         .expect("Failed to acquire a lock for reading logs");
-    assert_eq!(records.len(), 5);
+    assert_eq!(records.len(), 6);
 
     assert_eq!(records[0].body, "Hello from eBPF!");
     assert_eq!(records[0].level, Level::Debug);
@@ -133,4 +133,8 @@ async fn log() {
     assert_eq!(records[4].body, "hex lc: 2f, hex uc: 2F");
     assert_eq!(records[4].level, Level::Warn);
     assert_eq!(records[4].target, "log");
+
+    assert_eq!(records[5].body, "hex lc: deadbeef, hex uc: DEADBEEF");
+    assert_eq!(records[5].level, Level::Debug);
+    assert_eq!(records[5].target, "log");
 }


### PR DESCRIPTION
These only support LowerHex and UpperHex hints for now.