### PR TITLE
Cargo.toml: remove redundant keys

### DIFF
--- a/aya-obj/Cargo.toml
+++ b/aya-obj/Cargo.toml
@@ -15,11 +15,8 @@ bytes = { workspace = true }
 core-error = { workspace = true, default-features = true }
 hashbrown = { workspace = true, default-features = true }
 log = { workspace = true }
-object = { workspace = true, default-features = false, features = [
-    "elf",
-    "read_core",
-] }
-thiserror = { workspace = true, default-features = false }
+object = { workspace = true, features = ["elf", "read_core"] }
+thiserror = { workspace = true }
 
 [dev-dependencies]
 assert_matches = { workspace = true }

--- a/aya/Cargo.toml
+++ b/aya/Cargo.toml
@@ -20,11 +20,7 @@ bytes = { workspace = true }
 lazy_static = { workspace = true }
 libc = { workspace = true }
 log = { workspace = true }
-object = { workspace = true, default-features = false, features = [
-    "elf",
-    "read_core",
-    "std",
-] }
+object = { workspace = true, features = ["elf", "read_core", "std"] }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["rt"], optional = true }
 


### PR DESCRIPTION
`default-features = false` is already in the root Cargo.toml.
