### PR TITLE
aya: appease new nightly clippy lints

### DIFF
--- a/aya-obj/src/obj.rs
+++ b/aya-obj/src/obj.rs
@@ -1687,7 +1687,7 @@ mod tests {
             )),
             Ok(())
         );
-        assert!(obj.maps.get("foo").is_some());
+        assert!(obj.maps.contains_key("foo"));
     }
 
     #[test]
@@ -1774,9 +1774,9 @@ mod tests {
             )),
             Ok(())
         );
-        assert!(obj.maps.get("foo").is_some());
-        assert!(obj.maps.get("bar").is_some());
-        assert!(obj.maps.get("baz").is_some());
+        assert!(obj.maps.contains_key("foo"));
+        assert!(obj.maps.contains_key("bar"));
+        assert!(obj.maps.contains_key("baz"));
         for map in obj.maps.values() {
             assert_matches!(map, Map::Legacy(m) => {
                 assert_eq!(&m.def, def);
@@ -1796,7 +1796,7 @@ mod tests {
             )),
             Ok(())
         );
-        assert!(obj.maps.get(".bss").is_some());
+        assert!(obj.maps.contains_key(".bss"));
 
         assert_matches!(
             obj.parse_section(fake_section(
@@ -1807,7 +1807,7 @@ mod tests {
             )),
             Ok(())
         );
-        assert!(obj.maps.get(".rodata").is_some());
+        assert!(obj.maps.contains_key(".rodata"));
 
         assert_matches!(
             obj.parse_section(fake_section(
@@ -1818,7 +1818,7 @@ mod tests {
             )),
             Ok(())
         );
-        assert!(obj.maps.get(".rodata.boo").is_some());
+        assert!(obj.maps.contains_key(".rodata.boo"));
 
         assert_matches!(
             obj.parse_section(fake_section(
@@ -1829,7 +1829,7 @@ mod tests {
             )),
             Ok(())
         );
-        assert!(obj.maps.get(".data").is_some());
+        assert!(obj.maps.contains_key(".data"));
 
         assert_matches!(
             obj.parse_section(fake_section(
@@ -1840,7 +1840,7 @@ mod tests {
             )),
             Ok(())
         );
-        assert!(obj.maps.get(".data.boo").is_some());
+        assert!(obj.maps.contains_key(".data.boo"));
     }
 
     #[test]


### PR DESCRIPTION
```
  error: unnecessary use of `get("foo").is_some()`
      --> aya-obj/src/obj.rs:1690:26
       |
  1690 |         assert!(obj.maps.get("foo").is_some());
       |                          ^^^^^^^^^^^^^^^^^^^^ help: replace it with: `contains_key("foo")`
       |
       = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_get_then_check
  note: the lint level is defined here
      --> aya-obj/src/lib.rs:68:9
       |
  68   | #![deny(clippy::all, missing_docs)]
       |         ^^^^^^^^^^^
       = note: `#[deny(clippy::unnecessary_get_then_check)]` implied by `#[deny(clippy::all)]`

  error: unnecessary use of `get("foo").is_some()`
      --> aya-obj/src/obj.rs:1777:26
       |
  1777 |         assert!(obj.maps.get("foo").is_some());
       |                          ^^^^^^^^^^^^^^^^^^^^ help: replace it with: `contains_key("foo")`
       |
       = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_get_then_check

  error: unnecessary use of `get("bar").is_some()`
      --> aya-obj/src/obj.rs:1778:26
       |
  1778 |         assert!(obj.maps.get("bar").is_some());
       |                          ^^^^^^^^^^^^^^^^^^^^ help: replace it with: `contains_key("bar")`
       |
       = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_get_then_check

  error: unnecessary use of `get("baz").is_some()`
      --> aya-obj/src/obj.rs:1779:26
       |
  1779 |         assert!(obj.maps.get("baz").is_some());
       |                          ^^^^^^^^^^^^^^^^^^^^ help: replace it with: `contains_key("baz")`
       |
       = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_get_then_check

  error: unnecessary use of `get(".bss").is_some()`
      --> aya-obj/src/obj.rs:1799:26
       |
  1799 |         assert!(obj.maps.get(".bss").is_some());
       |                          ^^^^^^^^^^^^^^^^^^^^^ help: replace it with: `contains_key(".bss")`
       |
       = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_get_then_check

  error: unnecessary use of `get(".rodata").is_some()`
      --> aya-obj/src/obj.rs:1810:26
       |
  1810 |         assert!(obj.maps.get(".rodata").is_some());
       |                          ^^^^^^^^^^^^^^^^^^^^^^^^ help: replace it with: `contains_key(".rodata")`
       |
       = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_get_then_check

  error: unnecessary use of `get(".rodata.boo").is_some()`
      --> aya-obj/src/obj.rs:1821:26
       |
  1821 |         assert!(obj.maps.get(".rodata.boo").is_some());
       |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace it with: `contains_key(".rodata.boo")`
       |
       = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_get_then_check

  error: unnecessary use of `get(".data").is_some()`
      --> aya-obj/src/obj.rs:1832:26
       |
  1832 |         assert!(obj.maps.get(".data").is_some());
       |                          ^^^^^^^^^^^^^^^^^^^^^^ help: replace it with: `contains_key(".data")`
       |
       = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_get_then_check

  error: unnecessary use of `get(".data.boo").is_some()`
      --> aya-obj/src/obj.rs:1843:26
       |
  1843 |         assert!(obj.maps.get(".data.boo").is_some());
       |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace it with: `contains_key(".data.boo")`
```