### PR TITLE
bpf: Add `bpf_strncmp` helper

### DIFF
--- a/test/integration-ebpf/Cargo.toml
+++ b/test/integration-ebpf/Cargo.toml
@@ -58,6 +58,10 @@ name = "simple_prog"
 path = "src/simple_prog.rs"
 
 [[bin]]
+name = "strncmp"
+path = "src/strncmp.rs"
+
+[[bin]]
 name = "tcx"
 path = "src/tcx.rs"
 

--- a/test/integration-ebpf/Cargo.toml
+++ b/test/integration-ebpf/Cargo.toml
@@ -18,12 +18,20 @@ which = { workspace = true }
 xtask = { path = "../../xtask" }
 
 [[bin]]
+name = "bpf_probe_read"
+path = "src/bpf_probe_read.rs"
+
+[[bin]]
 name = "log"
 path = "src/log.rs"
 
 [[bin]]
 name = "map_test"
 path = "src/map_test.rs"
+
+[[bin]]
+name = "memmove_test"
+path = "src/memmove_test.rs"
 
 [[bin]]
 name = "name_test"
@@ -34,41 +42,33 @@ name = "pass"
 path = "src/pass.rs"
 
 [[bin]]
-name = "test"
-path = "src/test.rs"
-
-[[bin]]
-name = "tcx"
-path = "src/tcx.rs"
+name = "redirect"
+path = "src/redirect.rs"
 
 [[bin]]
 name = "relocations"
 path = "src/relocations.rs"
 
 [[bin]]
-name = "bpf_probe_read"
-path = "src/bpf_probe_read.rs"
+name = "ring_buf"
+path = "src/ring_buf.rs"
+
+[[bin]]
+name = "simple_prog"
+path = "src/simple_prog.rs"
+
+[[bin]]
+name = "tcx"
+path = "src/tcx.rs"
+
+[[bin]]
+name = "test"
+path = "src/test.rs"
 
 [[bin]]
 name = "two_progs"
 path = "src/two_progs.rs"
 
 [[bin]]
-name = "redirect"
-path = "src/redirect.rs"
-
-[[bin]]
 name = "xdp_sec"
 path = "src/xdp_sec.rs"
-
-[[bin]]
-name = "ring_buf"
-path = "src/ring_buf.rs"
-
-[[bin]]
-name = "memmove_test"
-path = "src/memmove_test.rs"
-
-[[bin]]
-name = "simple_prog"
-path = "src/simple_prog.rs"

--- a/test/integration-ebpf/src/strncmp.rs
+++ b/test/integration-ebpf/src/strncmp.rs
@@ -1,0 +1,38 @@
+#![no_std]
+#![no_main]
+
+use core::cmp::Ordering;
+
+use aya_ebpf::{
+    cty::c_long,
+    helpers::{bpf_probe_read_user_str_bytes, bpf_strncmp},
+    macros::{map, uprobe},
+    maps::Array,
+    programs::ProbeContext,
+};
+
+#[repr(C)]
+struct TestResult(Ordering);
+
+#[map]
+static RESULT: Array<TestResult> = Array::with_max_entries(1, 0);
+
+#[uprobe]
+pub fn test_bpf_strncmp(ctx: ProbeContext) -> Result<(), c_long> {
+    let s1: *const u8 = ctx.arg(0).ok_or(-1)?;
+    let mut b1 = [0u8; 3];
+    let _: &[u8] = unsafe { bpf_probe_read_user_str_bytes(s1, &mut b1) }?;
+
+    let ptr = RESULT.get_ptr_mut(0).ok_or(-1)?;
+    let dst = unsafe { ptr.as_mut() };
+    let TestResult(dst_res) = dst.ok_or(-1)?;
+    *dst_res = bpf_strncmp(&b1, c"ff");
+
+    Ok(())
+}
+
+#[cfg(not(test))]
+#[panic_handler]
+fn panic(_info: &core::panic::PanicInfo) -> ! {
+    loop {}
+}

--- a/test/integration-test/src/lib.rs
+++ b/test/integration-test/src/lib.rs
@@ -23,6 +23,7 @@ pub const REDIRECT: &[u8] = include_bytes_aligned!(concat!(env!("OUT_DIR"), "/re
 pub const RELOCATIONS: &[u8] = include_bytes_aligned!(concat!(env!("OUT_DIR"), "/relocations"));
 pub const RING_BUF: &[u8] = include_bytes_aligned!(concat!(env!("OUT_DIR"), "/ring_buf"));
 pub const SIMPLE_PROG: &[u8] = include_bytes_aligned!(concat!(env!("OUT_DIR"), "/simple_prog"));
+pub const STRNCMP: &[u8] = include_bytes_aligned!(concat!(env!("OUT_DIR"), "/strncmp"));
 pub const TCX: &[u8] = include_bytes_aligned!(concat!(env!("OUT_DIR"), "/tcx"));
 pub const TEST: &[u8] = include_bytes_aligned!(concat!(env!("OUT_DIR"), "/test"));
 pub const TWO_PROGS: &[u8] = include_bytes_aligned!(concat!(env!("OUT_DIR"), "/two_progs"));

--- a/test/integration-test/src/lib.rs
+++ b/test/integration-test/src/lib.rs
@@ -12,21 +12,21 @@ pub const TEXT_64_64_RELOC: &[u8] =
 pub const VARIABLES_RELOC: &[u8] =
     include_bytes_aligned!(concat!(env!("OUT_DIR"), "/variables_reloc.bpf.o"));
 
-pub const LOG: &[u8] = include_bytes_aligned!(concat!(env!("OUT_DIR"), "/log"));
-pub const MAP_TEST: &[u8] = include_bytes_aligned!(concat!(env!("OUT_DIR"), "/map_test"));
-pub const NAME_TEST: &[u8] = include_bytes_aligned!(concat!(env!("OUT_DIR"), "/name_test"));
-pub const PASS: &[u8] = include_bytes_aligned!(concat!(env!("OUT_DIR"), "/pass"));
-pub const TCX: &[u8] = include_bytes_aligned!(concat!(env!("OUT_DIR"), "/tcx"));
-pub const TEST: &[u8] = include_bytes_aligned!(concat!(env!("OUT_DIR"), "/test"));
-pub const RELOCATIONS: &[u8] = include_bytes_aligned!(concat!(env!("OUT_DIR"), "/relocations"));
-pub const TWO_PROGS: &[u8] = include_bytes_aligned!(concat!(env!("OUT_DIR"), "/two_progs"));
 pub const BPF_PROBE_READ: &[u8] =
     include_bytes_aligned!(concat!(env!("OUT_DIR"), "/bpf_probe_read"));
-pub const REDIRECT: &[u8] = include_bytes_aligned!(concat!(env!("OUT_DIR"), "/redirect"));
-pub const XDP_SEC: &[u8] = include_bytes_aligned!(concat!(env!("OUT_DIR"), "/xdp_sec"));
-pub const RING_BUF: &[u8] = include_bytes_aligned!(concat!(env!("OUT_DIR"), "/ring_buf"));
+pub const LOG: &[u8] = include_bytes_aligned!(concat!(env!("OUT_DIR"), "/log"));
+pub const MAP_TEST: &[u8] = include_bytes_aligned!(concat!(env!("OUT_DIR"), "/map_test"));
 pub const MEMMOVE_TEST: &[u8] = include_bytes_aligned!(concat!(env!("OUT_DIR"), "/memmove_test"));
+pub const NAME_TEST: &[u8] = include_bytes_aligned!(concat!(env!("OUT_DIR"), "/name_test"));
+pub const PASS: &[u8] = include_bytes_aligned!(concat!(env!("OUT_DIR"), "/pass"));
+pub const REDIRECT: &[u8] = include_bytes_aligned!(concat!(env!("OUT_DIR"), "/redirect"));
+pub const RELOCATIONS: &[u8] = include_bytes_aligned!(concat!(env!("OUT_DIR"), "/relocations"));
+pub const RING_BUF: &[u8] = include_bytes_aligned!(concat!(env!("OUT_DIR"), "/ring_buf"));
 pub const SIMPLE_PROG: &[u8] = include_bytes_aligned!(concat!(env!("OUT_DIR"), "/simple_prog"));
+pub const TCX: &[u8] = include_bytes_aligned!(concat!(env!("OUT_DIR"), "/tcx"));
+pub const TEST: &[u8] = include_bytes_aligned!(concat!(env!("OUT_DIR"), "/test"));
+pub const TWO_PROGS: &[u8] = include_bytes_aligned!(concat!(env!("OUT_DIR"), "/two_progs"));
+pub const XDP_SEC: &[u8] = include_bytes_aligned!(concat!(env!("OUT_DIR"), "/xdp_sec"));
 
 #[cfg(test)]
 mod tests;

--- a/test/integration-test/src/tests.rs
+++ b/test/integration-test/src/tests.rs
@@ -8,5 +8,6 @@ mod rbpf;
 mod relocations;
 mod ring_buf;
 mod smoke;
+mod strncmp;
 mod tcx;
 mod xdp;

--- a/test/integration-test/src/tests/strncmp.rs
+++ b/test/integration-test/src/tests/strncmp.rs
@@ -1,0 +1,55 @@
+use std::{
+    cmp::Ordering,
+    ffi::{c_char, CStr},
+};
+
+use aya::{
+    maps::{Array, MapData},
+    programs::UProbe,
+    Ebpf,
+};
+
+#[derive(Copy, Clone)]
+#[repr(C)]
+struct TestResult(Ordering);
+
+unsafe impl aya::Pod for TestResult {}
+
+#[test]
+fn bpf_strncmp() {
+    let mut bpf = Ebpf::load(crate::STRNCMP).unwrap();
+
+    {
+        let prog: &mut UProbe = bpf
+            .program_mut("test_bpf_strncmp")
+            .unwrap()
+            .try_into()
+            .unwrap();
+        prog.load().unwrap();
+
+        prog.attach(Some("trigger_bpf_strncmp"), 0, "/proc/self/exe", None)
+            .unwrap();
+    }
+
+    let array = Array::<_, TestResult>::try_from(bpf.map("RESULT").unwrap()).unwrap();
+
+    assert_eq!(do_bpf_strncmp(&array, c"ff"), Ordering::Equal);
+
+    // This is truncated in BPF; the buffer size is 3 including the null terminator.
+    assert_eq!(do_bpf_strncmp(&array, c"fff"), Ordering::Equal);
+
+    assert_eq!(do_bpf_strncmp(&array, c"aa"), Ordering::Less);
+    assert_eq!(do_bpf_strncmp(&array, c"zz"), Ordering::Greater);
+}
+
+fn do_bpf_strncmp(array: &Array<&MapData, TestResult>, s1: &CStr) -> Ordering {
+    trigger_bpf_strncmp(s1.as_ptr());
+    let TestResult(ord) = array.get(&0, 0).unwrap();
+    ord
+}
+
+#[no_mangle]
+#[inline(never)]
+pub extern "C" fn trigger_bpf_strncmp(s1: *const c_char) {
+    core::hint::black_box(s1);
+}

--- a/xtask/public-api/aya-ebpf.txt
+++ b/xtask/public-api/aya-ebpf.txt
@@ -76,6 +76,7 @@ pub unsafe fn aya_ebpf::helpers::bpf_probe_read_user_buf(src: *const u8, dst: &m
 pub unsafe fn aya_ebpf::helpers::bpf_probe_read_user_str(src: *const u8, dest: &mut [u8]) -> core::result::Result<usize, aya_ebpf_cty::od::c_long>
 pub unsafe fn aya_ebpf::helpers::bpf_probe_read_user_str_bytes(src: *const u8, dest: &mut [u8]) -> core::result::Result<&[u8], aya_ebpf_cty::od::c_long>
 pub unsafe fn aya_ebpf::helpers::bpf_probe_write_user<T>(dst: *mut T, src: *const T) -> core::result::Result<(), aya_ebpf_cty::od::c_long>
+pub fn aya_ebpf::helpers::bpf_strncmp<const N: usize>(s1: &[u8; N], s2: &core::ffi::c_str::CStr) -> core::cmp::Ordering
 pub mod aya_ebpf::maps
 pub mod aya_ebpf::maps::array
 #[repr(transparent)] pub struct aya_ebpf::maps::array::Array<T>


### PR DESCRIPTION
The `bpf_strncmp` helper allows for better string comparison in eBPF programs.

Kernel patchset:

https://lore.kernel.org/bpf/20211210141652.877186-1-houtao1@huawei.com/