### PR TITLE
integration-tests: run in release also

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,6 +132,14 @@ jobs:
 
   integration-test:
     runs-on: macos-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # See https://doc.rust-lang.org/cargo/reference/profiles.html for the names
+        # of the builtin profiles. Note that dev builds "debug" targets.
+        profile:
+          - release
+          - dev
     steps:
       - uses: actions/checkout@v3
         with:
@@ -154,7 +162,7 @@ jobs:
           key: tmp-files-${{ hashFiles('test/run.sh') }}
 
       - name: Run integration tests
-        run: test/run.sh
+        run: test/run.sh --cargo-arg=--profile=${{ matrix.profile }}
 
   # Provides a single status check for the entire build workflow.
   # This is used for merge automation, like Mergify, since GH actions

--- a/test/integration-test/src/tests/bpf_probe_read.rs
+++ b/test/integration-test/src/tests/bpf_probe_read.rs
@@ -116,8 +116,12 @@ fn load_and_attach_uprobe(prog_name: &str, func_name: &str, bytes: &[u8]) -> Bpf
 
 #[no_mangle]
 #[inline(never)]
-pub extern "C" fn trigger_bpf_probe_read_user(_string: *const u8, _len: usize) {}
+pub extern "C" fn trigger_bpf_probe_read_user(string: *const u8, len: usize) {
+    core::hint::black_box((string, len));
+}
 
 #[no_mangle]
 #[inline(never)]
-pub extern "C" fn trigger_bpf_probe_read_kernel(_len: usize) {}
+pub extern "C" fn trigger_bpf_probe_read_kernel(len: usize) {
+    core::hint::black_box(len);
+}

--- a/test/integration-test/src/tests/log.rs
+++ b/test/integration-test/src/tests/log.rs
@@ -9,7 +9,9 @@ use log::{Level, Log, Record};
 
 #[no_mangle]
 #[inline(never)]
-pub extern "C" fn trigger_ebpf_program() {}
+pub extern "C" fn trigger_ebpf_program() {
+    core::hint::black_box(trigger_ebpf_program);
+}
 
 struct TestingLogger<F> {
     log: F,

--- a/test/integration-test/src/tests/relocations.rs
+++ b/test/integration-test/src/tests/relocations.rs
@@ -49,4 +49,6 @@ fn load_and_attach(name: &str, bytes: &[u8]) -> Bpf {
 
 #[no_mangle]
 #[inline(never)]
-pub extern "C" fn trigger_relocations_program() {}
+pub extern "C" fn trigger_relocations_program() {
+    core::hint::black_box(trigger_relocations_program);
+}

--- a/test/run.sh
+++ b/test/run.sh
@@ -242,7 +242,7 @@ trap cleanup_vm EXIT
 exec_vm "rm -rf aya/*"
 rsync_vm "--exclude=target --exclude=.tmp $AYA_SOURCE_DIR"
 
-exec_vm "cd aya; cargo xtask integration-test"
+exec_vm "cd aya; cargo xtask integration-test $*"
 
 # we rm and sync but it doesn't seem to work reliably - I guess we could sleep a
 # few seconds after but ain't nobody got time for that. Instead we also rm


### PR DESCRIPTION
In release, the trigger functions were being optimized out and the tests did not work. Use core::hint::black_box to ensure that the functions are not optimized out. Also, run these integration tests in CI to ensure that we don't regress.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aya-rs/aya/661)
<!-- Reviewable:end -->
