### PR TITLE
maps: `MapFd` and `SockMapFd` are owned

### DIFF
--- a/aya-obj/src/lib.rs
+++ b/aya-obj/src/lib.rs
@@ -77,6 +77,12 @@ mod std {
         pub use core_error::Error;
     }
     pub use core::*;
+
+    pub mod os {
+        pub mod fd {
+            pub type RawFd = core::ffi::c_int;
+        }
+    }
 }
 
 pub mod btf;

--- a/aya-obj/src/relocation.rs
+++ b/aya-obj/src/relocation.rs
@@ -105,7 +105,7 @@ pub(crate) struct Symbol {
 
 impl Object {
     /// Relocates the map references
-    pub fn relocate_maps<'a, I: Iterator<Item = (&'a str, i32, &'a Map)>>(
+    pub fn relocate_maps<'a, I: Iterator<Item = (&'a str, std::os::fd::RawFd, &'a Map)>>(
         &mut self,
         maps: I,
         text_sections: &HashSet<usize>,
@@ -178,8 +178,8 @@ impl Object {
 fn relocate_maps<'a, I: Iterator<Item = &'a Relocation>>(
     fun: &mut Function,
     relocations: I,
-    maps_by_section: &HashMap<usize, (&str, i32, &Map)>,
-    maps_by_symbol: &HashMap<usize, (&str, i32, &Map)>,
+    maps_by_section: &HashMap<usize, (&str, std::os::fd::RawFd, &Map)>,
+    maps_by_symbol: &HashMap<usize, (&str, std::os::fd::RawFd, &Map)>,
     symbol_table: &HashMap<usize, Symbol>,
     text_sections: &HashSet<usize>,
 ) -> Result<(), RelocationError> {

--- a/aya/src/maps/array/array.rs
+++ b/aya/src/maps/array/array.rs
@@ -1,6 +1,7 @@
 use std::{
     borrow::{Borrow, BorrowMut},
     marker::PhantomData,
+    os::fd::AsFd as _,
 };
 
 use crate::{
@@ -61,7 +62,7 @@ impl<T: Borrow<MapData>, V: Pod> Array<T, V> {
     pub fn get(&self, index: &u32, flags: u64) -> Result<V, MapError> {
         let data = self.inner.borrow();
         check_bounds(data, *index)?;
-        let fd = data.fd;
+        let fd = data.fd().as_fd();
 
         let value =
             bpf_map_lookup_elem(fd, index, flags).map_err(|(_, io_error)| SyscallError {
@@ -88,7 +89,7 @@ impl<T: BorrowMut<MapData>, V: Pod> Array<T, V> {
     pub fn set(&mut self, index: u32, value: impl Borrow<V>, flags: u64) -> Result<(), MapError> {
         let data = self.inner.borrow_mut();
         check_bounds(data, index)?;
-        let fd = data.fd;
+        let fd = data.fd().as_fd();
         bpf_map_update_elem(fd, Some(&index), value.borrow(), flags).map_err(|(_, io_error)| {
             SyscallError {
                 call: "bpf_map_update_elem",

--- a/aya/src/maps/array/per_cpu_array.rs
+++ b/aya/src/maps/array/per_cpu_array.rs
@@ -1,6 +1,7 @@
 use std::{
     borrow::{Borrow, BorrowMut},
     marker::PhantomData,
+    os::fd::AsFd as _,
 };
 
 use crate::{
@@ -80,7 +81,7 @@ impl<T: Borrow<MapData>, V: Pod> PerCpuArray<T, V> {
     pub fn get(&self, index: &u32, flags: u64) -> Result<PerCpuValues<V>, MapError> {
         let data = self.inner.borrow();
         check_bounds(data, *index)?;
-        let fd = data.fd;
+        let fd = data.fd().as_fd();
 
         let value = bpf_map_lookup_elem_per_cpu(fd, index, flags).map_err(|(_, io_error)| {
             SyscallError {
@@ -108,7 +109,7 @@ impl<T: BorrowMut<MapData>, V: Pod> PerCpuArray<T, V> {
     pub fn set(&mut self, index: u32, values: PerCpuValues<V>, flags: u64) -> Result<(), MapError> {
         let data = self.inner.borrow_mut();
         check_bounds(data, index)?;
-        let fd = data.fd;
+        let fd = data.fd().as_fd();
 
         bpf_map_update_elem_per_cpu(fd, &index, &values, flags).map_err(|(_, io_error)| {
             SyscallError {

--- a/aya/src/maps/array/program_array.rs
+++ b/aya/src/maps/array/program_array.rs
@@ -74,7 +74,7 @@ impl<T: BorrowMut<MapData>> ProgramArray<T> {
     pub fn set(&mut self, index: u32, program: &ProgramFd, flags: u64) -> Result<(), MapError> {
         let data = self.inner.borrow_mut();
         check_bounds(data, index)?;
-        let fd = data.fd;
+        let fd = data.fd().as_fd();
         let prog_fd = program.as_fd();
         let prog_fd = prog_fd.as_raw_fd();
 
@@ -94,7 +94,7 @@ impl<T: BorrowMut<MapData>> ProgramArray<T> {
     pub fn clear_index(&mut self, index: &u32) -> Result<(), MapError> {
         let data = self.inner.borrow_mut();
         check_bounds(data, *index)?;
-        let fd = self.inner.borrow_mut().fd;
+        let fd = data.fd().as_fd();
 
         bpf_map_delete_elem(fd, index)
             .map(|_| ())

--- a/aya/src/maps/hash_map/hash_map.rs
+++ b/aya/src/maps/hash_map/hash_map.rs
@@ -1,6 +1,7 @@
 use std::{
     borrow::{Borrow, BorrowMut},
     marker::PhantomData,
+    os::fd::AsFd as _,
 };
 
 use crate::{
@@ -52,7 +53,7 @@ impl<T: Borrow<MapData>, K: Pod, V: Pod> HashMap<T, K, V> {
 
     /// Returns a copy of the value associated with the key.
     pub fn get(&self, key: &K, flags: u64) -> Result<V, MapError> {
-        let fd = self.inner.borrow().fd;
+        let fd = self.inner.borrow().fd().as_fd();
         let value = bpf_map_lookup_elem(fd, key, flags).map_err(|(_, io_error)| SyscallError {
             call: "bpf_map_lookup_elem",
             io_error,

--- a/aya/src/maps/hash_map/mod.rs
+++ b/aya/src/maps/hash_map/mod.rs
@@ -4,6 +4,7 @@ use crate::{
     sys::{bpf_map_delete_elem, bpf_map_update_elem, SyscallError},
     Pod,
 };
+use std::os::fd::AsFd as _;
 
 #[allow(clippy::module_inception)]
 mod hash_map;
@@ -20,7 +21,7 @@ pub(crate) fn insert<K: Pod, V: Pod>(
     value: &V,
     flags: u64,
 ) -> Result<(), MapError> {
-    let fd = map.fd;
+    let fd = map.fd().as_fd();
     bpf_map_update_elem(fd, Some(key), value, flags).map_err(|(_, io_error)| SyscallError {
         call: "bpf_map_update_elem",
         io_error,
@@ -30,7 +31,7 @@ pub(crate) fn insert<K: Pod, V: Pod>(
 }
 
 pub(crate) fn remove<K: Pod>(map: &MapData, key: &K) -> Result<(), MapError> {
-    let fd = map.fd;
+    let fd = map.fd().as_fd();
     bpf_map_delete_elem(fd, key)
         .map(|_| ())
         .map_err(|(_, io_error)| {

--- a/aya/src/maps/hash_map/per_cpu_hash_map.rs
+++ b/aya/src/maps/hash_map/per_cpu_hash_map.rs
@@ -2,6 +2,7 @@
 use std::{
     borrow::{Borrow, BorrowMut},
     marker::PhantomData,
+    os::fd::AsFd as _,
 };
 
 use crate::{
@@ -61,7 +62,7 @@ impl<T: Borrow<MapData>, K: Pod, V: Pod> PerCpuHashMap<T, K, V> {
 
     /// Returns a slice of values - one for each CPU - associated with the key.
     pub fn get(&self, key: &K, flags: u64) -> Result<PerCpuValues<V>, MapError> {
-        let fd = self.inner.borrow().fd;
+        let fd = self.inner.borrow().fd().as_fd();
         let values =
             bpf_map_lookup_elem_per_cpu(fd, key, flags).map_err(|(_, io_error)| SyscallError {
                 call: "bpf_map_lookup_elem",
@@ -118,7 +119,7 @@ impl<T: BorrowMut<MapData>, K: Pod, V: Pod> PerCpuHashMap<T, K, V> {
         values: PerCpuValues<V>,
         flags: u64,
     ) -> Result<(), MapError> {
-        let fd = self.inner.borrow_mut().fd;
+        let fd = self.inner.borrow_mut().fd().as_fd();
         bpf_map_update_elem_per_cpu(fd, key.borrow(), &values, flags).map_err(
             |(_, io_error)| SyscallError {
                 call: "bpf_map_update_elem",

--- a/aya/src/maps/perf/perf_event_array.rs
+++ b/aya/src/maps/perf/perf_event_array.rs
@@ -4,7 +4,7 @@
 use std::{
     borrow::{Borrow, BorrowMut},
     ops::Deref,
-    os::fd::{AsRawFd, RawFd},
+    os::fd::{AsFd as _, AsRawFd, RawFd},
     sync::Arc,
 };
 
@@ -181,7 +181,7 @@ impl<T: BorrowMut<MapData>> PerfEventArray<T> {
         // FIXME: keep track of open buffers
 
         let map_data: &MapData = self.map.deref().borrow();
-        let map_fd = map_data.fd;
+        let map_fd = map_data.fd().as_fd();
         let buf = PerfBuffer::open(index, self.page_size, page_count.unwrap_or(2))?;
         bpf_map_update_elem(map_fd, Some(&index), &buf.as_raw_fd(), 0)
             .map_err(|(_, io_error)| io_error)?;

--- a/aya/src/maps/queue.rs
+++ b/aya/src/maps/queue.rs
@@ -2,6 +2,7 @@
 use std::{
     borrow::{Borrow, BorrowMut},
     marker::PhantomData,
+    os::fd::AsFd as _,
 };
 
 use crate::{
@@ -60,7 +61,7 @@ impl<T: BorrowMut<MapData>, V: Pod> Queue<T, V> {
     /// Returns [`MapError::ElementNotFound`] if the queue is empty, [`MapError::SyscallError`]
     /// if `bpf_map_lookup_and_delete_elem` fails.
     pub fn pop(&mut self, flags: u64) -> Result<V, MapError> {
-        let fd = self.inner.borrow().fd;
+        let fd = self.inner.borrow().fd().as_fd();
 
         let value = bpf_map_lookup_and_delete_elem::<u32, _>(fd, None, flags).map_err(
             |(_, io_error)| SyscallError {
@@ -77,7 +78,7 @@ impl<T: BorrowMut<MapData>, V: Pod> Queue<T, V> {
     ///
     /// [`MapError::SyscallError`] if `bpf_map_update_elem` fails.
     pub fn push(&mut self, value: impl Borrow<V>, flags: u64) -> Result<(), MapError> {
-        let fd = self.inner.borrow().fd;
+        let fd = self.inner.borrow().fd().as_fd();
         bpf_map_push_elem(fd, value.borrow(), flags).map_err(|(_, io_error)| SyscallError {
             call: "bpf_map_push_elem",
             io_error,

--- a/aya/src/maps/sock/mod.rs
+++ b/aya/src/maps/sock/mod.rs
@@ -5,17 +5,29 @@ mod sock_map;
 pub use sock_hash::SockHash;
 pub use sock_map::SockMap;
 
-use std::os::fd::{AsFd, BorrowedFd, RawFd};
+use std::{
+    io,
+    os::fd::{AsFd, BorrowedFd},
+};
 
 /// A socket map file descriptor.
-#[derive(Copy, Clone)]
-pub struct SockMapFd(RawFd);
+#[repr(transparent)]
+pub struct SockMapFd(super::MapFd);
+
+impl SockMapFd {
+    /// Creates a new instance that shares the same underlying file description as [`self`].
+    pub fn try_clone(&self) -> io::Result<Self> {
+        let Self(inner) = self;
+        let super::MapFd(inner) = inner;
+        let inner = inner.try_clone()?;
+        let inner = super::MapFd(inner);
+        Ok(Self(inner))
+    }
+}
 
 impl AsFd for SockMapFd {
     fn as_fd(&self) -> BorrowedFd<'_> {
-        // SAFETY: This isn't necessarily safe, we need to find ways
-        // to enforce that the file descriptor is still
-        // valid. TODO(#612)
-        unsafe { BorrowedFd::borrow_raw(self.0) }
+        let Self(fd) = self;
+        fd.as_fd()
     }
 }

--- a/aya/src/maps/sock/sock_hash.rs
+++ b/aya/src/maps/sock/sock_hash.rs
@@ -1,12 +1,13 @@
 use std::{
     borrow::{Borrow, BorrowMut},
     marker::PhantomData,
-    os::fd::{AsRawFd, RawFd},
+    os::fd::{AsFd as _, AsRawFd, RawFd},
 };
 
 use crate::{
     maps::{
-        check_kv_size, hash_map, sock::SockMapFd, IterableMap, MapData, MapError, MapIter, MapKeys,
+        check_kv_size, hash_map, sock::SockMapFd, IterableMap, MapData, MapError, MapFd, MapIter,
+        MapKeys,
     },
     sys::{bpf_map_lookup_elem, SyscallError},
     Pod,
@@ -47,11 +48,11 @@ use crate::{
 /// use aya::programs::SkMsg;
 ///
 /// let mut intercept_egress = SockHash::<_, u32>::try_from(bpf.map("INTERCEPT_EGRESS").unwrap())?;
-/// let map_fd = intercept_egress.fd()?;
+/// let map_fd = intercept_egress.fd().try_clone()?;
 ///
 /// let prog: &mut SkMsg = bpf.program_mut("intercept_egress_packet").unwrap().try_into()?;
 /// prog.load()?;
-/// prog.attach(map_fd)?;
+/// prog.attach(&map_fd)?;
 ///
 /// let mut client = TcpStream::connect("127.0.0.1:1234")?;
 /// let mut intercept_egress = SockHash::try_from(bpf.map_mut("INTERCEPT_EGRESS").unwrap())?;
@@ -81,7 +82,7 @@ impl<T: Borrow<MapData>, K: Pod> SockHash<T, K> {
 
     /// Returns the fd of the socket stored at the given key.
     pub fn get(&self, key: &K, flags: u64) -> Result<RawFd, MapError> {
-        let fd = self.inner.borrow().fd;
+        let fd = self.inner.borrow().fd().as_fd();
         let value = bpf_map_lookup_elem(fd, key, flags).map_err(|(_, io_error)| SyscallError {
             call: "bpf_map_lookup_elem",
             io_error,
@@ -105,8 +106,11 @@ impl<T: Borrow<MapData>, K: Pod> SockHash<T, K> {
     ///
     /// The returned file descriptor can be used to attach programs that work with
     /// socket maps, like [`SkMsg`](crate::programs::SkMsg) and [`SkSkb`](crate::programs::SkSkb).
-    pub fn fd(&self) -> Result<SockMapFd, MapError> {
-        Ok(SockMapFd(self.inner.borrow().fd))
+    pub fn fd(&self) -> &SockMapFd {
+        let fd: &MapFd = self.inner.borrow().fd();
+        // TODO(https://github.com/rust-lang/rfcs/issues/3066): avoid this unsafe.
+        // SAFETY: `SockMapFd` is #[repr(transparent)] over `MapFd`.
+        unsafe { std::mem::transmute(fd) }
     }
 }
 

--- a/aya/src/maps/sock/sock_map.rs
+++ b/aya/src/maps/sock/sock_map.rs
@@ -2,11 +2,11 @@
 
 use std::{
     borrow::{Borrow, BorrowMut},
-    os::fd::{AsRawFd, RawFd},
+    os::fd::{AsFd as _, AsRawFd, RawFd},
 };
 
 use crate::{
-    maps::{check_bounds, check_kv_size, sock::SockMapFd, MapData, MapError, MapKeys},
+    maps::{check_bounds, check_kv_size, sock::SockMapFd, MapData, MapError, MapFd, MapKeys},
     sys::{bpf_map_delete_elem, bpf_map_update_elem, SyscallError},
 };
 
@@ -26,18 +26,29 @@ use crate::{
 /// # Examples
 ///
 /// ```no_run
+/// # #[derive(Debug, thiserror::Error)]
+/// # enum Error {
+/// #     #[error(transparent)]
+/// #     IO(#[from] std::io::Error),
+/// #     #[error(transparent)]
+/// #     Map(#[from] aya::maps::MapError),
+/// #     #[error(transparent)]
+/// #     Program(#[from] aya::programs::ProgramError),
+/// #     #[error(transparent)]
+/// #     Bpf(#[from] aya::BpfError)
+/// # }
 /// # let mut bpf = aya::Bpf::load(&[])?;
 /// use aya::maps::SockMap;
 /// use aya::programs::SkSkb;
 ///
 /// let intercept_ingress = SockMap::try_from(bpf.map("INTERCEPT_INGRESS").unwrap())?;
-/// let map_fd = intercept_ingress.fd()?;
+/// let map_fd = intercept_ingress.fd().try_clone()?;
 ///
 /// let prog: &mut SkSkb = bpf.program_mut("intercept_ingress_packet").unwrap().try_into()?;
 /// prog.load()?;
-/// prog.attach(map_fd)?;
+/// prog.attach(&map_fd)?;
 ///
-/// # Ok::<(), aya::BpfError>(())
+/// # Ok::<(), Error>(())
 /// ```
 #[doc(alias = "BPF_MAP_TYPE_SOCKMAP")]
 pub struct SockMap<T> {
@@ -62,8 +73,11 @@ impl<T: Borrow<MapData>> SockMap<T> {
     ///
     /// The returned file descriptor can be used to attach programs that work with
     /// socket maps, like [`SkMsg`](crate::programs::SkMsg) and [`SkSkb`](crate::programs::SkSkb).
-    pub fn fd(&self) -> Result<SockMapFd, MapError> {
-        Ok(SockMapFd(self.inner.borrow().fd))
+    pub fn fd(&self) -> &SockMapFd {
+        let fd: &MapFd = self.inner.borrow().fd();
+        // TODO(https://github.com/rust-lang/rfcs/issues/3066): avoid this unsafe.
+        // SAFETY: `SockMapFd` is #[repr(transparent)] over `MapFd`.
+        unsafe { std::mem::transmute(&fd) }
     }
 }
 
@@ -71,7 +85,7 @@ impl<T: BorrowMut<MapData>> SockMap<T> {
     /// Stores a socket into the map.
     pub fn set<I: AsRawFd>(&mut self, index: u32, socket: &I, flags: u64) -> Result<(), MapError> {
         let data = self.inner.borrow_mut();
-        let fd = data.fd;
+        let fd = data.fd().as_fd();
         check_bounds(data, index)?;
         bpf_map_update_elem(fd, Some(&index), &socket.as_raw_fd(), flags).map_err(
             |(_, io_error)| SyscallError {
@@ -85,7 +99,7 @@ impl<T: BorrowMut<MapData>> SockMap<T> {
     /// Removes the socket stored at `index` from the map.
     pub fn clear_index(&mut self, index: &u32) -> Result<(), MapError> {
         let data = self.inner.borrow_mut();
-        let fd = data.fd;
+        let fd = data.fd().as_fd();
         check_bounds(data, *index)?;
         bpf_map_delete_elem(fd, index)
             .map(|_| ())

--- a/aya/src/maps/stack.rs
+++ b/aya/src/maps/stack.rs
@@ -2,6 +2,7 @@
 use std::{
     borrow::{Borrow, BorrowMut},
     marker::PhantomData,
+    os::fd::AsFd as _,
 };
 
 use crate::{
@@ -60,7 +61,7 @@ impl<T: BorrowMut<MapData>, V: Pod> Stack<T, V> {
     /// Returns [`MapError::ElementNotFound`] if the stack is empty, [`MapError::SyscallError`]
     /// if `bpf_map_lookup_and_delete_elem` fails.
     pub fn pop(&mut self, flags: u64) -> Result<V, MapError> {
-        let fd = self.inner.borrow().fd;
+        let fd = self.inner.borrow().fd().as_fd();
 
         let value = bpf_map_lookup_and_delete_elem::<u32, _>(fd, None, flags).map_err(
             |(_, io_error)| SyscallError {
@@ -77,7 +78,7 @@ impl<T: BorrowMut<MapData>, V: Pod> Stack<T, V> {
     ///
     /// [`MapError::SyscallError`] if `bpf_map_update_elem` fails.
     pub fn push(&mut self, value: impl Borrow<V>, flags: u64) -> Result<(), MapError> {
-        let fd = self.inner.borrow().fd;
+        let fd = self.inner.borrow().fd().as_fd();
         bpf_map_update_elem(fd, None::<&u32>, value.borrow(), flags).map_err(|(_, io_error)| {
             SyscallError {
                 call: "bpf_map_update_elem",

--- a/aya/src/maps/stack_trace.rs
+++ b/aya/src/maps/stack_trace.rs
@@ -1,7 +1,7 @@
 //! A hash map of kernel or user space stack traces.
 //!
 //! See [`StackTraceMap`] for documentation and examples.
-use std::{borrow::Borrow, fs, io, mem, path::Path, str::FromStr};
+use std::{borrow::Borrow, fs, io, mem, os::fd::AsFd as _, path::Path, str::FromStr};
 
 use crate::{
     maps::{IterableMap, MapData, MapError, MapIter, MapKeys},
@@ -103,7 +103,7 @@ impl<T: Borrow<MapData>> StackTraceMap<T> {
     /// Returns [`MapError::KeyNotFound`] if there is no stack trace with the
     /// given `stack_id`, or [`MapError::SyscallError`] if `bpf_map_lookup_elem` fails.
     pub fn get(&self, stack_id: &u32, flags: u64) -> Result<StackTrace, MapError> {
-        let fd = self.inner.borrow().fd;
+        let fd = self.inner.borrow().fd().as_fd();
 
         let mut frames = vec![0; self.max_stack_depth];
         bpf_map_lookup_elem_ptr(fd, Some(stack_id), frames.as_mut_ptr(), flags)

--- a/aya/src/programs/links.rs
+++ b/aya/src/programs/links.rs
@@ -154,11 +154,9 @@ impl FdLink {
                 error,
             }
         })?;
-        bpf_pin_object(self.fd.as_raw_fd(), &path_string).map_err(|(_, io_error)| {
-            SyscallError {
-                call: "BPF_OBJ_PIN",
-                io_error,
-            }
+        bpf_pin_object(self.fd.as_fd(), &path_string).map_err(|(_, io_error)| SyscallError {
+            call: "BPF_OBJ_PIN",
+            io_error,
         })?;
         Ok(PinnedLink::new(path.into(), self))
     }

--- a/aya/src/programs/mod.rs
+++ b/aya/src/programs/mod.rs
@@ -218,9 +218,8 @@ pub enum ProgramError {
 pub struct ProgramFd(OwnedFd);
 
 impl ProgramFd {
-    /// Creates a new `ProgramFd` instance that shares the same underlying file
-    /// description as the existing `ProgramFd` instance.
-    pub fn try_clone(&self) -> Result<Self, ProgramError> {
+    /// Creates a new instance that shares the same underlying file description as [`self`].
+    pub fn try_clone(&self) -> io::Result<Self> {
         let Self(inner) = self;
         let inner = inner.try_clone()?;
         Ok(Self(inner))
@@ -536,7 +535,7 @@ fn pin_program<T: Link, P: AsRef<Path>>(data: &ProgramData<T>, path: P) -> Resul
             path: path.into(),
             error,
         })?;
-    bpf_pin_object(fd.as_fd().as_raw_fd(), &path_string).map_err(|(_, io_error)| SyscallError {
+    bpf_pin_object(fd.as_fd(), &path_string).map_err(|(_, io_error)| SyscallError {
         call: "BPF_OBJ_PIN",
         io_error,
     })?;

--- a/aya/src/programs/sk_msg.rs
+++ b/aya/src/programs/sk_msg.rs
@@ -43,11 +43,11 @@ use crate::{
 /// use aya::programs::SkMsg;
 ///
 /// let intercept_egress: SockHash<_, u32> = bpf.map("INTERCEPT_EGRESS").unwrap().try_into()?;
-/// let map_fd = intercept_egress.fd()?;
+/// let map_fd = intercept_egress.fd().try_clone()?;
 ///
 /// let prog: &mut SkMsg = bpf.program_mut("intercept_egress_packet").unwrap().try_into()?;
 /// prog.load()?;
-/// prog.attach(map_fd)?;
+/// prog.attach(&map_fd)?;
 ///
 /// let mut client = TcpStream::connect("127.0.0.1:1234")?;
 /// let mut intercept_egress: SockHash<_, u32> = bpf.map_mut("INTERCEPT_EGRESS").unwrap().try_into()?;
@@ -77,7 +77,7 @@ impl SkMsg {
     /// Attaches the program to the given sockmap.
     ///
     /// The returned value can be used to detach, see [SkMsg::detach].
-    pub fn attach(&mut self, map: SockMapFd) -> Result<SkMsgLinkId, ProgramError> {
+    pub fn attach(&mut self, map: &SockMapFd) -> Result<SkMsgLinkId, ProgramError> {
         let prog_fd = self.fd()?;
         let prog_fd = prog_fd.as_fd();
         let link = ProgAttachLink::attach(prog_fd, map.as_fd(), BPF_SK_MSG_VERDICT)?;

--- a/aya/src/programs/utils.rs
+++ b/aya/src/programs/utils.rs
@@ -82,7 +82,7 @@ pub(crate) fn get_fdinfo(fd: BorrowedFd<'_>, key: &str) -> Result<u32, ProgramEr
     let info = File::open(format!("/proc/self/fdinfo/{}", fd.as_raw_fd()))?;
     let reader = BufReader::new(info);
     for line in reader.lines() {
-        let line = line.map_err(ProgramError::IOError)?;
+        let line = line?;
         if !line.contains(key) {
             continue;
         }

--- a/aya/src/sys/bpf.rs
+++ b/aya/src/sys/bpf.rs
@@ -38,7 +38,7 @@ pub(crate) fn bpf_create_map(
     def: &obj::Map,
     btf_fd: Option<BorrowedFd<'_>>,
     kernel_version: KernelVersion,
-) -> SysResult<c_long> {
+) -> SysResult<OwnedFd> {
     let mut attr = unsafe { mem::zeroed::<bpf_attr>() };
 
     let u = unsafe { &mut attr.__bindgen_anon_1 };
@@ -91,13 +91,14 @@ pub(crate) fn bpf_create_map(
             .copy_from_slice(unsafe { slice::from_raw_parts(name.as_ptr(), name_len) });
     }
 
-    sys_bpf(bpf_cmd::BPF_MAP_CREATE, &mut attr)
+    // SAFETY: BPF_MAP_CREATE returns a new file descriptor.
+    unsafe { fd_sys_bpf(bpf_cmd::BPF_MAP_CREATE, &mut attr) }
 }
 
-pub(crate) fn bpf_pin_object(fd: RawFd, path: &CStr) -> SysResult<c_long> {
+pub(crate) fn bpf_pin_object(fd: BorrowedFd<'_>, path: &CStr) -> SysResult<c_long> {
     let mut attr = unsafe { mem::zeroed::<bpf_attr>() };
     let u = unsafe { &mut attr.__bindgen_anon_4 };
-    u.bpf_fd = fd as u32;
+    u.bpf_fd = fd.as_raw_fd() as u32;
     u.pathname = path.as_ptr() as u64;
     sys_bpf(bpf_cmd::BPF_OBJ_PIN, &mut attr)
 }
@@ -194,7 +195,7 @@ pub(crate) fn bpf_load_program(
 }
 
 fn lookup<K: Pod, V: Pod>(
-    fd: RawFd,
+    fd: BorrowedFd<'_>,
     key: Option<&K>,
     flags: u64,
     cmd: bpf_cmd,
@@ -203,7 +204,7 @@ fn lookup<K: Pod, V: Pod>(
     let mut value = MaybeUninit::zeroed();
 
     let u = unsafe { &mut attr.__bindgen_anon_2 };
-    u.map_fd = fd as u32;
+    u.map_fd = fd.as_raw_fd() as u32;
     if let Some(key) = key {
         u.key = key as *const _ as u64;
     }
@@ -218,7 +219,7 @@ fn lookup<K: Pod, V: Pod>(
 }
 
 pub(crate) fn bpf_map_lookup_elem<K: Pod, V: Pod>(
-    fd: RawFd,
+    fd: BorrowedFd<'_>,
     key: &K,
     flags: u64,
 ) -> Result<Option<V>, (c_long, io::Error)> {
@@ -226,7 +227,7 @@ pub(crate) fn bpf_map_lookup_elem<K: Pod, V: Pod>(
 }
 
 pub(crate) fn bpf_map_lookup_and_delete_elem<K: Pod, V: Pod>(
-    fd: RawFd,
+    fd: BorrowedFd<'_>,
     key: Option<&K>,
     flags: u64,
 ) -> Result<Option<V>, (c_long, io::Error)> {
@@ -234,7 +235,7 @@ pub(crate) fn bpf_map_lookup_and_delete_elem<K: Pod, V: Pod>(
 }
 
 pub(crate) fn bpf_map_lookup_elem_per_cpu<K: Pod, V: Pod>(
-    fd: RawFd,
+    fd: BorrowedFd<'_>,
     key: &K,
     flags: u64,
 ) -> Result<Option<PerCpuValues<V>>, (c_long, io::Error)> {
@@ -247,7 +248,7 @@ pub(crate) fn bpf_map_lookup_elem_per_cpu<K: Pod, V: Pod>(
 }
 
 pub(crate) fn bpf_map_lookup_elem_ptr<K: Pod, V>(
-    fd: RawFd,
+    fd: BorrowedFd<'_>,
     key: Option<&K>,
     value: *mut V,
     flags: u64,
@@ -255,7 +256,7 @@ pub(crate) fn bpf_map_lookup_elem_ptr<K: Pod, V>(
     let mut attr = unsafe { mem::zeroed::<bpf_attr>() };
 
     let u = unsafe { &mut attr.__bindgen_anon_2 };
-    u.map_fd = fd as u32;
+    u.map_fd = fd.as_raw_fd() as u32;
     if let Some(key) = key {
         u.key = key as *const _ as u64;
     }
@@ -270,7 +271,7 @@ pub(crate) fn bpf_map_lookup_elem_ptr<K: Pod, V>(
 }
 
 pub(crate) fn bpf_map_update_elem<K: Pod, V: Pod>(
-    fd: RawFd,
+    fd: BorrowedFd<'_>,
     key: Option<&K>,
     value: &V,
     flags: u64,
@@ -278,7 +279,7 @@ pub(crate) fn bpf_map_update_elem<K: Pod, V: Pod>(
     let mut attr = unsafe { mem::zeroed::<bpf_attr>() };
 
     let u = unsafe { &mut attr.__bindgen_anon_2 };
-    u.map_fd = fd as u32;
+    u.map_fd = fd.as_raw_fd() as u32;
     if let Some(key) = key {
         u.key = key as *const _ as u64;
     }
@@ -288,11 +289,15 @@ pub(crate) fn bpf_map_update_elem<K: Pod, V: Pod>(
     sys_bpf(bpf_cmd::BPF_MAP_UPDATE_ELEM, &mut attr)
 }
 
-pub(crate) fn bpf_map_push_elem<V: Pod>(fd: RawFd, value: &V, flags: u64) -> SysResult<c_long> {
+pub(crate) fn bpf_map_push_elem<V: Pod>(
+    fd: BorrowedFd<'_>,
+    value: &V,
+    flags: u64,
+) -> SysResult<c_long> {
     let mut attr = unsafe { mem::zeroed::<bpf_attr>() };
 
     let u = unsafe { &mut attr.__bindgen_anon_2 };
-    u.map_fd = fd as u32;
+    u.map_fd = fd.as_raw_fd() as u32;
     u.__bindgen_anon_1.value = value as *const _ as u64;
     u.flags = flags;
 
@@ -300,7 +305,7 @@ pub(crate) fn bpf_map_push_elem<V: Pod>(fd: RawFd, value: &V, flags: u64) -> Sys
 }
 
 pub(crate) fn bpf_map_update_elem_ptr<K, V>(
-    fd: RawFd,
+    fd: BorrowedFd<'_>,
     key: *const K,
     value: *mut V,
     flags: u64,
@@ -308,7 +313,7 @@ pub(crate) fn bpf_map_update_elem_ptr<K, V>(
     let mut attr = unsafe { mem::zeroed::<bpf_attr>() };
 
     let u = unsafe { &mut attr.__bindgen_anon_2 };
-    u.map_fd = fd as u32;
+    u.map_fd = fd.as_raw_fd() as u32;
     u.key = key as u64;
     u.__bindgen_anon_1.value = value as u64;
     u.flags = flags;
@@ -317,7 +322,7 @@ pub(crate) fn bpf_map_update_elem_ptr<K, V>(
 }
 
 pub(crate) fn bpf_map_update_elem_per_cpu<K: Pod, V: Pod>(
-    fd: RawFd,
+    fd: BorrowedFd<'_>,
     key: &K,
     values: &PerCpuValues<V>,
     flags: u64,
@@ -326,25 +331,25 @@ pub(crate) fn bpf_map_update_elem_per_cpu<K: Pod, V: Pod>(
     bpf_map_update_elem_ptr(fd, key, mem.as_mut_ptr(), flags)
 }
 
-pub(crate) fn bpf_map_delete_elem<K: Pod>(fd: RawFd, key: &K) -> SysResult<c_long> {
+pub(crate) fn bpf_map_delete_elem<K: Pod>(fd: BorrowedFd<'_>, key: &K) -> SysResult<c_long> {
     let mut attr = unsafe { mem::zeroed::<bpf_attr>() };
 
     let u = unsafe { &mut attr.__bindgen_anon_2 };
-    u.map_fd = fd as u32;
+    u.map_fd = fd.as_raw_fd() as u32;
     u.key = key as *const _ as u64;
 
     sys_bpf(bpf_cmd::BPF_MAP_DELETE_ELEM, &mut attr)
 }
 
 pub(crate) fn bpf_map_get_next_key<K: Pod>(
-    fd: RawFd,
+    fd: BorrowedFd<'_>,
     key: Option<&K>,
 ) -> Result<Option<K>, (c_long, io::Error)> {
     let mut attr = unsafe { mem::zeroed::<bpf_attr>() };
     let mut next_key = MaybeUninit::uninit();
 
     let u = unsafe { &mut attr.__bindgen_anon_2 };
-    u.map_fd = fd as u32;
+    u.map_fd = fd.as_raw_fd() as u32;
     if let Some(key) = key {
         u.key = key as *const _ as u64;
     }
@@ -358,10 +363,10 @@ pub(crate) fn bpf_map_get_next_key<K: Pod>(
 }
 
 // since kernel 5.2
-pub(crate) fn bpf_map_freeze(fd: RawFd) -> SysResult<c_long> {
+pub(crate) fn bpf_map_freeze(fd: BorrowedFd<'_>) -> SysResult<c_long> {
     let mut attr = unsafe { mem::zeroed::<bpf_attr>() };
     let u = unsafe { &mut attr.__bindgen_anon_2 };
-    u.map_fd = fd as u32;
+    u.map_fd = fd.as_raw_fd() as u32;
     sys_bpf(bpf_cmd::BPF_MAP_FREEZE, &mut attr)
 }
 
@@ -754,7 +759,7 @@ pub(crate) fn is_bpf_global_data_supported() -> bool {
     );
 
     if let Ok(map) = map {
-        insns[0].imm = map.fd;
+        insns[0].imm = map.fd().as_fd().as_raw_fd();
 
         let gpl = b"GPL\0";
         u.license = gpl.as_ptr() as u64;

--- a/test/integration-test/src/tests/rbpf.rs
+++ b/test/integration-test/src/tests/rbpf.rs
@@ -58,7 +58,7 @@ fn use_map_with_rbpf() {
         );
 
         let map_id = if name == "map_1" { 0 } else { 1 };
-        let fd = map_id as i32 | 0xCAFE00;
+        let fd = map_id as std::os::fd::RawFd | 0xCAFE00;
         maps.insert(name.to_owned(), (fd, map.clone()));
 
         unsafe {

--- a/xtask/public-api/aya-obj.txt
+++ b/xtask/public-api/aya-obj.txt
@@ -5972,7 +5972,7 @@ impl aya_obj::Object
 pub fn aya_obj::Object::relocate_btf(&mut self, target_btf: &aya_obj::btf::Btf) -> core::result::Result<(), aya_obj::btf::BtfRelocationError>
 impl aya_obj::Object
 pub fn aya_obj::Object::relocate_calls(&mut self, text_sections: &std::collections::hash::set::HashSet<usize>) -> core::result::Result<(), aya_obj::relocation::BpfRelocationError>
-pub fn aya_obj::Object::relocate_maps<'a, I: core::iter::traits::iterator::Iterator<Item = (&'a str, i32, &'a aya_obj::maps::Map)>>(&mut self, maps: I, text_sections: &std::collections::hash::set::HashSet<usize>) -> core::result::Result<(), aya_obj::relocation::BpfRelocationError>
+pub fn aya_obj::Object::relocate_maps<'a, I: core::iter::traits::iterator::Iterator<Item = (&'a str, std::os::fd::raw::RawFd, &'a aya_obj::maps::Map)>>(&mut self, maps: I, text_sections: &std::collections::hash::set::HashSet<usize>) -> core::result::Result<(), aya_obj::relocation::BpfRelocationError>
 impl core::clone::Clone for aya_obj::Object
 pub fn aya_obj::Object::clone(&self) -> aya_obj::Object
 impl core::fmt::Debug for aya_obj::Object
@@ -6684,7 +6684,7 @@ impl aya_obj::Object
 pub fn aya_obj::Object::relocate_btf(&mut self, target_btf: &aya_obj::btf::Btf) -> core::result::Result<(), aya_obj::btf::BtfRelocationError>
 impl aya_obj::Object
 pub fn aya_obj::Object::relocate_calls(&mut self, text_sections: &std::collections::hash::set::HashSet<usize>) -> core::result::Result<(), aya_obj::relocation::BpfRelocationError>
-pub fn aya_obj::Object::relocate_maps<'a, I: core::iter::traits::iterator::Iterator<Item = (&'a str, i32, &'a aya_obj::maps::Map)>>(&mut self, maps: I, text_sections: &std::collections::hash::set::HashSet<usize>) -> core::result::Result<(), aya_obj::relocation::BpfRelocationError>
+pub fn aya_obj::Object::relocate_maps<'a, I: core::iter::traits::iterator::Iterator<Item = (&'a str, std::os::fd::raw::RawFd, &'a aya_obj::maps::Map)>>(&mut self, maps: I, text_sections: &std::collections::hash::set::HashSet<usize>) -> core::result::Result<(), aya_obj::relocation::BpfRelocationError>
 impl core::clone::Clone for aya_obj::Object
 pub fn aya_obj::Object::clone(&self) -> aya_obj::Object
 impl core::fmt::Debug for aya_obj::Object

--- a/xtask/public-api/aya.txt
+++ b/xtask/public-api/aya.txt
@@ -559,7 +559,7 @@ pub fn aya::maps::queue::Queue<T, V>::from(t: T) -> T
 pub mod aya::maps::sock
 pub struct aya::maps::sock::SockHash<T, K>
 impl<T: core::borrow::Borrow<aya::maps::MapData>, K: aya::Pod> aya::maps::SockHash<T, K>
-pub fn aya::maps::SockHash<T, K>::fd(&self) -> core::result::Result<aya::maps::sock::SockMapFd, aya::maps::MapError>
+pub fn aya::maps::SockHash<T, K>::fd(&self) -> &aya::maps::sock::SockMapFd
 pub fn aya::maps::SockHash<T, K>::get(&self, key: &K, flags: u64) -> core::result::Result<std::os::fd::raw::RawFd, aya::maps::MapError>
 pub fn aya::maps::SockHash<T, K>::iter(&self) -> aya::maps::MapIter<'_, K, std::os::fd::raw::RawFd, Self>
 pub fn aya::maps::SockHash<T, K>::keys(&self) -> aya::maps::MapKeys<'_, K>
@@ -601,7 +601,7 @@ impl<T> core::convert::From<T> for aya::maps::SockHash<T, K>
 pub fn aya::maps::SockHash<T, K>::from(t: T) -> T
 pub struct aya::maps::sock::SockMap<T>
 impl<T: core::borrow::Borrow<aya::maps::MapData>> aya::maps::SockMap<T>
-pub fn aya::maps::SockMap<T>::fd(&self) -> core::result::Result<aya::maps::sock::SockMapFd, aya::maps::MapError>
+pub fn aya::maps::SockMap<T>::fd(&self) -> &aya::maps::sock::SockMapFd
 pub fn aya::maps::SockMap<T>::indices(&self) -> aya::maps::MapKeys<'_, u32>
 impl<T: core::borrow::BorrowMut<aya::maps::MapData>> aya::maps::SockMap<T>
 pub fn aya::maps::SockMap<T>::clear_index(&mut self, index: &u32) -> core::result::Result<(), aya::maps::MapError>
@@ -636,12 +636,11 @@ impl<T> core::borrow::BorrowMut<T> for aya::maps::SockMap<T> where T: core::mark
 pub fn aya::maps::SockMap<T>::borrow_mut(&mut self) -> &mut T
 impl<T> core::convert::From<T> for aya::maps::SockMap<T>
 pub fn aya::maps::SockMap<T>::from(t: T) -> T
-pub struct aya::maps::sock::SockMapFd(_)
+#[repr(transparent)] pub struct aya::maps::sock::SockMapFd(_)
+impl aya::maps::sock::SockMapFd
+pub fn aya::maps::sock::SockMapFd::try_clone(&self) -> std::io::error::Result<Self>
 impl std::os::fd::owned::AsFd for aya::maps::sock::SockMapFd
 pub fn aya::maps::sock::SockMapFd::as_fd(&self) -> std::os::fd::owned::BorrowedFd<'_>
-impl core::clone::Clone for aya::maps::sock::SockMapFd
-pub fn aya::maps::sock::SockMapFd::clone(&self) -> aya::maps::sock::SockMapFd
-impl core::marker::Copy for aya::maps::sock::SockMapFd
 impl core::marker::Send for aya::maps::sock::SockMapFd
 impl core::marker::Sync for aya::maps::sock::SockMapFd
 impl core::marker::Unpin for aya::maps::sock::SockMapFd
@@ -655,10 +654,6 @@ pub fn aya::maps::sock::SockMapFd::try_from(value: U) -> core::result::Result<T,
 impl<T, U> core::convert::TryInto<U> for aya::maps::sock::SockMapFd where U: core::convert::TryFrom<T>
 pub type aya::maps::sock::SockMapFd::Error = <U as core::convert::TryFrom<T>>::Error
 pub fn aya::maps::sock::SockMapFd::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya::maps::sock::SockMapFd where T: core::clone::Clone
-pub type aya::maps::sock::SockMapFd::Owned = T
-pub fn aya::maps::sock::SockMapFd::clone_into(&self, target: &mut T)
-pub fn aya::maps::sock::SockMapFd::to_owned(&self) -> T
 impl<T> core::any::Any for aya::maps::sock::SockMapFd where T: 'static + core::marker::Sized
 pub fn aya::maps::sock::SockMapFd::type_id(&self) -> core::any::TypeId
 impl<T> core::borrow::Borrow<T> for aya::maps::sock::SockMapFd where T: core::marker::Sized
@@ -1226,13 +1221,9 @@ pub struct aya::maps::MapData
 pub aya::maps::MapData::pinned: bool
 impl aya::maps::MapData
 pub fn aya::maps::MapData::create(obj: aya_obj::maps::Map, name: &str, btf_fd: core::option::Option<std::os::fd::owned::BorrowedFd<'_>>) -> core::result::Result<Self, aya::maps::MapError>
-pub fn aya::maps::MapData::fd(&self) -> aya::maps::MapFd
+pub fn aya::maps::MapData::fd(&self) -> &aya::maps::MapFd
 pub fn aya::maps::MapData::from_fd(fd: std::os::fd::owned::OwnedFd) -> core::result::Result<Self, aya::maps::MapError>
 pub fn aya::maps::MapData::from_pin<P: core::convert::AsRef<std::path::Path>>(path: P) -> core::result::Result<Self, aya::maps::MapError>
-impl core::clone::Clone for aya::maps::MapData
-pub fn aya::maps::MapData::clone(&self) -> Self
-impl core::ops::drop::Drop for aya::maps::MapData
-pub fn aya::maps::MapData::drop(&mut self)
 impl core::fmt::Debug for aya::maps::MapData
 pub fn aya::maps::MapData::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Send for aya::maps::MapData
@@ -1248,10 +1239,6 @@ pub fn aya::maps::MapData::try_from(value: U) -> core::result::Result<T, <T as c
 impl<T, U> core::convert::TryInto<U> for aya::maps::MapData where U: core::convert::TryFrom<T>
 pub type aya::maps::MapData::Error = <U as core::convert::TryFrom<T>>::Error
 pub fn aya::maps::MapData::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya::maps::MapData where T: core::clone::Clone
-pub type aya::maps::MapData::Owned = T
-pub fn aya::maps::MapData::clone_into(&self, target: &mut T)
-pub fn aya::maps::MapData::to_owned(&self) -> T
 impl<T> core::any::Any for aya::maps::MapData where T: 'static + core::marker::Sized
 pub fn aya::maps::MapData::type_id(&self) -> core::any::TypeId
 impl<T> core::borrow::Borrow<T> for aya::maps::MapData where T: core::marker::Sized
@@ -1261,8 +1248,10 @@ pub fn aya::maps::MapData::borrow_mut(&mut self) -> &mut T
 impl<T> core::convert::From<T> for aya::maps::MapData
 pub fn aya::maps::MapData::from(t: T) -> T
 pub struct aya::maps::MapFd(_)
-impl std::os::fd::raw::AsRawFd for aya::maps::MapFd
-pub fn aya::maps::MapFd::as_raw_fd(&self) -> std::os::fd::raw::RawFd
+impl std::os::fd::owned::AsFd for aya::maps::MapFd
+pub fn aya::maps::MapFd::as_fd(&self) -> std::os::fd::owned::BorrowedFd<'_>
+impl core::fmt::Debug for aya::maps::MapFd
+pub fn aya::maps::MapFd::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Send for aya::maps::MapFd
 impl core::marker::Sync for aya::maps::MapFd
 impl core::marker::Unpin for aya::maps::MapFd
@@ -1566,7 +1555,7 @@ impl<T> core::convert::From<T> for aya::maps::queue::Queue<T, V>
 pub fn aya::maps::queue::Queue<T, V>::from(t: T) -> T
 pub struct aya::maps::SockHash<T, K>
 impl<T: core::borrow::Borrow<aya::maps::MapData>, K: aya::Pod> aya::maps::SockHash<T, K>
-pub fn aya::maps::SockHash<T, K>::fd(&self) -> core::result::Result<aya::maps::sock::SockMapFd, aya::maps::MapError>
+pub fn aya::maps::SockHash<T, K>::fd(&self) -> &aya::maps::sock::SockMapFd
 pub fn aya::maps::SockHash<T, K>::get(&self, key: &K, flags: u64) -> core::result::Result<std::os::fd::raw::RawFd, aya::maps::MapError>
 pub fn aya::maps::SockHash<T, K>::iter(&self) -> aya::maps::MapIter<'_, K, std::os::fd::raw::RawFd, Self>
 pub fn aya::maps::SockHash<T, K>::keys(&self) -> aya::maps::MapKeys<'_, K>
@@ -1608,7 +1597,7 @@ impl<T> core::convert::From<T> for aya::maps::SockHash<T, K>
 pub fn aya::maps::SockHash<T, K>::from(t: T) -> T
 pub struct aya::maps::SockMap<T>
 impl<T: core::borrow::Borrow<aya::maps::MapData>> aya::maps::SockMap<T>
-pub fn aya::maps::SockMap<T>::fd(&self) -> core::result::Result<aya::maps::sock::SockMapFd, aya::maps::MapError>
+pub fn aya::maps::SockMap<T>::fd(&self) -> &aya::maps::sock::SockMapFd
 pub fn aya::maps::SockMap<T>::indices(&self) -> aya::maps::MapKeys<'_, u32>
 impl<T: core::borrow::BorrowMut<aya::maps::MapData>> aya::maps::SockMap<T>
 pub fn aya::maps::SockMap<T>::clear_index(&mut self, index: &u32) -> core::result::Result<(), aya::maps::MapError>
@@ -6190,7 +6179,7 @@ impl<T> core::convert::From<T> for aya::programs::perf_event::PerfEvent
 pub fn aya::programs::perf_event::PerfEvent::from(t: T) -> T
 pub struct aya::programs::ProgramFd(_)
 impl aya::programs::ProgramFd
-pub fn aya::programs::ProgramFd::try_clone(&self) -> core::result::Result<Self, aya::programs::ProgramError>
+pub fn aya::programs::ProgramFd::try_clone(&self) -> std::io::error::Result<Self>
 impl std::os::fd::owned::AsFd for aya::programs::ProgramFd
 pub fn aya::programs::ProgramFd::as_fd(&self) -> std::os::fd::owned::BorrowedFd<'_>
 impl core::fmt::Debug for aya::programs::ProgramFd
@@ -6402,7 +6391,7 @@ impl<T> core::convert::From<T> for aya::programs::SkLookup
 pub fn aya::programs::SkLookup::from(t: T) -> T
 pub struct aya::programs::SkMsg
 impl aya::programs::SkMsg
-pub fn aya::programs::SkMsg::attach(&mut self, map: aya::maps::sock::SockMapFd) -> core::result::Result<SkMsgLinkId, aya::programs::ProgramError>
+pub fn aya::programs::SkMsg::attach(&mut self, map: &aya::maps::sock::SockMapFd) -> core::result::Result<SkMsgLinkId, aya::programs::ProgramError>
 pub fn aya::programs::SkMsg::detach(&mut self, link_id: SkMsgLinkId) -> core::result::Result<(), aya::programs::ProgramError>
 pub fn aya::programs::SkMsg::load(&mut self) -> core::result::Result<(), aya::programs::ProgramError>
 pub fn aya::programs::SkMsg::take_link(&mut self, link_id: SkMsgLinkId) -> core::result::Result<SkMsgLink, aya::programs::ProgramError>
@@ -6450,7 +6439,7 @@ impl<T> core::convert::From<T> for aya::programs::SkMsg
 pub fn aya::programs::SkMsg::from(t: T) -> T
 pub struct aya::programs::SkSkb
 impl aya::programs::SkSkb
-pub fn aya::programs::SkSkb::attach(&mut self, map: aya::maps::sock::SockMapFd) -> core::result::Result<SkSkbLinkId, aya::programs::ProgramError>
+pub fn aya::programs::SkSkb::attach(&mut self, map: &aya::maps::sock::SockMapFd) -> core::result::Result<SkSkbLinkId, aya::programs::ProgramError>
 pub fn aya::programs::SkSkb::detach(&mut self, link_id: SkSkbLinkId) -> core::result::Result<(), aya::programs::ProgramError>
 pub fn aya::programs::SkSkb::from_pin<P: core::convert::AsRef<std::path::Path>>(path: P, kind: aya::programs::SkSkbKind) -> core::result::Result<Self, aya::programs::ProgramError>
 pub fn aya::programs::SkSkb::load(&mut self) -> core::result::Result<(), aya::programs::ProgramError>


### PR DESCRIPTION
`MapData::fd` is now a `MapFd`. This means that `MapData` now closes the
file descriptor on drop. In the future we might consider making `MapFd`
hold a `BorrowedFd` but this requires API design work due to overlapping
borrows.

Since `SockMapFd` is no longer `Copy`, attach methods to take it by
reference to allow callers to use it multiple times as they are
accustomed to doing.

`SockMapFd` implements `try_clone`. `MapFd` and `SockMapFd` are now
returned by reference to allow callers to avoid file descriptor cloning
when desired.

This is an API breaking change.

Updates #612.
