### PR TITLE
aya: Remove MapData::pinned

### DIFF
--- a/aya/src/pin.rs
+++ b/aya/src/pin.rs
@@ -6,12 +6,6 @@ use thiserror::Error;
 /// An error ocurred working with a pinned BPF object.
 #[derive(Error, Debug)]
 pub enum PinError {
-    /// The object has already been pinned.
-    #[error("the BPF object `{name}` has already been pinned")]
-    AlreadyPinned {
-        /// Object name.
-        name: String,
-    },
     /// The object FD is not known by Aya.
     #[error("the BPF object `{name}`'s FD is not known")]
     NoFd {


### PR DESCRIPTION
BPF objects can be pinned mutliple times, to multiple different places. Tracking whether or not a map is pinned in a bool is therefore not sufficient. We could track this in a HashSet<PathBuf>, but there is really no reason to track it at all.