### PR TITLE
chore: Fix release.toml

### DIFF
--- a/release.toml
+++ b/release.toml
@@ -1,3 +1,2 @@
 pre-release-commit-message = "{{crate_name}}: release version {{version}}"
-post-release-commit-message = "{{crate_name}}: start next development iteration {{next_version}}"
 consolidate-commits = true


### PR DESCRIPTION
post-release-commit-message was deprecated a while back.