### PR TITLE
public-api: regenerate

### DIFF
--- a/xtask/public-api/aya-bpf-bindings.txt
+++ b/xtask/public-api/aya-bpf-bindings.txt
@@ -1824,7 +1824,6 @@ pub fn aya_bpf_bindings::bindings::__BindgenBitfieldUnit<Storage>::fmt(&self, f:
 impl<Storage: core::hash::Hash> core::hash::Hash for aya_bpf_bindings::bindings::__BindgenBitfieldUnit<Storage>
 pub fn aya_bpf_bindings::bindings::__BindgenBitfieldUnit<Storage>::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
 impl<Storage: core::marker::Copy> core::marker::Copy for aya_bpf_bindings::bindings::__BindgenBitfieldUnit<Storage>
-impl<Storage> core::marker::StructuralEq for aya_bpf_bindings::bindings::__BindgenBitfieldUnit<Storage>
 impl<Storage> core::marker::StructuralPartialEq for aya_bpf_bindings::bindings::__BindgenBitfieldUnit<Storage>
 impl<Storage> core::marker::Send for aya_bpf_bindings::bindings::__BindgenBitfieldUnit<Storage> where Storage: core::marker::Send
 impl<Storage> core::marker::Sync for aya_bpf_bindings::bindings::__BindgenBitfieldUnit<Storage> where Storage: core::marker::Sync

--- a/xtask/public-api/aya-log-common.txt
+++ b/xtask/public-api/aya-log-common.txt
@@ -65,7 +65,6 @@ pub fn u8::from(enum_value: aya_log_common::DisplayHint) -> Self
 impl core::fmt::Debug for aya_log_common::DisplayHint
 pub fn aya_log_common::DisplayHint::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Copy for aya_log_common::DisplayHint
-impl core::marker::StructuralEq for aya_log_common::DisplayHint
 impl core::marker::StructuralPartialEq for aya_log_common::DisplayHint
 impl core::marker::Send for aya_log_common::DisplayHint
 impl core::marker::Sync for aya_log_common::DisplayHint
@@ -106,7 +105,6 @@ pub fn aya_log_common::Level::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> co
 impl core::hash::Hash for aya_log_common::Level
 pub fn aya_log_common::Level::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
 impl core::marker::Copy for aya_log_common::Level
-impl core::marker::StructuralEq for aya_log_common::Level
 impl core::marker::StructuralPartialEq for aya_log_common::Level
 impl core::marker::Send for aya_log_common::Level
 impl core::marker::Sync for aya_log_common::Level

--- a/xtask/public-api/aya-log-parser.txt
+++ b/xtask/public-api/aya-log-parser.txt
@@ -9,7 +9,6 @@ impl core::cmp::PartialEq for aya_log_parser::Fragment
 pub fn aya_log_parser::Fragment::eq(&self, other: &aya_log_parser::Fragment) -> bool
 impl core::fmt::Debug for aya_log_parser::Fragment
 pub fn aya_log_parser::Fragment::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl core::marker::StructuralEq for aya_log_parser::Fragment
 impl core::marker::StructuralPartialEq for aya_log_parser::Fragment
 impl core::marker::Send for aya_log_parser::Fragment
 impl core::marker::Sync for aya_log_parser::Fragment
@@ -45,7 +44,6 @@ impl core::cmp::PartialEq for aya_log_parser::Parameter
 pub fn aya_log_parser::Parameter::eq(&self, other: &aya_log_parser::Parameter) -> bool
 impl core::fmt::Debug for aya_log_parser::Parameter
 pub fn aya_log_parser::Parameter::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl core::marker::StructuralEq for aya_log_parser::Parameter
 impl core::marker::StructuralPartialEq for aya_log_parser::Parameter
 impl core::marker::Send for aya_log_parser::Parameter
 impl core::marker::Sync for aya_log_parser::Parameter

--- a/xtask/public-api/aya-obj.txt
+++ b/xtask/public-api/aya-obj.txt
@@ -105,7 +105,6 @@ pub fn aya_obj::btf::BtfKind::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> co
 impl core::fmt::Display for aya_obj::btf::BtfKind
 pub fn aya_obj::btf::BtfKind::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Copy for aya_obj::btf::BtfKind
-impl core::marker::StructuralEq for aya_obj::btf::BtfKind
 impl core::marker::StructuralPartialEq for aya_obj::btf::BtfKind
 impl core::marker::Send for aya_obj::btf::BtfKind
 impl core::marker::Sync for aya_obj::btf::BtfKind
@@ -198,7 +197,6 @@ impl core::convert::From<u32> for aya_obj::btf::FuncLinkage
 pub fn aya_obj::btf::FuncLinkage::from(v: u32) -> Self
 impl core::fmt::Debug for aya_obj::btf::FuncLinkage
 pub fn aya_obj::btf::FuncLinkage::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl core::marker::StructuralEq for aya_obj::btf::FuncLinkage
 impl core::marker::StructuralPartialEq for aya_obj::btf::FuncLinkage
 impl core::marker::Send for aya_obj::btf::FuncLinkage
 impl core::marker::Sync for aya_obj::btf::FuncLinkage
@@ -240,7 +238,6 @@ impl core::convert::From<u32> for aya_obj::btf::IntEncoding
 pub fn aya_obj::btf::IntEncoding::from(v: u32) -> Self
 impl core::fmt::Debug for aya_obj::btf::IntEncoding
 pub fn aya_obj::btf::IntEncoding::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl core::marker::StructuralEq for aya_obj::btf::IntEncoding
 impl core::marker::StructuralPartialEq for aya_obj::btf::IntEncoding
 impl core::marker::Send for aya_obj::btf::IntEncoding
 impl core::marker::Sync for aya_obj::btf::IntEncoding
@@ -281,7 +278,6 @@ impl core::convert::From<u32> for aya_obj::btf::VarLinkage
 pub fn aya_obj::btf::VarLinkage::from(v: u32) -> Self
 impl core::fmt::Debug for aya_obj::btf::VarLinkage
 pub fn aya_obj::btf::VarLinkage::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl core::marker::StructuralEq for aya_obj::btf::VarLinkage
 impl core::marker::StructuralPartialEq for aya_obj::btf::VarLinkage
 impl core::marker::Send for aya_obj::btf::VarLinkage
 impl core::marker::Sync for aya_obj::btf::VarLinkage
@@ -1354,7 +1350,6 @@ pub fn aya_obj::generated::bpf_attach_type::fmt(&self, f: &mut core::fmt::Format
 impl core::hash::Hash for aya_obj::generated::bpf_attach_type
 pub fn aya_obj::generated::bpf_attach_type::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
 impl core::marker::Copy for aya_obj::generated::bpf_attach_type
-impl core::marker::StructuralEq for aya_obj::generated::bpf_attach_type
 impl core::marker::StructuralPartialEq for aya_obj::generated::bpf_attach_type
 impl core::marker::Send for aya_obj::generated::bpf_attach_type
 impl core::marker::Sync for aya_obj::generated::bpf_attach_type
@@ -1430,7 +1425,6 @@ pub fn aya_obj::generated::bpf_cmd::fmt(&self, f: &mut core::fmt::Formatter<'_>)
 impl core::hash::Hash for aya_obj::generated::bpf_cmd
 pub fn aya_obj::generated::bpf_cmd::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
 impl core::marker::Copy for aya_obj::generated::bpf_cmd
-impl core::marker::StructuralEq for aya_obj::generated::bpf_cmd
 impl core::marker::StructuralPartialEq for aya_obj::generated::bpf_cmd
 impl core::marker::Send for aya_obj::generated::bpf_cmd
 impl core::marker::Sync for aya_obj::generated::bpf_cmd
@@ -1480,7 +1474,6 @@ pub fn aya_obj::generated::bpf_link_type::fmt(&self, f: &mut core::fmt::Formatte
 impl core::hash::Hash for aya_obj::generated::bpf_link_type
 pub fn aya_obj::generated::bpf_link_type::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
 impl core::marker::Copy for aya_obj::generated::bpf_link_type
-impl core::marker::StructuralEq for aya_obj::generated::bpf_link_type
 impl core::marker::StructuralPartialEq for aya_obj::generated::bpf_link_type
 impl core::marker::Send for aya_obj::generated::bpf_link_type
 impl core::marker::Sync for aya_obj::generated::bpf_link_type
@@ -1556,7 +1549,6 @@ pub fn aya_obj::generated::bpf_map_type::fmt(&self, f: &mut core::fmt::Formatter
 impl core::hash::Hash for aya_obj::generated::bpf_map_type
 pub fn aya_obj::generated::bpf_map_type::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
 impl core::marker::Copy for aya_obj::generated::bpf_map_type
-impl core::marker::StructuralEq for aya_obj::generated::bpf_map_type
 impl core::marker::StructuralPartialEq for aya_obj::generated::bpf_map_type
 impl core::marker::Send for aya_obj::generated::bpf_map_type
 impl core::marker::Sync for aya_obj::generated::bpf_map_type
@@ -1627,7 +1619,6 @@ pub fn aya_obj::generated::bpf_prog_type::fmt(&self, f: &mut core::fmt::Formatte
 impl core::hash::Hash for aya_obj::generated::bpf_prog_type
 pub fn aya_obj::generated::bpf_prog_type::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
 impl core::marker::Copy for aya_obj::generated::bpf_prog_type
-impl core::marker::StructuralEq for aya_obj::generated::bpf_prog_type
 impl core::marker::StructuralPartialEq for aya_obj::generated::bpf_prog_type
 impl core::marker::Send for aya_obj::generated::bpf_prog_type
 impl core::marker::Sync for aya_obj::generated::bpf_prog_type
@@ -1668,7 +1659,6 @@ pub fn aya_obj::generated::btf_func_linkage::fmt(&self, f: &mut core::fmt::Forma
 impl core::hash::Hash for aya_obj::generated::btf_func_linkage
 pub fn aya_obj::generated::btf_func_linkage::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
 impl core::marker::Copy for aya_obj::generated::btf_func_linkage
-impl core::marker::StructuralEq for aya_obj::generated::btf_func_linkage
 impl core::marker::StructuralPartialEq for aya_obj::generated::btf_func_linkage
 impl core::marker::Send for aya_obj::generated::btf_func_linkage
 impl core::marker::Sync for aya_obj::generated::btf_func_linkage
@@ -1732,7 +1722,6 @@ pub fn aya_obj::generated::perf_event_sample_format::fmt(&self, f: &mut core::fm
 impl core::hash::Hash for aya_obj::generated::perf_event_sample_format
 pub fn aya_obj::generated::perf_event_sample_format::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
 impl core::marker::Copy for aya_obj::generated::perf_event_sample_format
-impl core::marker::StructuralEq for aya_obj::generated::perf_event_sample_format
 impl core::marker::StructuralPartialEq for aya_obj::generated::perf_event_sample_format
 impl core::marker::Send for aya_obj::generated::perf_event_sample_format
 impl core::marker::Sync for aya_obj::generated::perf_event_sample_format
@@ -1792,7 +1781,6 @@ pub fn aya_obj::generated::perf_event_type::fmt(&self, f: &mut core::fmt::Format
 impl core::hash::Hash for aya_obj::generated::perf_event_type
 pub fn aya_obj::generated::perf_event_type::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
 impl core::marker::Copy for aya_obj::generated::perf_event_type
-impl core::marker::StructuralEq for aya_obj::generated::perf_event_type
 impl core::marker::StructuralPartialEq for aya_obj::generated::perf_event_type
 impl core::marker::Send for aya_obj::generated::perf_event_type
 impl core::marker::Sync for aya_obj::generated::perf_event_type
@@ -1838,7 +1826,6 @@ pub fn aya_obj::generated::perf_hw_cache_id::fmt(&self, f: &mut core::fmt::Forma
 impl core::hash::Hash for aya_obj::generated::perf_hw_cache_id
 pub fn aya_obj::generated::perf_hw_cache_id::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
 impl core::marker::Copy for aya_obj::generated::perf_hw_cache_id
-impl core::marker::StructuralEq for aya_obj::generated::perf_hw_cache_id
 impl core::marker::StructuralPartialEq for aya_obj::generated::perf_hw_cache_id
 impl core::marker::Send for aya_obj::generated::perf_hw_cache_id
 impl core::marker::Sync for aya_obj::generated::perf_hw_cache_id
@@ -1880,7 +1867,6 @@ pub fn aya_obj::generated::perf_hw_cache_op_id::fmt(&self, f: &mut core::fmt::Fo
 impl core::hash::Hash for aya_obj::generated::perf_hw_cache_op_id
 pub fn aya_obj::generated::perf_hw_cache_op_id::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
 impl core::marker::Copy for aya_obj::generated::perf_hw_cache_op_id
-impl core::marker::StructuralEq for aya_obj::generated::perf_hw_cache_op_id
 impl core::marker::StructuralPartialEq for aya_obj::generated::perf_hw_cache_op_id
 impl core::marker::Send for aya_obj::generated::perf_hw_cache_op_id
 impl core::marker::Sync for aya_obj::generated::perf_hw_cache_op_id
@@ -1921,7 +1907,6 @@ pub fn aya_obj::generated::perf_hw_cache_op_result_id::fmt(&self, f: &mut core::
 impl core::hash::Hash for aya_obj::generated::perf_hw_cache_op_result_id
 pub fn aya_obj::generated::perf_hw_cache_op_result_id::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
 impl core::marker::Copy for aya_obj::generated::perf_hw_cache_op_result_id
-impl core::marker::StructuralEq for aya_obj::generated::perf_hw_cache_op_result_id
 impl core::marker::StructuralPartialEq for aya_obj::generated::perf_hw_cache_op_result_id
 impl core::marker::Send for aya_obj::generated::perf_hw_cache_op_result_id
 impl core::marker::Sync for aya_obj::generated::perf_hw_cache_op_result_id
@@ -1970,7 +1955,6 @@ pub fn aya_obj::generated::perf_hw_id::fmt(&self, f: &mut core::fmt::Formatter<'
 impl core::hash::Hash for aya_obj::generated::perf_hw_id
 pub fn aya_obj::generated::perf_hw_id::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
 impl core::marker::Copy for aya_obj::generated::perf_hw_id
-impl core::marker::StructuralEq for aya_obj::generated::perf_hw_id
 impl core::marker::StructuralPartialEq for aya_obj::generated::perf_hw_id
 impl core::marker::Send for aya_obj::generated::perf_hw_id
 impl core::marker::Sync for aya_obj::generated::perf_hw_id
@@ -2021,7 +2005,6 @@ pub fn aya_obj::generated::perf_sw_ids::fmt(&self, f: &mut core::fmt::Formatter<
 impl core::hash::Hash for aya_obj::generated::perf_sw_ids
 pub fn aya_obj::generated::perf_sw_ids::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
 impl core::marker::Copy for aya_obj::generated::perf_sw_ids
-impl core::marker::StructuralEq for aya_obj::generated::perf_sw_ids
 impl core::marker::StructuralPartialEq for aya_obj::generated::perf_sw_ids
 impl core::marker::Send for aya_obj::generated::perf_sw_ids
 impl core::marker::Sync for aya_obj::generated::perf_sw_ids
@@ -2066,7 +2049,6 @@ pub fn aya_obj::generated::perf_type_id::fmt(&self, f: &mut core::fmt::Formatter
 impl core::hash::Hash for aya_obj::generated::perf_type_id
 pub fn aya_obj::generated::perf_type_id::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
 impl core::marker::Copy for aya_obj::generated::perf_type_id
-impl core::marker::StructuralEq for aya_obj::generated::perf_type_id
 impl core::marker::StructuralPartialEq for aya_obj::generated::perf_type_id
 impl core::marker::Send for aya_obj::generated::perf_type_id
 impl core::marker::Sync for aya_obj::generated::perf_type_id
@@ -2770,7 +2752,6 @@ pub fn aya_obj::generated::__BindgenBitfieldUnit<Storage>::fmt(&self, f: &mut co
 impl<Storage: core::hash::Hash> core::hash::Hash for aya_obj::generated::__BindgenBitfieldUnit<Storage>
 pub fn aya_obj::generated::__BindgenBitfieldUnit<Storage>::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
 impl<Storage: core::marker::Copy> core::marker::Copy for aya_obj::generated::__BindgenBitfieldUnit<Storage>
-impl<Storage> core::marker::StructuralEq for aya_obj::generated::__BindgenBitfieldUnit<Storage>
 impl<Storage> core::marker::StructuralPartialEq for aya_obj::generated::__BindgenBitfieldUnit<Storage>
 impl<Storage> core::marker::Send for aya_obj::generated::__BindgenBitfieldUnit<Storage> where Storage: core::marker::Send
 impl<Storage> core::marker::Sync for aya_obj::generated::__BindgenBitfieldUnit<Storage> where Storage: core::marker::Sync
@@ -5492,7 +5473,6 @@ pub fn aya_obj::maps::PinningType::default() -> aya_obj::maps::PinningType
 impl core::fmt::Debug for aya_obj::maps::PinningType
 pub fn aya_obj::maps::PinningType::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Copy for aya_obj::maps::PinningType
-impl core::marker::StructuralEq for aya_obj::maps::PinningType
 impl core::marker::StructuralPartialEq for aya_obj::maps::PinningType
 impl core::marker::Send for aya_obj::maps::PinningType
 impl core::marker::Sync for aya_obj::maps::PinningType
@@ -5563,7 +5543,6 @@ pub fn aya_obj::maps::BtfMapDef::default() -> aya_obj::maps::BtfMapDef
 impl core::fmt::Debug for aya_obj::maps::BtfMapDef
 pub fn aya_obj::maps::BtfMapDef::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Copy for aya_obj::maps::BtfMapDef
-impl core::marker::StructuralEq for aya_obj::maps::BtfMapDef
 impl core::marker::StructuralPartialEq for aya_obj::maps::BtfMapDef
 impl core::marker::Send for aya_obj::maps::BtfMapDef
 impl core::marker::Sync for aya_obj::maps::BtfMapDef
@@ -5666,7 +5645,6 @@ pub fn aya_obj::maps::bpf_map_def::default() -> aya_obj::maps::bpf_map_def
 impl core::fmt::Debug for aya_obj::maps::bpf_map_def
 pub fn aya_obj::maps::bpf_map_def::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Copy for aya_obj::maps::bpf_map_def
-impl core::marker::StructuralEq for aya_obj::maps::bpf_map_def
 impl core::marker::StructuralPartialEq for aya_obj::maps::bpf_map_def
 impl core::marker::Send for aya_obj::maps::bpf_map_def
 impl core::marker::Sync for aya_obj::maps::bpf_map_def
@@ -5715,7 +5693,6 @@ pub fn aya_obj::BpfSectionKind::eq(&self, other: &aya_obj::BpfSectionKind) -> bo
 impl core::fmt::Debug for aya_obj::BpfSectionKind
 pub fn aya_obj::BpfSectionKind::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Copy for aya_obj::BpfSectionKind
-impl core::marker::StructuralEq for aya_obj::BpfSectionKind
 impl core::marker::StructuralPartialEq for aya_obj::BpfSectionKind
 impl core::marker::Send for aya_obj::BpfSectionKind
 impl core::marker::Sync for aya_obj::BpfSectionKind
@@ -6458,7 +6435,6 @@ pub fn aya_obj::BpfSectionKind::eq(&self, other: &aya_obj::BpfSectionKind) -> bo
 impl core::fmt::Debug for aya_obj::BpfSectionKind
 pub fn aya_obj::BpfSectionKind::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Copy for aya_obj::BpfSectionKind
-impl core::marker::StructuralEq for aya_obj::BpfSectionKind
 impl core::marker::StructuralPartialEq for aya_obj::BpfSectionKind
 impl core::marker::Send for aya_obj::BpfSectionKind
 impl core::marker::Sync for aya_obj::BpfSectionKind

--- a/xtask/public-api/aya.txt
+++ b/xtask/public-api/aya.txt
@@ -451,7 +451,6 @@ impl core::cmp::PartialEq for aya::maps::perf::Events
 pub fn aya::maps::perf::Events::eq(&self, other: &aya::maps::perf::Events) -> bool
 impl core::fmt::Debug for aya::maps::perf::Events
 pub fn aya::maps::perf::Events::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl core::marker::StructuralEq for aya::maps::perf::Events
 impl core::marker::StructuralPartialEq for aya::maps::perf::Events
 impl core::marker::Send for aya::maps::perf::Events
 impl core::marker::Sync for aya::maps::perf::Events
@@ -2461,7 +2460,6 @@ impl core::fmt::Debug for aya::programs::cgroup_device::CgroupDeviceLinkId
 pub fn aya::programs::cgroup_device::CgroupDeviceLinkId::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::hash::Hash for aya::programs::cgroup_device::CgroupDeviceLinkId
 pub fn aya::programs::cgroup_device::CgroupDeviceLinkId::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
-impl core::marker::StructuralEq for aya::programs::cgroup_device::CgroupDeviceLinkId
 impl core::marker::StructuralPartialEq for aya::programs::cgroup_device::CgroupDeviceLinkId
 impl core::marker::Send for aya::programs::cgroup_device::CgroupDeviceLinkId
 impl core::marker::Sync for aya::programs::cgroup_device::CgroupDeviceLinkId
@@ -2604,7 +2602,6 @@ impl core::fmt::Debug for aya::programs::cgroup_skb::CgroupSkbLinkId
 pub fn aya::programs::cgroup_skb::CgroupSkbLinkId::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::hash::Hash for aya::programs::cgroup_skb::CgroupSkbLinkId
 pub fn aya::programs::cgroup_skb::CgroupSkbLinkId::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
-impl core::marker::StructuralEq for aya::programs::cgroup_skb::CgroupSkbLinkId
 impl core::marker::StructuralPartialEq for aya::programs::cgroup_skb::CgroupSkbLinkId
 impl core::marker::Send for aya::programs::cgroup_skb::CgroupSkbLinkId
 impl core::marker::Sync for aya::programs::cgroup_skb::CgroupSkbLinkId
@@ -2714,7 +2711,6 @@ impl core::fmt::Debug for aya::programs::cgroup_sock::CgroupSockLinkId
 pub fn aya::programs::cgroup_sock::CgroupSockLinkId::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::hash::Hash for aya::programs::cgroup_sock::CgroupSockLinkId
 pub fn aya::programs::cgroup_sock::CgroupSockLinkId::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
-impl core::marker::StructuralEq for aya::programs::cgroup_sock::CgroupSockLinkId
 impl core::marker::StructuralPartialEq for aya::programs::cgroup_sock::CgroupSockLinkId
 impl core::marker::Send for aya::programs::cgroup_sock::CgroupSockLinkId
 impl core::marker::Sync for aya::programs::cgroup_sock::CgroupSockLinkId
@@ -2824,7 +2820,6 @@ impl core::fmt::Debug for aya::programs::cgroup_sock_addr::CgroupSockAddrLinkId
 pub fn aya::programs::cgroup_sock_addr::CgroupSockAddrLinkId::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::hash::Hash for aya::programs::cgroup_sock_addr::CgroupSockAddrLinkId
 pub fn aya::programs::cgroup_sock_addr::CgroupSockAddrLinkId::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
-impl core::marker::StructuralEq for aya::programs::cgroup_sock_addr::CgroupSockAddrLinkId
 impl core::marker::StructuralPartialEq for aya::programs::cgroup_sock_addr::CgroupSockAddrLinkId
 impl core::marker::Send for aya::programs::cgroup_sock_addr::CgroupSockAddrLinkId
 impl core::marker::Sync for aya::programs::cgroup_sock_addr::CgroupSockAddrLinkId
@@ -2934,7 +2929,6 @@ impl core::fmt::Debug for aya::programs::cgroup_sockopt::CgroupSockoptLinkId
 pub fn aya::programs::cgroup_sockopt::CgroupSockoptLinkId::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::hash::Hash for aya::programs::cgroup_sockopt::CgroupSockoptLinkId
 pub fn aya::programs::cgroup_sockopt::CgroupSockoptLinkId::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
-impl core::marker::StructuralEq for aya::programs::cgroup_sockopt::CgroupSockoptLinkId
 impl core::marker::StructuralPartialEq for aya::programs::cgroup_sockopt::CgroupSockoptLinkId
 impl core::marker::Send for aya::programs::cgroup_sockopt::CgroupSockoptLinkId
 impl core::marker::Sync for aya::programs::cgroup_sockopt::CgroupSockoptLinkId
@@ -3044,7 +3038,6 @@ impl core::fmt::Debug for aya::programs::cgroup_sysctl::CgroupSysctlLinkId
 pub fn aya::programs::cgroup_sysctl::CgroupSysctlLinkId::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::hash::Hash for aya::programs::cgroup_sysctl::CgroupSysctlLinkId
 pub fn aya::programs::cgroup_sysctl::CgroupSysctlLinkId::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
-impl core::marker::StructuralEq for aya::programs::cgroup_sysctl::CgroupSysctlLinkId
 impl core::marker::StructuralPartialEq for aya::programs::cgroup_sysctl::CgroupSysctlLinkId
 impl core::marker::Send for aya::programs::cgroup_sysctl::CgroupSysctlLinkId
 impl core::marker::Sync for aya::programs::cgroup_sysctl::CgroupSysctlLinkId
@@ -3191,7 +3184,6 @@ impl core::fmt::Debug for aya::programs::extension::ExtensionLinkId
 pub fn aya::programs::extension::ExtensionLinkId::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::hash::Hash for aya::programs::extension::ExtensionLinkId
 pub fn aya::programs::extension::ExtensionLinkId::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
-impl core::marker::StructuralEq for aya::programs::extension::ExtensionLinkId
 impl core::marker::StructuralPartialEq for aya::programs::extension::ExtensionLinkId
 impl core::marker::Send for aya::programs::extension::ExtensionLinkId
 impl core::marker::Sync for aya::programs::extension::ExtensionLinkId
@@ -3305,7 +3297,6 @@ impl core::fmt::Debug for aya::programs::fentry::FEntryLinkId
 pub fn aya::programs::fentry::FEntryLinkId::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::hash::Hash for aya::programs::fentry::FEntryLinkId
 pub fn aya::programs::fentry::FEntryLinkId::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
-impl core::marker::StructuralEq for aya::programs::fentry::FEntryLinkId
 impl core::marker::StructuralPartialEq for aya::programs::fentry::FEntryLinkId
 impl core::marker::Send for aya::programs::fentry::FEntryLinkId
 impl core::marker::Sync for aya::programs::fentry::FEntryLinkId
@@ -3419,7 +3410,6 @@ impl core::fmt::Debug for aya::programs::fexit::FExitLinkId
 pub fn aya::programs::fexit::FExitLinkId::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::hash::Hash for aya::programs::fexit::FExitLinkId
 pub fn aya::programs::fexit::FExitLinkId::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
-impl core::marker::StructuralEq for aya::programs::fexit::FExitLinkId
 impl core::marker::StructuralPartialEq for aya::programs::fexit::FExitLinkId
 impl core::marker::Send for aya::programs::fexit::FExitLinkId
 impl core::marker::Sync for aya::programs::fexit::FExitLinkId
@@ -3570,7 +3560,6 @@ impl core::fmt::Debug for aya::programs::kprobe::KProbeLinkId
 pub fn aya::programs::kprobe::KProbeLinkId::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::hash::Hash for aya::programs::kprobe::KProbeLinkId
 pub fn aya::programs::kprobe::KProbeLinkId::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
-impl core::marker::StructuralEq for aya::programs::kprobe::KProbeLinkId
 impl core::marker::StructuralPartialEq for aya::programs::kprobe::KProbeLinkId
 impl core::marker::Send for aya::programs::kprobe::KProbeLinkId
 impl core::marker::Sync for aya::programs::kprobe::KProbeLinkId
@@ -3716,7 +3705,6 @@ impl core::fmt::Debug for aya::programs::links::FdLinkId
 pub fn aya::programs::links::FdLinkId::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::hash::Hash for aya::programs::links::FdLinkId
 pub fn aya::programs::links::FdLinkId::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
-impl core::marker::StructuralEq for aya::programs::links::FdLinkId
 impl core::marker::StructuralPartialEq for aya::programs::links::FdLinkId
 impl core::marker::Send for aya::programs::links::FdLinkId
 impl core::marker::Sync for aya::programs::links::FdLinkId
@@ -3804,7 +3792,6 @@ impl core::fmt::Debug for aya::programs::links::ProgAttachLinkId
 pub fn aya::programs::links::ProgAttachLinkId::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::hash::Hash for aya::programs::links::ProgAttachLinkId
 pub fn aya::programs::links::ProgAttachLinkId::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
-impl core::marker::StructuralEq for aya::programs::links::ProgAttachLinkId
 impl core::marker::StructuralPartialEq for aya::programs::links::ProgAttachLinkId
 impl core::marker::Send for aya::programs::links::ProgAttachLinkId
 impl core::marker::Sync for aya::programs::links::ProgAttachLinkId
@@ -3954,7 +3941,6 @@ impl core::fmt::Debug for aya::programs::lirc_mode2::LircLinkId
 pub fn aya::programs::lirc_mode2::LircLinkId::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::hash::Hash for aya::programs::lirc_mode2::LircLinkId
 pub fn aya::programs::lirc_mode2::LircLinkId::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
-impl core::marker::StructuralEq for aya::programs::lirc_mode2::LircLinkId
 impl core::marker::StructuralPartialEq for aya::programs::lirc_mode2::LircLinkId
 impl core::marker::Send for aya::programs::lirc_mode2::LircLinkId
 impl core::marker::Sync for aya::programs::lirc_mode2::LircLinkId
@@ -4117,7 +4103,6 @@ impl core::fmt::Debug for aya::programs::lsm::LsmLinkId
 pub fn aya::programs::lsm::LsmLinkId::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::hash::Hash for aya::programs::lsm::LsmLinkId
 pub fn aya::programs::lsm::LsmLinkId::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
-impl core::marker::StructuralEq for aya::programs::lsm::LsmLinkId
 impl core::marker::StructuralPartialEq for aya::programs::lsm::LsmLinkId
 impl core::marker::Send for aya::programs::lsm::LsmLinkId
 impl core::marker::Sync for aya::programs::lsm::LsmLinkId
@@ -4177,7 +4162,6 @@ impl core::fmt::Debug for aya::programs::perf_attach::PerfLinkId
 pub fn aya::programs::perf_attach::PerfLinkId::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::hash::Hash for aya::programs::perf_attach::PerfLinkId
 pub fn aya::programs::perf_attach::PerfLinkId::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
-impl core::marker::StructuralEq for aya::programs::perf_attach::PerfLinkId
 impl core::marker::StructuralPartialEq for aya::programs::perf_attach::PerfLinkId
 impl core::marker::Send for aya::programs::perf_attach::PerfLinkId
 impl core::marker::Sync for aya::programs::perf_attach::PerfLinkId
@@ -4406,7 +4390,6 @@ impl core::fmt::Debug for aya::programs::perf_event::PerfEventLinkId
 pub fn aya::programs::perf_event::PerfEventLinkId::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::hash::Hash for aya::programs::perf_event::PerfEventLinkId
 pub fn aya::programs::perf_event::PerfEventLinkId::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
-impl core::marker::StructuralEq for aya::programs::perf_event::PerfEventLinkId
 impl core::marker::StructuralPartialEq for aya::programs::perf_event::PerfEventLinkId
 impl core::marker::Send for aya::programs::perf_event::PerfEventLinkId
 impl core::marker::Sync for aya::programs::perf_event::PerfEventLinkId
@@ -4444,7 +4427,6 @@ pub fn aya::programs::tc::TcAttachType::fmt(&self, f: &mut core::fmt::Formatter<
 impl core::hash::Hash for aya::programs::tc::TcAttachType
 pub fn aya::programs::tc::TcAttachType::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
 impl core::marker::Copy for aya::programs::tc::TcAttachType
-impl core::marker::StructuralEq for aya::programs::tc::TcAttachType
 impl core::marker::StructuralPartialEq for aya::programs::tc::TcAttachType
 impl core::marker::Send for aya::programs::tc::TcAttachType
 impl core::marker::Sync for aya::programs::tc::TcAttachType
@@ -4598,7 +4580,6 @@ impl core::fmt::Debug for aya::programs::tc::SchedClassifierLinkId
 pub fn aya::programs::tc::SchedClassifierLinkId::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::hash::Hash for aya::programs::tc::SchedClassifierLinkId
 pub fn aya::programs::tc::SchedClassifierLinkId::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
-impl core::marker::StructuralEq for aya::programs::tc::SchedClassifierLinkId
 impl core::marker::StructuralPartialEq for aya::programs::tc::SchedClassifierLinkId
 impl core::marker::Send for aya::programs::tc::SchedClassifierLinkId
 impl core::marker::Sync for aya::programs::tc::SchedClassifierLinkId
@@ -4740,7 +4721,6 @@ impl core::fmt::Debug for aya::programs::tp_btf::BtfTracePointLinkId
 pub fn aya::programs::tp_btf::BtfTracePointLinkId::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::hash::Hash for aya::programs::tp_btf::BtfTracePointLinkId
 pub fn aya::programs::tp_btf::BtfTracePointLinkId::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
-impl core::marker::StructuralEq for aya::programs::tp_btf::BtfTracePointLinkId
 impl core::marker::StructuralPartialEq for aya::programs::tp_btf::BtfTracePointLinkId
 impl core::marker::Send for aya::programs::tp_btf::BtfTracePointLinkId
 impl core::marker::Sync for aya::programs::tp_btf::BtfTracePointLinkId
@@ -4891,7 +4871,6 @@ impl core::fmt::Debug for aya::programs::trace_point::TracePointLinkId
 pub fn aya::programs::trace_point::TracePointLinkId::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::hash::Hash for aya::programs::trace_point::TracePointLinkId
 pub fn aya::programs::trace_point::TracePointLinkId::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
-impl core::marker::StructuralEq for aya::programs::trace_point::TracePointLinkId
 impl core::marker::StructuralPartialEq for aya::programs::trace_point::TracePointLinkId
 impl core::marker::Send for aya::programs::trace_point::TracePointLinkId
 impl core::marker::Sync for aya::programs::trace_point::TracePointLinkId
@@ -5049,7 +5028,6 @@ impl core::fmt::Debug for aya::programs::uprobe::UProbeLinkId
 pub fn aya::programs::uprobe::UProbeLinkId::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::hash::Hash for aya::programs::uprobe::UProbeLinkId
 pub fn aya::programs::uprobe::UProbeLinkId::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
-impl core::marker::StructuralEq for aya::programs::uprobe::UProbeLinkId
 impl core::marker::StructuralPartialEq for aya::programs::uprobe::UProbeLinkId
 impl core::marker::Send for aya::programs::uprobe::UProbeLinkId
 impl core::marker::Sync for aya::programs::uprobe::UProbeLinkId
@@ -5310,7 +5288,6 @@ impl core::fmt::Debug for aya::programs::xdp::XdpLinkId
 pub fn aya::programs::xdp::XdpLinkId::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::hash::Hash for aya::programs::xdp::XdpLinkId
 pub fn aya::programs::xdp::XdpLinkId::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
-impl core::marker::StructuralEq for aya::programs::xdp::XdpLinkId
 impl core::marker::StructuralPartialEq for aya::programs::xdp::XdpLinkId
 impl core::marker::Send for aya::programs::xdp::XdpLinkId
 impl core::marker::Sync for aya::programs::xdp::XdpLinkId
@@ -5930,7 +5907,6 @@ pub fn aya::programs::tc::TcAttachType::fmt(&self, f: &mut core::fmt::Formatter<
 impl core::hash::Hash for aya::programs::tc::TcAttachType
 pub fn aya::programs::tc::TcAttachType::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
 impl core::marker::Copy for aya::programs::tc::TcAttachType
-impl core::marker::StructuralEq for aya::programs::tc::TcAttachType
 impl core::marker::StructuralPartialEq for aya::programs::tc::TcAttachType
 impl core::marker::Send for aya::programs::tc::TcAttachType
 impl core::marker::Sync for aya::programs::tc::TcAttachType
@@ -7538,7 +7514,6 @@ pub fn aya::util::KernelVersion::partial_cmp(&self, other: &aya::util::KernelVer
 impl core::fmt::Debug for aya::util::KernelVersion
 pub fn aya::util::KernelVersion::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Copy for aya::util::KernelVersion
-impl core::marker::StructuralEq for aya::util::KernelVersion
 impl core::marker::StructuralPartialEq for aya::util::KernelVersion
 impl core::marker::Send for aya::util::KernelVersion
 impl core::marker::Sync for aya::util::KernelVersion


### PR DESCRIPTION
StructuralEq has been removed.

See https://github.com/rust-lang/rust/commit/0df7810734d396d1a3082eee674d542c81c269d2.
