### PR TITLE
aya-bpf: Add helper `change_proto`

### DIFF
--- a/bpf/aya-bpf/src/programs/sk_buff.rs
+++ b/bpf/aya-bpf/src/programs/sk_buff.rs
@@ -6,8 +6,8 @@ use core::{
 
 use aya_bpf_bindings::helpers::{
     bpf_clone_redirect, bpf_get_socket_uid, bpf_l3_csum_replace, bpf_l4_csum_replace,
-    bpf_skb_adjust_room, bpf_skb_change_type, bpf_skb_load_bytes, bpf_skb_pull_data,
-    bpf_skb_store_bytes,
+    bpf_skb_adjust_room, bpf_skb_change_proto, bpf_skb_change_type, bpf_skb_load_bytes,
+    bpf_skb_pull_data, bpf_skb_store_bytes,
 };
 use aya_bpf_cty::c_long;
 
@@ -182,6 +182,16 @@ impl SkBuff {
     #[inline]
     pub fn clone_redirect(&self, if_index: u32, flags: u64) -> Result<(), c_long> {
         let ret = unsafe { bpf_clone_redirect(self.as_ptr() as *mut _, if_index, flags) };
+        if ret == 0 {
+            Ok(())
+        } else {
+            Err(ret)
+        }
+    }
+
+    #[inline]
+    pub fn change_proto(&self, proto: u16, flags: u64) -> Result<(), c_long> {
+        let ret = unsafe { bpf_skb_change_proto(self.as_ptr() as *mut _, proto, flags) };
         if ret == 0 {
             Ok(())
         } else {

--- a/bpf/aya-bpf/src/programs/tc.rs
+++ b/bpf/aya-bpf/src/programs/tc.rs
@@ -143,6 +143,11 @@ impl TcContext {
     }
 
     #[inline]
+    pub fn change_proto(&self, proto: u16, flags: u64) -> Result<(), c_long> {
+        self.skb.change_proto(proto, flags)
+    }
+
+    #[inline]
     pub fn change_type(&self, ty: u32) -> Result<(), c_long> {
         self.skb.change_type(ty)
     }


### PR DESCRIPTION
This patch adds a new helper function, `change_proto`, to the `SkBuff` struct in the `aya-bpf` crate.

The `change_proto` function allows changing the protocol of a socket buffer (`skb`) in BPF programs.
This patch also adds a corresponding wrapper for the `change_proto` function in the `TcContext` struct in the `aya-bpf` crate, making it accessible from TC (traffic control) programs as well.