### PR TITLE
aya: appease new nightly clippy lints

### DIFF
--- a/aya/src/maps/mod.rs
+++ b/aya/src/maps/mod.rs
@@ -222,7 +222,7 @@ impl AsFd for MapFd {
 /// Raises a warning about rlimit. Should be used only if creating a map was not
 /// successful.
 fn maybe_warn_rlimit() {
-    let mut limit = std::mem::MaybeUninit::<rlimit>::uninit();
+    let mut limit = mem::MaybeUninit::<rlimit>::uninit();
     let ret = unsafe { getrlimit(RLIMIT_MEMLOCK, limit.as_mut_ptr()) };
     if ret == 0 {
         let limit = unsafe { limit.assume_init() };
@@ -1127,7 +1127,7 @@ mod tests {
                 );
                 let map_info = unsafe { &mut *(attr.info.info as *mut bpf_map_info) };
                 map_info.name[..TEST_NAME.len()]
-                    .copy_from_slice(unsafe { std::mem::transmute(TEST_NAME) });
+                    .copy_from_slice(unsafe { mem::transmute(TEST_NAME) });
                 Ok(0)
             }
             _ => Err((-1, io::Error::from_raw_os_error(EFAULT))),

--- a/aya/src/maps/ring_buf.rs
+++ b/aya/src/maps/ring_buf.rs
@@ -431,7 +431,7 @@ impl MMap {
                 io_error: io::Error::last_os_error(),
             })),
             ptr => Ok(Self {
-                ptr: ptr::NonNull::new(ptr).ok_or(
+                ptr: NonNull::new(ptr).ok_or(
                     // This should never happen, but to be paranoid, and so we never need to talk
                     // about a null pointer, we check it anyway.
                     MapError::SyscallError(SyscallError {

--- a/aya/src/programs/mod.rs
+++ b/aya/src/programs/mod.rs
@@ -611,7 +611,7 @@ fn load_program<T: Link>(
     }
     let obj = obj.as_ref().unwrap();
     let (
-        crate::obj::Program {
+        obj::Program {
             license,
             kernel_version,
             ..

--- a/aya/src/util.rs
+++ b/aya/src/util.rs
@@ -370,7 +370,7 @@ pub(crate) fn bytes_of_bpf_name(bpf_name: &[core::ffi::c_char; 16]) -> &[u8] {
         .rposition(|ch| *ch != 0)
         .map(|pos| pos + 1)
         .unwrap_or(0);
-    unsafe { std::slice::from_raw_parts(bpf_name.as_ptr() as *const _, length) }
+    unsafe { slice::from_raw_parts(bpf_name.as_ptr() as *const _, length) }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
```
  error: unnecessary qualification
     --> aya/src/maps/ring_buf.rs:434:22
      |
  434 |                 ptr: ptr::NonNull::new(ptr).ok_or(
      |                      ^^^^^^^^^^^^^^^^^
      |
  note: the lint level is defined here
     --> aya/src/lib.rs:72:5
      |
  72  |     unused_qualifications,
      |     ^^^^^^^^^^^^^^^^^^^^^
  help: remove the unnecessary path segments
      |
  434 -                 ptr: ptr::NonNull::new(ptr).ok_or(
  434 +                 ptr: NonNull::new(ptr).ok_or(
      |

  error: unnecessary qualification
     --> aya/src/maps/mod.rs:225:21
      |
  225 |     let mut limit = std::mem::MaybeUninit::<rlimit>::uninit();
      |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      |
  help: remove the unnecessary path segments
      |
  225 -     let mut limit = std::mem::MaybeUninit::<rlimit>::uninit();
  225 +     let mut limit = mem::MaybeUninit::<rlimit>::uninit();
      |

  error: unnecessary qualification
     --> aya/src/programs/mod.rs:614:9
      |
  614 |         crate::obj::Program {
      |         ^^^^^^^^^^^^^^^^^^^
      |
  help: remove the unnecessary path segments
      |
  614 -         crate::obj::Program {
  614 +         obj::Program {
      |

  error: unnecessary qualification
     --> aya/src/util.rs:373:14
      |
  373 |     unsafe { std::slice::from_raw_parts(bpf_name.as_ptr() as
      *const _, length) }
      |              ^^^^^^^^^^^^^^^^^^^^^^^^^^
      |
  help: remove the unnecessary path segments
      |
  373 -     unsafe { std::slice::from_raw_parts(bpf_name.as_ptr() as
      *const _, length) }
  373 +     unsafe { slice::from_raw_parts(bpf_name.as_ptr() as *const _,
      length) }
      |

  error: unnecessary qualification
      --> aya/src/maps/mod.rs:1130:47
       |   
  1130 |                     .copy_from_slice(unsafe {
       std::mem::transmute(TEST_NAME) }); 
       |                                               ^^^^^^^^^^^^^^^^^^^
       |   
  note: the lint level is defined here
      --> aya/src/lib.rs:72:5
       |   
  72   |     unused_qualifications,
       |     ^^^^^^^^^^^^^^^^^^^^^
  help: remove the unnecessary path segments
       |   
  1130 -                     .copy_from_slice(unsafe {
       std::mem::transmute(TEST_NAME) }); 
  1130 +                     .copy_from_slice(unsafe {
       mem::transmute(TEST_NAME) }); 
       |   
```