### PR TITLE
Remove procfs dependency

### DIFF
--- a/aya-obj/src/btf/btf.rs
+++ b/aya-obj/src/btf/btf.rs
@@ -135,7 +135,7 @@ pub enum BtfError {
         #[source]
         io_error: std::io::Error,
         /// The error log produced by the kernel verifier.
-        verifier_log: Cow<'static, str>,
+        verifier_log: String,
     },
 
     /// offset not found for symbol

--- a/aya/Cargo.toml
+++ b/aya/Cargo.toml
@@ -24,6 +24,7 @@ object = { version = "0.31", default-features = false, features = [
     "elf",
 ] }
 parking_lot = { version = "0.12.0", features = ["send_guard"] }
+text_io = "0.1.12"
 thiserror = "1"
 tokio = { version = "1.24.0", features = [
     "macros",

--- a/aya/Cargo.toml
+++ b/aya/Cargo.toml
@@ -31,7 +31,6 @@ tokio = { version = "1.24.0", features = [
     "rt-multi-thread",
     "net",
 ], optional = true }
-procfs = { version = "0.15.1", default-features = false }
 
 [dev-dependencies]
 futures = { version = "0.3.12", default-features = false, features = ["std"] }

--- a/aya/src/maps/mod.rs
+++ b/aya/src/maps/mod.rs
@@ -47,9 +47,9 @@ use std::{
     ptr,
 };
 
+use crate::util::KernelVersion;
 use libc::{getrlimit, rlimit, RLIMIT_MEMLOCK, RLIM_INFINITY};
 use log::warn;
-use procfs::KernelVersion;
 use thiserror::Error;
 
 use crate::{

--- a/aya/src/programs/cgroup_device.rs
+++ b/aya/src/programs/cgroup_device.rs
@@ -1,6 +1,6 @@
 //! Cgroup device programs.
 
-use procfs::KernelVersion;
+use crate::util::KernelVersion;
 use std::os::fd::{AsRawFd, RawFd};
 
 use crate::{

--- a/aya/src/programs/cgroup_skb.rs
+++ b/aya/src/programs/cgroup_skb.rs
@@ -1,6 +1,6 @@
 //! Cgroup skb programs.
 
-use procfs::KernelVersion;
+use crate::util::KernelVersion;
 use std::{
     hash::Hash,
     os::fd::{AsRawFd, RawFd},

--- a/aya/src/programs/cgroup_sock.rs
+++ b/aya/src/programs/cgroup_sock.rs
@@ -2,7 +2,7 @@
 
 pub use aya_obj::programs::CgroupSockAttachType;
 
-use procfs::KernelVersion;
+use crate::util::KernelVersion;
 use std::{
     hash::Hash,
     os::fd::{AsRawFd, RawFd},

--- a/aya/src/programs/cgroup_sock_addr.rs
+++ b/aya/src/programs/cgroup_sock_addr.rs
@@ -2,7 +2,7 @@
 
 pub use aya_obj::programs::CgroupSockAddrAttachType;
 
-use procfs::KernelVersion;
+use crate::util::KernelVersion;
 use std::{
     hash::Hash,
     os::fd::{AsRawFd, RawFd},

--- a/aya/src/programs/cgroup_sockopt.rs
+++ b/aya/src/programs/cgroup_sockopt.rs
@@ -2,7 +2,7 @@
 
 pub use aya_obj::programs::CgroupSockoptAttachType;
 
-use procfs::KernelVersion;
+use crate::util::KernelVersion;
 use std::{
     hash::Hash,
     os::fd::{AsRawFd, RawFd},

--- a/aya/src/programs/cgroup_sysctl.rs
+++ b/aya/src/programs/cgroup_sysctl.rs
@@ -1,6 +1,6 @@
 //! Cgroup sysctl programs.
 
-use procfs::KernelVersion;
+use crate::util::KernelVersion;
 use std::{
     hash::Hash,
     os::fd::{AsRawFd, RawFd},

--- a/aya/src/programs/mod.rs
+++ b/aya/src/programs/mod.rs
@@ -67,7 +67,6 @@ pub mod xdp;
 use libc::ENOSPC;
 use procfs::KernelVersion;
 use std::{
-    borrow::Cow,
     ffi::CString,
     io,
     os::unix::io::{AsRawFd, RawFd},
@@ -143,7 +142,7 @@ pub enum ProgramError {
         #[source]
         io_error: io::Error,
         /// The error log produced by the kernel verifier.
-        verifier_log: Cow<'static, str>,
+        verifier_log: String,
     },
 
     /// A syscall failed.

--- a/aya/src/programs/mod.rs
+++ b/aya/src/programs/mod.rs
@@ -64,8 +64,8 @@ pub mod uprobe;
 mod utils;
 pub mod xdp;
 
+use crate::util::KernelVersion;
 use libc::ENOSPC;
-use procfs::KernelVersion;
 use std::{
     ffi::CString,
     io,

--- a/aya/src/programs/probe.rs
+++ b/aya/src/programs/probe.rs
@@ -50,7 +50,7 @@ pub(crate) fn attach<T: Link + From<PerfLinkInner>>(
 ) -> Result<T::Id, ProgramError> {
     // https://github.com/torvalds/linux/commit/e12f03d7031a977356e3d7b75a68c2185ff8d155
     // Use debugfs to create probe
-    if KernelVersion::current().unwrap() >= KernelVersion::new(4, 17, 0) {
+    if KernelVersion::current().unwrap() < KernelVersion::new(4, 17, 0) {
         let (fd, event_alias) = create_as_trace_point(kind, fn_name, offset, pid)?;
         let link = T::from(perf_attach_debugfs(
             program_data.fd_or_err()?,

--- a/aya/src/programs/probe.rs
+++ b/aya/src/programs/probe.rs
@@ -1,5 +1,5 @@
+use crate::util::KernelVersion;
 use libc::pid_t;
-use procfs::KernelVersion;
 use std::{
     fs::{self, OpenOptions},
     io::{self, Write},

--- a/aya/src/programs/xdp.rs
+++ b/aya/src/programs/xdp.rs
@@ -1,8 +1,8 @@
 //! eXpress Data Path (XDP) programs.
 
+use crate::util::KernelVersion;
 use bitflags;
 use libc::if_nametoindex;
-use procfs::KernelVersion;
 use std::{convert::TryFrom, ffi::CString, hash::Hash, io, mem, os::unix::io::RawFd};
 use thiserror::Error;
 

--- a/aya/src/sys/bpf.rs
+++ b/aya/src/sys/bpf.rs
@@ -7,12 +7,12 @@ use std::{
     slice,
 };
 
+use crate::util::KernelVersion;
 use libc::{c_char, c_long, close, ENOENT, ENOSPC};
 use obj::{
     maps::{bpf_map_def, LegacyMap},
     BpfSectionKind,
 };
-use procfs::KernelVersion;
 
 use crate::{
     generated::{

--- a/test/integration-test/Cargo.toml
+++ b/test/integration-test/Cargo.toml
@@ -12,7 +12,6 @@ aya-obj = { path = "../../aya-obj" }
 libc = { version = "0.2.105" }
 log = "0.4"
 object = { version = "0.31", default-features = false, features = ["std", "read_core", "elf"] }
-procfs = "0.15.1"
 rbpf = "0.2.0"
 tempfile = "3.3.0"
 tokio = { version = "1.24", features = ["rt", "rt-multi-thread", "sync", "time"] }

--- a/test/integration-test/tests/btf_relocations.rs
+++ b/test/integration-test/tests/btf_relocations.rs
@@ -1,9 +1,8 @@
 use anyhow::{bail, Context as _, Result};
-use procfs::KernelVersion;
 use std::{path::PathBuf, process::Command, thread::sleep, time::Duration};
 use tempfile::TempDir;
 
-use aya::{maps::Array, programs::TracePoint, BpfLoader, Btf, Endianness};
+use aya::{maps::Array, programs::TracePoint, util::KernelVersion, BpfLoader, Btf, Endianness};
 
 // In the tests below we often use values like 0xAAAAAAAA or -0x7AAAAAAA. Those values have no
 // special meaning, they just have "nice" bit patterns that can be helpful while debugging.

--- a/test/integration-test/tests/load.rs
+++ b/test/integration-test/tests/load.rs
@@ -1,4 +1,3 @@
-use procfs::KernelVersion;
 use std::{convert::TryInto as _, thread, time};
 
 use aya::{
@@ -8,6 +7,7 @@ use aya::{
         links::{FdLink, PinnedLink},
         loaded_programs, KProbe, TracePoint, Xdp, XdpFlags,
     },
+    util::KernelVersion,
     Bpf,
 };
 

--- a/test/integration-test/tests/smoke.rs
+++ b/test/integration-test/tests/smoke.rs
@@ -1,8 +1,7 @@
-use procfs::KernelVersion;
-
 use aya::{
     include_bytes_aligned,
     programs::{Extension, Xdp, XdpFlags},
+    util::KernelVersion,
     Bpf, BpfLoader,
 };
 


### PR DESCRIPTION
- Remove verifier log special case
- Remove procfs dependency
- Rewrite kernel version logic

This restores and enhances the logic originally added in #579.