### PR TITLE
Fix load errors for empty (but existent) BTF/BTF.ext sections

### DIFF
--- a/aya-obj/src/btf/btf.rs
+++ b/aya-obj/src/btf/btf.rs
@@ -210,6 +210,11 @@ impl Btf {
         }
     }
 
+    pub(crate) fn is_empty(&self) -> bool {
+        // the first one is awlays BtfType::Unknown
+        self.types.types.len() < 2
+    }
+
     pub(crate) fn types(&self) -> impl Iterator<Item = &BtfType> {
         self.types.types.iter()
     }
@@ -628,7 +633,10 @@ impl Object {
         &mut self,
         features: &BtfFeatures,
     ) -> Result<Option<&Btf>, BtfError> {
-        if let Some(ref mut obj_btf) = self.btf {
+        if let Some(ref mut obj_btf) = &mut self.btf {
+            if obj_btf.is_empty() {
+                return Ok(None);
+            }
             // fixup btf
             obj_btf.fixup_and_sanitize(
                 &self.section_sizes,

--- a/aya-obj/src/btf/btf.rs
+++ b/aya-obj/src/btf/btf.rs
@@ -712,10 +712,13 @@ impl BtfExt {
             // BTF.ext sections
             let mut header = std::mem::MaybeUninit::<btf_ext_header>::zeroed();
             // Safety: we have checked that len_to_read is less than
-            // size_of::<btf_ext_header> and less than data.len()
-            unsafe { std::ptr::copy(data.as_ptr(), header.as_mut_ptr() as *mut u8, len_to_read) };
-            // Safety: the header began initialized to zero (and we rewrote some of its initla bytes)
-            unsafe { header.assume_init() }
+            // size_of::<btf_ext_header> and less than
+            // data.len(). Additionally, we know that the header has
+            // been initialized so it's safe to call for assume_init.
+            unsafe {
+                std::ptr::copy(data.as_ptr(), header.as_mut_ptr() as *mut u8, len_to_read);
+                header.assume_init()
+            }
         };
 
         let btf_ext_header {

--- a/aya-obj/src/btf/btf.rs
+++ b/aya-obj/src/btf/btf.rs
@@ -1083,6 +1083,21 @@ mod tests {
     }
 
     #[test]
+    fn parsing_older_ext_data() {
+        let btf_data = [
+            159, 235, 1, 0, 24, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0,
+        ];
+        let btf_ext_data = [
+            159, 235, 1, 0, 24, 0, 0, 0, 0, 0, 0, 0, 4, 0, 0, 0, 4, 0, 0, 0, 4, 0, 0, 0, 8, 0, 0,
+            0, 16, 0, 0, 0,
+        ];
+        let btf = Btf::parse(&btf_data, Endianness::default()).unwrap();
+        let btf_ext = BtfExt::parse(&btf_ext_data, Endianness::default(), &btf).unwrap();
+        assert_eq!(btf_ext.func_info_rec_size(), 8);
+        assert_eq!(btf_ext.line_info_rec_size(), 16);
+    }
+
+    #[test]
     fn test_write_btf() {
         let mut btf = Btf::new();
         let name_offset = btf.add_string("int".to_string());

--- a/aya-obj/src/btf/btf.rs
+++ b/aya-obj/src/btf/btf.rs
@@ -681,7 +681,7 @@ impl BtfExt {
             pub magic: u16,
             pub version: u8,
             pub flags: u8,
-            pub hdr_len: i32,
+            pub hdr_len: u32,
         }
 
         if data.len() < std::mem::size_of::<MinimalHeader>() {

--- a/aya-obj/src/obj.rs
+++ b/aya-obj/src/obj.rs
@@ -1635,6 +1635,31 @@ mod tests {
     }
 
     #[test]
+    fn sanitizes_empty_btf_files_to_none() {
+        let mut obj = fake_obj();
+        obj.parse_section(fake_section(
+            BpfSectionKind::Btf,
+            ".BTF",
+            &[
+                159, 235, 1, 0, 24, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0,
+            ],
+        ))
+        .unwrap();
+        obj.parse_section(fake_section(
+            BpfSectionKind::BtfExt,
+            ".BTF.ext",
+            &[
+                159, 235, 1, 0, 24, 0, 0, 0, 0, 0, 0, 0, 4, 0, 0, 0, 4, 0, 0, 0, 4, 0, 0, 0, 8, 0,
+                0, 0, 16, 0, 0, 0,
+            ],
+        ))
+        .unwrap();
+
+        let btf = obj.fixup_and_sanitize_btf(&BtfFeatures::default()).unwrap();
+        assert!(btf.is_none());
+    }
+
+    #[test]
     fn test_parse_program_error() {
         let obj = fake_obj();
 


### PR DESCRIPTION
Compiling a program using an older version of clang (tested w/ clang 8) for a non-CORE program creates a `.BTF` and a `.BTF.ext` section that aya fails to load.

* `.BTF.ext` error: the `.BTF.ext` section is from an older header and `aya` isn't checking the `hdr_len` and instead assumes that the size of its pregenerated struct will work no matter what. This PR fixes this by first loading the data into a "minimal header" and then only loads as much data into the full fledged header as it is allowed to per the spec. 
* `.BTF` error: The created section has no types which returns an error at load type saying "type not found". This PR uses the existing "sanitize" method to check if there are any types and if not then it skips the load of the `.BTF` section as there is no gain in trying to load it. 