### PR TITLE
aya-obj: reduce indirection in section parsing

### DIFF
--- a/aya-obj/src/programs/cgroup_sock.rs
+++ b/aya-obj/src/programs/cgroup_sock.rs
@@ -1,10 +1,5 @@
 //! Cgroup socket programs.
-use alloc::{borrow::ToOwned, string::String};
-
 use crate::generated::bpf_attach_type;
-
-#[cfg(not(feature = "std"))]
-use crate::std;
 
 /// Defines where to attach a `CgroupSock` program.
 #[derive(Copy, Clone, Debug, Default)]
@@ -27,22 +22,6 @@ impl From<CgroupSockAttachType> for bpf_attach_type {
             CgroupSockAttachType::PostBind6 => bpf_attach_type::BPF_CGROUP_INET6_POST_BIND,
             CgroupSockAttachType::SockCreate => bpf_attach_type::BPF_CGROUP_INET_SOCK_CREATE,
             CgroupSockAttachType::SockRelease => bpf_attach_type::BPF_CGROUP_INET_SOCK_RELEASE,
-        }
-    }
-}
-
-#[derive(Debug, thiserror::Error)]
-#[error("{0} is not a valid attach type for a CGROUP_SOCK program")]
-pub(crate) struct InvalidAttachType(String);
-
-impl CgroupSockAttachType {
-    pub(crate) fn try_from(value: &str) -> Result<CgroupSockAttachType, InvalidAttachType> {
-        match value {
-            "post_bind4" => Ok(CgroupSockAttachType::PostBind4),
-            "post_bind6" => Ok(CgroupSockAttachType::PostBind6),
-            "sock_create" => Ok(CgroupSockAttachType::SockCreate),
-            "sock_release" => Ok(CgroupSockAttachType::SockRelease),
-            _ => Err(InvalidAttachType(value.to_owned())),
         }
     }
 }

--- a/aya-obj/src/programs/cgroup_sock_addr.rs
+++ b/aya-obj/src/programs/cgroup_sock_addr.rs
@@ -1,10 +1,5 @@
 //! Cgroup socket address programs.
-use alloc::{borrow::ToOwned, string::String};
-
 use crate::generated::bpf_attach_type;
-
-#[cfg(not(feature = "std"))]
-use crate::std;
 
 /// Defines where to attach a `CgroupSockAddr` program.
 #[derive(Copy, Clone, Debug)]
@@ -50,30 +45,6 @@ impl From<CgroupSockAddrAttachType> for bpf_attach_type {
             CgroupSockAddrAttachType::UDPSendMsg6 => bpf_attach_type::BPF_CGROUP_UDP6_SENDMSG,
             CgroupSockAddrAttachType::UDPRecvMsg4 => bpf_attach_type::BPF_CGROUP_UDP4_RECVMSG,
             CgroupSockAddrAttachType::UDPRecvMsg6 => bpf_attach_type::BPF_CGROUP_UDP6_RECVMSG,
-        }
-    }
-}
-
-#[derive(Debug, thiserror::Error)]
-#[error("{0} is not a valid attach type for a CGROUP_SOCK_ADDR program")]
-pub(crate) struct InvalidAttachType(String);
-
-impl CgroupSockAddrAttachType {
-    pub(crate) fn try_from(value: &str) -> Result<CgroupSockAddrAttachType, InvalidAttachType> {
-        match value {
-            "bind4" => Ok(CgroupSockAddrAttachType::Bind4),
-            "bind6" => Ok(CgroupSockAddrAttachType::Bind6),
-            "connect4" => Ok(CgroupSockAddrAttachType::Connect4),
-            "connect6" => Ok(CgroupSockAddrAttachType::Connect6),
-            "getpeername4" => Ok(CgroupSockAddrAttachType::GetPeerName4),
-            "getpeername6" => Ok(CgroupSockAddrAttachType::GetPeerName6),
-            "getsockname4" => Ok(CgroupSockAddrAttachType::GetSockName4),
-            "getsockname6" => Ok(CgroupSockAddrAttachType::GetSockName6),
-            "sendmsg4" => Ok(CgroupSockAddrAttachType::UDPSendMsg4),
-            "sendmsg6" => Ok(CgroupSockAddrAttachType::UDPSendMsg6),
-            "recvmsg4" => Ok(CgroupSockAddrAttachType::UDPRecvMsg4),
-            "recvmsg6" => Ok(CgroupSockAddrAttachType::UDPRecvMsg6),
-            _ => Err(InvalidAttachType(value.to_owned())),
         }
     }
 }

--- a/aya-obj/src/programs/cgroup_sockopt.rs
+++ b/aya-obj/src/programs/cgroup_sockopt.rs
@@ -1,10 +1,5 @@
 //! Cgroup socket option programs.
-use alloc::{borrow::ToOwned, string::String};
-
 use crate::generated::bpf_attach_type;
-
-#[cfg(not(feature = "std"))]
-use crate::std;
 
 /// Defines where to attach a `CgroupSockopt` program.
 #[derive(Copy, Clone, Debug)]
@@ -20,20 +15,6 @@ impl From<CgroupSockoptAttachType> for bpf_attach_type {
         match s {
             CgroupSockoptAttachType::Get => bpf_attach_type::BPF_CGROUP_GETSOCKOPT,
             CgroupSockoptAttachType::Set => bpf_attach_type::BPF_CGROUP_SETSOCKOPT,
-        }
-    }
-}
-
-#[derive(Debug, thiserror::Error)]
-#[error("{0} is not a valid attach type for a CGROUP_SOCKOPT program")]
-pub(crate) struct InvalidAttachType(String);
-
-impl CgroupSockoptAttachType {
-    pub(crate) fn try_from(value: &str) -> Result<CgroupSockoptAttachType, InvalidAttachType> {
-        match value {
-            "getsockopt" => Ok(CgroupSockoptAttachType::Get),
-            "setsockopt" => Ok(CgroupSockoptAttachType::Set),
-            _ => Err(InvalidAttachType(value.to_owned())),
         }
     }
 }


### PR DESCRIPTION
Remove repetition of permitted cgroup attach types. Make optionality of
name more explicit rather than pretending both kind and name are equal
to section.
