### PR TITLE
Remove 6.4.x kernels from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -223,7 +223,6 @@ jobs:
           # linux-image-5.10.0-23-cloud-arm64-unsigned_5.10.179-3_arm64.deb \
           printf '%s\0' \
             linux-image-6.1.0-10-cloud-arm64-unsigned_6.1.38-2_arm64.deb \
-            linux-image-6.4.0-3-cloud-arm64-unsigned_6.4.11-1_arm64.deb \
           | xargs -0 -t -P0 -I {} wget -nd -nv -P test/.tmp/debian-kernels/arm64 ftp://ftp.us.debian.org/debian/pool/main/l/linux/{}
 
       - name: Download debian kernels
@@ -236,7 +235,6 @@ jobs:
           # linux-image-5.10.0-23-cloud-amd64-unsigned_5.10.179-3_amd64.deb \
           printf '%s\0' \
             linux-image-6.1.0-10-cloud-amd64-unsigned_6.1.38-2_amd64.deb \
-            linux-image-6.4.0-4-cloud-amd64-unsigned_6.4.13-1_amd64.deb \
           | xargs -0 -t -P0 -I {} wget -nd -nv -P test/.tmp/debian-kernels/amd64 ftp://ftp.us.debian.org/debian/pool/main/l/linux/{}
 
       - name: Extract debian kernels

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,9 @@ on:
     branches:
       - main
 
+  schedule:
+    - cron: 00 4 * * *
+
 env:
   CARGO_TERM_COLOR: always
 


### PR DESCRIPTION
- .github: remove 6.4.x kernel tests
- .github: run tests nightly
