### PR TITLE
aya: Return error messages from netlink

### DIFF
--- a/aya/src/programs/mod.rs
+++ b/aya/src/programs/mod.rs
@@ -123,7 +123,8 @@ use crate::{
     sys::{
         bpf_btf_get_fd_by_id, bpf_get_object, bpf_link_get_fd_by_id, bpf_link_get_info_by_fd,
         bpf_load_program, bpf_pin_object, bpf_prog_get_fd_by_id, bpf_prog_query, iter_link_ids,
-        retry_with_verifier_logs, EbpfLoadProgramAttrs, ProgQueryTarget, SyscallError,
+        retry_with_verifier_logs, EbpfLoadProgramAttrs, NetlinkError, ProgQueryTarget,
+        SyscallError,
     },
     util::KernelVersion,
     VerifierLogLevel,
@@ -223,6 +224,10 @@ pub enum ProgramError {
     /// Providing an attach cookie is not supported.
     #[error("providing an attach cookie is not supported")]
     AttachCookieNotSupported,
+
+    /// An error occurred while working with Netlink.
+    #[error(transparent)]
+    NetlinkError(#[from] NetlinkError),
 }
 
 /// A [`Program`] file descriptor.

--- a/aya/src/programs/tc.rs
+++ b/aya/src/programs/tc.rs
@@ -23,7 +23,8 @@ use crate::{
     sys::{
         bpf_link_create, bpf_link_get_info_by_fd, bpf_link_update, bpf_prog_get_fd_by_id,
         netlink_find_filter_with_name, netlink_qdisc_add_clsact, netlink_qdisc_attach,
-        netlink_qdisc_detach, BpfLinkCreateArgs, LinkTarget, ProgQueryTarget, SyscallError,
+        netlink_qdisc_detach, BpfLinkCreateArgs, LinkTarget, NetlinkError, ProgQueryTarget,
+        SyscallError,
     },
     util::{ifindex_from_ifname, tc_handler_make, KernelVersion},
     VerifierLogLevel,
@@ -63,6 +64,8 @@ pub enum TcAttachType {
 /// #     #[error(transparent)]
 /// #     Program(#[from] aya::programs::ProgramError),
 /// #     #[error(transparent)]
+/// #     Tc(#[from] aya::programs::tc::TcError),
+/// #     #[error(transparent)]
 /// #     Ebpf(#[from] aya::EbpfError)
 /// # }
 /// # let mut bpf = aya::Ebpf::load(&[])?;
@@ -87,20 +90,22 @@ pub struct SchedClassifier {
 /// Errors from TC programs
 #[derive(Debug, Error)]
 pub enum TcError {
-    /// netlink error while attaching ebpf program
-    #[error("netlink error while attaching ebpf program to tc")]
-    NetlinkError {
-        /// the [`io::Error`] from the netlink call
-        #[source]
-        io_error: io::Error,
-    },
-    /// the clsact qdisc is already attached
+    /// a netlink error occurred.
+    #[error(transparent)]
+    NetlinkError(#[from] NetlinkError),
+    /// the provided string contains a nul byte.
+    #[error(transparent)]
+    NulError(#[from] std::ffi::NulError),
+    /// an IO error occurred.
+    #[error(transparent)]
+    IoError(#[from] io::Error),
+    /// the clsact qdisc is already attached.
     #[error("the clsact qdisc is already attached")]
     AlreadyAttached,
-    /// tcx links can only be attached to ingress or egress, custom attachment is not supported
+    /// tcx links can only be attached to ingress or egress, custom attachment is not supported.
     #[error("tcx links can only be attached to ingress or egress, custom attachment: {0} is not supported")]
     InvalidTcxAttach(u32),
-    /// operation not supported for programs loaded via tcx
+    /// operation not supported for programs loaded via tcx.
     #[error("operation not supported for programs loaded via tcx")]
     InvalidLinkOperation,
 }
@@ -209,8 +214,7 @@ impl SchedClassifier {
         attach_type: TcAttachType,
         options: TcAttachOptions,
     ) -> Result<SchedClassifierLinkId, ProgramError> {
-        let if_index = ifindex_from_ifname(interface)
-            .map_err(|io_error| TcError::NetlinkError { io_error })?;
+        let if_index = ifindex_from_ifname(interface).map_err(TcError::IoError)?;
         self.do_attach(if_index, attach_type, options, true)
     }
 
@@ -281,7 +285,7 @@ impl SchedClassifier {
                         create,
                     )
                 }
-                .map_err(|io_error| TcError::NetlinkError { io_error })?;
+                .map_err(TcError::NetlinkError)?;
 
                 self.data
                     .links
@@ -343,8 +347,7 @@ impl SchedClassifier {
         interface: &str,
         attach_type: TcAttachType,
     ) -> Result<(u64, Vec<ProgramInfo>), ProgramError> {
-        let if_index = ifindex_from_ifname(interface)
-            .map_err(|io_error| TcError::NetlinkError { io_error })?;
+        let if_index = ifindex_from_ifname(interface).map_err(TcError::IoError)?;
 
         let (revision, prog_ids) = query(
             ProgQueryTarget::IfIndex(if_index),
@@ -393,7 +396,7 @@ impl Link for NlLink {
                 self.handle,
             )
         }
-        .map_err(|io_error| TcError::NetlinkError { io_error })?;
+        .map_err(ProgramError::NetlinkError)?;
         Ok(())
     }
 }
@@ -557,9 +560,9 @@ impl SchedClassifierLink {
 ///
 /// The `clsact` qdisc must be added to an interface before [`SchedClassifier`]
 /// programs can be attached.
-pub fn qdisc_add_clsact(if_name: &str) -> Result<(), io::Error> {
+pub fn qdisc_add_clsact(if_name: &str) -> Result<(), TcError> {
     let if_index = ifindex_from_ifname(if_name)?;
-    unsafe { netlink_qdisc_add_clsact(if_index as i32) }
+    unsafe { netlink_qdisc_add_clsact(if_index as i32).map_err(TcError::NetlinkError) }
 }
 
 /// Detaches the programs with the given name.
@@ -573,8 +576,8 @@ pub fn qdisc_detach_program(
     if_name: &str,
     attach_type: TcAttachType,
     name: &str,
-) -> Result<(), io::Error> {
-    let cstr = CString::new(name)?;
+) -> Result<(), TcError> {
+    let cstr = CString::new(name).map_err(TcError::NulError)?;
     qdisc_detach_program_fast(if_name, attach_type, &cstr)
 }
 
@@ -591,15 +594,15 @@ fn qdisc_detach_program_fast(
     if_name: &str,
     attach_type: TcAttachType,
     name: &CStr,
-) -> Result<(), io::Error> {
+) -> Result<(), TcError> {
     let if_index = ifindex_from_ifname(if_name)? as i32;
 
     let filter_info = unsafe { netlink_find_filter_with_name(if_index, attach_type, name)? };
     if filter_info.is_empty() {
-        return Err(io::Error::new(
+        return Err(TcError::IoError(io::Error::new(
             io::ErrorKind::NotFound,
             name.to_string_lossy(),
-        ));
+        )));
     }
 
     for (prio, handle) in filter_info {

--- a/xtask/public-api/aya.txt
+++ b/xtask/public-api/aya.txt
@@ -6060,10 +6060,15 @@ pub enum aya::programs::tc::TcError
 pub aya::programs::tc::TcError::AlreadyAttached
 pub aya::programs::tc::TcError::InvalidLinkOperation
 pub aya::programs::tc::TcError::InvalidTcxAttach(u32)
-pub aya::programs::tc::TcError::NetlinkError
-pub aya::programs::tc::TcError::NetlinkError::io_error: std::io::error::Error
+pub aya::programs::tc::TcError::IoError(std::io::error::Error)
+pub aya::programs::tc::TcError::NetlinkError(aya::sys::netlink::NetlinkError)
+pub aya::programs::tc::TcError::NulError(alloc::ffi::c_str::NulError)
+impl core::convert::From<alloc::ffi::c_str::NulError> for aya::programs::tc::TcError
+pub fn aya::programs::tc::TcError::from(source: alloc::ffi::c_str::NulError) -> Self
 impl core::convert::From<aya::programs::tc::TcError> for aya::programs::ProgramError
 pub fn aya::programs::ProgramError::from(source: aya::programs::tc::TcError) -> Self
+impl core::convert::From<std::io::error::Error> for aya::programs::tc::TcError
+pub fn aya::programs::tc::TcError::from(source: std::io::error::Error) -> Self
 impl core::error::Error for aya::programs::tc::TcError
 pub fn aya::programs::tc::TcError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
 impl core::fmt::Debug for aya::programs::tc::TcError
@@ -6276,8 +6281,8 @@ impl<T> core::borrow::BorrowMut<T> for aya::programs::tc::SchedClassifierLinkId 
 pub fn aya::programs::tc::SchedClassifierLinkId::borrow_mut(&mut self) -> &mut T
 impl<T> core::convert::From<T> for aya::programs::tc::SchedClassifierLinkId
 pub fn aya::programs::tc::SchedClassifierLinkId::from(t: T) -> T
-pub fn aya::programs::tc::qdisc_add_clsact(if_name: &str) -> core::result::Result<(), std::io::error::Error>
-pub fn aya::programs::tc::qdisc_detach_program(if_name: &str, attach_type: aya::programs::tc::TcAttachType, name: &str) -> core::result::Result<(), std::io::error::Error>
+pub fn aya::programs::tc::qdisc_add_clsact(if_name: &str) -> core::result::Result<(), aya::programs::tc::TcError>
+pub fn aya::programs::tc::qdisc_detach_program(if_name: &str, attach_type: aya::programs::tc::TcAttachType, name: &str) -> core::result::Result<(), aya::programs::tc::TcError>
 pub mod aya::programs::tp_btf
 pub struct aya::programs::tp_btf::BtfTracePoint
 impl aya::programs::tp_btf::BtfTracePoint
@@ -6783,8 +6788,7 @@ impl<T> core::convert::From<T> for aya::programs::uprobe::UProbeLinkId
 pub fn aya::programs::uprobe::UProbeLinkId::from(t: T) -> T
 pub mod aya::programs::xdp
 pub enum aya::programs::xdp::XdpError
-pub aya::programs::xdp::XdpError::NetlinkError
-pub aya::programs::xdp::XdpError::NetlinkError::io_error: std::io::error::Error
+pub aya::programs::xdp::XdpError::NetlinkError(aya::sys::netlink::NetlinkError)
 impl core::convert::From<aya::programs::xdp::XdpError> for aya::programs::ProgramError
 pub fn aya::programs::ProgramError::from(source: aya::programs::xdp::XdpError) -> Self
 impl core::error::Error for aya::programs::xdp::XdpError
@@ -7548,6 +7552,7 @@ pub aya::programs::ProgramError::LoadError
 pub aya::programs::ProgramError::LoadError::io_error: std::io::error::Error
 pub aya::programs::ProgramError::LoadError::verifier_log: aya_obj::VerifierLog
 pub aya::programs::ProgramError::MapError(aya::maps::MapError)
+pub aya::programs::ProgramError::NetlinkError(aya::sys::netlink::NetlinkError)
 pub aya::programs::ProgramError::NotAttached
 pub aya::programs::ProgramError::NotLoaded
 pub aya::programs::ProgramError::SocketFilterError(aya::programs::socket_filter::SocketFilterError)
@@ -7841,10 +7846,15 @@ pub enum aya::programs::TcError
 pub aya::programs::TcError::AlreadyAttached
 pub aya::programs::TcError::InvalidLinkOperation
 pub aya::programs::TcError::InvalidTcxAttach(u32)
-pub aya::programs::TcError::NetlinkError
-pub aya::programs::TcError::NetlinkError::io_error: std::io::error::Error
+pub aya::programs::TcError::IoError(std::io::error::Error)
+pub aya::programs::TcError::NetlinkError(aya::sys::netlink::NetlinkError)
+pub aya::programs::TcError::NulError(alloc::ffi::c_str::NulError)
+impl core::convert::From<alloc::ffi::c_str::NulError> for aya::programs::tc::TcError
+pub fn aya::programs::tc::TcError::from(source: alloc::ffi::c_str::NulError) -> Self
 impl core::convert::From<aya::programs::tc::TcError> for aya::programs::ProgramError
 pub fn aya::programs::ProgramError::from(source: aya::programs::tc::TcError) -> Self
+impl core::convert::From<std::io::error::Error> for aya::programs::tc::TcError
+pub fn aya::programs::tc::TcError::from(source: std::io::error::Error) -> Self
 impl core::error::Error for aya::programs::tc::TcError
 pub fn aya::programs::tc::TcError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
 impl core::fmt::Debug for aya::programs::tc::TcError
@@ -7955,8 +7965,7 @@ pub fn aya::programs::uprobe::UProbeError::borrow_mut(&mut self) -> &mut T
 impl<T> core::convert::From<T> for aya::programs::uprobe::UProbeError
 pub fn aya::programs::uprobe::UProbeError::from(t: T) -> T
 pub enum aya::programs::XdpError
-pub aya::programs::XdpError::NetlinkError
-pub aya::programs::XdpError::NetlinkError::io_error: std::io::error::Error
+pub aya::programs::XdpError::NetlinkError(aya::sys::netlink::NetlinkError)
 impl core::convert::From<aya::programs::xdp::XdpError> for aya::programs::ProgramError
 pub fn aya::programs::ProgramError::from(source: aya::programs::xdp::XdpError) -> Self
 impl core::error::Error for aya::programs::xdp::XdpError


### PR DESCRIPTION
This returns error strings from netlink since they are more informative than the raw os error. For example:

"Device or Resource Busy" vs. "XDP program already attached".

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aya-rs/aya/690)
<!-- Reviewable:end -->
