### PR TITLE
aya: fix create pinned map path.

### DIFF
--- a/aya/src/maps/mod.rs
+++ b/aya/src/maps/mod.rs
@@ -490,7 +490,6 @@ impl MapData {
             }
             Err(_) => {
                 let mut map = Self::create(obj, name, btf_fd)?;
-                let path = path.join(name);
                 map.pin(&path).map_err(|error| MapError::PinError {
                     name: Some(name.into()),
                     error,


### PR DESCRIPTION
Seems MapData::create_pinned did something unexcepted when handling `BPF_OBJ_GET` and creating new maps.
```rust
    pub(crate) fn create_pinned<P: AsRef<Path>>(
        path: P,
        obj: obj::Map,
        name: &str,
        btf_fd: Option<BorrowedFd<'_>>,
    ) -> Result<Self, MapError> {
        use std::os::unix::ffi::OsStrExt as _;

        // try to open map in case it's already pinned
        let path = path.as_ref().join(name);
        let path_string = match CString::new(path.as_os_str().as_bytes()) {
            Ok(path) => path,
            Err(error) => {
                return Err(MapError::PinError {
                    name: Some(name.into()),
                    error: PinError::InvalidPinPath { path, error },
                });
            }
        };
        // `path_string` is already `PATH/MAP_NAME`
        match bpf_get_object(&path_string).map_err(|(_, io_error)| SyscallError {
            call: "BPF_OBJ_GET",
            io_error,
        }) {
            Ok(fd) => {
                let fd = MapFd(fd);
                Ok(Self { obj, fd })
            }
            Err(_) => {
                let mut map = Self::create(obj, name, btf_fd)?;
                // Join again making it `PATH/MAP_NAME/MAP_NAME`, causing inconsistency.
                // let path = path.join(name);
                map.pin(&path).map_err(|error| MapError::PinError {
                    name: Some(name.into()),
                    error,
                })?;
                Ok(map)
            }
        }
    }
```