### PR TITLE
aya: fix docs build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -204,6 +204,8 @@ jobs:
           echo /usr/local/opt/findutils/libexec/gnubin >> $GITHUB_PATH
           echo /usr/local/opt/gnu-tar/libexec/gnubin >> $GITHUB_PATH
           echo /usr/local/opt/llvm/bin >> $GITHUB_PATH
+          # https://github.com/Homebrew/homebrew-core/issues/140244
+          codesign --verify $(which qemu-system-x86_64) || brew reinstall qemu --build-from-source
 
       - name: bpf-linker
         if: runner.os == 'macOS'

--- a/aya/src/maps/mod.rs
+++ b/aya/src/maps/mod.rs
@@ -5,17 +5,17 @@
 //! [`Bpf::load_file`](crate::Bpf::load_file) or
 //! [`Bpf::load`](crate::Bpf::load), all the maps defined in the eBPF code get
 //! initialized and can then be accessed using [`Bpf::map`](crate::Bpf::map),
-//! [`Bpf::map_mut`](crate::Bpf::map_mut), or [`Bpf::take_map`](crate::Bpf::take_map).
+//! [`Bpf::map_mut`](crate::Bpf::map_mut), or
+//! [`Bpf::take_map`](crate::Bpf::take_map).
 //!
 //! # Typed maps
 //!
 //! The eBPF API includes many map types each supporting different operations.
 //! [`Bpf::map`](crate::Bpf::map), [`Bpf::map_mut`](crate::Bpf::map_mut), and
-//! [`Bpf::take_map`](crate::Bpf::take_map) always return the
-//! opaque [`&Map`](crate::maps::Map), [`&mut Map`](crate::maps::Map), and [`Map`](crate::maps::Map)
+//! [`Bpf::take_map`](crate::Bpf::take_map) always return the opaque
+//! [`&Map`](crate::maps::Map), [`&mut Map`](crate::maps::Map), and [`Map`]
 //! types respectively. Those three types can be converted to *typed maps* using
-//! the [`TryFrom`](std::convert::TryFrom) or [`TryInto`](std::convert::TryInto)
-//! trait. For example:
+//! the [`TryFrom`] or [`TryInto`] trait. For example:
 //!
 //! ```no_run
 //! # let mut bpf = aya::Bpf::load(&[])?;

--- a/aya/src/maps/perf/mod.rs
+++ b/aya/src/maps/perf/mod.rs
@@ -1,6 +1,7 @@
-//! Ring buffer types used to receive events from eBPF programs using the linux `perf` API.
+//! Ring buffer types used to receive events from eBPF programs using the linux
+//! `perf` API.
 //!
-//! See the [`PerfEventArray`](crate::maps::PerfEventArray) and [`AsyncPerfEventArray`](crate::maps::perf::AsyncPerfEventArray).
+//! See [`PerfEventArray`] and [`AsyncPerfEventArray`].
 #[cfg(any(feature = "async_tokio", feature = "async_std"))]
 #[cfg_attr(docsrs, doc(cfg(any(feature = "async_tokio", feature = "async_std"))))]
 mod async_perf_event_array;


### PR DESCRIPTION
Appease the new lint rustdoc::redundant_explicit_links that was added in
https://github.com/rust-lang/rust/pull/113167.
