### PR TITLE
integration-test: Remove cargo symlink workaround

### DIFF
--- a/test/integration-ebpf/Cargo.toml
+++ b/test/integration-ebpf/Cargo.toml
@@ -9,6 +9,7 @@ aya-bpf = { path = "../../bpf/aya-bpf" }
 aya-log-ebpf = { path = "../../bpf/aya-log-ebpf" }
 
 [build-dependencies]
+which = { workspace = true }
 xtask = { path = "../../xtask" }
 
 [[bin]]

--- a/test/integration-ebpf/build.rs
+++ b/test/integration-ebpf/build.rs
@@ -1,6 +1,7 @@
-use std::{env, path::PathBuf};
+use std::env;
 
-use xtask::{create_symlink_to_binary, AYA_BUILD_INTEGRATION_BPF};
+use which::which;
+use xtask::AYA_BUILD_INTEGRATION_BPF;
 
 /// Building this crate has an undeclared dependency on the `bpf-linker` binary. This would be
 /// better expressed by [artifact-dependencies][bindeps] but issues such as
@@ -24,12 +25,7 @@ fn main() {
         .unwrap_or_default();
 
     if build_integration_bpf {
-        let out_dir = env::var_os("OUT_DIR").unwrap();
-        let out_dir = PathBuf::from(out_dir);
-        let bpf_linker_symlink = create_symlink_to_binary(&out_dir, "bpf-linker").unwrap();
-        println!(
-            "cargo:rerun-if-changed={}",
-            bpf_linker_symlink.to_str().unwrap()
-        );
+        let bpf_linker = which("bpf-linker").unwrap();
+        println!("cargo:rerun-if-changed={}", bpf_linker.to_str().unwrap());
     }
 }

--- a/xtask/src/lib.rs
+++ b/xtask/src/lib.rs
@@ -1,10 +1,5 @@
 use anyhow::{bail, Context as _, Result};
-use std::{
-    fs,
-    path::{Path, PathBuf},
-    process::Command,
-};
-use which::which;
+use std::process::Command;
 
 pub const AYA_BUILD_INTEGRATION_BPF: &str = "AYA_BUILD_INTEGRATION_BPF";
 pub const LIBBPF_DIR: &str = "xtask/libbpf";
@@ -17,27 +12,4 @@ pub fn exec(cmd: &mut Command) -> Result<()> {
         bail!("{cmd:?} failed: {status:?}")
     }
     Ok(())
-}
-
-// Create a symlink in the out directory to work around the fact that cargo ignores anything
-// in `$CARGO_HOME`, which is also where `cargo install` likes to place binaries. Cargo will
-// stat through the symlink and discover that the binary has changed.
-//
-// This was introduced in https://github.com/rust-lang/cargo/commit/99f841c.
-//
-// TODO(https://github.com/rust-lang/cargo/pull/12369): Remove this when the fix is available.
-pub fn create_symlink_to_binary(out_dir: &Path, binary_name: &str) -> Result<PathBuf> {
-    let binary = which(binary_name).unwrap();
-    let symlink = out_dir.join(binary_name);
-    match fs::remove_file(&symlink) {
-        Ok(()) => {}
-        Err(err) => {
-            if err.kind() != std::io::ErrorKind::NotFound {
-                return Err(err).context(format!("failed to remove symlink {}", symlink.display()));
-            }
-        }
-    }
-    std::os::unix::fs::symlink(binary, &symlink)
-        .with_context(|| format!("failed to create symlink {}", symlink.display()))?;
-    Ok(symlink)
 }


### PR DESCRIPTION
https://github.com/rust-lang/cargo/pull/12369 fixed this bug and was
picked up in https://github.com/rust-lang/rust/pull/114027.
