### PR TITLE
aya-bpf-macros: appease clippy

### DIFF
--- a/aya-bpf-macros/src/args.rs
+++ b/aya-bpf-macros/src/args.rs
@@ -68,7 +68,7 @@ pub(crate) fn pop_bool_arg(args: &mut Args, name: &str) -> bool {
 }
 
 pub(crate) fn err_on_unknown_args(args: &Args) -> Result<()> {
-    if let Some(arg) = args.args.get(0) {
+    if let Some(arg) = args.args.first() {
         let tokens = match arg {
             Arg::String(name_val) => name_val.name.clone(),
             Arg::Bool(ident) => ident.clone(),


### PR DESCRIPTION
```
warning: accessing first element with `args.args.get(0)`
  --> aya-bpf-macros/src/args.rs:71:24
   |
71 |     if let Some(arg) = args.args.get(0) {
   |                        ^^^^^^^^^^^^^^^^ help: try: `args.args.first()`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#get_first
   = note: `#[warn(clippy::get_first)]` on by default
```

Appears https://github.com/rust-lang/rust-clippy/commit/31fd282732e15811 has just landed in nightly.