### PR TITLE
PerfEvent: add option to set the inherit bit

### DIFF
--- a/aya/src/programs/perf_event.rs
+++ b/aya/src/programs/perf_event.rs
@@ -66,6 +66,11 @@ pub enum PerfEventScope {
         /// process id
         pid: u32,
     },
+    /// one process, any cpu, including child processes
+    OneProcessIncludingChildren {
+        /// process id
+        pid: u32,
+    },
     /// one process, one cpu
     OneProcessOneCpu {
         /// cpu id
@@ -157,6 +162,7 @@ impl PerfEvent {
             PerfEventScope::OneProcessAnyCpu { pid } => (pid as i32, -1),
             PerfEventScope::OneProcessOneCpu { cpu, pid } => (pid as i32, cpu as i32),
             PerfEventScope::AllProcessesOneCpu { cpu } => (-1, cpu as i32),
+            PerfEventScope::OneProcessIncludingChildren { pid } => (pid as i32, -1),
         };
         let fd = perf_event_open(
             perf_type as u32,
@@ -167,6 +173,7 @@ impl PerfEvent {
             sample_frequency,
             false,
             0,
+            matches!(scope, PerfEventScope::OneProcessIncludingChildren { .. }),
         )
         .map_err(|(_code, io_error)| SyscallError {
             call: "perf_event_open",

--- a/aya/src/sys/perf_event.rs
+++ b/aya/src/sys/perf_event.rs
@@ -25,6 +25,7 @@ pub(crate) fn perf_event_open(
     sample_frequency: Option<u64>,
     wakeup: bool,
     flags: u32,
+    inherit: bool,
 ) -> SysResult<OwnedFd> {
     let mut attr = unsafe { mem::zeroed::<perf_event_attr>() };
 
@@ -32,7 +33,7 @@ pub(crate) fn perf_event_open(
     attr.size = mem::size_of::<perf_event_attr>() as u32;
     attr.type_ = perf_type;
     attr.sample_type = PERF_SAMPLE_RAW as u64;
-    // attr.inherits = if pid > 0 { 1 } else { 0 };
+    attr.set_inherit(if inherit { 1 } else { 0 });
     attr.__bindgen_anon_2.wakeup_events = u32::from(wakeup);
 
     if let Some(frequency) = sample_frequency {
@@ -55,6 +56,7 @@ pub(crate) fn perf_event_open_bpf(cpu: c_int) -> SysResult<OwnedFd> {
         None,
         true,
         PERF_FLAG_FD_CLOEXEC,
+        false,
     )
 }
 

--- a/xtask/public-api/aya.txt
+++ b/xtask/public-api/aya.txt
@@ -3989,6 +3989,8 @@ pub aya::programs::perf_event::PerfEventScope::CallingProcessOneCpu
 pub aya::programs::perf_event::PerfEventScope::CallingProcessOneCpu::cpu: u32
 pub aya::programs::perf_event::PerfEventScope::OneProcessAnyCpu
 pub aya::programs::perf_event::PerfEventScope::OneProcessAnyCpu::pid: u32
+pub aya::programs::perf_event::PerfEventScope::OneProcessIncludingChildren
+pub aya::programs::perf_event::PerfEventScope::OneProcessIncludingChildren::pid: u32
 pub aya::programs::perf_event::PerfEventScope::OneProcessOneCpu
 pub aya::programs::perf_event::PerfEventScope::OneProcessOneCpu::cpu: u32
 pub aya::programs::perf_event::PerfEventScope::OneProcessOneCpu::pid: u32
@@ -5214,6 +5216,8 @@ pub aya::programs::PerfEventScope::CallingProcessOneCpu
 pub aya::programs::PerfEventScope::CallingProcessOneCpu::cpu: u32
 pub aya::programs::PerfEventScope::OneProcessAnyCpu
 pub aya::programs::PerfEventScope::OneProcessAnyCpu::pid: u32
+pub aya::programs::PerfEventScope::OneProcessIncludingChildren
+pub aya::programs::PerfEventScope::OneProcessIncludingChildren::pid: u32
 pub aya::programs::PerfEventScope::OneProcessOneCpu
 pub aya::programs::PerfEventScope::OneProcessOneCpu::cpu: u32
 pub aya::programs::PerfEventScope::OneProcessOneCpu::pid: u32


### PR DESCRIPTION
The inherit bit allows extending perf scope to the new child processes.

(I am not sure about the API, though)