### PR TITLE
bpf: Add `pt_regs` handling in aya-bpf/args.rs for riscv64

### DIFF
--- a/.github/workflows/build-aya-bpf.yml
+++ b/.github/workflows/build-aya-bpf.yml
@@ -21,8 +21,7 @@ jobs:
           - x86_64
           - aarch64
           - arm
-          # Disable riscv64 due to missing pt_regs handling in aya-bpf/args.rs
-          # - riscv64
+          - riscv64
     runs-on: ubuntu-20.04
 
     steps:

--- a/bpf/aya-bpf-cty/src/lib.rs
+++ b/bpf/aya-bpf-cty/src/lib.rs
@@ -26,6 +26,9 @@ mod ad {
     #[cfg(bpf_target_arch = "aarch64")]
     pub type c_char = super::c_uchar;
 
+    #[cfg(bpf_target_arch = "riscv64")]
+    pub type c_char = super::c_uchar;
+
     #[cfg(any(bpf_target_arch = "x86", bpf_target_arch = "x86_64"))]
     pub type c_char = super::c_schar;
 

--- a/bpf/aya-bpf/src/programs/probe.rs
+++ b/bpf/aya-bpf/src/programs/probe.rs
@@ -2,11 +2,14 @@ use core::ffi::c_void;
 
 use crate::{args::FromPtRegs, BpfContext};
 
-// aarch64 uses user_pt_regs instead of pt_regs
-#[cfg(not(bpf_target_arch = "aarch64"))]
+#[cfg(not(any(bpf_target_arch = "aarch64", bpf_target_arch = "riscv64")))]
 use crate::bindings::pt_regs;
+
 #[cfg(bpf_target_arch = "aarch64")]
 use crate::bindings::user_pt_regs as pt_regs;
+
+#[cfg(bpf_target_arch = "riscv64")]
+use crate::bindings::user_regs_struct as pt_regs;
 
 pub struct ProbeContext {
     pub regs: *mut pt_regs,


### PR DESCRIPTION
This patch introduces `pt_regs` handling in aya-bpf/args.rs for
the riscv64 architecture. The current CI is disabled for riscv64
because this implementation is missing.