### PR TITLE
all: better panic messages

### DIFF
--- a/aya-obj/src/btf/relocation.rs
+++ b/aya-obj/src/btf/relocation.rs
@@ -580,7 +580,7 @@ fn match_member<'target>(
         // this won't panic, bounds are checked when local_spec is built in AccessSpec::new
         BtfType::Struct(s) => s.members.get(local_accessor.index).unwrap(),
         BtfType::Union(u) => u.members.get(local_accessor.index).unwrap(),
-        _ => panic!("bug! this should only be called for structs and unions"),
+        local_ty => panic!("unexpected type {:?}", local_ty),
     };
 
     let local_name = &*local_btf.string_at(local_member.name_offset)?;
@@ -1210,8 +1210,10 @@ impl ComputedRelocation {
             FieldRShift64 => {
                 value.value = 64 - bit_size as u64;
             }
-            FieldExists // this is handled at the start of the function
-            | _ => panic!("bug! this should not be reached"),
+            kind @ (FieldExists | TypeIdLocal | TypeIdTarget | TypeExists | TypeSize
+            | EnumVariantExists | EnumVariantValue) => {
+                panic!("unexpected relocation kind {:?}", kind)
+            }
         }
 
         Ok(value)

--- a/aya-obj/src/obj.rs
+++ b/aya-obj/src/obj.rs
@@ -1771,11 +1771,9 @@ mod tests {
         assert!(obj.maps.get("bar").is_some());
         assert!(obj.maps.get("baz").is_some());
         for map in obj.maps.values() {
-            if let Map::Legacy(m) = map {
+            assert_matches!(map, Map::Legacy(m) => {
                 assert_eq!(&m.def, def);
-            } else {
-                panic!("expected a BTF map")
-            }
+            })
         }
     }
 
@@ -2462,12 +2460,10 @@ mod tests {
         obj.parse_section(map_section).unwrap();
 
         let map = obj.maps.get("map_1").unwrap();
-        if let Map::Btf(m) = map {
+        assert_matches!(map, Map::Btf(m) => {
             assert_eq!(m.def.key_size, 4);
             assert_eq!(m.def.value_size, 8);
             assert_eq!(m.def.max_entries, 1);
-        } else {
-            panic!("expected a BTF map")
-        }
+        });
     }
 }

--- a/aya/src/maps/hash_map/hash_map.rs
+++ b/aya/src/maps/hash_map/hash_map.rs
@@ -623,7 +623,7 @@ mod tests {
                     Some(10) => set_next_key(attr, 20),
                     Some(20) => return sys_error(EFAULT),
                     Some(30) => return sys_error(ENOENT),
-                    Some(_) => panic!(),
+                    Some(i) => panic!("invalid key {}", i),
                 };
 
                 Ok(1)

--- a/aya/src/maps/perf/perf_buffer.rs
+++ b/aya/src/maps/perf/perf_buffer.rs
@@ -331,7 +331,7 @@ mod tests {
     fn fake_mmap(buf: &MMappedBuf) {
         override_syscall(|call| match call {
             Syscall::PerfEventOpen { .. } | Syscall::PerfEventIoctl { .. } => Ok(42),
-            _ => panic!(),
+            call => panic!("unexpected syscall: {:?}", call),
         });
         TEST_MMAP_RET.with(|ret| *ret.borrow_mut() = buf as *const _ as *mut _);
     }

--- a/aya/src/sys/mod.rs
+++ b/aya/src/sys/mod.rs
@@ -38,6 +38,38 @@ pub(crate) enum Syscall<'a> {
     },
 }
 
+impl std::fmt::Debug for Syscall<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Bpf { cmd, attr: _ } => f
+                .debug_struct("Syscall::Bpf")
+                .field("cmd", cmd)
+                .field("attr", &format_args!("_"))
+                .finish(),
+            Self::PerfEventOpen {
+                attr: _,
+                pid,
+                cpu,
+                group,
+                flags,
+            } => f
+                .debug_struct("Syscall::PerfEventOpen")
+                .field("attr", &format_args!("_"))
+                .field("pid", pid)
+                .field("cpu", cpu)
+                .field("group", group)
+                .field("flags", flags)
+                .finish(),
+            Self::PerfEventIoctl { fd, request, arg } => f
+                .debug_struct("Syscall::PerfEventIoctl")
+                .field("fd", fd)
+                .field("request", request)
+                .field("arg", arg)
+                .finish(),
+        }
+    }
+}
+
 fn syscall(call: Syscall) -> SysResult<c_long> {
     #[cfg(test)]
     return TEST_SYSCALL.with(|test_impl| unsafe { test_impl.borrow()(call) });

--- a/test/integration-test/src/tests/elf.rs
+++ b/test/integration-test/src/tests/elf.rs
@@ -3,19 +3,6 @@ use object::{Object, ObjectSymbol};
 #[test]
 fn test_maps() {
     let obj_file = object::File::parse(crate::MAP_TEST).unwrap();
-    if obj_file.section_by_name("maps").is_none() {
-        panic!("No 'maps' ELF section");
-    }
-    let mut found = false;
-    for sym in obj_file.symbols() {
-        if let Ok(name) = sym.name() {
-            if name == "BAR" {
-                found = true;
-                break;
-            }
-        }
-    }
-    if !found {
-        panic!("No symbol 'BAR' in ELF file")
-    }
+    assert!(obj_file.section_by_name("maps").is_some());
+    assert!(obj_file.symbols().any(|sym| sym.name() == Ok("BAR")));
 }


### PR DESCRIPTION
Always include operands in failing assertions. Use assert_matches over
manual match + panic.
