### PR TITLE
aya-obj: Fix ProgramSection::from_str for bss and rodata sections

### DIFF
--- a/aya-obj/src/obj.rs
+++ b/aya-obj/src/obj.rs
@@ -1093,11 +1093,12 @@ impl BpfSectionKind {
             BpfSectionKind::BtfMaps
         } else if name.starts_with(".text") {
             BpfSectionKind::Text
-        } else if name.starts_with(".bss")
-            || name.starts_with(".data")
-            || name.starts_with(".rodata")
-        {
+        } else if name.starts_with(".bss") {
+            BpfSectionKind::Bss
+        } else if name.starts_with(".data") {
             BpfSectionKind::Data
+        } else if name.starts_with(".rodata") {
+            BpfSectionKind::Rodata
         } else if name == ".BTF" {
             BpfSectionKind::Btf
         } else if name == ".BTF.ext" {


### PR DESCRIPTION
That was missing from https://github.com/aya-rs/aya/commit/401ea5e8482ece34b6c88de85ec474bdfc577fd4.