### PR TITLE
bpf: Remove builtin global functions

### DIFF
--- a/bpf/aya-bpf/src/lib.rs
+++ b/bpf/aya-bpf/src/lib.rs
@@ -31,7 +31,7 @@ use core::ffi::c_void;
 
 pub use aya_bpf_cty as cty;
 pub use aya_bpf_macros as macros;
-use cty::{c_int, c_long};
+use cty::c_long;
 use helpers::{bpf_get_current_comm, bpf_get_current_pid_tgid, bpf_get_current_uid_gid};
 
 pub const TASK_COMM_LEN: usize = 16;
@@ -58,22 +58,6 @@ pub trait BpfContext {
 
     fn gid(&self) -> u32 {
         (bpf_get_current_uid_gid() >> 32) as u32
-    }
-}
-
-#[no_mangle]
-pub unsafe extern "C" fn memset(s: *mut u8, c: c_int, n: usize) {
-    #[allow(clippy::cast_sign_loss)]
-    let b = c as u8;
-    for i in 0..n {
-        *s.add(i) = b;
-    }
-}
-
-#[no_mangle]
-pub unsafe extern "C" fn memcpy(dest: *mut u8, src: *mut u8, n: usize) {
-    for i in 0..n {
-        *dest.add(i) = *src.add(i);
     }
 }
 

--- a/test/integration-ebpf/src/bpf_probe_read.rs
+++ b/test/integration-ebpf/src/bpf_probe_read.rs
@@ -1,5 +1,6 @@
-#![no_std]
+#![no_builtins]
 #![no_main]
+#![no_std]
 
 use aya_bpf::{
     helpers::{bpf_probe_read_kernel_str_bytes, bpf_probe_read_user_str_bytes},

--- a/test/integration-ebpf/src/log.rs
+++ b/test/integration-ebpf/src/log.rs
@@ -1,5 +1,6 @@
-#![no_std]
+#![no_builtins]
 #![no_main]
+#![no_std]
 
 use aya_bpf::{macros::uprobe, programs::ProbeContext};
 use aya_log_ebpf::{debug, error, info, trace, warn};

--- a/test/integration-ebpf/src/map_test.rs
+++ b/test/integration-ebpf/src/map_test.rs
@@ -1,5 +1,6 @@
-#![no_std]
+#![no_builtins]
 #![no_main]
+#![no_std]
 
 use aya_bpf::{
     bindings::xdp_action,

--- a/test/integration-ebpf/src/name_test.rs
+++ b/test/integration-ebpf/src/name_test.rs
@@ -1,5 +1,6 @@
-#![no_std]
+#![no_builtins]
 #![no_main]
+#![no_std]
 
 use aya_bpf::{bindings::xdp_action, macros::xdp, programs::XdpContext};
 

--- a/test/integration-ebpf/src/pass.rs
+++ b/test/integration-ebpf/src/pass.rs
@@ -1,5 +1,6 @@
-#![no_std]
+#![no_builtins]
 #![no_main]
+#![no_std]
 
 use aya_bpf::{bindings::xdp_action, macros::xdp, programs::XdpContext};
 

--- a/test/integration-ebpf/src/relocations.rs
+++ b/test/integration-ebpf/src/relocations.rs
@@ -1,5 +1,6 @@
-#![no_std]
+#![no_builtins]
 #![no_main]
+#![no_std]
 
 use core::hint;
 

--- a/test/integration-ebpf/src/test.rs
+++ b/test/integration-ebpf/src/test.rs
@@ -1,5 +1,6 @@
-#![no_std]
+#![no_builtins]
 #![no_main]
+#![no_std]
 
 use aya_bpf::{
     bindings::xdp_action,

--- a/xtask/public-api/aya-bpf.txt
+++ b/xtask/public-api/aya-bpf.txt
@@ -2587,5 +2587,3 @@ pub fn aya_bpf::programs::tracepoint::TracePointContext::as_ptr(&self) -> *mut c
 impl aya_bpf::BpfContext for aya_bpf::programs::xdp::XdpContext
 pub fn aya_bpf::programs::xdp::XdpContext::as_ptr(&self) -> *mut core::ffi::c_void
 pub fn aya_bpf::check_bounds_signed(value: i64, lower: i64, upper: i64) -> bool
-#[no_mangle] pub unsafe c fn aya_bpf::memcpy(dest: *mut u8, src: *mut u8, n: usize)
-#[no_mangle] pub unsafe c fn aya_bpf::memset(s: *mut u8, c: aya_bpf_cty::ad::c_int, n: usize)


### PR DESCRIPTION
This commit removes memset and memcpy, relying instead on
implementations provided by std/compiler-builtins.

This commit adds `#![no_builtins]` to all the BPF programs written in
Rust, and the same should be propagated to aya-template and all examples
in the book and elsewhere before this commit is merged.

It turns out that without the `#![no_builtins]` annotation rustc
generates LLVM IR that calls LLVM intrinsics rather than libcalls. These
may end up as libcalls after lowering, but not before emitting errors in
BPF lowering[0].

This works thanks to https://github.com/rust-lang/rust/pull/113716 which
causes `#![no_builtins]` to behave similarly to `-fno-builtin` in clang,
which was added in https://reviews.llvm.org/D68028 with similar
motivation.

This commit implies that we now require rustc nightly >= 2023-07-20.

[0] https://github.com/llvm/llvm-project/blob/7b2745b/llvm/lib/Target/BPF/BPFISelLowering.cpp#L472-L474
