### PR TITLE
aya: drop unnecessary `mut`

### DIFF
--- a/aya-obj/src/btf/btf.rs
+++ b/aya-obj/src/btf/btf.rs
@@ -531,7 +531,7 @@ impl Btf {
                 // Fixup FUNC_PROTO
                 BtfType::FuncProto(ty) if features.btf_func => {
                     let mut ty = ty.clone();
-                    for (i, mut param) in ty.params.iter_mut().enumerate() {
+                    for (i, param) in ty.params.iter_mut().enumerate() {
                         if param.name_offset == 0 && param.btf_type != 0 {
                             param.name_offset = self.add_string(format!("param{i}"));
                         }

--- a/aya-obj/src/btf/relocation.rs
+++ b/aya-obj/src/btf/relocation.rs
@@ -855,7 +855,7 @@ impl ComputedRelocation {
         let instructions = &mut program.function.instructions;
         let num_instructions = instructions.len();
         let ins_index = rel.ins_offset / mem::size_of::<bpf_insn>();
-        let mut ins =
+        let ins =
             instructions
                 .get_mut(ins_index)
                 .ok_or(RelocationError::InvalidInstructionIndex {
@@ -934,7 +934,7 @@ impl ComputedRelocation {
             }
             BPF_LD => {
                 ins.imm = target_value as i32;
-                let mut next_ins = instructions.get_mut(ins_index + 1).ok_or(
+                let next_ins = instructions.get_mut(ins_index + 1).ok_or(
                     RelocationError::InvalidInstructionIndex {
                         index: ins_index + 1,
                         num_instructions,

--- a/aya-obj/src/relocation.rs
+++ b/aya-obj/src/relocation.rs
@@ -429,7 +429,7 @@ impl<'a> FunctionLinker<'a> {
 
             let callee_ins_index = self.link_function(program, callee)? as i32;
 
-            let mut ins = &mut program.instructions[ins_index];
+            let ins = &mut program.instructions[ins_index];
             let ins_index = ins_index as i32;
             ins.imm = callee_ins_index - ins_index - 1;
             debug!(


### PR DESCRIPTION
As per title, this patch drops unnecessary `mut`.