### PR TITLE
aya: make KernelVersion::code public

### DIFF
--- a/aya/src/util.rs
+++ b/aya/src/util.rs
@@ -53,7 +53,7 @@ impl KernelVersion {
     }
 
     /// The equivalent of LINUX_VERSION_CODE.
-    pub(crate) fn code(self) -> u32 {
+    pub fn code(self) -> u32 {
         let Self {
             major,
             minor,

--- a/xtask/public-api/aya.txt
+++ b/xtask/public-api/aya.txt
@@ -7477,6 +7477,7 @@ pub fn aya::programs::loaded_programs() -> impl core::iter::traits::iterator::It
 pub mod aya::util
 pub struct aya::util::KernelVersion
 impl aya::util::KernelVersion
+pub fn aya::util::KernelVersion::code(self) -> u32
 pub fn aya::util::KernelVersion::current() -> core::result::Result<Self, impl core::error::Error>
 pub fn aya::util::KernelVersion::new(major: u8, minor: u8, patch: u16) -> Self
 impl core::clone::Clone for aya::util::KernelVersion


### PR DESCRIPTION
I need to be able to access the current kernel version code so I can make some decisions  in user space and/or send the information to the eBPF programs to make the decisions. 

I could re-implement the logic to get the kernel version myself but since `aya` already has all the logic and is well tested I figured it made the most sense to expose the method I had previously implemented here. Another alternative would be to expose the fields inside `KernelVersion` but that felt like a bigger surface area to guarantee no breaking changes rather than just the one method. 

Maybe in the future we should implement the `__kconfig` stuff that libbpf and cilium allow so that the eBPF programs will know the `KERNEL_VERSION_CODE` but that felt heavyweight to implement at the moment and I wasn't sure if CO-RE was required for it which my current programs do not support. 