### PR TITLE
feat(aya-log): check format and value type in proc macro

### DIFF
--- a/aya-log-common/src/lib.rs
+++ b/aya-log-common/src/lib.rs
@@ -43,7 +43,6 @@ macro_rules! impl_formatter_for_types {
     };
 }
 
-// Any value impl `ToString`
 pub trait DefaultFormatter {}
 impl_formatter_for_types!(
     DefaultFormatter: {
@@ -61,23 +60,19 @@ pub trait LowerHexFormatter {}
 impl_formatter_for_types!(
     LowerHexFormatter: {
         i8, i16, i32, i64, isize,
-        u8, u16, u32, u64, usize
+        u8, u16, u32, u64, usize,
+        &[u8]
     }
 );
-
-pub trait LowerHexDebugFormatter {}
-impl LowerHexDebugFormatter for &[u8] {}
 
 pub trait UpperHexFormatter {}
 impl_formatter_for_types!(
     UpperHexFormatter: {
         i8, i16, i32, i64, isize,
-        u8, u16, u32, u64, usize
+        u8, u16, u32, u64, usize,
+        &[u8]
     }
 );
-
-pub trait UpperHexDebugFormatter {}
-impl UpperHexDebugFormatter for &[u8] {}
 
 pub trait Ipv4Formatter {}
 impl Ipv4Formatter for u32 {}
@@ -97,11 +92,7 @@ pub fn check_impl_default<T: DefaultFormatter>(_v: T) {}
 #[inline(always)]
 pub fn check_impl_lower_hex<T: LowerHexFormatter>(_v: T) {}
 #[inline(always)]
-pub fn check_impl_lower_hex_debug<T: LowerHexDebugFormatter>(_v: T) {}
-#[inline(always)]
 pub fn check_impl_upper_hex<T: UpperHexFormatter>(_v: T) {}
-#[inline(always)]
-pub fn check_impl_upper_hex_debug<T: UpperHexDebugFormatter>(_v: T) {}
 #[inline(always)]
 pub fn check_impl_ipv4<T: Ipv4Formatter>(_v: T) {}
 #[inline(always)]

--- a/aya-log-common/src/lib.rs
+++ b/aya-log-common/src/lib.rs
@@ -35,6 +35,82 @@ pub enum Level {
     Trace,
 }
 
+macro_rules! impl_formatter_for_types {
+    ($trait:path : { $($type:ty),*}) => {
+        $(
+            impl $trait for $type {}
+        )*
+    };
+}
+
+// Any value impl `ToString`
+pub trait DefaultFormatter {}
+impl_formatter_for_types!(
+    DefaultFormatter: {
+        bool,
+        i8, i16, i32, i64, isize,
+        u8, u16, u32, u64, usize,
+        f32, f64,
+        char,
+        str,
+        &str
+    }
+);
+
+pub trait LowerHexFormatter {}
+impl_formatter_for_types!(
+    LowerHexFormatter: {
+        i8, i16, i32, i64, isize,
+        u8, u16, u32, u64, usize
+    }
+);
+
+pub trait LowerHexDebugFormatter {}
+impl LowerHexDebugFormatter for &[u8] {}
+
+pub trait UpperHexFormatter {}
+impl_formatter_for_types!(
+    UpperHexFormatter: {
+        i8, i16, i32, i64, isize,
+        u8, u16, u32, u64, usize
+    }
+);
+
+pub trait UpperHexDebugFormatter {}
+impl UpperHexDebugFormatter for &[u8] {}
+
+pub trait Ipv4Formatter {}
+impl Ipv4Formatter for u32 {}
+
+pub trait Ipv6Formatter {}
+impl Ipv6Formatter for [u8; 16] {}
+impl Ipv6Formatter for [u16; 8] {}
+
+pub trait LowerMacFormatter {}
+impl LowerMacFormatter for [u8; 6] {}
+
+pub trait UpperMacFormatter {}
+impl UpperMacFormatter for [u8; 6] {}
+
+#[inline(always)]
+pub fn check_impl_default<T: DefaultFormatter>(_v: T) {}
+#[inline(always)]
+pub fn check_impl_lower_hex<T: LowerHexFormatter>(_v: T) {}
+#[inline(always)]
+pub fn check_impl_lower_hex_debug<T: LowerHexDebugFormatter>(_v: T) {}
+#[inline(always)]
+pub fn check_impl_upper_hex<T: UpperHexFormatter>(_v: T) {}
+#[inline(always)]
+pub fn check_impl_upper_hex_debug<T: UpperHexDebugFormatter>(_v: T) {}
+#[inline(always)]
+pub fn check_impl_ipv4<T: Ipv4Formatter>(_v: T) {}
+#[inline(always)]
+pub fn check_impl_ipv6<T: Ipv6Formatter>(_v: T) {}
+#[inline(always)]
+pub fn check_impl_lower_mac<T: LowerMacFormatter>(_v: T) {}
+#[inline(always)]
+pub fn check_impl_upper_mac<T: UpperMacFormatter>(_v: T) {}
+
 #[repr(u8)]
 #[derive(Copy, Clone, Debug)]
 pub enum RecordField {

--- a/aya-log-ebpf-macros/src/expand.rs
+++ b/aya-log-ebpf-macros/src/expand.rs
@@ -86,6 +86,18 @@ fn hint_to_expr(hint: DisplayHint) -> Result<Expr> {
     }
 }
 
+fn hint_to_format_check(hint: DisplayHint) -> Result<Expr> {
+    match hint {
+        DisplayHint::Default => parse_str("::aya_log_ebpf::macro_support::check_impl_default"),
+        DisplayHint::LowerHex => parse_str("::aya_log_ebpf::macro_support::check_impl_lower_hex"),
+        DisplayHint::UpperHex => parse_str("::aya_log_ebpf::macro_support::check_impl_upper_hex"),
+        DisplayHint::Ipv4 => parse_str("::aya_log_ebpf::macro_support::check_impl_ipv4"),
+        DisplayHint::Ipv6 => parse_str("::aya_log_ebpf::macro_support::check_impl_ipv6"),
+        DisplayHint::LowerMac => parse_str("::aya_log_ebpf::macro_support::check_impl_lower_mac"),
+        DisplayHint::UpperMac => parse_str("::aya_log_ebpf::macro_support::check_impl_upper_mac"),
+    }
+}
+
 pub(crate) fn log(args: LogArgs, level: Option<TokenStream>) -> Result<TokenStream> {
     let ctx = args.ctx;
     let target = match args.target {
@@ -115,6 +127,8 @@ pub(crate) fn log(args: LogArgs, level: Option<TokenStream>) -> Result<TokenStre
     let mut arg_i = 0;
 
     let mut values = Vec::new();
+    let mut f_keys = Vec::new();
+    let mut f_values = Vec::new();
     for fragment in fragments {
         match fragment {
             Fragment::Literal(s) => {
@@ -126,7 +140,10 @@ pub(crate) fn log(args: LogArgs, level: Option<TokenStream>) -> Result<TokenStre
                     None => return Err(Error::new(format_string.span(), "no arguments provided")),
                 };
                 values.push(hint_to_expr(p.hint)?);
-                values.push(arg);
+                values.push(arg.clone());
+
+                f_keys.push(hint_to_format_check(p.hint)?);
+                f_values.push(arg.clone());
                 arg_i += 1;
             }
         }
@@ -135,8 +152,15 @@ pub(crate) fn log(args: LogArgs, level: Option<TokenStream>) -> Result<TokenStre
     let num_args = values.len();
     let values_iter = values.iter();
 
+    let f_keys = f_keys.iter();
+    let f_values = f_values.iter();
+
     Ok(quote! {
         {
+            #(
+                #f_keys(#f_values);
+            )*
+
             if let Some(buf_ptr) = unsafe { ::aya_log_ebpf::AYA_LOG_BUF.get_ptr_mut(0) } {
                 let buf = unsafe { &mut *buf_ptr };
                 if let Ok(header_len) = ::aya_log_ebpf::write_record_header(

--- a/aya-log/src/lib.rs
+++ b/aya-log/src/lib.rs
@@ -126,7 +126,10 @@ impl BpfLogger {
                     #[allow(clippy::needless_range_loop)]
                     for i in 0..events.read {
                         let buf = &mut buffers[i];
-                        log_buf(buf, &*log).unwrap();
+                        match log_buf(buf, &*log) {
+                            Ok(()) => {}
+                            Err(e) => error!("internal error => {:?}", e),
+                        }
                     }
                 }
             });

--- a/aya-log/src/lib.rs
+++ b/aya-log/src/lib.rs
@@ -126,10 +126,7 @@ impl BpfLogger {
                     #[allow(clippy::needless_range_loop)]
                     for i in 0..events.read {
                         let buf = &mut buffers[i];
-                        match log_buf(buf, &*log) {
-                            Ok(()) => {}
-                            Err(e) => error!("internal error => {:?}", e),
-                        }
+                        log_buf(buf, &*log).unwrap();
                     }
                 }
             });

--- a/bpf/aya-log-ebpf/src/lib.rs
+++ b/bpf/aya-log-ebpf/src/lib.rs
@@ -22,6 +22,11 @@ pub static mut AYA_LOGS: PerfEventByteArray = PerfEventByteArray::new(0);
 
 #[doc(hidden)]
 pub mod macro_support {
-    pub use aya_log_common::{DisplayHint, Level, LOG_BUF_CAPACITY};
+    pub use aya_log_common::{
+        check_impl_default, check_impl_ipv4, check_impl_ipv6, check_impl_lower_hex,
+        check_impl_lower_mac, check_impl_upper_hex, check_impl_upper_mac, DefaultFormatter,
+        DisplayHint, Ipv4Formatter, Ipv6Formatter, Level, LowerHexFormatter, LowerMacFormatter,
+        UpperHexFormatter, UpperMacFormatter, LOG_BUF_CAPACITY,
+    };
     pub use aya_log_ebpf_macros::log;
 }


### PR DESCRIPTION
Fix https://github.com/aya-rs/aya/issues/513

Currently, we are not checking in the log macro if a parameter can be formatted using a specific type of format, which can lead to a runtime panic. This PR implements validation logic in proc macro.

This will add the following code in the generated code:

![2023-05-18_13-48](https://github.com/aya-rs/aya/assets/9482395/eb77788c-a577-42a8-acd9-cce40dd41373)

This is a function that checks the type bound, and the function body is empty. When built with a release level optimization, e.g. `opt-level=3`, it will be optimized out.


Some tests

```Rust
unsafe fn try_xdp_hello(ctx: XdpContext) -> Result<u32, u32> {
    // test default formatter
    info!(&ctx, "test default formatter");
    info!(&ctx, "i8 {}", 8);
    info!(&ctx, "i16 {}", 16);
    info!(&ctx, "i32 {}", 32);
    info!(&ctx, "i64 {}", 64);
    info!(&ctx, "isize {}", 128);

    info!(&ctx, "u8 {}", 8);
    info!(&ctx, "u16 {}", 16);
    info!(&ctx, "u32 {}", 32);
    info!(&ctx, "u64 {}", 64);
    info!(&ctx, "usize {}", 128);

    info!(&ctx, "str {}", "hello");

    // test lowerhex
    info!(&ctx, "test lowerhex formatter");
    info!(&ctx, "i8 {:x}", 8);
    info!(&ctx, "i16 {:x}", 16);
    info!(&ctx, "i32 {:x}", 32);
    info!(&ctx, "i64 {:x}", 64);
    info!(&ctx, "isize {:x}", 128);

    info!(&ctx, "u8 {:x}", 8);
    info!(&ctx, "u16 {:x}", 16);
    info!(&ctx, "u32 {:x}", 32);
    info!(&ctx, "u64 {:x}", 64);
    info!(&ctx, "usize {:x}", 128);

    info!(&ctx, "slice: {:x}", [1u8; 4].as_slice());

    // test upperhex
    info!(&ctx, "test upperhex formatter");
    info!(&ctx, "i8 {:X}", 8);
    info!(&ctx, "i16 {:X}", 16);
    info!(&ctx, "i32 {:X}", 32);
    info!(&ctx, "i64 {:X}", 64);
    info!(&ctx, "isize {:X}", 128);

    info!(&ctx, "u8 {:X}", 8);
    info!(&ctx, "u16 {:X}", 16);
    info!(&ctx, "u32 {:X}", 32);
    info!(&ctx, "u64 {:X}", 64);
    info!(&ctx, "usize {:X}", 128);

    info!(&ctx, "slice: {:X}", [1u8; 4].as_slice());

    info!(&ctx, "test ipv4 formatter");
    info!(&ctx, "received a packet: {:ipv4}", 0u32);

    info!(&ctx, "test ipv6 formatter");
    info!(&ctx, "received a packet: {:ipv6}", [0u8; 16]);

    info!(&ctx, "received a packet: {:mac}", [0u8; 6]);
    info!(&ctx, "received a packet: {:MAC}", [0u8; 6]);

    // comments are some invalid case
    // info!(&ctx, "received a packet: {}", [0_u8; 6]);
    // info!(&ctx, "received a packet: {:ipv6}", 10);
    // info!(&ctx, "received a packet: {:x}", "AAAAAA");
    Ok(xdp_action::XDP_PASS)
}


```

