### PR TITLE
remove programfd in favor of borrowedfd

### DIFF
--- a/aya/src/maps/array/program_array.rs
+++ b/aya/src/maps/array/program_array.rs
@@ -2,12 +2,11 @@
 
 use std::{
     borrow::{Borrow, BorrowMut},
-    os::fd::{AsRawFd, RawFd},
+    os::fd::{AsRawFd, BorrowedFd, RawFd},
 };
 
 use crate::{
     maps::{check_bounds, check_kv_size, MapData, MapError, MapKeys},
-    programs::ProgramFd,
     sys::{bpf_map_delete_elem, bpf_map_update_elem},
 };
 
@@ -73,7 +72,7 @@ impl<T: BorrowMut<MapData>> ProgramArray<T> {
     ///
     /// When an eBPF program calls `bpf_tail_call(ctx, prog_array, index)`, control
     /// flow will jump to `program`.
-    pub fn set(&mut self, index: u32, program: ProgramFd, flags: u64) -> Result<(), MapError> {
+    pub fn set(&mut self, index: u32, program: BorrowedFd, flags: u64) -> Result<(), MapError> {
         let data = self.inner.borrow_mut();
         check_bounds(data, index)?;
         let fd = data.fd_or_err()?;

--- a/aya/src/programs/extension.rs
+++ b/aya/src/programs/extension.rs
@@ -1,5 +1,5 @@
 //! Extension programs.
-use std::os::fd::{AsRawFd, RawFd};
+use std::os::fd::{AsRawFd, BorrowedFd, RawFd};
 use thiserror::Error;
 
 use object::Endianness;
@@ -7,9 +7,7 @@ use object::Endianness;
 use crate::{
     generated::{bpf_attach_type::BPF_CGROUP_INET_INGRESS, bpf_prog_type::BPF_PROG_TYPE_EXT},
     obj::btf::BtfKind,
-    programs::{
-        define_link_wrapper, load_program, FdLink, FdLinkId, ProgramData, ProgramError, ProgramFd,
-    },
+    programs::{define_link_wrapper, load_program, FdLink, FdLinkId, ProgramData, ProgramError},
     sys::{self, bpf_link_create},
     Btf,
 };
@@ -68,7 +66,7 @@ impl Extension {
     /// The extension code will be loaded but inactive until it's attached.
     /// There are no restrictions on what functions may be replaced, so you could replace
     /// the main entry point of your program with an extension.
-    pub fn load(&mut self, program: ProgramFd, func_name: &str) -> Result<(), ProgramError> {
+    pub fn load(&mut self, program: BorrowedFd, func_name: &str) -> Result<(), ProgramError> {
         let target_prog_fd = program.as_raw_fd();
         let (btf_fd, btf_id) = get_btf_info(target_prog_fd, func_name)?;
 
@@ -113,7 +111,7 @@ impl Extension {
     /// original function, see [Extension::detach].
     pub fn attach_to_program(
         &mut self,
-        program: ProgramFd,
+        program: BorrowedFd,
         func_name: &str,
     ) -> Result<ExtensionLinkId, ProgramError> {
         let target_fd = program.as_raw_fd();


### PR DESCRIPTION
Remove the Aya specific Programfd type in favor of the built in BorrowedFd type. The semantics are essentially the same since `ProgramFd` is essentially just a wrapper around `RawFd` which doesn't implement Drop.

  The "Complete" fix for this will be to turn the[ `ProgramData.fd` ](https://github.com/aya-rs/aya/blob/main/aya/src/programs/mod.rs#L410) into an `OwnedFd` however I'm waiting to see what the outcome of https://github.com/aya-rs/aya/pull/662 is/ looks like. 

In the meantime this seems like a fairly isolated change. cc @nrxus 

The only thing I'm not 100% sure on is if the unsafe call to transform a `RawFd` into a `BorrowedFd`.

specifically it states for `BorrowedFd::borrow_raw(fd)`

```
The resource pointed to by fd must remain open for the duration of the returned BorrowedFd, and it must not have the value -1.
```

Which is something we were assuming anyways with `ProgramFd` which is why I figured it'd be alright