### PR TITLE
Add back bpf/.cargo/config.toml

### DIFF
--- a/bpf/.cargo/config.toml
+++ b/bpf/.cargo/config.toml
@@ -1,0 +1,14 @@
+# We have this so that one doesn't need to manually pass
+# --target=bpfel-unknown-none -Z build-std=core when running cargo
+# check/build/doc etc.
+#
+# NB: this file gets loaded only if you run cargo from this directory, it's
+# ignored if you run from the workspace root. See
+# https://doc.rust-lang.org/cargo/reference/config.html#hierarchical-structure
+#
+# NB-2: cargo xtask docs currently relies on this file existing.
+[build]
+target = "bpfel-unknown-none"
+
+[unstable]
+build-std = ["core"]


### PR DESCRIPTION
So to build/check things using the bpf target one can:

    cd bpf && cargo check && cargo build

without having to manually pass --target=bpfel-unknown-none -Z build-std=core.

It also fixes cargo xtask docs, since the command relies on bpf docs being built with the bpfel-unknown-none target.