### PR TITLE
aya-bpf: Add BTF maps (as a feature)

### DIFF
--- a/aya-bpf-macros/Cargo.toml
+++ b/aya-bpf-macros/Cargo.toml
@@ -14,3 +14,6 @@ syn = {version = "1.0", features = ["full"]}
 
 [dev-dependencies]
 aya-bpf = { path = "../bpf/aya-bpf" }
+
+[features]
+btf-maps = []

--- a/aya-bpf-macros/src/expand.rs
+++ b/aya-bpf-macros/src/expand.rs
@@ -93,7 +93,8 @@ impl Map {
     }
 
     pub fn expand(&self) -> Result<TokenStream> {
-        let section_name = "maps".to_string();
+        // TODO(vadorovsky): Handle with feature.
+        let section_name = ".maps".to_string();
         let name = &self.name;
         let item = &self.item;
         Ok(quote! {

--- a/bpf/aya-bpf-bindings/src/lib.rs
+++ b/bpf/aya-bpf-bindings/src/lib.rs
@@ -43,6 +43,78 @@ pub mod bindings {
     pub const TC_ACT_VALUE_MAX: i32 = crate::gen::bindings::TC_ACT_VALUE_MAX as i32;
     pub const TC_ACT_EXT_VAL_MASK: i32 = 268435455;
 
+    // TODO(vadorovsky): Handle that with a macro.
+    pub mod bpf_map_type {
+        pub const BPF_MAP_TYPE_UNSPEC: usize =
+            crate::gen::bindings::bpf_map_type::BPF_MAP_TYPE_UNSPEC as usize;
+        pub const BPF_MAP_TYPE_HASH: usize =
+            crate::gen::bindings::bpf_map_type::BPF_MAP_TYPE_HASH as usize;
+        pub const BPF_MAP_TYPE_ARRAY: usize =
+            crate::gen::bindings::bpf_map_type::BPF_MAP_TYPE_ARRAY as usize;
+        pub const BPF_MAP_TYPE_PROG_ARRAY: usize =
+            crate::gen::bindings::bpf_map_type::BPF_MAP_TYPE_PROG_ARRAY as usize;
+        pub const BPF_MAP_TYPE_PERF_EVENT_ARRAY: usize =
+            crate::gen::bindings::bpf_map_type::BPF_MAP_TYPE_PERF_EVENT_ARRAY as usize;
+        pub const BPF_MAP_TYPE_PERCPU_HASH: usize =
+            crate::gen::bindings::bpf_map_type::BPF_MAP_TYPE_PERCPU_HASH as usize;
+        pub const BPF_MAP_TYPE_PERCPU_ARRAY: usize =
+            crate::gen::bindings::bpf_map_type::BPF_MAP_TYPE_PERCPU_ARRAY as usize;
+        pub const BPF_MAP_TYPE_STACK_TRACE: usize =
+            crate::gen::bindings::bpf_map_type::BPF_MAP_TYPE_STACK_TRACE as usize;
+        pub const BPF_MAP_TYPE_CGROUP_ARRAY: usize =
+            crate::gen::bindings::bpf_map_type::BPF_MAP_TYPE_CGROUP_ARRAY as usize;
+        pub const BPF_MAP_TYPE_LRU_HASH: usize =
+            crate::gen::bindings::bpf_map_type::BPF_MAP_TYPE_LRU_HASH as usize;
+        pub const BPF_MAP_TYPE_LRU_PERCPU_HASH: usize =
+            crate::gen::bindings::bpf_map_type::BPF_MAP_TYPE_LRU_PERCPU_HASH as usize;
+        pub const BPF_MAP_TYPE_LPM_TRIE: usize =
+            crate::gen::bindings::bpf_map_type::BPF_MAP_TYPE_LPM_TRIE as usize;
+        pub const BPF_MAP_TYPE_ARRAY_OF_MAPS: usize =
+            crate::gen::bindings::bpf_map_type::BPF_MAP_TYPE_ARRAY_OF_MAPS as usize;
+        pub const BPF_MAP_TYPE_HASH_OF_MAPS: usize =
+            crate::gen::bindings::bpf_map_type::BPF_MAP_TYPE_HASH_OF_MAPS as usize;
+        pub const BPF_MAP_TYPE_DEVMAP: usize =
+            crate::gen::bindings::bpf_map_type::BPF_MAP_TYPE_DEVMAP as usize;
+        pub const BPF_MAP_TYPE_SOCKMAP: usize =
+            crate::gen::bindings::bpf_map_type::BPF_MAP_TYPE_SOCKMAP as usize;
+        pub const BPF_MAP_TYPE_CPUMAP: usize =
+            crate::gen::bindings::bpf_map_type::BPF_MAP_TYPE_CPUMAP as usize;
+        pub const BPF_MAP_TYPE_XSKMAP: usize =
+            crate::gen::bindings::bpf_map_type::BPF_MAP_TYPE_XSKMAP as usize;
+        pub const BPF_MAP_TYPE_SOCKHASH: usize =
+            crate::gen::bindings::bpf_map_type::BPF_MAP_TYPE_SOCKHASH as usize;
+        pub const BPF_MAP_TYPE_CGROUP_STORAGE_DEPRECATED: usize =
+            crate::gen::bindings::bpf_map_type::BPF_MAP_TYPE_CGROUP_STORAGE_DEPRECATED as usize;
+        pub const BPF_MAP_TYPE_CGROUP_STORAGE: usize =
+            crate::gen::bindings::bpf_map_type::BPF_MAP_TYPE_CGROUP_STORAGE as usize;
+        pub const BPF_MAP_TYPE_REUSEPORT_SOCKARRAY: usize =
+            crate::gen::bindings::bpf_map_type::BPF_MAP_TYPE_REUSEPORT_SOCKARRAY as usize;
+        pub const BPF_MAP_TYPE_PERCPU_CGROUP_STORAGE: usize =
+            crate::gen::bindings::bpf_map_type::BPF_MAP_TYPE_PERCPU_CGROUP_STORAGE as usize;
+        pub const BPF_MAP_TYPE_QUEUE: usize =
+            crate::gen::bindings::bpf_map_type::BPF_MAP_TYPE_QUEUE as usize;
+        pub const BPF_MAP_TYPE_STACK: usize =
+            crate::gen::bindings::bpf_map_type::BPF_MAP_TYPE_STACK as usize;
+        pub const BPF_MAP_TYPE_SK_STORAGE: usize =
+            crate::gen::bindings::bpf_map_type::BPF_MAP_TYPE_SK_STORAGE as usize;
+        pub const BPF_MAP_TYPE_DEVMAP_HASH: usize =
+            crate::gen::bindings::bpf_map_type::BPF_MAP_TYPE_DEVMAP_HASH as usize;
+        pub const BPF_MAP_TYPE_STRUCT_OPS: usize =
+            crate::gen::bindings::bpf_map_type::BPF_MAP_TYPE_STRUCT_OPS as usize;
+        pub const BPF_MAP_TYPE_RINGBUF: usize =
+            crate::gen::bindings::bpf_map_type::BPF_MAP_TYPE_RINGBUF as usize;
+        pub const BPF_MAP_TYPE_INODE_STORAGE: usize =
+            crate::gen::bindings::bpf_map_type::BPF_MAP_TYPE_INODE_STORAGE as usize;
+        pub const BPF_MAP_TYPE_TASK_STORAGE: usize =
+            crate::gen::bindings::bpf_map_type::BPF_MAP_TYPE_TASK_STORAGE as usize;
+        pub const BPF_MAP_TYPE_BLOOM_FILTER: usize =
+            crate::gen::bindings::bpf_map_type::BPF_MAP_TYPE_BLOOM_FILTER as usize;
+        pub const BPF_MAP_TYPE_USER_RINGBUF: usize =
+            crate::gen::bindings::bpf_map_type::BPF_MAP_TYPE_USER_RINGBUF as usize;
+        pub const BPF_MAP_TYPE_CGRP_STORAGE: usize =
+            crate::gen::bindings::bpf_map_type::BPF_MAP_TYPE_CGRP_STORAGE as usize;
+    }
+
     #[repr(C)]
     #[derive(Debug, Copy, Clone)]
     pub struct bpf_map_def {

--- a/bpf/aya-bpf/Cargo.toml
+++ b/bpf/aya-bpf/Cargo.toml
@@ -11,3 +11,7 @@ aya-bpf-bindings = { path = "../aya-bpf-bindings" }
 
 [build-dependencies]
 rustversion = "1.0"
+
+[features]
+default = []
+btf-maps = ["aya-bpf-macros/btf-maps"]

--- a/bpf/aya-bpf/src/maps/array.rs
+++ b/bpf/aya-bpf/src/maps/array.rs
@@ -8,6 +8,11 @@ use crate::{
     maps::PinningType,
 };
 
+// #[cfg(feature = "btf-maps")]
+// #[repr(transparent)]
+// pub struct Array<T, const MAX_ENTRIES: usize, const FLAGS: usize = 0> {
+//     def: UnsafeCell<super>,
+// }
 #[repr(transparent)]
 pub struct Array<T> {
     def: UnsafeCell<bpf_map_def>,
@@ -20,7 +25,7 @@ impl<T> Array<T> {
     pub const fn with_max_entries(max_entries: u32, flags: u32) -> Array<T> {
         Array {
             def: UnsafeCell::new(bpf_map_def {
-                type_: BPF_MAP_TYPE_ARRAY,
+                type_: BPF_MAP_TYPE_ARRAY as u32,
                 key_size: mem::size_of::<u32>() as u32,
                 value_size: mem::size_of::<T>() as u32,
                 max_entries,
@@ -35,7 +40,7 @@ impl<T> Array<T> {
     pub const fn pinned(max_entries: u32, flags: u32) -> Array<T> {
         Array {
             def: UnsafeCell::new(bpf_map_def {
-                type_: BPF_MAP_TYPE_ARRAY,
+                type_: BPF_MAP_TYPE_ARRAY as u32,
                 key_size: mem::size_of::<u32>() as u32,
                 value_size: mem::size_of::<T>() as u32,
                 max_entries,

--- a/bpf/aya-bpf/src/maps/bloom_filter.rs
+++ b/bpf/aya-bpf/src/maps/bloom_filter.rs
@@ -18,7 +18,7 @@ impl<T> BloomFilter<T> {
     pub const fn with_max_entries(max_entries: u32, flags: u32) -> BloomFilter<T> {
         BloomFilter {
             def: build_def::<T>(
-                BPF_MAP_TYPE_BLOOM_FILTER,
+                BPF_MAP_TYPE_BLOOM_FILTER as u32,
                 max_entries,
                 flags,
                 PinningType::None,
@@ -30,7 +30,7 @@ impl<T> BloomFilter<T> {
     pub const fn pinned(max_entries: u32, flags: u32) -> BloomFilter<T> {
         BloomFilter {
             def: build_def::<T>(
-                BPF_MAP_TYPE_BLOOM_FILTER,
+                BPF_MAP_TYPE_BLOOM_FILTER as u32,
                 max_entries,
                 flags,
                 PinningType::ByName,

--- a/bpf/aya-bpf/src/maps/lpm_trie.rs
+++ b/bpf/aya-bpf/src/maps/lpm_trie.rs
@@ -37,7 +37,7 @@ impl<K, V> LpmTrie<K, V> {
         let flags = flags | BPF_F_NO_PREALLOC;
         LpmTrie {
             def: UnsafeCell::new(build_def::<K, V>(
-                BPF_MAP_TYPE_LPM_TRIE,
+                BPF_MAP_TYPE_LPM_TRIE as u32,
                 max_entries,
                 flags,
                 PinningType::None,
@@ -51,7 +51,7 @@ impl<K, V> LpmTrie<K, V> {
         let flags = flags | BPF_F_NO_PREALLOC;
         LpmTrie {
             def: UnsafeCell::new(build_def::<K, V>(
-                BPF_MAP_TYPE_LPM_TRIE,
+                BPF_MAP_TYPE_LPM_TRIE as u32,
                 max_entries,
                 flags,
                 PinningType::ByName,

--- a/bpf/aya-bpf/src/maps/mod.rs
+++ b/bpf/aya-bpf/src/maps/mod.rs
@@ -30,3 +30,38 @@ pub use sock_hash::SockHash;
 pub use sock_map::SockMap;
 pub use stack::Stack;
 pub use stack_trace::StackTrace;
+
+#[cfg(feature = "btf-maps")]
+mod btf_maps {
+    #[repr(C)]
+    pub(crate) struct MapDef<
+        K,
+        V,
+        const MAP_TYPE: usize,
+        const MAX_ENTRIES: usize,
+        const FLAGS: usize = 0,
+    > {
+        r#type: *const [i32; MAP_TYPE],
+        key: *const K,
+        value: *const V,
+        max_entries: *const [i32; MAX_ENTRIES],
+        map_flags: *const [i32; FLAGS],
+    }
+
+    impl<K, V, const MAP_TYPE: usize, const MAX_ENTRIES: usize, const FLAGS: usize>
+        MapDef<K, V, MAP_TYPE, MAX_ENTRIES, FLAGS>
+    {
+        pub const fn new() -> Self {
+            Self {
+                r#type: ::core::ptr::null(),
+                key: ::core::ptr::null(),
+                value: ::core::ptr::null(),
+                max_entries: ::core::ptr::null(),
+                map_flags: ::core::ptr::null(),
+            }
+        }
+    }
+}
+
+#[cfg(feature = "btf-maps")]
+pub(crate) use btf_maps::*;

--- a/bpf/aya-bpf/src/maps/per_cpu_array.rs
+++ b/bpf/aya-bpf/src/maps/per_cpu_array.rs
@@ -20,7 +20,7 @@ impl<T> PerCpuArray<T> {
     pub const fn with_max_entries(max_entries: u32, flags: u32) -> PerCpuArray<T> {
         PerCpuArray {
             def: UnsafeCell::new(bpf_map_def {
-                type_: BPF_MAP_TYPE_PERCPU_ARRAY,
+                type_: BPF_MAP_TYPE_PERCPU_ARRAY as u32,
                 key_size: mem::size_of::<u32>() as u32,
                 value_size: mem::size_of::<T>() as u32,
                 max_entries,
@@ -35,7 +35,7 @@ impl<T> PerCpuArray<T> {
     pub const fn pinned(max_entries: u32, flags: u32) -> PerCpuArray<T> {
         PerCpuArray {
             def: UnsafeCell::new(bpf_map_def {
-                type_: BPF_MAP_TYPE_PERCPU_ARRAY,
+                type_: BPF_MAP_TYPE_PERCPU_ARRAY as u32,
                 key_size: mem::size_of::<u32>() as u32,
                 value_size: mem::size_of::<T>() as u32,
                 max_entries,

--- a/bpf/aya-bpf/src/maps/perf/perf_event_array.rs
+++ b/bpf/aya-bpf/src/maps/perf/perf_event_array.rs
@@ -23,7 +23,7 @@ impl<T> PerfEventArray<T> {
     pub const fn with_max_entries(max_entries: u32, flags: u32) -> PerfEventArray<T> {
         PerfEventArray {
             def: UnsafeCell::new(bpf_map_def {
-                type_: BPF_MAP_TYPE_PERF_EVENT_ARRAY,
+                type_: BPF_MAP_TYPE_PERF_EVENT_ARRAY as u32,
                 key_size: mem::size_of::<u32>() as u32,
                 value_size: mem::size_of::<u32>() as u32,
                 max_entries,
@@ -38,7 +38,7 @@ impl<T> PerfEventArray<T> {
     pub const fn pinned(max_entries: u32, flags: u32) -> PerfEventArray<T> {
         PerfEventArray {
             def: UnsafeCell::new(bpf_map_def {
-                type_: BPF_MAP_TYPE_PERF_EVENT_ARRAY,
+                type_: BPF_MAP_TYPE_PERF_EVENT_ARRAY as u32,
                 key_size: mem::size_of::<u32>() as u32,
                 value_size: mem::size_of::<u32>() as u32,
                 max_entries,

--- a/bpf/aya-bpf/src/maps/perf/perf_event_byte_array.rs
+++ b/bpf/aya-bpf/src/maps/perf/perf_event_byte_array.rs
@@ -22,7 +22,7 @@ impl PerfEventByteArray {
     pub const fn with_max_entries(max_entries: u32, flags: u32) -> PerfEventByteArray {
         PerfEventByteArray {
             def: UnsafeCell::new(bpf_map_def {
-                type_: BPF_MAP_TYPE_PERF_EVENT_ARRAY,
+                type_: BPF_MAP_TYPE_PERF_EVENT_ARRAY as u32,
                 key_size: mem::size_of::<u32>() as u32,
                 value_size: mem::size_of::<u32>() as u32,
                 max_entries,
@@ -36,7 +36,7 @@ impl PerfEventByteArray {
     pub const fn pinned(max_entries: u32, flags: u32) -> PerfEventByteArray {
         PerfEventByteArray {
             def: UnsafeCell::new(bpf_map_def {
-                type_: BPF_MAP_TYPE_PERF_EVENT_ARRAY,
+                type_: BPF_MAP_TYPE_PERF_EVENT_ARRAY as u32,
                 key_size: mem::size_of::<u32>() as u32,
                 value_size: mem::size_of::<u32>() as u32,
                 max_entries,

--- a/bpf/aya-bpf/src/maps/program_array.rs
+++ b/bpf/aya-bpf/src/maps/program_array.rs
@@ -42,7 +42,7 @@ impl ProgramArray {
     pub const fn with_max_entries(max_entries: u32, flags: u32) -> ProgramArray {
         ProgramArray {
             def: UnsafeCell::new(bpf_map_def {
-                type_: BPF_MAP_TYPE_PROG_ARRAY,
+                type_: BPF_MAP_TYPE_PROG_ARRAY as u32,
                 key_size: mem::size_of::<u32>() as u32,
                 value_size: mem::size_of::<u32>() as u32,
                 max_entries,
@@ -56,7 +56,7 @@ impl ProgramArray {
     pub const fn pinned(max_entries: u32, flags: u32) -> ProgramArray {
         ProgramArray {
             def: UnsafeCell::new(bpf_map_def {
-                type_: BPF_MAP_TYPE_PROG_ARRAY,
+                type_: BPF_MAP_TYPE_PROG_ARRAY as u32,
                 key_size: mem::size_of::<u32>() as u32,
                 value_size: mem::size_of::<u32>() as u32,
                 max_entries,

--- a/bpf/aya-bpf/src/maps/queue.rs
+++ b/bpf/aya-bpf/src/maps/queue.rs
@@ -18,7 +18,7 @@ impl<T> Queue<T> {
     pub const fn with_max_entries(max_entries: u32, flags: u32) -> Queue<T> {
         Queue {
             def: UnsafeCell::new(bpf_map_def {
-                type_: BPF_MAP_TYPE_QUEUE,
+                type_: BPF_MAP_TYPE_QUEUE as u32,
                 key_size: 0,
                 value_size: mem::size_of::<T>() as u32,
                 max_entries,
@@ -33,7 +33,7 @@ impl<T> Queue<T> {
     pub const fn pinned(max_entries: u32, flags: u32) -> Queue<T> {
         Queue {
             def: UnsafeCell::new(bpf_map_def {
-                type_: BPF_MAP_TYPE_QUEUE,
+                type_: BPF_MAP_TYPE_QUEUE as u32,
                 key_size: 0,
                 value_size: mem::size_of::<T>() as u32,
                 max_entries,

--- a/bpf/aya-bpf/src/maps/sock_hash.rs
+++ b/bpf/aya-bpf/src/maps/sock_hash.rs
@@ -25,7 +25,7 @@ impl<K> SockHash<K> {
     pub const fn with_max_entries(max_entries: u32, flags: u32) -> SockHash<K> {
         SockHash {
             def: UnsafeCell::new(bpf_map_def {
-                type_: BPF_MAP_TYPE_SOCKHASH,
+                type_: BPF_MAP_TYPE_SOCKHASH as u32,
                 key_size: mem::size_of::<K>() as u32,
                 value_size: mem::size_of::<u32>() as u32,
                 max_entries,
@@ -40,7 +40,7 @@ impl<K> SockHash<K> {
     pub const fn pinned(max_entries: u32, flags: u32) -> SockHash<K> {
         SockHash {
             def: UnsafeCell::new(bpf_map_def {
-                type_: BPF_MAP_TYPE_SOCKHASH,
+                type_: BPF_MAP_TYPE_SOCKHASH as u32,
                 key_size: mem::size_of::<K>() as u32,
                 value_size: mem::size_of::<u32>() as u32,
                 max_entries,

--- a/bpf/aya-bpf/src/maps/sock_map.rs
+++ b/bpf/aya-bpf/src/maps/sock_map.rs
@@ -24,7 +24,7 @@ impl SockMap {
     pub const fn with_max_entries(max_entries: u32, flags: u32) -> SockMap {
         SockMap {
             def: UnsafeCell::new(bpf_map_def {
-                type_: BPF_MAP_TYPE_SOCKMAP,
+                type_: BPF_MAP_TYPE_SOCKMAP as u32,
                 key_size: mem::size_of::<u32>() as u32,
                 value_size: mem::size_of::<u32>() as u32,
                 max_entries,
@@ -38,7 +38,7 @@ impl SockMap {
     pub const fn pinned(max_entries: u32, flags: u32) -> SockMap {
         SockMap {
             def: UnsafeCell::new(bpf_map_def {
-                type_: BPF_MAP_TYPE_SOCKMAP,
+                type_: BPF_MAP_TYPE_SOCKMAP as u32,
                 key_size: mem::size_of::<u32>() as u32,
                 value_size: mem::size_of::<u32>() as u32,
                 max_entries,

--- a/bpf/aya-bpf/src/maps/stack.rs
+++ b/bpf/aya-bpf/src/maps/stack.rs
@@ -16,7 +16,7 @@ impl<T> Stack<T> {
     pub const fn with_max_entries(max_entries: u32, flags: u32) -> Stack<T> {
         Stack {
             def: bpf_map_def {
-                type_: BPF_MAP_TYPE_STACK,
+                type_: BPF_MAP_TYPE_STACK as u32,
                 key_size: 0,
                 value_size: mem::size_of::<T>() as u32,
                 max_entries,
@@ -31,7 +31,7 @@ impl<T> Stack<T> {
     pub const fn pinned(max_entries: u32, flags: u32) -> Stack<T> {
         Stack {
             def: bpf_map_def {
-                type_: BPF_MAP_TYPE_STACK,
+                type_: BPF_MAP_TYPE_STACK as u32,
                 key_size: 0,
                 value_size: mem::size_of::<T>() as u32,
                 max_entries,

--- a/bpf/aya-bpf/src/maps/stack_trace.rs
+++ b/bpf/aya-bpf/src/maps/stack_trace.rs
@@ -20,7 +20,7 @@ impl StackTrace {
     pub const fn with_max_entries(max_entries: u32, flags: u32) -> StackTrace {
         StackTrace {
             def: UnsafeCell::new(bpf_map_def {
-                type_: BPF_MAP_TYPE_STACK_TRACE,
+                type_: BPF_MAP_TYPE_STACK_TRACE as u32,
                 key_size: mem::size_of::<u32>() as u32,
                 value_size: mem::size_of::<u64>() as u32 * PERF_MAX_STACK_DEPTH,
                 max_entries,
@@ -34,7 +34,7 @@ impl StackTrace {
     pub const fn pinned(max_entries: u32, flags: u32) -> StackTrace {
         StackTrace {
             def: UnsafeCell::new(bpf_map_def {
-                type_: BPF_MAP_TYPE_STACK_TRACE,
+                type_: BPF_MAP_TYPE_STACK_TRACE as u32,
                 key_size: mem::size_of::<u32>() as u32,
                 value_size: mem::size_of::<u64>() as u32 * PERF_MAX_STACK_DEPTH,
                 max_entries,


### PR DESCRIPTION
The new `btf-maps` feature enables usage of BTF-defined BPF map definitions[0] instead of legacy ones.

This is still work in progress and it needs modification of debug info with bpf-linker, which is being worked on in aya-rs/bpf-linker#35. This draft PR is a reference for the bpf-linker work for now.

[0] https://lwn.net/Articles/790177/