### PR TITLE
xtask: codegen: generate bindings for user_regs_struct

### DIFF
--- a/xtask/src/codegen/aya_bpf_bindings.rs
+++ b/xtask/src/codegen/aya_bpf_bindings.rs
@@ -46,6 +46,7 @@ pub fn codegen(opts: &Options) -> Result<(), anyhow::Error> {
             "sk_action",
             "pt_regs",
             "user_pt_regs",
+            "user_regs_struct",
             "xdp_action",
         ];
         let vars = ["BPF_.*", "bpf_.*", "TC_ACT_.*", "SOL_SOCKET", "SO_.*"];


### PR DESCRIPTION
This patch adds `user_regs_struct`.

riscv provides struct `user_regs_struct` instead of struct `pt_regs` to userspace.
After bindings generates the code, adding the riscv support in `bpf/aya-bpf/src/args.rs`
then aya-bpf could be built for riscv.