### PR TITLE
Fix macOS CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -187,11 +187,24 @@ jobs:
         with:
           submodules: recursive
 
-      - uses: dtolnay/rust-toolchain@master
+      - if: runner.os == 'Linux'
+        uses: dtolnay/rust-toolchain@master
         with:
           toolchain: nightly
           components: rust-src
           targets: aarch64-unknown-linux-musl,x86_64-unknown-linux-musl
+
+      #### Temporary workaround for LLVM 18 not being released yet.
+      - if: runner.os == 'macOS'
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: nightly-2024-02-12
+          components: rust-src
+          targets: aarch64-unknown-linux-musl,x86_64-unknown-linux-musl
+
+      - if: runner.os == 'macOS'
+        run: sed -i '' 's/nightly/nightly-2024-02-12/' test/integration-ebpf/rust-toolchain.toml
+      #### End of temporary workaround.
 
       - uses: Swatinem/rust-cache@v2
 
@@ -244,7 +257,8 @@ jobs:
       - name: bpf-linker
         if: runner.os == 'macOS'
         # NB: rustc doesn't ship libLLVM.so on macOS, so disable proxying (default feature).
-        run: cargo install bpf-linker --git https://github.com/aya-rs/bpf-linker.git --no-default-features
+        # Remove --rev when LLVM18 is released.
+        run: cargo install bpf-linker --git https://github.com/aya-rs/bpf-linker.git --rev 821f92990074cb7e950e25129dcd55e20424cede --no-default-features
 
       - name: Download debian kernels
         if: runner.arch == 'ARM64'

--- a/test/integration-test/build.rs
+++ b/test/integration-test/build.rs
@@ -243,7 +243,9 @@ fn main() {
                     }
                 }
                 Message::CompilerMessage(CompilerMessage { message, .. }) => {
-                    println!("cargo:warning={message}");
+                    for line in message.rendered.unwrap_or_default().split('\n') {
+                        println!("cargo:warning={line}");
+                    }
                 }
                 Message::TextLine(line) => {
                     println!("cargo:warning={line}");

--- a/xtask/src/run.rs
+++ b/xtask/src/run.rs
@@ -86,7 +86,9 @@ where
                 }
             }
             Message::CompilerMessage(CompilerMessage { message, .. }) => {
-                println!("{message}");
+                for line in message.rendered.unwrap_or_default().split('\n') {
+                    println!("cargo:warning={line}");
+                }
             }
             Message::TextLine(line) => {
                 println!("{line}");


### PR DESCRIPTION
This PR contains 3 commits to fix the macOS CI job which has been failing since ~12th February.

The causes was that Rust nightly updated to LLVM v18.1-RC2 but bpf-linker was linked against LLVM 17. Even with the bpf-linker v0.9.11 release (which supports the LLVM RC) macOS CI still fails due to LLVM 18.1-RC2 not being installable via `brew` to link against. Solving this with homebrew tap/bottles and/or binstalls of bpf-linker is the best long term solution. In the short term we revert to the last working rust nightly toolchain + bpf-linker v0.9.10

This was pretty hard to debug due to missing output from `cargo xtask integration-test`.
A commit in this PR provides a fix for that too which should make this easier to debug in future.

Note: At some point in CI we were also seeing errors about missing libelf. This seems to be a red herring 🐟 
Commits in this PR that added libelf to the brew dependencies have been reverted