### PR TITLE
aya: appease new nightly clippy lints

### DIFF
--- a/aya/src/bpf.rs
+++ b/aya/src/bpf.rs
@@ -533,7 +533,7 @@ impl<'a> BpfLoader<'a> {
                 let section = prog_obj.section.clone();
                 let obj = (prog_obj, function_obj);
 
-                let btf_fd = btf_fd.as_ref().map(Arc::clone);
+                let btf_fd = btf_fd.clone();
                 let program = if extensions.contains(name.as_str()) {
                     Program::Extension(Extension {
                         data: ProgramData::new(prog_name, obj, btf_fd, *verifier_log_level),

--- a/aya/src/sys/fake.rs
+++ b/aya/src/sys/fake.rs
@@ -11,7 +11,7 @@ type SyscallFn = unsafe fn(Syscall<'_>) -> SysResult<c_long>;
 #[cfg(test)]
 thread_local! {
     pub(crate) static TEST_SYSCALL: RefCell<SyscallFn> = RefCell::new(test_syscall);
-    pub(crate) static TEST_MMAP_RET: RefCell<*mut c_void> = RefCell::new(ptr::null_mut());
+    pub(crate) static TEST_MMAP_RET: RefCell<*mut c_void> = const { RefCell::new(ptr::null_mut()) };
 }
 
 #[cfg(test)]


### PR DESCRIPTION
```
  error: this call to `as_ref.map(...)` does nothing
     --> aya/src/bpf.rs:536:30
      |
  536 |                 let btf_fd = btf_fd.as_ref().map(Arc::clone);
      |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `btf_fd.clone()`
      |
      = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#useless_asref
  note: the lint level is defined here
     --> aya/src/lib.rs:41:5
      |
  41  |     clippy::all,
      |     ^^^^^^^^^^^
      = note: `#[deny(clippy::useless_asref)]` implied by `#[deny(clippy::all)]`

  error: could not compile `aya` (lib) due to 1 previous error
  warning: build failed, waiting for other jobs to finish...
  error: initializer for `thread_local` value can be made `const`
    --> aya/src/sys/fake.rs:14:61
     |
  14 |     pub(crate) static TEST_MMAP_RET: RefCell<*mut c_void> = RefCell::new(ptr::null_mut());
     |                                                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace with: `const { RefCell::new(ptr::null_mut()) }`
     |
     = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#thread_local_initializer_can_be_made_const
     = note: `#[deny(clippy::thread_local_initializer_can_be_made_const)]` implied by `#[deny(clippy::all)]`
```
