### PR TITLE
aya: include license in crate workspace

### DIFF
--- a/aya/LICENSE-APACHE
+++ b/aya/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../LICENSE-APACHE

--- a/aya/LICENSE-MIT
+++ b/aya/LICENSE-MIT
@@ -1,0 +1,1 @@
+../LICENSE-MIT


### PR DESCRIPTION
This PR includes the licenses files in the crate workspace subdirectory.
Without this, they won't be showing on crates.io and would be giving out
errors on tooling such as rust2rpm.

Signed-off-by: Daniel Mellado <dmellado@redhat.com>