### PR TITLE
sys: add map_ids to bpf_prog_get_info_by_fd

### DIFF
--- a/aya/src/programs/extension.rs
+++ b/aya/src/programs/extension.rs
@@ -151,7 +151,7 @@ impl Extension {
 /// with the name `func_name` within that BTF object.
 fn get_btf_info(prog_fd: i32, func_name: &str) -> Result<(RawFd, u32), ProgramError> {
     // retrieve program information
-    let info = sys::bpf_prog_get_info_by_fd(prog_fd)?;
+    let info = sys::bpf_prog_get_info_by_fd(prog_fd, &mut [])?;
 
     // btf_id refers to the ID of the program btf that was loaded with bpf(BPF_BTF_LOAD)
     if info.btf_id == 0 {

--- a/aya/src/programs/lirc_mode2.rs
+++ b/aya/src/programs/lirc_mode2.rs
@@ -131,7 +131,7 @@ impl LircLink {
 
     /// Get ProgramInfo from this link
     pub fn info(&self) -> Result<ProgramInfo, ProgramError> {
-        bpf_prog_get_info_by_fd(self.prog_fd)
+        bpf_prog_get_info_by_fd(self.prog_fd, &mut [])
             .map(ProgramInfo)
             .map_err(Into::into)
     }

--- a/aya/src/programs/mod.rs
+++ b/aya/src/programs/mod.rs
@@ -488,7 +488,7 @@ impl<T: Link> ProgramData<T> {
             io_error,
         })?;
 
-        let info = bpf_prog_get_info_by_fd(fd.as_raw_fd())?;
+        let info = bpf_prog_get_info_by_fd(fd.as_raw_fd(), &mut [])?;
         let name = ProgramInfo(info).name_as_str().map(|s| s.to_string());
         ProgramData::from_bpf_prog_info(name, fd, path.as_ref(), info, verifier_log_level)
     }
@@ -955,7 +955,7 @@ impl ProgramInfo {
             io_error,
         })?;
 
-        let info = bpf_prog_get_info_by_fd(fd.as_raw_fd())?;
+        let info = bpf_prog_get_info_by_fd(fd.as_raw_fd(), &mut [])?;
         Ok(ProgramInfo(info))
     }
 }
@@ -991,7 +991,7 @@ pub fn loaded_programs() -> impl Iterator<Item = Result<ProgramInfo, ProgramErro
         })
         .map(|fd| {
             let fd = fd?;
-            bpf_prog_get_info_by_fd(fd.as_raw_fd())
+            bpf_prog_get_info_by_fd(fd.as_raw_fd(), &mut [])
         })
         .map(|result| result.map(ProgramInfo).map_err(Into::into))
 }


### PR DESCRIPTION
Allows the caller to pass a slice which the kernel will populate with
map ids used by the program.
