### PR TITLE
chore: Use the cargo workspace package table

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,13 @@ default-members = [
     # CARGO_CFG_BPF_TARGET_ARCH={x86_64,aarch64,arm,riscv64}
 ]
 
+[workspace.package]
+authors = ["Aya Contributors"]
+license = "MIT OR Apache-2.0"
+repository = "https://github.com/aya-rs/aya"
+homepage = "https://aya-rs.dev"
+edition = "2021"
+
 # NOTE(vadorovsky): Neither cargo-udeps nor cargo-machete are able to detect
 # unused crates defined in this section. It would be nice to teach either of
 # them to do that, but in the meantime we need to be careful.

--- a/aya-bpf-macros/Cargo.toml
+++ b/aya-bpf-macros/Cargo.toml
@@ -1,8 +1,12 @@
 [package]
 name = "aya-bpf-macros"
 version = "0.1.0"
-authors = ["Alessandro Decina <alessandro.d@gmail.com>"]
-edition = "2021"
+description = "Proc macros used by aya-bpf"
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+edition.workspace = true
 
 [lib]
 proc-macro = true

--- a/aya-log-common/Cargo.toml
+++ b/aya-log-common/Cargo.toml
@@ -3,11 +3,12 @@ name = "aya-log-common"
 version = "0.1.13"
 description = "A logging library for eBPF programs."
 keywords = ["bpf", "ebpf", "log", "logging"]
-license = "MIT OR Apache-2.0"
-authors = ["The Aya Contributors"]
-repository = "https://github.com/aya-rs/aya-log"
 documentation = "https://docs.rs/aya-log"
-edition = "2021"
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+edition.workspace = true
 
 [dependencies]
 num_enum = { workspace = true }

--- a/aya-log-ebpf-macros/Cargo.toml
+++ b/aya-log-ebpf-macros/Cargo.toml
@@ -1,7 +1,12 @@
 [package]
 name = "aya-log-ebpf-macros"
 version = "0.1.0"
-edition = "2021"
+description = "Proc macros used by aya-log-ebpf"
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+edition.workspace = true
 
 [dependencies]
 aya-log-common = { workspace = true }

--- a/aya-log-parser/Cargo.toml
+++ b/aya-log-parser/Cargo.toml
@@ -1,7 +1,12 @@
 [package]
 name = "aya-log-parser"
 version = "0.1.11-dev.0"
-edition = "2021"
+description = "A parser for the aya log format strings"
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+edition.workspace = true
 
 [dependencies]
 aya-log-common = { workspace = true }

--- a/aya-log/Cargo.toml
+++ b/aya-log/Cargo.toml
@@ -3,12 +3,13 @@ name = "aya-log"
 version = "0.1.13"
 description = "A logging library for eBPF programs."
 keywords = ["bpf", "ebpf", "log", "logging"]
-license = "MIT OR Apache-2.0"
-authors = ["The Aya Contributors"]
-repository = "https://github.com/aya-rs/aya-log"
 readme = "README.md"
 documentation = "https://docs.rs/aya-log"
-edition = "2021"
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+edition.workspace = true
 
 [dependencies]
 aya = { workspace = true, features = ["async_tokio"] }

--- a/aya-obj/Cargo.toml
+++ b/aya-obj/Cargo.toml
@@ -3,12 +3,13 @@ name = "aya-obj"
 version = "0.1.0"
 description = "An eBPF object file parsing library with BTF and relocation support."
 keywords = ["bpf", "btf", "ebpf", "elf", "object"]
-license = "MIT OR Apache-2.0"
-authors = ["The Aya Contributors"]
-repository = "https://github.com/aya-rs/aya"
 readme = "README.md"
 documentation = "https://docs.rs/aya-obj"
-edition = "2021"
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+edition.workspace = true
 
 [dependencies]
 bytes = { workspace = true }

--- a/aya-tool/Cargo.toml
+++ b/aya-tool/Cargo.toml
@@ -1,8 +1,12 @@
 [package]
 name = "aya-tool"
 version = "0.1.0"
-authors = ["Alessandro Decina <alessandro.d@gmail.com>"]
-edition = "2021"
+description = "A tool for generating bindings for Linux Kernel types"
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+edition.workspace = true
 
 [dependencies]
 bindgen = { workspace = true, default-features = true }

--- a/aya/Cargo.toml
+++ b/aya/Cargo.toml
@@ -3,13 +3,14 @@ name = "aya"
 version = "0.11.0"
 description = "An eBPF library with a focus on developer experience and operability."
 keywords = ["bpf", "ebpf", "kernel", "linux"]
-license = "MIT OR Apache-2.0"
-authors = ["The Aya Contributors"]
-repository = "https://github.com/aya-rs/aya"
 readme = "README.md"
 documentation = "https://docs.rs/aya"
-edition = "2021"
 rust-version = "1.66"
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+edition.workspace = true
 
 [dependencies]
 assert_matches = { workspace = true }

--- a/bpf/aya-bpf-bindings/Cargo.toml
+++ b/bpf/aya-bpf-bindings/Cargo.toml
@@ -1,8 +1,12 @@
 [package]
 name = "aya-bpf-bindings"
 version = "0.1.0"
-authors = ["Alessandro Decina <alessandro.d@gmail.com>"]
-edition = "2021"
+description = "Bindings for Linux Kernel eBPF types and helpers"
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+edition.workspace = true
 
 [dependencies]
 aya-bpf-cty = { path = "../aya-bpf-cty" }

--- a/bpf/aya-bpf-cty/Cargo.toml
+++ b/bpf/aya-bpf-cty/Cargo.toml
@@ -1,9 +1,11 @@
 [package]
-authors = ["Jorge Aparicio <jorge@japaric.io>"]
-edition = "2021"
 categories = ["embedded", "external-ffi-bindings", "no-std"]
 description = "Type aliases to C types like c_int for use with bindgen"
-documentation = "https://docs.rs/cty"
-license = "MIT OR Apache-2.0"
+documentation = "https://docs.rs/aya-bpf-cty"
 name = "aya-bpf-cty"
 version = "0.2.1"
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+edition.workspace = true

--- a/bpf/aya-bpf/Cargo.toml
+++ b/bpf/aya-bpf/Cargo.toml
@@ -1,8 +1,12 @@
 [package]
 name = "aya-bpf"
 version = "0.1.0"
-authors = ["Alessandro Decina <alessandro.d@gmail.com>"]
-edition = "2021"
+description = "A library for writing eBPF programs"
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+edition.workspace = true
 
 [dependencies]
 aya-bpf-cty = { path = "../aya-bpf-cty" }

--- a/bpf/aya-log-ebpf/Cargo.toml
+++ b/bpf/aya-log-ebpf/Cargo.toml
@@ -1,7 +1,12 @@
 [package]
 name = "aya-log-ebpf"
 version = "0.1.0"
-edition = "2021"
+description = "Logging for eBPF programs"
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+edition.workspace = true
 
 [dependencies]
 aya-bpf = { path = "../aya-bpf" }

--- a/init/Cargo.toml
+++ b/init/Cargo.toml
@@ -1,9 +1,12 @@
 [package]
 name = "init"
 version = "0.1.0"
-authors = ["Tamir Duberstein <tamird@gmail.com>"]
-edition = "2021"
 publish = false
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+edition.workspace = true
 
 [dependencies]
 anyhow = { workspace = true, features = ["std"] }

--- a/test/integration-ebpf/Cargo.toml
+++ b/test/integration-ebpf/Cargo.toml
@@ -1,8 +1,12 @@
 [package]
 name = "integration-ebpf"
 version = "0.1.0"
-edition = "2021"
 publish = false
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+edition.workspace = true
 
 [dependencies]
 aya-bpf = { path = "../../bpf/aya-bpf" }

--- a/test/integration-test/Cargo.toml
+++ b/test/integration-test/Cargo.toml
@@ -1,8 +1,12 @@
 [package]
 name = "integration-test"
 version = "0.1.0"
-edition = "2021"
 publish = false
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+edition.workspace = true
 
 [dependencies]
 anyhow = { workspace = true, features = ["std"] }

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -1,9 +1,12 @@
 [package]
 name = "xtask"
 version = "0.1.0"
-authors = ["Alessandro Decina <alessandro.d@gmail.com>"]
-edition = "2021"
 publish = false
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+edition.workspace = true
 
 [dependencies]
 anyhow = { workspace = true, features = ["std"] }


### PR DESCRIPTION
This allows for inheritance of common fields from the workspace root. The following fields have been made common:

- authors
- license
- repository
- homepage
- edition