### PR TITLE
aya: Do not create data maps on kernel without global data support

### DIFF
--- a/aya-obj/src/obj.rs
+++ b/aya-obj/src/obj.rs
@@ -44,6 +44,7 @@ pub struct Features {
     pub bpf_name: bool,
     pub bpf_probe_read_kernel: bool,
     pub bpf_perf_link: bool,
+    pub bpf_global_data: bool,
     pub btf: Option<BtfFeatures>,
 }
 


### PR DESCRIPTION
Fix map creation failure when a BPF have a data section on older kernel. (< 5.2)

If the BPF uses that section, relocation will fail accordingly and report an error.