### PR TITLE
Revert "bpf: appease nightly lint"

### DIFF
--- a/bpf/aya-bpf/src/helpers.rs
+++ b/bpf/aya-bpf/src/helpers.rs
@@ -734,10 +734,7 @@ pub use bpf_printk;
 /// Argument ready to be passed to `printk` BPF helper.
 #[repr(transparent)]
 #[derive(Copy, Clone)]
-pub struct PrintkArg(
-    #[allow(dead_code)] // TODO(https://github.com/rust-lang/rust/issues/119659): Remove.
-    u64,
-);
+pub struct PrintkArg(u64);
 
 impl PrintkArg {
     /// Manually construct a `printk` BPF helper argument.


### PR DESCRIPTION
This reverts commit 9861c1446efbd7303bf9485c864d5a00853368bd.

This no longer warns. See
https://github.com/rust-lang/rust/commit/d95d6ceecb372c66ed18a4e7a0bbb7.
