### PR TITLE
clippy: clean useless `any` in cfg

### DIFF
--- a/aya/src/maps/perf/async_perf_event_array.rs
+++ b/aya/src/maps/perf/async_perf_event_array.rs
@@ -137,7 +137,7 @@ pub struct AsyncPerfEventArrayBuffer<T> {
     async_fd: Async<RawFd>,
 }
 
-#[cfg(any(feature = "async_tokio"))]
+#[cfg(feature = "async_tokio")]
 impl<T: BorrowMut<MapData> + Borrow<MapData>> AsyncPerfEventArrayBuffer<T> {
     /// Reads events from the buffer.
     ///

--- a/aya/src/maps/perf/mod.rs
+++ b/aya/src/maps/perf/mod.rs
@@ -1,13 +1,13 @@
 //! Ring buffer types used to receive events from eBPF programs using the linux `perf` API.
 //!
 //! See the [`PerfEventArray`](crate::maps::PerfEventArray) and [`AsyncPerfEventArray`](crate::maps::perf::AsyncPerfEventArray).
-#[cfg(any(feature = "async"))]
+#[cfg(feature = "async")]
 #[cfg_attr(docsrs, doc(cfg(feature = "async")))]
 mod async_perf_event_array;
 mod perf_buffer;
 mod perf_event_array;
 
-#[cfg(any(feature = "async"))]
+#[cfg(feature = "async")]
 #[cfg_attr(docsrs, doc(cfg(feature = "async")))]
 pub use async_perf_event_array::*;
 pub use perf_buffer::*;

--- a/bpf/aya-bpf-cty/src/lib.rs
+++ b/bpf/aya-bpf-cty/src/lib.rs
@@ -15,7 +15,7 @@ pub use od::*;
 // PWD = Pointer Width Dependent
 pub use pwd::*;
 
-#[cfg(any(target_arch = "bpf"))]
+#[cfg(target_arch = "bpf")]
 mod ad {
     pub type c_int = i32;
     pub type c_uint = u32;


### PR DESCRIPTION
New lint rules is add in https://github.com/rust-lang/rust-clippy/pull/10763.