### PR TITLE
fix(aya-sock-map): invalid transmute when calling fd

### DIFF
--- a/aya/src/maps/sock/sock_map.rs
+++ b/aya/src/maps/sock/sock_map.rs
@@ -77,7 +77,7 @@ impl<T: Borrow<MapData>> SockMap<T> {
         let fd: &MapFd = self.inner.borrow().fd();
         // TODO(https://github.com/rust-lang/rfcs/issues/3066): avoid this unsafe.
         // SAFETY: `SockMapFd` is #[repr(transparent)] over `MapFd`.
-        unsafe { std::mem::transmute(&fd) }
+        unsafe { std::mem::transmute(fd) }
     }
 }
 


### PR DESCRIPTION
Corrent an invalid transmutation for sock_map.
fd is already a ref of MapFd, so transmuting &fd to &SockMapFd is equivalent to transmuting &&SockMapFd into &SockMapFd which is buggy.

### Step to reproduce
This simple program terminates in error with `Os error 9, invalid file descriptor`
```
    let mut intercept_ingress: SockMap<_> = bpf.take_map("INTERCEPT_INGRESS").unwrap().try_into()?;
    let map_fd = intercept_ingress.fd().try_clone()?;
```

SockHash is doing it correctly BTW https://github.com/aya-rs/aya/blob/main/aya/src/maps/sock/sock_hash.rs#L113