### PR TITLE
.github: avoid homebrew automatic update

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -208,6 +208,7 @@ jobs:
           # https://github.com/actions/setup-python/issues/577
           find /usr/local/bin -type l -exec sh -c 'readlink -f "$1" \
           | grep -q ^/Library/Frameworks/Python.framework/Versions/' _ {} \; -exec rm -v {} \;
+          HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK=1 \
           brew install dpkg findutils gnu-tar llvm pkg-config qemu
           echo /usr/local/opt/findutils/libexec/gnubin >> $GITHUB_PATH
           echo /usr/local/opt/gnu-tar/libexec/gnubin >> $GITHUB_PATH


### PR DESCRIPTION
This is slow and prone to failure; see
https://github.com/aya-rs/aya/actions/runs/7204446013/job/19625908097.
