### PR TITLE
test/integration-test: use +nightly for ebpf

### DIFF
--- a/test/integration-ebpf/rust-toolchain.toml
+++ b/test/integration-ebpf/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "nightly"

--- a/test/integration-test/build.rs
+++ b/test/integration-test/build.rs
@@ -163,8 +163,6 @@ fn main() {
         let mut cmd = Command::new("cargo");
         cmd.args([
             "build",
-            "-p",
-            "integration-ebpf",
             "-Z",
             "build-std=core",
             "--release",
@@ -172,6 +170,12 @@ fn main() {
             "--target",
             &target,
         ]);
+
+        // Workaround to make sure that the rust-toolchain.toml is respected.
+        let Package { manifest_path, .. } = packages.get(INTEGRATION_EBPF_PACKAGE).unwrap();
+        let integration_ebpf_dir = manifest_path.parent().unwrap();
+        cmd.env_remove("RUSTUP_TOOLCHAIN")
+            .current_dir(integration_ebpf_dir);
 
         // Workaround for https://github.com/rust-lang/cargo/issues/6412 where cargo flocks itself.
         let ebpf_target_dir = out_dir.join("integration-ebpf");


### PR DESCRIPTION
The ebpf probes require a nightly compiler. Before this change, if you ran `cargo xtask integration-test` with a stable compiler toolchain as default, or you ran `cargo +stable xtask integration-test`, you would have seen an error like the one below. This is now fixed.

```
  --- stderr
  /home/ajwerner/src/github.com/aya-rs/aya/test/integration-test/bpf/ring_buf_sched_tracepoint.bpf.c:18:21: warning: declaration of 'struct switch_args' will not be visible outside of this function [-Wvisibility]
  int bpf_prog(struct switch_args* ctx)
                      ^
  1 warning generated.
  error: the `-Z` flag is only accepted on the nightly channel of Cargo, but this is the `stable` channel
  See https://doc.rust-lang.org/book/appendix-07-nightly-rust.html for more information about Rust release channels.
  thread 'main' panicked at '"cargo" "build" "-p" "integration-ebpf" "-Z" "build-std=core" "--release" "--message-format=json" "--target" "bpfel-unknown-none" "--target-dir" "/home/ajwerner/src/github.com/aya-rs/aya/target/debug/build/integration-test-9bbcb3db5e9f8f57/out/integration-ebpf" exited
with status code 101:
  ', test/integration-test/build.rs:219:25
  note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
Error: error while building userspace application

Caused by:
    Child { stdin: None, stdout: None, stderr: None, .. } exited with status code 101:
```

Relates to #670.