### PR TITLE
aya: Implement .kconfig support

### DIFF
--- a/aya-obj/src/btf/types.rs
+++ b/aya-obj/src/btf/types.rs
@@ -1112,9 +1112,13 @@ impl BtfType {
             BtfType::Struct(t) => Some(t.size),
             BtfType::Union(t) => Some(t.size),
             BtfType::DataSec(t) => Some(t.size),
-            BtfType::Ptr(_) => Some(mem::size_of::<&()>() as u32),
+            BtfType::Ptr(_) => Some(Self::ptr_size()),
             _ => None,
         }
+    }
+
+    pub(crate) fn ptr_size() -> u32 {
+        mem::size_of::<&()>() as u32
     }
 
     pub(crate) fn btf_type(&self) -> Option<u32> {

--- a/aya-obj/src/obj.rs
+++ b/aya-obj/src/obj.rs
@@ -47,6 +47,7 @@ pub struct Features {
     bpf_perf_link: bool,
     bpf_global_data: bool,
     bpf_cookie: bool,
+    bpf_syscall_wrapper: bool,
     btf: Option<BtfFeatures>,
 }
 
@@ -58,6 +59,7 @@ impl Features {
         bpf_perf_link: bool,
         bpf_global_data: bool,
         bpf_cookie: bool,
+        bpf_syscall_wrapper: bool,
         btf: Option<BtfFeatures>,
     ) -> Self {
         Self {
@@ -66,6 +68,7 @@ impl Features {
             bpf_perf_link,
             bpf_global_data,
             bpf_cookie,
+            bpf_syscall_wrapper,
             btf,
         }
     }
@@ -93,6 +96,11 @@ impl Features {
     /// Returns whether BPF program cookie is supported.
     pub fn bpf_cookie(&self) -> bool {
         self.bpf_cookie
+    }
+
+    /// Returns whether BPF syscall wrapper hooking is supported.
+    pub fn bpf_syscall_wrapper(&self) -> bool {
+        self.bpf_syscall_wrapper
     }
 
     /// If BTF is supported, returns which BTF features are supported.
@@ -598,6 +606,8 @@ impl Object {
                     address: symbol.address(),
                     size: symbol.size(),
                     is_definition: symbol.is_definition(),
+                    is_external: symbol.is_undefined() && (symbol.is_global() || symbol.is_weak()),
+                    is_weak: symbol.is_weak(),
                     kind: symbol.kind(),
                 };
                 bpf_obj.symbol_table.insert(symbol.index().0, sym);
@@ -1525,6 +1535,8 @@ mod tests {
                 address,
                 size,
                 is_definition: false,
+                is_external: false,
+                is_weak: false,
                 kind: SymbolKind::Data,
             },
         );
@@ -2371,6 +2383,8 @@ mod tests {
                 address: 0,
                 size: 3,
                 is_definition: true,
+                is_external: false,
+                is_weak: false,
                 kind: SymbolKind::Data,
             },
         );

--- a/aya-obj/src/relocation.rs
+++ b/aya-obj/src/relocation.rs
@@ -109,6 +109,8 @@ pub(crate) struct Symbol {
     pub(crate) address: u64,
     pub(crate) size: u64,
     pub(crate) is_definition: bool,
+    pub(crate) is_external: bool,
+    pub(crate) is_weak: bool,
     pub(crate) kind: SymbolKind,
 }
 
@@ -226,7 +228,9 @@ fn relocate_maps<'a, I: Iterator<Item = &'a Relocation>>(
         };
 
         // calls and relocation to .text symbols are handled in a separate step
-        if insn_is_call(&instructions[ins_index]) || text_sections.contains(&section_index) {
+        if insn_is_call(&instructions[ins_index])
+            || (text_sections.contains(&section_index) && !sym.is_external)
+        {
             continue;
         }
 
@@ -380,10 +384,11 @@ impl<'a> FunctionLinker<'a> {
                     // only consider text relocations, data relocations are
                     // relocated in relocate_maps()
                     sym.kind == SymbolKind::Text
-                        || sym
-                            .section_index
-                            .map(|section_index| self.text_sections.contains(&section_index))
-                            .unwrap_or(false)
+                        || (!sym.is_external
+                            && sym
+                                .section_index
+                                .map(|section_index| self.text_sections.contains(&section_index))
+                                .unwrap_or(false))
                 });
 
             // not a call and not a text relocation, we don't need to do anything
@@ -527,6 +532,8 @@ mod test {
             address,
             size,
             is_definition: false,
+            is_external: false,
+            is_weak: false,
             kind: SymbolKind::Data,
         }
     }

--- a/aya/Cargo.toml
+++ b/aya/Cargo.toml
@@ -32,6 +32,7 @@ tokio = { version = "1.24.0", features = [
     "rt-multi-thread",
     "net",
 ], optional = true }
+flate2 = "1.0"
 
 [dev-dependencies]
 futures = { version = "0.3.12", default-features = false, features = ["std"] }

--- a/aya/src/programs/mod.rs
+++ b/aya/src/programs/mod.rs
@@ -50,7 +50,7 @@ pub mod lirc_mode2;
 pub mod lsm;
 pub mod perf_attach;
 pub mod perf_event;
-mod probe;
+pub(crate) mod probe;
 mod raw_trace_point;
 mod sk_lookup;
 mod sk_msg;

--- a/aya/src/programs/probe.rs
+++ b/aya/src/programs/probe.rs
@@ -81,7 +81,7 @@ pub(crate) fn detach_debug_fs(kind: ProbeKind, event_alias: &str) -> Result<(), 
     Ok(())
 }
 
-fn create_as_probe(
+pub(crate) fn create_as_probe(
     kind: ProbeKind,
     fn_name: &str,
     offset: u64,

--- a/aya/src/sys/mod.rs
+++ b/aya/src/sys/mod.rs
@@ -64,3 +64,26 @@ fn syscall(call: Syscall) -> SysResult {
         ret => Err((ret, io::Error::last_os_error())),
     }
 }
+
+#[cfg(test)]
+pub(crate) fn kernel_release() -> Result<String, ()> {
+    Ok("unknown".to_string())
+}
+
+#[cfg(not(test))]
+pub(crate) fn kernel_release() -> Result<String, ()> {
+    use std::ffi::CStr;
+
+    use libc::utsname;
+
+    unsafe {
+        let mut v = mem::zeroed::<utsname>();
+        if libc::uname(&mut v as *mut _) != 0 {
+            return Err(());
+        }
+
+        let release = CStr::from_ptr(v.release.as_ptr());
+
+        Ok(release.to_string_lossy().into_owned())
+    }
+}

--- a/aya/src/util.rs
+++ b/aya/src/util.rs
@@ -20,9 +20,12 @@ use libc::{if_nametoindex, sysconf, uname, utsname, _SC_PAGESIZE};
 // Adapted from https://docs.rs/procfs/latest/procfs/sys/kernel/struct.Version.html.
 #[derive(Debug, Copy, Clone, Eq, PartialEq, PartialOrd)]
 pub struct KernelVersion {
-    pub(crate) major: u8,
-    pub(crate) minor: u8,
-    pub(crate) patch: u16,
+    /// Major version.
+    pub major: u8,
+    /// Minor version.
+    pub minor: u8,
+    /// Patch version.
+    pub patch: u16,
 }
 
 /// An error encountered while fetching the current kernel version.

--- a/test/integration-test/bpf/kconfig.bpf.c
+++ b/test/integration-test/bpf/kconfig.bpf.c
@@ -1,0 +1,16 @@
+#include <linux/bpf.h>
+#include <bpf/bpf_helpers.h>
+
+extern unsigned int CONFIG_BPF __kconfig;
+
+SEC("xdp/pass")
+int xdp_pass(struct xdp_md *ctx)
+{
+    if (!CONFIG_BPF) {
+        return XDP_DROP;
+    }
+
+    return XDP_PASS;
+}
+
+char _license[] SEC("license") = "GPL";

--- a/test/integration-test/build.rs
+++ b/test/integration-test/build.rs
@@ -44,6 +44,7 @@ fn main() {
         ("main.bpf.c", "main.bpf.o"),
         ("multimap-btf.bpf.c", "multimap-btf.bpf.o"),
         ("text_64_64_reloc.c", "text_64_64_reloc.o"),
+        ("kconfig.bpf.c", "kconfig.bpf.o"),
     ];
 
     let c_bpf_probes = C_BPF_PROBES

--- a/test/integration-test/src/lib.rs
+++ b/test/integration-test/src/lib.rs
@@ -6,6 +6,7 @@ pub const MULTIMAP_BTF: &[u8] =
     include_bytes_aligned!(concat!(env!("OUT_DIR"), "/multimap-btf.bpf.o"));
 pub const TEXT_64_64_RELOC: &[u8] =
     include_bytes_aligned!(concat!(env!("OUT_DIR"), "/text_64_64_reloc.o"));
+pub const KCONFIG: &[u8] = include_bytes_aligned!(concat!(env!("OUT_DIR"), "/kconfig.bpf.o"));
 
 pub const LOG: &[u8] = include_bytes_aligned!(concat!(env!("OUT_DIR"), "/log"));
 pub const MAP_TEST: &[u8] = include_bytes_aligned!(concat!(env!("OUT_DIR"), "/map_test"));

--- a/test/integration-test/src/tests/smoke.rs
+++ b/test/integration-test/src/tests/smoke.rs
@@ -34,3 +34,16 @@ fn extension() {
     let drop_: &mut Extension = bpf.program_mut("drop").unwrap().try_into().unwrap();
     drop_.load(pass.fd().unwrap(), "xdp_pass").unwrap();
 }
+
+#[test]
+fn kconfig() {
+    let kernel_version = KernelVersion::current().unwrap();
+    if kernel_version < KernelVersion::new(5, 9, 0) {
+        eprintln!("skipping test on kernel {kernel_version:?}, XDP uses netlink");
+        return;
+    }
+    let mut bpf = Bpf::load(crate::KCONFIG).unwrap();
+    let pass: &mut Xdp = bpf.program_mut("pass").unwrap().try_into().unwrap();
+    pass.load().unwrap();
+    pass.attach("lo", XdpFlags::default()).unwrap();
+}


### PR DESCRIPTION
Implement support for external data symbols (kconfig) following libbpf logic.