### PR TITLE
xtask: reverse public API diff direction

### DIFF
--- a/xtask/src/public_api.rs
+++ b/xtask/src/public_api.rs
@@ -99,7 +99,7 @@ fn check_package_api(
     let current_api =
         read_to_string(&path).with_context(|| format!("error reading {}", path.display()))?;
 
-    Ok(lines(&current_api, &public_api.to_string())
+    Ok(lines(&public_api.to_string(), &current_api)
         .into_iter()
         .fold(String::new(), |mut buf, diff| {
             match diff {


### PR DESCRIPTION
This is currently producing inverse diffs.