### PR TITLE
aya: deny various allow-by-default lints

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,7 +66,6 @@ core-error = { version = "0.0.0", default-features = false }
 dialoguer = { version = "0.10", default-features = false }
 diff = { version = "0.1.13", default-features = false }
 env_logger = { version = "0.10", default-features = false }
-futures = { version = "0.3.12", default-features = false }
 hashbrown = { version = "0.14", default-features = false }
 indoc = { version = "2.0", default-features = false }
 integration-ebpf = { path = "test/integration-ebpf", default-features = false }
@@ -77,7 +76,6 @@ netns-rs = { version = "0.1", default-features = false }
 nix = { version = "0.26.2", default-features = false }
 num_enum = { version = "0.7", default-features = false }
 object = { version = "0.32", default-features = false }
-parking_lot = { version = "0.12.0", default-features = false }
 proc-macro-error = { version = "1.0", default-features = false }
 proc-macro2 = { version = "1", default-features = false }
 public-api = { version = "0.31.2", default-features = false }

--- a/aya/Cargo.toml
+++ b/aya/Cargo.toml
@@ -24,13 +24,11 @@ object = { workspace = true, default-features = false, features = [
     "read_core",
     "std",
 ] }
-parking_lot = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["rt"], optional = true }
 
 [dev-dependencies]
 assert_matches = { workspace = true }
-futures = { workspace = true }
 tempfile = { workspace = true }
 
 [features]

--- a/aya/src/bpf.rs
+++ b/aya/src/bpf.rs
@@ -71,7 +71,7 @@ unsafe impl<T: Pod, const N: usize> Pod for [T; N] {}
 
 pub use aya_obj::maps::{bpf_map_def, PinningType};
 
-lazy_static! {
+lazy_static::lazy_static! {
     pub(crate) static ref FEATURES: Features = detect_features();
 }
 
@@ -138,7 +138,7 @@ pub struct BpfLoader<'a> {
     allow_unsupported_maps: bool,
 }
 
-bitflags! {
+bitflags::bitflags! {
     /// Used to set the verifier log level flags in [BpfLoader](BpfLoader::verifier_log_level()).
     #[derive(Clone, Copy, Debug)]
     pub struct VerifierLogLevel: u32 {
@@ -161,8 +161,8 @@ impl Default for VerifierLogLevel {
 
 impl<'a> BpfLoader<'a> {
     /// Creates a new loader instance.
-    pub fn new() -> BpfLoader<'a> {
-        BpfLoader {
+    pub fn new() -> Self {
+        Self {
             btf: Btf::from_sys_fs().ok().map(Cow::Owned),
             map_pin_path: None,
             globals: HashMap::new(),
@@ -738,7 +738,7 @@ fn parse_map(data: (String, MapData)) -> Result<(String, Map), BpfError> {
     Ok((name, map))
 }
 
-impl<'a> Default for BpfLoader<'a> {
+impl Default for BpfLoader<'_> {
     fn default() -> Self {
         BpfLoader::new()
     }
@@ -768,7 +768,7 @@ impl Bpf {
     /// let bpf = Bpf::load_file("file.o")?;
     /// # Ok::<(), aya::BpfError>(())
     /// ```
-    pub fn load_file<P: AsRef<Path>>(path: P) -> Result<Bpf, BpfError> {
+    pub fn load_file<P: AsRef<Path>>(path: P) -> Result<Self, BpfError> {
         BpfLoader::new()
             .btf(Btf::from_sys_fs().ok().as_ref())
             .load_file(path)
@@ -793,7 +793,7 @@ impl Bpf {
     /// let bpf = Bpf::load(&data)?;
     /// # Ok::<(), aya::BpfError>(())
     /// ```
-    pub fn load(data: &[u8]) -> Result<Bpf, BpfError> {
+    pub fn load(data: &[u8]) -> Result<Self, BpfError> {
         BpfLoader::new()
             .btf(Btf::from_sys_fs().ok().as_ref())
             .load(data)

--- a/aya/src/lib.rs
+++ b/aya/src/lib.rs
@@ -37,13 +37,47 @@
     html_favicon_url = "https://aya-rs.dev/assets/images/crabby.svg"
 )]
 #![cfg_attr(docsrs, feature(doc_cfg))]
-#![deny(clippy::all, missing_docs)]
+#![deny(
+    clippy::all,
+    clippy::use_self,
+    absolute_paths_not_starting_with_crate,
+    deprecated_in_future,
+    elided_lifetimes_in_paths,
+    explicit_outlives_requirements,
+    ffi_unwind_calls,
+    keyword_idents,
+    //let_underscore_drop,
+    macro_use_extern_crate,
+    meta_variable_misuse,
+    missing_abi,
+    //missing_copy_implementations,
+    missing_docs,
+    non_ascii_idents,
+    noop_method_call,
+    pointer_structural_match,
+    rust_2021_incompatible_closure_captures,
+    rust_2021_incompatible_or_patterns,
+    rust_2021_prefixes_incompatible_syntax,
+    rust_2021_prelude_collisions,
+    single_use_lifetimes,
+    trivial_numeric_casts,
+    unreachable_pub,
+    //unsafe_op_in_unsafe_fn,
+    unstable_features,
+    unused_crate_dependencies,
+    unused_extern_crates,
+    unused_import_braces,
+    unused_lifetimes,
+    unused_macro_rules,
+    unused_qualifications,
+    //unused_results,
+    unused_tuple_struct_fields,
+)]
 #![allow(clippy::missing_safety_doc, clippy::len_without_is_empty)]
-
-#[macro_use]
-extern crate lazy_static;
-#[macro_use]
-extern crate bitflags;
+#![cfg_attr(
+    all(feature = "async_tokio", feature = "async_std"),
+    allow(unused_crate_dependencies)
+)]
 
 mod bpf;
 use aya_obj::generated;

--- a/aya/src/maps/array/array.rs
+++ b/aya/src/maps/array/array.rs
@@ -35,11 +35,11 @@ pub struct Array<T, V: Pod> {
 }
 
 impl<T: Borrow<MapData>, V: Pod> Array<T, V> {
-    pub(crate) fn new(map: T) -> Result<Array<T, V>, MapError> {
+    pub(crate) fn new(map: T) -> Result<Self, MapError> {
         let data = map.borrow();
         check_kv_size::<u32, V>(data)?;
 
-        Ok(Array {
+        Ok(Self {
             inner: map,
             _v: PhantomData,
         })

--- a/aya/src/maps/array/per_cpu_array.rs
+++ b/aya/src/maps/array/per_cpu_array.rs
@@ -54,11 +54,11 @@ pub struct PerCpuArray<T, V: Pod> {
 }
 
 impl<T: Borrow<MapData>, V: Pod> PerCpuArray<T, V> {
-    pub(crate) fn new(map: T) -> Result<PerCpuArray<T, V>, MapError> {
+    pub(crate) fn new(map: T) -> Result<Self, MapError> {
         let data = map.borrow();
         check_kv_size::<u32, V>(data)?;
 
-        Ok(PerCpuArray {
+        Ok(Self {
             inner: map,
             _v: PhantomData,
         })

--- a/aya/src/maps/array/program_array.rs
+++ b/aya/src/maps/array/program_array.rs
@@ -52,11 +52,11 @@ pub struct ProgramArray<T> {
 }
 
 impl<T: Borrow<MapData>> ProgramArray<T> {
-    pub(crate) fn new(map: T) -> Result<ProgramArray<T>, MapError> {
+    pub(crate) fn new(map: T) -> Result<Self, MapError> {
         let data = map.borrow();
         check_kv_size::<u32, RawFd>(data)?;
 
-        Ok(ProgramArray { inner: map })
+        Ok(Self { inner: map })
     }
 
     /// An iterator over the indices of the array that point to a program. The iterator item type

--- a/aya/src/maps/bloom_filter.rs
+++ b/aya/src/maps/bloom_filter.rs
@@ -40,11 +40,11 @@ pub struct BloomFilter<T, V: Pod> {
 }
 
 impl<T: Borrow<MapData>, V: Pod> BloomFilter<T, V> {
-    pub(crate) fn new(map: T) -> Result<BloomFilter<T, V>, MapError> {
+    pub(crate) fn new(map: T) -> Result<Self, MapError> {
         let data = map.borrow();
         check_v_size::<V>(data)?;
 
-        Ok(BloomFilter {
+        Ok(Self {
             inner: map,
             _v: PhantomData,
         })

--- a/aya/src/maps/hash_map/hash_map.rs
+++ b/aya/src/maps/hash_map/hash_map.rs
@@ -39,11 +39,11 @@ pub struct HashMap<T, K, V> {
 }
 
 impl<T: Borrow<MapData>, K: Pod, V: Pod> HashMap<T, K, V> {
-    pub(crate) fn new(map: T) -> Result<HashMap<T, K, V>, MapError> {
+    pub(crate) fn new(map: T) -> Result<Self, MapError> {
         let data = map.borrow();
         check_kv_size::<K, V>(data)?;
 
-        Ok(HashMap {
+        Ok(Self {
             inner: map,
             _k: PhantomData,
             _v: PhantomData,
@@ -96,7 +96,7 @@ impl<T: Borrow<MapData>, K: Pod, V: Pod> IterableMap<K, V> for HashMap<T, K, V> 
     }
 
     fn get(&self, key: &K) -> Result<V, MapError> {
-        HashMap::get(self, key, 0)
+        Self::get(self, key, 0)
     }
 }
 

--- a/aya/src/maps/hash_map/per_cpu_hash_map.rs
+++ b/aya/src/maps/hash_map/per_cpu_hash_map.rs
@@ -48,11 +48,11 @@ pub struct PerCpuHashMap<T, K: Pod, V: Pod> {
 }
 
 impl<T: Borrow<MapData>, K: Pod, V: Pod> PerCpuHashMap<T, K, V> {
-    pub(crate) fn new(map: T) -> Result<PerCpuHashMap<T, K, V>, MapError> {
+    pub(crate) fn new(map: T) -> Result<Self, MapError> {
         let data = map.borrow();
         check_kv_size::<K, V>(data)?;
 
-        Ok(PerCpuHashMap {
+        Ok(Self {
             inner: map,
             _k: PhantomData,
             _v: PhantomData,
@@ -143,6 +143,6 @@ impl<T: Borrow<MapData>, K: Pod, V: Pod> IterableMap<K, PerCpuValues<V>>
     }
 
     fn get(&self, key: &K) -> Result<PerCpuValues<V>, MapError> {
-        PerCpuHashMap::get(self, key, 0)
+        Self::get(self, key, 0)
     }
 }

--- a/aya/src/maps/lpm_trie.rs
+++ b/aya/src/maps/lpm_trie.rs
@@ -113,11 +113,11 @@ impl<K: Pod> Clone for Key<K> {
 unsafe impl<K: Pod> Pod for Key<K> {}
 
 impl<T: Borrow<MapData>, K: Pod, V: Pod> LpmTrie<T, K, V> {
-    pub(crate) fn new(map: T) -> Result<LpmTrie<T, K, V>, MapError> {
+    pub(crate) fn new(map: T) -> Result<Self, MapError> {
         let data = map.borrow();
         check_kv_size::<Key<K>, V>(data)?;
 
-        Ok(LpmTrie {
+        Ok(Self {
             inner: map,
             _k: PhantomData,
             _v: PhantomData,

--- a/aya/src/maps/mod.rs
+++ b/aya/src/maps/mod.rs
@@ -261,22 +261,22 @@ impl Map {
     /// Returns the low level map type.
     fn map_type(&self) -> u32 {
         match self {
-            Map::Array(map) => map.obj.map_type(),
-            Map::PerCpuArray(map) => map.obj.map_type(),
-            Map::ProgramArray(map) => map.obj.map_type(),
-            Map::HashMap(map) => map.obj.map_type(),
-            Map::LruHashMap(map) => map.obj.map_type(),
-            Map::PerCpuHashMap(map) => map.obj.map_type(),
-            Map::PerCpuLruHashMap(map) => map.obj.map_type(),
-            Map::PerfEventArray(map) => map.obj.map_type(),
-            Map::SockHash(map) => map.obj.map_type(),
-            Map::SockMap(map) => map.obj.map_type(),
-            Map::BloomFilter(map) => map.obj.map_type(),
-            Map::LpmTrie(map) => map.obj.map_type(),
-            Map::Stack(map) => map.obj.map_type(),
-            Map::StackTraceMap(map) => map.obj.map_type(),
-            Map::Queue(map) => map.obj.map_type(),
-            Map::Unsupported(map) => map.obj.map_type(),
+            Self::Array(map) => map.obj.map_type(),
+            Self::PerCpuArray(map) => map.obj.map_type(),
+            Self::ProgramArray(map) => map.obj.map_type(),
+            Self::HashMap(map) => map.obj.map_type(),
+            Self::LruHashMap(map) => map.obj.map_type(),
+            Self::PerCpuHashMap(map) => map.obj.map_type(),
+            Self::PerCpuLruHashMap(map) => map.obj.map_type(),
+            Self::PerfEventArray(map) => map.obj.map_type(),
+            Self::SockHash(map) => map.obj.map_type(),
+            Self::SockMap(map) => map.obj.map_type(),
+            Self::BloomFilter(map) => map.obj.map_type(),
+            Self::LpmTrie(map) => map.obj.map_type(),
+            Self::Stack(map) => map.obj.map_type(),
+            Self::StackTraceMap(map) => map.obj.map_type(),
+            Self::Queue(map) => map.obj.map_type(),
+            Self::Unsupported(map) => map.obj.map_type(),
         }
     }
 }
@@ -500,9 +500,11 @@ impl MapData {
                 }
             })?;
 
+        #[allow(trivial_numeric_casts)]
+        let fd = fd as RawFd;
         Ok(Self {
             obj,
-            fd: fd as RawFd,
+            fd,
             pinned: false,
         })
     }
@@ -537,7 +539,7 @@ impl MapData {
     }
 
     /// Loads a map from a pinned path in bpffs.
-    pub fn from_pin<P: AsRef<Path>>(path: P) -> Result<MapData, MapError> {
+    pub fn from_pin<P: AsRef<Path>>(path: P) -> Result<Self, MapError> {
         let path_string =
             CString::new(path.as_ref().to_string_lossy().into_owned()).map_err(|e| {
                 MapError::PinError {
@@ -555,7 +557,7 @@ impl MapData {
 
         let info = bpf_map_get_info_by_fd(fd.as_fd())?;
 
-        Ok(MapData {
+        Ok(Self {
             obj: parse_map_info(info, PinningType::ByName),
             fd: fd.into_raw_fd(),
             pinned: true,
@@ -567,10 +569,10 @@ impl MapData {
     /// If loading from a BPF Filesystem (bpffs) you should use [`Map::from_pin`](crate::maps::MapData::from_pin).
     /// This API is intended for cases where you have received a valid BPF FD from some other means.
     /// For example, you received an FD over Unix Domain Socket.
-    pub fn from_fd(fd: OwnedFd) -> Result<MapData, MapError> {
+    pub fn from_fd(fd: OwnedFd) -> Result<Self, MapError> {
         let info = bpf_map_get_info_by_fd(fd.as_fd())?;
 
-        Ok(MapData {
+        Ok(Self {
             obj: parse_map_info(info, PinningType::None),
             fd: fd.into_raw_fd(),
             pinned: false,
@@ -641,8 +643,8 @@ pub struct MapKeys<'coll, K: Pod> {
 }
 
 impl<'coll, K: Pod> MapKeys<'coll, K> {
-    fn new(map: &'coll MapData) -> MapKeys<'coll, K> {
-        MapKeys {
+    fn new(map: &'coll MapData) -> Self {
+        Self {
             map,
             err: false,
             key: None,
@@ -685,8 +687,8 @@ pub struct MapIter<'coll, K: Pod, V, I: IterableMap<K, V>> {
 }
 
 impl<'coll, K: Pod, V, I: IterableMap<K, V>> MapIter<'coll, K, V, I> {
-    fn new(map: &'coll I) -> MapIter<'coll, K, V, I> {
-        MapIter {
+    fn new(map: &'coll I) -> Self {
+        Self {
             keys: MapKeys::new(map.map()),
             map,
             _v: PhantomData,
@@ -761,7 +763,7 @@ impl<T: Pod> TryFrom<Vec<T>> for PerCpuValues<T> {
                 format!("not enough values ({}), nr_cpus: {}", values.len(), nr_cpus),
             ));
         }
-        Ok(PerCpuValues {
+        Ok(Self {
             values: values.into_boxed_slice(),
         })
     }
@@ -775,7 +777,7 @@ impl<T: Pod> PerCpuValues<T> {
         })
     }
 
-    pub(crate) unsafe fn from_kernel_mem(mem: PerCpuKernelMem) -> PerCpuValues<T> {
+    pub(crate) unsafe fn from_kernel_mem(mem: PerCpuKernelMem) -> Self {
         let mem_ptr = mem.bytes.as_ptr() as usize;
         let value_size = (mem::size_of::<T>() + 7) & !7;
         let mut values = Vec::new();
@@ -785,13 +787,13 @@ impl<T: Pod> PerCpuValues<T> {
             offset += value_size;
         }
 
-        PerCpuValues {
+        Self {
             values: values.into_boxed_slice(),
         }
     }
 
     pub(crate) fn build_kernel_mem(&self) -> Result<PerCpuKernelMem, io::Error> {
-        let mut mem = PerCpuValues::<T>::alloc_kernel_mem()?;
+        let mut mem = Self::alloc_kernel_mem()?;
         let mem_ptr = mem.as_mut_ptr() as usize;
         let value_size = (mem::size_of::<T>() + 7) & !7;
         for i in 0..self.values.len() {

--- a/aya/src/maps/perf/async_perf_event_array.rs
+++ b/aya/src/maps/perf/async_perf_event_array.rs
@@ -52,7 +52,6 @@ use crate::maps::{
 /// # let mut bpf = aya::Bpf::load(&[])?;
 /// use aya::maps::perf::{AsyncPerfEventArray, PerfBufferError};
 /// use aya::util::online_cpus;
-/// use futures::future;
 /// use bytes::BytesMut;
 /// use tokio::task; // or async_std::task
 ///
@@ -118,8 +117,8 @@ impl<T: BorrowMut<MapData> + Borrow<MapData>> AsyncPerfEventArray<T> {
 }
 
 impl<T: Borrow<MapData>> AsyncPerfEventArray<T> {
-    pub(crate) fn new(map: T) -> Result<AsyncPerfEventArray<T>, MapError> {
-        Ok(AsyncPerfEventArray {
+    pub(crate) fn new(map: T) -> Result<Self, MapError> {
+        Ok(Self {
             perf_map: PerfEventArray::new(map)?,
         })
     }

--- a/aya/src/maps/perf/perf_buffer.rs
+++ b/aya/src/maps/perf/perf_buffer.rs
@@ -96,7 +96,7 @@ impl PerfBuffer {
         cpu_id: u32,
         page_size: usize,
         page_count: usize,
-    ) -> Result<PerfBuffer, PerfBufferError> {
+    ) -> Result<Self, PerfBufferError> {
         if !page_count.is_power_of_two() {
             return Err(PerfBufferError::InvalidPageCount { page_count });
         }
@@ -120,7 +120,7 @@ impl PerfBuffer {
             });
         }
 
-        let perf_buf = PerfBuffer {
+        let perf_buf = Self {
             buf: AtomicPtr::new(buf as *mut perf_event_mmap_page),
             fd,
             size,
@@ -305,15 +305,15 @@ unsafe fn mmap(
 #[repr(C)]
 struct Sample {
     header: perf_event_header,
-    pub size: u32,
+    size: u32,
 }
 
 #[repr(C)]
 #[derive(Debug)]
 struct LostSamples {
     header: perf_event_header,
-    pub id: u64,
-    pub count: u64,
+    id: u64,
+    count: u64,
 }
 
 #[cfg(test)]

--- a/aya/src/maps/perf/perf_event_array.rs
+++ b/aya/src/maps/perf/perf_event_array.rs
@@ -161,8 +161,8 @@ pub struct PerfEventArray<T> {
 }
 
 impl<T: Borrow<MapData>> PerfEventArray<T> {
-    pub(crate) fn new(map: T) -> Result<PerfEventArray<T>, MapError> {
-        Ok(PerfEventArray {
+    pub(crate) fn new(map: T) -> Result<Self, MapError> {
+        Ok(Self {
             map: Arc::new(map),
             page_size: page_size(),
         })

--- a/aya/src/maps/queue.rs
+++ b/aya/src/maps/queue.rs
@@ -34,11 +34,11 @@ pub struct Queue<T, V: Pod> {
 }
 
 impl<T: Borrow<MapData>, V: Pod> Queue<T, V> {
-    pub(crate) fn new(map: T) -> Result<Queue<T, V>, MapError> {
+    pub(crate) fn new(map: T) -> Result<Self, MapError> {
         let data = map.borrow();
         check_kv_size::<(), V>(data)?;
 
-        Ok(Queue {
+        Ok(Self {
             inner: map,
             _v: PhantomData,
         })

--- a/aya/src/maps/sock/sock_hash.rs
+++ b/aya/src/maps/sock/sock_hash.rs
@@ -69,11 +69,11 @@ pub struct SockHash<T, K> {
 }
 
 impl<T: Borrow<MapData>, K: Pod> SockHash<T, K> {
-    pub(crate) fn new(map: T) -> Result<SockHash<T, K>, MapError> {
+    pub(crate) fn new(map: T) -> Result<Self, MapError> {
         let data = map.borrow();
         check_kv_size::<K, u32>(data)?;
 
-        Ok(SockHash {
+        Ok(Self {
             inner: map,
             _k: PhantomData,
         })
@@ -138,6 +138,6 @@ impl<T: Borrow<MapData>, K: Pod> IterableMap<K, RawFd> for SockHash<T, K> {
     }
 
     fn get(&self, key: &K) -> Result<RawFd, MapError> {
-        SockHash::get(self, key, 0)
+        Self::get(self, key, 0)
     }
 }

--- a/aya/src/maps/sock/sock_map.rs
+++ b/aya/src/maps/sock/sock_map.rs
@@ -45,11 +45,11 @@ pub struct SockMap<T> {
 }
 
 impl<T: Borrow<MapData>> SockMap<T> {
-    pub(crate) fn new(map: T) -> Result<SockMap<T>, MapError> {
+    pub(crate) fn new(map: T) -> Result<Self, MapError> {
         let data = map.borrow();
         check_kv_size::<u32, RawFd>(data)?;
 
-        Ok(SockMap { inner: map })
+        Ok(Self { inner: map })
     }
 
     /// An iterator over the indices of the array that point to a program. The iterator item type

--- a/aya/src/maps/stack.rs
+++ b/aya/src/maps/stack.rs
@@ -34,11 +34,11 @@ pub struct Stack<T, V: Pod> {
 }
 
 impl<T: Borrow<MapData>, V: Pod> Stack<T, V> {
-    pub(crate) fn new(map: T) -> Result<Stack<T, V>, MapError> {
+    pub(crate) fn new(map: T) -> Result<Self, MapError> {
         let data = map.borrow();
         check_kv_size::<(), V>(data)?;
 
-        Ok(Stack {
+        Ok(Self {
             inner: map,
             _v: PhantomData,
         })

--- a/aya/src/maps/stack_trace.rs
+++ b/aya/src/maps/stack_trace.rs
@@ -72,7 +72,7 @@ pub struct StackTraceMap<T> {
 }
 
 impl<T: Borrow<MapData>> StackTraceMap<T> {
-    pub(crate) fn new(map: T) -> Result<StackTraceMap<T>, MapError> {
+    pub(crate) fn new(map: T) -> Result<Self, MapError> {
         let data = map.borrow();
         let expected = mem::size_of::<u32>();
         let size = data.obj.key_size() as usize;
@@ -90,7 +90,7 @@ impl<T: Borrow<MapData>> StackTraceMap<T> {
             return Err(MapError::InvalidValueSize { size, expected });
         }
 
-        Ok(StackTraceMap {
+        Ok(Self {
             inner: map,
             max_stack_depth,
         })

--- a/aya/src/programs/cgroup_device.rs
+++ b/aya/src/programs/cgroup_device.rs
@@ -129,15 +129,15 @@ impl Link for CgroupDeviceLinkInner {
 
     fn id(&self) -> Self::Id {
         match self {
-            CgroupDeviceLinkInner::Fd(fd) => CgroupDeviceLinkIdInner::Fd(fd.id()),
-            CgroupDeviceLinkInner::ProgAttach(p) => CgroupDeviceLinkIdInner::ProgAttach(p.id()),
+            Self::Fd(fd) => CgroupDeviceLinkIdInner::Fd(fd.id()),
+            Self::ProgAttach(p) => CgroupDeviceLinkIdInner::ProgAttach(p.id()),
         }
     }
 
     fn detach(self) -> Result<(), ProgramError> {
         match self {
-            CgroupDeviceLinkInner::Fd(fd) => fd.detach(),
-            CgroupDeviceLinkInner::ProgAttach(p) => p.detach(),
+            Self::Fd(fd) => fd.detach(),
+            Self::ProgAttach(p) => p.detach(),
         }
     }
 }

--- a/aya/src/programs/cgroup_skb.rs
+++ b/aya/src/programs/cgroup_skb.rs
@@ -179,15 +179,15 @@ impl Link for CgroupSkbLinkInner {
 
     fn id(&self) -> Self::Id {
         match self {
-            CgroupSkbLinkInner::Fd(fd) => CgroupSkbLinkIdInner::Fd(fd.id()),
-            CgroupSkbLinkInner::ProgAttach(p) => CgroupSkbLinkIdInner::ProgAttach(p.id()),
+            Self::Fd(fd) => CgroupSkbLinkIdInner::Fd(fd.id()),
+            Self::ProgAttach(p) => CgroupSkbLinkIdInner::ProgAttach(p.id()),
         }
     }
 
     fn detach(self) -> Result<(), ProgramError> {
         match self {
-            CgroupSkbLinkInner::Fd(fd) => fd.detach(),
-            CgroupSkbLinkInner::ProgAttach(p) => p.detach(),
+            Self::Fd(fd) => fd.detach(),
+            Self::ProgAttach(p) => p.detach(),
         }
     }
 }

--- a/aya/src/programs/cgroup_sock.rs
+++ b/aya/src/programs/cgroup_sock.rs
@@ -151,15 +151,15 @@ impl Link for CgroupSockLinkInner {
 
     fn id(&self) -> Self::Id {
         match self {
-            CgroupSockLinkInner::Fd(fd) => CgroupSockLinkIdInner::Fd(fd.id()),
-            CgroupSockLinkInner::ProgAttach(p) => CgroupSockLinkIdInner::ProgAttach(p.id()),
+            Self::Fd(fd) => CgroupSockLinkIdInner::Fd(fd.id()),
+            Self::ProgAttach(p) => CgroupSockLinkIdInner::ProgAttach(p.id()),
         }
     }
 
     fn detach(self) -> Result<(), ProgramError> {
         match self {
-            CgroupSockLinkInner::Fd(fd) => fd.detach(),
-            CgroupSockLinkInner::ProgAttach(p) => p.detach(),
+            Self::Fd(fd) => fd.detach(),
+            Self::ProgAttach(p) => p.detach(),
         }
     }
 }

--- a/aya/src/programs/cgroup_sock_addr.rs
+++ b/aya/src/programs/cgroup_sock_addr.rs
@@ -157,15 +157,15 @@ impl Link for CgroupSockAddrLinkInner {
 
     fn id(&self) -> Self::Id {
         match self {
-            CgroupSockAddrLinkInner::Fd(fd) => CgroupSockAddrLinkIdInner::Fd(fd.id()),
-            CgroupSockAddrLinkInner::ProgAttach(p) => CgroupSockAddrLinkIdInner::ProgAttach(p.id()),
+            Self::Fd(fd) => CgroupSockAddrLinkIdInner::Fd(fd.id()),
+            Self::ProgAttach(p) => CgroupSockAddrLinkIdInner::ProgAttach(p.id()),
         }
     }
 
     fn detach(self) -> Result<(), ProgramError> {
         match self {
-            CgroupSockAddrLinkInner::Fd(fd) => fd.detach(),
-            CgroupSockAddrLinkInner::ProgAttach(p) => p.detach(),
+            Self::Fd(fd) => fd.detach(),
+            Self::ProgAttach(p) => p.detach(),
         }
     }
 }

--- a/aya/src/programs/cgroup_sockopt.rs
+++ b/aya/src/programs/cgroup_sockopt.rs
@@ -152,15 +152,15 @@ impl Link for CgroupSockoptLinkInner {
 
     fn id(&self) -> Self::Id {
         match self {
-            CgroupSockoptLinkInner::Fd(fd) => CgroupSockoptLinkIdInner::Fd(fd.id()),
-            CgroupSockoptLinkInner::ProgAttach(p) => CgroupSockoptLinkIdInner::ProgAttach(p.id()),
+            Self::Fd(fd) => CgroupSockoptLinkIdInner::Fd(fd.id()),
+            Self::ProgAttach(p) => CgroupSockoptLinkIdInner::ProgAttach(p.id()),
         }
     }
 
     fn detach(self) -> Result<(), ProgramError> {
         match self {
-            CgroupSockoptLinkInner::Fd(fd) => fd.detach(),
-            CgroupSockoptLinkInner::ProgAttach(p) => p.detach(),
+            Self::Fd(fd) => fd.detach(),
+            Self::ProgAttach(p) => p.detach(),
         }
     }
 }

--- a/aya/src/programs/cgroup_sysctl.rs
+++ b/aya/src/programs/cgroup_sysctl.rs
@@ -132,15 +132,15 @@ impl Link for CgroupSysctlLinkInner {
 
     fn id(&self) -> Self::Id {
         match self {
-            CgroupSysctlLinkInner::Fd(fd) => CgroupSysctlLinkIdInner::Fd(fd.id()),
-            CgroupSysctlLinkInner::ProgAttach(p) => CgroupSysctlLinkIdInner::ProgAttach(p.id()),
+            Self::Fd(fd) => CgroupSysctlLinkIdInner::Fd(fd.id()),
+            Self::ProgAttach(p) => CgroupSysctlLinkIdInner::ProgAttach(p.id()),
         }
     }
 
     fn detach(self) -> Result<(), ProgramError> {
         match self {
-            CgroupSysctlLinkInner::Fd(fd) => fd.detach(),
-            CgroupSysctlLinkInner::ProgAttach(p) => p.detach(),
+            Self::Fd(fd) => fd.detach(),
+            Self::ProgAttach(p) => p.detach(),
         }
     }
 }

--- a/aya/src/programs/kprobe.rs
+++ b/aya/src/programs/kprobe.rs
@@ -139,7 +139,7 @@ impl TryFrom<FdLink> for KProbeLink {
     fn try_from(fd_link: FdLink) -> Result<Self, Self::Error> {
         let info = bpf_link_get_info_by_fd(fd_link.fd.as_fd())?;
         if info.type_ == (bpf_link_type::BPF_LINK_TYPE_KPROBE_MULTI as u32) {
-            return Ok(KProbeLink::new(PerfLinkInner::FdLink(fd_link)));
+            return Ok(Self::new(PerfLinkInner::FdLink(fd_link)));
         }
         Err(LinkError::InvalidLink)
     }

--- a/aya/src/programs/links.rs
+++ b/aya/src/programs/links.rs
@@ -35,8 +35,8 @@ pub(crate) struct LinkMap<T: Link> {
 }
 
 impl<T: Link> LinkMap<T> {
-    pub(crate) fn new() -> LinkMap<T> {
-        LinkMap {
+    pub(crate) fn new() -> Self {
+        Self {
             links: HashMap::new(),
         }
     }
@@ -112,8 +112,8 @@ pub struct FdLink {
 }
 
 impl FdLink {
-    pub(crate) fn new(fd: OwnedFd) -> FdLink {
-        FdLink { fd }
+    pub(crate) fn new(fd: OwnedFd) -> Self {
+        Self { fd }
     }
 
     /// Pins the link to a BPF file system.
@@ -198,7 +198,7 @@ pub struct PinnedLink {
 
 impl PinnedLink {
     fn new(path: PathBuf, link: FdLink) -> Self {
-        PinnedLink { inner: link, path }
+        Self { inner: link, path }
     }
 
     /// Creates a [`crate::programs::links::PinnedLink`] from a valid path on bpffs.
@@ -210,10 +210,7 @@ impl PinnedLink {
                 io_error,
             })
         })?;
-        Ok(PinnedLink::new(
-            path.as_ref().to_path_buf(),
-            FdLink::new(fd),
-        ))
+        Ok(Self::new(path.as_ref().to_path_buf(), FdLink::new(fd)))
     }
 
     /// Removes the pinned link from the filesystem and returns an [`FdLink`].
@@ -236,12 +233,8 @@ pub struct ProgAttachLink {
 }
 
 impl ProgAttachLink {
-    pub(crate) fn new(
-        prog_fd: RawFd,
-        target_fd: RawFd,
-        attach_type: bpf_attach_type,
-    ) -> ProgAttachLink {
-        ProgAttachLink {
+    pub(crate) fn new(prog_fd: RawFd, target_fd: RawFd, attach_type: bpf_attach_type) -> Self {
+        Self {
             prog_fd,
             target_fd: unsafe { dup(target_fd) },
             attach_type,
@@ -300,7 +293,7 @@ macro_rules! define_link_wrapper {
             }
         }
 
-        impl crate::programs::Link for $wrapper {
+        impl $crate::programs::Link for $wrapper {
             type Id = $wrapper_id;
 
             fn id(&self) -> Self::Id {
@@ -359,8 +352,8 @@ mod tests {
     }
 
     impl TestLink {
-        fn new(a: u8, b: u8) -> TestLink {
-            TestLink {
+        fn new(a: u8, b: u8) -> Self {
+            Self {
                 id: (a, b),
                 detached: Rc::new(RefCell::new(0)),
             }

--- a/aya/src/programs/lirc_mode2.rs
+++ b/aya/src/programs/lirc_mode2.rs
@@ -121,8 +121,8 @@ pub struct LircLink {
 }
 
 impl LircLink {
-    pub(crate) fn new(prog_fd: RawFd, target_fd: RawFd) -> LircLink {
-        LircLink {
+    pub(crate) fn new(prog_fd: RawFd, target_fd: RawFd) -> Self {
+        Self {
             prog_fd,
             target_fd: unsafe { dup(target_fd) },
         }

--- a/aya/src/programs/mod.rs
+++ b/aya/src/programs/mod.rs
@@ -108,7 +108,7 @@ pub use xdp::{Xdp, XdpError, XdpFlags};
 use crate::{
     generated::{bpf_attach_type, bpf_link_info, bpf_prog_info, bpf_prog_type},
     maps::MapError,
-    obj::{self, btf::BtfError, Function, VerifierLog},
+    obj::{self, btf::BtfError, VerifierLog},
     pin::PinError,
     programs::utils::{boot_time, get_fdinfo},
     sys::{
@@ -292,90 +292,90 @@ impl Program {
     pub fn prog_type(&self) -> bpf_prog_type {
         use crate::generated::bpf_prog_type::*;
         match self {
-            Program::KProbe(_) => BPF_PROG_TYPE_KPROBE,
-            Program::UProbe(_) => BPF_PROG_TYPE_KPROBE,
-            Program::TracePoint(_) => BPF_PROG_TYPE_TRACEPOINT,
-            Program::SocketFilter(_) => BPF_PROG_TYPE_SOCKET_FILTER,
-            Program::Xdp(_) => BPF_PROG_TYPE_XDP,
-            Program::SkMsg(_) => BPF_PROG_TYPE_SK_MSG,
-            Program::SkSkb(_) => BPF_PROG_TYPE_SK_SKB,
-            Program::SockOps(_) => BPF_PROG_TYPE_SOCK_OPS,
-            Program::SchedClassifier(_) => BPF_PROG_TYPE_SCHED_CLS,
-            Program::CgroupSkb(_) => BPF_PROG_TYPE_CGROUP_SKB,
-            Program::CgroupSysctl(_) => BPF_PROG_TYPE_CGROUP_SYSCTL,
-            Program::CgroupSockopt(_) => BPF_PROG_TYPE_CGROUP_SOCKOPT,
-            Program::LircMode2(_) => BPF_PROG_TYPE_LIRC_MODE2,
-            Program::PerfEvent(_) => BPF_PROG_TYPE_PERF_EVENT,
-            Program::RawTracePoint(_) => BPF_PROG_TYPE_RAW_TRACEPOINT,
-            Program::Lsm(_) => BPF_PROG_TYPE_LSM,
-            Program::BtfTracePoint(_) => BPF_PROG_TYPE_TRACING,
-            Program::FEntry(_) => BPF_PROG_TYPE_TRACING,
-            Program::FExit(_) => BPF_PROG_TYPE_TRACING,
-            Program::Extension(_) => BPF_PROG_TYPE_EXT,
-            Program::CgroupSockAddr(_) => BPF_PROG_TYPE_CGROUP_SOCK_ADDR,
-            Program::SkLookup(_) => BPF_PROG_TYPE_SK_LOOKUP,
-            Program::CgroupSock(_) => BPF_PROG_TYPE_CGROUP_SOCK,
-            Program::CgroupDevice(_) => BPF_PROG_TYPE_CGROUP_DEVICE,
+            Self::KProbe(_) => BPF_PROG_TYPE_KPROBE,
+            Self::UProbe(_) => BPF_PROG_TYPE_KPROBE,
+            Self::TracePoint(_) => BPF_PROG_TYPE_TRACEPOINT,
+            Self::SocketFilter(_) => BPF_PROG_TYPE_SOCKET_FILTER,
+            Self::Xdp(_) => BPF_PROG_TYPE_XDP,
+            Self::SkMsg(_) => BPF_PROG_TYPE_SK_MSG,
+            Self::SkSkb(_) => BPF_PROG_TYPE_SK_SKB,
+            Self::SockOps(_) => BPF_PROG_TYPE_SOCK_OPS,
+            Self::SchedClassifier(_) => BPF_PROG_TYPE_SCHED_CLS,
+            Self::CgroupSkb(_) => BPF_PROG_TYPE_CGROUP_SKB,
+            Self::CgroupSysctl(_) => BPF_PROG_TYPE_CGROUP_SYSCTL,
+            Self::CgroupSockopt(_) => BPF_PROG_TYPE_CGROUP_SOCKOPT,
+            Self::LircMode2(_) => BPF_PROG_TYPE_LIRC_MODE2,
+            Self::PerfEvent(_) => BPF_PROG_TYPE_PERF_EVENT,
+            Self::RawTracePoint(_) => BPF_PROG_TYPE_RAW_TRACEPOINT,
+            Self::Lsm(_) => BPF_PROG_TYPE_LSM,
+            Self::BtfTracePoint(_) => BPF_PROG_TYPE_TRACING,
+            Self::FEntry(_) => BPF_PROG_TYPE_TRACING,
+            Self::FExit(_) => BPF_PROG_TYPE_TRACING,
+            Self::Extension(_) => BPF_PROG_TYPE_EXT,
+            Self::CgroupSockAddr(_) => BPF_PROG_TYPE_CGROUP_SOCK_ADDR,
+            Self::SkLookup(_) => BPF_PROG_TYPE_SK_LOOKUP,
+            Self::CgroupSock(_) => BPF_PROG_TYPE_CGROUP_SOCK,
+            Self::CgroupDevice(_) => BPF_PROG_TYPE_CGROUP_DEVICE,
         }
     }
 
     /// Pin the program to the provided path
     pub fn pin<P: AsRef<Path>>(&mut self, path: P) -> Result<(), PinError> {
         match self {
-            Program::KProbe(p) => p.pin(path),
-            Program::UProbe(p) => p.pin(path),
-            Program::TracePoint(p) => p.pin(path),
-            Program::SocketFilter(p) => p.pin(path),
-            Program::Xdp(p) => p.pin(path),
-            Program::SkMsg(p) => p.pin(path),
-            Program::SkSkb(p) => p.pin(path),
-            Program::SockOps(p) => p.pin(path),
-            Program::SchedClassifier(p) => p.pin(path),
-            Program::CgroupSkb(p) => p.pin(path),
-            Program::CgroupSysctl(p) => p.pin(path),
-            Program::CgroupSockopt(p) => p.pin(path),
-            Program::LircMode2(p) => p.pin(path),
-            Program::PerfEvent(p) => p.pin(path),
-            Program::RawTracePoint(p) => p.pin(path),
-            Program::Lsm(p) => p.pin(path),
-            Program::BtfTracePoint(p) => p.pin(path),
-            Program::FEntry(p) => p.pin(path),
-            Program::FExit(p) => p.pin(path),
-            Program::Extension(p) => p.pin(path),
-            Program::CgroupSockAddr(p) => p.pin(path),
-            Program::SkLookup(p) => p.pin(path),
-            Program::CgroupSock(p) => p.pin(path),
-            Program::CgroupDevice(p) => p.pin(path),
+            Self::KProbe(p) => p.pin(path),
+            Self::UProbe(p) => p.pin(path),
+            Self::TracePoint(p) => p.pin(path),
+            Self::SocketFilter(p) => p.pin(path),
+            Self::Xdp(p) => p.pin(path),
+            Self::SkMsg(p) => p.pin(path),
+            Self::SkSkb(p) => p.pin(path),
+            Self::SockOps(p) => p.pin(path),
+            Self::SchedClassifier(p) => p.pin(path),
+            Self::CgroupSkb(p) => p.pin(path),
+            Self::CgroupSysctl(p) => p.pin(path),
+            Self::CgroupSockopt(p) => p.pin(path),
+            Self::LircMode2(p) => p.pin(path),
+            Self::PerfEvent(p) => p.pin(path),
+            Self::RawTracePoint(p) => p.pin(path),
+            Self::Lsm(p) => p.pin(path),
+            Self::BtfTracePoint(p) => p.pin(path),
+            Self::FEntry(p) => p.pin(path),
+            Self::FExit(p) => p.pin(path),
+            Self::Extension(p) => p.pin(path),
+            Self::CgroupSockAddr(p) => p.pin(path),
+            Self::SkLookup(p) => p.pin(path),
+            Self::CgroupSock(p) => p.pin(path),
+            Self::CgroupDevice(p) => p.pin(path),
         }
     }
 
     /// Unloads the program from the kernel.
     pub fn unload(self) -> Result<(), ProgramError> {
         match self {
-            Program::KProbe(mut p) => p.unload(),
-            Program::UProbe(mut p) => p.unload(),
-            Program::TracePoint(mut p) => p.unload(),
-            Program::SocketFilter(mut p) => p.unload(),
-            Program::Xdp(mut p) => p.unload(),
-            Program::SkMsg(mut p) => p.unload(),
-            Program::SkSkb(mut p) => p.unload(),
-            Program::SockOps(mut p) => p.unload(),
-            Program::SchedClassifier(mut p) => p.unload(),
-            Program::CgroupSkb(mut p) => p.unload(),
-            Program::CgroupSysctl(mut p) => p.unload(),
-            Program::CgroupSockopt(mut p) => p.unload(),
-            Program::LircMode2(mut p) => p.unload(),
-            Program::PerfEvent(mut p) => p.unload(),
-            Program::RawTracePoint(mut p) => p.unload(),
-            Program::Lsm(mut p) => p.unload(),
-            Program::BtfTracePoint(mut p) => p.unload(),
-            Program::FEntry(mut p) => p.unload(),
-            Program::FExit(mut p) => p.unload(),
-            Program::Extension(mut p) => p.unload(),
-            Program::CgroupSockAddr(mut p) => p.unload(),
-            Program::SkLookup(mut p) => p.unload(),
-            Program::CgroupSock(mut p) => p.unload(),
-            Program::CgroupDevice(mut p) => p.unload(),
+            Self::KProbe(mut p) => p.unload(),
+            Self::UProbe(mut p) => p.unload(),
+            Self::TracePoint(mut p) => p.unload(),
+            Self::SocketFilter(mut p) => p.unload(),
+            Self::Xdp(mut p) => p.unload(),
+            Self::SkMsg(mut p) => p.unload(),
+            Self::SkSkb(mut p) => p.unload(),
+            Self::SockOps(mut p) => p.unload(),
+            Self::SchedClassifier(mut p) => p.unload(),
+            Self::CgroupSkb(mut p) => p.unload(),
+            Self::CgroupSysctl(mut p) => p.unload(),
+            Self::CgroupSockopt(mut p) => p.unload(),
+            Self::LircMode2(mut p) => p.unload(),
+            Self::PerfEvent(mut p) => p.unload(),
+            Self::RawTracePoint(mut p) => p.unload(),
+            Self::Lsm(mut p) => p.unload(),
+            Self::BtfTracePoint(mut p) => p.unload(),
+            Self::FEntry(mut p) => p.unload(),
+            Self::FExit(mut p) => p.unload(),
+            Self::Extension(mut p) => p.unload(),
+            Self::CgroupSockAddr(mut p) => p.unload(),
+            Self::SkLookup(mut p) => p.unload(),
+            Self::CgroupSock(mut p) => p.unload(),
+            Self::CgroupDevice(mut p) => p.unload(),
         }
     }
 
@@ -384,30 +384,30 @@ impl Program {
     /// Can be used to add a program to a [`crate::maps::ProgramArray`] or attach an [`Extension`] program.
     pub fn fd(&self) -> Result<&ProgramFd, ProgramError> {
         match self {
-            Program::KProbe(p) => p.fd(),
-            Program::UProbe(p) => p.fd(),
-            Program::TracePoint(p) => p.fd(),
-            Program::SocketFilter(p) => p.fd(),
-            Program::Xdp(p) => p.fd(),
-            Program::SkMsg(p) => p.fd(),
-            Program::SkSkb(p) => p.fd(),
-            Program::SockOps(p) => p.fd(),
-            Program::SchedClassifier(p) => p.fd(),
-            Program::CgroupSkb(p) => p.fd(),
-            Program::CgroupSysctl(p) => p.fd(),
-            Program::CgroupSockopt(p) => p.fd(),
-            Program::LircMode2(p) => p.fd(),
-            Program::PerfEvent(p) => p.fd(),
-            Program::RawTracePoint(p) => p.fd(),
-            Program::Lsm(p) => p.fd(),
-            Program::BtfTracePoint(p) => p.fd(),
-            Program::FEntry(p) => p.fd(),
-            Program::FExit(p) => p.fd(),
-            Program::Extension(p) => p.fd(),
-            Program::CgroupSockAddr(p) => p.fd(),
-            Program::SkLookup(p) => p.fd(),
-            Program::CgroupSock(p) => p.fd(),
-            Program::CgroupDevice(p) => p.fd(),
+            Self::KProbe(p) => p.fd(),
+            Self::UProbe(p) => p.fd(),
+            Self::TracePoint(p) => p.fd(),
+            Self::SocketFilter(p) => p.fd(),
+            Self::Xdp(p) => p.fd(),
+            Self::SkMsg(p) => p.fd(),
+            Self::SkSkb(p) => p.fd(),
+            Self::SockOps(p) => p.fd(),
+            Self::SchedClassifier(p) => p.fd(),
+            Self::CgroupSkb(p) => p.fd(),
+            Self::CgroupSysctl(p) => p.fd(),
+            Self::CgroupSockopt(p) => p.fd(),
+            Self::LircMode2(p) => p.fd(),
+            Self::PerfEvent(p) => p.fd(),
+            Self::RawTracePoint(p) => p.fd(),
+            Self::Lsm(p) => p.fd(),
+            Self::BtfTracePoint(p) => p.fd(),
+            Self::FEntry(p) => p.fd(),
+            Self::FExit(p) => p.fd(),
+            Self::Extension(p) => p.fd(),
+            Self::CgroupSockAddr(p) => p.fd(),
+            Self::SkLookup(p) => p.fd(),
+            Self::CgroupSock(p) => p.fd(),
+            Self::CgroupDevice(p) => p.fd(),
         }
     }
 }
@@ -434,8 +434,8 @@ impl<T: Link> ProgramData<T> {
         obj: (obj::Program, obj::Function),
         btf_fd: Option<Arc<OwnedFd>>,
         verifier_log_level: VerifierLogLevel,
-    ) -> ProgramData<T> {
-        ProgramData {
+    ) -> Self {
+        Self {
             name,
             obj: Some(obj),
             fd: None,
@@ -457,7 +457,7 @@ impl<T: Link> ProgramData<T> {
         path: &Path,
         info: bpf_prog_info,
         verifier_log_level: VerifierLogLevel,
-    ) -> Result<ProgramData<T>, ProgramError> {
+    ) -> Result<Self, ProgramError> {
         let attach_btf_id = if info.attach_btf_id > 0 {
             Some(info.attach_btf_id)
         } else {
@@ -467,7 +467,7 @@ impl<T: Link> ProgramData<T> {
             .then(|| bpf_btf_get_fd_by_id(info.attach_btf_obj_id))
             .transpose()?;
 
-        Ok(ProgramData {
+        Ok(Self {
             name,
             obj: None,
             fd: Some(ProgramFd(fd)),
@@ -486,7 +486,7 @@ impl<T: Link> ProgramData<T> {
     pub(crate) fn from_pinned_path<P: AsRef<Path>>(
         path: P,
         verifier_log_level: VerifierLogLevel,
-    ) -> Result<ProgramData<T>, ProgramError> {
+    ) -> Result<Self, ProgramError> {
         let path_string =
             CString::new(path.as_ref().as_os_str().to_string_lossy().as_bytes()).unwrap();
 
@@ -497,7 +497,7 @@ impl<T: Link> ProgramData<T> {
 
         let info = ProgramInfo::new_from_fd(fd.as_fd())?;
         let name = info.name_as_str().map(|s| s.to_string());
-        ProgramData::from_bpf_prog_info(name, fd, path.as_ref(), info.0, verifier_log_level)
+        Self::from_bpf_prog_info(name, fd, path.as_ref(), info.0, verifier_log_level)
     }
 }
 
@@ -571,7 +571,7 @@ fn load_program<T: Link>(
             kernel_version,
             ..
         },
-        Function {
+        obj::Function {
             instructions,
             func_info,
             line_info,
@@ -1072,7 +1072,7 @@ impl ProgramInfo {
     }
 
     /// Loads a program from a pinned path in bpffs.
-    pub fn from_pin<P: AsRef<Path>>(path: P) -> Result<ProgramInfo, ProgramError> {
+    pub fn from_pin<P: AsRef<Path>>(path: P) -> Result<Self, ProgramError> {
         let path_string = CString::new(path.as_ref().to_str().unwrap()).unwrap();
         let fd = bpf_get_object(&path_string).map_err(|(_, io_error)| SyscallError {
             call: "BPF_OBJ_GET",
@@ -1080,7 +1080,7 @@ impl ProgramInfo {
         })?;
 
         let info = bpf_prog_get_info_by_fd(fd.as_fd(), &mut [])?;
-        Ok(ProgramInfo(info))
+        Ok(Self(info))
     }
 }
 

--- a/aya/src/programs/perf_attach.rs
+++ b/aya/src/programs/perf_attach.rs
@@ -28,15 +28,15 @@ impl Link for PerfLinkInner {
 
     fn id(&self) -> Self::Id {
         match self {
-            PerfLinkInner::FdLink(link) => PerfLinkIdInner::FdLinkId(link.id()),
-            PerfLinkInner::PerfLink(link) => PerfLinkIdInner::PerfLinkId(link.id()),
+            Self::FdLink(link) => PerfLinkIdInner::FdLinkId(link.id()),
+            Self::PerfLink(link) => PerfLinkIdInner::PerfLinkId(link.id()),
         }
     }
 
     fn detach(self) -> Result<(), ProgramError> {
         match self {
-            PerfLinkInner::FdLink(link) => link.detach(),
-            PerfLinkInner::PerfLink(link) => link.detach(),
+            Self::FdLink(link) => link.detach(),
+            Self::PerfLink(link) => link.detach(),
         }
     }
 }

--- a/aya/src/programs/perf_event.rs
+++ b/aya/src/programs/perf_event.rs
@@ -213,7 +213,7 @@ impl TryFrom<FdLink> for PerfEventLink {
     fn try_from(fd_link: FdLink) -> Result<Self, Self::Error> {
         let info = bpf_link_get_info_by_fd(fd_link.fd.as_fd())?;
         if info.type_ == (bpf_link_type::BPF_LINK_TYPE_PERF_EVENT as u32) {
-            return Ok(PerfEventLink::new(PerfLinkInner::FdLink(fd_link)));
+            return Ok(Self::new(PerfLinkInner::FdLink(fd_link)));
         }
         Err(LinkError::InvalidLink)
     }

--- a/aya/src/programs/probe.rs
+++ b/aya/src/programs/probe.rs
@@ -36,8 +36,8 @@ pub enum ProbeKind {
 impl ProbeKind {
     fn pmu(&self) -> &'static str {
         match *self {
-            ProbeKind::KProbe | ProbeKind::KRetProbe => "kprobe",
-            ProbeKind::UProbe | ProbeKind::URetProbe => "uprobe",
+            Self::KProbe | Self::KRetProbe => "kprobe",
+            Self::UProbe | Self::URetProbe => "uprobe",
         }
     }
 }

--- a/aya/src/programs/tc.rs
+++ b/aya/src/programs/tc.rs
@@ -95,9 +95,9 @@ pub enum TcError {
 impl TcAttachType {
     pub(crate) fn parent(&self) -> u32 {
         match self {
-            TcAttachType::Custom(parent) => *parent,
-            TcAttachType::Ingress => tc_handler_make(TC_H_CLSACT, TC_H_MIN_INGRESS),
-            TcAttachType::Egress => tc_handler_make(TC_H_CLSACT, TC_H_MIN_EGRESS),
+            Self::Custom(parent) => *parent,
+            Self::Ingress => tc_handler_make(TC_H_CLSACT, TC_H_MIN_INGRESS),
+            Self::Egress => tc_handler_make(TC_H_CLSACT, TC_H_MIN_EGRESS),
         }
     }
 }
@@ -284,9 +284,9 @@ impl SchedClassifierLink {
         attach_type: TcAttachType,
         priority: u16,
         handle: u32,
-    ) -> Result<SchedClassifierLink, io::Error> {
+    ) -> Result<Self, io::Error> {
         let if_index = ifindex_from_ifname(if_name)?;
-        Ok(SchedClassifierLink(Some(TcLink {
+        Ok(Self(Some(TcLink {
             if_index: if_index as i32,
             attach_type,
             priority,

--- a/aya/src/programs/trace_point.rs
+++ b/aya/src/programs/trace_point.rs
@@ -140,7 +140,7 @@ impl TryFrom<FdLink> for TracePointLink {
     fn try_from(fd_link: FdLink) -> Result<Self, Self::Error> {
         let info = bpf_link_get_info_by_fd(fd_link.fd.as_fd())?;
         if info.type_ == (bpf_link_type::BPF_LINK_TYPE_TRACING as u32) {
-            return Ok(TracePointLink::new(PerfLinkInner::FdLink(fd_link)));
+            return Ok(Self::new(PerfLinkInner::FdLink(fd_link)));
         }
         Err(LinkError::InvalidLink)
     }

--- a/aya/src/programs/uprobe.rs
+++ b/aya/src/programs/uprobe.rs
@@ -28,7 +28,7 @@ use crate::{
 
 const LD_SO_CACHE_FILE: &str = "/etc/ld.so.cache";
 
-lazy_static! {
+lazy_static::lazy_static! {
     static ref LD_SO_CACHE: Result<LdSoCache, Arc<io::Error>> =
         LdSoCache::load(LD_SO_CACHE_FILE).map_err(Arc::new);
 }
@@ -204,7 +204,7 @@ impl TryFrom<FdLink> for UProbeLink {
     fn try_from(fd_link: FdLink) -> Result<Self, Self::Error> {
         let info = bpf_link_get_info_by_fd(fd_link.fd.as_fd())?;
         if info.type_ == (bpf_link_type::BPF_LINK_TYPE_TRACING as u32) {
-            return Ok(UProbeLink::new(PerfLinkInner::FdLink(fd_link)));
+            return Ok(Self::new(PerfLinkInner::FdLink(fd_link)));
         }
         Err(LinkError::InvalidLink)
     }
@@ -297,7 +297,7 @@ pub(crate) struct LdSoCache {
 }
 
 impl LdSoCache {
-    pub fn load<T: AsRef<Path>>(path: T) -> Result<Self, io::Error> {
+    fn load<T: AsRef<Path>>(path: T) -> Result<Self, io::Error> {
         let data = fs::read(path)?;
         Self::parse(&data)
     }
@@ -386,10 +386,10 @@ impl LdSoCache {
             })
             .collect::<Result<_, _>>()?;
 
-        Ok(LdSoCache { entries })
+        Ok(Self { entries })
     }
 
-    pub fn resolve(&self, lib: &str) -> Option<&str> {
+    fn resolve(&self, lib: &str) -> Option<&str> {
         let lib = if !lib.contains(".so") {
             lib.to_string() + ".so"
         } else {

--- a/aya/src/programs/utils.rs
+++ b/aya/src/programs/utils.rs
@@ -79,7 +79,7 @@ pub(crate) fn boot_time() -> SystemTime {
 }
 
 /// Get the specified information from a file descriptor's fdinfo.
-pub(crate) fn get_fdinfo(fd: BorrowedFd, key: &str) -> Result<u32, ProgramError> {
+pub(crate) fn get_fdinfo(fd: BorrowedFd<'_>, key: &str) -> Result<u32, ProgramError> {
     let info = File::open(format!("/proc/self/fdinfo/{}", fd.as_raw_fd()))?;
     let reader = BufReader::new(info);
     for line in reader.lines() {

--- a/aya/src/sys/bpf.rs
+++ b/aya/src/sys/bpf.rs
@@ -1,5 +1,5 @@
 use std::{
-    cmp::{self, min},
+    cmp,
     ffi::{CStr, CString},
     io, iter,
     mem::{self, MaybeUninit},
@@ -129,7 +129,7 @@ pub(crate) struct BpfLoadProgramAttrs<'a> {
 }
 
 pub(crate) fn bpf_load_program(
-    aya_attr: &BpfLoadProgramAttrs,
+    aya_attr: &BpfLoadProgramAttrs<'_>,
     log_buf: &mut [u8],
     verifier_log_level: VerifierLogLevel,
 ) -> SysResult<OwnedFd> {
@@ -140,7 +140,7 @@ pub(crate) fn bpf_load_program(
     if let Some(prog_name) = &aya_attr.name {
         let mut name: [c_char; 16] = [0; 16];
         let name_bytes = prog_name.to_bytes();
-        let len = min(name.len(), name_bytes.len());
+        let len = cmp::min(name.len(), name_bytes.len());
         name[..len].copy_from_slice(unsafe {
             slice::from_raw_parts(name_bytes.as_ptr() as *const c_char, len)
         });
@@ -613,7 +613,7 @@ pub(crate) fn is_prog_name_supported() -> bool {
     let mut name: [c_char; 16] = [0; 16];
     let cstring = CString::new("aya_name_check").unwrap();
     let name_bytes = cstring.to_bytes();
-    let len = min(name.len(), name_bytes.len());
+    let len = cmp::min(name.len(), name_bytes.len());
     name[..len].copy_from_slice(unsafe {
         slice::from_raw_parts(name_bytes.as_ptr() as *const c_char, len)
     });
@@ -980,7 +980,7 @@ pub(crate) fn retry_with_verifier_logs<T>(
     f: impl Fn(&mut [u8]) -> SysResult<T>,
 ) -> (SysResult<T>, VerifierLog) {
     const MIN_LOG_BUF_SIZE: usize = 1024 * 10;
-    const MAX_LOG_BUF_SIZE: usize = (std::u32::MAX >> 8) as usize;
+    const MAX_LOG_BUF_SIZE: usize = (u32::MAX >> 8) as usize;
 
     let mut log_buf = Vec::new();
     let mut retries = 0;

--- a/aya/src/sys/fake.rs
+++ b/aya/src/sys/fake.rs
@@ -4,7 +4,7 @@ use libc::c_void;
 
 use super::{SysResult, Syscall};
 
-type SyscallFn = unsafe fn(Syscall) -> SysResult<c_long>;
+type SyscallFn = unsafe fn(Syscall<'_>) -> SysResult<c_long>;
 
 #[cfg(test)]
 thread_local! {
@@ -13,11 +13,11 @@ thread_local! {
 }
 
 #[cfg(test)]
-unsafe fn test_syscall(_call: Syscall) -> SysResult<c_long> {
+unsafe fn test_syscall(_call: Syscall<'_>) -> SysResult<c_long> {
     Err((-1, io::Error::from_raw_os_error(libc::EINVAL)))
 }
 
 #[cfg(test)]
-pub(crate) fn override_syscall(call: unsafe fn(Syscall) -> SysResult<c_long>) {
+pub(crate) fn override_syscall(call: unsafe fn(Syscall<'_>) -> SysResult<c_long>) {
     TEST_SYSCALL.with(|test_impl| *test_impl.borrow_mut() = call);
 }

--- a/aya/src/util.rs
+++ b/aya/src/util.rs
@@ -133,10 +133,10 @@ impl KernelVersion {
     }
 
     fn parse_kernel_version_string(s: &str) -> Result<Self, CurrentKernelVersionError> {
-        fn parse<T: FromStr<Err = std::num::ParseIntError>>(s: Option<&str>) -> Option<T> {
+        fn parse<T: FromStr<Err = ParseIntError>>(s: Option<&str>) -> Option<T> {
             match s.map(str::parse).transpose() {
                 Ok(option) => option,
-                Err(std::num::ParseIntError { .. }) => None,
+                Err(ParseIntError { .. }) => None,
             }
         }
         let error = || CurrentKernelVersionError::ParseError(s.to_string());

--- a/xtask/public-api/aya.txt
+++ b/xtask/public-api/aya.txt
@@ -1227,8 +1227,8 @@ pub aya::maps::MapData::pinned: bool
 impl aya::maps::MapData
 pub fn aya::maps::MapData::create(obj: aya_obj::maps::Map, name: &str, btf_fd: core::option::Option<std::os::fd::owned::BorrowedFd<'_>>) -> core::result::Result<Self, aya::maps::MapError>
 pub fn aya::maps::MapData::fd(&self) -> aya::maps::MapFd
-pub fn aya::maps::MapData::from_fd(fd: std::os::fd::owned::OwnedFd) -> core::result::Result<aya::maps::MapData, aya::maps::MapError>
-pub fn aya::maps::MapData::from_pin<P: core::convert::AsRef<std::path::Path>>(path: P) -> core::result::Result<aya::maps::MapData, aya::maps::MapError>
+pub fn aya::maps::MapData::from_fd(fd: std::os::fd::owned::OwnedFd) -> core::result::Result<Self, aya::maps::MapError>
+pub fn aya::maps::MapData::from_pin<P: core::convert::AsRef<std::path::Path>>(path: P) -> core::result::Result<Self, aya::maps::MapError>
 impl core::clone::Clone for aya::maps::MapData
 pub fn aya::maps::MapData::clone(&self) -> Self
 impl core::ops::drop::Drop for aya::maps::MapData
@@ -3971,7 +3971,7 @@ impl<T> core::convert::From<T> for aya::programs::tc::SchedClassifier
 pub fn aya::programs::tc::SchedClassifier::from(t: T) -> T
 pub struct aya::programs::tc::SchedClassifierLink(_)
 impl aya::programs::tc::SchedClassifierLink
-pub fn aya::programs::tc::SchedClassifierLink::attached(if_name: &str, attach_type: aya::programs::tc::TcAttachType, priority: u16, handle: u32) -> core::result::Result<aya::programs::tc::SchedClassifierLink, std::io::error::Error>
+pub fn aya::programs::tc::SchedClassifierLink::attached(if_name: &str, attach_type: aya::programs::tc::TcAttachType, priority: u16, handle: u32) -> core::result::Result<Self, std::io::error::Error>
 pub fn aya::programs::tc::SchedClassifierLink::handle(&self) -> u32
 pub fn aya::programs::tc::SchedClassifierLink::priority(&self) -> u16
 impl aya::programs::links::Link for aya::programs::tc::SchedClassifierLink
@@ -6219,7 +6219,7 @@ pub struct aya::programs::ProgramInfo(_)
 impl aya::programs::ProgramInfo
 pub fn aya::programs::ProgramInfo::btf_id(&self) -> core::option::Option<core::num::nonzero::NonZeroU32>
 pub fn aya::programs::ProgramInfo::fd(&self) -> core::result::Result<aya::programs::ProgramFd, aya::programs::ProgramError>
-pub fn aya::programs::ProgramInfo::from_pin<P: core::convert::AsRef<std::path::Path>>(path: P) -> core::result::Result<aya::programs::ProgramInfo, aya::programs::ProgramError>
+pub fn aya::programs::ProgramInfo::from_pin<P: core::convert::AsRef<std::path::Path>>(path: P) -> core::result::Result<Self, aya::programs::ProgramError>
 pub fn aya::programs::ProgramInfo::gpl_compatible(&self) -> bool
 pub fn aya::programs::ProgramInfo::id(&self) -> u32
 pub fn aya::programs::ProgramInfo::loaded_at(&self) -> std::time::SystemTime
@@ -7041,8 +7041,8 @@ impl<T> core::convert::From<T> for aya::BpfError
 pub fn aya::BpfError::from(t: T) -> T
 pub struct aya::Bpf
 impl aya::Bpf
-pub fn aya::Bpf::load(data: &[u8]) -> core::result::Result<aya::Bpf, aya::BpfError>
-pub fn aya::Bpf::load_file<P: core::convert::AsRef<std::path::Path>>(path: P) -> core::result::Result<aya::Bpf, aya::BpfError>
+pub fn aya::Bpf::load(data: &[u8]) -> core::result::Result<Self, aya::BpfError>
+pub fn aya::Bpf::load_file<P: core::convert::AsRef<std::path::Path>>(path: P) -> core::result::Result<Self, aya::BpfError>
 pub fn aya::Bpf::map(&self, name: &str) -> core::option::Option<&aya::maps::Map>
 pub fn aya::Bpf::map_mut(&mut self, name: &str) -> core::option::Option<&mut aya::maps::Map>
 pub fn aya::Bpf::maps(&self) -> impl core::iter::traits::iterator::Iterator<Item = (&str, &aya::maps::Map)>
@@ -7082,12 +7082,12 @@ pub fn aya::BpfLoader<'a>::extension(&mut self, name: &'a str) -> &mut aya::BpfL
 pub fn aya::BpfLoader<'a>::load(&mut self, data: &[u8]) -> core::result::Result<aya::Bpf, aya::BpfError>
 pub fn aya::BpfLoader<'a>::load_file<P: core::convert::AsRef<std::path::Path>>(&mut self, path: P) -> core::result::Result<aya::Bpf, aya::BpfError>
 pub fn aya::BpfLoader<'a>::map_pin_path<P: core::convert::AsRef<std::path::Path>>(&mut self, path: P) -> &mut aya::BpfLoader<'a>
-pub fn aya::BpfLoader<'a>::new() -> aya::BpfLoader<'a>
+pub fn aya::BpfLoader<'a>::new() -> Self
 pub fn aya::BpfLoader<'a>::set_global<T: core::convert::Into<aya::GlobalData<'a>>>(&mut self, name: &'a str, value: T, must_exist: bool) -> &mut aya::BpfLoader<'a>
 pub fn aya::BpfLoader<'a>::set_max_entries(&mut self, name: &'a str, size: u32) -> &mut aya::BpfLoader<'a>
 pub fn aya::BpfLoader<'a>::verifier_log_level(&mut self, level: aya::VerifierLogLevel) -> &mut aya::BpfLoader<'a>
-impl<'a> core::default::Default for aya::BpfLoader<'a>
-pub fn aya::BpfLoader<'a>::default() -> Self
+impl core::default::Default for aya::BpfLoader<'_>
+pub fn aya::BpfLoader<'_>::default() -> Self
 impl<'a> core::fmt::Debug for aya::BpfLoader<'a>
 pub fn aya::BpfLoader<'a>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl<'a> core::marker::Send for aya::BpfLoader<'a>


### PR DESCRIPTION
Notably:
- clippy::use_self: replaced many T with Self.
- single_use_lifetimes: removed some single use lifetimes.
- unreachable_pub: removed some unreachable pub items.
- unused_crate_dependencies: removed unused futures,parking_lot deps.
- unused_qualifications: found a potential `crate` vs `$crate` bug.
- let_underscore_drop: not enabled, seems to trigger false positives.
- missing_copy_implementations: not enabled, unclear if we want this.
- unsafe_op_in_unsafe_fn: not enabled, unclear if we want this.
- unused_results: not enabled, needs many fixes (but I think wanted).
