### PR TITLE
aya: fix unused async-io dependency linter error

### DIFF
--- a/aya/Cargo.toml
+++ b/aya/Cargo.toml
@@ -30,7 +30,7 @@ tempfile = { workspace = true }
 [features]
 default = []
 async_tokio = ["tokio/net"]
-async_std = ["async-io"]
+async_std = ["dep:async-io"]
 
 [package.metadata.docs.rs]
 all-features = true


### PR DESCRIPTION
Not using the `dep:` syntax created a Cargo feature flag for async-io, though this feature alone does nothing without the `async_std` or `async_tokio` features.