### PR TITLE
Refactor log macro for readability

### DIFF
--- a/aya-log-ebpf-macros/src/expand.rs
+++ b/aya-log-ebpf-macros/src/expand.rs
@@ -144,34 +144,27 @@ pub(crate) fn log(args: LogArgs, level: Option<TokenStream>) -> Result<TokenStre
     let values_iter = values.iter();
 
     Ok(quote! {
-        {
-            if let Some(buf_ptr) = unsafe { ::aya_log_ebpf::AYA_LOG_BUF.get_ptr_mut(0) } {
-                let buf = unsafe { &mut *buf_ptr };
-                if let Ok(header_len) = ::aya_log_ebpf::write_record_header(
-                    &mut buf.buf,
-                    #target,
-                    #lvl,
-                    module_path!(),
-                    file!(),
-                    line!(),
-                    #num_args,
-                ) {
-                    let record_len = header_len;
-
-                    if let Ok(record_len) = {
-                        Ok::<_, ()>(record_len) #( .and_then(|record_len| {
-                            if record_len >= buf.buf.len() {
-                                return Err(());
-                            }
-                            aya_log_ebpf::WriteToBuf::write({ #values_iter }, &mut buf.buf[record_len..]).map(|len| record_len + len)
-                        }) )*
-                    } {
-                        unsafe { ::aya_log_ebpf::AYA_LOGS.output(
-                            #ctx,
-                            &buf.buf[..record_len], 0
-                        )}
-                    }
-                }
+        match unsafe { &mut ::aya_log_ebpf::AYA_LOG_BUF }.get_ptr_mut(0).and_then(|ptr| unsafe { ptr.as_mut() }) {
+            None => {},
+            Some(::aya_log_ebpf::LogBuf { buf }) => {
+                let _: Result<(), ()> = (|| {
+                    let mut len = ::aya_log_ebpf::write_record_header(
+                        buf,
+                        #target,
+                        #lvl,
+                        module_path!(),
+                        file!(),
+                        line!(),
+                        #num_args,
+                    )?;
+                    #(
+                        let slice = buf.get_mut(len..).ok_or(())?;
+                        len += ::aya_log_ebpf::WriteToBuf::write(#values_iter, slice)?;
+                    )*
+                    let record = buf.get(..len).ok_or(())?;
+                    unsafe { &mut ::aya_log_ebpf::AYA_LOGS }.output(#ctx, record, 0);
+                    Ok(())
+                })();
             }
         }
     })


### PR DESCRIPTION
This happens to fix the miscompilation that occurs when bpf-linker is
moved to LLVM's new pass manager. A later commit will avoid the
miscompilation more convincingly.
