### PR TITLE
Use procfs crate commit import a bug: kernel vesion must be smaller t…

### DIFF
--- a/aya/src/programs/probe.rs
+++ b/aya/src/programs/probe.rs
@@ -50,7 +50,7 @@ pub(crate) fn attach<T: Link + From<PerfLinkInner>>(
 ) -> Result<T::Id, ProgramError> {
     // https://github.com/torvalds/linux/commit/e12f03d7031a977356e3d7b75a68c2185ff8d155
     // Use debugfs to create probe
-    if KernelVersion::current().unwrap() >= KernelVersion::new(4, 17, 0) {
+    if KernelVersion::current().unwrap() < KernelVersion::new(4, 17, 0) {
         let (fd, event_alias) = create_as_trace_point(kind, fn_name, offset, pid)?;
         let link = T::from(perf_attach_debugfs(
             program_data.fd_or_err()?,


### PR DESCRIPTION
In this commit : [Use procfs crate for kernel version parsing](https://github.com/aya-rs/aya/commit/b611038d5b41a45ca70553550dbdef9aa1fd117c)

Before this commit, in probe.rs, the code is  k_ver < 4.17.0
```
    let k_ver = kernel_version().unwrap();
    if k_ver < (4, 17, 0) {
```
but after this commit, the code became  KernelVersion >= 4.17.0
```
    if KernelVersion::current().unwrap() >= KernelVersion::new(4, 17, 0) {
```

This will cause this kind of error on android device:
```
Error: `/sys/kernel/tracing/uprobe_events`
Caused by:
    Invalid argument (os error 22)
```