### PR TITLE
aya: Don't store btf_fd in MapData

### DIFF
--- a/aya/src/maps/bloom_filter.rs
+++ b/aya/src/maps/bloom_filter.rs
@@ -116,7 +116,6 @@ mod tests {
             obj: new_obj_map(),
             fd: None,
             pinned: false,
-            btf_fd: None,
         };
         assert_matches!(
             BloomFilter::<_, u16>::new(&map),
@@ -145,7 +144,6 @@ mod tests {
             }),
             fd: None,
             pinned: false,
-            btf_fd: None,
         };
 
         let map = Map::PerfEventArray(map_data);
@@ -162,7 +160,6 @@ mod tests {
             obj: new_obj_map(),
             fd: None,
             pinned: false,
-            btf_fd: None,
         };
 
         assert_matches!(
@@ -177,7 +174,6 @@ mod tests {
             obj: new_obj_map(),
             fd: Some(42),
             pinned: false,
-            btf_fd: None,
         };
 
         assert!(BloomFilter::<_, u32>::new(&mut map).is_ok());
@@ -189,7 +185,6 @@ mod tests {
             obj: new_obj_map(),
             fd: Some(42),
             pinned: false,
-            btf_fd: None,
         };
 
         let map = Map::BloomFilter(map_data);
@@ -204,7 +199,6 @@ mod tests {
             obj: new_obj_map(),
             fd: Some(42),
             pinned: false,
-            btf_fd: None,
         };
         let bloom_filter = BloomFilter::<_, u32>::new(&mut map).unwrap();
 
@@ -228,7 +222,6 @@ mod tests {
             obj: new_obj_map(),
             fd: Some(42),
             pinned: false,
-            btf_fd: None,
         };
 
         let bloom_filter = BloomFilter::<_, u32>::new(&mut map).unwrap();
@@ -242,7 +235,6 @@ mod tests {
             obj: new_obj_map(),
             fd: Some(42),
             pinned: false,
-            btf_fd: None,
         };
         let bloom_filter = BloomFilter::<_, u32>::new(&map).unwrap();
 
@@ -265,7 +257,6 @@ mod tests {
             obj: new_obj_map(),
             fd: Some(42),
             pinned: false,
-            btf_fd: None,
         };
         let bloom_filter = BloomFilter::<_, u32>::new(&map).unwrap();
 

--- a/aya/src/maps/hash_map/hash_map.rs
+++ b/aya/src/maps/hash_map/hash_map.rs
@@ -147,7 +147,6 @@ mod tests {
             obj: new_obj_map(),
             fd: None,
             pinned: false,
-            btf_fd: None,
         };
         assert_matches!(
             HashMap::<_, u8, u32>::new(&map),
@@ -164,7 +163,6 @@ mod tests {
             obj: new_obj_map(),
             fd: None,
             pinned: false,
-            btf_fd: None,
         };
         assert_matches!(
             HashMap::<_, u32, u16>::new(&map),
@@ -181,7 +179,6 @@ mod tests {
             obj: new_obj_map(),
             fd: None,
             pinned: false,
-            btf_fd: None,
         };
 
         let map = Map::Array(map_data);
@@ -197,7 +194,6 @@ mod tests {
             obj: new_obj_map(),
             fd: None,
             pinned: false,
-            btf_fd: None,
         };
 
         let map = Map::HashMap(map_data);
@@ -216,7 +212,6 @@ mod tests {
             obj: new_obj_map(),
             fd: None,
             pinned: false,
-            btf_fd: None,
         };
 
         assert_matches!(
@@ -231,7 +226,6 @@ mod tests {
             obj: new_obj_map(),
             fd: Some(42),
             pinned: false,
-            btf_fd: None,
         };
 
         assert!(HashMap::<_, u32, u32>::new(&mut map).is_ok());
@@ -243,7 +237,6 @@ mod tests {
             obj: new_obj_map(),
             fd: Some(42),
             pinned: false,
-            btf_fd: None,
         };
 
         let map = Map::HashMap(map_data);
@@ -268,7 +261,6 @@ mod tests {
             }),
             fd: Some(42),
             pinned: false,
-            btf_fd: None,
         };
 
         let map = Map::HashMap(map_data);
@@ -284,7 +276,6 @@ mod tests {
             obj: new_obj_map(),
             fd: Some(42),
             pinned: false,
-            btf_fd: None,
         };
         let mut hm = HashMap::<_, u32, u32>::new(&mut map).unwrap();
 
@@ -308,7 +299,6 @@ mod tests {
             obj: new_obj_map(),
             fd: Some(42),
             pinned: false,
-            btf_fd: None,
         };
         let mut hm = HashMap::<_, u32, u32>::new(&mut map).unwrap();
 
@@ -329,7 +319,6 @@ mod tests {
             obj: new_obj_map(),
             fd: Some(42),
             pinned: false,
-            btf_fd: None,
         };
         let mut hm = HashMap::<_, u32, u32>::new(&mut map).unwrap();
 
@@ -344,7 +333,6 @@ mod tests {
             obj: new_obj_map(),
             fd: Some(42),
             pinned: false,
-            btf_fd: None,
         };
         let mut hm = HashMap::<_, u32, u32>::new(&mut map).unwrap();
 
@@ -368,7 +356,6 @@ mod tests {
             obj: new_obj_map(),
             fd: Some(42),
             pinned: false,
-            btf_fd: None,
         };
         let mut hm = HashMap::<_, u32, u32>::new(&mut map).unwrap();
 
@@ -382,7 +369,6 @@ mod tests {
             obj: new_obj_map(),
             fd: Some(42),
             pinned: false,
-            btf_fd: None,
         };
         let hm = HashMap::<_, u32, u32>::new(&map).unwrap();
 
@@ -405,7 +391,6 @@ mod tests {
             obj: new_obj_map(),
             fd: Some(42),
             pinned: false,
-            btf_fd: None,
         };
         let hm = HashMap::<_, u32, u32>::new(&map).unwrap();
 
@@ -442,7 +427,6 @@ mod tests {
             obj: new_obj_map(),
             fd: Some(42),
             pinned: false,
-            btf_fd: None,
         };
         let hm = HashMap::<_, u32, u32>::new(&map).unwrap();
         let keys = hm.keys().collect::<Result<Vec<_>, _>>();
@@ -491,7 +475,6 @@ mod tests {
             obj: new_obj_map(),
             fd: Some(42),
             pinned: false,
-            btf_fd: None,
         };
         let hm = HashMap::<_, u32, u32>::new(&map).unwrap();
 
@@ -524,7 +507,6 @@ mod tests {
             obj: new_obj_map(),
             fd: Some(42),
             pinned: false,
-            btf_fd: None,
         };
         let hm = HashMap::<_, u32, u32>::new(&map).unwrap();
 
@@ -562,7 +544,6 @@ mod tests {
             obj: new_obj_map(),
             fd: Some(42),
             pinned: false,
-            btf_fd: None,
         };
         let hm = HashMap::<_, u32, u32>::new(&map).unwrap();
         let items = hm.iter().collect::<Result<Vec<_>, _>>().unwrap();
@@ -600,7 +581,6 @@ mod tests {
             obj: new_obj_map(),
             fd: Some(42),
             pinned: false,
-            btf_fd: None,
         };
         let hm = HashMap::<_, u32, u32>::new(&map).unwrap();
 
@@ -639,7 +619,6 @@ mod tests {
             obj: new_obj_map(),
             fd: Some(42),
             pinned: false,
-            btf_fd: None,
         };
         let hm = HashMap::<_, u32, u32>::new(&map).unwrap();
 
@@ -687,7 +666,6 @@ mod tests {
             obj: new_obj_map(),
             fd: Some(42),
             pinned: false,
-            btf_fd: None,
         };
         let hm = HashMap::<_, u32, u32>::new(&map).unwrap();
 

--- a/aya/src/maps/lpm_trie.rs
+++ b/aya/src/maps/lpm_trie.rs
@@ -238,7 +238,6 @@ mod tests {
             obj: new_obj_map(),
             fd: None,
             pinned: false,
-            btf_fd: None,
         };
         assert_matches!(
             LpmTrie::<_, u16, u32>::new(&map),
@@ -255,7 +254,6 @@ mod tests {
             obj: new_obj_map(),
             fd: None,
             pinned: false,
-            btf_fd: None,
         };
         assert_matches!(
             LpmTrie::<_, u32, u16>::new(&map),
@@ -283,7 +281,6 @@ mod tests {
                 data: Vec::new(),
             }),
             fd: None,
-            btf_fd: None,
             pinned: false,
         };
 
@@ -301,7 +298,6 @@ mod tests {
             obj: new_obj_map(),
             fd: None,
             pinned: false,
-            btf_fd: None,
         };
 
         assert_matches!(
@@ -316,7 +312,6 @@ mod tests {
             obj: new_obj_map(),
             fd: Some(42),
             pinned: false,
-            btf_fd: None,
         };
 
         assert!(LpmTrie::<_, u32, u32>::new(&mut map).is_ok());
@@ -328,7 +323,6 @@ mod tests {
             obj: new_obj_map(),
             fd: Some(42),
             pinned: false,
-            btf_fd: None,
         };
 
         let map = Map::LpmTrie(map_data);
@@ -343,7 +337,6 @@ mod tests {
             obj: new_obj_map(),
             fd: Some(42),
             pinned: false,
-            btf_fd: None,
         };
         let mut trie = LpmTrie::<_, u32, u32>::new(&mut map).unwrap();
         let ipaddr = Ipv4Addr::new(8, 8, 8, 8);
@@ -368,7 +361,6 @@ mod tests {
             obj: new_obj_map(),
             fd: Some(42),
             pinned: false,
-            btf_fd: None,
         };
 
         let mut trie = LpmTrie::<_, u32, u32>::new(&mut map).unwrap();
@@ -385,7 +377,6 @@ mod tests {
             obj: new_obj_map(),
             fd: Some(42),
             pinned: false,
-            btf_fd: None,
         };
         let mut trie = LpmTrie::<_, u32, u32>::new(&mut map).unwrap();
         let ipaddr = Ipv4Addr::new(8, 8, 8, 8);
@@ -410,7 +401,6 @@ mod tests {
             obj: new_obj_map(),
             fd: Some(42),
             pinned: false,
-            btf_fd: None,
         };
         let mut trie = LpmTrie::<_, u32, u32>::new(&mut map).unwrap();
         let ipaddr = Ipv4Addr::new(8, 8, 8, 8);
@@ -425,7 +415,6 @@ mod tests {
             obj: new_obj_map(),
             fd: Some(42),
             pinned: false,
-            btf_fd: None,
         };
         let trie = LpmTrie::<_, u32, u32>::new(&map).unwrap();
         let ipaddr = Ipv4Addr::new(8, 8, 8, 8);
@@ -450,7 +439,6 @@ mod tests {
             obj: new_obj_map(),
             fd: Some(42),
             pinned: false,
-            btf_fd: None,
         };
         let trie = LpmTrie::<_, u32, u32>::new(&map).unwrap();
         let ipaddr = Ipv4Addr::new(8, 8, 8, 8);

--- a/aya/src/sys/bpf.rs
+++ b/aya/src/sys/bpf.rs
@@ -732,10 +732,9 @@ pub(crate) fn is_bpf_global_data_supported() -> bool {
         }),
         fd: None,
         pinned: false,
-        btf_fd: None,
     };
 
-    if let Ok(map_fd) = map_data.create("aya_global") {
+    if let Ok(map_fd) = map_data.create("aya_global", None) {
         insns[0].imm = map_fd;
 
         let gpl = b"GPL\0";

--- a/xtask/public-api/aya.txt
+++ b/xtask/public-api/aya.txt
@@ -1230,7 +1230,7 @@ pub fn aya::maps::lpm_trie::LpmTrie<T, K, V>::from(t: T) -> T
 pub struct aya::maps::MapData
 pub aya::maps::MapData::pinned: bool
 impl aya::maps::MapData
-pub fn aya::maps::MapData::create(&mut self, name: &str) -> core::result::Result<std::os::fd::raw::RawFd, aya::maps::MapError>
+pub fn aya::maps::MapData::create(&mut self, name: &str, btf_fd: core::option::Option<std::os::fd::owned::BorrowedFd<'_>>) -> core::result::Result<std::os::fd::raw::RawFd, aya::maps::MapError>
 pub fn aya::maps::MapData::fd(&self) -> core::option::Option<aya::maps::MapFd>
 pub fn aya::maps::MapData::from_fd(fd: std::os::fd::owned::OwnedFd) -> core::result::Result<aya::maps::MapData, aya::maps::MapError>
 pub fn aya::maps::MapData::from_pin<P: core::convert::AsRef<std::path::Path>>(path: P) -> core::result::Result<aya::maps::MapData, aya::maps::MapError>


### PR DESCRIPTION
This is only used in create and therefore can be passed
as a parameter.