### PR TITLE
Install libelf on macOS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -234,7 +234,7 @@ jobs:
           find /usr/local/bin -type l -exec sh -c 'readlink -f "$1" \
           | grep -q ^/Library/Frameworks/Python.framework/Versions/' _ {} \; -exec rm -v {} \;
           HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK=1 \
-          brew install dpkg findutils gnu-tar llvm pkg-config qemu
+          brew install dpkg findutils gnu-tar llvm pkg-config qemu libelf
           echo /usr/local/opt/findutils/libexec/gnubin >> $GITHUB_PATH
           echo /usr/local/opt/gnu-tar/libexec/gnubin >> $GITHUB_PATH
           echo /usr/local/opt/llvm/bin >> $GITHUB_PATH


### PR DESCRIPTION
Seems it was removed in
https://github.com/actions/runner-images/releases/tag/macos-13%2F20240204.1
though it's not called out in the notes.
