### PR TITLE
aya-bpf-macros: Remove pop_required_string_args

### DIFF
--- a/aya-bpf-macros/src/args.rs
+++ b/aya-bpf-macros/src/args.rs
@@ -7,22 +7,32 @@ use syn::{
 
 pub(crate) struct NameValue {
     name: Ident,
-    _eq: Eq,
     value: LitStr,
 }
 
+pub(crate) enum Arg {
+    String(NameValue),
+    Bool(Ident),
+}
+
 pub(crate) struct Args {
-    pub(crate) args: Vec<NameValue>,
+    pub(crate) args: Vec<Arg>,
 }
 
 impl Parse for Args {
     fn parse(input: ParseStream) -> Result<Args> {
-        let args = Punctuated::<NameValue, Token![,]>::parse_terminated_with(input, |input| {
-            Ok(NameValue {
-                name: input.parse()?,
-                _eq: input.parse()?,
-                value: input.parse()?,
-            })
+        let args = Punctuated::<Arg, Token![,]>::parse_terminated_with(input, |input| {
+            let ident = input.parse::<Ident>()?;
+            let lookahead = input.lookahead1();
+            if lookahead.peek(Token![=]) {
+                let _ = input.parse::<Eq>()?;
+                Ok(Arg::String(NameValue {
+                    name: ident,
+                    value: input.parse()?,
+                }))
+            } else {
+                Ok(Arg::Bool(ident))
+            }
         })?
         .into_pairs()
         .map(|pair| match pair {
@@ -35,35 +45,66 @@ impl Parse for Args {
     }
 }
 
-pub(crate) fn pop_arg(args: &mut Args, name: &str) -> Option<String> {
-    match args.args.iter().position(|arg| arg.name == name) {
-        Some(index) => Some(args.args.remove(index).value.value()),
-        None => None,
-    }
-}
-
-pub(crate) fn pop_required_arg(args: &mut Args, name: &str) -> Result<String> {
-    let value = match args.args.iter().position(|arg| arg.name == name) {
-        Some(index) => Some(args.args.remove(index).value.value()),
+pub(crate) fn pop_string_arg(args: &mut Args, name: &str) -> Option<String> {
+    let value = match args.args.iter().position(|arg| match arg {
+        Arg::String(name_val) => name_val.name == name,
+        Arg::Bool(_) => false,
+    }) {
+        Some(index) => Some(args.args.remove(index)),
         None => None,
     };
     match value {
-        Some(value) => Ok(value),
-        None => Err(Error::new_spanned(
-            args.args.first().unwrap().name.clone(),
-            format!("missing required argument `{}`", name),
-        )),
+        Some(Arg::String(value)) => Some(value.value.value()),
+        Some(Arg::Bool(_)) | None => None,
+    }
+}
+
+pub(crate) fn pop_bool_arg(args: &mut Args, name: &str) -> bool {
+    let value = match args.args.iter().position(|arg| match arg {
+        Arg::String(_) => false,
+        Arg::Bool(ident) => ident == name,
+    }) {
+        Some(index) => Some(args.args.remove(index)),
+        None => None,
+    };
+    value.is_some()
+}
+
+pub(crate) fn pop_required_string_arg(args: &mut Args, name: &str) -> Result<String> {
+    let value = match args.args.iter().position(|arg| match arg {
+        Arg::String(name_val) => name_val.name == name,
+        Arg::Bool(_) => false,
+    }) {
+        Some(index) => Some(args.args.remove(index)),
+        None => None,
+    };
+    match value {
+        Some(Arg::String(value)) => Ok(value.value.value()),
+        Some(Arg::Bool(_)) => unreachable!("arg bool were filtered out"),
+        None => {
+            let tokens = match args.args.first().unwrap() {
+                Arg::String(name_val) => &name_val.name,
+                Arg::Bool(ident) => ident,
+            };
+            Err(Error::new_spanned(
+                tokens,
+                format!("missing required argument `{}`", name),
+            ))
+        }
     }
 }
 
 pub(crate) fn err_on_unknown_args(args: &Args) -> Result<()> {
     if let Some(arg) = args.args.get(0) {
-        return Err(Error::new_spanned(&arg.name, "invalid argument"));
+        let tokens = match arg {
+            Arg::String(name_val) => name_val.name.clone(),
+            Arg::Bool(ident) => ident.clone(),
+        };
+        return Err(Error::new_spanned(tokens, "invalid argument"));
     }
     Ok(())
 }
 
-pub(crate) fn name_arg(args: &mut Args) -> Result<Option<String>> {
-    let name = pop_arg(args, "name");
-    Ok(name)
+pub(crate) fn name_arg(args: &mut Args) -> Option<String> {
+    pop_string_arg(args, "name")
 }

--- a/aya-bpf-macros/src/args.rs
+++ b/aya-bpf-macros/src/args.rs
@@ -70,30 +70,6 @@ pub(crate) fn pop_bool_arg(args: &mut Args, name: &str) -> bool {
     value.is_some()
 }
 
-pub(crate) fn pop_required_string_arg(args: &mut Args, name: &str) -> Result<String> {
-    let value = match args.args.iter().position(|arg| match arg {
-        Arg::String(name_val) => name_val.name == name,
-        Arg::Bool(_) => false,
-    }) {
-        Some(index) => Some(args.args.remove(index)),
-        None => None,
-    };
-    match value {
-        Some(Arg::String(value)) => Ok(value.value.value()),
-        Some(Arg::Bool(_)) => unreachable!("arg bool were filtered out"),
-        None => {
-            let tokens = match args.args.first().unwrap() {
-                Arg::String(name_val) => &name_val.name,
-                Arg::Bool(ident) => ident,
-            };
-            Err(Error::new_spanned(
-                tokens,
-                format!("missing required argument `{}`", name),
-            ))
-        }
-    }
-}
-
 pub(crate) fn err_on_unknown_args(args: &Args) -> Result<()> {
     if let Some(arg) = args.args.get(0) {
         let tokens = match arg {

--- a/aya-bpf-macros/src/btf_tracepoint.rs
+++ b/aya-bpf-macros/src/btf_tracepoint.rs
@@ -4,24 +4,33 @@ use proc_macro2::TokenStream;
 use quote::quote;
 use syn::{ItemFn, Result};
 
-use crate::args::{err_on_unknown_args, pop_required_string_arg, Args};
+use crate::args::{err_on_unknown_args, pop_string_arg, Args};
 
 pub(crate) struct BtfTracePoint {
     item: ItemFn,
-    function: String,
+    function: Option<String>,
 }
 
 impl BtfTracePoint {
     pub(crate) fn parse(attrs: TokenStream, item: TokenStream) -> Result<Self> {
-        let mut args: Args = syn::parse2(attrs)?;
         let item = syn::parse2(item)?;
-        let function = pop_required_string_arg(&mut args, "function")?;
-        err_on_unknown_args(&args)?;
+        let mut function = None;
+        if !attrs.is_empty() {
+            let mut args: Args = syn::parse2(attrs)?;
+            if let Some(f) = pop_string_arg(&mut args, "function") {
+                function = Some(f);
+            }
+            err_on_unknown_args(&args)?;
+        }
         Ok(BtfTracePoint { item, function })
     }
 
     pub(crate) fn expand(&self) -> Result<TokenStream> {
-        let section_name: Cow<'_, _> = format!("tp_btf/{}", self.function).into();
+        let section_name: Cow<'_, _> = if self.function.is_none() {
+            "tp_btf".into()
+        } else {
+            format!("tp_btf/{}", self.function.as_ref().unwrap()).into()
+        };
         let fn_vis = &self.item.vis;
         let fn_name = self.item.sig.ident.clone();
         let item = &self.item;
@@ -45,6 +54,33 @@ mod tests {
 
     #[test]
     fn test_btf_tracepoint() {
+        let prog = BtfTracePoint::parse(
+            parse_quote!(),
+            parse_quote!(
+                fn foo(ctx: BtfTracePointContext) -> i32 {
+                    0
+                }
+            ),
+        )
+        .unwrap();
+        let expanded = prog.expand().unwrap();
+        let expected = quote!(
+            #[no_mangle]
+            #[link_section = "tp_btf"]
+            fn foo(ctx: *mut ::core::ffi::c_void) -> i32 {
+                let _ = foo(::aya_bpf::programs::BtfTracePointContext::new(ctx));
+                return 0;
+
+                fn foo(ctx: BtfTracePointContext) -> i32 {
+                    0
+                }
+            }
+        );
+        assert_eq!(expected.to_string(), expanded.to_string());
+    }
+
+    #[test]
+    fn test_btf_tracepoint_with_function() {
         let prog = BtfTracePoint::parse(
             parse_quote!(function = "some_func"),
             parse_quote!(

--- a/aya-bpf-macros/src/fentry.rs
+++ b/aya-bpf-macros/src/fentry.rs
@@ -1,28 +1,30 @@
 use std::borrow::Cow;
 
 use proc_macro2::TokenStream;
-use proc_macro_error::abort;
 use quote::quote;
 use syn::{ItemFn, Result};
 
-use crate::args::{err_on_unknown_args, pop_bool_arg, pop_required_string_arg};
+use crate::args::{err_on_unknown_args, pop_bool_arg, pop_string_arg};
 
 pub(crate) struct FEntry {
     item: ItemFn,
-    function: String,
+    function: Option<String>,
     sleepable: bool,
 }
 
 impl FEntry {
     pub(crate) fn parse(attrs: TokenStream, item: TokenStream) -> Result<FEntry> {
-        if attrs.is_empty() {
-            abort!(attrs, "missing function name");
-        }
-        let mut args = syn::parse2(attrs)?;
         let item = syn::parse2(item)?;
-        let function = pop_required_string_arg(&mut args, "function")?;
-        let sleepable = pop_bool_arg(&mut args, "sleepable");
-        err_on_unknown_args(&args)?;
+        let mut function = None;
+        let mut sleepable = false;
+        if !attrs.is_empty() {
+            let mut args = syn::parse2(attrs)?;
+            if let Some(f) = pop_string_arg(&mut args, "function") {
+                function = Some(f);
+            };
+            sleepable = pop_bool_arg(&mut args, "sleepable");
+            err_on_unknown_args(&args)?;
+        }
         Ok(FEntry {
             item,
             function,
@@ -32,7 +34,11 @@ impl FEntry {
 
     pub(crate) fn expand(&self) -> Result<TokenStream> {
         let section_prefix = if self.sleepable { "fentry.s" } else { "fentry" };
-        let section_name: Cow<'_, _> = format!("{}/{}", section_prefix, self.function).into();
+        let section_name: Cow<'_, _> = if self.function.is_none() {
+            section_prefix.into()
+        } else {
+            format!("{}/{}", section_prefix, self.function.as_ref().unwrap()).into()
+        };
         let fn_vis = &self.item.vis;
         let fn_name = self.item.sig.ident.clone();
         let item = &self.item;
@@ -56,6 +62,33 @@ mod tests {
 
     #[test]
     fn test_fentry() {
+        let prog = FEntry::parse(
+            parse_quote! {},
+            parse_quote! {
+                fn sys_clone(ctx: &mut aya_bpf::programs::FEntryContext) -> i32 {
+                    0
+                }
+            },
+        )
+        .unwrap();
+        let expanded = prog.expand().unwrap();
+        let expected = quote! {
+            #[no_mangle]
+            #[link_section = "fentry"]
+            fn sys_clone(ctx: *mut ::core::ffi::c_void) -> i32 {
+                let _ = sys_clone(::aya_bpf::programs::FEntryContext::new(ctx));
+                return 0;
+
+                fn sys_clone(ctx: &mut aya_bpf::programs::FEntryContext) -> i32 {
+                    0
+                }
+            }
+        };
+        assert_eq!(expected.to_string(), expanded.to_string());
+    }
+
+    #[test]
+    fn test_fentry_with_function() {
         let prog = FEntry::parse(
             parse_quote! {
                 function = "sys_clone"
@@ -87,7 +120,6 @@ mod tests {
     fn test_fentry_sleepable() {
         let prog = FEntry::parse(
             parse_quote! {
-                function = "sys_clone",
                 sleepable
             },
             parse_quote! {
@@ -100,7 +132,7 @@ mod tests {
         let expanded = prog.expand().unwrap();
         let expected = quote! {
             #[no_mangle]
-            #[link_section = "fentry.s/sys_clone"]
+            #[link_section = "fentry.s"]
             fn sys_clone(ctx: *mut ::core::ffi::c_void) -> i32 {
                 let _ = sys_clone(::aya_bpf::programs::FEntryContext::new(ctx));
                 return 0;

--- a/aya-bpf-macros/src/kprobe.rs
+++ b/aya-bpf-macros/src/kprobe.rs
@@ -5,7 +5,7 @@ use proc_macro2::TokenStream;
 use quote::quote;
 use syn::{ItemFn, Result};
 
-use crate::args::{err_on_unknown_args, pop_arg};
+use crate::args::{err_on_unknown_args, pop_string_arg};
 
 #[allow(clippy::enum_variant_names)]
 #[derive(Debug, Copy, Clone)]
@@ -38,8 +38,8 @@ impl KProbe {
 
         if !attrs.is_empty() {
             let mut args = syn::parse2(attrs)?;
-            function = pop_arg(&mut args, "function");
-            offset = pop_arg(&mut args, "offset").map(|v| v.parse::<u64>().unwrap());
+            function = pop_string_arg(&mut args, "function");
+            offset = pop_string_arg(&mut args, "offset").map(|v| v.parse::<u64>().unwrap());
             err_on_unknown_args(&args)?;
         }
         let item = syn::parse2(item)?;

--- a/aya-bpf-macros/src/lib.rs
+++ b/aya-bpf-macros/src/lib.rs
@@ -309,7 +309,7 @@ pub fn raw_tracepoint(attrs: TokenStream, item: TokenStream) -> TokenStream {
 /// Used to implement security policy and audit logging.
 ///
 /// The hook name is the first argument to the macro.
-/// You may also provide `sleepable = true` to mark the program as sleepable.
+/// You may also provide `sleepable` to mark the program as sleepable.
 /// Arguments should be comma separated.
 ///
 /// LSM probes can be attached to the kernel's security hooks to implement mandatory

--- a/aya-bpf-macros/src/map.rs
+++ b/aya-bpf-macros/src/map.rs
@@ -16,7 +16,7 @@ impl Map {
     pub(crate) fn parse(attrs: TokenStream, item: TokenStream) -> Result<Map> {
         let mut args = syn::parse2(attrs)?;
         let item: ItemStatic = syn::parse2(item)?;
-        let name = name_arg(&mut args)?.unwrap_or_else(|| item.ident.to_string());
+        let name = name_arg(&mut args).unwrap_or_else(|| item.ident.to_string());
         Ok(Map { item, name })
     }
 

--- a/aya-bpf-macros/src/raw_tracepoint.rs
+++ b/aya-bpf-macros/src/raw_tracepoint.rs
@@ -5,7 +5,7 @@ use proc_macro_error::abort;
 use quote::quote;
 use syn::{ItemFn, Result};
 
-use crate::args::{err_on_unknown_args, pop_required_arg};
+use crate::args::{err_on_unknown_args, pop_required_string_arg};
 
 pub(crate) struct RawTracePoint {
     item: ItemFn,
@@ -19,7 +19,7 @@ impl RawTracePoint {
         }
         let mut args = syn::parse2(attrs)?;
         let item = syn::parse2(item)?;
-        let tracepoint = pop_required_arg(&mut args, "tracepoint")?;
+        let tracepoint = pop_required_string_arg(&mut args, "tracepoint")?;
         err_on_unknown_args(&args)?;
         Ok(RawTracePoint { item, tracepoint })
     }

--- a/aya-bpf-macros/src/raw_tracepoint.rs
+++ b/aya-bpf-macros/src/raw_tracepoint.rs
@@ -1,31 +1,37 @@
 use std::borrow::Cow;
 
 use proc_macro2::TokenStream;
-use proc_macro_error::abort;
+
 use quote::quote;
 use syn::{ItemFn, Result};
 
-use crate::args::{err_on_unknown_args, pop_required_string_arg};
+use crate::args::{err_on_unknown_args, pop_string_arg};
 
 pub(crate) struct RawTracePoint {
     item: ItemFn,
-    tracepoint: String,
+    tracepoint: Option<String>,
 }
 
 impl RawTracePoint {
     pub(crate) fn parse(attrs: TokenStream, item: TokenStream) -> Result<RawTracePoint> {
-        if attrs.is_empty() {
-            abort!(attrs, "expected `tracepoint` attribute")
-        }
-        let mut args = syn::parse2(attrs)?;
         let item = syn::parse2(item)?;
-        let tracepoint = pop_required_string_arg(&mut args, "tracepoint")?;
-        err_on_unknown_args(&args)?;
+        let mut tracepoint = None;
+        if !attrs.is_empty() {
+            let mut args = syn::parse2(attrs)?;
+            if let Some(tp) = pop_string_arg(&mut args, "tracepoint") {
+                tracepoint = Some(tp)
+            };
+            err_on_unknown_args(&args)?;
+        }
         Ok(RawTracePoint { item, tracepoint })
     }
 
     pub(crate) fn expand(&self) -> Result<TokenStream> {
-        let section_name: Cow<'_, _> = format!("raw_tp/{}", self.tracepoint).into();
+        let section_name: Cow<'_, _> = if self.tracepoint.is_none() {
+            "raw_tp".into()
+        } else {
+            format!("raw_tp/{}", self.tracepoint.as_ref().unwrap()).into()
+        };
         let fn_vis = &self.item.vis;
         let fn_name = self.item.sig.ident.clone();
         let item = &self.item;

--- a/aya-bpf-macros/src/tracepoint.rs
+++ b/aya-bpf-macros/src/tracepoint.rs
@@ -5,7 +5,7 @@ use proc_macro_error::abort;
 use quote::quote;
 use syn::{ItemFn, Result};
 
-use crate::args::{err_on_unknown_args, pop_arg};
+use crate::args::{err_on_unknown_args, pop_string_arg};
 
 pub(crate) struct TracePoint {
     item: ItemFn,
@@ -17,8 +17,8 @@ impl TracePoint {
     pub(crate) fn parse(attrs: TokenStream, item: TokenStream) -> Result<TracePoint> {
         let mut args = syn::parse2(attrs)?;
         let item = syn::parse2(item)?;
-        let name = pop_arg(&mut args, "name");
-        let category = pop_arg(&mut args, "category");
+        let name = pop_string_arg(&mut args, "name");
+        let category = pop_string_arg(&mut args, "category");
         err_on_unknown_args(&args)?;
         Ok(TracePoint {
             item,

--- a/aya/src/bpf.rs
+++ b/aya/src/bpf.rs
@@ -562,14 +562,28 @@ impl<'a> BpfLoader<'a> {
                             data: ProgramData::new(prog_name, obj, btf_fd, *verifier_log_level),
                             kind: ProbeKind::KRetProbe,
                         }),
-                        ProgramSection::UProbe { .. } => Program::UProbe(UProbe {
-                            data: ProgramData::new(prog_name, obj, btf_fd, *verifier_log_level),
-                            kind: ProbeKind::UProbe,
-                        }),
-                        ProgramSection::URetProbe { .. } => Program::UProbe(UProbe {
-                            data: ProgramData::new(prog_name, obj, btf_fd, *verifier_log_level),
-                            kind: ProbeKind::URetProbe,
-                        }),
+                        ProgramSection::UProbe { sleepable, .. } => {
+                            let mut data =
+                                ProgramData::new(prog_name, obj, btf_fd, *verifier_log_level);
+                            if *sleepable {
+                                data.flags = BPF_F_SLEEPABLE;
+                            }
+                            Program::UProbe(UProbe {
+                                data,
+                                kind: ProbeKind::UProbe,
+                            })
+                        }
+                        ProgramSection::URetProbe { sleepable, .. } => {
+                            let mut data =
+                                ProgramData::new(prog_name, obj, btf_fd, *verifier_log_level);
+                            if *sleepable {
+                                data.flags = BPF_F_SLEEPABLE;
+                            }
+                            Program::UProbe(UProbe {
+                                data,
+                                kind: ProbeKind::URetProbe,
+                            })
+                        }
                         ProgramSection::TracePoint { .. } => Program::TracePoint(TracePoint {
                             data: ProgramData::new(prog_name, obj, btf_fd, *verifier_log_level),
                         }),
@@ -662,12 +676,22 @@ impl<'a> BpfLoader<'a> {
                                 data: ProgramData::new(prog_name, obj, btf_fd, *verifier_log_level),
                             })
                         }
-                        ProgramSection::FEntry { .. } => Program::FEntry(FEntry {
-                            data: ProgramData::new(prog_name, obj, btf_fd, *verifier_log_level),
-                        }),
-                        ProgramSection::FExit { .. } => Program::FExit(FExit {
-                            data: ProgramData::new(prog_name, obj, btf_fd, *verifier_log_level),
-                        }),
+                        ProgramSection::FEntry { sleepable, .. } => {
+                            let mut data =
+                                ProgramData::new(prog_name, obj, btf_fd, *verifier_log_level);
+                            if *sleepable {
+                                data.flags = BPF_F_SLEEPABLE;
+                            }
+                            Program::FEntry(FEntry { data })
+                        }
+                        ProgramSection::FExit { sleepable, .. } => {
+                            let mut data =
+                                ProgramData::new(prog_name, obj, btf_fd, *verifier_log_level);
+                            if *sleepable {
+                                data.flags = BPF_F_SLEEPABLE;
+                            }
+                            Program::FExit(FExit { data })
+                        }
                         ProgramSection::Extension { .. } => Program::Extension(Extension {
                             data: ProgramData::new(prog_name, obj, btf_fd, *verifier_log_level),
                         }),

--- a/xtask/public-api/aya-obj.txt
+++ b/xtask/public-api/aya-obj.txt
@@ -5837,8 +5837,10 @@ pub aya_obj::obj::ProgramSection::Extension
 pub aya_obj::obj::ProgramSection::Extension::name: alloc::string::String
 pub aya_obj::obj::ProgramSection::FEntry
 pub aya_obj::obj::ProgramSection::FEntry::name: alloc::string::String
+pub aya_obj::obj::ProgramSection::FEntry::sleepable: bool
 pub aya_obj::obj::ProgramSection::FExit
 pub aya_obj::obj::ProgramSection::FExit::name: alloc::string::String
+pub aya_obj::obj::ProgramSection::FExit::sleepable: bool
 pub aya_obj::obj::ProgramSection::KProbe
 pub aya_obj::obj::ProgramSection::KProbe::name: alloc::string::String
 pub aya_obj::obj::ProgramSection::KRetProbe
@@ -5870,8 +5872,10 @@ pub aya_obj::obj::ProgramSection::TracePoint
 pub aya_obj::obj::ProgramSection::TracePoint::name: alloc::string::String
 pub aya_obj::obj::ProgramSection::UProbe
 pub aya_obj::obj::ProgramSection::UProbe::name: alloc::string::String
+pub aya_obj::obj::ProgramSection::UProbe::sleepable: bool
 pub aya_obj::obj::ProgramSection::URetProbe
 pub aya_obj::obj::ProgramSection::URetProbe::name: alloc::string::String
+pub aya_obj::obj::ProgramSection::URetProbe::sleepable: bool
 pub aya_obj::obj::ProgramSection::Xdp
 pub aya_obj::obj::ProgramSection::Xdp::frags: bool
 pub aya_obj::obj::ProgramSection::Xdp::name: alloc::string::String
@@ -6585,8 +6589,10 @@ pub aya_obj::ProgramSection::Extension
 pub aya_obj::ProgramSection::Extension::name: alloc::string::String
 pub aya_obj::ProgramSection::FEntry
 pub aya_obj::ProgramSection::FEntry::name: alloc::string::String
+pub aya_obj::ProgramSection::FEntry::sleepable: bool
 pub aya_obj::ProgramSection::FExit
 pub aya_obj::ProgramSection::FExit::name: alloc::string::String
+pub aya_obj::ProgramSection::FExit::sleepable: bool
 pub aya_obj::ProgramSection::KProbe
 pub aya_obj::ProgramSection::KProbe::name: alloc::string::String
 pub aya_obj::ProgramSection::KRetProbe
@@ -6618,8 +6624,10 @@ pub aya_obj::ProgramSection::TracePoint
 pub aya_obj::ProgramSection::TracePoint::name: alloc::string::String
 pub aya_obj::ProgramSection::UProbe
 pub aya_obj::ProgramSection::UProbe::name: alloc::string::String
+pub aya_obj::ProgramSection::UProbe::sleepable: bool
 pub aya_obj::ProgramSection::URetProbe
 pub aya_obj::ProgramSection::URetProbe::name: alloc::string::String
+pub aya_obj::ProgramSection::URetProbe::sleepable: bool
 pub aya_obj::ProgramSection::Xdp
 pub aya_obj::ProgramSection::Xdp::frags: bool
 pub aya_obj::ProgramSection::Xdp::name: alloc::string::String


### PR DESCRIPTION
I got a little carried away with refactoring the macros and started
making some macro arguments required when they previously were not.
While I'm all for doing this eventually, for stronger type guarantees
and de-duplicating information from BPF and userspace, it's premature
to do that now.
    
    
Depends on #711 