### PR TITLE
aya-log: fix hygiene

### DIFF
--- a/aya-log-ebpf-macros/src/expand.rs
+++ b/aya-log-ebpf-macros/src/expand.rs
@@ -1,6 +1,6 @@
 use aya_log_common::DisplayHint;
 use aya_log_parser::{parse, Fragment};
-use proc_macro2::TokenStream;
+use proc_macro2::{Ident, Span, TokenStream};
 use quote::quote;
 use syn::{
     parse::{Parse, ParseStream},
@@ -141,13 +141,16 @@ pub(crate) fn log(args: LogArgs, level: Option<TokenStream>) -> Result<TokenStre
 
     let num_args = values.len();
     let values_iter = values.iter();
-
+    let size = Ident::new("size", Span::mixed_site());
+    let len = Ident::new("len", Span::mixed_site());
+    let slice = Ident::new("slice", Span::mixed_site());
+    let record = Ident::new("record", Span::mixed_site());
     Ok(quote! {
         match unsafe { &mut ::aya_log_ebpf::AYA_LOG_BUF }.get_ptr_mut(0).and_then(|ptr| unsafe { ptr.as_mut() }) {
             None => {},
             Some(::aya_log_ebpf::LogBuf { buf }) => {
                 let _: Option<()> = (|| {
-                    let size = ::aya_log_ebpf::write_record_header(
+                    let #size = ::aya_log_ebpf::write_record_header(
                         buf,
                         #target,
                         #lvl,
@@ -156,14 +159,14 @@ pub(crate) fn log(args: LogArgs, level: Option<TokenStream>) -> Result<TokenStre
                         line!(),
                         #num_args,
                     )?;
-                    let mut size = size.get();
+                    let mut #size = #size.get();
                     #(
-                        let slice = buf.get_mut(size..)?;
-                        let len = ::aya_log_ebpf::WriteToBuf::write(#values_iter, slice)?;
-                        size += len.get();
+                        let #slice = buf.get_mut(#size..)?;
+                        let #len = ::aya_log_ebpf::WriteToBuf::write(#values_iter, #slice)?;
+                        #size += #len.get();
                     )*
-                    let record = buf.get(..size)?;
-                    unsafe { &mut ::aya_log_ebpf::AYA_LOGS }.output(#ctx, record, 0);
+                    let #record = buf.get(..#size)?;
+                    unsafe { &mut ::aya_log_ebpf::AYA_LOGS }.output(#ctx, #record, 0);
                     Some(())
                 })();
             }

--- a/test/integration-ebpf/src/log.rs
+++ b/test/integration-ebpf/src/log.rs
@@ -26,6 +26,11 @@ pub fn test_log(ctx: ProbeContext) {
     warn!(&ctx, "hex lc: {:x}, hex uc: {:X}", hex, hex);
     let hex = [0xde, 0xad, 0xbe, 0xef].as_slice();
     debug!(&ctx, "hex lc: {:x}, hex uc: {:X}", hex, hex);
+    let len = 42;
+    let size = 43;
+    let slice = 44;
+    let record = 45;
+    debug!(&ctx, "{} {} {} {}", len, size, slice, record);
 
     // Testing compilation only.
     if false {

--- a/test/integration-test/src/tests/log.rs
+++ b/test/integration-test/src/tests/log.rs
@@ -138,5 +138,14 @@ async fn log() {
         })
     );
 
+    assert_eq!(
+        records.next(),
+        Some(&CapturedLog {
+            body: "42 43 44 45".into(),
+            level: Level::Debug,
+            target: "log".into(),
+        })
+    );
+
     assert_eq!(records.next(), None);
 }


### PR DESCRIPTION
Before this change we leaked some bindings to the calling scope, so for instance logging a variable named "len" led to a compile error.