### PR TITLE
Remove MapData::pinned. Make MapData::pin public

### DIFF
--- a/aya/src/maps/mod.rs
+++ b/aya/src/maps/mod.rs
@@ -469,7 +469,8 @@ impl MapData {
             }
             Err(_) => {
                 let mut map = Self::create(obj, name, btf_fd)?;
-                map.pin(name, path).map_err(|error| MapError::PinError {
+                let path = path.join(name);
+                map.pin(&path).map_err(|error| MapError::PinError {
                     name: Some(name.into()),
                     error,
                 })?;
@@ -542,14 +543,38 @@ impl MapData {
         })
     }
 
-    pub(crate) fn pin<P: AsRef<Path>>(&mut self, name: &str, path: P) -> Result<(), PinError> {
+    /// Allows the map to be pinned to the provided path.
+    ///
+    /// Any directories in the the path provided should have been created by the caller.
+    /// The path must be on a BPF filesystem.
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`PinError::SyscallError`] if the underlying syscall fails.
+    /// This may also happen if the path already exists, in which case the wrapped
+    /// [`std::io::Error`] kind will be [`std::io::ErrorKind::AlreadyExists`].
+    /// Returns a [`PinError::InvalidPinPath`] if the path provided cannot be
+    /// converted to a [`CString`].
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// # let mut bpf = aya::Bpf::load(&[])?;
+    /// # use aya::maps::MapData;
+    ///
+    /// let mut map = MapData::from_pin("/sys/fs/bpf/my_map")?;
+    /// map.pin("/sys/fs/bpf/my_map2")?;
+    ///
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// ```
+    pub fn pin<P: AsRef<Path>>(&mut self, path: P) -> Result<(), PinError> {
         use std::os::unix::ffi::OsStrExt as _;
 
         let Self { fd, obj: _ } = self;
-        let path = path.as_ref().join(name);
+        let path = path.as_ref();
         let path_string = CString::new(path.as_os_str().as_bytes()).map_err(|error| {
             PinError::InvalidPinPath {
-                path: path.clone(),
+                path: path.to_path_buf(),
                 error,
             }
         })?;

--- a/aya/src/maps/mod.rs
+++ b/aya/src/maps/mod.rs
@@ -409,8 +409,6 @@ pub(crate) fn check_v_size<V>(map: &MapData) -> Result<(), MapError> {
 pub struct MapData {
     obj: obj::Map,
     fd: MapFd,
-    /// Indicates if this map has been pinned to bpffs
-    pub pinned: bool,
 }
 
 impl MapData {
@@ -439,11 +437,7 @@ impl MapData {
                 }
             })?;
         let fd = MapFd(fd);
-        Ok(Self {
-            obj,
-            fd,
-            pinned: false,
-        })
+        Ok(Self { obj, fd })
     }
 
     pub(crate) fn create_pinned<P: AsRef<Path>>(
@@ -471,11 +465,7 @@ impl MapData {
         }) {
             Ok(fd) => {
                 let fd = MapFd(fd);
-                Ok(Self {
-                    obj,
-                    fd,
-                    pinned: false,
-                })
+                Ok(Self { obj, fd })
             }
             Err(_) => {
                 let mut map = Self::create(obj, name, btf_fd)?;
@@ -489,7 +479,7 @@ impl MapData {
     }
 
     pub(crate) fn finalize(&mut self) -> Result<(), MapError> {
-        let Self { obj, fd, pinned: _ } = self;
+        let Self { obj, fd } = self;
         if !obj.data().is_empty() && obj.section_kind() != BpfSectionKind::Bss {
             bpf_map_update_elem_ptr(fd.as_fd(), &0 as *const _, obj.data_mut().as_mut_ptr(), 0)
                 .map_err(|(_, io_error)| SyscallError {
@@ -534,7 +524,6 @@ impl MapData {
         Ok(Self {
             obj: parse_map_info(info, PinningType::ByName),
             fd,
-            pinned: true,
         })
     }
 
@@ -550,44 +539,35 @@ impl MapData {
         Ok(Self {
             obj: parse_map_info(info, PinningType::None),
             fd,
-            pinned: false,
         })
     }
 
     pub(crate) fn pin<P: AsRef<Path>>(&mut self, name: &str, path: P) -> Result<(), PinError> {
         use std::os::unix::ffi::OsStrExt as _;
 
-        let Self { fd, pinned, obj: _ } = self;
-        if *pinned {
-            return Err(PinError::AlreadyPinned { name: name.into() });
-        }
+        let Self { fd, obj: _ } = self;
         let path = path.as_ref().join(name);
-        let path_string = CString::new(path.as_os_str().as_bytes())
-            .map_err(|error| PinError::InvalidPinPath { path, error })?;
+        let path_string = CString::new(path.as_os_str().as_bytes()).map_err(|error| {
+            PinError::InvalidPinPath {
+                path: path.clone(),
+                error,
+            }
+        })?;
         bpf_pin_object(fd.as_fd(), &path_string).map_err(|(_, io_error)| SyscallError {
             call: "BPF_OBJ_PIN",
             io_error,
         })?;
-        *pinned = true;
         Ok(())
     }
 
     /// Returns the file descriptor of the map.
     pub fn fd(&self) -> &MapFd {
-        let Self {
-            obj: _,
-            fd,
-            pinned: _,
-        } = self;
+        let Self { obj: _, fd } = self;
         fd
     }
 
     pub(crate) fn obj(&self) -> &obj::Map {
-        let Self {
-            obj,
-            fd: _,
-            pinned: _,
-        } = self;
+        let Self { obj, fd: _ } = self;
         obj
     }
 }
@@ -825,7 +805,6 @@ mod tests {
             Ok(MapData {
                 obj: _,
                 fd,
-                pinned: false
             }) => assert_eq!(fd.as_fd().as_raw_fd(), 42)
         );
     }

--- a/aya/src/pin.rs
+++ b/aya/src/pin.rs
@@ -6,12 +6,6 @@ use thiserror::Error;
 /// An error ocurred working with a pinned BPF object.
 #[derive(Error, Debug)]
 pub enum PinError {
-    /// The object has already been pinned.
-    #[error("the BPF object `{name}` has already been pinned")]
-    AlreadyPinned {
-        /// Object name.
-        name: String,
-    },
     /// The object FD is not known by Aya.
     #[error("the BPF object `{name}`'s FD is not known")]
     NoFd {

--- a/xtask/public-api/aya.txt
+++ b/xtask/public-api/aya.txt
@@ -1218,7 +1218,6 @@ pub fn aya::maps::lpm_trie::LpmTrie<T, K, V>::borrow_mut(&mut self) -> &mut T
 impl<T> core::convert::From<T> for aya::maps::lpm_trie::LpmTrie<T, K, V>
 pub fn aya::maps::lpm_trie::LpmTrie<T, K, V>::from(t: T) -> T
 pub struct aya::maps::MapData
-pub aya::maps::MapData::pinned: bool
 impl aya::maps::MapData
 pub fn aya::maps::MapData::create(obj: aya_obj::maps::Map, name: &str, btf_fd: core::option::Option<std::os::fd::owned::BorrowedFd<'_>>) -> core::result::Result<Self, aya::maps::MapError>
 pub fn aya::maps::MapData::fd(&self) -> &aya::maps::MapFd
@@ -1738,8 +1737,6 @@ pub fn aya::maps::stack_trace::StackTraceMap<T>::get(&self, index: &u32) -> core
 pub fn aya::maps::stack_trace::StackTraceMap<T>::map(&self) -> &aya::maps::MapData
 pub mod aya::pin
 pub enum aya::pin::PinError
-pub aya::pin::PinError::AlreadyPinned
-pub aya::pin::PinError::AlreadyPinned::name: alloc::string::String
 pub aya::pin::PinError::InvalidPinPath
 pub aya::pin::PinError::InvalidPinPath::error: alloc::ffi::c_str::NulError
 pub aya::pin::PinError::InvalidPinPath::path: std::path::PathBuf

--- a/xtask/public-api/aya.txt
+++ b/xtask/public-api/aya.txt
@@ -1223,6 +1223,7 @@ pub fn aya::maps::MapData::create(obj: aya_obj::maps::Map, name: &str, btf_fd: c
 pub fn aya::maps::MapData::fd(&self) -> &aya::maps::MapFd
 pub fn aya::maps::MapData::from_fd(fd: std::os::fd::owned::OwnedFd) -> core::result::Result<Self, aya::maps::MapError>
 pub fn aya::maps::MapData::from_pin<P: core::convert::AsRef<std::path::Path>>(path: P) -> core::result::Result<Self, aya::maps::MapError>
+pub fn aya::maps::MapData::pin<P: core::convert::AsRef<std::path::Path>>(&mut self, path: P) -> core::result::Result<(), aya::pin::PinError>
 impl core::fmt::Debug for aya::maps::MapData
 pub fn aya::maps::MapData::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Send for aya::maps::MapData


### PR DESCRIPTION
This is 2 small changes.

The first removes tracking of whether or not a Map has been pinned from MapData.
This is unnecessary since Maps may be pinned multiple times to multiple locations on a BPF filesystem.

The second change makes MapData::pin part of the public API.
This is to solve a use-case where a user (in this case bpfd) may want to:

- `MapData::from_pin` to open a pinned map from bpffs
- `MapData::pin` to pin that object into another bpffs

Both operations should be easily accomplished without needing to cast a `MapData` into a concrete Map type - e.g aya::maps::HashMap.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aya-rs/aya/790)
<!-- Reviewable:end -->
