### PR TITLE
aya-log-ebpf-macros: fix compile errors

### DIFF
--- a/aya-log-common/src/lib.rs
+++ b/aya-log-common/src/lib.rs
@@ -74,12 +74,10 @@ impl_formatter_for_types!(
     }
 );
 
-pub trait Ipv4Formatter {}
-impl Ipv4Formatter for u32 {}
-
-pub trait Ipv6Formatter {}
-impl Ipv6Formatter for [u8; 16] {}
-impl Ipv6Formatter for [u16; 8] {}
+pub trait IpFormatter {}
+impl IpFormatter for u32 {}
+impl IpFormatter for [u8; 16] {}
+impl IpFormatter for [u16; 8] {}
 
 pub trait LowerMacFormatter {}
 impl LowerMacFormatter for [u8; 6] {}
@@ -94,9 +92,7 @@ pub fn check_impl_lower_hex<T: LowerHexFormatter>(_v: T) {}
 #[inline(always)]
 pub fn check_impl_upper_hex<T: UpperHexFormatter>(_v: T) {}
 #[inline(always)]
-pub fn check_impl_ipv4<T: Ipv4Formatter>(_v: T) {}
-#[inline(always)]
-pub fn check_impl_ipv6<T: Ipv6Formatter>(_v: T) {}
+pub fn check_impl_ip<T: IpFormatter>(_v: T) {}
 #[inline(always)]
 pub fn check_impl_lower_mac<T: LowerMacFormatter>(_v: T) {}
 #[inline(always)]

--- a/aya-log-ebpf-macros/src/expand.rs
+++ b/aya-log-ebpf-macros/src/expand.rs
@@ -90,8 +90,7 @@ fn hint_to_format_check(hint: DisplayHint) -> Result<Expr> {
         DisplayHint::Default => parse_str("::aya_log_ebpf::macro_support::check_impl_default"),
         DisplayHint::LowerHex => parse_str("::aya_log_ebpf::macro_support::check_impl_lower_hex"),
         DisplayHint::UpperHex => parse_str("::aya_log_ebpf::macro_support::check_impl_upper_hex"),
-        DisplayHint::Ipv4 => parse_str("::aya_log_ebpf::macro_support::check_impl_ipv4"),
-        DisplayHint::Ipv6 => parse_str("::aya_log_ebpf::macro_support::check_impl_ipv6"),
+        DisplayHint::Ip => parse_str("::aya_log_ebpf::macro_support::check_impl_ip"),
         DisplayHint::LowerMac => parse_str("::aya_log_ebpf::macro_support::check_impl_lower_mac"),
         DisplayHint::UpperMac => parse_str("::aya_log_ebpf::macro_support::check_impl_upper_mac"),
     }

--- a/bpf/aya-log-ebpf/src/lib.rs
+++ b/bpf/aya-log-ebpf/src/lib.rs
@@ -23,10 +23,10 @@ pub static mut AYA_LOGS: PerfEventByteArray = PerfEventByteArray::new(0);
 #[doc(hidden)]
 pub mod macro_support {
     pub use aya_log_common::{
-        check_impl_default, check_impl_ipv4, check_impl_ipv6, check_impl_lower_hex,
-        check_impl_lower_mac, check_impl_upper_hex, check_impl_upper_mac, DefaultFormatter,
-        DisplayHint, Ipv4Formatter, Ipv6Formatter, Level, LowerHexFormatter, LowerMacFormatter,
-        UpperHexFormatter, UpperMacFormatter, LOG_BUF_CAPACITY,
+        check_impl_default, check_impl_ip, check_impl_lower_hex, check_impl_lower_mac,
+        check_impl_upper_hex, check_impl_upper_mac, DefaultFormatter, DisplayHint, IpFormatter,
+        Level, LowerHexFormatter, LowerMacFormatter, UpperHexFormatter, UpperMacFormatter,
+        LOG_BUF_CAPACITY,
     };
     pub use aya_log_ebpf_macros::log;
 }


### PR DESCRIPTION
aya-log-ebpf-macros was failing to compile because it was referencing a couple of `DisplayHint` variants that no longer exist. These were removed in #599.

```
    Compiling aya-log-ebpf-macros v0.1.0 (/home/robert/aya/aya-log-ebpf-macros)
error[E0599]: no variant or associated item named `Ipv4` found for enum `DisplayHint` in the current scope
  --> aya-log-ebpf-macros/src/expand.rs:93:22
   |
93 |         DisplayHint::Ipv4 => parse_str("::aya_log_ebpf::macro_support::check_impl_ipv4"),
   |                      ^^^^ variant or associated item not found in `DisplayHint`

error[E0599]: no variant or associated item named `Ipv6` found for enum `DisplayHint` in the current scope
  --> aya-log-ebpf-macros/src/expand.rs:94:22
   |
94 |         DisplayHint::Ipv6 => parse_str("::aya_log_ebpf::macro_support::check_impl_ipv6"),
   |                      ^^^^ variant or associated item not found in `DisplayHint`

For more information about this error, try `rustc --explain E0599`.
```