### PR TITLE
No Submodules

### DIFF
--- a/.github/workflows/gen.yml
+++ b/.github/workflows/gen.yml
@@ -8,6 +8,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+      - uses: actions/checkout@v3
+        with:
+          repository: libbpf/libbpf
+          path: libbpf
 
       - name: libbpf-version
         working-directory: libbpf

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -18,8 +18,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+      - uses: actions/checkout@v3
         with:
-          submodules: recursive
+          repository: libbpf/libbpf
+          path: libbpf
 
       - name: Install Pre-requisites
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ target/
 !.vscode/settings.json
 site/
 .idea/
+# Checkout of libbpf, used for codegen + compiling C test code
+libbpf/

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "libbpf"]
-	path = libbpf
-	url = https://github.com/libbpf/libbpf

--- a/test/integration-test/build.rs
+++ b/test/integration-test/build.rs
@@ -71,6 +71,15 @@ fn main() {
             .unwrap()
             .join("libbpf");
 
+        if !libbpf_dir.exists() {
+            panic!(
+                "Directory does not exist at {:?}\n\
+                Please perform a shallow clone of libbpf:\n\
+                git clone https://github.com/libbpf/libbpf --depth 1\n",
+                libbpf_dir
+            );
+        }
+
         let libbpf_headers_dir = out_dir.join("libbpf_headers");
 
         let mut includedir = OsString::new();


### PR DESCRIPTION
Submodules are notoriously annoying to manage.
 
We don't actually care about the libbpf version at all since it's only
ever used as a shortcut to:
    
    - Generate struct bindings from kernel structs
    - Provide the bpf/* headers to C-BPF files so they can be compiled

The UX for people running the integration test is not nice either - as I found out - since if you update via `git pull` to aya@main then integration tests will refuse to run with no clear error message.

Since the libbpf version used isn't special and doesn't need tracking (outside of git commit message for bindings updates) this PR reverts the use of submodules.
It keeps the assumption that libbpf is in the root of the checkout though, but if it is not found a nice error message is produced telling you how to acquire it.
Fully re-instating `--libbpf-dir` would be an ideal option, yet this isn't possible without also reverting the move to `build.rs` for compiling the C-eBPF probes.