### PR TITLE
github: update Swatinem/rust-cache@{v1,v2}

### DIFF
--- a/.github/workflows/build-aya-bpf.yml
+++ b/.github/workflows/build-aya-bpf.yml
@@ -33,7 +33,7 @@ jobs:
           toolchain: nightly
           components: rust-src
 
-      - uses: Swatinem/rust-cache@v1
+      - uses: Swatinem/rust-cache@v2
 
       - name: Prereqs
         run: cargo install bpf-linker

--- a/.github/workflows/build-aya.yml
+++ b/.github/workflows/build-aya.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Check
         run: cargo hack check --all-targets --feature-powerset --ignore-private
 
-      - uses: Swatinem/rust-cache@v1
+      - uses: Swatinem/rust-cache@v2
       - name: Prereqs
         run: cargo install cross --git https://github.com/cross-rs/cross
 

--- a/.github/workflows/gen.yml
+++ b/.github/workflows/gen.yml
@@ -23,7 +23,7 @@ jobs:
           toolchain: nightly
           components: rustfmt, clippy
 
-      - uses: Swatinem/rust-cache@v1
+      - uses: Swatinem/rust-cache@v2
 
       - name: Install headers
         run: |


### PR DESCRIPTION
I don't understand why, but dependabot isn't updating this. See
https://github.com/dependabot/dependabot-core/issues/7384.
