### PR TITLE
Improve AF_XDP test

### DIFF
--- a/test/integration-ebpf/src/redirect.rs
+++ b/test/integration-ebpf/src/redirect.rs
@@ -31,7 +31,9 @@ pub fn redirect_sock(ctx: XdpContext) -> u32 {
     // Check whether incoming packet's queue ID matches the queue ID of the socket in XSKMAP at index `queue_id`.
     if SOCKS.get(queue_id) == Some(queue_id) {
         // Queue ID matches, redirect to AF_XDP socket.
-        SOCKS.redirect(0, 0).unwrap_or(xdp_action::XDP_ABORTED)
+        SOCKS
+            .redirect(queue_id, 0)
+            .unwrap_or(xdp_action::XDP_ABORTED)
     } else {
         // Queue ID did not match, pass packet to kernel network stack.
         xdp_action::XDP_PASS

--- a/test/integration-test/src/tests/xdp.rs
+++ b/test/integration-test/src/tests/xdp.rs
@@ -32,9 +32,9 @@ fn af_xdp() {
     struct PacketMap(MaybeUninit<[u8; 4096]>);
 
     // Safety: don't access alloc down the line.
-    let mut alloc = Box::new(PacketMap(MaybeUninit::uninit()));
+    let mut alloc = Box::new(PacketMap(MaybeUninit::zeroed()));
     let umem = {
-        // Safety: this is a shared buffer between the kernel and us, uninitialized memory is valid.
+        // Safety: Zeroed memory is valid for u8 arrays.
         let mem = unsafe { alloc.0.assume_init_mut() }.as_mut().into();
         // Safety: we cannot access `mem` further down the line because it falls out of scope.
         unsafe { Umem::new(UmemConfig::default(), mem).unwrap() }


### PR DESCRIPTION
- Fix UB in AF_XDP test: [Calling `assume_init_mut()` on uninitialized memory causes UB](https://doc.rust-lang.org/beta/std/mem/union.MaybeUninit.html#method.assume_init_mut). By using `zeroed()` the memory is guaranteed to be zero and with that is properly initialized for `u8`.
- Add queue ID matching to AF_XDP test: Improves clarity how AF_XDP works for people using the test as an example. Basically does the same as the [kernel docs](https://www.kernel.org/doc/html/latest/bpf/map_xskmap.html#kernel).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aya-rs/aya/846)
<!-- Reviewable:end -->
