### PR TITLE
integration-tests: enable logs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,6 +91,7 @@ rustversion = { version = "1.0.0", default-features = false }
 syn = { version = "2", default-features = false }
 tempfile = { version = "3", default-features = false }
 test-case = { version = "3.1.0", default-features = false }
+test-log = { version = "0.2.13", default-features = false }
 testing_logger = { version = "0.1.1", default-features = false }
 thiserror = { version = "1", default-features = false }
 tokio = { version = "1.24.0", default-features = false }

--- a/test/integration-test/Cargo.toml
+++ b/test/integration-test/Cargo.toml
@@ -10,6 +10,7 @@ assert_matches = { workspace = true }
 aya = { workspace = true }
 aya-log = { workspace = true }
 aya-obj = { workspace = true }
+env_logger = { workspace = true }
 epoll = { workspace = true }
 futures = { workspace = true, features = ["std"] }
 libc = { workspace = true }
@@ -19,6 +20,7 @@ object = { workspace = true, features = ["elf", "read_core", "std"] }
 rand = { workspace = true, features = ["std", "std_rng"] }
 rbpf = { workspace = true }
 test-case = { workspace = true }
+test-log = { workspace = true, features = ["log"] }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread", "time"] }
 
 [build-dependencies]

--- a/test/integration-test/src/tests/bpf_probe_read.rs
+++ b/test/integration-test/src/tests/bpf_probe_read.rs
@@ -1,4 +1,5 @@
 use aya::{maps::Array, programs::UProbe, Bpf};
+use test_log::test;
 
 const RESULT_BUF_LEN: usize = 1024;
 

--- a/test/integration-test/src/tests/elf.rs
+++ b/test/integration-test/src/tests/elf.rs
@@ -1,4 +1,5 @@
 use object::{Object, ObjectSymbol};
+use test_log::test;
 
 #[test]
 fn test_maps() {

--- a/test/integration-test/src/tests/load.rs
+++ b/test/integration-test/src/tests/load.rs
@@ -16,6 +16,7 @@ use aya::{
     Bpf,
 };
 use aya_obj::programs::XdpAttachType;
+use test_log::test;
 
 const MAX_RETRIES: usize = 100;
 const RETRY_DURATION: Duration = Duration::from_millis(10);

--- a/test/integration-test/src/tests/log.rs
+++ b/test/integration-test/src/tests/log.rs
@@ -6,6 +6,7 @@ use std::{
 use aya::{programs::UProbe, Bpf};
 use aya_log::BpfLogger;
 use log::{Level, Log, Record};
+use test_log::test;
 
 #[no_mangle]
 #[inline(never)]
@@ -37,7 +38,7 @@ struct CapturedLog<'a> {
     pub target: Cow<'a, str>,
 }
 
-#[tokio::test]
+#[test(tokio::test)]
 async fn log() {
     let mut bpf = Bpf::load(crate::LOG).unwrap();
 

--- a/test/integration-test/src/tests/rbpf.rs
+++ b/test/integration-test/src/tests/rbpf.rs
@@ -3,6 +3,7 @@ use std::collections::HashMap;
 
 use assert_matches::assert_matches;
 use aya_obj::{generated::bpf_insn, programs::XdpAttachType, Object, ProgramSection};
+use test_log::test;
 
 #[test]
 fn run_with_rbpf() {

--- a/test/integration-test/src/tests/relocations.rs
+++ b/test/integration-test/src/tests/relocations.rs
@@ -1,4 +1,5 @@
 use aya::{programs::UProbe, Bpf};
+use test_log::test;
 
 #[test]
 fn relocations() {

--- a/test/integration-test/src/tests/ring_buf.rs
+++ b/test/integration-test/src/tests/ring_buf.rs
@@ -17,6 +17,7 @@ use aya::{
 };
 use aya_obj::generated::BPF_RINGBUF_HDR_SZ;
 use rand::Rng as _;
+use test_log::test;
 use tokio::{
     io::unix::AsyncFd,
     time::{sleep, Duration},
@@ -175,7 +176,7 @@ pub extern "C" fn ring_buf_trigger_ebpf_program(arg: u64) {
 // to fill the ring_buf. We just ensure that the number of events we see is sane given
 // what the producer sees, and that the logic does not hang. This exercises interleaving
 // discards, successful commits, and drops due to the ring_buf being full.
-#[tokio::test(flavor = "multi_thread")]
+#[test(tokio::test(flavor = "multi_thread"))]
 async fn ring_buf_async_with_drops() {
     let WithData(
         RingBufTest {
@@ -282,7 +283,7 @@ async fn ring_buf_async_with_drops() {
     );
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[test(tokio::test(flavor = "multi_thread"))]
 async fn ring_buf_async_no_drop() {
     let WithData(
         RingBufTest {
@@ -380,7 +381,7 @@ fn ring_buf_epoll_wakeup() {
 }
 
 // This test is like the above test but uses tokio and AsyncFd instead of raw epoll.
-#[tokio::test]
+#[test(tokio::test)]
 async fn ring_buf_asyncfd_events() {
     let RingBufTest {
         ring_buf,

--- a/test/integration-test/src/tests/smoke.rs
+++ b/test/integration-test/src/tests/smoke.rs
@@ -3,6 +3,7 @@ use aya::{
     util::KernelVersion,
     Bpf, BpfLoader,
 };
+use test_log::test;
 
 use crate::utils::NetNsGuard;
 

--- a/test/integration-test/src/tests/xdp.rs
+++ b/test/integration-test/src/tests/xdp.rs
@@ -6,6 +6,7 @@ use aya::{
     Bpf,
 };
 use object::{Object, ObjectSection, ObjectSymbol, SymbolSection};
+use test_log::test;
 
 use crate::utils::NetNsGuard;
 


### PR DESCRIPTION
Use test_log::test so setting RUST_LOG=aya=debug works and it's easier to debug failures.

Note that sadly this doesn't work for tests that use the `test_case` macro since it hardcodes the stock rust #[test] attribute internally.