### PR TITLE
public-api: regenerate

### DIFF
--- a/xtask/public-api/aya-ebpf-bindings.txt
+++ b/xtask/public-api/aya-ebpf-bindings.txt
@@ -484,6 +484,7 @@ pub fn aya_ebpf_bindings::bindings::__sk_buff__bindgen_ty_1::new_bitfield_1() ->
 impl core::clone::Clone for aya_ebpf_bindings::bindings::__sk_buff__bindgen_ty_1
 pub fn aya_ebpf_bindings::bindings::__sk_buff__bindgen_ty_1::clone(&self) -> aya_ebpf_bindings::bindings::__sk_buff__bindgen_ty_1
 impl core::marker::Copy for aya_ebpf_bindings::bindings::__sk_buff__bindgen_ty_1
+impl core::marker::Freeze for aya_ebpf_bindings::bindings::__sk_buff__bindgen_ty_1
 impl !core::marker::Send for aya_ebpf_bindings::bindings::__sk_buff__bindgen_ty_1
 impl !core::marker::Sync for aya_ebpf_bindings::bindings::__sk_buff__bindgen_ty_1
 impl core::marker::Unpin for aya_ebpf_bindings::bindings::__sk_buff__bindgen_ty_1
@@ -514,6 +515,7 @@ pub fn aya_ebpf_bindings::bindings::__sk_buff__bindgen_ty_2::new_bitfield_1() ->
 impl core::clone::Clone for aya_ebpf_bindings::bindings::__sk_buff__bindgen_ty_2
 pub fn aya_ebpf_bindings::bindings::__sk_buff__bindgen_ty_2::clone(&self) -> aya_ebpf_bindings::bindings::__sk_buff__bindgen_ty_2
 impl core::marker::Copy for aya_ebpf_bindings::bindings::__sk_buff__bindgen_ty_2
+impl core::marker::Freeze for aya_ebpf_bindings::bindings::__sk_buff__bindgen_ty_2
 impl !core::marker::Send for aya_ebpf_bindings::bindings::__sk_buff__bindgen_ty_2
 impl !core::marker::Sync for aya_ebpf_bindings::bindings::__sk_buff__bindgen_ty_2
 impl core::marker::Unpin for aya_ebpf_bindings::bindings::__sk_buff__bindgen_ty_2
@@ -558,6 +560,7 @@ pub aya_ebpf_bindings::bindings::bpf_attr::test: aya_ebpf_bindings::bindings::bp
 impl core::clone::Clone for aya_ebpf_bindings::bindings::bpf_attr
 pub fn aya_ebpf_bindings::bindings::bpf_attr::clone(&self) -> aya_ebpf_bindings::bindings::bpf_attr
 impl core::marker::Copy for aya_ebpf_bindings::bindings::bpf_attr
+impl core::marker::Freeze for aya_ebpf_bindings::bindings::bpf_attr
 impl core::marker::Send for aya_ebpf_bindings::bindings::bpf_attr
 impl core::marker::Sync for aya_ebpf_bindings::bindings::bpf_attr
 impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_attr
@@ -585,6 +588,7 @@ pub aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_1::prog_fd:
 impl core::clone::Clone for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_1
 pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_1::clone(&self) -> aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_1
 impl core::marker::Copy for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_1
+impl core::marker::Freeze for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_1
 impl core::marker::Send for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_1
 impl core::marker::Sync for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_1
 impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_1
@@ -612,6 +616,7 @@ pub aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_2::target_i
 impl core::clone::Clone for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_2
 pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_2::clone(&self) -> aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_2
 impl core::marker::Copy for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_2
+impl core::marker::Freeze for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_2
 impl core::marker::Send for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_2
 impl core::marker::Sync for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_2
 impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_2
@@ -643,6 +648,7 @@ pub aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3::tracing:
 impl core::clone::Clone for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3
 pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3::clone(&self) -> aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3
 impl core::marker::Copy for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3
+impl core::marker::Freeze for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3
 impl core::marker::Send for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3
 impl core::marker::Sync for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3
 impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3
@@ -670,6 +676,7 @@ pub aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_15__bindgen_ty_1::new_prog
 impl core::clone::Clone for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_15__bindgen_ty_1
 pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_15__bindgen_ty_1::clone(&self) -> aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_15__bindgen_ty_1
 impl core::marker::Copy for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_15__bindgen_ty_1
+impl core::marker::Freeze for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_15__bindgen_ty_1
 impl core::marker::Send for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_15__bindgen_ty_1
 impl core::marker::Sync for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_15__bindgen_ty_1
 impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_15__bindgen_ty_1
@@ -697,6 +704,7 @@ pub aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_15__bindgen_ty_2::old_prog
 impl core::clone::Clone for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_15__bindgen_ty_2
 pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_15__bindgen_ty_2::clone(&self) -> aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_15__bindgen_ty_2
 impl core::marker::Copy for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_15__bindgen_ty_2
+impl core::marker::Freeze for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_15__bindgen_ty_2
 impl core::marker::Send for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_15__bindgen_ty_2
 impl core::marker::Sync for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_15__bindgen_ty_2
 impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_15__bindgen_ty_2
@@ -724,6 +732,7 @@ pub aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_2__bindgen_ty_1::value: ay
 impl core::clone::Clone for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_2__bindgen_ty_1
 pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_2__bindgen_ty_1::clone(&self) -> aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_2__bindgen_ty_1
 impl core::marker::Copy for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_2__bindgen_ty_1
+impl core::marker::Freeze for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_2__bindgen_ty_1
 impl core::marker::Send for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_2__bindgen_ty_1
 impl core::marker::Sync for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_2__bindgen_ty_1
 impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_2__bindgen_ty_1
@@ -751,6 +760,7 @@ pub aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_4__bindgen_ty_1::attach_pr
 impl core::clone::Clone for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_4__bindgen_ty_1
 pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_4__bindgen_ty_1::clone(&self) -> aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_4__bindgen_ty_1
 impl core::marker::Copy for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_4__bindgen_ty_1
+impl core::marker::Freeze for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_4__bindgen_ty_1
 impl core::marker::Send for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_4__bindgen_ty_1
 impl core::marker::Sync for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_4__bindgen_ty_1
 impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_4__bindgen_ty_1
@@ -781,6 +791,7 @@ pub aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_8__bindgen_ty_1::start_id:
 impl core::clone::Clone for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_8__bindgen_ty_1
 pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_8__bindgen_ty_1::clone(&self) -> aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_8__bindgen_ty_1
 impl core::marker::Copy for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_8__bindgen_ty_1
+impl core::marker::Freeze for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_8__bindgen_ty_1
 impl core::marker::Send for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_8__bindgen_ty_1
 impl core::marker::Sync for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_8__bindgen_ty_1
 impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_8__bindgen_ty_1
@@ -808,6 +819,7 @@ pub aya_ebpf_bindings::bindings::bpf_cpumap_val__bindgen_ty_1::id: aya_ebpf_bind
 impl core::clone::Clone for aya_ebpf_bindings::bindings::bpf_cpumap_val__bindgen_ty_1
 pub fn aya_ebpf_bindings::bindings::bpf_cpumap_val__bindgen_ty_1::clone(&self) -> aya_ebpf_bindings::bindings::bpf_cpumap_val__bindgen_ty_1
 impl core::marker::Copy for aya_ebpf_bindings::bindings::bpf_cpumap_val__bindgen_ty_1
+impl core::marker::Freeze for aya_ebpf_bindings::bindings::bpf_cpumap_val__bindgen_ty_1
 impl core::marker::Send for aya_ebpf_bindings::bindings::bpf_cpumap_val__bindgen_ty_1
 impl core::marker::Sync for aya_ebpf_bindings::bindings::bpf_cpumap_val__bindgen_ty_1
 impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_cpumap_val__bindgen_ty_1
@@ -835,6 +847,7 @@ pub aya_ebpf_bindings::bindings::bpf_devmap_val__bindgen_ty_1::id: aya_ebpf_bind
 impl core::clone::Clone for aya_ebpf_bindings::bindings::bpf_devmap_val__bindgen_ty_1
 pub fn aya_ebpf_bindings::bindings::bpf_devmap_val__bindgen_ty_1::clone(&self) -> aya_ebpf_bindings::bindings::bpf_devmap_val__bindgen_ty_1
 impl core::marker::Copy for aya_ebpf_bindings::bindings::bpf_devmap_val__bindgen_ty_1
+impl core::marker::Freeze for aya_ebpf_bindings::bindings::bpf_devmap_val__bindgen_ty_1
 impl core::marker::Send for aya_ebpf_bindings::bindings::bpf_devmap_val__bindgen_ty_1
 impl core::marker::Sync for aya_ebpf_bindings::bindings::bpf_devmap_val__bindgen_ty_1
 impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_devmap_val__bindgen_ty_1
@@ -862,6 +875,7 @@ pub aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_1::tot_len: aya_ebpf
 impl core::clone::Clone for aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_1
 pub fn aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_1::clone(&self) -> aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_1
 impl core::marker::Copy for aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_1
+impl core::marker::Freeze for aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_1
 impl core::marker::Send for aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_1
 impl core::marker::Sync for aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_1
 impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_1
@@ -890,6 +904,7 @@ pub aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_2::tos: aya_ebpf_bin
 impl core::clone::Clone for aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_2
 pub fn aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_2::clone(&self) -> aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_2
 impl core::marker::Copy for aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_2
+impl core::marker::Freeze for aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_2
 impl core::marker::Send for aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_2
 impl core::marker::Sync for aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_2
 impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_2
@@ -917,6 +932,7 @@ pub aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_3::ipv6_src: [aya_eb
 impl core::clone::Clone for aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_3
 pub fn aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_3::clone(&self) -> aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_3
 impl core::marker::Copy for aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_3
+impl core::marker::Freeze for aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_3
 impl core::marker::Send for aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_3
 impl core::marker::Sync for aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_3
 impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_3
@@ -944,6 +960,7 @@ pub aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_4::ipv6_dst: [aya_eb
 impl core::clone::Clone for aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_4
 pub fn aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_4::clone(&self) -> aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_4
 impl core::marker::Copy for aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_4
+impl core::marker::Freeze for aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_4
 impl core::marker::Send for aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_4
 impl core::marker::Sync for aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_4
 impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_4
@@ -971,6 +988,7 @@ pub aya_ebpf_bindings::bindings::bpf_flow_keys__bindgen_ty_1::__bindgen_anon_2: 
 impl core::clone::Clone for aya_ebpf_bindings::bindings::bpf_flow_keys__bindgen_ty_1
 pub fn aya_ebpf_bindings::bindings::bpf_flow_keys__bindgen_ty_1::clone(&self) -> aya_ebpf_bindings::bindings::bpf_flow_keys__bindgen_ty_1
 impl core::marker::Copy for aya_ebpf_bindings::bindings::bpf_flow_keys__bindgen_ty_1
+impl core::marker::Freeze for aya_ebpf_bindings::bindings::bpf_flow_keys__bindgen_ty_1
 impl core::marker::Send for aya_ebpf_bindings::bindings::bpf_flow_keys__bindgen_ty_1
 impl core::marker::Sync for aya_ebpf_bindings::bindings::bpf_flow_keys__bindgen_ty_1
 impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_flow_keys__bindgen_ty_1
@@ -999,6 +1017,7 @@ pub aya_ebpf_bindings::bindings::bpf_iter_link_info::task: aya_ebpf_bindings::bi
 impl core::clone::Clone for aya_ebpf_bindings::bindings::bpf_iter_link_info
 pub fn aya_ebpf_bindings::bindings::bpf_iter_link_info::clone(&self) -> aya_ebpf_bindings::bindings::bpf_iter_link_info
 impl core::marker::Copy for aya_ebpf_bindings::bindings::bpf_iter_link_info
+impl core::marker::Freeze for aya_ebpf_bindings::bindings::bpf_iter_link_info
 impl core::marker::Send for aya_ebpf_bindings::bindings::bpf_iter_link_info
 impl core::marker::Sync for aya_ebpf_bindings::bindings::bpf_iter_link_info
 impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_iter_link_info
@@ -1032,6 +1051,7 @@ pub aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1::xdp: aya_ebpf_bind
 impl core::clone::Clone for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1
 pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1::clone(&self) -> aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1
 impl core::marker::Copy for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1
+impl core::marker::Freeze for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1
 impl core::marker::Send for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1
 impl core::marker::Sync for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1
 impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1
@@ -1058,6 +1078,7 @@ pub aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bind
 impl core::clone::Clone for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_1
 pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_1::clone(&self) -> aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_1
 impl core::marker::Copy for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_1
+impl core::marker::Freeze for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_1
 impl core::marker::Send for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_1
 impl core::marker::Sync for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_1
 impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_1
@@ -1085,6 +1106,7 @@ pub aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bind
 impl core::clone::Clone for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2
 pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2::clone(&self) -> aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2
 impl core::marker::Copy for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2
+impl core::marker::Freeze for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2
 impl core::marker::Send for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2
 impl core::marker::Sync for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2
 impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2
@@ -1112,6 +1134,7 @@ pub aya_ebpf_bindings::bindings::bpf_redir_neigh__bindgen_ty_1::ipv6_nh: [aya_eb
 impl core::clone::Clone for aya_ebpf_bindings::bindings::bpf_redir_neigh__bindgen_ty_1
 pub fn aya_ebpf_bindings::bindings::bpf_redir_neigh__bindgen_ty_1::clone(&self) -> aya_ebpf_bindings::bindings::bpf_redir_neigh__bindgen_ty_1
 impl core::marker::Copy for aya_ebpf_bindings::bindings::bpf_redir_neigh__bindgen_ty_1
+impl core::marker::Freeze for aya_ebpf_bindings::bindings::bpf_redir_neigh__bindgen_ty_1
 impl core::marker::Send for aya_ebpf_bindings::bindings::bpf_redir_neigh__bindgen_ty_1
 impl core::marker::Sync for aya_ebpf_bindings::bindings::bpf_redir_neigh__bindgen_ty_1
 impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_redir_neigh__bindgen_ty_1
@@ -1139,6 +1162,7 @@ pub aya_ebpf_bindings::bindings::bpf_sk_lookup__bindgen_ty_1::cookie: aya_ebpf_b
 impl core::clone::Clone for aya_ebpf_bindings::bindings::bpf_sk_lookup__bindgen_ty_1
 pub fn aya_ebpf_bindings::bindings::bpf_sk_lookup__bindgen_ty_1::clone(&self) -> aya_ebpf_bindings::bindings::bpf_sk_lookup__bindgen_ty_1
 impl core::marker::Copy for aya_ebpf_bindings::bindings::bpf_sk_lookup__bindgen_ty_1
+impl core::marker::Freeze for aya_ebpf_bindings::bindings::bpf_sk_lookup__bindgen_ty_1
 impl !core::marker::Send for aya_ebpf_bindings::bindings::bpf_sk_lookup__bindgen_ty_1
 impl !core::marker::Sync for aya_ebpf_bindings::bindings::bpf_sk_lookup__bindgen_ty_1
 impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_sk_lookup__bindgen_ty_1
@@ -1169,6 +1193,7 @@ pub fn aya_ebpf_bindings::bindings::bpf_sk_lookup__bindgen_ty_1__bindgen_ty_1::n
 impl core::clone::Clone for aya_ebpf_bindings::bindings::bpf_sk_lookup__bindgen_ty_1__bindgen_ty_1
 pub fn aya_ebpf_bindings::bindings::bpf_sk_lookup__bindgen_ty_1__bindgen_ty_1::clone(&self) -> aya_ebpf_bindings::bindings::bpf_sk_lookup__bindgen_ty_1__bindgen_ty_1
 impl core::marker::Copy for aya_ebpf_bindings::bindings::bpf_sk_lookup__bindgen_ty_1__bindgen_ty_1
+impl core::marker::Freeze for aya_ebpf_bindings::bindings::bpf_sk_lookup__bindgen_ty_1__bindgen_ty_1
 impl !core::marker::Send for aya_ebpf_bindings::bindings::bpf_sk_lookup__bindgen_ty_1__bindgen_ty_1
 impl !core::marker::Sync for aya_ebpf_bindings::bindings::bpf_sk_lookup__bindgen_ty_1__bindgen_ty_1
 impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_sk_lookup__bindgen_ty_1__bindgen_ty_1
@@ -1199,6 +1224,7 @@ pub fn aya_ebpf_bindings::bindings::bpf_sock_addr__bindgen_ty_1::new_bitfield_1(
 impl core::clone::Clone for aya_ebpf_bindings::bindings::bpf_sock_addr__bindgen_ty_1
 pub fn aya_ebpf_bindings::bindings::bpf_sock_addr__bindgen_ty_1::clone(&self) -> aya_ebpf_bindings::bindings::bpf_sock_addr__bindgen_ty_1
 impl core::marker::Copy for aya_ebpf_bindings::bindings::bpf_sock_addr__bindgen_ty_1
+impl core::marker::Freeze for aya_ebpf_bindings::bindings::bpf_sock_addr__bindgen_ty_1
 impl !core::marker::Send for aya_ebpf_bindings::bindings::bpf_sock_addr__bindgen_ty_1
 impl !core::marker::Sync for aya_ebpf_bindings::bindings::bpf_sock_addr__bindgen_ty_1
 impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_sock_addr__bindgen_ty_1
@@ -1227,6 +1253,7 @@ pub aya_ebpf_bindings::bindings::bpf_sock_ops__bindgen_ty_1::replylong: [aya_ebp
 impl core::clone::Clone for aya_ebpf_bindings::bindings::bpf_sock_ops__bindgen_ty_1
 pub fn aya_ebpf_bindings::bindings::bpf_sock_ops__bindgen_ty_1::clone(&self) -> aya_ebpf_bindings::bindings::bpf_sock_ops__bindgen_ty_1
 impl core::marker::Copy for aya_ebpf_bindings::bindings::bpf_sock_ops__bindgen_ty_1
+impl core::marker::Freeze for aya_ebpf_bindings::bindings::bpf_sock_ops__bindgen_ty_1
 impl core::marker::Send for aya_ebpf_bindings::bindings::bpf_sock_ops__bindgen_ty_1
 impl core::marker::Sync for aya_ebpf_bindings::bindings::bpf_sock_ops__bindgen_ty_1
 impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_sock_ops__bindgen_ty_1
@@ -1257,6 +1284,7 @@ pub fn aya_ebpf_bindings::bindings::bpf_sock_ops__bindgen_ty_2::new_bitfield_1()
 impl core::clone::Clone for aya_ebpf_bindings::bindings::bpf_sock_ops__bindgen_ty_2
 pub fn aya_ebpf_bindings::bindings::bpf_sock_ops__bindgen_ty_2::clone(&self) -> aya_ebpf_bindings::bindings::bpf_sock_ops__bindgen_ty_2
 impl core::marker::Copy for aya_ebpf_bindings::bindings::bpf_sock_ops__bindgen_ty_2
+impl core::marker::Freeze for aya_ebpf_bindings::bindings::bpf_sock_ops__bindgen_ty_2
 impl !core::marker::Send for aya_ebpf_bindings::bindings::bpf_sock_ops__bindgen_ty_2
 impl !core::marker::Sync for aya_ebpf_bindings::bindings::bpf_sock_ops__bindgen_ty_2
 impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_sock_ops__bindgen_ty_2
@@ -1287,6 +1315,7 @@ pub fn aya_ebpf_bindings::bindings::bpf_sock_ops__bindgen_ty_3::new_bitfield_1()
 impl core::clone::Clone for aya_ebpf_bindings::bindings::bpf_sock_ops__bindgen_ty_3
 pub fn aya_ebpf_bindings::bindings::bpf_sock_ops__bindgen_ty_3::clone(&self) -> aya_ebpf_bindings::bindings::bpf_sock_ops__bindgen_ty_3
 impl core::marker::Copy for aya_ebpf_bindings::bindings::bpf_sock_ops__bindgen_ty_3
+impl core::marker::Freeze for aya_ebpf_bindings::bindings::bpf_sock_ops__bindgen_ty_3
 impl !core::marker::Send for aya_ebpf_bindings::bindings::bpf_sock_ops__bindgen_ty_3
 impl !core::marker::Sync for aya_ebpf_bindings::bindings::bpf_sock_ops__bindgen_ty_3
 impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_sock_ops__bindgen_ty_3
@@ -1317,6 +1346,7 @@ pub fn aya_ebpf_bindings::bindings::bpf_sock_ops__bindgen_ty_4::new_bitfield_1()
 impl core::clone::Clone for aya_ebpf_bindings::bindings::bpf_sock_ops__bindgen_ty_4
 pub fn aya_ebpf_bindings::bindings::bpf_sock_ops__bindgen_ty_4::clone(&self) -> aya_ebpf_bindings::bindings::bpf_sock_ops__bindgen_ty_4
 impl core::marker::Copy for aya_ebpf_bindings::bindings::bpf_sock_ops__bindgen_ty_4
+impl core::marker::Freeze for aya_ebpf_bindings::bindings::bpf_sock_ops__bindgen_ty_4
 impl !core::marker::Send for aya_ebpf_bindings::bindings::bpf_sock_ops__bindgen_ty_4
 impl !core::marker::Sync for aya_ebpf_bindings::bindings::bpf_sock_ops__bindgen_ty_4
 impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_sock_ops__bindgen_ty_4
@@ -1344,6 +1374,7 @@ pub aya_ebpf_bindings::bindings::bpf_sock_tuple__bindgen_ty_1::ipv6: aya_ebpf_bi
 impl core::clone::Clone for aya_ebpf_bindings::bindings::bpf_sock_tuple__bindgen_ty_1
 pub fn aya_ebpf_bindings::bindings::bpf_sock_tuple__bindgen_ty_1::clone(&self) -> aya_ebpf_bindings::bindings::bpf_sock_tuple__bindgen_ty_1
 impl core::marker::Copy for aya_ebpf_bindings::bindings::bpf_sock_tuple__bindgen_ty_1
+impl core::marker::Freeze for aya_ebpf_bindings::bindings::bpf_sock_tuple__bindgen_ty_1
 impl core::marker::Send for aya_ebpf_bindings::bindings::bpf_sock_tuple__bindgen_ty_1
 impl core::marker::Sync for aya_ebpf_bindings::bindings::bpf_sock_tuple__bindgen_ty_1
 impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_sock_tuple__bindgen_ty_1
@@ -1374,6 +1405,7 @@ pub fn aya_ebpf_bindings::bindings::bpf_sockopt__bindgen_ty_1::new_bitfield_1() 
 impl core::clone::Clone for aya_ebpf_bindings::bindings::bpf_sockopt__bindgen_ty_1
 pub fn aya_ebpf_bindings::bindings::bpf_sockopt__bindgen_ty_1::clone(&self) -> aya_ebpf_bindings::bindings::bpf_sockopt__bindgen_ty_1
 impl core::marker::Copy for aya_ebpf_bindings::bindings::bpf_sockopt__bindgen_ty_1
+impl core::marker::Freeze for aya_ebpf_bindings::bindings::bpf_sockopt__bindgen_ty_1
 impl !core::marker::Send for aya_ebpf_bindings::bindings::bpf_sockopt__bindgen_ty_1
 impl !core::marker::Sync for aya_ebpf_bindings::bindings::bpf_sockopt__bindgen_ty_1
 impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_sockopt__bindgen_ty_1
@@ -1404,6 +1436,7 @@ pub fn aya_ebpf_bindings::bindings::bpf_sockopt__bindgen_ty_2::new_bitfield_1() 
 impl core::clone::Clone for aya_ebpf_bindings::bindings::bpf_sockopt__bindgen_ty_2
 pub fn aya_ebpf_bindings::bindings::bpf_sockopt__bindgen_ty_2::clone(&self) -> aya_ebpf_bindings::bindings::bpf_sockopt__bindgen_ty_2
 impl core::marker::Copy for aya_ebpf_bindings::bindings::bpf_sockopt__bindgen_ty_2
+impl core::marker::Freeze for aya_ebpf_bindings::bindings::bpf_sockopt__bindgen_ty_2
 impl !core::marker::Send for aya_ebpf_bindings::bindings::bpf_sockopt__bindgen_ty_2
 impl !core::marker::Sync for aya_ebpf_bindings::bindings::bpf_sockopt__bindgen_ty_2
 impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_sockopt__bindgen_ty_2
@@ -1434,6 +1467,7 @@ pub fn aya_ebpf_bindings::bindings::bpf_sockopt__bindgen_ty_3::new_bitfield_1() 
 impl core::clone::Clone for aya_ebpf_bindings::bindings::bpf_sockopt__bindgen_ty_3
 pub fn aya_ebpf_bindings::bindings::bpf_sockopt__bindgen_ty_3::clone(&self) -> aya_ebpf_bindings::bindings::bpf_sockopt__bindgen_ty_3
 impl core::marker::Copy for aya_ebpf_bindings::bindings::bpf_sockopt__bindgen_ty_3
+impl core::marker::Freeze for aya_ebpf_bindings::bindings::bpf_sockopt__bindgen_ty_3
 impl !core::marker::Send for aya_ebpf_bindings::bindings::bpf_sockopt__bindgen_ty_3
 impl !core::marker::Sync for aya_ebpf_bindings::bindings::bpf_sockopt__bindgen_ty_3
 impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_sockopt__bindgen_ty_3
@@ -1461,6 +1495,7 @@ pub aya_ebpf_bindings::bindings::bpf_stack_build_id__bindgen_ty_1::offset: aya_e
 impl core::clone::Clone for aya_ebpf_bindings::bindings::bpf_stack_build_id__bindgen_ty_1
 pub fn aya_ebpf_bindings::bindings::bpf_stack_build_id__bindgen_ty_1::clone(&self) -> aya_ebpf_bindings::bindings::bpf_stack_build_id__bindgen_ty_1
 impl core::marker::Copy for aya_ebpf_bindings::bindings::bpf_stack_build_id__bindgen_ty_1
+impl core::marker::Freeze for aya_ebpf_bindings::bindings::bpf_stack_build_id__bindgen_ty_1
 impl core::marker::Send for aya_ebpf_bindings::bindings::bpf_stack_build_id__bindgen_ty_1
 impl core::marker::Sync for aya_ebpf_bindings::bindings::bpf_stack_build_id__bindgen_ty_1
 impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_stack_build_id__bindgen_ty_1
@@ -1488,6 +1523,7 @@ pub aya_ebpf_bindings::bindings::bpf_tunnel_key__bindgen_ty_1::remote_ipv6: [aya
 impl core::clone::Clone for aya_ebpf_bindings::bindings::bpf_tunnel_key__bindgen_ty_1
 pub fn aya_ebpf_bindings::bindings::bpf_tunnel_key__bindgen_ty_1::clone(&self) -> aya_ebpf_bindings::bindings::bpf_tunnel_key__bindgen_ty_1
 impl core::marker::Copy for aya_ebpf_bindings::bindings::bpf_tunnel_key__bindgen_ty_1
+impl core::marker::Freeze for aya_ebpf_bindings::bindings::bpf_tunnel_key__bindgen_ty_1
 impl core::marker::Send for aya_ebpf_bindings::bindings::bpf_tunnel_key__bindgen_ty_1
 impl core::marker::Sync for aya_ebpf_bindings::bindings::bpf_tunnel_key__bindgen_ty_1
 impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_tunnel_key__bindgen_ty_1
@@ -1515,6 +1551,7 @@ pub aya_ebpf_bindings::bindings::bpf_tunnel_key__bindgen_ty_2::tunnel_flags: aya
 impl core::clone::Clone for aya_ebpf_bindings::bindings::bpf_tunnel_key__bindgen_ty_2
 pub fn aya_ebpf_bindings::bindings::bpf_tunnel_key__bindgen_ty_2::clone(&self) -> aya_ebpf_bindings::bindings::bpf_tunnel_key__bindgen_ty_2
 impl core::marker::Copy for aya_ebpf_bindings::bindings::bpf_tunnel_key__bindgen_ty_2
+impl core::marker::Freeze for aya_ebpf_bindings::bindings::bpf_tunnel_key__bindgen_ty_2
 impl core::marker::Send for aya_ebpf_bindings::bindings::bpf_tunnel_key__bindgen_ty_2
 impl core::marker::Sync for aya_ebpf_bindings::bindings::bpf_tunnel_key__bindgen_ty_2
 impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_tunnel_key__bindgen_ty_2
@@ -1542,6 +1579,7 @@ pub aya_ebpf_bindings::bindings::bpf_tunnel_key__bindgen_ty_3::local_ipv6: [aya_
 impl core::clone::Clone for aya_ebpf_bindings::bindings::bpf_tunnel_key__bindgen_ty_3
 pub fn aya_ebpf_bindings::bindings::bpf_tunnel_key__bindgen_ty_3::clone(&self) -> aya_ebpf_bindings::bindings::bpf_tunnel_key__bindgen_ty_3
 impl core::marker::Copy for aya_ebpf_bindings::bindings::bpf_tunnel_key__bindgen_ty_3
+impl core::marker::Freeze for aya_ebpf_bindings::bindings::bpf_tunnel_key__bindgen_ty_3
 impl core::marker::Send for aya_ebpf_bindings::bindings::bpf_tunnel_key__bindgen_ty_3
 impl core::marker::Sync for aya_ebpf_bindings::bindings::bpf_tunnel_key__bindgen_ty_3
 impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_tunnel_key__bindgen_ty_3
@@ -1569,6 +1607,7 @@ pub aya_ebpf_bindings::bindings::bpf_xfrm_state__bindgen_ty_1::remote_ipv6: [aya
 impl core::clone::Clone for aya_ebpf_bindings::bindings::bpf_xfrm_state__bindgen_ty_1
 pub fn aya_ebpf_bindings::bindings::bpf_xfrm_state__bindgen_ty_1::clone(&self) -> aya_ebpf_bindings::bindings::bpf_xfrm_state__bindgen_ty_1
 impl core::marker::Copy for aya_ebpf_bindings::bindings::bpf_xfrm_state__bindgen_ty_1
+impl core::marker::Freeze for aya_ebpf_bindings::bindings::bpf_xfrm_state__bindgen_ty_1
 impl core::marker::Send for aya_ebpf_bindings::bindings::bpf_xfrm_state__bindgen_ty_1
 impl core::marker::Sync for aya_ebpf_bindings::bindings::bpf_xfrm_state__bindgen_ty_1
 impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_xfrm_state__bindgen_ty_1
@@ -1599,6 +1638,7 @@ pub fn aya_ebpf_bindings::bindings::sk_msg_md__bindgen_ty_1::new_bitfield_1() ->
 impl core::clone::Clone for aya_ebpf_bindings::bindings::sk_msg_md__bindgen_ty_1
 pub fn aya_ebpf_bindings::bindings::sk_msg_md__bindgen_ty_1::clone(&self) -> aya_ebpf_bindings::bindings::sk_msg_md__bindgen_ty_1
 impl core::marker::Copy for aya_ebpf_bindings::bindings::sk_msg_md__bindgen_ty_1
+impl core::marker::Freeze for aya_ebpf_bindings::bindings::sk_msg_md__bindgen_ty_1
 impl !core::marker::Send for aya_ebpf_bindings::bindings::sk_msg_md__bindgen_ty_1
 impl !core::marker::Sync for aya_ebpf_bindings::bindings::sk_msg_md__bindgen_ty_1
 impl core::marker::Unpin for aya_ebpf_bindings::bindings::sk_msg_md__bindgen_ty_1
@@ -1629,6 +1669,7 @@ pub fn aya_ebpf_bindings::bindings::sk_msg_md__bindgen_ty_2::new_bitfield_1() ->
 impl core::clone::Clone for aya_ebpf_bindings::bindings::sk_msg_md__bindgen_ty_2
 pub fn aya_ebpf_bindings::bindings::sk_msg_md__bindgen_ty_2::clone(&self) -> aya_ebpf_bindings::bindings::sk_msg_md__bindgen_ty_2
 impl core::marker::Copy for aya_ebpf_bindings::bindings::sk_msg_md__bindgen_ty_2
+impl core::marker::Freeze for aya_ebpf_bindings::bindings::sk_msg_md__bindgen_ty_2
 impl !core::marker::Send for aya_ebpf_bindings::bindings::sk_msg_md__bindgen_ty_2
 impl !core::marker::Sync for aya_ebpf_bindings::bindings::sk_msg_md__bindgen_ty_2
 impl core::marker::Unpin for aya_ebpf_bindings::bindings::sk_msg_md__bindgen_ty_2
@@ -1659,6 +1700,7 @@ pub fn aya_ebpf_bindings::bindings::sk_msg_md__bindgen_ty_3::new_bitfield_1() ->
 impl core::clone::Clone for aya_ebpf_bindings::bindings::sk_msg_md__bindgen_ty_3
 pub fn aya_ebpf_bindings::bindings::sk_msg_md__bindgen_ty_3::clone(&self) -> aya_ebpf_bindings::bindings::sk_msg_md__bindgen_ty_3
 impl core::marker::Copy for aya_ebpf_bindings::bindings::sk_msg_md__bindgen_ty_3
+impl core::marker::Freeze for aya_ebpf_bindings::bindings::sk_msg_md__bindgen_ty_3
 impl !core::marker::Send for aya_ebpf_bindings::bindings::sk_msg_md__bindgen_ty_3
 impl !core::marker::Sync for aya_ebpf_bindings::bindings::sk_msg_md__bindgen_ty_3
 impl core::marker::Unpin for aya_ebpf_bindings::bindings::sk_msg_md__bindgen_ty_3
@@ -1689,6 +1731,7 @@ pub fn aya_ebpf_bindings::bindings::sk_reuseport_md__bindgen_ty_1::new_bitfield_
 impl core::clone::Clone for aya_ebpf_bindings::bindings::sk_reuseport_md__bindgen_ty_1
 pub fn aya_ebpf_bindings::bindings::sk_reuseport_md__bindgen_ty_1::clone(&self) -> aya_ebpf_bindings::bindings::sk_reuseport_md__bindgen_ty_1
 impl core::marker::Copy for aya_ebpf_bindings::bindings::sk_reuseport_md__bindgen_ty_1
+impl core::marker::Freeze for aya_ebpf_bindings::bindings::sk_reuseport_md__bindgen_ty_1
 impl !core::marker::Send for aya_ebpf_bindings::bindings::sk_reuseport_md__bindgen_ty_1
 impl !core::marker::Sync for aya_ebpf_bindings::bindings::sk_reuseport_md__bindgen_ty_1
 impl core::marker::Unpin for aya_ebpf_bindings::bindings::sk_reuseport_md__bindgen_ty_1
@@ -1719,6 +1762,7 @@ pub fn aya_ebpf_bindings::bindings::sk_reuseport_md__bindgen_ty_2::new_bitfield_
 impl core::clone::Clone for aya_ebpf_bindings::bindings::sk_reuseport_md__bindgen_ty_2
 pub fn aya_ebpf_bindings::bindings::sk_reuseport_md__bindgen_ty_2::clone(&self) -> aya_ebpf_bindings::bindings::sk_reuseport_md__bindgen_ty_2
 impl core::marker::Copy for aya_ebpf_bindings::bindings::sk_reuseport_md__bindgen_ty_2
+impl core::marker::Freeze for aya_ebpf_bindings::bindings::sk_reuseport_md__bindgen_ty_2
 impl !core::marker::Send for aya_ebpf_bindings::bindings::sk_reuseport_md__bindgen_ty_2
 impl !core::marker::Sync for aya_ebpf_bindings::bindings::sk_reuseport_md__bindgen_ty_2
 impl core::marker::Unpin for aya_ebpf_bindings::bindings::sk_reuseport_md__bindgen_ty_2
@@ -1749,6 +1793,7 @@ pub fn aya_ebpf_bindings::bindings::sk_reuseport_md__bindgen_ty_3::new_bitfield_
 impl core::clone::Clone for aya_ebpf_bindings::bindings::sk_reuseport_md__bindgen_ty_3
 pub fn aya_ebpf_bindings::bindings::sk_reuseport_md__bindgen_ty_3::clone(&self) -> aya_ebpf_bindings::bindings::sk_reuseport_md__bindgen_ty_3
 impl core::marker::Copy for aya_ebpf_bindings::bindings::sk_reuseport_md__bindgen_ty_3
+impl core::marker::Freeze for aya_ebpf_bindings::bindings::sk_reuseport_md__bindgen_ty_3
 impl !core::marker::Send for aya_ebpf_bindings::bindings::sk_reuseport_md__bindgen_ty_3
 impl !core::marker::Sync for aya_ebpf_bindings::bindings::sk_reuseport_md__bindgen_ty_3
 impl core::marker::Unpin for aya_ebpf_bindings::bindings::sk_reuseport_md__bindgen_ty_3
@@ -1779,6 +1824,7 @@ pub fn aya_ebpf_bindings::bindings::sk_reuseport_md__bindgen_ty_4::new_bitfield_
 impl core::clone::Clone for aya_ebpf_bindings::bindings::sk_reuseport_md__bindgen_ty_4
 pub fn aya_ebpf_bindings::bindings::sk_reuseport_md__bindgen_ty_4::clone(&self) -> aya_ebpf_bindings::bindings::sk_reuseport_md__bindgen_ty_4
 impl core::marker::Copy for aya_ebpf_bindings::bindings::sk_reuseport_md__bindgen_ty_4
+impl core::marker::Freeze for aya_ebpf_bindings::bindings::sk_reuseport_md__bindgen_ty_4
 impl !core::marker::Send for aya_ebpf_bindings::bindings::sk_reuseport_md__bindgen_ty_4
 impl !core::marker::Sync for aya_ebpf_bindings::bindings::sk_reuseport_md__bindgen_ty_4
 impl core::marker::Unpin for aya_ebpf_bindings::bindings::sk_reuseport_md__bindgen_ty_4
@@ -1825,6 +1871,7 @@ impl<Storage: core::hash::Hash> core::hash::Hash for aya_ebpf_bindings::bindings
 pub fn aya_ebpf_bindings::bindings::__BindgenBitfieldUnit<Storage>::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
 impl<Storage: core::marker::Copy> core::marker::Copy for aya_ebpf_bindings::bindings::__BindgenBitfieldUnit<Storage>
 impl<Storage> core::marker::StructuralPartialEq for aya_ebpf_bindings::bindings::__BindgenBitfieldUnit<Storage>
+impl<Storage> core::marker::Freeze for aya_ebpf_bindings::bindings::__BindgenBitfieldUnit<Storage> where Storage: core::marker::Freeze
 impl<Storage> core::marker::Send for aya_ebpf_bindings::bindings::__BindgenBitfieldUnit<Storage> where Storage: core::marker::Send
 impl<Storage> core::marker::Sync for aya_ebpf_bindings::bindings::__BindgenBitfieldUnit<Storage> where Storage: core::marker::Sync
 impl<Storage> core::marker::Unpin for aya_ebpf_bindings::bindings::__BindgenBitfieldUnit<Storage> where Storage: core::marker::Unpin
@@ -1857,6 +1904,7 @@ impl<T: core::default::Default> core::default::Default for aya_ebpf_bindings::bi
 pub fn aya_ebpf_bindings::bindings::__IncompleteArrayField<T>::default() -> aya_ebpf_bindings::bindings::__IncompleteArrayField<T>
 impl<T> core::fmt::Debug for aya_ebpf_bindings::bindings::__IncompleteArrayField<T>
 pub fn aya_ebpf_bindings::bindings::__IncompleteArrayField<T>::fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl<T> core::marker::Freeze for aya_ebpf_bindings::bindings::__IncompleteArrayField<T> where T: core::marker::Freeze
 impl<T> core::marker::Send for aya_ebpf_bindings::bindings::__IncompleteArrayField<T> where T: core::marker::Send
 impl<T> core::marker::Sync for aya_ebpf_bindings::bindings::__IncompleteArrayField<T> where T: core::marker::Sync
 impl<T> core::marker::Unpin for aya_ebpf_bindings::bindings::__IncompleteArrayField<T> where T: core::marker::Unpin
@@ -1920,6 +1968,7 @@ pub fn aya_ebpf_bindings::bindings::__sk_buff::new_bitfield_1() -> aya_ebpf_bind
 impl core::clone::Clone for aya_ebpf_bindings::bindings::__sk_buff
 pub fn aya_ebpf_bindings::bindings::__sk_buff::clone(&self) -> aya_ebpf_bindings::bindings::__sk_buff
 impl core::marker::Copy for aya_ebpf_bindings::bindings::__sk_buff
+impl core::marker::Freeze for aya_ebpf_bindings::bindings::__sk_buff
 impl !core::marker::Send for aya_ebpf_bindings::bindings::__sk_buff
 impl !core::marker::Sync for aya_ebpf_bindings::bindings::__sk_buff
 impl core::marker::Unpin for aya_ebpf_bindings::bindings::__sk_buff
@@ -1961,6 +2010,7 @@ pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_1::clone(&self) -> aya_
 impl core::fmt::Debug for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_1
 pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_1::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Copy for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_1
+impl core::marker::Freeze for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_1
 impl core::marker::Send for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_1
 impl core::marker::Sync for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_1
 impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_1
@@ -1995,6 +2045,7 @@ pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_10::clone(&self) -> aya
 impl core::fmt::Debug for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_10
 pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_10::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Copy for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_10
+impl core::marker::Freeze for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_10
 impl core::marker::Send for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_10
 impl core::marker::Sync for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_10
 impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_10
@@ -2024,6 +2075,7 @@ pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_11::clone(&self) -> aya
 impl core::fmt::Debug for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_11
 pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_11::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Copy for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_11
+impl core::marker::Freeze for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_11
 impl core::marker::Send for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_11
 impl core::marker::Sync for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_11
 impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_11
@@ -2057,6 +2109,7 @@ pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_12::clone(&self) -> aya
 impl core::fmt::Debug for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_12
 pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_12::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Copy for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_12
+impl core::marker::Freeze for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_12
 impl core::marker::Send for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_12
 impl core::marker::Sync for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_12
 impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_12
@@ -2093,6 +2146,7 @@ pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_13::clone(&self) -> aya
 impl core::fmt::Debug for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_13
 pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_13::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Copy for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_13
+impl core::marker::Freeze for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_13
 impl core::marker::Send for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_13
 impl core::marker::Sync for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_13
 impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_13
@@ -2123,6 +2177,7 @@ pub aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14::flags: aya_ebpf_bindin
 impl core::clone::Clone for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14
 pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14::clone(&self) -> aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14
 impl core::marker::Copy for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14
+impl core::marker::Freeze for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14
 impl core::marker::Send for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14
 impl core::marker::Sync for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14
 impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14
@@ -2152,6 +2207,7 @@ pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindg
 impl core::fmt::Debug for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_1
 pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_1::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Copy for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_1
+impl core::marker::Freeze for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_1
 impl core::marker::Send for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_1
 impl core::marker::Sync for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_1
 impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_1
@@ -2180,6 +2236,7 @@ pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindg
 impl core::fmt::Debug for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_2
 pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_2::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Copy for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_2
+impl core::marker::Freeze for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_2
 impl core::marker::Send for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_2
 impl core::marker::Sync for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_2
 impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_2
@@ -2212,6 +2269,7 @@ pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindg
 impl core::fmt::Debug for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_3
 pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_3::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Copy for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_3
+impl core::marker::Freeze for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_3
 impl core::marker::Send for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_3
 impl core::marker::Sync for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_3
 impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_3
@@ -2241,6 +2299,7 @@ pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindg
 impl core::fmt::Debug for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_4
 pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_4::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Copy for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_4
+impl core::marker::Freeze for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_4
 impl core::marker::Send for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_4
 impl core::marker::Sync for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_4
 impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_4
@@ -2272,6 +2331,7 @@ pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindg
 impl core::fmt::Debug for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_5
 pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_5::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Copy for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_5
+impl core::marker::Freeze for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_5
 impl core::marker::Send for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_5
 impl core::marker::Sync for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_5
 impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_5
@@ -2301,6 +2361,7 @@ pub aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_15::link_fd: aya_ebpf_bind
 impl core::clone::Clone for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_15
 pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_15::clone(&self) -> aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_15
 impl core::marker::Copy for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_15
+impl core::marker::Freeze for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_15
 impl core::marker::Send for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_15
 impl core::marker::Sync for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_15
 impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_15
@@ -2329,6 +2390,7 @@ pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_16::clone(&self) -> aya
 impl core::fmt::Debug for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_16
 pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_16::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Copy for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_16
+impl core::marker::Freeze for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_16
 impl core::marker::Send for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_16
 impl core::marker::Sync for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_16
 impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_16
@@ -2357,6 +2419,7 @@ pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_17::clone(&self) -> aya
 impl core::fmt::Debug for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_17
 pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_17::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Copy for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_17
+impl core::marker::Freeze for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_17
 impl core::marker::Send for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_17
 impl core::marker::Sync for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_17
 impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_17
@@ -2386,6 +2449,7 @@ pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_18::clone(&self) -> aya
 impl core::fmt::Debug for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_18
 pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_18::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Copy for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_18
+impl core::marker::Freeze for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_18
 impl core::marker::Send for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_18
 impl core::marker::Sync for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_18
 impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_18
@@ -2416,6 +2480,7 @@ pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_19::clone(&self) -> aya
 impl core::fmt::Debug for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_19
 pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_19::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Copy for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_19
+impl core::marker::Freeze for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_19
 impl core::marker::Send for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_19
 impl core::marker::Sync for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_19
 impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_19
@@ -2445,6 +2510,7 @@ pub aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_2::map_fd: aya_ebpf_bindin
 impl core::clone::Clone for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_2
 pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_2::clone(&self) -> aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_2
 impl core::marker::Copy for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_2
+impl core::marker::Freeze for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_2
 impl core::marker::Send for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_2
 impl core::marker::Sync for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_2
 impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_2
@@ -2480,6 +2546,7 @@ pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_3::clone(&self) -> aya_
 impl core::fmt::Debug for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_3
 pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_3::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Copy for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_3
+impl core::marker::Freeze for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_3
 impl core::marker::Send for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_3
 impl core::marker::Sync for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_3
 impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_3
@@ -2531,6 +2598,7 @@ pub aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_4::prog_type: aya_ebpf_bin
 impl core::clone::Clone for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_4
 pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_4::clone(&self) -> aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_4
 impl core::marker::Copy for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_4
+impl core::marker::Freeze for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_4
 impl core::marker::Send for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_4
 impl core::marker::Sync for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_4
 impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_4
@@ -2562,6 +2630,7 @@ pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_5::clone(&self) -> aya_
 impl core::fmt::Debug for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_5
 pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_5::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Copy for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_5
+impl core::marker::Freeze for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_5
 impl core::marker::Send for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_5
 impl core::marker::Sync for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_5
 impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_5
@@ -2594,6 +2663,7 @@ pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_6::clone(&self) -> aya_
 impl core::fmt::Debug for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_6
 pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_6::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Copy for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_6
+impl core::marker::Freeze for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_6
 impl core::marker::Send for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_6
 impl core::marker::Sync for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_6
 impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_6
@@ -2636,6 +2706,7 @@ pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_7::clone(&self) -> aya_
 impl core::fmt::Debug for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_7
 pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_7::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Copy for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_7
+impl core::marker::Freeze for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_7
 impl core::marker::Send for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_7
 impl core::marker::Sync for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_7
 impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_7
@@ -2664,6 +2735,7 @@ pub aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_8::open_flags: aya_ebpf_bi
 impl core::clone::Clone for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_8
 pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_8::clone(&self) -> aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_8
 impl core::marker::Copy for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_8
+impl core::marker::Freeze for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_8
 impl core::marker::Send for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_8
 impl core::marker::Sync for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_8
 impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_8
@@ -2694,6 +2766,7 @@ pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_9::clone(&self) -> aya_
 impl core::fmt::Debug for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_9
 pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_9::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Copy for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_9
+impl core::marker::Freeze for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_9
 impl core::marker::Send for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_9
 impl core::marker::Sync for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_9
 impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_9
@@ -2727,6 +2800,7 @@ pub fn aya_ebpf_bindings::bindings::bpf_btf_info::clone(&self) -> aya_ebpf_bindi
 impl core::fmt::Debug for aya_ebpf_bindings::bindings::bpf_btf_info
 pub fn aya_ebpf_bindings::bindings::bpf_btf_info::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Copy for aya_ebpf_bindings::bindings::bpf_btf_info
+impl core::marker::Freeze for aya_ebpf_bindings::bindings::bpf_btf_info
 impl core::marker::Send for aya_ebpf_bindings::bindings::bpf_btf_info
 impl core::marker::Sync for aya_ebpf_bindings::bindings::bpf_btf_info
 impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_btf_info
@@ -2757,6 +2831,7 @@ pub fn aya_ebpf_bindings::bindings::bpf_cgroup_dev_ctx::clone(&self) -> aya_ebpf
 impl core::fmt::Debug for aya_ebpf_bindings::bindings::bpf_cgroup_dev_ctx
 pub fn aya_ebpf_bindings::bindings::bpf_cgroup_dev_ctx::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Copy for aya_ebpf_bindings::bindings::bpf_cgroup_dev_ctx
+impl core::marker::Freeze for aya_ebpf_bindings::bindings::bpf_cgroup_dev_ctx
 impl core::marker::Send for aya_ebpf_bindings::bindings::bpf_cgroup_dev_ctx
 impl core::marker::Sync for aya_ebpf_bindings::bindings::bpf_cgroup_dev_ctx
 impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_cgroup_dev_ctx
@@ -2786,6 +2861,7 @@ pub fn aya_ebpf_bindings::bindings::bpf_cgroup_storage_key::clone(&self) -> aya_
 impl core::fmt::Debug for aya_ebpf_bindings::bindings::bpf_cgroup_storage_key
 pub fn aya_ebpf_bindings::bindings::bpf_cgroup_storage_key::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Copy for aya_ebpf_bindings::bindings::bpf_cgroup_storage_key
+impl core::marker::Freeze for aya_ebpf_bindings::bindings::bpf_cgroup_storage_key
 impl core::marker::Send for aya_ebpf_bindings::bindings::bpf_cgroup_storage_key
 impl core::marker::Sync for aya_ebpf_bindings::bindings::bpf_cgroup_storage_key
 impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_cgroup_storage_key
@@ -2817,6 +2893,7 @@ pub fn aya_ebpf_bindings::bindings::bpf_core_relo::clone(&self) -> aya_ebpf_bind
 impl core::fmt::Debug for aya_ebpf_bindings::bindings::bpf_core_relo
 pub fn aya_ebpf_bindings::bindings::bpf_core_relo::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Copy for aya_ebpf_bindings::bindings::bpf_core_relo
+impl core::marker::Freeze for aya_ebpf_bindings::bindings::bpf_core_relo
 impl core::marker::Send for aya_ebpf_bindings::bindings::bpf_core_relo
 impl core::marker::Sync for aya_ebpf_bindings::bindings::bpf_core_relo
 impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_core_relo
@@ -2844,6 +2921,7 @@ pub aya_ebpf_bindings::bindings::bpf_cpumap_val::qsize: aya_ebpf_bindings::bindi
 impl core::clone::Clone for aya_ebpf_bindings::bindings::bpf_cpumap_val
 pub fn aya_ebpf_bindings::bindings::bpf_cpumap_val::clone(&self) -> aya_ebpf_bindings::bindings::bpf_cpumap_val
 impl core::marker::Copy for aya_ebpf_bindings::bindings::bpf_cpumap_val
+impl core::marker::Freeze for aya_ebpf_bindings::bindings::bpf_cpumap_val
 impl core::marker::Send for aya_ebpf_bindings::bindings::bpf_cpumap_val
 impl core::marker::Sync for aya_ebpf_bindings::bindings::bpf_cpumap_val
 impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_cpumap_val
@@ -2871,6 +2949,7 @@ pub aya_ebpf_bindings::bindings::bpf_devmap_val::ifindex: aya_ebpf_bindings::bin
 impl core::clone::Clone for aya_ebpf_bindings::bindings::bpf_devmap_val
 pub fn aya_ebpf_bindings::bindings::bpf_devmap_val::clone(&self) -> aya_ebpf_bindings::bindings::bpf_devmap_val
 impl core::marker::Copy for aya_ebpf_bindings::bindings::bpf_devmap_val
+impl core::marker::Freeze for aya_ebpf_bindings::bindings::bpf_devmap_val
 impl core::marker::Send for aya_ebpf_bindings::bindings::bpf_devmap_val
 impl core::marker::Sync for aya_ebpf_bindings::bindings::bpf_devmap_val
 impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_devmap_val
@@ -2902,6 +2981,7 @@ pub fn aya_ebpf_bindings::bindings::bpf_dynptr::clone(&self) -> aya_ebpf_binding
 impl core::fmt::Debug for aya_ebpf_bindings::bindings::bpf_dynptr
 pub fn aya_ebpf_bindings::bindings::bpf_dynptr::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Copy for aya_ebpf_bindings::bindings::bpf_dynptr
+impl core::marker::Freeze for aya_ebpf_bindings::bindings::bpf_dynptr
 impl core::marker::Send for aya_ebpf_bindings::bindings::bpf_dynptr
 impl core::marker::Sync for aya_ebpf_bindings::bindings::bpf_dynptr
 impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_dynptr
@@ -2940,6 +3020,7 @@ pub aya_ebpf_bindings::bindings::bpf_fib_lookup::sport: aya_ebpf_bindings::bindi
 impl core::clone::Clone for aya_ebpf_bindings::bindings::bpf_fib_lookup
 pub fn aya_ebpf_bindings::bindings::bpf_fib_lookup::clone(&self) -> aya_ebpf_bindings::bindings::bpf_fib_lookup
 impl core::marker::Copy for aya_ebpf_bindings::bindings::bpf_fib_lookup
+impl core::marker::Freeze for aya_ebpf_bindings::bindings::bpf_fib_lookup
 impl core::marker::Send for aya_ebpf_bindings::bindings::bpf_fib_lookup
 impl core::marker::Sync for aya_ebpf_bindings::bindings::bpf_fib_lookup
 impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_fib_lookup
@@ -2978,6 +3059,7 @@ pub aya_ebpf_bindings::bindings::bpf_flow_keys::thoff: aya_ebpf_bindings::bindin
 impl core::clone::Clone for aya_ebpf_bindings::bindings::bpf_flow_keys
 pub fn aya_ebpf_bindings::bindings::bpf_flow_keys::clone(&self) -> aya_ebpf_bindings::bindings::bpf_flow_keys
 impl core::marker::Copy for aya_ebpf_bindings::bindings::bpf_flow_keys
+impl core::marker::Freeze for aya_ebpf_bindings::bindings::bpf_flow_keys
 impl core::marker::Send for aya_ebpf_bindings::bindings::bpf_flow_keys
 impl core::marker::Sync for aya_ebpf_bindings::bindings::bpf_flow_keys
 impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_flow_keys
@@ -3007,6 +3089,7 @@ pub fn aya_ebpf_bindings::bindings::bpf_flow_keys__bindgen_ty_1__bindgen_ty_1::c
 impl core::fmt::Debug for aya_ebpf_bindings::bindings::bpf_flow_keys__bindgen_ty_1__bindgen_ty_1
 pub fn aya_ebpf_bindings::bindings::bpf_flow_keys__bindgen_ty_1__bindgen_ty_1::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Copy for aya_ebpf_bindings::bindings::bpf_flow_keys__bindgen_ty_1__bindgen_ty_1
+impl core::marker::Freeze for aya_ebpf_bindings::bindings::bpf_flow_keys__bindgen_ty_1__bindgen_ty_1
 impl core::marker::Send for aya_ebpf_bindings::bindings::bpf_flow_keys__bindgen_ty_1__bindgen_ty_1
 impl core::marker::Sync for aya_ebpf_bindings::bindings::bpf_flow_keys__bindgen_ty_1__bindgen_ty_1
 impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_flow_keys__bindgen_ty_1__bindgen_ty_1
@@ -3036,6 +3119,7 @@ pub fn aya_ebpf_bindings::bindings::bpf_flow_keys__bindgen_ty_1__bindgen_ty_2::c
 impl core::fmt::Debug for aya_ebpf_bindings::bindings::bpf_flow_keys__bindgen_ty_1__bindgen_ty_2
 pub fn aya_ebpf_bindings::bindings::bpf_flow_keys__bindgen_ty_1__bindgen_ty_2::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Copy for aya_ebpf_bindings::bindings::bpf_flow_keys__bindgen_ty_1__bindgen_ty_2
+impl core::marker::Freeze for aya_ebpf_bindings::bindings::bpf_flow_keys__bindgen_ty_1__bindgen_ty_2
 impl core::marker::Send for aya_ebpf_bindings::bindings::bpf_flow_keys__bindgen_ty_1__bindgen_ty_2
 impl core::marker::Sync for aya_ebpf_bindings::bindings::bpf_flow_keys__bindgen_ty_1__bindgen_ty_2
 impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_flow_keys__bindgen_ty_1__bindgen_ty_2
@@ -3065,6 +3149,7 @@ pub fn aya_ebpf_bindings::bindings::bpf_func_info::clone(&self) -> aya_ebpf_bind
 impl core::fmt::Debug for aya_ebpf_bindings::bindings::bpf_func_info
 pub fn aya_ebpf_bindings::bindings::bpf_func_info::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Copy for aya_ebpf_bindings::bindings::bpf_func_info
+impl core::marker::Freeze for aya_ebpf_bindings::bindings::bpf_func_info
 impl core::marker::Send for aya_ebpf_bindings::bindings::bpf_func_info
 impl core::marker::Sync for aya_ebpf_bindings::bindings::bpf_func_info
 impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_func_info
@@ -3103,6 +3188,7 @@ pub fn aya_ebpf_bindings::bindings::bpf_insn::clone(&self) -> aya_ebpf_bindings:
 impl core::fmt::Debug for aya_ebpf_bindings::bindings::bpf_insn
 pub fn aya_ebpf_bindings::bindings::bpf_insn::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Copy for aya_ebpf_bindings::bindings::bpf_insn
+impl core::marker::Freeze for aya_ebpf_bindings::bindings::bpf_insn
 impl core::marker::Send for aya_ebpf_bindings::bindings::bpf_insn
 impl core::marker::Sync for aya_ebpf_bindings::bindings::bpf_insn
 impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_insn
@@ -3131,6 +3217,7 @@ pub fn aya_ebpf_bindings::bindings::bpf_iter_link_info__bindgen_ty_1::clone(&sel
 impl core::fmt::Debug for aya_ebpf_bindings::bindings::bpf_iter_link_info__bindgen_ty_1
 pub fn aya_ebpf_bindings::bindings::bpf_iter_link_info__bindgen_ty_1::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Copy for aya_ebpf_bindings::bindings::bpf_iter_link_info__bindgen_ty_1
+impl core::marker::Freeze for aya_ebpf_bindings::bindings::bpf_iter_link_info__bindgen_ty_1
 impl core::marker::Send for aya_ebpf_bindings::bindings::bpf_iter_link_info__bindgen_ty_1
 impl core::marker::Sync for aya_ebpf_bindings::bindings::bpf_iter_link_info__bindgen_ty_1
 impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_iter_link_info__bindgen_ty_1
@@ -3161,6 +3248,7 @@ pub fn aya_ebpf_bindings::bindings::bpf_iter_link_info__bindgen_ty_2::clone(&sel
 impl core::fmt::Debug for aya_ebpf_bindings::bindings::bpf_iter_link_info__bindgen_ty_2
 pub fn aya_ebpf_bindings::bindings::bpf_iter_link_info__bindgen_ty_2::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Copy for aya_ebpf_bindings::bindings::bpf_iter_link_info__bindgen_ty_2
+impl core::marker::Freeze for aya_ebpf_bindings::bindings::bpf_iter_link_info__bindgen_ty_2
 impl core::marker::Send for aya_ebpf_bindings::bindings::bpf_iter_link_info__bindgen_ty_2
 impl core::marker::Sync for aya_ebpf_bindings::bindings::bpf_iter_link_info__bindgen_ty_2
 impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_iter_link_info__bindgen_ty_2
@@ -3191,6 +3279,7 @@ pub fn aya_ebpf_bindings::bindings::bpf_iter_link_info__bindgen_ty_3::clone(&sel
 impl core::fmt::Debug for aya_ebpf_bindings::bindings::bpf_iter_link_info__bindgen_ty_3
 pub fn aya_ebpf_bindings::bindings::bpf_iter_link_info__bindgen_ty_3::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Copy for aya_ebpf_bindings::bindings::bpf_iter_link_info__bindgen_ty_3
+impl core::marker::Freeze for aya_ebpf_bindings::bindings::bpf_iter_link_info__bindgen_ty_3
 impl core::marker::Send for aya_ebpf_bindings::bindings::bpf_iter_link_info__bindgen_ty_3
 impl core::marker::Sync for aya_ebpf_bindings::bindings::bpf_iter_link_info__bindgen_ty_3
 impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_iter_link_info__bindgen_ty_3
@@ -3219,6 +3308,7 @@ pub fn aya_ebpf_bindings::bindings::bpf_iter_num::clone(&self) -> aya_ebpf_bindi
 impl core::fmt::Debug for aya_ebpf_bindings::bindings::bpf_iter_num
 pub fn aya_ebpf_bindings::bindings::bpf_iter_num::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Copy for aya_ebpf_bindings::bindings::bpf_iter_num
+impl core::marker::Freeze for aya_ebpf_bindings::bindings::bpf_iter_num
 impl core::marker::Send for aya_ebpf_bindings::bindings::bpf_iter_num
 impl core::marker::Sync for aya_ebpf_bindings::bindings::bpf_iter_num
 impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_iter_num
@@ -3250,6 +3340,7 @@ pub fn aya_ebpf_bindings::bindings::bpf_line_info::clone(&self) -> aya_ebpf_bind
 impl core::fmt::Debug for aya_ebpf_bindings::bindings::bpf_line_info
 pub fn aya_ebpf_bindings::bindings::bpf_line_info::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Copy for aya_ebpf_bindings::bindings::bpf_line_info
+impl core::marker::Freeze for aya_ebpf_bindings::bindings::bpf_line_info
 impl core::marker::Send for aya_ebpf_bindings::bindings::bpf_line_info
 impl core::marker::Sync for aya_ebpf_bindings::bindings::bpf_line_info
 impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_line_info
@@ -3279,6 +3370,7 @@ pub aya_ebpf_bindings::bindings::bpf_link_info::type_: aya_ebpf_bindings::bindin
 impl core::clone::Clone for aya_ebpf_bindings::bindings::bpf_link_info
 pub fn aya_ebpf_bindings::bindings::bpf_link_info::clone(&self) -> aya_ebpf_bindings::bindings::bpf_link_info
 impl core::marker::Copy for aya_ebpf_bindings::bindings::bpf_link_info
+impl core::marker::Freeze for aya_ebpf_bindings::bindings::bpf_link_info
 impl core::marker::Send for aya_ebpf_bindings::bindings::bpf_link_info
 impl core::marker::Sync for aya_ebpf_bindings::bindings::bpf_link_info
 impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_link_info
@@ -3308,6 +3400,7 @@ pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_1::c
 impl core::fmt::Debug for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_1
 pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_1::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Copy for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_1
+impl core::marker::Freeze for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_1
 impl core::marker::Send for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_1
 impl core::marker::Sync for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_1
 impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_1
@@ -3338,6 +3431,7 @@ pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_2::c
 impl core::fmt::Debug for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_2
 pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_2::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Copy for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_2
+impl core::marker::Freeze for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_2
 impl core::marker::Send for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_2
 impl core::marker::Sync for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_2
 impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_2
@@ -3367,6 +3461,7 @@ pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_3::c
 impl core::fmt::Debug for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_3
 pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_3::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Copy for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_3
+impl core::marker::Freeze for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_3
 impl core::marker::Send for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_3
 impl core::marker::Sync for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_3
 impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_3
@@ -3396,6 +3491,7 @@ pub aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4::targ
 impl core::clone::Clone for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4
 pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4::clone(&self) -> aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4
 impl core::marker::Copy for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4
+impl core::marker::Freeze for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4
 impl core::marker::Send for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4
 impl core::marker::Sync for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4
 impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4
@@ -3424,6 +3520,7 @@ pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4__b
 impl core::fmt::Debug for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_1__bindgen_ty_1
 pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_1__bindgen_ty_1::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Copy for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_1__bindgen_ty_1
+impl core::marker::Freeze for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_1__bindgen_ty_1
 impl core::marker::Send for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_1__bindgen_ty_1
 impl core::marker::Sync for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_1__bindgen_ty_1
 impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_1__bindgen_ty_1
@@ -3453,6 +3550,7 @@ pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4__b
 impl core::fmt::Debug for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2__bindgen_ty_1
 pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2__bindgen_ty_1::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Copy for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2__bindgen_ty_1
+impl core::marker::Freeze for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2__bindgen_ty_1
 impl core::marker::Send for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2__bindgen_ty_1
 impl core::marker::Sync for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2__bindgen_ty_1
 impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2__bindgen_ty_1
@@ -3482,6 +3580,7 @@ pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4__b
 impl core::fmt::Debug for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2__bindgen_ty_2
 pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2__bindgen_ty_2::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Copy for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2__bindgen_ty_2
+impl core::marker::Freeze for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2__bindgen_ty_2
 impl core::marker::Send for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2__bindgen_ty_2
 impl core::marker::Sync for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2__bindgen_ty_2
 impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2__bindgen_ty_2
@@ -3511,6 +3610,7 @@ pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_5::c
 impl core::fmt::Debug for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_5
 pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_5::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Copy for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_5
+impl core::marker::Freeze for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_5
 impl core::marker::Send for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_5
 impl core::marker::Sync for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_5
 impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_5
@@ -3539,6 +3639,7 @@ pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_6::c
 impl core::fmt::Debug for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_6
 pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_6::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Copy for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_6
+impl core::marker::Freeze for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_6
 impl core::marker::Send for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_6
 impl core::marker::Sync for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_6
 impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_6
@@ -3567,6 +3668,7 @@ pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_7::c
 impl core::fmt::Debug for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_7
 pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_7::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Copy for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_7
+impl core::marker::Freeze for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_7
 impl core::marker::Send for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_7
 impl core::marker::Sync for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_7
 impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_7
@@ -3598,6 +3700,7 @@ pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_8::c
 impl core::fmt::Debug for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_8
 pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_8::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Copy for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_8
+impl core::marker::Freeze for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_8
 impl core::marker::Send for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_8
 impl core::marker::Sync for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_8
 impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_8
@@ -3629,6 +3732,7 @@ pub fn aya_ebpf_bindings::bindings::bpf_list_head::clone(&self) -> aya_ebpf_bind
 impl core::fmt::Debug for aya_ebpf_bindings::bindings::bpf_list_head
 pub fn aya_ebpf_bindings::bindings::bpf_list_head::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Copy for aya_ebpf_bindings::bindings::bpf_list_head
+impl core::marker::Freeze for aya_ebpf_bindings::bindings::bpf_list_head
 impl core::marker::Send for aya_ebpf_bindings::bindings::bpf_list_head
 impl core::marker::Sync for aya_ebpf_bindings::bindings::bpf_list_head
 impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_list_head
@@ -3660,6 +3764,7 @@ pub fn aya_ebpf_bindings::bindings::bpf_list_node::clone(&self) -> aya_ebpf_bind
 impl core::fmt::Debug for aya_ebpf_bindings::bindings::bpf_list_node
 pub fn aya_ebpf_bindings::bindings::bpf_list_node::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Copy for aya_ebpf_bindings::bindings::bpf_list_node
+impl core::marker::Freeze for aya_ebpf_bindings::bindings::bpf_list_node
 impl core::marker::Send for aya_ebpf_bindings::bindings::bpf_list_node
 impl core::marker::Sync for aya_ebpf_bindings::bindings::bpf_list_node
 impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_list_node
@@ -3686,6 +3791,7 @@ pub aya_ebpf_bindings::bindings::bpf_lpm_trie_key::data: aya_ebpf_bindings::bind
 pub aya_ebpf_bindings::bindings::bpf_lpm_trie_key::prefixlen: aya_ebpf_bindings::bindings::__u32
 impl core::fmt::Debug for aya_ebpf_bindings::bindings::bpf_lpm_trie_key
 pub fn aya_ebpf_bindings::bindings::bpf_lpm_trie_key::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for aya_ebpf_bindings::bindings::bpf_lpm_trie_key
 impl core::marker::Send for aya_ebpf_bindings::bindings::bpf_lpm_trie_key
 impl core::marker::Sync for aya_ebpf_bindings::bindings::bpf_lpm_trie_key
 impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_lpm_trie_key
@@ -3720,6 +3826,7 @@ pub fn aya_ebpf_bindings::bindings::bpf_map_def::clone(&self) -> aya_ebpf_bindin
 impl core::fmt::Debug for aya_ebpf_bindings::bindings::bpf_map_def
 pub fn aya_ebpf_bindings::bindings::bpf_map_def::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Copy for aya_ebpf_bindings::bindings::bpf_map_def
+impl core::marker::Freeze for aya_ebpf_bindings::bindings::bpf_map_def
 impl core::marker::Send for aya_ebpf_bindings::bindings::bpf_map_def
 impl core::marker::Sync for aya_ebpf_bindings::bindings::bpf_map_def
 impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_map_def
@@ -3766,6 +3873,7 @@ pub fn aya_ebpf_bindings::bindings::bpf_map_info::clone(&self) -> aya_ebpf_bindi
 impl core::fmt::Debug for aya_ebpf_bindings::bindings::bpf_map_info
 pub fn aya_ebpf_bindings::bindings::bpf_map_info::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Copy for aya_ebpf_bindings::bindings::bpf_map_info
+impl core::marker::Freeze for aya_ebpf_bindings::bindings::bpf_map_info
 impl core::marker::Send for aya_ebpf_bindings::bindings::bpf_map_info
 impl core::marker::Sync for aya_ebpf_bindings::bindings::bpf_map_info
 impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_map_info
@@ -3793,6 +3901,7 @@ pub fn aya_ebpf_bindings::bindings::bpf_perf_event_data::clone(&self) -> aya_ebp
 impl core::fmt::Debug for aya_ebpf_bindings::bindings::bpf_perf_event_data
 pub fn aya_ebpf_bindings::bindings::bpf_perf_event_data::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Copy for aya_ebpf_bindings::bindings::bpf_perf_event_data
+impl core::marker::Freeze for aya_ebpf_bindings::bindings::bpf_perf_event_data
 impl core::marker::Send for aya_ebpf_bindings::bindings::bpf_perf_event_data
 impl core::marker::Sync for aya_ebpf_bindings::bindings::bpf_perf_event_data
 impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_perf_event_data
@@ -3823,6 +3932,7 @@ pub fn aya_ebpf_bindings::bindings::bpf_perf_event_value::clone(&self) -> aya_eb
 impl core::fmt::Debug for aya_ebpf_bindings::bindings::bpf_perf_event_value
 pub fn aya_ebpf_bindings::bindings::bpf_perf_event_value::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Copy for aya_ebpf_bindings::bindings::bpf_perf_event_value
+impl core::marker::Freeze for aya_ebpf_bindings::bindings::bpf_perf_event_value
 impl core::marker::Send for aya_ebpf_bindings::bindings::bpf_perf_event_value
 impl core::marker::Sync for aya_ebpf_bindings::bindings::bpf_perf_event_value
 impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_perf_event_value
@@ -3852,6 +3962,7 @@ pub fn aya_ebpf_bindings::bindings::bpf_pidns_info::clone(&self) -> aya_ebpf_bin
 impl core::fmt::Debug for aya_ebpf_bindings::bindings::bpf_pidns_info
 pub fn aya_ebpf_bindings::bindings::bpf_pidns_info::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Copy for aya_ebpf_bindings::bindings::bpf_pidns_info
+impl core::marker::Freeze for aya_ebpf_bindings::bindings::bpf_pidns_info
 impl core::marker::Send for aya_ebpf_bindings::bindings::bpf_pidns_info
 impl core::marker::Sync for aya_ebpf_bindings::bindings::bpf_pidns_info
 impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_pidns_info
@@ -3922,6 +4033,7 @@ pub fn aya_ebpf_bindings::bindings::bpf_prog_info::clone(&self) -> aya_ebpf_bind
 impl core::fmt::Debug for aya_ebpf_bindings::bindings::bpf_prog_info
 pub fn aya_ebpf_bindings::bindings::bpf_prog_info::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Copy for aya_ebpf_bindings::bindings::bpf_prog_info
+impl core::marker::Freeze for aya_ebpf_bindings::bindings::bpf_prog_info
 impl core::marker::Send for aya_ebpf_bindings::bindings::bpf_prog_info
 impl core::marker::Sync for aya_ebpf_bindings::bindings::bpf_prog_info
 impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_prog_info
@@ -3947,6 +4059,7 @@ pub fn aya_ebpf_bindings::bindings::bpf_prog_info::from(t: T) -> T
 pub aya_ebpf_bindings::bindings::bpf_raw_tracepoint_args::args: aya_ebpf_bindings::bindings::__IncompleteArrayField<aya_ebpf_bindings::bindings::__u64>
 impl core::fmt::Debug for aya_ebpf_bindings::bindings::bpf_raw_tracepoint_args
 pub fn aya_ebpf_bindings::bindings::bpf_raw_tracepoint_args::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for aya_ebpf_bindings::bindings::bpf_raw_tracepoint_args
 impl core::marker::Send for aya_ebpf_bindings::bindings::bpf_raw_tracepoint_args
 impl core::marker::Sync for aya_ebpf_bindings::bindings::bpf_raw_tracepoint_args
 impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_raw_tracepoint_args
@@ -3978,6 +4091,7 @@ pub fn aya_ebpf_bindings::bindings::bpf_rb_node::clone(&self) -> aya_ebpf_bindin
 impl core::fmt::Debug for aya_ebpf_bindings::bindings::bpf_rb_node
 pub fn aya_ebpf_bindings::bindings::bpf_rb_node::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Copy for aya_ebpf_bindings::bindings::bpf_rb_node
+impl core::marker::Freeze for aya_ebpf_bindings::bindings::bpf_rb_node
 impl core::marker::Send for aya_ebpf_bindings::bindings::bpf_rb_node
 impl core::marker::Sync for aya_ebpf_bindings::bindings::bpf_rb_node
 impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_rb_node
@@ -4009,6 +4123,7 @@ pub fn aya_ebpf_bindings::bindings::bpf_rb_root::clone(&self) -> aya_ebpf_bindin
 impl core::fmt::Debug for aya_ebpf_bindings::bindings::bpf_rb_root
 pub fn aya_ebpf_bindings::bindings::bpf_rb_root::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Copy for aya_ebpf_bindings::bindings::bpf_rb_root
+impl core::marker::Freeze for aya_ebpf_bindings::bindings::bpf_rb_root
 impl core::marker::Send for aya_ebpf_bindings::bindings::bpf_rb_root
 impl core::marker::Sync for aya_ebpf_bindings::bindings::bpf_rb_root
 impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_rb_root
@@ -4036,6 +4151,7 @@ pub aya_ebpf_bindings::bindings::bpf_redir_neigh::nh_family: aya_ebpf_bindings::
 impl core::clone::Clone for aya_ebpf_bindings::bindings::bpf_redir_neigh
 pub fn aya_ebpf_bindings::bindings::bpf_redir_neigh::clone(&self) -> aya_ebpf_bindings::bindings::bpf_redir_neigh
 impl core::marker::Copy for aya_ebpf_bindings::bindings::bpf_redir_neigh
+impl core::marker::Freeze for aya_ebpf_bindings::bindings::bpf_redir_neigh
 impl core::marker::Send for aya_ebpf_bindings::bindings::bpf_redir_neigh
 impl core::marker::Sync for aya_ebpf_bindings::bindings::bpf_redir_neigh
 impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_redir_neigh
@@ -4067,6 +4183,7 @@ pub fn aya_ebpf_bindings::bindings::bpf_refcount::clone(&self) -> aya_ebpf_bindi
 impl core::fmt::Debug for aya_ebpf_bindings::bindings::bpf_refcount
 pub fn aya_ebpf_bindings::bindings::bpf_refcount::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Copy for aya_ebpf_bindings::bindings::bpf_refcount
+impl core::marker::Freeze for aya_ebpf_bindings::bindings::bpf_refcount
 impl core::marker::Send for aya_ebpf_bindings::bindings::bpf_refcount
 impl core::marker::Sync for aya_ebpf_bindings::bindings::bpf_refcount
 impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_refcount
@@ -4106,6 +4223,7 @@ pub fn aya_ebpf_bindings::bindings::bpf_sk_lookup::new_bitfield_1() -> aya_ebpf_
 impl core::clone::Clone for aya_ebpf_bindings::bindings::bpf_sk_lookup
 pub fn aya_ebpf_bindings::bindings::bpf_sk_lookup::clone(&self) -> aya_ebpf_bindings::bindings::bpf_sk_lookup
 impl core::marker::Copy for aya_ebpf_bindings::bindings::bpf_sk_lookup
+impl core::marker::Freeze for aya_ebpf_bindings::bindings::bpf_sk_lookup
 impl !core::marker::Send for aya_ebpf_bindings::bindings::bpf_sk_lookup
 impl !core::marker::Sync for aya_ebpf_bindings::bindings::bpf_sk_lookup
 impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_sk_lookup
@@ -4151,6 +4269,7 @@ pub fn aya_ebpf_bindings::bindings::bpf_sock::clone(&self) -> aya_ebpf_bindings:
 impl core::fmt::Debug for aya_ebpf_bindings::bindings::bpf_sock
 pub fn aya_ebpf_bindings::bindings::bpf_sock::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Copy for aya_ebpf_bindings::bindings::bpf_sock
+impl core::marker::Freeze for aya_ebpf_bindings::bindings::bpf_sock
 impl core::marker::Send for aya_ebpf_bindings::bindings::bpf_sock
 impl core::marker::Sync for aya_ebpf_bindings::bindings::bpf_sock
 impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_sock
@@ -4186,6 +4305,7 @@ pub aya_ebpf_bindings::bindings::bpf_sock_addr::user_port: aya_ebpf_bindings::bi
 impl core::clone::Clone for aya_ebpf_bindings::bindings::bpf_sock_addr
 pub fn aya_ebpf_bindings::bindings::bpf_sock_addr::clone(&self) -> aya_ebpf_bindings::bindings::bpf_sock_addr
 impl core::marker::Copy for aya_ebpf_bindings::bindings::bpf_sock_addr
+impl core::marker::Freeze for aya_ebpf_bindings::bindings::bpf_sock_addr
 impl !core::marker::Send for aya_ebpf_bindings::bindings::bpf_sock_addr
 impl !core::marker::Sync for aya_ebpf_bindings::bindings::bpf_sock_addr
 impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_sock_addr
@@ -4252,6 +4372,7 @@ pub aya_ebpf_bindings::bindings::bpf_sock_ops::total_retrans: aya_ebpf_bindings:
 impl core::clone::Clone for aya_ebpf_bindings::bindings::bpf_sock_ops
 pub fn aya_ebpf_bindings::bindings::bpf_sock_ops::clone(&self) -> aya_ebpf_bindings::bindings::bpf_sock_ops
 impl core::marker::Copy for aya_ebpf_bindings::bindings::bpf_sock_ops
+impl core::marker::Freeze for aya_ebpf_bindings::bindings::bpf_sock_ops
 impl !core::marker::Send for aya_ebpf_bindings::bindings::bpf_sock_ops
 impl !core::marker::Sync for aya_ebpf_bindings::bindings::bpf_sock_ops
 impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_sock_ops
@@ -4278,6 +4399,7 @@ pub aya_ebpf_bindings::bindings::bpf_sock_tuple::__bindgen_anon_1: aya_ebpf_bind
 impl core::clone::Clone for aya_ebpf_bindings::bindings::bpf_sock_tuple
 pub fn aya_ebpf_bindings::bindings::bpf_sock_tuple::clone(&self) -> aya_ebpf_bindings::bindings::bpf_sock_tuple
 impl core::marker::Copy for aya_ebpf_bindings::bindings::bpf_sock_tuple
+impl core::marker::Freeze for aya_ebpf_bindings::bindings::bpf_sock_tuple
 impl core::marker::Send for aya_ebpf_bindings::bindings::bpf_sock_tuple
 impl core::marker::Sync for aya_ebpf_bindings::bindings::bpf_sock_tuple
 impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_sock_tuple
@@ -4309,6 +4431,7 @@ pub fn aya_ebpf_bindings::bindings::bpf_sock_tuple__bindgen_ty_1__bindgen_ty_1::
 impl core::fmt::Debug for aya_ebpf_bindings::bindings::bpf_sock_tuple__bindgen_ty_1__bindgen_ty_1
 pub fn aya_ebpf_bindings::bindings::bpf_sock_tuple__bindgen_ty_1__bindgen_ty_1::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Copy for aya_ebpf_bindings::bindings::bpf_sock_tuple__bindgen_ty_1__bindgen_ty_1
+impl core::marker::Freeze for aya_ebpf_bindings::bindings::bpf_sock_tuple__bindgen_ty_1__bindgen_ty_1
 impl core::marker::Send for aya_ebpf_bindings::bindings::bpf_sock_tuple__bindgen_ty_1__bindgen_ty_1
 impl core::marker::Sync for aya_ebpf_bindings::bindings::bpf_sock_tuple__bindgen_ty_1__bindgen_ty_1
 impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_sock_tuple__bindgen_ty_1__bindgen_ty_1
@@ -4340,6 +4463,7 @@ pub fn aya_ebpf_bindings::bindings::bpf_sock_tuple__bindgen_ty_1__bindgen_ty_2::
 impl core::fmt::Debug for aya_ebpf_bindings::bindings::bpf_sock_tuple__bindgen_ty_1__bindgen_ty_2
 pub fn aya_ebpf_bindings::bindings::bpf_sock_tuple__bindgen_ty_1__bindgen_ty_2::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Copy for aya_ebpf_bindings::bindings::bpf_sock_tuple__bindgen_ty_1__bindgen_ty_2
+impl core::marker::Freeze for aya_ebpf_bindings::bindings::bpf_sock_tuple__bindgen_ty_1__bindgen_ty_2
 impl core::marker::Send for aya_ebpf_bindings::bindings::bpf_sock_tuple__bindgen_ty_1__bindgen_ty_2
 impl core::marker::Sync for aya_ebpf_bindings::bindings::bpf_sock_tuple__bindgen_ty_1__bindgen_ty_2
 impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_sock_tuple__bindgen_ty_1__bindgen_ty_2
@@ -4372,6 +4496,7 @@ pub aya_ebpf_bindings::bindings::bpf_sockopt::retval: aya_ebpf_bindings::binding
 impl core::clone::Clone for aya_ebpf_bindings::bindings::bpf_sockopt
 pub fn aya_ebpf_bindings::bindings::bpf_sockopt::clone(&self) -> aya_ebpf_bindings::bindings::bpf_sockopt
 impl core::marker::Copy for aya_ebpf_bindings::bindings::bpf_sockopt
+impl core::marker::Freeze for aya_ebpf_bindings::bindings::bpf_sockopt
 impl !core::marker::Send for aya_ebpf_bindings::bindings::bpf_sockopt
 impl !core::marker::Sync for aya_ebpf_bindings::bindings::bpf_sockopt
 impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_sockopt
@@ -4400,6 +4525,7 @@ pub fn aya_ebpf_bindings::bindings::bpf_spin_lock::clone(&self) -> aya_ebpf_bind
 impl core::fmt::Debug for aya_ebpf_bindings::bindings::bpf_spin_lock
 pub fn aya_ebpf_bindings::bindings::bpf_spin_lock::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Copy for aya_ebpf_bindings::bindings::bpf_spin_lock
+impl core::marker::Freeze for aya_ebpf_bindings::bindings::bpf_spin_lock
 impl core::marker::Send for aya_ebpf_bindings::bindings::bpf_spin_lock
 impl core::marker::Sync for aya_ebpf_bindings::bindings::bpf_spin_lock
 impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_spin_lock
@@ -4428,6 +4554,7 @@ pub aya_ebpf_bindings::bindings::bpf_stack_build_id::status: aya_ebpf_bindings::
 impl core::clone::Clone for aya_ebpf_bindings::bindings::bpf_stack_build_id
 pub fn aya_ebpf_bindings::bindings::bpf_stack_build_id::clone(&self) -> aya_ebpf_bindings::bindings::bpf_stack_build_id
 impl core::marker::Copy for aya_ebpf_bindings::bindings::bpf_stack_build_id
+impl core::marker::Freeze for aya_ebpf_bindings::bindings::bpf_stack_build_id
 impl core::marker::Send for aya_ebpf_bindings::bindings::bpf_stack_build_id
 impl core::marker::Sync for aya_ebpf_bindings::bindings::bpf_stack_build_id
 impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_stack_build_id
@@ -4457,6 +4584,7 @@ pub fn aya_ebpf_bindings::bindings::bpf_sysctl::clone(&self) -> aya_ebpf_binding
 impl core::fmt::Debug for aya_ebpf_bindings::bindings::bpf_sysctl
 pub fn aya_ebpf_bindings::bindings::bpf_sysctl::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Copy for aya_ebpf_bindings::bindings::bpf_sysctl
+impl core::marker::Freeze for aya_ebpf_bindings::bindings::bpf_sysctl
 impl core::marker::Send for aya_ebpf_bindings::bindings::bpf_sysctl
 impl core::marker::Sync for aya_ebpf_bindings::bindings::bpf_sysctl
 impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_sysctl
@@ -4510,6 +4638,7 @@ pub fn aya_ebpf_bindings::bindings::bpf_tcp_sock::clone(&self) -> aya_ebpf_bindi
 impl core::fmt::Debug for aya_ebpf_bindings::bindings::bpf_tcp_sock
 pub fn aya_ebpf_bindings::bindings::bpf_tcp_sock::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Copy for aya_ebpf_bindings::bindings::bpf_tcp_sock
+impl core::marker::Freeze for aya_ebpf_bindings::bindings::bpf_tcp_sock
 impl core::marker::Send for aya_ebpf_bindings::bindings::bpf_tcp_sock
 impl core::marker::Sync for aya_ebpf_bindings::bindings::bpf_tcp_sock
 impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_tcp_sock
@@ -4541,6 +4670,7 @@ pub fn aya_ebpf_bindings::bindings::bpf_timer::clone(&self) -> aya_ebpf_bindings
 impl core::fmt::Debug for aya_ebpf_bindings::bindings::bpf_timer
 pub fn aya_ebpf_bindings::bindings::bpf_timer::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Copy for aya_ebpf_bindings::bindings::bpf_timer
+impl core::marker::Freeze for aya_ebpf_bindings::bindings::bpf_timer
 impl core::marker::Send for aya_ebpf_bindings::bindings::bpf_timer
 impl core::marker::Sync for aya_ebpf_bindings::bindings::bpf_timer
 impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_timer
@@ -4573,6 +4703,7 @@ pub aya_ebpf_bindings::bindings::bpf_tunnel_key::tunnel_ttl: aya_ebpf_bindings::
 impl core::clone::Clone for aya_ebpf_bindings::bindings::bpf_tunnel_key
 pub fn aya_ebpf_bindings::bindings::bpf_tunnel_key::clone(&self) -> aya_ebpf_bindings::bindings::bpf_tunnel_key
 impl core::marker::Copy for aya_ebpf_bindings::bindings::bpf_tunnel_key
+impl core::marker::Freeze for aya_ebpf_bindings::bindings::bpf_tunnel_key
 impl core::marker::Send for aya_ebpf_bindings::bindings::bpf_tunnel_key
 impl core::marker::Sync for aya_ebpf_bindings::bindings::bpf_tunnel_key
 impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_tunnel_key
@@ -4601,6 +4732,7 @@ pub fn aya_ebpf_bindings::bindings::bpf_xdp_sock::clone(&self) -> aya_ebpf_bindi
 impl core::fmt::Debug for aya_ebpf_bindings::bindings::bpf_xdp_sock
 pub fn aya_ebpf_bindings::bindings::bpf_xdp_sock::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Copy for aya_ebpf_bindings::bindings::bpf_xdp_sock
+impl core::marker::Freeze for aya_ebpf_bindings::bindings::bpf_xdp_sock
 impl core::marker::Send for aya_ebpf_bindings::bindings::bpf_xdp_sock
 impl core::marker::Sync for aya_ebpf_bindings::bindings::bpf_xdp_sock
 impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_xdp_sock
@@ -4631,6 +4763,7 @@ pub aya_ebpf_bindings::bindings::bpf_xfrm_state::spi: aya_ebpf_bindings::binding
 impl core::clone::Clone for aya_ebpf_bindings::bindings::bpf_xfrm_state
 pub fn aya_ebpf_bindings::bindings::bpf_xfrm_state::clone(&self) -> aya_ebpf_bindings::bindings::bpf_xfrm_state
 impl core::marker::Copy for aya_ebpf_bindings::bindings::bpf_xfrm_state
+impl core::marker::Freeze for aya_ebpf_bindings::bindings::bpf_xfrm_state
 impl core::marker::Send for aya_ebpf_bindings::bindings::bpf_xfrm_state
 impl core::marker::Sync for aya_ebpf_bindings::bindings::bpf_xfrm_state
 impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_xfrm_state
@@ -4661,6 +4794,7 @@ pub fn aya_ebpf_bindings::bindings::btf_ptr::clone(&self) -> aya_ebpf_bindings::
 impl core::fmt::Debug for aya_ebpf_bindings::bindings::btf_ptr
 pub fn aya_ebpf_bindings::bindings::btf_ptr::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Copy for aya_ebpf_bindings::bindings::btf_ptr
+impl core::marker::Freeze for aya_ebpf_bindings::bindings::btf_ptr
 impl !core::marker::Send for aya_ebpf_bindings::bindings::btf_ptr
 impl !core::marker::Sync for aya_ebpf_bindings::bindings::btf_ptr
 impl core::marker::Unpin for aya_ebpf_bindings::bindings::btf_ptr
@@ -4688,6 +4822,7 @@ pub fn aya_ebpf_bindings::bindings::cgroup::clone(&self) -> aya_ebpf_bindings::b
 impl core::fmt::Debug for aya_ebpf_bindings::bindings::cgroup
 pub fn aya_ebpf_bindings::bindings::cgroup::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Copy for aya_ebpf_bindings::bindings::cgroup
+impl core::marker::Freeze for aya_ebpf_bindings::bindings::cgroup
 impl core::marker::Send for aya_ebpf_bindings::bindings::cgroup
 impl core::marker::Sync for aya_ebpf_bindings::bindings::cgroup
 impl core::marker::Unpin for aya_ebpf_bindings::bindings::cgroup
@@ -4715,6 +4850,7 @@ pub fn aya_ebpf_bindings::bindings::file::clone(&self) -> aya_ebpf_bindings::bin
 impl core::fmt::Debug for aya_ebpf_bindings::bindings::file
 pub fn aya_ebpf_bindings::bindings::file::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Copy for aya_ebpf_bindings::bindings::file
+impl core::marker::Freeze for aya_ebpf_bindings::bindings::file
 impl core::marker::Send for aya_ebpf_bindings::bindings::file
 impl core::marker::Sync for aya_ebpf_bindings::bindings::file
 impl core::marker::Unpin for aya_ebpf_bindings::bindings::file
@@ -4742,6 +4878,7 @@ pub fn aya_ebpf_bindings::bindings::inode::clone(&self) -> aya_ebpf_bindings::bi
 impl core::fmt::Debug for aya_ebpf_bindings::bindings::inode
 pub fn aya_ebpf_bindings::bindings::inode::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Copy for aya_ebpf_bindings::bindings::inode
+impl core::marker::Freeze for aya_ebpf_bindings::bindings::inode
 impl core::marker::Send for aya_ebpf_bindings::bindings::inode
 impl core::marker::Sync for aya_ebpf_bindings::bindings::inode
 impl core::marker::Unpin for aya_ebpf_bindings::bindings::inode
@@ -4769,6 +4906,7 @@ pub fn aya_ebpf_bindings::bindings::iphdr::clone(&self) -> aya_ebpf_bindings::bi
 impl core::fmt::Debug for aya_ebpf_bindings::bindings::iphdr
 pub fn aya_ebpf_bindings::bindings::iphdr::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Copy for aya_ebpf_bindings::bindings::iphdr
+impl core::marker::Freeze for aya_ebpf_bindings::bindings::iphdr
 impl core::marker::Send for aya_ebpf_bindings::bindings::iphdr
 impl core::marker::Sync for aya_ebpf_bindings::bindings::iphdr
 impl core::marker::Unpin for aya_ebpf_bindings::bindings::iphdr
@@ -4796,6 +4934,7 @@ pub fn aya_ebpf_bindings::bindings::ipv6hdr::clone(&self) -> aya_ebpf_bindings::
 impl core::fmt::Debug for aya_ebpf_bindings::bindings::ipv6hdr
 pub fn aya_ebpf_bindings::bindings::ipv6hdr::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Copy for aya_ebpf_bindings::bindings::ipv6hdr
+impl core::marker::Freeze for aya_ebpf_bindings::bindings::ipv6hdr
 impl core::marker::Send for aya_ebpf_bindings::bindings::ipv6hdr
 impl core::marker::Sync for aya_ebpf_bindings::bindings::ipv6hdr
 impl core::marker::Unpin for aya_ebpf_bindings::bindings::ipv6hdr
@@ -4823,6 +4962,7 @@ pub fn aya_ebpf_bindings::bindings::linux_binprm::clone(&self) -> aya_ebpf_bindi
 impl core::fmt::Debug for aya_ebpf_bindings::bindings::linux_binprm
 pub fn aya_ebpf_bindings::bindings::linux_binprm::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Copy for aya_ebpf_bindings::bindings::linux_binprm
+impl core::marker::Freeze for aya_ebpf_bindings::bindings::linux_binprm
 impl core::marker::Send for aya_ebpf_bindings::bindings::linux_binprm
 impl core::marker::Sync for aya_ebpf_bindings::bindings::linux_binprm
 impl core::marker::Unpin for aya_ebpf_bindings::bindings::linux_binprm
@@ -4850,6 +4990,7 @@ pub fn aya_ebpf_bindings::bindings::mptcp_sock::clone(&self) -> aya_ebpf_binding
 impl core::fmt::Debug for aya_ebpf_bindings::bindings::mptcp_sock
 pub fn aya_ebpf_bindings::bindings::mptcp_sock::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Copy for aya_ebpf_bindings::bindings::mptcp_sock
+impl core::marker::Freeze for aya_ebpf_bindings::bindings::mptcp_sock
 impl core::marker::Send for aya_ebpf_bindings::bindings::mptcp_sock
 impl core::marker::Sync for aya_ebpf_bindings::bindings::mptcp_sock
 impl core::marker::Unpin for aya_ebpf_bindings::bindings::mptcp_sock
@@ -4877,6 +5018,7 @@ pub fn aya_ebpf_bindings::bindings::path::clone(&self) -> aya_ebpf_bindings::bin
 impl core::fmt::Debug for aya_ebpf_bindings::bindings::path
 pub fn aya_ebpf_bindings::bindings::path::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Copy for aya_ebpf_bindings::bindings::path
+impl core::marker::Freeze for aya_ebpf_bindings::bindings::path
 impl core::marker::Send for aya_ebpf_bindings::bindings::path
 impl core::marker::Sync for aya_ebpf_bindings::bindings::path
 impl core::marker::Unpin for aya_ebpf_bindings::bindings::path
@@ -4925,6 +5067,7 @@ pub fn aya_ebpf_bindings::bindings::pt_regs::clone(&self) -> aya_ebpf_bindings::
 impl core::fmt::Debug for aya_ebpf_bindings::bindings::pt_regs
 pub fn aya_ebpf_bindings::bindings::pt_regs::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Copy for aya_ebpf_bindings::bindings::pt_regs
+impl core::marker::Freeze for aya_ebpf_bindings::bindings::pt_regs
 impl core::marker::Send for aya_ebpf_bindings::bindings::pt_regs
 impl core::marker::Sync for aya_ebpf_bindings::bindings::pt_regs
 impl core::marker::Unpin for aya_ebpf_bindings::bindings::pt_regs
@@ -4952,6 +5095,7 @@ pub fn aya_ebpf_bindings::bindings::seq_file::clone(&self) -> aya_ebpf_bindings:
 impl core::fmt::Debug for aya_ebpf_bindings::bindings::seq_file
 pub fn aya_ebpf_bindings::bindings::seq_file::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Copy for aya_ebpf_bindings::bindings::seq_file
+impl core::marker::Freeze for aya_ebpf_bindings::bindings::seq_file
 impl core::marker::Send for aya_ebpf_bindings::bindings::seq_file
 impl core::marker::Sync for aya_ebpf_bindings::bindings::seq_file
 impl core::marker::Unpin for aya_ebpf_bindings::bindings::seq_file
@@ -4988,6 +5132,7 @@ pub aya_ebpf_bindings::bindings::sk_msg_md::size: aya_ebpf_bindings::bindings::_
 impl core::clone::Clone for aya_ebpf_bindings::bindings::sk_msg_md
 pub fn aya_ebpf_bindings::bindings::sk_msg_md::clone(&self) -> aya_ebpf_bindings::bindings::sk_msg_md
 impl core::marker::Copy for aya_ebpf_bindings::bindings::sk_msg_md
+impl core::marker::Freeze for aya_ebpf_bindings::bindings::sk_msg_md
 impl !core::marker::Send for aya_ebpf_bindings::bindings::sk_msg_md
 impl !core::marker::Sync for aya_ebpf_bindings::bindings::sk_msg_md
 impl core::marker::Unpin for aya_ebpf_bindings::bindings::sk_msg_md
@@ -5022,6 +5167,7 @@ pub aya_ebpf_bindings::bindings::sk_reuseport_md::len: aya_ebpf_bindings::bindin
 impl core::clone::Clone for aya_ebpf_bindings::bindings::sk_reuseport_md
 pub fn aya_ebpf_bindings::bindings::sk_reuseport_md::clone(&self) -> aya_ebpf_bindings::bindings::sk_reuseport_md
 impl core::marker::Copy for aya_ebpf_bindings::bindings::sk_reuseport_md
+impl core::marker::Freeze for aya_ebpf_bindings::bindings::sk_reuseport_md
 impl !core::marker::Send for aya_ebpf_bindings::bindings::sk_reuseport_md
 impl !core::marker::Sync for aya_ebpf_bindings::bindings::sk_reuseport_md
 impl core::marker::Unpin for aya_ebpf_bindings::bindings::sk_reuseport_md
@@ -5051,6 +5197,7 @@ pub fn aya_ebpf_bindings::bindings::sockaddr::clone(&self) -> aya_ebpf_bindings:
 impl core::fmt::Debug for aya_ebpf_bindings::bindings::sockaddr
 pub fn aya_ebpf_bindings::bindings::sockaddr::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Copy for aya_ebpf_bindings::bindings::sockaddr
+impl core::marker::Freeze for aya_ebpf_bindings::bindings::sockaddr
 impl core::marker::Send for aya_ebpf_bindings::bindings::sockaddr
 impl core::marker::Sync for aya_ebpf_bindings::bindings::sockaddr
 impl core::marker::Unpin for aya_ebpf_bindings::bindings::sockaddr
@@ -5078,6 +5225,7 @@ pub fn aya_ebpf_bindings::bindings::socket::clone(&self) -> aya_ebpf_bindings::b
 impl core::fmt::Debug for aya_ebpf_bindings::bindings::socket
 pub fn aya_ebpf_bindings::bindings::socket::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Copy for aya_ebpf_bindings::bindings::socket
+impl core::marker::Freeze for aya_ebpf_bindings::bindings::socket
 impl core::marker::Send for aya_ebpf_bindings::bindings::socket
 impl core::marker::Sync for aya_ebpf_bindings::bindings::socket
 impl core::marker::Unpin for aya_ebpf_bindings::bindings::socket
@@ -5105,6 +5253,7 @@ pub fn aya_ebpf_bindings::bindings::task_struct::clone(&self) -> aya_ebpf_bindin
 impl core::fmt::Debug for aya_ebpf_bindings::bindings::task_struct
 pub fn aya_ebpf_bindings::bindings::task_struct::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Copy for aya_ebpf_bindings::bindings::task_struct
+impl core::marker::Freeze for aya_ebpf_bindings::bindings::task_struct
 impl core::marker::Send for aya_ebpf_bindings::bindings::task_struct
 impl core::marker::Sync for aya_ebpf_bindings::bindings::task_struct
 impl core::marker::Unpin for aya_ebpf_bindings::bindings::task_struct
@@ -5132,6 +5281,7 @@ pub fn aya_ebpf_bindings::bindings::tcp6_sock::clone(&self) -> aya_ebpf_bindings
 impl core::fmt::Debug for aya_ebpf_bindings::bindings::tcp6_sock
 pub fn aya_ebpf_bindings::bindings::tcp6_sock::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Copy for aya_ebpf_bindings::bindings::tcp6_sock
+impl core::marker::Freeze for aya_ebpf_bindings::bindings::tcp6_sock
 impl core::marker::Send for aya_ebpf_bindings::bindings::tcp6_sock
 impl core::marker::Sync for aya_ebpf_bindings::bindings::tcp6_sock
 impl core::marker::Unpin for aya_ebpf_bindings::bindings::tcp6_sock
@@ -5159,6 +5309,7 @@ pub fn aya_ebpf_bindings::bindings::tcp_request_sock::clone(&self) -> aya_ebpf_b
 impl core::fmt::Debug for aya_ebpf_bindings::bindings::tcp_request_sock
 pub fn aya_ebpf_bindings::bindings::tcp_request_sock::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Copy for aya_ebpf_bindings::bindings::tcp_request_sock
+impl core::marker::Freeze for aya_ebpf_bindings::bindings::tcp_request_sock
 impl core::marker::Send for aya_ebpf_bindings::bindings::tcp_request_sock
 impl core::marker::Sync for aya_ebpf_bindings::bindings::tcp_request_sock
 impl core::marker::Unpin for aya_ebpf_bindings::bindings::tcp_request_sock
@@ -5186,6 +5337,7 @@ pub fn aya_ebpf_bindings::bindings::tcp_sock::clone(&self) -> aya_ebpf_bindings:
 impl core::fmt::Debug for aya_ebpf_bindings::bindings::tcp_sock
 pub fn aya_ebpf_bindings::bindings::tcp_sock::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Copy for aya_ebpf_bindings::bindings::tcp_sock
+impl core::marker::Freeze for aya_ebpf_bindings::bindings::tcp_sock
 impl core::marker::Send for aya_ebpf_bindings::bindings::tcp_sock
 impl core::marker::Sync for aya_ebpf_bindings::bindings::tcp_sock
 impl core::marker::Unpin for aya_ebpf_bindings::bindings::tcp_sock
@@ -5213,6 +5365,7 @@ pub fn aya_ebpf_bindings::bindings::tcp_timewait_sock::clone(&self) -> aya_ebpf_
 impl core::fmt::Debug for aya_ebpf_bindings::bindings::tcp_timewait_sock
 pub fn aya_ebpf_bindings::bindings::tcp_timewait_sock::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Copy for aya_ebpf_bindings::bindings::tcp_timewait_sock
+impl core::marker::Freeze for aya_ebpf_bindings::bindings::tcp_timewait_sock
 impl core::marker::Send for aya_ebpf_bindings::bindings::tcp_timewait_sock
 impl core::marker::Sync for aya_ebpf_bindings::bindings::tcp_timewait_sock
 impl core::marker::Unpin for aya_ebpf_bindings::bindings::tcp_timewait_sock
@@ -5240,6 +5393,7 @@ pub fn aya_ebpf_bindings::bindings::tcphdr::clone(&self) -> aya_ebpf_bindings::b
 impl core::fmt::Debug for aya_ebpf_bindings::bindings::tcphdr
 pub fn aya_ebpf_bindings::bindings::tcphdr::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Copy for aya_ebpf_bindings::bindings::tcphdr
+impl core::marker::Freeze for aya_ebpf_bindings::bindings::tcphdr
 impl core::marker::Send for aya_ebpf_bindings::bindings::tcphdr
 impl core::marker::Sync for aya_ebpf_bindings::bindings::tcphdr
 impl core::marker::Unpin for aya_ebpf_bindings::bindings::tcphdr
@@ -5267,6 +5421,7 @@ pub fn aya_ebpf_bindings::bindings::udp6_sock::clone(&self) -> aya_ebpf_bindings
 impl core::fmt::Debug for aya_ebpf_bindings::bindings::udp6_sock
 pub fn aya_ebpf_bindings::bindings::udp6_sock::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Copy for aya_ebpf_bindings::bindings::udp6_sock
+impl core::marker::Freeze for aya_ebpf_bindings::bindings::udp6_sock
 impl core::marker::Send for aya_ebpf_bindings::bindings::udp6_sock
 impl core::marker::Sync for aya_ebpf_bindings::bindings::udp6_sock
 impl core::marker::Unpin for aya_ebpf_bindings::bindings::udp6_sock
@@ -5294,6 +5449,7 @@ pub fn aya_ebpf_bindings::bindings::unix_sock::clone(&self) -> aya_ebpf_bindings
 impl core::fmt::Debug for aya_ebpf_bindings::bindings::unix_sock
 pub fn aya_ebpf_bindings::bindings::unix_sock::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Copy for aya_ebpf_bindings::bindings::unix_sock
+impl core::marker::Freeze for aya_ebpf_bindings::bindings::unix_sock
 impl core::marker::Send for aya_ebpf_bindings::bindings::unix_sock
 impl core::marker::Sync for aya_ebpf_bindings::bindings::unix_sock
 impl core::marker::Unpin for aya_ebpf_bindings::bindings::unix_sock
@@ -5327,6 +5483,7 @@ pub fn aya_ebpf_bindings::bindings::xdp_md::clone(&self) -> aya_ebpf_bindings::b
 impl core::fmt::Debug for aya_ebpf_bindings::bindings::xdp_md
 pub fn aya_ebpf_bindings::bindings::xdp_md::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Copy for aya_ebpf_bindings::bindings::xdp_md
+impl core::marker::Freeze for aya_ebpf_bindings::bindings::xdp_md
 impl core::marker::Send for aya_ebpf_bindings::bindings::xdp_md
 impl core::marker::Sync for aya_ebpf_bindings::bindings::xdp_md
 impl core::marker::Unpin for aya_ebpf_bindings::bindings::xdp_md

--- a/xtask/public-api/aya-ebpf.txt
+++ b/xtask/public-api/aya-ebpf.txt
@@ -37,6 +37,7 @@ impl<T> core::convert::From<*const T> for aya_ebpf::helpers::PrintkArg
 pub fn aya_ebpf::helpers::PrintkArg::from(x: *const T) -> Self
 impl<T> core::convert::From<*mut T> for aya_ebpf::helpers::PrintkArg
 pub fn aya_ebpf::helpers::PrintkArg::from(x: *mut T) -> Self
+impl core::marker::Freeze for aya_ebpf::helpers::PrintkArg
 impl core::marker::Send for aya_ebpf::helpers::PrintkArg
 impl core::marker::Sync for aya_ebpf::helpers::PrintkArg
 impl core::marker::Unpin for aya_ebpf::helpers::PrintkArg
@@ -83,6 +84,7 @@ pub fn aya_ebpf::maps::array::Array<T>::get_ptr_mut(&self, index: u32) -> core::
 pub const fn aya_ebpf::maps::array::Array<T>::pinned(max_entries: u32, flags: u32) -> aya_ebpf::maps::array::Array<T>
 pub const fn aya_ebpf::maps::array::Array<T>::with_max_entries(max_entries: u32, flags: u32) -> aya_ebpf::maps::array::Array<T>
 impl<T: core::marker::Sync> core::marker::Sync for aya_ebpf::maps::array::Array<T>
+impl<T> !core::marker::Freeze for aya_ebpf::maps::array::Array<T>
 impl<T> core::marker::Send for aya_ebpf::maps::array::Array<T> where T: core::marker::Send
 impl<T> core::marker::Unpin for aya_ebpf::maps::array::Array<T> where T: core::marker::Unpin
 impl<T> !core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::maps::array::Array<T>
@@ -110,6 +112,7 @@ pub fn aya_ebpf::maps::bloom_filter::BloomFilter<T>::contains(&mut self, value: 
 pub fn aya_ebpf::maps::bloom_filter::BloomFilter<T>::insert(&mut self, value: &T, flags: u64) -> core::result::Result<(), i64>
 pub const fn aya_ebpf::maps::bloom_filter::BloomFilter<T>::pinned(max_entries: u32, flags: u32) -> aya_ebpf::maps::bloom_filter::BloomFilter<T>
 pub const fn aya_ebpf::maps::bloom_filter::BloomFilter<T>::with_max_entries(max_entries: u32, flags: u32) -> aya_ebpf::maps::bloom_filter::BloomFilter<T>
+impl<T> core::marker::Freeze for aya_ebpf::maps::bloom_filter::BloomFilter<T>
 impl<T> core::marker::Send for aya_ebpf::maps::bloom_filter::BloomFilter<T> where T: core::marker::Send
 impl<T> core::marker::Sync for aya_ebpf::maps::bloom_filter::BloomFilter<T> where T: core::marker::Sync
 impl<T> core::marker::Unpin for aya_ebpf::maps::bloom_filter::BloomFilter<T> where T: core::marker::Unpin
@@ -142,6 +145,7 @@ pub const fn aya_ebpf::maps::hash_map::HashMap<K, V>::pinned(max_entries: u32, f
 pub fn aya_ebpf::maps::hash_map::HashMap<K, V>::remove(&self, key: &K) -> core::result::Result<(), aya_ebpf_cty::od::c_long>
 pub const fn aya_ebpf::maps::hash_map::HashMap<K, V>::with_max_entries(max_entries: u32, flags: u32) -> aya_ebpf::maps::hash_map::HashMap<K, V>
 impl<K: core::marker::Sync, V: core::marker::Sync> core::marker::Sync for aya_ebpf::maps::hash_map::HashMap<K, V>
+impl<K, V> !core::marker::Freeze for aya_ebpf::maps::hash_map::HashMap<K, V>
 impl<K, V> core::marker::Send for aya_ebpf::maps::hash_map::HashMap<K, V> where K: core::marker::Send, V: core::marker::Send
 impl<K, V> core::marker::Unpin for aya_ebpf::maps::hash_map::HashMap<K, V> where K: core::marker::Unpin, V: core::marker::Unpin
 impl<K, V> !core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::maps::hash_map::HashMap<K, V>
@@ -172,6 +176,7 @@ pub const fn aya_ebpf::maps::hash_map::LruHashMap<K, V>::pinned(max_entries: u32
 pub fn aya_ebpf::maps::hash_map::LruHashMap<K, V>::remove(&self, key: &K) -> core::result::Result<(), aya_ebpf_cty::od::c_long>
 pub const fn aya_ebpf::maps::hash_map::LruHashMap<K, V>::with_max_entries(max_entries: u32, flags: u32) -> aya_ebpf::maps::hash_map::LruHashMap<K, V>
 impl<K: core::marker::Sync, V: core::marker::Sync> core::marker::Sync for aya_ebpf::maps::hash_map::LruHashMap<K, V>
+impl<K, V> !core::marker::Freeze for aya_ebpf::maps::hash_map::LruHashMap<K, V>
 impl<K, V> core::marker::Send for aya_ebpf::maps::hash_map::LruHashMap<K, V> where K: core::marker::Send, V: core::marker::Send
 impl<K, V> core::marker::Unpin for aya_ebpf::maps::hash_map::LruHashMap<K, V> where K: core::marker::Unpin, V: core::marker::Unpin
 impl<K, V> !core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::maps::hash_map::LruHashMap<K, V>
@@ -202,6 +207,7 @@ pub const fn aya_ebpf::maps::hash_map::LruPerCpuHashMap<K, V>::pinned(max_entrie
 pub fn aya_ebpf::maps::hash_map::LruPerCpuHashMap<K, V>::remove(&self, key: &K) -> core::result::Result<(), aya_ebpf_cty::od::c_long>
 pub const fn aya_ebpf::maps::hash_map::LruPerCpuHashMap<K, V>::with_max_entries(max_entries: u32, flags: u32) -> aya_ebpf::maps::hash_map::LruPerCpuHashMap<K, V>
 impl<K, V> core::marker::Sync for aya_ebpf::maps::hash_map::LruPerCpuHashMap<K, V>
+impl<K, V> !core::marker::Freeze for aya_ebpf::maps::hash_map::LruPerCpuHashMap<K, V>
 impl<K, V> core::marker::Send for aya_ebpf::maps::hash_map::LruPerCpuHashMap<K, V> where K: core::marker::Send, V: core::marker::Send
 impl<K, V> core::marker::Unpin for aya_ebpf::maps::hash_map::LruPerCpuHashMap<K, V> where K: core::marker::Unpin, V: core::marker::Unpin
 impl<K, V> !core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::maps::hash_map::LruPerCpuHashMap<K, V>
@@ -232,6 +238,7 @@ pub const fn aya_ebpf::maps::hash_map::PerCpuHashMap<K, V>::pinned(max_entries: 
 pub fn aya_ebpf::maps::hash_map::PerCpuHashMap<K, V>::remove(&self, key: &K) -> core::result::Result<(), aya_ebpf_cty::od::c_long>
 pub const fn aya_ebpf::maps::hash_map::PerCpuHashMap<K, V>::with_max_entries(max_entries: u32, flags: u32) -> aya_ebpf::maps::hash_map::PerCpuHashMap<K, V>
 impl<K, V> core::marker::Sync for aya_ebpf::maps::hash_map::PerCpuHashMap<K, V>
+impl<K, V> !core::marker::Freeze for aya_ebpf::maps::hash_map::PerCpuHashMap<K, V>
 impl<K, V> core::marker::Send for aya_ebpf::maps::hash_map::PerCpuHashMap<K, V> where K: core::marker::Send, V: core::marker::Send
 impl<K, V> core::marker::Unpin for aya_ebpf::maps::hash_map::PerCpuHashMap<K, V> where K: core::marker::Unpin, V: core::marker::Unpin
 impl<K, V> !core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::maps::hash_map::PerCpuHashMap<K, V>
@@ -258,6 +265,7 @@ pub aya_ebpf::maps::lpm_trie::Key::data: K
 pub aya_ebpf::maps::lpm_trie::Key::prefix_len: u32
 impl<K> aya_ebpf::maps::lpm_trie::Key<K>
 pub fn aya_ebpf::maps::lpm_trie::Key<K>::new(prefix_len: u32, data: K) -> Self
+impl<K> core::marker::Freeze for aya_ebpf::maps::lpm_trie::Key<K> where K: core::marker::Freeze
 impl<K> core::marker::Send for aya_ebpf::maps::lpm_trie::Key<K> where K: core::marker::Send
 impl<K> core::marker::Sync for aya_ebpf::maps::lpm_trie::Key<K> where K: core::marker::Sync
 impl<K> core::marker::Unpin for aya_ebpf::maps::lpm_trie::Key<K> where K: core::marker::Unpin
@@ -287,6 +295,7 @@ pub const fn aya_ebpf::maps::lpm_trie::LpmTrie<K, V>::pinned(max_entries: u32, f
 pub fn aya_ebpf::maps::lpm_trie::LpmTrie<K, V>::remove(&self, key: &aya_ebpf::maps::lpm_trie::Key<K>) -> core::result::Result<(), aya_ebpf_cty::od::c_long>
 pub const fn aya_ebpf::maps::lpm_trie::LpmTrie<K, V>::with_max_entries(max_entries: u32, flags: u32) -> aya_ebpf::maps::lpm_trie::LpmTrie<K, V>
 impl<K: core::marker::Sync, V: core::marker::Sync> core::marker::Sync for aya_ebpf::maps::lpm_trie::LpmTrie<K, V>
+impl<K, V> !core::marker::Freeze for aya_ebpf::maps::lpm_trie::LpmTrie<K, V>
 impl<K, V> core::marker::Send for aya_ebpf::maps::lpm_trie::LpmTrie<K, V> where K: core::marker::Send, V: core::marker::Send
 impl<K, V> core::marker::Unpin for aya_ebpf::maps::lpm_trie::LpmTrie<K, V> where K: core::marker::Unpin, V: core::marker::Unpin
 impl<K, V> !core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::maps::lpm_trie::LpmTrie<K, V>
@@ -316,6 +325,7 @@ pub fn aya_ebpf::maps::per_cpu_array::PerCpuArray<T>::get_ptr_mut(&self, index: 
 pub const fn aya_ebpf::maps::per_cpu_array::PerCpuArray<T>::pinned(max_entries: u32, flags: u32) -> aya_ebpf::maps::per_cpu_array::PerCpuArray<T>
 pub const fn aya_ebpf::maps::per_cpu_array::PerCpuArray<T>::with_max_entries(max_entries: u32, flags: u32) -> aya_ebpf::maps::per_cpu_array::PerCpuArray<T>
 impl<T> core::marker::Sync for aya_ebpf::maps::per_cpu_array::PerCpuArray<T>
+impl<T> !core::marker::Freeze for aya_ebpf::maps::per_cpu_array::PerCpuArray<T>
 impl<T> core::marker::Send for aya_ebpf::maps::per_cpu_array::PerCpuArray<T> where T: core::marker::Send
 impl<T> core::marker::Unpin for aya_ebpf::maps::per_cpu_array::PerCpuArray<T> where T: core::marker::Unpin
 impl<T> !core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::maps::per_cpu_array::PerCpuArray<T>
@@ -345,6 +355,7 @@ pub fn aya_ebpf::maps::PerfEventArray<T>::output_at_index<C: aya_ebpf::EbpfConte
 pub const fn aya_ebpf::maps::PerfEventArray<T>::pinned(max_entries: u32, flags: u32) -> aya_ebpf::maps::PerfEventArray<T>
 pub const fn aya_ebpf::maps::PerfEventArray<T>::with_max_entries(max_entries: u32, flags: u32) -> aya_ebpf::maps::PerfEventArray<T>
 impl<T: core::marker::Sync> core::marker::Sync for aya_ebpf::maps::PerfEventArray<T>
+impl<T> !core::marker::Freeze for aya_ebpf::maps::PerfEventArray<T>
 impl<T> core::marker::Send for aya_ebpf::maps::PerfEventArray<T> where T: core::marker::Send
 impl<T> core::marker::Unpin for aya_ebpf::maps::PerfEventArray<T> where T: core::marker::Unpin
 impl<T> !core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::maps::PerfEventArray<T>
@@ -373,6 +384,7 @@ pub fn aya_ebpf::maps::PerfEventByteArray::output_at_index<C: aya_ebpf::EbpfCont
 pub const fn aya_ebpf::maps::PerfEventByteArray::pinned(max_entries: u32, flags: u32) -> aya_ebpf::maps::PerfEventByteArray
 pub const fn aya_ebpf::maps::PerfEventByteArray::with_max_entries(max_entries: u32, flags: u32) -> aya_ebpf::maps::PerfEventByteArray
 impl core::marker::Sync for aya_ebpf::maps::PerfEventByteArray
+impl !core::marker::Freeze for aya_ebpf::maps::PerfEventByteArray
 impl core::marker::Send for aya_ebpf::maps::PerfEventByteArray
 impl core::marker::Unpin for aya_ebpf::maps::PerfEventByteArray
 impl !core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::maps::PerfEventByteArray
@@ -400,6 +412,7 @@ pub const fn aya_ebpf::maps::program_array::ProgramArray::pinned(max_entries: u3
 pub unsafe fn aya_ebpf::maps::program_array::ProgramArray::tail_call<C: aya_ebpf::EbpfContext>(&self, ctx: &C, index: u32) -> core::result::Result<never, aya_ebpf_cty::od::c_long>
 pub const fn aya_ebpf::maps::program_array::ProgramArray::with_max_entries(max_entries: u32, flags: u32) -> aya_ebpf::maps::program_array::ProgramArray
 impl core::marker::Sync for aya_ebpf::maps::program_array::ProgramArray
+impl !core::marker::Freeze for aya_ebpf::maps::program_array::ProgramArray
 impl core::marker::Send for aya_ebpf::maps::program_array::ProgramArray
 impl core::marker::Unpin for aya_ebpf::maps::program_array::ProgramArray
 impl !core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::maps::program_array::ProgramArray
@@ -428,6 +441,7 @@ pub fn aya_ebpf::maps::queue::Queue<T>::pop(&self) -> core::option::Option<T>
 pub fn aya_ebpf::maps::queue::Queue<T>::push(&self, value: &T, flags: u64) -> core::result::Result<(), i64>
 pub const fn aya_ebpf::maps::queue::Queue<T>::with_max_entries(max_entries: u32, flags: u32) -> aya_ebpf::maps::queue::Queue<T>
 impl<T: core::marker::Sync> core::marker::Sync for aya_ebpf::maps::queue::Queue<T>
+impl<T> !core::marker::Freeze for aya_ebpf::maps::queue::Queue<T>
 impl<T> core::marker::Send for aya_ebpf::maps::queue::Queue<T> where T: core::marker::Send
 impl<T> core::marker::Unpin for aya_ebpf::maps::queue::Queue<T> where T: core::marker::Unpin
 impl<T> !core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::maps::queue::Queue<T>
@@ -457,6 +471,7 @@ pub fn aya_ebpf::maps::ring_buf::RingBuf::query(&self, flags: u64) -> u64
 pub fn aya_ebpf::maps::ring_buf::RingBuf::reserve<T: 'static>(&self, flags: u64) -> core::option::Option<aya_ebpf::maps::ring_buf::RingBufEntry<T>> where const_assert::Assert<{ _ }>: const_assert::IsTrue
 pub const fn aya_ebpf::maps::ring_buf::RingBuf::with_byte_size(byte_size: u32, flags: u32) -> Self
 impl core::marker::Sync for aya_ebpf::maps::ring_buf::RingBuf
+impl !core::marker::Freeze for aya_ebpf::maps::ring_buf::RingBuf
 impl core::marker::Send for aya_ebpf::maps::ring_buf::RingBuf
 impl core::marker::Unpin for aya_ebpf::maps::ring_buf::RingBuf
 impl !core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::maps::ring_buf::RingBuf
@@ -486,6 +501,7 @@ pub type aya_ebpf::maps::ring_buf::RingBufEntry<T>::Target = core::mem::maybe_un
 pub fn aya_ebpf::maps::ring_buf::RingBufEntry<T>::deref(&self) -> &Self::Target
 impl<T> core::ops::deref::DerefMut for aya_ebpf::maps::ring_buf::RingBufEntry<T>
 pub fn aya_ebpf::maps::ring_buf::RingBufEntry<T>::deref_mut(&mut self) -> &mut Self::Target
+impl<T> core::marker::Freeze for aya_ebpf::maps::ring_buf::RingBufEntry<T>
 impl<T> core::marker::Send for aya_ebpf::maps::ring_buf::RingBufEntry<T> where T: core::marker::Send
 impl<T> core::marker::Sync for aya_ebpf::maps::ring_buf::RingBufEntry<T> where T: core::marker::Sync
 impl<T> core::marker::Unpin for aya_ebpf::maps::ring_buf::RingBufEntry<T>
@@ -517,6 +533,7 @@ pub fn aya_ebpf::maps::sock_hash::SockHash<K>::redirect_skb(&self, ctx: &aya_ebp
 pub fn aya_ebpf::maps::sock_hash::SockHash<K>::update(&self, key: &mut K, sk_ops: &mut aya_ebpf_bindings::x86_64::bindings::bpf_sock_ops, flags: u64) -> core::result::Result<(), i64>
 pub const fn aya_ebpf::maps::sock_hash::SockHash<K>::with_max_entries(max_entries: u32, flags: u32) -> aya_ebpf::maps::sock_hash::SockHash<K>
 impl<K: core::marker::Sync> core::marker::Sync for aya_ebpf::maps::sock_hash::SockHash<K>
+impl<K> !core::marker::Freeze for aya_ebpf::maps::sock_hash::SockHash<K>
 impl<K> core::marker::Send for aya_ebpf::maps::sock_hash::SockHash<K> where K: core::marker::Send
 impl<K> core::marker::Unpin for aya_ebpf::maps::sock_hash::SockHash<K> where K: core::marker::Unpin
 impl<K> !core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::maps::sock_hash::SockHash<K>
@@ -547,6 +564,7 @@ pub unsafe fn aya_ebpf::maps::sock_map::SockMap::redirect_skb(&self, ctx: &aya_e
 pub unsafe fn aya_ebpf::maps::sock_map::SockMap::update(&self, index: u32, sk_ops: *mut aya_ebpf_bindings::x86_64::bindings::bpf_sock_ops, flags: u64) -> core::result::Result<(), i64>
 pub const fn aya_ebpf::maps::sock_map::SockMap::with_max_entries(max_entries: u32, flags: u32) -> aya_ebpf::maps::sock_map::SockMap
 impl core::marker::Sync for aya_ebpf::maps::sock_map::SockMap
+impl !core::marker::Freeze for aya_ebpf::maps::sock_map::SockMap
 impl core::marker::Send for aya_ebpf::maps::sock_map::SockMap
 impl core::marker::Unpin for aya_ebpf::maps::sock_map::SockMap
 impl !core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::maps::sock_map::SockMap
@@ -574,6 +592,7 @@ pub const fn aya_ebpf::maps::stack::Stack<T>::pinned(max_entries: u32, flags: u3
 pub fn aya_ebpf::maps::stack::Stack<T>::pop(&mut self) -> core::option::Option<T>
 pub fn aya_ebpf::maps::stack::Stack<T>::push(&mut self, value: &T, flags: u64) -> core::result::Result<(), i64>
 pub const fn aya_ebpf::maps::stack::Stack<T>::with_max_entries(max_entries: u32, flags: u32) -> aya_ebpf::maps::stack::Stack<T>
+impl<T> core::marker::Freeze for aya_ebpf::maps::stack::Stack<T>
 impl<T> core::marker::Send for aya_ebpf::maps::stack::Stack<T> where T: core::marker::Send
 impl<T> core::marker::Sync for aya_ebpf::maps::stack::Stack<T> where T: core::marker::Sync
 impl<T> core::marker::Unpin for aya_ebpf::maps::stack::Stack<T> where T: core::marker::Unpin
@@ -602,6 +621,7 @@ pub unsafe fn aya_ebpf::maps::stack_trace::StackTrace::get_stackid<C: aya_ebpf::
 pub const fn aya_ebpf::maps::stack_trace::StackTrace::pinned(max_entries: u32, flags: u32) -> aya_ebpf::maps::stack_trace::StackTrace
 pub const fn aya_ebpf::maps::stack_trace::StackTrace::with_max_entries(max_entries: u32, flags: u32) -> aya_ebpf::maps::stack_trace::StackTrace
 impl core::marker::Sync for aya_ebpf::maps::stack_trace::StackTrace
+impl !core::marker::Freeze for aya_ebpf::maps::stack_trace::StackTrace
 impl core::marker::Send for aya_ebpf::maps::stack_trace::StackTrace
 impl core::marker::Unpin for aya_ebpf::maps::stack_trace::StackTrace
 impl !core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::maps::stack_trace::StackTrace
@@ -629,6 +649,7 @@ pub const fn aya_ebpf::maps::CpuMap::pinned(max_entries: u32, flags: u32) -> aya
 pub fn aya_ebpf::maps::CpuMap::redirect(&self, index: u32, flags: u64) -> core::result::Result<u32, u32>
 pub const fn aya_ebpf::maps::CpuMap::with_max_entries(max_entries: u32, flags: u32) -> aya_ebpf::maps::CpuMap
 impl core::marker::Sync for aya_ebpf::maps::CpuMap
+impl !core::marker::Freeze for aya_ebpf::maps::CpuMap
 impl core::marker::Send for aya_ebpf::maps::CpuMap
 impl core::marker::Unpin for aya_ebpf::maps::CpuMap
 impl !core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::maps::CpuMap
@@ -656,6 +677,7 @@ pub const fn aya_ebpf::maps::DevMap::pinned(max_entries: u32, flags: u32) -> aya
 pub fn aya_ebpf::maps::DevMap::redirect(&self, index: u32, flags: u64) -> core::result::Result<u32, u32>
 pub const fn aya_ebpf::maps::DevMap::with_max_entries(max_entries: u32, flags: u32) -> aya_ebpf::maps::DevMap
 impl core::marker::Sync for aya_ebpf::maps::DevMap
+impl !core::marker::Freeze for aya_ebpf::maps::DevMap
 impl core::marker::Send for aya_ebpf::maps::DevMap
 impl core::marker::Unpin for aya_ebpf::maps::DevMap
 impl !core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::maps::DevMap
@@ -683,6 +705,7 @@ pub const fn aya_ebpf::maps::DevMapHash::pinned(max_entries: u32, flags: u32) ->
 pub fn aya_ebpf::maps::DevMapHash::redirect(&self, key: u32, flags: u64) -> core::result::Result<u32, u32>
 pub const fn aya_ebpf::maps::DevMapHash::with_max_entries(max_entries: u32, flags: u32) -> aya_ebpf::maps::DevMapHash
 impl core::marker::Sync for aya_ebpf::maps::DevMapHash
+impl !core::marker::Freeze for aya_ebpf::maps::DevMapHash
 impl core::marker::Send for aya_ebpf::maps::DevMapHash
 impl core::marker::Unpin for aya_ebpf::maps::DevMapHash
 impl !core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::maps::DevMapHash
@@ -710,6 +733,7 @@ pub const fn aya_ebpf::maps::XskMap::pinned(max_entries: u32, flags: u32) -> aya
 pub fn aya_ebpf::maps::XskMap::redirect(&self, index: u32, flags: u64) -> core::result::Result<u32, u32>
 pub const fn aya_ebpf::maps::XskMap::with_max_entries(max_entries: u32, flags: u32) -> aya_ebpf::maps::XskMap
 impl core::marker::Sync for aya_ebpf::maps::XskMap
+impl !core::marker::Freeze for aya_ebpf::maps::XskMap
 impl core::marker::Send for aya_ebpf::maps::XskMap
 impl core::marker::Unpin for aya_ebpf::maps::XskMap
 impl !core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::maps::XskMap
@@ -738,6 +762,7 @@ pub fn aya_ebpf::maps::array::Array<T>::get_ptr_mut(&self, index: u32) -> core::
 pub const fn aya_ebpf::maps::array::Array<T>::pinned(max_entries: u32, flags: u32) -> aya_ebpf::maps::array::Array<T>
 pub const fn aya_ebpf::maps::array::Array<T>::with_max_entries(max_entries: u32, flags: u32) -> aya_ebpf::maps::array::Array<T>
 impl<T: core::marker::Sync> core::marker::Sync for aya_ebpf::maps::array::Array<T>
+impl<T> !core::marker::Freeze for aya_ebpf::maps::array::Array<T>
 impl<T> core::marker::Send for aya_ebpf::maps::array::Array<T> where T: core::marker::Send
 impl<T> core::marker::Unpin for aya_ebpf::maps::array::Array<T> where T: core::marker::Unpin
 impl<T> !core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::maps::array::Array<T>
@@ -764,6 +789,7 @@ pub fn aya_ebpf::maps::bloom_filter::BloomFilter<T>::contains(&mut self, value: 
 pub fn aya_ebpf::maps::bloom_filter::BloomFilter<T>::insert(&mut self, value: &T, flags: u64) -> core::result::Result<(), i64>
 pub const fn aya_ebpf::maps::bloom_filter::BloomFilter<T>::pinned(max_entries: u32, flags: u32) -> aya_ebpf::maps::bloom_filter::BloomFilter<T>
 pub const fn aya_ebpf::maps::bloom_filter::BloomFilter<T>::with_max_entries(max_entries: u32, flags: u32) -> aya_ebpf::maps::bloom_filter::BloomFilter<T>
+impl<T> core::marker::Freeze for aya_ebpf::maps::bloom_filter::BloomFilter<T>
 impl<T> core::marker::Send for aya_ebpf::maps::bloom_filter::BloomFilter<T> where T: core::marker::Send
 impl<T> core::marker::Sync for aya_ebpf::maps::bloom_filter::BloomFilter<T> where T: core::marker::Sync
 impl<T> core::marker::Unpin for aya_ebpf::maps::bloom_filter::BloomFilter<T> where T: core::marker::Unpin
@@ -791,6 +817,7 @@ pub const fn aya_ebpf::maps::CpuMap::pinned(max_entries: u32, flags: u32) -> aya
 pub fn aya_ebpf::maps::CpuMap::redirect(&self, index: u32, flags: u64) -> core::result::Result<u32, u32>
 pub const fn aya_ebpf::maps::CpuMap::with_max_entries(max_entries: u32, flags: u32) -> aya_ebpf::maps::CpuMap
 impl core::marker::Sync for aya_ebpf::maps::CpuMap
+impl !core::marker::Freeze for aya_ebpf::maps::CpuMap
 impl core::marker::Send for aya_ebpf::maps::CpuMap
 impl core::marker::Unpin for aya_ebpf::maps::CpuMap
 impl !core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::maps::CpuMap
@@ -818,6 +845,7 @@ pub const fn aya_ebpf::maps::DevMap::pinned(max_entries: u32, flags: u32) -> aya
 pub fn aya_ebpf::maps::DevMap::redirect(&self, index: u32, flags: u64) -> core::result::Result<u32, u32>
 pub const fn aya_ebpf::maps::DevMap::with_max_entries(max_entries: u32, flags: u32) -> aya_ebpf::maps::DevMap
 impl core::marker::Sync for aya_ebpf::maps::DevMap
+impl !core::marker::Freeze for aya_ebpf::maps::DevMap
 impl core::marker::Send for aya_ebpf::maps::DevMap
 impl core::marker::Unpin for aya_ebpf::maps::DevMap
 impl !core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::maps::DevMap
@@ -845,6 +873,7 @@ pub const fn aya_ebpf::maps::DevMapHash::pinned(max_entries: u32, flags: u32) ->
 pub fn aya_ebpf::maps::DevMapHash::redirect(&self, key: u32, flags: u64) -> core::result::Result<u32, u32>
 pub const fn aya_ebpf::maps::DevMapHash::with_max_entries(max_entries: u32, flags: u32) -> aya_ebpf::maps::DevMapHash
 impl core::marker::Sync for aya_ebpf::maps::DevMapHash
+impl !core::marker::Freeze for aya_ebpf::maps::DevMapHash
 impl core::marker::Send for aya_ebpf::maps::DevMapHash
 impl core::marker::Unpin for aya_ebpf::maps::DevMapHash
 impl !core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::maps::DevMapHash
@@ -875,6 +904,7 @@ pub const fn aya_ebpf::maps::hash_map::HashMap<K, V>::pinned(max_entries: u32, f
 pub fn aya_ebpf::maps::hash_map::HashMap<K, V>::remove(&self, key: &K) -> core::result::Result<(), aya_ebpf_cty::od::c_long>
 pub const fn aya_ebpf::maps::hash_map::HashMap<K, V>::with_max_entries(max_entries: u32, flags: u32) -> aya_ebpf::maps::hash_map::HashMap<K, V>
 impl<K: core::marker::Sync, V: core::marker::Sync> core::marker::Sync for aya_ebpf::maps::hash_map::HashMap<K, V>
+impl<K, V> !core::marker::Freeze for aya_ebpf::maps::hash_map::HashMap<K, V>
 impl<K, V> core::marker::Send for aya_ebpf::maps::hash_map::HashMap<K, V> where K: core::marker::Send, V: core::marker::Send
 impl<K, V> core::marker::Unpin for aya_ebpf::maps::hash_map::HashMap<K, V> where K: core::marker::Unpin, V: core::marker::Unpin
 impl<K, V> !core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::maps::hash_map::HashMap<K, V>
@@ -903,6 +933,7 @@ pub const fn aya_ebpf::maps::lpm_trie::LpmTrie<K, V>::pinned(max_entries: u32, f
 pub fn aya_ebpf::maps::lpm_trie::LpmTrie<K, V>::remove(&self, key: &aya_ebpf::maps::lpm_trie::Key<K>) -> core::result::Result<(), aya_ebpf_cty::od::c_long>
 pub const fn aya_ebpf::maps::lpm_trie::LpmTrie<K, V>::with_max_entries(max_entries: u32, flags: u32) -> aya_ebpf::maps::lpm_trie::LpmTrie<K, V>
 impl<K: core::marker::Sync, V: core::marker::Sync> core::marker::Sync for aya_ebpf::maps::lpm_trie::LpmTrie<K, V>
+impl<K, V> !core::marker::Freeze for aya_ebpf::maps::lpm_trie::LpmTrie<K, V>
 impl<K, V> core::marker::Send for aya_ebpf::maps::lpm_trie::LpmTrie<K, V> where K: core::marker::Send, V: core::marker::Send
 impl<K, V> core::marker::Unpin for aya_ebpf::maps::lpm_trie::LpmTrie<K, V> where K: core::marker::Unpin, V: core::marker::Unpin
 impl<K, V> !core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::maps::lpm_trie::LpmTrie<K, V>
@@ -933,6 +964,7 @@ pub const fn aya_ebpf::maps::hash_map::LruHashMap<K, V>::pinned(max_entries: u32
 pub fn aya_ebpf::maps::hash_map::LruHashMap<K, V>::remove(&self, key: &K) -> core::result::Result<(), aya_ebpf_cty::od::c_long>
 pub const fn aya_ebpf::maps::hash_map::LruHashMap<K, V>::with_max_entries(max_entries: u32, flags: u32) -> aya_ebpf::maps::hash_map::LruHashMap<K, V>
 impl<K: core::marker::Sync, V: core::marker::Sync> core::marker::Sync for aya_ebpf::maps::hash_map::LruHashMap<K, V>
+impl<K, V> !core::marker::Freeze for aya_ebpf::maps::hash_map::LruHashMap<K, V>
 impl<K, V> core::marker::Send for aya_ebpf::maps::hash_map::LruHashMap<K, V> where K: core::marker::Send, V: core::marker::Send
 impl<K, V> core::marker::Unpin for aya_ebpf::maps::hash_map::LruHashMap<K, V> where K: core::marker::Unpin, V: core::marker::Unpin
 impl<K, V> !core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::maps::hash_map::LruHashMap<K, V>
@@ -963,6 +995,7 @@ pub const fn aya_ebpf::maps::hash_map::LruPerCpuHashMap<K, V>::pinned(max_entrie
 pub fn aya_ebpf::maps::hash_map::LruPerCpuHashMap<K, V>::remove(&self, key: &K) -> core::result::Result<(), aya_ebpf_cty::od::c_long>
 pub const fn aya_ebpf::maps::hash_map::LruPerCpuHashMap<K, V>::with_max_entries(max_entries: u32, flags: u32) -> aya_ebpf::maps::hash_map::LruPerCpuHashMap<K, V>
 impl<K, V> core::marker::Sync for aya_ebpf::maps::hash_map::LruPerCpuHashMap<K, V>
+impl<K, V> !core::marker::Freeze for aya_ebpf::maps::hash_map::LruPerCpuHashMap<K, V>
 impl<K, V> core::marker::Send for aya_ebpf::maps::hash_map::LruPerCpuHashMap<K, V> where K: core::marker::Send, V: core::marker::Send
 impl<K, V> core::marker::Unpin for aya_ebpf::maps::hash_map::LruPerCpuHashMap<K, V> where K: core::marker::Unpin, V: core::marker::Unpin
 impl<K, V> !core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::maps::hash_map::LruPerCpuHashMap<K, V>
@@ -991,6 +1024,7 @@ pub fn aya_ebpf::maps::per_cpu_array::PerCpuArray<T>::get_ptr_mut(&self, index: 
 pub const fn aya_ebpf::maps::per_cpu_array::PerCpuArray<T>::pinned(max_entries: u32, flags: u32) -> aya_ebpf::maps::per_cpu_array::PerCpuArray<T>
 pub const fn aya_ebpf::maps::per_cpu_array::PerCpuArray<T>::with_max_entries(max_entries: u32, flags: u32) -> aya_ebpf::maps::per_cpu_array::PerCpuArray<T>
 impl<T> core::marker::Sync for aya_ebpf::maps::per_cpu_array::PerCpuArray<T>
+impl<T> !core::marker::Freeze for aya_ebpf::maps::per_cpu_array::PerCpuArray<T>
 impl<T> core::marker::Send for aya_ebpf::maps::per_cpu_array::PerCpuArray<T> where T: core::marker::Send
 impl<T> core::marker::Unpin for aya_ebpf::maps::per_cpu_array::PerCpuArray<T> where T: core::marker::Unpin
 impl<T> !core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::maps::per_cpu_array::PerCpuArray<T>
@@ -1021,6 +1055,7 @@ pub const fn aya_ebpf::maps::hash_map::PerCpuHashMap<K, V>::pinned(max_entries: 
 pub fn aya_ebpf::maps::hash_map::PerCpuHashMap<K, V>::remove(&self, key: &K) -> core::result::Result<(), aya_ebpf_cty::od::c_long>
 pub const fn aya_ebpf::maps::hash_map::PerCpuHashMap<K, V>::with_max_entries(max_entries: u32, flags: u32) -> aya_ebpf::maps::hash_map::PerCpuHashMap<K, V>
 impl<K, V> core::marker::Sync for aya_ebpf::maps::hash_map::PerCpuHashMap<K, V>
+impl<K, V> !core::marker::Freeze for aya_ebpf::maps::hash_map::PerCpuHashMap<K, V>
 impl<K, V> core::marker::Send for aya_ebpf::maps::hash_map::PerCpuHashMap<K, V> where K: core::marker::Send, V: core::marker::Send
 impl<K, V> core::marker::Unpin for aya_ebpf::maps::hash_map::PerCpuHashMap<K, V> where K: core::marker::Unpin, V: core::marker::Unpin
 impl<K, V> !core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::maps::hash_map::PerCpuHashMap<K, V>
@@ -1049,6 +1084,7 @@ pub fn aya_ebpf::maps::PerfEventArray<T>::output_at_index<C: aya_ebpf::EbpfConte
 pub const fn aya_ebpf::maps::PerfEventArray<T>::pinned(max_entries: u32, flags: u32) -> aya_ebpf::maps::PerfEventArray<T>
 pub const fn aya_ebpf::maps::PerfEventArray<T>::with_max_entries(max_entries: u32, flags: u32) -> aya_ebpf::maps::PerfEventArray<T>
 impl<T: core::marker::Sync> core::marker::Sync for aya_ebpf::maps::PerfEventArray<T>
+impl<T> !core::marker::Freeze for aya_ebpf::maps::PerfEventArray<T>
 impl<T> core::marker::Send for aya_ebpf::maps::PerfEventArray<T> where T: core::marker::Send
 impl<T> core::marker::Unpin for aya_ebpf::maps::PerfEventArray<T> where T: core::marker::Unpin
 impl<T> !core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::maps::PerfEventArray<T>
@@ -1077,6 +1113,7 @@ pub fn aya_ebpf::maps::PerfEventByteArray::output_at_index<C: aya_ebpf::EbpfCont
 pub const fn aya_ebpf::maps::PerfEventByteArray::pinned(max_entries: u32, flags: u32) -> aya_ebpf::maps::PerfEventByteArray
 pub const fn aya_ebpf::maps::PerfEventByteArray::with_max_entries(max_entries: u32, flags: u32) -> aya_ebpf::maps::PerfEventByteArray
 impl core::marker::Sync for aya_ebpf::maps::PerfEventByteArray
+impl !core::marker::Freeze for aya_ebpf::maps::PerfEventByteArray
 impl core::marker::Send for aya_ebpf::maps::PerfEventByteArray
 impl core::marker::Unpin for aya_ebpf::maps::PerfEventByteArray
 impl !core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::maps::PerfEventByteArray
@@ -1103,6 +1140,7 @@ pub const fn aya_ebpf::maps::program_array::ProgramArray::pinned(max_entries: u3
 pub unsafe fn aya_ebpf::maps::program_array::ProgramArray::tail_call<C: aya_ebpf::EbpfContext>(&self, ctx: &C, index: u32) -> core::result::Result<never, aya_ebpf_cty::od::c_long>
 pub const fn aya_ebpf::maps::program_array::ProgramArray::with_max_entries(max_entries: u32, flags: u32) -> aya_ebpf::maps::program_array::ProgramArray
 impl core::marker::Sync for aya_ebpf::maps::program_array::ProgramArray
+impl !core::marker::Freeze for aya_ebpf::maps::program_array::ProgramArray
 impl core::marker::Send for aya_ebpf::maps::program_array::ProgramArray
 impl core::marker::Unpin for aya_ebpf::maps::program_array::ProgramArray
 impl !core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::maps::program_array::ProgramArray
@@ -1130,6 +1168,7 @@ pub fn aya_ebpf::maps::queue::Queue<T>::pop(&self) -> core::option::Option<T>
 pub fn aya_ebpf::maps::queue::Queue<T>::push(&self, value: &T, flags: u64) -> core::result::Result<(), i64>
 pub const fn aya_ebpf::maps::queue::Queue<T>::with_max_entries(max_entries: u32, flags: u32) -> aya_ebpf::maps::queue::Queue<T>
 impl<T: core::marker::Sync> core::marker::Sync for aya_ebpf::maps::queue::Queue<T>
+impl<T> !core::marker::Freeze for aya_ebpf::maps::queue::Queue<T>
 impl<T> core::marker::Send for aya_ebpf::maps::queue::Queue<T> where T: core::marker::Send
 impl<T> core::marker::Unpin for aya_ebpf::maps::queue::Queue<T> where T: core::marker::Unpin
 impl<T> !core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::maps::queue::Queue<T>
@@ -1158,6 +1197,7 @@ pub fn aya_ebpf::maps::ring_buf::RingBuf::query(&self, flags: u64) -> u64
 pub fn aya_ebpf::maps::ring_buf::RingBuf::reserve<T: 'static>(&self, flags: u64) -> core::option::Option<aya_ebpf::maps::ring_buf::RingBufEntry<T>> where const_assert::Assert<{ _ }>: const_assert::IsTrue
 pub const fn aya_ebpf::maps::ring_buf::RingBuf::with_byte_size(byte_size: u32, flags: u32) -> Self
 impl core::marker::Sync for aya_ebpf::maps::ring_buf::RingBuf
+impl !core::marker::Freeze for aya_ebpf::maps::ring_buf::RingBuf
 impl core::marker::Send for aya_ebpf::maps::ring_buf::RingBuf
 impl core::marker::Unpin for aya_ebpf::maps::ring_buf::RingBuf
 impl !core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::maps::ring_buf::RingBuf
@@ -1187,6 +1227,7 @@ pub fn aya_ebpf::maps::sock_hash::SockHash<K>::redirect_skb(&self, ctx: &aya_ebp
 pub fn aya_ebpf::maps::sock_hash::SockHash<K>::update(&self, key: &mut K, sk_ops: &mut aya_ebpf_bindings::x86_64::bindings::bpf_sock_ops, flags: u64) -> core::result::Result<(), i64>
 pub const fn aya_ebpf::maps::sock_hash::SockHash<K>::with_max_entries(max_entries: u32, flags: u32) -> aya_ebpf::maps::sock_hash::SockHash<K>
 impl<K: core::marker::Sync> core::marker::Sync for aya_ebpf::maps::sock_hash::SockHash<K>
+impl<K> !core::marker::Freeze for aya_ebpf::maps::sock_hash::SockHash<K>
 impl<K> core::marker::Send for aya_ebpf::maps::sock_hash::SockHash<K> where K: core::marker::Send
 impl<K> core::marker::Unpin for aya_ebpf::maps::sock_hash::SockHash<K> where K: core::marker::Unpin
 impl<K> !core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::maps::sock_hash::SockHash<K>
@@ -1216,6 +1257,7 @@ pub unsafe fn aya_ebpf::maps::sock_map::SockMap::redirect_skb(&self, ctx: &aya_e
 pub unsafe fn aya_ebpf::maps::sock_map::SockMap::update(&self, index: u32, sk_ops: *mut aya_ebpf_bindings::x86_64::bindings::bpf_sock_ops, flags: u64) -> core::result::Result<(), i64>
 pub const fn aya_ebpf::maps::sock_map::SockMap::with_max_entries(max_entries: u32, flags: u32) -> aya_ebpf::maps::sock_map::SockMap
 impl core::marker::Sync for aya_ebpf::maps::sock_map::SockMap
+impl !core::marker::Freeze for aya_ebpf::maps::sock_map::SockMap
 impl core::marker::Send for aya_ebpf::maps::sock_map::SockMap
 impl core::marker::Unpin for aya_ebpf::maps::sock_map::SockMap
 impl !core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::maps::sock_map::SockMap
@@ -1242,6 +1284,7 @@ pub const fn aya_ebpf::maps::stack::Stack<T>::pinned(max_entries: u32, flags: u3
 pub fn aya_ebpf::maps::stack::Stack<T>::pop(&mut self) -> core::option::Option<T>
 pub fn aya_ebpf::maps::stack::Stack<T>::push(&mut self, value: &T, flags: u64) -> core::result::Result<(), i64>
 pub const fn aya_ebpf::maps::stack::Stack<T>::with_max_entries(max_entries: u32, flags: u32) -> aya_ebpf::maps::stack::Stack<T>
+impl<T> core::marker::Freeze for aya_ebpf::maps::stack::Stack<T>
 impl<T> core::marker::Send for aya_ebpf::maps::stack::Stack<T> where T: core::marker::Send
 impl<T> core::marker::Sync for aya_ebpf::maps::stack::Stack<T> where T: core::marker::Sync
 impl<T> core::marker::Unpin for aya_ebpf::maps::stack::Stack<T> where T: core::marker::Unpin
@@ -1269,6 +1312,7 @@ pub unsafe fn aya_ebpf::maps::stack_trace::StackTrace::get_stackid<C: aya_ebpf::
 pub const fn aya_ebpf::maps::stack_trace::StackTrace::pinned(max_entries: u32, flags: u32) -> aya_ebpf::maps::stack_trace::StackTrace
 pub const fn aya_ebpf::maps::stack_trace::StackTrace::with_max_entries(max_entries: u32, flags: u32) -> aya_ebpf::maps::stack_trace::StackTrace
 impl core::marker::Sync for aya_ebpf::maps::stack_trace::StackTrace
+impl !core::marker::Freeze for aya_ebpf::maps::stack_trace::StackTrace
 impl core::marker::Send for aya_ebpf::maps::stack_trace::StackTrace
 impl core::marker::Unpin for aya_ebpf::maps::stack_trace::StackTrace
 impl !core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::maps::stack_trace::StackTrace
@@ -1296,6 +1340,7 @@ pub const fn aya_ebpf::maps::XskMap::pinned(max_entries: u32, flags: u32) -> aya
 pub fn aya_ebpf::maps::XskMap::redirect(&self, index: u32, flags: u64) -> core::result::Result<u32, u32>
 pub const fn aya_ebpf::maps::XskMap::with_max_entries(max_entries: u32, flags: u32) -> aya_ebpf::maps::XskMap
 impl core::marker::Sync for aya_ebpf::maps::XskMap
+impl !core::marker::Freeze for aya_ebpf::maps::XskMap
 impl core::marker::Send for aya_ebpf::maps::XskMap
 impl core::marker::Unpin for aya_ebpf::maps::XskMap
 impl !core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::maps::XskMap
@@ -1324,6 +1369,7 @@ impl aya_ebpf::programs::device::DeviceContext
 pub fn aya_ebpf::programs::device::DeviceContext::new(device: *mut aya_ebpf_bindings::x86_64::bindings::bpf_cgroup_dev_ctx) -> aya_ebpf::programs::device::DeviceContext
 impl aya_ebpf::EbpfContext for aya_ebpf::programs::device::DeviceContext
 pub fn aya_ebpf::programs::device::DeviceContext::as_ptr(&self) -> *mut core::ffi::c_void
+impl core::marker::Freeze for aya_ebpf::programs::device::DeviceContext
 impl !core::marker::Send for aya_ebpf::programs::device::DeviceContext
 impl !core::marker::Sync for aya_ebpf::programs::device::DeviceContext
 impl core::marker::Unpin for aya_ebpf::programs::device::DeviceContext
@@ -1352,6 +1398,7 @@ pub unsafe fn aya_ebpf::programs::fentry::FEntryContext::arg<T: FromBtfArgument>
 pub fn aya_ebpf::programs::fentry::FEntryContext::new(ctx: *mut core::ffi::c_void) -> aya_ebpf::programs::fentry::FEntryContext
 impl aya_ebpf::EbpfContext for aya_ebpf::programs::fentry::FEntryContext
 pub fn aya_ebpf::programs::fentry::FEntryContext::as_ptr(&self) -> *mut core::ffi::c_void
+impl core::marker::Freeze for aya_ebpf::programs::fentry::FEntryContext
 impl !core::marker::Send for aya_ebpf::programs::fentry::FEntryContext
 impl !core::marker::Sync for aya_ebpf::programs::fentry::FEntryContext
 impl core::marker::Unpin for aya_ebpf::programs::fentry::FEntryContext
@@ -1380,6 +1427,7 @@ pub unsafe fn aya_ebpf::programs::fexit::FExitContext::arg<T: FromBtfArgument>(&
 pub fn aya_ebpf::programs::fexit::FExitContext::new(ctx: *mut core::ffi::c_void) -> aya_ebpf::programs::fexit::FExitContext
 impl aya_ebpf::EbpfContext for aya_ebpf::programs::fexit::FExitContext
 pub fn aya_ebpf::programs::fexit::FExitContext::as_ptr(&self) -> *mut core::ffi::c_void
+impl core::marker::Freeze for aya_ebpf::programs::fexit::FExitContext
 impl !core::marker::Send for aya_ebpf::programs::fexit::FExitContext
 impl !core::marker::Sync for aya_ebpf::programs::fexit::FExitContext
 impl core::marker::Unpin for aya_ebpf::programs::fexit::FExitContext
@@ -1408,6 +1456,7 @@ pub unsafe fn aya_ebpf::programs::lsm::LsmContext::arg<T: FromBtfArgument>(&self
 pub fn aya_ebpf::programs::lsm::LsmContext::new(ctx: *mut core::ffi::c_void) -> aya_ebpf::programs::lsm::LsmContext
 impl aya_ebpf::EbpfContext for aya_ebpf::programs::lsm::LsmContext
 pub fn aya_ebpf::programs::lsm::LsmContext::as_ptr(&self) -> *mut core::ffi::c_void
+impl core::marker::Freeze for aya_ebpf::programs::lsm::LsmContext
 impl !core::marker::Send for aya_ebpf::programs::lsm::LsmContext
 impl !core::marker::Sync for aya_ebpf::programs::lsm::LsmContext
 impl core::marker::Unpin for aya_ebpf::programs::lsm::LsmContext
@@ -1435,6 +1484,7 @@ impl aya_ebpf::programs::perf_event::PerfEventContext
 pub fn aya_ebpf::programs::perf_event::PerfEventContext::new(ctx: *mut core::ffi::c_void) -> aya_ebpf::programs::perf_event::PerfEventContext
 impl aya_ebpf::EbpfContext for aya_ebpf::programs::perf_event::PerfEventContext
 pub fn aya_ebpf::programs::perf_event::PerfEventContext::as_ptr(&self) -> *mut core::ffi::c_void
+impl core::marker::Freeze for aya_ebpf::programs::perf_event::PerfEventContext
 impl !core::marker::Send for aya_ebpf::programs::perf_event::PerfEventContext
 impl !core::marker::Sync for aya_ebpf::programs::perf_event::PerfEventContext
 impl core::marker::Unpin for aya_ebpf::programs::perf_event::PerfEventContext
@@ -1465,6 +1515,7 @@ pub fn aya_ebpf::programs::probe::ProbeContext::new(ctx: *mut core::ffi::c_void)
 pub fn aya_ebpf::programs::probe::ProbeContext::ret<T: FromPtRegs>(&self) -> core::option::Option<T>
 impl aya_ebpf::EbpfContext for aya_ebpf::programs::probe::ProbeContext
 pub fn aya_ebpf::programs::probe::ProbeContext::as_ptr(&self) -> *mut core::ffi::c_void
+impl core::marker::Freeze for aya_ebpf::programs::probe::ProbeContext
 impl !core::marker::Send for aya_ebpf::programs::probe::ProbeContext
 impl !core::marker::Sync for aya_ebpf::programs::probe::ProbeContext
 impl core::marker::Unpin for aya_ebpf::programs::probe::ProbeContext
@@ -1492,6 +1543,7 @@ impl aya_ebpf::programs::raw_tracepoint::RawTracePointContext
 pub fn aya_ebpf::programs::raw_tracepoint::RawTracePointContext::new(ctx: *mut core::ffi::c_void) -> aya_ebpf::programs::raw_tracepoint::RawTracePointContext
 impl aya_ebpf::EbpfContext for aya_ebpf::programs::raw_tracepoint::RawTracePointContext
 pub fn aya_ebpf::programs::raw_tracepoint::RawTracePointContext::as_ptr(&self) -> *mut core::ffi::c_void
+impl core::marker::Freeze for aya_ebpf::programs::raw_tracepoint::RawTracePointContext
 impl !core::marker::Send for aya_ebpf::programs::raw_tracepoint::RawTracePointContext
 impl !core::marker::Sync for aya_ebpf::programs::raw_tracepoint::RawTracePointContext
 impl core::marker::Unpin for aya_ebpf::programs::raw_tracepoint::RawTracePointContext
@@ -1541,6 +1593,7 @@ pub fn aya_ebpf::programs::sk_buff::SkBuff::remote_ipv6(&self) -> &[u32; 4]
 pub fn aya_ebpf::programs::sk_buff::SkBuff::remote_port(&self) -> u32
 pub fn aya_ebpf::programs::sk_buff::SkBuff::set_mark(&mut self, mark: u32)
 pub fn aya_ebpf::programs::sk_buff::SkBuff::store<T>(&mut self, offset: usize, v: &T, flags: u64) -> core::result::Result<(), aya_ebpf_cty::od::c_long>
+impl core::marker::Freeze for aya_ebpf::programs::sk_buff::SkBuff
 impl !core::marker::Send for aya_ebpf::programs::sk_buff::SkBuff
 impl !core::marker::Sync for aya_ebpf::programs::sk_buff::SkBuff
 impl core::marker::Unpin for aya_ebpf::programs::sk_buff::SkBuff
@@ -1582,6 +1635,7 @@ pub fn aya_ebpf::programs::sk_buff::SkBuffContext::set_mark(&mut self, mark: u32
 pub fn aya_ebpf::programs::sk_buff::SkBuffContext::store<T>(&mut self, offset: usize, v: &T, flags: u64) -> core::result::Result<(), aya_ebpf_cty::od::c_long>
 impl aya_ebpf::EbpfContext for aya_ebpf::programs::sk_buff::SkBuffContext
 pub fn aya_ebpf::programs::sk_buff::SkBuffContext::as_ptr(&self) -> *mut core::ffi::c_void
+impl core::marker::Freeze for aya_ebpf::programs::sk_buff::SkBuffContext
 impl !core::marker::Send for aya_ebpf::programs::sk_buff::SkBuffContext
 impl !core::marker::Sync for aya_ebpf::programs::sk_buff::SkBuffContext
 impl core::marker::Unpin for aya_ebpf::programs::sk_buff::SkBuffContext
@@ -1610,6 +1664,7 @@ impl aya_ebpf::programs::sk_lookup::SkLookupContext
 pub fn aya_ebpf::programs::sk_lookup::SkLookupContext::new(lookup: *mut aya_ebpf_bindings::x86_64::bindings::bpf_sk_lookup) -> aya_ebpf::programs::sk_lookup::SkLookupContext
 impl aya_ebpf::EbpfContext for aya_ebpf::programs::sk_lookup::SkLookupContext
 pub fn aya_ebpf::programs::sk_lookup::SkLookupContext::as_ptr(&self) -> *mut core::ffi::c_void
+impl core::marker::Freeze for aya_ebpf::programs::sk_lookup::SkLookupContext
 impl !core::marker::Send for aya_ebpf::programs::sk_lookup::SkLookupContext
 impl !core::marker::Sync for aya_ebpf::programs::sk_lookup::SkLookupContext
 impl core::marker::Unpin for aya_ebpf::programs::sk_lookup::SkLookupContext
@@ -1643,6 +1698,7 @@ pub fn aya_ebpf::programs::sk_msg::SkMsgContext::push_data(&self, start: u32, le
 pub fn aya_ebpf::programs::sk_msg::SkMsgContext::size(&self) -> u32
 impl aya_ebpf::EbpfContext for aya_ebpf::programs::sk_msg::SkMsgContext
 pub fn aya_ebpf::programs::sk_msg::SkMsgContext::as_ptr(&self) -> *mut core::ffi::c_void
+impl core::marker::Freeze for aya_ebpf::programs::sk_msg::SkMsgContext
 impl !core::marker::Send for aya_ebpf::programs::sk_msg::SkMsgContext
 impl !core::marker::Sync for aya_ebpf::programs::sk_msg::SkMsgContext
 impl core::marker::Unpin for aya_ebpf::programs::sk_msg::SkMsgContext
@@ -1671,6 +1727,7 @@ impl aya_ebpf::programs::sock::SockContext
 pub fn aya_ebpf::programs::sock::SockContext::new(sock: *mut aya_ebpf_bindings::x86_64::bindings::bpf_sock) -> aya_ebpf::programs::sock::SockContext
 impl aya_ebpf::EbpfContext for aya_ebpf::programs::sock::SockContext
 pub fn aya_ebpf::programs::sock::SockContext::as_ptr(&self) -> *mut core::ffi::c_void
+impl core::marker::Freeze for aya_ebpf::programs::sock::SockContext
 impl !core::marker::Send for aya_ebpf::programs::sock::SockContext
 impl !core::marker::Sync for aya_ebpf::programs::sock::SockContext
 impl core::marker::Unpin for aya_ebpf::programs::sock::SockContext
@@ -1699,6 +1756,7 @@ impl aya_ebpf::programs::sock_addr::SockAddrContext
 pub fn aya_ebpf::programs::sock_addr::SockAddrContext::new(sock_addr: *mut aya_ebpf_bindings::x86_64::bindings::bpf_sock_addr) -> aya_ebpf::programs::sock_addr::SockAddrContext
 impl aya_ebpf::EbpfContext for aya_ebpf::programs::sock_addr::SockAddrContext
 pub fn aya_ebpf::programs::sock_addr::SockAddrContext::as_ptr(&self) -> *mut core::ffi::c_void
+impl core::marker::Freeze for aya_ebpf::programs::sock_addr::SockAddrContext
 impl !core::marker::Send for aya_ebpf::programs::sock_addr::SockAddrContext
 impl !core::marker::Sync for aya_ebpf::programs::sock_addr::SockAddrContext
 impl core::marker::Unpin for aya_ebpf::programs::sock_addr::SockAddrContext
@@ -1738,6 +1796,7 @@ pub fn aya_ebpf::programs::sock_ops::SockOpsContext::remote_port(&self) -> u32
 pub fn aya_ebpf::programs::sock_ops::SockOpsContext::set_cb_flags(&self, flags: i32) -> core::result::Result<(), i64>
 impl aya_ebpf::EbpfContext for aya_ebpf::programs::sock_ops::SockOpsContext
 pub fn aya_ebpf::programs::sock_ops::SockOpsContext::as_ptr(&self) -> *mut core::ffi::c_void
+impl core::marker::Freeze for aya_ebpf::programs::sock_ops::SockOpsContext
 impl !core::marker::Send for aya_ebpf::programs::sock_ops::SockOpsContext
 impl !core::marker::Sync for aya_ebpf::programs::sock_ops::SockOpsContext
 impl core::marker::Unpin for aya_ebpf::programs::sock_ops::SockOpsContext
@@ -1766,6 +1825,7 @@ impl aya_ebpf::programs::sockopt::SockoptContext
 pub fn aya_ebpf::programs::sockopt::SockoptContext::new(sockopt: *mut aya_ebpf_bindings::x86_64::bindings::bpf_sockopt) -> aya_ebpf::programs::sockopt::SockoptContext
 impl aya_ebpf::EbpfContext for aya_ebpf::programs::sockopt::SockoptContext
 pub fn aya_ebpf::programs::sockopt::SockoptContext::as_ptr(&self) -> *mut core::ffi::c_void
+impl core::marker::Freeze for aya_ebpf::programs::sockopt::SockoptContext
 impl !core::marker::Send for aya_ebpf::programs::sockopt::SockoptContext
 impl !core::marker::Sync for aya_ebpf::programs::sockopt::SockoptContext
 impl core::marker::Unpin for aya_ebpf::programs::sockopt::SockoptContext
@@ -1794,6 +1854,7 @@ impl aya_ebpf::programs::sysctl::SysctlContext
 pub fn aya_ebpf::programs::sysctl::SysctlContext::new(sysctl: *mut aya_ebpf_bindings::x86_64::bindings::bpf_sysctl) -> aya_ebpf::programs::sysctl::SysctlContext
 impl aya_ebpf::EbpfContext for aya_ebpf::programs::sysctl::SysctlContext
 pub fn aya_ebpf::programs::sysctl::SysctlContext::as_ptr(&self) -> *mut core::ffi::c_void
+impl core::marker::Freeze for aya_ebpf::programs::sysctl::SysctlContext
 impl !core::marker::Send for aya_ebpf::programs::sysctl::SysctlContext
 impl !core::marker::Sync for aya_ebpf::programs::sysctl::SysctlContext
 impl core::marker::Unpin for aya_ebpf::programs::sysctl::SysctlContext
@@ -1839,6 +1900,7 @@ pub fn aya_ebpf::programs::tc::TcContext::set_mark(&mut self, mark: u32)
 pub fn aya_ebpf::programs::tc::TcContext::store<T>(&mut self, offset: usize, v: &T, flags: u64) -> core::result::Result<(), aya_ebpf_cty::od::c_long>
 impl aya_ebpf::EbpfContext for aya_ebpf::programs::tc::TcContext
 pub fn aya_ebpf::programs::tc::TcContext::as_ptr(&self) -> *mut aya_ebpf_cty::c_void
+impl core::marker::Freeze for aya_ebpf::programs::tc::TcContext
 impl !core::marker::Send for aya_ebpf::programs::tc::TcContext
 impl !core::marker::Sync for aya_ebpf::programs::tc::TcContext
 impl core::marker::Unpin for aya_ebpf::programs::tc::TcContext
@@ -1867,6 +1929,7 @@ pub unsafe fn aya_ebpf::programs::tp_btf::BtfTracePointContext::arg<T: FromBtfAr
 pub fn aya_ebpf::programs::tp_btf::BtfTracePointContext::new(ctx: *mut core::ffi::c_void) -> aya_ebpf::programs::tp_btf::BtfTracePointContext
 impl aya_ebpf::EbpfContext for aya_ebpf::programs::tp_btf::BtfTracePointContext
 pub fn aya_ebpf::programs::tp_btf::BtfTracePointContext::as_ptr(&self) -> *mut core::ffi::c_void
+impl core::marker::Freeze for aya_ebpf::programs::tp_btf::BtfTracePointContext
 impl !core::marker::Send for aya_ebpf::programs::tp_btf::BtfTracePointContext
 impl !core::marker::Sync for aya_ebpf::programs::tp_btf::BtfTracePointContext
 impl core::marker::Unpin for aya_ebpf::programs::tp_btf::BtfTracePointContext
@@ -1895,6 +1958,7 @@ pub fn aya_ebpf::programs::tracepoint::TracePointContext::new(ctx: *mut core::ff
 pub unsafe fn aya_ebpf::programs::tracepoint::TracePointContext::read_at<T>(&self, offset: usize) -> core::result::Result<T, i64>
 impl aya_ebpf::EbpfContext for aya_ebpf::programs::tracepoint::TracePointContext
 pub fn aya_ebpf::programs::tracepoint::TracePointContext::as_ptr(&self) -> *mut core::ffi::c_void
+impl core::marker::Freeze for aya_ebpf::programs::tracepoint::TracePointContext
 impl !core::marker::Send for aya_ebpf::programs::tracepoint::TracePointContext
 impl !core::marker::Sync for aya_ebpf::programs::tracepoint::TracePointContext
 impl core::marker::Unpin for aya_ebpf::programs::tracepoint::TracePointContext
@@ -1927,6 +1991,7 @@ pub fn aya_ebpf::programs::xdp::XdpContext::metadata_end(&self) -> usize
 pub fn aya_ebpf::programs::xdp::XdpContext::new(ctx: *mut aya_ebpf_bindings::x86_64::bindings::xdp_md) -> aya_ebpf::programs::xdp::XdpContext
 impl aya_ebpf::EbpfContext for aya_ebpf::programs::xdp::XdpContext
 pub fn aya_ebpf::programs::xdp::XdpContext::as_ptr(&self) -> *mut core::ffi::c_void
+impl core::marker::Freeze for aya_ebpf::programs::xdp::XdpContext
 impl !core::marker::Send for aya_ebpf::programs::xdp::XdpContext
 impl !core::marker::Sync for aya_ebpf::programs::xdp::XdpContext
 impl core::marker::Unpin for aya_ebpf::programs::xdp::XdpContext
@@ -1954,6 +2019,7 @@ pub unsafe fn aya_ebpf::programs::tp_btf::BtfTracePointContext::arg<T: FromBtfAr
 pub fn aya_ebpf::programs::tp_btf::BtfTracePointContext::new(ctx: *mut core::ffi::c_void) -> aya_ebpf::programs::tp_btf::BtfTracePointContext
 impl aya_ebpf::EbpfContext for aya_ebpf::programs::tp_btf::BtfTracePointContext
 pub fn aya_ebpf::programs::tp_btf::BtfTracePointContext::as_ptr(&self) -> *mut core::ffi::c_void
+impl core::marker::Freeze for aya_ebpf::programs::tp_btf::BtfTracePointContext
 impl !core::marker::Send for aya_ebpf::programs::tp_btf::BtfTracePointContext
 impl !core::marker::Sync for aya_ebpf::programs::tp_btf::BtfTracePointContext
 impl core::marker::Unpin for aya_ebpf::programs::tp_btf::BtfTracePointContext
@@ -1981,6 +2047,7 @@ impl aya_ebpf::programs::device::DeviceContext
 pub fn aya_ebpf::programs::device::DeviceContext::new(device: *mut aya_ebpf_bindings::x86_64::bindings::bpf_cgroup_dev_ctx) -> aya_ebpf::programs::device::DeviceContext
 impl aya_ebpf::EbpfContext for aya_ebpf::programs::device::DeviceContext
 pub fn aya_ebpf::programs::device::DeviceContext::as_ptr(&self) -> *mut core::ffi::c_void
+impl core::marker::Freeze for aya_ebpf::programs::device::DeviceContext
 impl !core::marker::Send for aya_ebpf::programs::device::DeviceContext
 impl !core::marker::Sync for aya_ebpf::programs::device::DeviceContext
 impl core::marker::Unpin for aya_ebpf::programs::device::DeviceContext
@@ -2008,6 +2075,7 @@ pub unsafe fn aya_ebpf::programs::fentry::FEntryContext::arg<T: FromBtfArgument>
 pub fn aya_ebpf::programs::fentry::FEntryContext::new(ctx: *mut core::ffi::c_void) -> aya_ebpf::programs::fentry::FEntryContext
 impl aya_ebpf::EbpfContext for aya_ebpf::programs::fentry::FEntryContext
 pub fn aya_ebpf::programs::fentry::FEntryContext::as_ptr(&self) -> *mut core::ffi::c_void
+impl core::marker::Freeze for aya_ebpf::programs::fentry::FEntryContext
 impl !core::marker::Send for aya_ebpf::programs::fentry::FEntryContext
 impl !core::marker::Sync for aya_ebpf::programs::fentry::FEntryContext
 impl core::marker::Unpin for aya_ebpf::programs::fentry::FEntryContext
@@ -2035,6 +2103,7 @@ pub unsafe fn aya_ebpf::programs::fexit::FExitContext::arg<T: FromBtfArgument>(&
 pub fn aya_ebpf::programs::fexit::FExitContext::new(ctx: *mut core::ffi::c_void) -> aya_ebpf::programs::fexit::FExitContext
 impl aya_ebpf::EbpfContext for aya_ebpf::programs::fexit::FExitContext
 pub fn aya_ebpf::programs::fexit::FExitContext::as_ptr(&self) -> *mut core::ffi::c_void
+impl core::marker::Freeze for aya_ebpf::programs::fexit::FExitContext
 impl !core::marker::Send for aya_ebpf::programs::fexit::FExitContext
 impl !core::marker::Sync for aya_ebpf::programs::fexit::FExitContext
 impl core::marker::Unpin for aya_ebpf::programs::fexit::FExitContext
@@ -2062,6 +2131,7 @@ pub unsafe fn aya_ebpf::programs::lsm::LsmContext::arg<T: FromBtfArgument>(&self
 pub fn aya_ebpf::programs::lsm::LsmContext::new(ctx: *mut core::ffi::c_void) -> aya_ebpf::programs::lsm::LsmContext
 impl aya_ebpf::EbpfContext for aya_ebpf::programs::lsm::LsmContext
 pub fn aya_ebpf::programs::lsm::LsmContext::as_ptr(&self) -> *mut core::ffi::c_void
+impl core::marker::Freeze for aya_ebpf::programs::lsm::LsmContext
 impl !core::marker::Send for aya_ebpf::programs::lsm::LsmContext
 impl !core::marker::Sync for aya_ebpf::programs::lsm::LsmContext
 impl core::marker::Unpin for aya_ebpf::programs::lsm::LsmContext
@@ -2088,6 +2158,7 @@ impl aya_ebpf::programs::perf_event::PerfEventContext
 pub fn aya_ebpf::programs::perf_event::PerfEventContext::new(ctx: *mut core::ffi::c_void) -> aya_ebpf::programs::perf_event::PerfEventContext
 impl aya_ebpf::EbpfContext for aya_ebpf::programs::perf_event::PerfEventContext
 pub fn aya_ebpf::programs::perf_event::PerfEventContext::as_ptr(&self) -> *mut core::ffi::c_void
+impl core::marker::Freeze for aya_ebpf::programs::perf_event::PerfEventContext
 impl !core::marker::Send for aya_ebpf::programs::perf_event::PerfEventContext
 impl !core::marker::Sync for aya_ebpf::programs::perf_event::PerfEventContext
 impl core::marker::Unpin for aya_ebpf::programs::perf_event::PerfEventContext
@@ -2117,6 +2188,7 @@ pub fn aya_ebpf::programs::probe::ProbeContext::new(ctx: *mut core::ffi::c_void)
 pub fn aya_ebpf::programs::probe::ProbeContext::ret<T: FromPtRegs>(&self) -> core::option::Option<T>
 impl aya_ebpf::EbpfContext for aya_ebpf::programs::probe::ProbeContext
 pub fn aya_ebpf::programs::probe::ProbeContext::as_ptr(&self) -> *mut core::ffi::c_void
+impl core::marker::Freeze for aya_ebpf::programs::probe::ProbeContext
 impl !core::marker::Send for aya_ebpf::programs::probe::ProbeContext
 impl !core::marker::Sync for aya_ebpf::programs::probe::ProbeContext
 impl core::marker::Unpin for aya_ebpf::programs::probe::ProbeContext
@@ -2143,6 +2215,7 @@ impl aya_ebpf::programs::raw_tracepoint::RawTracePointContext
 pub fn aya_ebpf::programs::raw_tracepoint::RawTracePointContext::new(ctx: *mut core::ffi::c_void) -> aya_ebpf::programs::raw_tracepoint::RawTracePointContext
 impl aya_ebpf::EbpfContext for aya_ebpf::programs::raw_tracepoint::RawTracePointContext
 pub fn aya_ebpf::programs::raw_tracepoint::RawTracePointContext::as_ptr(&self) -> *mut core::ffi::c_void
+impl core::marker::Freeze for aya_ebpf::programs::raw_tracepoint::RawTracePointContext
 impl !core::marker::Send for aya_ebpf::programs::raw_tracepoint::RawTracePointContext
 impl !core::marker::Sync for aya_ebpf::programs::raw_tracepoint::RawTracePointContext
 impl core::marker::Unpin for aya_ebpf::programs::raw_tracepoint::RawTracePointContext
@@ -2184,6 +2257,7 @@ pub fn aya_ebpf::programs::sk_buff::SkBuffContext::set_mark(&mut self, mark: u32
 pub fn aya_ebpf::programs::sk_buff::SkBuffContext::store<T>(&mut self, offset: usize, v: &T, flags: u64) -> core::result::Result<(), aya_ebpf_cty::od::c_long>
 impl aya_ebpf::EbpfContext for aya_ebpf::programs::sk_buff::SkBuffContext
 pub fn aya_ebpf::programs::sk_buff::SkBuffContext::as_ptr(&self) -> *mut core::ffi::c_void
+impl core::marker::Freeze for aya_ebpf::programs::sk_buff::SkBuffContext
 impl !core::marker::Send for aya_ebpf::programs::sk_buff::SkBuffContext
 impl !core::marker::Sync for aya_ebpf::programs::sk_buff::SkBuffContext
 impl core::marker::Unpin for aya_ebpf::programs::sk_buff::SkBuffContext
@@ -2211,6 +2285,7 @@ impl aya_ebpf::programs::sk_lookup::SkLookupContext
 pub fn aya_ebpf::programs::sk_lookup::SkLookupContext::new(lookup: *mut aya_ebpf_bindings::x86_64::bindings::bpf_sk_lookup) -> aya_ebpf::programs::sk_lookup::SkLookupContext
 impl aya_ebpf::EbpfContext for aya_ebpf::programs::sk_lookup::SkLookupContext
 pub fn aya_ebpf::programs::sk_lookup::SkLookupContext::as_ptr(&self) -> *mut core::ffi::c_void
+impl core::marker::Freeze for aya_ebpf::programs::sk_lookup::SkLookupContext
 impl !core::marker::Send for aya_ebpf::programs::sk_lookup::SkLookupContext
 impl !core::marker::Sync for aya_ebpf::programs::sk_lookup::SkLookupContext
 impl core::marker::Unpin for aya_ebpf::programs::sk_lookup::SkLookupContext
@@ -2243,6 +2318,7 @@ pub fn aya_ebpf::programs::sk_msg::SkMsgContext::push_data(&self, start: u32, le
 pub fn aya_ebpf::programs::sk_msg::SkMsgContext::size(&self) -> u32
 impl aya_ebpf::EbpfContext for aya_ebpf::programs::sk_msg::SkMsgContext
 pub fn aya_ebpf::programs::sk_msg::SkMsgContext::as_ptr(&self) -> *mut core::ffi::c_void
+impl core::marker::Freeze for aya_ebpf::programs::sk_msg::SkMsgContext
 impl !core::marker::Send for aya_ebpf::programs::sk_msg::SkMsgContext
 impl !core::marker::Sync for aya_ebpf::programs::sk_msg::SkMsgContext
 impl core::marker::Unpin for aya_ebpf::programs::sk_msg::SkMsgContext
@@ -2270,6 +2346,7 @@ impl aya_ebpf::programs::sock_addr::SockAddrContext
 pub fn aya_ebpf::programs::sock_addr::SockAddrContext::new(sock_addr: *mut aya_ebpf_bindings::x86_64::bindings::bpf_sock_addr) -> aya_ebpf::programs::sock_addr::SockAddrContext
 impl aya_ebpf::EbpfContext for aya_ebpf::programs::sock_addr::SockAddrContext
 pub fn aya_ebpf::programs::sock_addr::SockAddrContext::as_ptr(&self) -> *mut core::ffi::c_void
+impl core::marker::Freeze for aya_ebpf::programs::sock_addr::SockAddrContext
 impl !core::marker::Send for aya_ebpf::programs::sock_addr::SockAddrContext
 impl !core::marker::Sync for aya_ebpf::programs::sock_addr::SockAddrContext
 impl core::marker::Unpin for aya_ebpf::programs::sock_addr::SockAddrContext
@@ -2297,6 +2374,7 @@ impl aya_ebpf::programs::sock::SockContext
 pub fn aya_ebpf::programs::sock::SockContext::new(sock: *mut aya_ebpf_bindings::x86_64::bindings::bpf_sock) -> aya_ebpf::programs::sock::SockContext
 impl aya_ebpf::EbpfContext for aya_ebpf::programs::sock::SockContext
 pub fn aya_ebpf::programs::sock::SockContext::as_ptr(&self) -> *mut core::ffi::c_void
+impl core::marker::Freeze for aya_ebpf::programs::sock::SockContext
 impl !core::marker::Send for aya_ebpf::programs::sock::SockContext
 impl !core::marker::Sync for aya_ebpf::programs::sock::SockContext
 impl core::marker::Unpin for aya_ebpf::programs::sock::SockContext
@@ -2335,6 +2413,7 @@ pub fn aya_ebpf::programs::sock_ops::SockOpsContext::remote_port(&self) -> u32
 pub fn aya_ebpf::programs::sock_ops::SockOpsContext::set_cb_flags(&self, flags: i32) -> core::result::Result<(), i64>
 impl aya_ebpf::EbpfContext for aya_ebpf::programs::sock_ops::SockOpsContext
 pub fn aya_ebpf::programs::sock_ops::SockOpsContext::as_ptr(&self) -> *mut core::ffi::c_void
+impl core::marker::Freeze for aya_ebpf::programs::sock_ops::SockOpsContext
 impl !core::marker::Send for aya_ebpf::programs::sock_ops::SockOpsContext
 impl !core::marker::Sync for aya_ebpf::programs::sock_ops::SockOpsContext
 impl core::marker::Unpin for aya_ebpf::programs::sock_ops::SockOpsContext
@@ -2362,6 +2441,7 @@ impl aya_ebpf::programs::sockopt::SockoptContext
 pub fn aya_ebpf::programs::sockopt::SockoptContext::new(sockopt: *mut aya_ebpf_bindings::x86_64::bindings::bpf_sockopt) -> aya_ebpf::programs::sockopt::SockoptContext
 impl aya_ebpf::EbpfContext for aya_ebpf::programs::sockopt::SockoptContext
 pub fn aya_ebpf::programs::sockopt::SockoptContext::as_ptr(&self) -> *mut core::ffi::c_void
+impl core::marker::Freeze for aya_ebpf::programs::sockopt::SockoptContext
 impl !core::marker::Send for aya_ebpf::programs::sockopt::SockoptContext
 impl !core::marker::Sync for aya_ebpf::programs::sockopt::SockoptContext
 impl core::marker::Unpin for aya_ebpf::programs::sockopt::SockoptContext
@@ -2389,6 +2469,7 @@ impl aya_ebpf::programs::sysctl::SysctlContext
 pub fn aya_ebpf::programs::sysctl::SysctlContext::new(sysctl: *mut aya_ebpf_bindings::x86_64::bindings::bpf_sysctl) -> aya_ebpf::programs::sysctl::SysctlContext
 impl aya_ebpf::EbpfContext for aya_ebpf::programs::sysctl::SysctlContext
 pub fn aya_ebpf::programs::sysctl::SysctlContext::as_ptr(&self) -> *mut core::ffi::c_void
+impl core::marker::Freeze for aya_ebpf::programs::sysctl::SysctlContext
 impl !core::marker::Send for aya_ebpf::programs::sysctl::SysctlContext
 impl !core::marker::Sync for aya_ebpf::programs::sysctl::SysctlContext
 impl core::marker::Unpin for aya_ebpf::programs::sysctl::SysctlContext
@@ -2433,6 +2514,7 @@ pub fn aya_ebpf::programs::tc::TcContext::set_mark(&mut self, mark: u32)
 pub fn aya_ebpf::programs::tc::TcContext::store<T>(&mut self, offset: usize, v: &T, flags: u64) -> core::result::Result<(), aya_ebpf_cty::od::c_long>
 impl aya_ebpf::EbpfContext for aya_ebpf::programs::tc::TcContext
 pub fn aya_ebpf::programs::tc::TcContext::as_ptr(&self) -> *mut aya_ebpf_cty::c_void
+impl core::marker::Freeze for aya_ebpf::programs::tc::TcContext
 impl !core::marker::Send for aya_ebpf::programs::tc::TcContext
 impl !core::marker::Sync for aya_ebpf::programs::tc::TcContext
 impl core::marker::Unpin for aya_ebpf::programs::tc::TcContext
@@ -2460,6 +2542,7 @@ pub fn aya_ebpf::programs::tracepoint::TracePointContext::new(ctx: *mut core::ff
 pub unsafe fn aya_ebpf::programs::tracepoint::TracePointContext::read_at<T>(&self, offset: usize) -> core::result::Result<T, i64>
 impl aya_ebpf::EbpfContext for aya_ebpf::programs::tracepoint::TracePointContext
 pub fn aya_ebpf::programs::tracepoint::TracePointContext::as_ptr(&self) -> *mut core::ffi::c_void
+impl core::marker::Freeze for aya_ebpf::programs::tracepoint::TracePointContext
 impl !core::marker::Send for aya_ebpf::programs::tracepoint::TracePointContext
 impl !core::marker::Sync for aya_ebpf::programs::tracepoint::TracePointContext
 impl core::marker::Unpin for aya_ebpf::programs::tracepoint::TracePointContext
@@ -2491,6 +2574,7 @@ pub fn aya_ebpf::programs::xdp::XdpContext::metadata_end(&self) -> usize
 pub fn aya_ebpf::programs::xdp::XdpContext::new(ctx: *mut aya_ebpf_bindings::x86_64::bindings::xdp_md) -> aya_ebpf::programs::xdp::XdpContext
 impl aya_ebpf::EbpfContext for aya_ebpf::programs::xdp::XdpContext
 pub fn aya_ebpf::programs::xdp::XdpContext::as_ptr(&self) -> *mut core::ffi::c_void
+impl core::marker::Freeze for aya_ebpf::programs::xdp::XdpContext
 impl !core::marker::Send for aya_ebpf::programs::xdp::XdpContext
 impl !core::marker::Sync for aya_ebpf::programs::xdp::XdpContext
 impl core::marker::Unpin for aya_ebpf::programs::xdp::XdpContext
@@ -2519,6 +2603,7 @@ pub fn aya_ebpf::PtRegs::arg<T: FromPtRegs>(&self, n: usize) -> core::option::Op
 pub fn aya_ebpf::PtRegs::as_ptr(&self) -> *mut aya_ebpf_bindings::x86_64::bindings::pt_regs
 pub fn aya_ebpf::PtRegs::new(regs: *mut aya_ebpf_bindings::x86_64::bindings::pt_regs) -> Self
 pub fn aya_ebpf::PtRegs::ret<T: FromPtRegs>(&self) -> core::option::Option<T>
+impl core::marker::Freeze for aya_ebpf::PtRegs
 impl !core::marker::Send for aya_ebpf::PtRegs
 impl !core::marker::Sync for aya_ebpf::PtRegs
 impl core::marker::Unpin for aya_ebpf::PtRegs

--- a/xtask/public-api/aya-log-common.txt
+++ b/xtask/public-api/aya-log-common.txt
@@ -25,6 +25,7 @@ pub fn u8::from(enum_value: aya_log_common::Argument) -> Self
 impl core::fmt::Debug for aya_log_common::Argument
 pub fn aya_log_common::Argument::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Copy for aya_log_common::Argument
+impl core::marker::Freeze for aya_log_common::Argument
 impl core::marker::Send for aya_log_common::Argument
 impl core::marker::Sync for aya_log_common::Argument
 impl core::marker::Unpin for aya_log_common::Argument
@@ -66,6 +67,7 @@ impl core::fmt::Debug for aya_log_common::DisplayHint
 pub fn aya_log_common::DisplayHint::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Copy for aya_log_common::DisplayHint
 impl core::marker::StructuralPartialEq for aya_log_common::DisplayHint
+impl core::marker::Freeze for aya_log_common::DisplayHint
 impl core::marker::Send for aya_log_common::DisplayHint
 impl core::marker::Sync for aya_log_common::DisplayHint
 impl core::marker::Unpin for aya_log_common::DisplayHint
@@ -106,6 +108,7 @@ impl core::hash::Hash for aya_log_common::Level
 pub fn aya_log_common::Level::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
 impl core::marker::Copy for aya_log_common::Level
 impl core::marker::StructuralPartialEq for aya_log_common::Level
+impl core::marker::Freeze for aya_log_common::Level
 impl core::marker::Send for aya_log_common::Level
 impl core::marker::Sync for aya_log_common::Level
 impl core::marker::Unpin for aya_log_common::Level
@@ -141,6 +144,7 @@ pub fn u8::from(enum_value: aya_log_common::RecordField) -> Self
 impl core::fmt::Debug for aya_log_common::RecordField
 pub fn aya_log_common::RecordField::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Copy for aya_log_common::RecordField
+impl core::marker::Freeze for aya_log_common::RecordField
 impl core::marker::Send for aya_log_common::RecordField
 impl core::marker::Sync for aya_log_common::RecordField
 impl core::marker::Unpin for aya_log_common::RecordField

--- a/xtask/public-api/aya-log-parser.txt
+++ b/xtask/public-api/aya-log-parser.txt
@@ -10,6 +10,7 @@ pub fn aya_log_parser::Fragment::eq(&self, other: &aya_log_parser::Fragment) -> 
 impl core::fmt::Debug for aya_log_parser::Fragment
 pub fn aya_log_parser::Fragment::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::StructuralPartialEq for aya_log_parser::Fragment
+impl core::marker::Freeze for aya_log_parser::Fragment
 impl core::marker::Send for aya_log_parser::Fragment
 impl core::marker::Sync for aya_log_parser::Fragment
 impl core::marker::Unpin for aya_log_parser::Fragment
@@ -45,6 +46,7 @@ pub fn aya_log_parser::Parameter::eq(&self, other: &aya_log_parser::Parameter) -
 impl core::fmt::Debug for aya_log_parser::Parameter
 pub fn aya_log_parser::Parameter::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::StructuralPartialEq for aya_log_parser::Parameter
+impl core::marker::Freeze for aya_log_parser::Parameter
 impl core::marker::Send for aya_log_parser::Parameter
 impl core::marker::Sync for aya_log_parser::Parameter
 impl core::marker::Unpin for aya_log_parser::Parameter

--- a/xtask/public-api/aya-log.txt
+++ b/xtask/public-api/aya-log.txt
@@ -14,6 +14,7 @@ impl core::fmt::Debug for aya_log::Error
 pub fn aya_log::Error::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::fmt::Display for aya_log::Error
 pub fn aya_log::Error::fmt(&self, __formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for aya_log::Error
 impl core::marker::Send for aya_log::Error
 impl core::marker::Sync for aya_log::Error
 impl core::marker::Unpin for aya_log::Error
@@ -40,6 +41,7 @@ pub fn aya_log::Error::from(t: T) -> T
 pub struct aya_log::DefaultFormatter
 impl<T> aya_log::Formatter<T> for aya_log::DefaultFormatter where T: alloc::string::ToString
 pub fn aya_log::DefaultFormatter::format(v: T) -> alloc::string::String
+impl core::marker::Freeze for aya_log::DefaultFormatter
 impl core::marker::Send for aya_log::DefaultFormatter
 impl core::marker::Sync for aya_log::DefaultFormatter
 impl core::marker::Unpin for aya_log::DefaultFormatter
@@ -65,6 +67,7 @@ pub struct aya_log::EbpfLogger
 impl aya_log::EbpfLogger
 pub fn aya_log::EbpfLogger::init(bpf: &mut aya::bpf::Ebpf) -> core::result::Result<aya_log::EbpfLogger, aya_log::Error>
 pub fn aya_log::EbpfLogger::init_with_logger<T: log::Log + 'static>(bpf: &mut aya::bpf::Ebpf, logger: T) -> core::result::Result<aya_log::EbpfLogger, aya_log::Error>
+impl core::marker::Freeze for aya_log::EbpfLogger
 impl core::marker::Send for aya_log::EbpfLogger
 impl core::marker::Sync for aya_log::EbpfLogger
 impl core::marker::Unpin for aya_log::EbpfLogger
@@ -89,6 +92,7 @@ pub fn aya_log::EbpfLogger::from(t: T) -> T
 pub struct aya_log::Ipv4Formatter
 impl<T> aya_log::Formatter<T> for aya_log::Ipv4Formatter where T: core::convert::Into<core::net::ip_addr::Ipv4Addr>
 pub fn aya_log::Ipv4Formatter::format(v: T) -> alloc::string::String
+impl core::marker::Freeze for aya_log::Ipv4Formatter
 impl core::marker::Send for aya_log::Ipv4Formatter
 impl core::marker::Sync for aya_log::Ipv4Formatter
 impl core::marker::Unpin for aya_log::Ipv4Formatter
@@ -113,6 +117,7 @@ pub fn aya_log::Ipv4Formatter::from(t: T) -> T
 pub struct aya_log::Ipv6Formatter
 impl<T> aya_log::Formatter<T> for aya_log::Ipv6Formatter where T: core::convert::Into<core::net::ip_addr::Ipv6Addr>
 pub fn aya_log::Ipv6Formatter::format(v: T) -> alloc::string::String
+impl core::marker::Freeze for aya_log::Ipv6Formatter
 impl core::marker::Send for aya_log::Ipv6Formatter
 impl core::marker::Sync for aya_log::Ipv6Formatter
 impl core::marker::Unpin for aya_log::Ipv6Formatter
@@ -137,6 +142,7 @@ pub fn aya_log::Ipv6Formatter::from(t: T) -> T
 pub struct aya_log::LowerHexDebugFormatter
 impl<T> aya_log::Formatter<&[T]> for aya_log::LowerHexDebugFormatter where T: core::fmt::LowerHex
 pub fn aya_log::LowerHexDebugFormatter::format(v: &[T]) -> alloc::string::String
+impl core::marker::Freeze for aya_log::LowerHexDebugFormatter
 impl core::marker::Send for aya_log::LowerHexDebugFormatter
 impl core::marker::Sync for aya_log::LowerHexDebugFormatter
 impl core::marker::Unpin for aya_log::LowerHexDebugFormatter
@@ -161,6 +167,7 @@ pub fn aya_log::LowerHexDebugFormatter::from(t: T) -> T
 pub struct aya_log::LowerHexFormatter
 impl<T> aya_log::Formatter<T> for aya_log::LowerHexFormatter where T: core::fmt::LowerHex
 pub fn aya_log::LowerHexFormatter::format(v: T) -> alloc::string::String
+impl core::marker::Freeze for aya_log::LowerHexFormatter
 impl core::marker::Send for aya_log::LowerHexFormatter
 impl core::marker::Sync for aya_log::LowerHexFormatter
 impl core::marker::Unpin for aya_log::LowerHexFormatter
@@ -185,6 +192,7 @@ pub fn aya_log::LowerHexFormatter::from(t: T) -> T
 pub struct aya_log::LowerMacFormatter
 impl aya_log::Formatter<[u8; 6]> for aya_log::LowerMacFormatter
 pub fn aya_log::LowerMacFormatter::format(v: [u8; 6]) -> alloc::string::String
+impl core::marker::Freeze for aya_log::LowerMacFormatter
 impl core::marker::Send for aya_log::LowerMacFormatter
 impl core::marker::Sync for aya_log::LowerMacFormatter
 impl core::marker::Unpin for aya_log::LowerMacFormatter
@@ -209,6 +217,7 @@ pub fn aya_log::LowerMacFormatter::from(t: T) -> T
 pub struct aya_log::UpperHexDebugFormatter
 impl<T> aya_log::Formatter<&[T]> for aya_log::UpperHexDebugFormatter where T: core::fmt::UpperHex
 pub fn aya_log::UpperHexDebugFormatter::format(v: &[T]) -> alloc::string::String
+impl core::marker::Freeze for aya_log::UpperHexDebugFormatter
 impl core::marker::Send for aya_log::UpperHexDebugFormatter
 impl core::marker::Sync for aya_log::UpperHexDebugFormatter
 impl core::marker::Unpin for aya_log::UpperHexDebugFormatter
@@ -233,6 +242,7 @@ pub fn aya_log::UpperHexDebugFormatter::from(t: T) -> T
 pub struct aya_log::UpperHexFormatter
 impl<T> aya_log::Formatter<T> for aya_log::UpperHexFormatter where T: core::fmt::UpperHex
 pub fn aya_log::UpperHexFormatter::format(v: T) -> alloc::string::String
+impl core::marker::Freeze for aya_log::UpperHexFormatter
 impl core::marker::Send for aya_log::UpperHexFormatter
 impl core::marker::Sync for aya_log::UpperHexFormatter
 impl core::marker::Unpin for aya_log::UpperHexFormatter
@@ -257,6 +267,7 @@ pub fn aya_log::UpperHexFormatter::from(t: T) -> T
 pub struct aya_log::UpperMacFormatter
 impl aya_log::Formatter<[u8; 6]> for aya_log::UpperMacFormatter
 pub fn aya_log::UpperMacFormatter::format(v: [u8; 6]) -> alloc::string::String
+impl core::marker::Freeze for aya_log::UpperMacFormatter
 impl core::marker::Send for aya_log::UpperMacFormatter
 impl core::marker::Sync for aya_log::UpperMacFormatter
 impl core::marker::Unpin for aya_log::UpperMacFormatter

--- a/xtask/public-api/aya-obj.txt
+++ b/xtask/public-api/aya-obj.txt
@@ -46,6 +46,7 @@ impl core::fmt::Debug for aya_obj::btf::BtfError
 pub fn aya_obj::btf::BtfError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::fmt::Display for aya_obj::btf::BtfError
 pub fn aya_obj::btf::BtfError::fmt(&self, __formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for aya_obj::btf::BtfError
 impl core::marker::Send for aya_obj::btf::BtfError
 impl core::marker::Sync for aya_obj::btf::BtfError
 impl core::marker::Unpin for aya_obj::btf::BtfError
@@ -106,6 +107,7 @@ impl core::fmt::Display for aya_obj::btf::BtfKind
 pub fn aya_obj::btf::BtfKind::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Copy for aya_obj::btf::BtfKind
 impl core::marker::StructuralPartialEq for aya_obj::btf::BtfKind
+impl core::marker::Freeze for aya_obj::btf::BtfKind
 impl core::marker::Send for aya_obj::btf::BtfKind
 impl core::marker::Sync for aya_obj::btf::BtfKind
 impl core::marker::Unpin for aya_obj::btf::BtfKind
@@ -158,6 +160,7 @@ impl core::clone::Clone for aya_obj::btf::BtfType
 pub fn aya_obj::btf::BtfType::clone(&self) -> aya_obj::btf::BtfType
 impl core::fmt::Debug for aya_obj::btf::BtfType
 pub fn aya_obj::btf::BtfType::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for aya_obj::btf::BtfType
 impl core::marker::Send for aya_obj::btf::BtfType
 impl core::marker::Sync for aya_obj::btf::BtfType
 impl core::marker::Unpin for aya_obj::btf::BtfType
@@ -198,6 +201,7 @@ pub fn aya_obj::btf::FuncLinkage::from(v: u32) -> Self
 impl core::fmt::Debug for aya_obj::btf::FuncLinkage
 pub fn aya_obj::btf::FuncLinkage::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::StructuralPartialEq for aya_obj::btf::FuncLinkage
+impl core::marker::Freeze for aya_obj::btf::FuncLinkage
 impl core::marker::Send for aya_obj::btf::FuncLinkage
 impl core::marker::Sync for aya_obj::btf::FuncLinkage
 impl core::marker::Unpin for aya_obj::btf::FuncLinkage
@@ -239,6 +243,7 @@ pub fn aya_obj::btf::IntEncoding::from(v: u32) -> Self
 impl core::fmt::Debug for aya_obj::btf::IntEncoding
 pub fn aya_obj::btf::IntEncoding::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::StructuralPartialEq for aya_obj::btf::IntEncoding
+impl core::marker::Freeze for aya_obj::btf::IntEncoding
 impl core::marker::Send for aya_obj::btf::IntEncoding
 impl core::marker::Sync for aya_obj::btf::IntEncoding
 impl core::marker::Unpin for aya_obj::btf::IntEncoding
@@ -279,6 +284,7 @@ pub fn aya_obj::btf::VarLinkage::from(v: u32) -> Self
 impl core::fmt::Debug for aya_obj::btf::VarLinkage
 pub fn aya_obj::btf::VarLinkage::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::StructuralPartialEq for aya_obj::btf::VarLinkage
+impl core::marker::Freeze for aya_obj::btf::VarLinkage
 impl core::marker::Send for aya_obj::btf::VarLinkage
 impl core::marker::Sync for aya_obj::btf::VarLinkage
 impl core::marker::Unpin for aya_obj::btf::VarLinkage
@@ -309,6 +315,7 @@ impl core::clone::Clone for aya_obj::btf::Array
 pub fn aya_obj::btf::Array::clone(&self) -> aya_obj::btf::Array
 impl core::fmt::Debug for aya_obj::btf::Array
 pub fn aya_obj::btf::Array::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for aya_obj::btf::Array
 impl core::marker::Send for aya_obj::btf::Array
 impl core::marker::Sync for aya_obj::btf::Array
 impl core::marker::Unpin for aya_obj::btf::Array
@@ -350,6 +357,7 @@ impl core::default::Default for aya_obj::btf::Btf
 pub fn aya_obj::btf::Btf::default() -> Self
 impl core::fmt::Debug for aya_obj::btf::Btf
 pub fn aya_obj::btf::Btf::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for aya_obj::btf::Btf
 impl core::marker::Send for aya_obj::btf::Btf
 impl core::marker::Sync for aya_obj::btf::Btf
 impl core::marker::Unpin for aya_obj::btf::Btf
@@ -384,6 +392,7 @@ impl core::clone::Clone for aya_obj::btf::BtfEnum
 pub fn aya_obj::btf::BtfEnum::clone(&self) -> aya_obj::btf::BtfEnum
 impl core::fmt::Debug for aya_obj::btf::BtfEnum
 pub fn aya_obj::btf::BtfEnum::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for aya_obj::btf::BtfEnum
 impl core::marker::Send for aya_obj::btf::BtfEnum
 impl core::marker::Sync for aya_obj::btf::BtfEnum
 impl core::marker::Unpin for aya_obj::btf::BtfEnum
@@ -416,6 +425,7 @@ impl core::clone::Clone for aya_obj::btf::BtfEnum64
 pub fn aya_obj::btf::BtfEnum64::clone(&self) -> aya_obj::btf::BtfEnum64
 impl core::fmt::Debug for aya_obj::btf::BtfEnum64
 pub fn aya_obj::btf::BtfEnum64::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for aya_obj::btf::BtfEnum64
 impl core::marker::Send for aya_obj::btf::BtfEnum64
 impl core::marker::Sync for aya_obj::btf::BtfEnum64
 impl core::marker::Unpin for aya_obj::btf::BtfEnum64
@@ -446,6 +456,7 @@ impl core::clone::Clone for aya_obj::btf::BtfExt
 pub fn aya_obj::btf::BtfExt::clone(&self) -> aya_obj::btf::BtfExt
 impl core::fmt::Debug for aya_obj::btf::BtfExt
 pub fn aya_obj::btf::BtfExt::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for aya_obj::btf::BtfExt
 impl core::marker::Send for aya_obj::btf::BtfExt
 impl core::marker::Sync for aya_obj::btf::BtfExt
 impl core::marker::Unpin for aya_obj::btf::BtfExt
@@ -485,6 +496,7 @@ impl core::default::Default for aya_obj::btf::BtfFeatures
 pub fn aya_obj::btf::BtfFeatures::default() -> aya_obj::btf::BtfFeatures
 impl core::fmt::Debug for aya_obj::btf::BtfFeatures
 pub fn aya_obj::btf::BtfFeatures::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for aya_obj::btf::BtfFeatures
 impl core::marker::Send for aya_obj::btf::BtfFeatures
 impl core::marker::Sync for aya_obj::btf::BtfFeatures
 impl core::marker::Unpin for aya_obj::btf::BtfFeatures
@@ -513,6 +525,7 @@ impl core::clone::Clone for aya_obj::btf::BtfParam
 pub fn aya_obj::btf::BtfParam::clone(&self) -> aya_obj::btf::BtfParam
 impl core::fmt::Debug for aya_obj::btf::BtfParam
 pub fn aya_obj::btf::BtfParam::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for aya_obj::btf::BtfParam
 impl core::marker::Send for aya_obj::btf::BtfParam
 impl core::marker::Sync for aya_obj::btf::BtfParam
 impl core::marker::Unpin for aya_obj::btf::BtfParam
@@ -546,6 +559,7 @@ impl core::fmt::Debug for aya_obj::btf::BtfRelocationError
 pub fn aya_obj::btf::BtfRelocationError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::fmt::Display for aya_obj::btf::BtfRelocationError
 pub fn aya_obj::btf::BtfRelocationError::fmt(&self, __formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for aya_obj::btf::BtfRelocationError
 impl core::marker::Send for aya_obj::btf::BtfRelocationError
 impl core::marker::Sync for aya_obj::btf::BtfRelocationError
 impl core::marker::Unpin for aya_obj::btf::BtfRelocationError
@@ -574,6 +588,7 @@ impl core::clone::Clone for aya_obj::btf::Const
 pub fn aya_obj::btf::Const::clone(&self) -> aya_obj::btf::Const
 impl core::fmt::Debug for aya_obj::btf::Const
 pub fn aya_obj::btf::Const::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for aya_obj::btf::Const
 impl core::marker::Send for aya_obj::btf::Const
 impl core::marker::Sync for aya_obj::btf::Const
 impl core::marker::Unpin for aya_obj::btf::Const
@@ -606,6 +621,7 @@ impl core::clone::Clone for aya_obj::btf::DataSec
 pub fn aya_obj::btf::DataSec::clone(&self) -> aya_obj::btf::DataSec
 impl core::fmt::Debug for aya_obj::btf::DataSec
 pub fn aya_obj::btf::DataSec::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for aya_obj::btf::DataSec
 impl core::marker::Send for aya_obj::btf::DataSec
 impl core::marker::Sync for aya_obj::btf::DataSec
 impl core::marker::Unpin for aya_obj::btf::DataSec
@@ -639,6 +655,7 @@ impl core::clone::Clone for aya_obj::btf::DataSecEntry
 pub fn aya_obj::btf::DataSecEntry::clone(&self) -> aya_obj::btf::DataSecEntry
 impl core::fmt::Debug for aya_obj::btf::DataSecEntry
 pub fn aya_obj::btf::DataSecEntry::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for aya_obj::btf::DataSecEntry
 impl core::marker::Send for aya_obj::btf::DataSecEntry
 impl core::marker::Sync for aya_obj::btf::DataSecEntry
 impl core::marker::Unpin for aya_obj::btf::DataSecEntry
@@ -671,6 +688,7 @@ impl core::clone::Clone for aya_obj::btf::DeclTag
 pub fn aya_obj::btf::DeclTag::clone(&self) -> aya_obj::btf::DeclTag
 impl core::fmt::Debug for aya_obj::btf::DeclTag
 pub fn aya_obj::btf::DeclTag::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for aya_obj::btf::DeclTag
 impl core::marker::Send for aya_obj::btf::DeclTag
 impl core::marker::Sync for aya_obj::btf::DeclTag
 impl core::marker::Unpin for aya_obj::btf::DeclTag
@@ -703,6 +721,7 @@ impl core::clone::Clone for aya_obj::btf::Enum
 pub fn aya_obj::btf::Enum::clone(&self) -> aya_obj::btf::Enum
 impl core::fmt::Debug for aya_obj::btf::Enum
 pub fn aya_obj::btf::Enum::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for aya_obj::btf::Enum
 impl core::marker::Send for aya_obj::btf::Enum
 impl core::marker::Sync for aya_obj::btf::Enum
 impl core::marker::Unpin for aya_obj::btf::Enum
@@ -735,6 +754,7 @@ impl core::clone::Clone for aya_obj::btf::Enum64
 pub fn aya_obj::btf::Enum64::clone(&self) -> aya_obj::btf::Enum64
 impl core::fmt::Debug for aya_obj::btf::Enum64
 pub fn aya_obj::btf::Enum64::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for aya_obj::btf::Enum64
 impl core::marker::Send for aya_obj::btf::Enum64
 impl core::marker::Sync for aya_obj::btf::Enum64
 impl core::marker::Unpin for aya_obj::btf::Enum64
@@ -767,6 +787,7 @@ impl core::clone::Clone for aya_obj::btf::Float
 pub fn aya_obj::btf::Float::clone(&self) -> aya_obj::btf::Float
 impl core::fmt::Debug for aya_obj::btf::Float
 pub fn aya_obj::btf::Float::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for aya_obj::btf::Float
 impl core::marker::Send for aya_obj::btf::Float
 impl core::marker::Sync for aya_obj::btf::Float
 impl core::marker::Unpin for aya_obj::btf::Float
@@ -799,6 +820,7 @@ impl core::clone::Clone for aya_obj::btf::Func
 pub fn aya_obj::btf::Func::clone(&self) -> aya_obj::btf::Func
 impl core::fmt::Debug for aya_obj::btf::Func
 pub fn aya_obj::btf::Func::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for aya_obj::btf::Func
 impl core::marker::Send for aya_obj::btf::Func
 impl core::marker::Sync for aya_obj::btf::Func
 impl core::marker::Unpin for aya_obj::btf::Func
@@ -830,6 +852,7 @@ impl core::clone::Clone for aya_obj::btf::FuncInfo
 pub fn aya_obj::btf::FuncInfo::clone(&self) -> aya_obj::btf::FuncInfo
 impl core::fmt::Debug for aya_obj::btf::FuncInfo
 pub fn aya_obj::btf::FuncInfo::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for aya_obj::btf::FuncInfo
 impl core::marker::Send for aya_obj::btf::FuncInfo
 impl core::marker::Sync for aya_obj::btf::FuncInfo
 impl core::marker::Unpin for aya_obj::btf::FuncInfo
@@ -862,6 +885,7 @@ impl core::clone::Clone for aya_obj::btf::FuncProto
 pub fn aya_obj::btf::FuncProto::clone(&self) -> aya_obj::btf::FuncProto
 impl core::fmt::Debug for aya_obj::btf::FuncProto
 pub fn aya_obj::btf::FuncProto::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for aya_obj::btf::FuncProto
 impl core::marker::Send for aya_obj::btf::FuncProto
 impl core::marker::Sync for aya_obj::btf::FuncProto
 impl core::marker::Unpin for aya_obj::btf::FuncProto
@@ -899,6 +923,7 @@ impl core::default::Default for aya_obj::btf::FuncSecInfo
 pub fn aya_obj::btf::FuncSecInfo::default() -> aya_obj::btf::FuncSecInfo
 impl core::fmt::Debug for aya_obj::btf::FuncSecInfo
 pub fn aya_obj::btf::FuncSecInfo::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for aya_obj::btf::FuncSecInfo
 impl core::marker::Send for aya_obj::btf::FuncSecInfo
 impl core::marker::Sync for aya_obj::btf::FuncSecInfo
 impl core::marker::Unpin for aya_obj::btf::FuncSecInfo
@@ -929,6 +954,7 @@ impl core::clone::Clone for aya_obj::btf::Fwd
 pub fn aya_obj::btf::Fwd::clone(&self) -> aya_obj::btf::Fwd
 impl core::fmt::Debug for aya_obj::btf::Fwd
 pub fn aya_obj::btf::Fwd::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for aya_obj::btf::Fwd
 impl core::marker::Send for aya_obj::btf::Fwd
 impl core::marker::Sync for aya_obj::btf::Fwd
 impl core::marker::Unpin for aya_obj::btf::Fwd
@@ -961,6 +987,7 @@ impl core::clone::Clone for aya_obj::btf::Int
 pub fn aya_obj::btf::Int::clone(&self) -> aya_obj::btf::Int
 impl core::fmt::Debug for aya_obj::btf::Int
 pub fn aya_obj::btf::Int::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for aya_obj::btf::Int
 impl core::marker::Send for aya_obj::btf::Int
 impl core::marker::Sync for aya_obj::btf::Int
 impl core::marker::Unpin for aya_obj::btf::Int
@@ -998,6 +1025,7 @@ impl core::default::Default for aya_obj::btf::LineSecInfo
 pub fn aya_obj::btf::LineSecInfo::default() -> aya_obj::btf::LineSecInfo
 impl core::fmt::Debug for aya_obj::btf::LineSecInfo
 pub fn aya_obj::btf::LineSecInfo::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for aya_obj::btf::LineSecInfo
 impl core::marker::Send for aya_obj::btf::LineSecInfo
 impl core::marker::Sync for aya_obj::btf::LineSecInfo
 impl core::marker::Unpin for aya_obj::btf::LineSecInfo
@@ -1030,6 +1058,7 @@ impl core::clone::Clone for aya_obj::btf::Ptr
 pub fn aya_obj::btf::Ptr::clone(&self) -> aya_obj::btf::Ptr
 impl core::fmt::Debug for aya_obj::btf::Ptr
 pub fn aya_obj::btf::Ptr::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for aya_obj::btf::Ptr
 impl core::marker::Send for aya_obj::btf::Ptr
 impl core::marker::Sync for aya_obj::btf::Ptr
 impl core::marker::Unpin for aya_obj::btf::Ptr
@@ -1060,6 +1089,7 @@ impl core::clone::Clone for aya_obj::btf::Restrict
 pub fn aya_obj::btf::Restrict::clone(&self) -> aya_obj::btf::Restrict
 impl core::fmt::Debug for aya_obj::btf::Restrict
 pub fn aya_obj::btf::Restrict::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for aya_obj::btf::Restrict
 impl core::marker::Send for aya_obj::btf::Restrict
 impl core::marker::Sync for aya_obj::btf::Restrict
 impl core::marker::Unpin for aya_obj::btf::Restrict
@@ -1090,6 +1120,7 @@ impl core::clone::Clone for aya_obj::btf::Struct
 pub fn aya_obj::btf::Struct::clone(&self) -> aya_obj::btf::Struct
 impl core::fmt::Debug for aya_obj::btf::Struct
 pub fn aya_obj::btf::Struct::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for aya_obj::btf::Struct
 impl core::marker::Send for aya_obj::btf::Struct
 impl core::marker::Sync for aya_obj::btf::Struct
 impl core::marker::Unpin for aya_obj::btf::Struct
@@ -1122,6 +1153,7 @@ impl core::clone::Clone for aya_obj::btf::TypeTag
 pub fn aya_obj::btf::TypeTag::clone(&self) -> aya_obj::btf::TypeTag
 impl core::fmt::Debug for aya_obj::btf::TypeTag
 pub fn aya_obj::btf::TypeTag::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for aya_obj::btf::TypeTag
 impl core::marker::Send for aya_obj::btf::TypeTag
 impl core::marker::Sync for aya_obj::btf::TypeTag
 impl core::marker::Unpin for aya_obj::btf::TypeTag
@@ -1152,6 +1184,7 @@ impl core::clone::Clone for aya_obj::btf::Typedef
 pub fn aya_obj::btf::Typedef::clone(&self) -> aya_obj::btf::Typedef
 impl core::fmt::Debug for aya_obj::btf::Typedef
 pub fn aya_obj::btf::Typedef::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for aya_obj::btf::Typedef
 impl core::marker::Send for aya_obj::btf::Typedef
 impl core::marker::Sync for aya_obj::btf::Typedef
 impl core::marker::Unpin for aya_obj::btf::Typedef
@@ -1182,6 +1215,7 @@ impl core::clone::Clone for aya_obj::btf::Union
 pub fn aya_obj::btf::Union::clone(&self) -> aya_obj::btf::Union
 impl core::fmt::Debug for aya_obj::btf::Union
 pub fn aya_obj::btf::Union::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for aya_obj::btf::Union
 impl core::marker::Send for aya_obj::btf::Union
 impl core::marker::Sync for aya_obj::btf::Union
 impl core::marker::Unpin for aya_obj::btf::Union
@@ -1214,6 +1248,7 @@ impl core::clone::Clone for aya_obj::btf::Var
 pub fn aya_obj::btf::Var::clone(&self) -> aya_obj::btf::Var
 impl core::fmt::Debug for aya_obj::btf::Var
 pub fn aya_obj::btf::Var::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for aya_obj::btf::Var
 impl core::marker::Send for aya_obj::btf::Var
 impl core::marker::Sync for aya_obj::btf::Var
 impl core::marker::Unpin for aya_obj::btf::Var
@@ -1244,6 +1279,7 @@ impl core::clone::Clone for aya_obj::btf::Volatile
 pub fn aya_obj::btf::Volatile::clone(&self) -> aya_obj::btf::Volatile
 impl core::fmt::Debug for aya_obj::btf::Volatile
 pub fn aya_obj::btf::Volatile::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for aya_obj::btf::Volatile
 impl core::marker::Send for aya_obj::btf::Volatile
 impl core::marker::Sync for aya_obj::btf::Volatile
 impl core::marker::Unpin for aya_obj::btf::Volatile
@@ -1351,6 +1387,7 @@ impl core::hash::Hash for aya_obj::generated::bpf_attach_type
 pub fn aya_obj::generated::bpf_attach_type::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
 impl core::marker::Copy for aya_obj::generated::bpf_attach_type
 impl core::marker::StructuralPartialEq for aya_obj::generated::bpf_attach_type
+impl core::marker::Freeze for aya_obj::generated::bpf_attach_type
 impl core::marker::Send for aya_obj::generated::bpf_attach_type
 impl core::marker::Sync for aya_obj::generated::bpf_attach_type
 impl core::marker::Unpin for aya_obj::generated::bpf_attach_type
@@ -1426,6 +1463,7 @@ impl core::hash::Hash for aya_obj::generated::bpf_cmd
 pub fn aya_obj::generated::bpf_cmd::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
 impl core::marker::Copy for aya_obj::generated::bpf_cmd
 impl core::marker::StructuralPartialEq for aya_obj::generated::bpf_cmd
+impl core::marker::Freeze for aya_obj::generated::bpf_cmd
 impl core::marker::Send for aya_obj::generated::bpf_cmd
 impl core::marker::Sync for aya_obj::generated::bpf_cmd
 impl core::marker::Unpin for aya_obj::generated::bpf_cmd
@@ -1475,6 +1513,7 @@ impl core::hash::Hash for aya_obj::generated::bpf_link_type
 pub fn aya_obj::generated::bpf_link_type::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
 impl core::marker::Copy for aya_obj::generated::bpf_link_type
 impl core::marker::StructuralPartialEq for aya_obj::generated::bpf_link_type
+impl core::marker::Freeze for aya_obj::generated::bpf_link_type
 impl core::marker::Send for aya_obj::generated::bpf_link_type
 impl core::marker::Sync for aya_obj::generated::bpf_link_type
 impl core::marker::Unpin for aya_obj::generated::bpf_link_type
@@ -1550,6 +1589,7 @@ impl core::hash::Hash for aya_obj::generated::bpf_map_type
 pub fn aya_obj::generated::bpf_map_type::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
 impl core::marker::Copy for aya_obj::generated::bpf_map_type
 impl core::marker::StructuralPartialEq for aya_obj::generated::bpf_map_type
+impl core::marker::Freeze for aya_obj::generated::bpf_map_type
 impl core::marker::Send for aya_obj::generated::bpf_map_type
 impl core::marker::Sync for aya_obj::generated::bpf_map_type
 impl core::marker::Unpin for aya_obj::generated::bpf_map_type
@@ -1620,6 +1660,7 @@ impl core::hash::Hash for aya_obj::generated::bpf_prog_type
 pub fn aya_obj::generated::bpf_prog_type::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
 impl core::marker::Copy for aya_obj::generated::bpf_prog_type
 impl core::marker::StructuralPartialEq for aya_obj::generated::bpf_prog_type
+impl core::marker::Freeze for aya_obj::generated::bpf_prog_type
 impl core::marker::Send for aya_obj::generated::bpf_prog_type
 impl core::marker::Sync for aya_obj::generated::bpf_prog_type
 impl core::marker::Unpin for aya_obj::generated::bpf_prog_type
@@ -1660,6 +1701,7 @@ impl core::hash::Hash for aya_obj::generated::btf_func_linkage
 pub fn aya_obj::generated::btf_func_linkage::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
 impl core::marker::Copy for aya_obj::generated::btf_func_linkage
 impl core::marker::StructuralPartialEq for aya_obj::generated::btf_func_linkage
+impl core::marker::Freeze for aya_obj::generated::btf_func_linkage
 impl core::marker::Send for aya_obj::generated::btf_func_linkage
 impl core::marker::Sync for aya_obj::generated::btf_func_linkage
 impl core::marker::Unpin for aya_obj::generated::btf_func_linkage
@@ -1723,6 +1765,7 @@ impl core::hash::Hash for aya_obj::generated::perf_event_sample_format
 pub fn aya_obj::generated::perf_event_sample_format::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
 impl core::marker::Copy for aya_obj::generated::perf_event_sample_format
 impl core::marker::StructuralPartialEq for aya_obj::generated::perf_event_sample_format
+impl core::marker::Freeze for aya_obj::generated::perf_event_sample_format
 impl core::marker::Send for aya_obj::generated::perf_event_sample_format
 impl core::marker::Sync for aya_obj::generated::perf_event_sample_format
 impl core::marker::Unpin for aya_obj::generated::perf_event_sample_format
@@ -1782,6 +1825,7 @@ impl core::hash::Hash for aya_obj::generated::perf_event_type
 pub fn aya_obj::generated::perf_event_type::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
 impl core::marker::Copy for aya_obj::generated::perf_event_type
 impl core::marker::StructuralPartialEq for aya_obj::generated::perf_event_type
+impl core::marker::Freeze for aya_obj::generated::perf_event_type
 impl core::marker::Send for aya_obj::generated::perf_event_type
 impl core::marker::Sync for aya_obj::generated::perf_event_type
 impl core::marker::Unpin for aya_obj::generated::perf_event_type
@@ -1827,6 +1871,7 @@ impl core::hash::Hash for aya_obj::generated::perf_hw_cache_id
 pub fn aya_obj::generated::perf_hw_cache_id::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
 impl core::marker::Copy for aya_obj::generated::perf_hw_cache_id
 impl core::marker::StructuralPartialEq for aya_obj::generated::perf_hw_cache_id
+impl core::marker::Freeze for aya_obj::generated::perf_hw_cache_id
 impl core::marker::Send for aya_obj::generated::perf_hw_cache_id
 impl core::marker::Sync for aya_obj::generated::perf_hw_cache_id
 impl core::marker::Unpin for aya_obj::generated::perf_hw_cache_id
@@ -1868,6 +1913,7 @@ impl core::hash::Hash for aya_obj::generated::perf_hw_cache_op_id
 pub fn aya_obj::generated::perf_hw_cache_op_id::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
 impl core::marker::Copy for aya_obj::generated::perf_hw_cache_op_id
 impl core::marker::StructuralPartialEq for aya_obj::generated::perf_hw_cache_op_id
+impl core::marker::Freeze for aya_obj::generated::perf_hw_cache_op_id
 impl core::marker::Send for aya_obj::generated::perf_hw_cache_op_id
 impl core::marker::Sync for aya_obj::generated::perf_hw_cache_op_id
 impl core::marker::Unpin for aya_obj::generated::perf_hw_cache_op_id
@@ -1908,6 +1954,7 @@ impl core::hash::Hash for aya_obj::generated::perf_hw_cache_op_result_id
 pub fn aya_obj::generated::perf_hw_cache_op_result_id::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
 impl core::marker::Copy for aya_obj::generated::perf_hw_cache_op_result_id
 impl core::marker::StructuralPartialEq for aya_obj::generated::perf_hw_cache_op_result_id
+impl core::marker::Freeze for aya_obj::generated::perf_hw_cache_op_result_id
 impl core::marker::Send for aya_obj::generated::perf_hw_cache_op_result_id
 impl core::marker::Sync for aya_obj::generated::perf_hw_cache_op_result_id
 impl core::marker::Unpin for aya_obj::generated::perf_hw_cache_op_result_id
@@ -1956,6 +2003,7 @@ impl core::hash::Hash for aya_obj::generated::perf_hw_id
 pub fn aya_obj::generated::perf_hw_id::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
 impl core::marker::Copy for aya_obj::generated::perf_hw_id
 impl core::marker::StructuralPartialEq for aya_obj::generated::perf_hw_id
+impl core::marker::Freeze for aya_obj::generated::perf_hw_id
 impl core::marker::Send for aya_obj::generated::perf_hw_id
 impl core::marker::Sync for aya_obj::generated::perf_hw_id
 impl core::marker::Unpin for aya_obj::generated::perf_hw_id
@@ -2006,6 +2054,7 @@ impl core::hash::Hash for aya_obj::generated::perf_sw_ids
 pub fn aya_obj::generated::perf_sw_ids::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
 impl core::marker::Copy for aya_obj::generated::perf_sw_ids
 impl core::marker::StructuralPartialEq for aya_obj::generated::perf_sw_ids
+impl core::marker::Freeze for aya_obj::generated::perf_sw_ids
 impl core::marker::Send for aya_obj::generated::perf_sw_ids
 impl core::marker::Sync for aya_obj::generated::perf_sw_ids
 impl core::marker::Unpin for aya_obj::generated::perf_sw_ids
@@ -2050,6 +2099,7 @@ impl core::hash::Hash for aya_obj::generated::perf_type_id
 pub fn aya_obj::generated::perf_type_id::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
 impl core::marker::Copy for aya_obj::generated::perf_type_id
 impl core::marker::StructuralPartialEq for aya_obj::generated::perf_type_id
+impl core::marker::Freeze for aya_obj::generated::perf_type_id
 impl core::marker::Send for aya_obj::generated::perf_type_id
 impl core::marker::Sync for aya_obj::generated::perf_type_id
 impl core::marker::Unpin for aya_obj::generated::perf_type_id
@@ -2098,6 +2148,7 @@ pub aya_obj::generated::bpf_attr::test: aya_obj::generated::bpf_attr__bindgen_ty
 impl core::clone::Clone for aya_obj::generated::bpf_attr
 pub fn aya_obj::generated::bpf_attr::clone(&self) -> aya_obj::generated::bpf_attr
 impl core::marker::Copy for aya_obj::generated::bpf_attr
+impl core::marker::Freeze for aya_obj::generated::bpf_attr
 impl core::marker::Send for aya_obj::generated::bpf_attr
 impl core::marker::Sync for aya_obj::generated::bpf_attr
 impl core::marker::Unpin for aya_obj::generated::bpf_attr
@@ -2129,6 +2180,7 @@ pub aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_1::prog_fd: aya_obj:
 impl core::clone::Clone for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_1
 pub fn aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_1::clone(&self) -> aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_1
 impl core::marker::Copy for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_1
+impl core::marker::Freeze for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_1
 impl core::marker::Send for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_1
 impl core::marker::Sync for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_1
 impl core::marker::Unpin for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_1
@@ -2160,6 +2212,7 @@ pub aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_2::target_ifindex: a
 impl core::clone::Clone for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_2
 pub fn aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_2::clone(&self) -> aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_2
 impl core::marker::Copy for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_2
+impl core::marker::Freeze for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_2
 impl core::marker::Send for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_2
 impl core::marker::Sync for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_2
 impl core::marker::Unpin for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_2
@@ -2195,6 +2248,7 @@ pub aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3::tracing: aya_obj:
 impl core::clone::Clone for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3
 pub fn aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3::clone(&self) -> aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3
 impl core::marker::Copy for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3
+impl core::marker::Freeze for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3
 impl core::marker::Send for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3
 impl core::marker::Sync for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3
 impl core::marker::Unpin for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3
@@ -2226,6 +2280,7 @@ pub aya_obj::generated::bpf_attr__bindgen_ty_15__bindgen_ty_1::new_prog_fd: aya_
 impl core::clone::Clone for aya_obj::generated::bpf_attr__bindgen_ty_15__bindgen_ty_1
 pub fn aya_obj::generated::bpf_attr__bindgen_ty_15__bindgen_ty_1::clone(&self) -> aya_obj::generated::bpf_attr__bindgen_ty_15__bindgen_ty_1
 impl core::marker::Copy for aya_obj::generated::bpf_attr__bindgen_ty_15__bindgen_ty_1
+impl core::marker::Freeze for aya_obj::generated::bpf_attr__bindgen_ty_15__bindgen_ty_1
 impl core::marker::Send for aya_obj::generated::bpf_attr__bindgen_ty_15__bindgen_ty_1
 impl core::marker::Sync for aya_obj::generated::bpf_attr__bindgen_ty_15__bindgen_ty_1
 impl core::marker::Unpin for aya_obj::generated::bpf_attr__bindgen_ty_15__bindgen_ty_1
@@ -2257,6 +2312,7 @@ pub aya_obj::generated::bpf_attr__bindgen_ty_15__bindgen_ty_2::old_prog_fd: aya_
 impl core::clone::Clone for aya_obj::generated::bpf_attr__bindgen_ty_15__bindgen_ty_2
 pub fn aya_obj::generated::bpf_attr__bindgen_ty_15__bindgen_ty_2::clone(&self) -> aya_obj::generated::bpf_attr__bindgen_ty_15__bindgen_ty_2
 impl core::marker::Copy for aya_obj::generated::bpf_attr__bindgen_ty_15__bindgen_ty_2
+impl core::marker::Freeze for aya_obj::generated::bpf_attr__bindgen_ty_15__bindgen_ty_2
 impl core::marker::Send for aya_obj::generated::bpf_attr__bindgen_ty_15__bindgen_ty_2
 impl core::marker::Sync for aya_obj::generated::bpf_attr__bindgen_ty_15__bindgen_ty_2
 impl core::marker::Unpin for aya_obj::generated::bpf_attr__bindgen_ty_15__bindgen_ty_2
@@ -2288,6 +2344,7 @@ pub aya_obj::generated::bpf_attr__bindgen_ty_2__bindgen_ty_1::value: aya_obj::ge
 impl core::clone::Clone for aya_obj::generated::bpf_attr__bindgen_ty_2__bindgen_ty_1
 pub fn aya_obj::generated::bpf_attr__bindgen_ty_2__bindgen_ty_1::clone(&self) -> aya_obj::generated::bpf_attr__bindgen_ty_2__bindgen_ty_1
 impl core::marker::Copy for aya_obj::generated::bpf_attr__bindgen_ty_2__bindgen_ty_1
+impl core::marker::Freeze for aya_obj::generated::bpf_attr__bindgen_ty_2__bindgen_ty_1
 impl core::marker::Send for aya_obj::generated::bpf_attr__bindgen_ty_2__bindgen_ty_1
 impl core::marker::Sync for aya_obj::generated::bpf_attr__bindgen_ty_2__bindgen_ty_1
 impl core::marker::Unpin for aya_obj::generated::bpf_attr__bindgen_ty_2__bindgen_ty_1
@@ -2319,6 +2376,7 @@ pub aya_obj::generated::bpf_attr__bindgen_ty_4__bindgen_ty_1::attach_prog_fd: ay
 impl core::clone::Clone for aya_obj::generated::bpf_attr__bindgen_ty_4__bindgen_ty_1
 pub fn aya_obj::generated::bpf_attr__bindgen_ty_4__bindgen_ty_1::clone(&self) -> aya_obj::generated::bpf_attr__bindgen_ty_4__bindgen_ty_1
 impl core::marker::Copy for aya_obj::generated::bpf_attr__bindgen_ty_4__bindgen_ty_1
+impl core::marker::Freeze for aya_obj::generated::bpf_attr__bindgen_ty_4__bindgen_ty_1
 impl core::marker::Send for aya_obj::generated::bpf_attr__bindgen_ty_4__bindgen_ty_1
 impl core::marker::Sync for aya_obj::generated::bpf_attr__bindgen_ty_4__bindgen_ty_1
 impl core::marker::Unpin for aya_obj::generated::bpf_attr__bindgen_ty_4__bindgen_ty_1
@@ -2353,6 +2411,7 @@ pub aya_obj::generated::bpf_attr__bindgen_ty_8__bindgen_ty_1::start_id: aya_obj:
 impl core::clone::Clone for aya_obj::generated::bpf_attr__bindgen_ty_8__bindgen_ty_1
 pub fn aya_obj::generated::bpf_attr__bindgen_ty_8__bindgen_ty_1::clone(&self) -> aya_obj::generated::bpf_attr__bindgen_ty_8__bindgen_ty_1
 impl core::marker::Copy for aya_obj::generated::bpf_attr__bindgen_ty_8__bindgen_ty_1
+impl core::marker::Freeze for aya_obj::generated::bpf_attr__bindgen_ty_8__bindgen_ty_1
 impl core::marker::Send for aya_obj::generated::bpf_attr__bindgen_ty_8__bindgen_ty_1
 impl core::marker::Sync for aya_obj::generated::bpf_attr__bindgen_ty_8__bindgen_ty_1
 impl core::marker::Unpin for aya_obj::generated::bpf_attr__bindgen_ty_8__bindgen_ty_1
@@ -2384,6 +2443,7 @@ pub aya_obj::generated::bpf_cpumap_val__bindgen_ty_1::id: aya_obj::generated::__
 impl core::clone::Clone for aya_obj::generated::bpf_cpumap_val__bindgen_ty_1
 pub fn aya_obj::generated::bpf_cpumap_val__bindgen_ty_1::clone(&self) -> aya_obj::generated::bpf_cpumap_val__bindgen_ty_1
 impl core::marker::Copy for aya_obj::generated::bpf_cpumap_val__bindgen_ty_1
+impl core::marker::Freeze for aya_obj::generated::bpf_cpumap_val__bindgen_ty_1
 impl core::marker::Send for aya_obj::generated::bpf_cpumap_val__bindgen_ty_1
 impl core::marker::Sync for aya_obj::generated::bpf_cpumap_val__bindgen_ty_1
 impl core::marker::Unpin for aya_obj::generated::bpf_cpumap_val__bindgen_ty_1
@@ -2415,6 +2475,7 @@ pub aya_obj::generated::bpf_devmap_val__bindgen_ty_1::id: aya_obj::generated::__
 impl core::clone::Clone for aya_obj::generated::bpf_devmap_val__bindgen_ty_1
 pub fn aya_obj::generated::bpf_devmap_val__bindgen_ty_1::clone(&self) -> aya_obj::generated::bpf_devmap_val__bindgen_ty_1
 impl core::marker::Copy for aya_obj::generated::bpf_devmap_val__bindgen_ty_1
+impl core::marker::Freeze for aya_obj::generated::bpf_devmap_val__bindgen_ty_1
 impl core::marker::Send for aya_obj::generated::bpf_devmap_val__bindgen_ty_1
 impl core::marker::Sync for aya_obj::generated::bpf_devmap_val__bindgen_ty_1
 impl core::marker::Unpin for aya_obj::generated::bpf_devmap_val__bindgen_ty_1
@@ -2452,6 +2513,7 @@ pub aya_obj::generated::bpf_link_info__bindgen_ty_1::xdp: aya_obj::generated::bp
 impl core::clone::Clone for aya_obj::generated::bpf_link_info__bindgen_ty_1
 pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1::clone(&self) -> aya_obj::generated::bpf_link_info__bindgen_ty_1
 impl core::marker::Copy for aya_obj::generated::bpf_link_info__bindgen_ty_1
+impl core::marker::Freeze for aya_obj::generated::bpf_link_info__bindgen_ty_1
 impl core::marker::Send for aya_obj::generated::bpf_link_info__bindgen_ty_1
 impl core::marker::Sync for aya_obj::generated::bpf_link_info__bindgen_ty_1
 impl core::marker::Unpin for aya_obj::generated::bpf_link_info__bindgen_ty_1
@@ -2482,6 +2544,7 @@ pub aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_1:
 impl core::clone::Clone for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_1
 pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_1::clone(&self) -> aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_1
 impl core::marker::Copy for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_1
+impl core::marker::Freeze for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_1
 impl core::marker::Send for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_1
 impl core::marker::Sync for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_1
 impl core::marker::Unpin for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_1
@@ -2513,6 +2576,7 @@ pub aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2:
 impl core::clone::Clone for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2
 pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2::clone(&self) -> aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2
 impl core::marker::Copy for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2
+impl core::marker::Freeze for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2
 impl core::marker::Send for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2
 impl core::marker::Sync for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2
 impl core::marker::Unpin for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2
@@ -2544,6 +2608,7 @@ pub aya_obj::generated::btf_type__bindgen_ty_1::type_: aya_obj::generated::__u32
 impl core::clone::Clone for aya_obj::generated::btf_type__bindgen_ty_1
 pub fn aya_obj::generated::btf_type__bindgen_ty_1::clone(&self) -> aya_obj::generated::btf_type__bindgen_ty_1
 impl core::marker::Copy for aya_obj::generated::btf_type__bindgen_ty_1
+impl core::marker::Freeze for aya_obj::generated::btf_type__bindgen_ty_1
 impl core::marker::Send for aya_obj::generated::btf_type__bindgen_ty_1
 impl core::marker::Sync for aya_obj::generated::btf_type__bindgen_ty_1
 impl core::marker::Unpin for aya_obj::generated::btf_type__bindgen_ty_1
@@ -2575,6 +2640,7 @@ pub aya_obj::generated::perf_event_attr__bindgen_ty_1::sample_period: aya_obj::g
 impl core::clone::Clone for aya_obj::generated::perf_event_attr__bindgen_ty_1
 pub fn aya_obj::generated::perf_event_attr__bindgen_ty_1::clone(&self) -> aya_obj::generated::perf_event_attr__bindgen_ty_1
 impl core::marker::Copy for aya_obj::generated::perf_event_attr__bindgen_ty_1
+impl core::marker::Freeze for aya_obj::generated::perf_event_attr__bindgen_ty_1
 impl core::marker::Send for aya_obj::generated::perf_event_attr__bindgen_ty_1
 impl core::marker::Sync for aya_obj::generated::perf_event_attr__bindgen_ty_1
 impl core::marker::Unpin for aya_obj::generated::perf_event_attr__bindgen_ty_1
@@ -2606,6 +2672,7 @@ pub aya_obj::generated::perf_event_attr__bindgen_ty_2::wakeup_watermark: aya_obj
 impl core::clone::Clone for aya_obj::generated::perf_event_attr__bindgen_ty_2
 pub fn aya_obj::generated::perf_event_attr__bindgen_ty_2::clone(&self) -> aya_obj::generated::perf_event_attr__bindgen_ty_2
 impl core::marker::Copy for aya_obj::generated::perf_event_attr__bindgen_ty_2
+impl core::marker::Freeze for aya_obj::generated::perf_event_attr__bindgen_ty_2
 impl core::marker::Send for aya_obj::generated::perf_event_attr__bindgen_ty_2
 impl core::marker::Sync for aya_obj::generated::perf_event_attr__bindgen_ty_2
 impl core::marker::Unpin for aya_obj::generated::perf_event_attr__bindgen_ty_2
@@ -2639,6 +2706,7 @@ pub aya_obj::generated::perf_event_attr__bindgen_ty_3::uprobe_path: aya_obj::gen
 impl core::clone::Clone for aya_obj::generated::perf_event_attr__bindgen_ty_3
 pub fn aya_obj::generated::perf_event_attr__bindgen_ty_3::clone(&self) -> aya_obj::generated::perf_event_attr__bindgen_ty_3
 impl core::marker::Copy for aya_obj::generated::perf_event_attr__bindgen_ty_3
+impl core::marker::Freeze for aya_obj::generated::perf_event_attr__bindgen_ty_3
 impl core::marker::Send for aya_obj::generated::perf_event_attr__bindgen_ty_3
 impl core::marker::Sync for aya_obj::generated::perf_event_attr__bindgen_ty_3
 impl core::marker::Unpin for aya_obj::generated::perf_event_attr__bindgen_ty_3
@@ -2672,6 +2740,7 @@ pub aya_obj::generated::perf_event_attr__bindgen_ty_4::probe_offset: aya_obj::ge
 impl core::clone::Clone for aya_obj::generated::perf_event_attr__bindgen_ty_4
 pub fn aya_obj::generated::perf_event_attr__bindgen_ty_4::clone(&self) -> aya_obj::generated::perf_event_attr__bindgen_ty_4
 impl core::marker::Copy for aya_obj::generated::perf_event_attr__bindgen_ty_4
+impl core::marker::Freeze for aya_obj::generated::perf_event_attr__bindgen_ty_4
 impl core::marker::Send for aya_obj::generated::perf_event_attr__bindgen_ty_4
 impl core::marker::Sync for aya_obj::generated::perf_event_attr__bindgen_ty_4
 impl core::marker::Unpin for aya_obj::generated::perf_event_attr__bindgen_ty_4
@@ -2703,6 +2772,7 @@ pub aya_obj::generated::perf_event_mmap_page__bindgen_ty_1::capabilities: aya_ob
 impl core::clone::Clone for aya_obj::generated::perf_event_mmap_page__bindgen_ty_1
 pub fn aya_obj::generated::perf_event_mmap_page__bindgen_ty_1::clone(&self) -> aya_obj::generated::perf_event_mmap_page__bindgen_ty_1
 impl core::marker::Copy for aya_obj::generated::perf_event_mmap_page__bindgen_ty_1
+impl core::marker::Freeze for aya_obj::generated::perf_event_mmap_page__bindgen_ty_1
 impl core::marker::Send for aya_obj::generated::perf_event_mmap_page__bindgen_ty_1
 impl core::marker::Sync for aya_obj::generated::perf_event_mmap_page__bindgen_ty_1
 impl core::marker::Unpin for aya_obj::generated::perf_event_mmap_page__bindgen_ty_1
@@ -2753,6 +2823,7 @@ impl<Storage: core::hash::Hash> core::hash::Hash for aya_obj::generated::__Bindg
 pub fn aya_obj::generated::__BindgenBitfieldUnit<Storage>::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
 impl<Storage: core::marker::Copy> core::marker::Copy for aya_obj::generated::__BindgenBitfieldUnit<Storage>
 impl<Storage> core::marker::StructuralPartialEq for aya_obj::generated::__BindgenBitfieldUnit<Storage>
+impl<Storage> core::marker::Freeze for aya_obj::generated::__BindgenBitfieldUnit<Storage> where Storage: core::marker::Freeze
 impl<Storage> core::marker::Send for aya_obj::generated::__BindgenBitfieldUnit<Storage> where Storage: core::marker::Send
 impl<Storage> core::marker::Sync for aya_obj::generated::__BindgenBitfieldUnit<Storage> where Storage: core::marker::Sync
 impl<Storage> core::marker::Unpin for aya_obj::generated::__BindgenBitfieldUnit<Storage> where Storage: core::marker::Unpin
@@ -2789,6 +2860,7 @@ impl<T: core::default::Default> core::default::Default for aya_obj::generated::_
 pub fn aya_obj::generated::__IncompleteArrayField<T>::default() -> aya_obj::generated::__IncompleteArrayField<T>
 impl<T> core::fmt::Debug for aya_obj::generated::__IncompleteArrayField<T>
 pub fn aya_obj::generated::__IncompleteArrayField<T>::fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl<T> core::marker::Freeze for aya_obj::generated::__IncompleteArrayField<T> where T: core::marker::Freeze
 impl<T> core::marker::Send for aya_obj::generated::__IncompleteArrayField<T> where T: core::marker::Send
 impl<T> core::marker::Sync for aya_obj::generated::__IncompleteArrayField<T> where T: core::marker::Sync
 impl<T> core::marker::Unpin for aya_obj::generated::__IncompleteArrayField<T> where T: core::marker::Unpin
@@ -2830,6 +2902,7 @@ pub fn aya_obj::generated::bpf_attr__bindgen_ty_1::clone(&self) -> aya_obj::gene
 impl core::fmt::Debug for aya_obj::generated::bpf_attr__bindgen_ty_1
 pub fn aya_obj::generated::bpf_attr__bindgen_ty_1::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Copy for aya_obj::generated::bpf_attr__bindgen_ty_1
+impl core::marker::Freeze for aya_obj::generated::bpf_attr__bindgen_ty_1
 impl core::marker::Send for aya_obj::generated::bpf_attr__bindgen_ty_1
 impl core::marker::Sync for aya_obj::generated::bpf_attr__bindgen_ty_1
 impl core::marker::Unpin for aya_obj::generated::bpf_attr__bindgen_ty_1
@@ -2868,6 +2941,7 @@ pub fn aya_obj::generated::bpf_attr__bindgen_ty_10::clone(&self) -> aya_obj::gen
 impl core::fmt::Debug for aya_obj::generated::bpf_attr__bindgen_ty_10
 pub fn aya_obj::generated::bpf_attr__bindgen_ty_10::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Copy for aya_obj::generated::bpf_attr__bindgen_ty_10
+impl core::marker::Freeze for aya_obj::generated::bpf_attr__bindgen_ty_10
 impl core::marker::Send for aya_obj::generated::bpf_attr__bindgen_ty_10
 impl core::marker::Sync for aya_obj::generated::bpf_attr__bindgen_ty_10
 impl core::marker::Unpin for aya_obj::generated::bpf_attr__bindgen_ty_10
@@ -2901,6 +2975,7 @@ pub fn aya_obj::generated::bpf_attr__bindgen_ty_11::clone(&self) -> aya_obj::gen
 impl core::fmt::Debug for aya_obj::generated::bpf_attr__bindgen_ty_11
 pub fn aya_obj::generated::bpf_attr__bindgen_ty_11::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Copy for aya_obj::generated::bpf_attr__bindgen_ty_11
+impl core::marker::Freeze for aya_obj::generated::bpf_attr__bindgen_ty_11
 impl core::marker::Send for aya_obj::generated::bpf_attr__bindgen_ty_11
 impl core::marker::Sync for aya_obj::generated::bpf_attr__bindgen_ty_11
 impl core::marker::Unpin for aya_obj::generated::bpf_attr__bindgen_ty_11
@@ -2938,6 +3013,7 @@ pub fn aya_obj::generated::bpf_attr__bindgen_ty_12::clone(&self) -> aya_obj::gen
 impl core::fmt::Debug for aya_obj::generated::bpf_attr__bindgen_ty_12
 pub fn aya_obj::generated::bpf_attr__bindgen_ty_12::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Copy for aya_obj::generated::bpf_attr__bindgen_ty_12
+impl core::marker::Freeze for aya_obj::generated::bpf_attr__bindgen_ty_12
 impl core::marker::Send for aya_obj::generated::bpf_attr__bindgen_ty_12
 impl core::marker::Sync for aya_obj::generated::bpf_attr__bindgen_ty_12
 impl core::marker::Unpin for aya_obj::generated::bpf_attr__bindgen_ty_12
@@ -2978,6 +3054,7 @@ pub fn aya_obj::generated::bpf_attr__bindgen_ty_13::clone(&self) -> aya_obj::gen
 impl core::fmt::Debug for aya_obj::generated::bpf_attr__bindgen_ty_13
 pub fn aya_obj::generated::bpf_attr__bindgen_ty_13::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Copy for aya_obj::generated::bpf_attr__bindgen_ty_13
+impl core::marker::Freeze for aya_obj::generated::bpf_attr__bindgen_ty_13
 impl core::marker::Send for aya_obj::generated::bpf_attr__bindgen_ty_13
 impl core::marker::Sync for aya_obj::generated::bpf_attr__bindgen_ty_13
 impl core::marker::Unpin for aya_obj::generated::bpf_attr__bindgen_ty_13
@@ -3012,6 +3089,7 @@ pub aya_obj::generated::bpf_attr__bindgen_ty_14::flags: aya_obj::generated::__u3
 impl core::clone::Clone for aya_obj::generated::bpf_attr__bindgen_ty_14
 pub fn aya_obj::generated::bpf_attr__bindgen_ty_14::clone(&self) -> aya_obj::generated::bpf_attr__bindgen_ty_14
 impl core::marker::Copy for aya_obj::generated::bpf_attr__bindgen_ty_14
+impl core::marker::Freeze for aya_obj::generated::bpf_attr__bindgen_ty_14
 impl core::marker::Send for aya_obj::generated::bpf_attr__bindgen_ty_14
 impl core::marker::Sync for aya_obj::generated::bpf_attr__bindgen_ty_14
 impl core::marker::Unpin for aya_obj::generated::bpf_attr__bindgen_ty_14
@@ -3045,6 +3123,7 @@ pub fn aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_1::
 impl core::fmt::Debug for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_1
 pub fn aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_1::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Copy for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_1
+impl core::marker::Freeze for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_1
 impl core::marker::Send for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_1
 impl core::marker::Sync for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_1
 impl core::marker::Unpin for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_1
@@ -3077,6 +3156,7 @@ pub fn aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_2::
 impl core::fmt::Debug for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_2
 pub fn aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_2::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Copy for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_2
+impl core::marker::Freeze for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_2
 impl core::marker::Send for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_2
 impl core::marker::Sync for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_2
 impl core::marker::Unpin for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_2
@@ -3113,6 +3193,7 @@ pub fn aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_3::
 impl core::fmt::Debug for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_3
 pub fn aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_3::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Copy for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_3
+impl core::marker::Freeze for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_3
 impl core::marker::Send for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_3
 impl core::marker::Sync for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_3
 impl core::marker::Unpin for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_3
@@ -3146,6 +3227,7 @@ pub fn aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_4::
 impl core::fmt::Debug for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_4
 pub fn aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_4::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Copy for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_4
+impl core::marker::Freeze for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_4
 impl core::marker::Send for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_4
 impl core::marker::Sync for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_4
 impl core::marker::Unpin for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_4
@@ -3181,6 +3263,7 @@ pub fn aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_5::
 impl core::fmt::Debug for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_5
 pub fn aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_5::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Copy for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_5
+impl core::marker::Freeze for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_5
 impl core::marker::Send for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_5
 impl core::marker::Sync for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_5
 impl core::marker::Unpin for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_5
@@ -3214,6 +3297,7 @@ pub aya_obj::generated::bpf_attr__bindgen_ty_15::link_fd: aya_obj::generated::__
 impl core::clone::Clone for aya_obj::generated::bpf_attr__bindgen_ty_15
 pub fn aya_obj::generated::bpf_attr__bindgen_ty_15::clone(&self) -> aya_obj::generated::bpf_attr__bindgen_ty_15
 impl core::marker::Copy for aya_obj::generated::bpf_attr__bindgen_ty_15
+impl core::marker::Freeze for aya_obj::generated::bpf_attr__bindgen_ty_15
 impl core::marker::Send for aya_obj::generated::bpf_attr__bindgen_ty_15
 impl core::marker::Sync for aya_obj::generated::bpf_attr__bindgen_ty_15
 impl core::marker::Unpin for aya_obj::generated::bpf_attr__bindgen_ty_15
@@ -3246,6 +3330,7 @@ pub fn aya_obj::generated::bpf_attr__bindgen_ty_16::clone(&self) -> aya_obj::gen
 impl core::fmt::Debug for aya_obj::generated::bpf_attr__bindgen_ty_16
 pub fn aya_obj::generated::bpf_attr__bindgen_ty_16::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Copy for aya_obj::generated::bpf_attr__bindgen_ty_16
+impl core::marker::Freeze for aya_obj::generated::bpf_attr__bindgen_ty_16
 impl core::marker::Send for aya_obj::generated::bpf_attr__bindgen_ty_16
 impl core::marker::Sync for aya_obj::generated::bpf_attr__bindgen_ty_16
 impl core::marker::Unpin for aya_obj::generated::bpf_attr__bindgen_ty_16
@@ -3278,6 +3363,7 @@ pub fn aya_obj::generated::bpf_attr__bindgen_ty_17::clone(&self) -> aya_obj::gen
 impl core::fmt::Debug for aya_obj::generated::bpf_attr__bindgen_ty_17
 pub fn aya_obj::generated::bpf_attr__bindgen_ty_17::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Copy for aya_obj::generated::bpf_attr__bindgen_ty_17
+impl core::marker::Freeze for aya_obj::generated::bpf_attr__bindgen_ty_17
 impl core::marker::Send for aya_obj::generated::bpf_attr__bindgen_ty_17
 impl core::marker::Sync for aya_obj::generated::bpf_attr__bindgen_ty_17
 impl core::marker::Unpin for aya_obj::generated::bpf_attr__bindgen_ty_17
@@ -3311,6 +3397,7 @@ pub fn aya_obj::generated::bpf_attr__bindgen_ty_18::clone(&self) -> aya_obj::gen
 impl core::fmt::Debug for aya_obj::generated::bpf_attr__bindgen_ty_18
 pub fn aya_obj::generated::bpf_attr__bindgen_ty_18::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Copy for aya_obj::generated::bpf_attr__bindgen_ty_18
+impl core::marker::Freeze for aya_obj::generated::bpf_attr__bindgen_ty_18
 impl core::marker::Send for aya_obj::generated::bpf_attr__bindgen_ty_18
 impl core::marker::Sync for aya_obj::generated::bpf_attr__bindgen_ty_18
 impl core::marker::Unpin for aya_obj::generated::bpf_attr__bindgen_ty_18
@@ -3345,6 +3432,7 @@ pub fn aya_obj::generated::bpf_attr__bindgen_ty_19::clone(&self) -> aya_obj::gen
 impl core::fmt::Debug for aya_obj::generated::bpf_attr__bindgen_ty_19
 pub fn aya_obj::generated::bpf_attr__bindgen_ty_19::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Copy for aya_obj::generated::bpf_attr__bindgen_ty_19
+impl core::marker::Freeze for aya_obj::generated::bpf_attr__bindgen_ty_19
 impl core::marker::Send for aya_obj::generated::bpf_attr__bindgen_ty_19
 impl core::marker::Sync for aya_obj::generated::bpf_attr__bindgen_ty_19
 impl core::marker::Unpin for aya_obj::generated::bpf_attr__bindgen_ty_19
@@ -3378,6 +3466,7 @@ pub aya_obj::generated::bpf_attr__bindgen_ty_2::map_fd: aya_obj::generated::__u3
 impl core::clone::Clone for aya_obj::generated::bpf_attr__bindgen_ty_2
 pub fn aya_obj::generated::bpf_attr__bindgen_ty_2::clone(&self) -> aya_obj::generated::bpf_attr__bindgen_ty_2
 impl core::marker::Copy for aya_obj::generated::bpf_attr__bindgen_ty_2
+impl core::marker::Freeze for aya_obj::generated::bpf_attr__bindgen_ty_2
 impl core::marker::Send for aya_obj::generated::bpf_attr__bindgen_ty_2
 impl core::marker::Sync for aya_obj::generated::bpf_attr__bindgen_ty_2
 impl core::marker::Unpin for aya_obj::generated::bpf_attr__bindgen_ty_2
@@ -3417,6 +3506,7 @@ pub fn aya_obj::generated::bpf_attr__bindgen_ty_3::clone(&self) -> aya_obj::gene
 impl core::fmt::Debug for aya_obj::generated::bpf_attr__bindgen_ty_3
 pub fn aya_obj::generated::bpf_attr__bindgen_ty_3::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Copy for aya_obj::generated::bpf_attr__bindgen_ty_3
+impl core::marker::Freeze for aya_obj::generated::bpf_attr__bindgen_ty_3
 impl core::marker::Send for aya_obj::generated::bpf_attr__bindgen_ty_3
 impl core::marker::Sync for aya_obj::generated::bpf_attr__bindgen_ty_3
 impl core::marker::Unpin for aya_obj::generated::bpf_attr__bindgen_ty_3
@@ -3472,6 +3562,7 @@ pub aya_obj::generated::bpf_attr__bindgen_ty_4::prog_type: aya_obj::generated::_
 impl core::clone::Clone for aya_obj::generated::bpf_attr__bindgen_ty_4
 pub fn aya_obj::generated::bpf_attr__bindgen_ty_4::clone(&self) -> aya_obj::generated::bpf_attr__bindgen_ty_4
 impl core::marker::Copy for aya_obj::generated::bpf_attr__bindgen_ty_4
+impl core::marker::Freeze for aya_obj::generated::bpf_attr__bindgen_ty_4
 impl core::marker::Send for aya_obj::generated::bpf_attr__bindgen_ty_4
 impl core::marker::Sync for aya_obj::generated::bpf_attr__bindgen_ty_4
 impl core::marker::Unpin for aya_obj::generated::bpf_attr__bindgen_ty_4
@@ -3507,6 +3598,7 @@ pub fn aya_obj::generated::bpf_attr__bindgen_ty_5::clone(&self) -> aya_obj::gene
 impl core::fmt::Debug for aya_obj::generated::bpf_attr__bindgen_ty_5
 pub fn aya_obj::generated::bpf_attr__bindgen_ty_5::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Copy for aya_obj::generated::bpf_attr__bindgen_ty_5
+impl core::marker::Freeze for aya_obj::generated::bpf_attr__bindgen_ty_5
 impl core::marker::Send for aya_obj::generated::bpf_attr__bindgen_ty_5
 impl core::marker::Sync for aya_obj::generated::bpf_attr__bindgen_ty_5
 impl core::marker::Unpin for aya_obj::generated::bpf_attr__bindgen_ty_5
@@ -3543,6 +3635,7 @@ pub fn aya_obj::generated::bpf_attr__bindgen_ty_6::clone(&self) -> aya_obj::gene
 impl core::fmt::Debug for aya_obj::generated::bpf_attr__bindgen_ty_6
 pub fn aya_obj::generated::bpf_attr__bindgen_ty_6::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Copy for aya_obj::generated::bpf_attr__bindgen_ty_6
+impl core::marker::Freeze for aya_obj::generated::bpf_attr__bindgen_ty_6
 impl core::marker::Send for aya_obj::generated::bpf_attr__bindgen_ty_6
 impl core::marker::Sync for aya_obj::generated::bpf_attr__bindgen_ty_6
 impl core::marker::Unpin for aya_obj::generated::bpf_attr__bindgen_ty_6
@@ -3589,6 +3682,7 @@ pub fn aya_obj::generated::bpf_attr__bindgen_ty_7::clone(&self) -> aya_obj::gene
 impl core::fmt::Debug for aya_obj::generated::bpf_attr__bindgen_ty_7
 pub fn aya_obj::generated::bpf_attr__bindgen_ty_7::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Copy for aya_obj::generated::bpf_attr__bindgen_ty_7
+impl core::marker::Freeze for aya_obj::generated::bpf_attr__bindgen_ty_7
 impl core::marker::Send for aya_obj::generated::bpf_attr__bindgen_ty_7
 impl core::marker::Sync for aya_obj::generated::bpf_attr__bindgen_ty_7
 impl core::marker::Unpin for aya_obj::generated::bpf_attr__bindgen_ty_7
@@ -3621,6 +3715,7 @@ pub aya_obj::generated::bpf_attr__bindgen_ty_8::open_flags: aya_obj::generated::
 impl core::clone::Clone for aya_obj::generated::bpf_attr__bindgen_ty_8
 pub fn aya_obj::generated::bpf_attr__bindgen_ty_8::clone(&self) -> aya_obj::generated::bpf_attr__bindgen_ty_8
 impl core::marker::Copy for aya_obj::generated::bpf_attr__bindgen_ty_8
+impl core::marker::Freeze for aya_obj::generated::bpf_attr__bindgen_ty_8
 impl core::marker::Send for aya_obj::generated::bpf_attr__bindgen_ty_8
 impl core::marker::Sync for aya_obj::generated::bpf_attr__bindgen_ty_8
 impl core::marker::Unpin for aya_obj::generated::bpf_attr__bindgen_ty_8
@@ -3655,6 +3750,7 @@ pub fn aya_obj::generated::bpf_attr__bindgen_ty_9::clone(&self) -> aya_obj::gene
 impl core::fmt::Debug for aya_obj::generated::bpf_attr__bindgen_ty_9
 pub fn aya_obj::generated::bpf_attr__bindgen_ty_9::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Copy for aya_obj::generated::bpf_attr__bindgen_ty_9
+impl core::marker::Freeze for aya_obj::generated::bpf_attr__bindgen_ty_9
 impl core::marker::Send for aya_obj::generated::bpf_attr__bindgen_ty_9
 impl core::marker::Sync for aya_obj::generated::bpf_attr__bindgen_ty_9
 impl core::marker::Unpin for aya_obj::generated::bpf_attr__bindgen_ty_9
@@ -3692,6 +3788,7 @@ pub fn aya_obj::generated::bpf_btf_info::clone(&self) -> aya_obj::generated::bpf
 impl core::fmt::Debug for aya_obj::generated::bpf_btf_info
 pub fn aya_obj::generated::bpf_btf_info::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Copy for aya_obj::generated::bpf_btf_info
+impl core::marker::Freeze for aya_obj::generated::bpf_btf_info
 impl core::marker::Send for aya_obj::generated::bpf_btf_info
 impl core::marker::Sync for aya_obj::generated::bpf_btf_info
 impl core::marker::Unpin for aya_obj::generated::bpf_btf_info
@@ -3727,6 +3824,7 @@ pub fn aya_obj::generated::bpf_core_relo::clone(&self) -> aya_obj::generated::bp
 impl core::fmt::Debug for aya_obj::generated::bpf_core_relo
 pub fn aya_obj::generated::bpf_core_relo::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Copy for aya_obj::generated::bpf_core_relo
+impl core::marker::Freeze for aya_obj::generated::bpf_core_relo
 impl core::marker::Send for aya_obj::generated::bpf_core_relo
 impl core::marker::Sync for aya_obj::generated::bpf_core_relo
 impl core::marker::Unpin for aya_obj::generated::bpf_core_relo
@@ -3758,6 +3856,7 @@ pub aya_obj::generated::bpf_cpumap_val::qsize: aya_obj::generated::__u32
 impl core::clone::Clone for aya_obj::generated::bpf_cpumap_val
 pub fn aya_obj::generated::bpf_cpumap_val::clone(&self) -> aya_obj::generated::bpf_cpumap_val
 impl core::marker::Copy for aya_obj::generated::bpf_cpumap_val
+impl core::marker::Freeze for aya_obj::generated::bpf_cpumap_val
 impl core::marker::Send for aya_obj::generated::bpf_cpumap_val
 impl core::marker::Sync for aya_obj::generated::bpf_cpumap_val
 impl core::marker::Unpin for aya_obj::generated::bpf_cpumap_val
@@ -3789,6 +3888,7 @@ pub aya_obj::generated::bpf_devmap_val::ifindex: aya_obj::generated::__u32
 impl core::clone::Clone for aya_obj::generated::bpf_devmap_val
 pub fn aya_obj::generated::bpf_devmap_val::clone(&self) -> aya_obj::generated::bpf_devmap_val
 impl core::marker::Copy for aya_obj::generated::bpf_devmap_val
+impl core::marker::Freeze for aya_obj::generated::bpf_devmap_val
 impl core::marker::Send for aya_obj::generated::bpf_devmap_val
 impl core::marker::Sync for aya_obj::generated::bpf_devmap_val
 impl core::marker::Unpin for aya_obj::generated::bpf_devmap_val
@@ -3822,6 +3922,7 @@ pub fn aya_obj::generated::bpf_func_info::clone(&self) -> aya_obj::generated::bp
 impl core::fmt::Debug for aya_obj::generated::bpf_func_info
 pub fn aya_obj::generated::bpf_func_info::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Copy for aya_obj::generated::bpf_func_info
+impl core::marker::Freeze for aya_obj::generated::bpf_func_info
 impl core::marker::Send for aya_obj::generated::bpf_func_info
 impl core::marker::Sync for aya_obj::generated::bpf_func_info
 impl core::marker::Unpin for aya_obj::generated::bpf_func_info
@@ -3864,6 +3965,7 @@ pub fn aya_obj::generated::bpf_insn::clone(&self) -> aya_obj::generated::bpf_ins
 impl core::fmt::Debug for aya_obj::generated::bpf_insn
 pub fn aya_obj::generated::bpf_insn::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Copy for aya_obj::generated::bpf_insn
+impl core::marker::Freeze for aya_obj::generated::bpf_insn
 impl core::marker::Send for aya_obj::generated::bpf_insn
 impl core::marker::Sync for aya_obj::generated::bpf_insn
 impl core::marker::Unpin for aya_obj::generated::bpf_insn
@@ -3899,6 +4001,7 @@ pub fn aya_obj::generated::bpf_line_info::clone(&self) -> aya_obj::generated::bp
 impl core::fmt::Debug for aya_obj::generated::bpf_line_info
 pub fn aya_obj::generated::bpf_line_info::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Copy for aya_obj::generated::bpf_line_info
+impl core::marker::Freeze for aya_obj::generated::bpf_line_info
 impl core::marker::Send for aya_obj::generated::bpf_line_info
 impl core::marker::Sync for aya_obj::generated::bpf_line_info
 impl core::marker::Unpin for aya_obj::generated::bpf_line_info
@@ -3932,6 +4035,7 @@ pub aya_obj::generated::bpf_link_info::type_: aya_obj::generated::__u32
 impl core::clone::Clone for aya_obj::generated::bpf_link_info
 pub fn aya_obj::generated::bpf_link_info::clone(&self) -> aya_obj::generated::bpf_link_info
 impl core::marker::Copy for aya_obj::generated::bpf_link_info
+impl core::marker::Freeze for aya_obj::generated::bpf_link_info
 impl core::marker::Send for aya_obj::generated::bpf_link_info
 impl core::marker::Sync for aya_obj::generated::bpf_link_info
 impl core::marker::Unpin for aya_obj::generated::bpf_link_info
@@ -3965,6 +4069,7 @@ pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_1::clone(&sel
 impl core::fmt::Debug for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_1
 pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_1::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Copy for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_1
+impl core::marker::Freeze for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_1
 impl core::marker::Send for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_1
 impl core::marker::Sync for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_1
 impl core::marker::Unpin for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_1
@@ -3999,6 +4104,7 @@ pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_2::clone(&sel
 impl core::fmt::Debug for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_2
 pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_2::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Copy for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_2
+impl core::marker::Freeze for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_2
 impl core::marker::Send for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_2
 impl core::marker::Sync for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_2
 impl core::marker::Unpin for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_2
@@ -4032,6 +4138,7 @@ pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_3::clone(&sel
 impl core::fmt::Debug for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_3
 pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_3::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Copy for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_3
+impl core::marker::Freeze for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_3
 impl core::marker::Send for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_3
 impl core::marker::Sync for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_3
 impl core::marker::Unpin for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_3
@@ -4065,6 +4172,7 @@ pub aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4::target_name_l
 impl core::clone::Clone for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4
 pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4::clone(&self) -> aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4
 impl core::marker::Copy for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4
+impl core::marker::Freeze for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4
 impl core::marker::Send for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4
 impl core::marker::Sync for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4
 impl core::marker::Unpin for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4
@@ -4097,6 +4205,7 @@ pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty
 impl core::fmt::Debug for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_1__bindgen_ty_1
 pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_1__bindgen_ty_1::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Copy for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_1__bindgen_ty_1
+impl core::marker::Freeze for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_1__bindgen_ty_1
 impl core::marker::Send for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_1__bindgen_ty_1
 impl core::marker::Sync for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_1__bindgen_ty_1
 impl core::marker::Unpin for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_1__bindgen_ty_1
@@ -4130,6 +4239,7 @@ pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty
 impl core::fmt::Debug for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2__bindgen_ty_1
 pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2__bindgen_ty_1::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Copy for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2__bindgen_ty_1
+impl core::marker::Freeze for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2__bindgen_ty_1
 impl core::marker::Send for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2__bindgen_ty_1
 impl core::marker::Sync for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2__bindgen_ty_1
 impl core::marker::Unpin for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2__bindgen_ty_1
@@ -4163,6 +4273,7 @@ pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty
 impl core::fmt::Debug for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2__bindgen_ty_2
 pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2__bindgen_ty_2::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Copy for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2__bindgen_ty_2
+impl core::marker::Freeze for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2__bindgen_ty_2
 impl core::marker::Send for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2__bindgen_ty_2
 impl core::marker::Sync for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2__bindgen_ty_2
 impl core::marker::Unpin for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2__bindgen_ty_2
@@ -4196,6 +4307,7 @@ pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_5::clone(&sel
 impl core::fmt::Debug for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_5
 pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_5::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Copy for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_5
+impl core::marker::Freeze for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_5
 impl core::marker::Send for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_5
 impl core::marker::Sync for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_5
 impl core::marker::Unpin for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_5
@@ -4228,6 +4340,7 @@ pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_6::clone(&sel
 impl core::fmt::Debug for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_6
 pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_6::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Copy for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_6
+impl core::marker::Freeze for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_6
 impl core::marker::Send for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_6
 impl core::marker::Sync for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_6
 impl core::marker::Unpin for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_6
@@ -4260,6 +4373,7 @@ pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_7::clone(&sel
 impl core::fmt::Debug for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_7
 pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_7::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Copy for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_7
+impl core::marker::Freeze for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_7
 impl core::marker::Send for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_7
 impl core::marker::Sync for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_7
 impl core::marker::Unpin for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_7
@@ -4295,6 +4409,7 @@ pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_8::clone(&sel
 impl core::fmt::Debug for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_8
 pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_8::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Copy for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_8
+impl core::marker::Freeze for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_8
 impl core::marker::Send for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_8
 impl core::marker::Sync for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_8
 impl core::marker::Unpin for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_8
@@ -4325,6 +4440,7 @@ pub aya_obj::generated::bpf_lpm_trie_key::data: aya_obj::generated::__Incomplete
 pub aya_obj::generated::bpf_lpm_trie_key::prefixlen: aya_obj::generated::__u32
 impl core::fmt::Debug for aya_obj::generated::bpf_lpm_trie_key
 pub fn aya_obj::generated::bpf_lpm_trie_key::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for aya_obj::generated::bpf_lpm_trie_key
 impl core::marker::Send for aya_obj::generated::bpf_lpm_trie_key
 impl core::marker::Sync for aya_obj::generated::bpf_lpm_trie_key
 impl core::marker::Unpin for aya_obj::generated::bpf_lpm_trie_key
@@ -4371,6 +4487,7 @@ pub fn aya_obj::generated::bpf_map_info::clone(&self) -> aya_obj::generated::bpf
 impl core::fmt::Debug for aya_obj::generated::bpf_map_info
 pub fn aya_obj::generated::bpf_map_info::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Copy for aya_obj::generated::bpf_map_info
+impl core::marker::Freeze for aya_obj::generated::bpf_map_info
 impl core::marker::Send for aya_obj::generated::bpf_map_info
 impl core::marker::Sync for aya_obj::generated::bpf_map_info
 impl core::marker::Unpin for aya_obj::generated::bpf_map_info
@@ -4445,6 +4562,7 @@ pub fn aya_obj::generated::bpf_prog_info::clone(&self) -> aya_obj::generated::bp
 impl core::fmt::Debug for aya_obj::generated::bpf_prog_info
 pub fn aya_obj::generated::bpf_prog_info::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Copy for aya_obj::generated::bpf_prog_info
+impl core::marker::Freeze for aya_obj::generated::bpf_prog_info
 impl core::marker::Send for aya_obj::generated::bpf_prog_info
 impl core::marker::Sync for aya_obj::generated::bpf_prog_info
 impl core::marker::Unpin for aya_obj::generated::bpf_prog_info
@@ -4479,6 +4597,7 @@ pub fn aya_obj::generated::btf_array::clone(&self) -> aya_obj::generated::btf_ar
 impl core::fmt::Debug for aya_obj::generated::btf_array
 pub fn aya_obj::generated::btf_array::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Copy for aya_obj::generated::btf_array
+impl core::marker::Freeze for aya_obj::generated::btf_array
 impl core::marker::Send for aya_obj::generated::btf_array
 impl core::marker::Sync for aya_obj::generated::btf_array
 impl core::marker::Unpin for aya_obj::generated::btf_array
@@ -4511,6 +4630,7 @@ pub fn aya_obj::generated::btf_decl_tag::clone(&self) -> aya_obj::generated::btf
 impl core::fmt::Debug for aya_obj::generated::btf_decl_tag
 pub fn aya_obj::generated::btf_decl_tag::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Copy for aya_obj::generated::btf_decl_tag
+impl core::marker::Freeze for aya_obj::generated::btf_decl_tag
 impl core::marker::Send for aya_obj::generated::btf_decl_tag
 impl core::marker::Sync for aya_obj::generated::btf_decl_tag
 impl core::marker::Unpin for aya_obj::generated::btf_decl_tag
@@ -4544,6 +4664,7 @@ pub fn aya_obj::generated::btf_enum::clone(&self) -> aya_obj::generated::btf_enu
 impl core::fmt::Debug for aya_obj::generated::btf_enum
 pub fn aya_obj::generated::btf_enum::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Copy for aya_obj::generated::btf_enum
+impl core::marker::Freeze for aya_obj::generated::btf_enum
 impl core::marker::Send for aya_obj::generated::btf_enum
 impl core::marker::Sync for aya_obj::generated::btf_enum
 impl core::marker::Unpin for aya_obj::generated::btf_enum
@@ -4585,6 +4706,7 @@ pub fn aya_obj::generated::btf_ext_header::clone(&self) -> aya_obj::generated::b
 impl core::fmt::Debug for aya_obj::generated::btf_ext_header
 pub fn aya_obj::generated::btf_ext_header::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Copy for aya_obj::generated::btf_ext_header
+impl core::marker::Freeze for aya_obj::generated::btf_ext_header
 impl core::marker::Send for aya_obj::generated::btf_ext_header
 impl core::marker::Sync for aya_obj::generated::btf_ext_header
 impl core::marker::Unpin for aya_obj::generated::btf_ext_header
@@ -4624,6 +4746,7 @@ pub fn aya_obj::generated::btf_header::clone(&self) -> aya_obj::generated::btf_h
 impl core::fmt::Debug for aya_obj::generated::btf_header
 pub fn aya_obj::generated::btf_header::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Copy for aya_obj::generated::btf_header
+impl core::marker::Freeze for aya_obj::generated::btf_header
 impl core::marker::Send for aya_obj::generated::btf_header
 impl core::marker::Sync for aya_obj::generated::btf_header
 impl core::marker::Unpin for aya_obj::generated::btf_header
@@ -4658,6 +4781,7 @@ pub fn aya_obj::generated::btf_member::clone(&self) -> aya_obj::generated::btf_m
 impl core::fmt::Debug for aya_obj::generated::btf_member
 pub fn aya_obj::generated::btf_member::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Copy for aya_obj::generated::btf_member
+impl core::marker::Freeze for aya_obj::generated::btf_member
 impl core::marker::Send for aya_obj::generated::btf_member
 impl core::marker::Sync for aya_obj::generated::btf_member
 impl core::marker::Unpin for aya_obj::generated::btf_member
@@ -4691,6 +4815,7 @@ pub fn aya_obj::generated::btf_param::clone(&self) -> aya_obj::generated::btf_pa
 impl core::fmt::Debug for aya_obj::generated::btf_param
 pub fn aya_obj::generated::btf_param::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Copy for aya_obj::generated::btf_param
+impl core::marker::Freeze for aya_obj::generated::btf_param
 impl core::marker::Send for aya_obj::generated::btf_param
 impl core::marker::Sync for aya_obj::generated::btf_param
 impl core::marker::Unpin for aya_obj::generated::btf_param
@@ -4723,6 +4848,7 @@ pub aya_obj::generated::btf_type::name_off: aya_obj::generated::__u32
 impl core::clone::Clone for aya_obj::generated::btf_type
 pub fn aya_obj::generated::btf_type::clone(&self) -> aya_obj::generated::btf_type
 impl core::marker::Copy for aya_obj::generated::btf_type
+impl core::marker::Freeze for aya_obj::generated::btf_type
 impl core::marker::Send for aya_obj::generated::btf_type
 impl core::marker::Sync for aya_obj::generated::btf_type
 impl core::marker::Unpin for aya_obj::generated::btf_type
@@ -4755,6 +4881,7 @@ pub fn aya_obj::generated::btf_var::clone(&self) -> aya_obj::generated::btf_var
 impl core::fmt::Debug for aya_obj::generated::btf_var
 pub fn aya_obj::generated::btf_var::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Copy for aya_obj::generated::btf_var
+impl core::marker::Freeze for aya_obj::generated::btf_var
 impl core::marker::Send for aya_obj::generated::btf_var
 impl core::marker::Sync for aya_obj::generated::btf_var
 impl core::marker::Unpin for aya_obj::generated::btf_var
@@ -4789,6 +4916,7 @@ pub fn aya_obj::generated::btf_var_secinfo::clone(&self) -> aya_obj::generated::
 impl core::fmt::Debug for aya_obj::generated::btf_var_secinfo
 pub fn aya_obj::generated::btf_var_secinfo::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Copy for aya_obj::generated::btf_var_secinfo
+impl core::marker::Freeze for aya_obj::generated::btf_var_secinfo
 impl core::marker::Send for aya_obj::generated::btf_var_secinfo
 impl core::marker::Sync for aya_obj::generated::btf_var_secinfo
 impl core::marker::Unpin for aya_obj::generated::btf_var_secinfo
@@ -4826,6 +4954,7 @@ pub fn aya_obj::generated::ifinfomsg::clone(&self) -> aya_obj::generated::ifinfo
 impl core::fmt::Debug for aya_obj::generated::ifinfomsg
 pub fn aya_obj::generated::ifinfomsg::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Copy for aya_obj::generated::ifinfomsg
+impl core::marker::Freeze for aya_obj::generated::ifinfomsg
 impl core::marker::Send for aya_obj::generated::ifinfomsg
 impl core::marker::Sync for aya_obj::generated::ifinfomsg
 impl core::marker::Unpin for aya_obj::generated::ifinfomsg
@@ -4957,6 +5086,7 @@ pub fn aya_obj::generated::perf_event_attr::write_backward(&self) -> aya_obj::ge
 impl core::clone::Clone for aya_obj::generated::perf_event_attr
 pub fn aya_obj::generated::perf_event_attr::clone(&self) -> aya_obj::generated::perf_event_attr
 impl core::marker::Copy for aya_obj::generated::perf_event_attr
+impl core::marker::Freeze for aya_obj::generated::perf_event_attr
 impl core::marker::Send for aya_obj::generated::perf_event_attr
 impl core::marker::Sync for aya_obj::generated::perf_event_attr
 impl core::marker::Unpin for aya_obj::generated::perf_event_attr
@@ -4991,6 +5121,7 @@ pub fn aya_obj::generated::perf_event_header::clone(&self) -> aya_obj::generated
 impl core::fmt::Debug for aya_obj::generated::perf_event_header
 pub fn aya_obj::generated::perf_event_header::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Copy for aya_obj::generated::perf_event_header
+impl core::marker::Freeze for aya_obj::generated::perf_event_header
 impl core::marker::Send for aya_obj::generated::perf_event_header
 impl core::marker::Sync for aya_obj::generated::perf_event_header
 impl core::marker::Unpin for aya_obj::generated::perf_event_header
@@ -5046,6 +5177,7 @@ pub aya_obj::generated::perf_event_mmap_page::version: aya_obj::generated::__u32
 impl core::clone::Clone for aya_obj::generated::perf_event_mmap_page
 pub fn aya_obj::generated::perf_event_mmap_page::clone(&self) -> aya_obj::generated::perf_event_mmap_page
 impl core::marker::Copy for aya_obj::generated::perf_event_mmap_page
+impl core::marker::Freeze for aya_obj::generated::perf_event_mmap_page
 impl core::marker::Send for aya_obj::generated::perf_event_mmap_page
 impl core::marker::Sync for aya_obj::generated::perf_event_mmap_page
 impl core::marker::Unpin for aya_obj::generated::perf_event_mmap_page
@@ -5095,6 +5227,7 @@ pub fn aya_obj::generated::perf_event_mmap_page__bindgen_ty_1__bindgen_ty_1::clo
 impl core::fmt::Debug for aya_obj::generated::perf_event_mmap_page__bindgen_ty_1__bindgen_ty_1
 pub fn aya_obj::generated::perf_event_mmap_page__bindgen_ty_1__bindgen_ty_1::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Copy for aya_obj::generated::perf_event_mmap_page__bindgen_ty_1__bindgen_ty_1
+impl core::marker::Freeze for aya_obj::generated::perf_event_mmap_page__bindgen_ty_1__bindgen_ty_1
 impl core::marker::Send for aya_obj::generated::perf_event_mmap_page__bindgen_ty_1__bindgen_ty_1
 impl core::marker::Sync for aya_obj::generated::perf_event_mmap_page__bindgen_ty_1__bindgen_ty_1
 impl core::marker::Unpin for aya_obj::generated::perf_event_mmap_page__bindgen_ty_1__bindgen_ty_1
@@ -5133,6 +5266,7 @@ pub fn aya_obj::generated::tcmsg::clone(&self) -> aya_obj::generated::tcmsg
 impl core::fmt::Debug for aya_obj::generated::tcmsg
 pub fn aya_obj::generated::tcmsg::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Copy for aya_obj::generated::tcmsg
+impl core::marker::Freeze for aya_obj::generated::tcmsg
 impl core::marker::Send for aya_obj::generated::tcmsg
 impl core::marker::Sync for aya_obj::generated::tcmsg
 impl core::marker::Unpin for aya_obj::generated::tcmsg
@@ -5401,6 +5535,7 @@ impl core::clone::Clone for aya_obj::maps::Map
 pub fn aya_obj::maps::Map::clone(&self) -> aya_obj::maps::Map
 impl core::fmt::Debug for aya_obj::maps::Map
 pub fn aya_obj::maps::Map::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for aya_obj::maps::Map
 impl core::marker::Send for aya_obj::maps::Map
 impl core::marker::Sync for aya_obj::maps::Map
 impl core::marker::Unpin for aya_obj::maps::Map
@@ -5434,6 +5569,7 @@ impl core::fmt::Debug for aya_obj::maps::PinningError
 pub fn aya_obj::maps::PinningError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::fmt::Display for aya_obj::maps::PinningError
 pub fn aya_obj::maps::PinningError::fmt(&self, __formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for aya_obj::maps::PinningError
 impl core::marker::Send for aya_obj::maps::PinningError
 impl core::marker::Sync for aya_obj::maps::PinningError
 impl core::marker::Unpin for aya_obj::maps::PinningError
@@ -5474,6 +5610,7 @@ impl core::fmt::Debug for aya_obj::maps::PinningType
 pub fn aya_obj::maps::PinningType::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Copy for aya_obj::maps::PinningType
 impl core::marker::StructuralPartialEq for aya_obj::maps::PinningType
+impl core::marker::Freeze for aya_obj::maps::PinningType
 impl core::marker::Send for aya_obj::maps::PinningType
 impl core::marker::Sync for aya_obj::maps::PinningType
 impl core::marker::Unpin for aya_obj::maps::PinningType
@@ -5505,6 +5642,7 @@ impl core::clone::Clone for aya_obj::maps::BtfMap
 pub fn aya_obj::maps::BtfMap::clone(&self) -> aya_obj::maps::BtfMap
 impl core::fmt::Debug for aya_obj::maps::BtfMap
 pub fn aya_obj::maps::BtfMap::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for aya_obj::maps::BtfMap
 impl core::marker::Send for aya_obj::maps::BtfMap
 impl core::marker::Sync for aya_obj::maps::BtfMap
 impl core::marker::Unpin for aya_obj::maps::BtfMap
@@ -5544,6 +5682,7 @@ impl core::fmt::Debug for aya_obj::maps::BtfMapDef
 pub fn aya_obj::maps::BtfMapDef::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Copy for aya_obj::maps::BtfMapDef
 impl core::marker::StructuralPartialEq for aya_obj::maps::BtfMapDef
+impl core::marker::Freeze for aya_obj::maps::BtfMapDef
 impl core::marker::Send for aya_obj::maps::BtfMapDef
 impl core::marker::Sync for aya_obj::maps::BtfMapDef
 impl core::marker::Unpin for aya_obj::maps::BtfMapDef
@@ -5571,6 +5710,7 @@ impl<T> core::convert::From<T> for aya_obj::maps::BtfMapDef
 pub fn aya_obj::maps::BtfMapDef::from(t: T) -> T
 pub struct aya_obj::maps::InvalidMapTypeError
 pub aya_obj::maps::InvalidMapTypeError::map_type: u32
+impl core::marker::Freeze for aya_obj::maps::InvalidMapTypeError
 impl core::marker::Send for aya_obj::maps::InvalidMapTypeError
 impl core::marker::Sync for aya_obj::maps::InvalidMapTypeError
 impl core::marker::Unpin for aya_obj::maps::InvalidMapTypeError
@@ -5602,6 +5742,7 @@ impl core::clone::Clone for aya_obj::maps::LegacyMap
 pub fn aya_obj::maps::LegacyMap::clone(&self) -> aya_obj::maps::LegacyMap
 impl core::fmt::Debug for aya_obj::maps::LegacyMap
 pub fn aya_obj::maps::LegacyMap::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for aya_obj::maps::LegacyMap
 impl core::marker::Send for aya_obj::maps::LegacyMap
 impl core::marker::Sync for aya_obj::maps::LegacyMap
 impl core::marker::Unpin for aya_obj::maps::LegacyMap
@@ -5646,6 +5787,7 @@ impl core::fmt::Debug for aya_obj::maps::bpf_map_def
 pub fn aya_obj::maps::bpf_map_def::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Copy for aya_obj::maps::bpf_map_def
 impl core::marker::StructuralPartialEq for aya_obj::maps::bpf_map_def
+impl core::marker::Freeze for aya_obj::maps::bpf_map_def
 impl core::marker::Send for aya_obj::maps::bpf_map_def
 impl core::marker::Sync for aya_obj::maps::bpf_map_def
 impl core::marker::Unpin for aya_obj::maps::bpf_map_def
@@ -5694,6 +5836,7 @@ impl core::fmt::Debug for aya_obj::EbpfSectionKind
 pub fn aya_obj::EbpfSectionKind::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Copy for aya_obj::EbpfSectionKind
 impl core::marker::StructuralPartialEq for aya_obj::EbpfSectionKind
+impl core::marker::Freeze for aya_obj::EbpfSectionKind
 impl core::marker::Send for aya_obj::EbpfSectionKind
 impl core::marker::Sync for aya_obj::EbpfSectionKind
 impl core::marker::Unpin for aya_obj::EbpfSectionKind
@@ -5767,6 +5910,7 @@ impl core::fmt::Debug for aya_obj::ParseError
 pub fn aya_obj::ParseError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::fmt::Display for aya_obj::ParseError
 pub fn aya_obj::ParseError::fmt(&self, __formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for aya_obj::ParseError
 impl core::marker::Send for aya_obj::ParseError
 impl core::marker::Sync for aya_obj::ParseError
 impl core::marker::Unpin for aya_obj::ParseError
@@ -5837,6 +5981,7 @@ pub fn aya_obj::ProgramSection::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> 
 impl core::str::traits::FromStr for aya_obj::ProgramSection
 pub type aya_obj::ProgramSection::Err = aya_obj::ParseError
 pub fn aya_obj::ProgramSection::from_str(section: &str) -> core::result::Result<aya_obj::ProgramSection, aya_obj::ParseError>
+impl core::marker::Freeze for aya_obj::ProgramSection
 impl core::marker::Send for aya_obj::ProgramSection
 impl core::marker::Sync for aya_obj::ProgramSection
 impl core::marker::Unpin for aya_obj::ProgramSection
@@ -5876,6 +6021,7 @@ impl core::default::Default for aya_obj::Features
 pub fn aya_obj::Features::default() -> aya_obj::Features
 impl core::fmt::Debug for aya_obj::Features
 pub fn aya_obj::Features::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for aya_obj::Features
 impl core::marker::Send for aya_obj::Features
 impl core::marker::Sync for aya_obj::Features
 impl core::marker::Unpin for aya_obj::Features
@@ -5911,6 +6057,7 @@ impl core::clone::Clone for aya_obj::Function
 pub fn aya_obj::Function::clone(&self) -> aya_obj::Function
 impl core::fmt::Debug for aya_obj::Function
 pub fn aya_obj::Function::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for aya_obj::Function
 impl core::marker::Send for aya_obj::Function
 impl core::marker::Sync for aya_obj::Function
 impl core::marker::Unpin for aya_obj::Function
@@ -5960,6 +6107,7 @@ impl core::clone::Clone for aya_obj::Object
 pub fn aya_obj::Object::clone(&self) -> aya_obj::Object
 impl core::fmt::Debug for aya_obj::Object
 pub fn aya_obj::Object::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for aya_obj::Object
 impl core::marker::Send for aya_obj::Object
 impl core::marker::Sync for aya_obj::Object
 impl core::marker::Unpin for aya_obj::Object
@@ -5997,6 +6145,7 @@ impl core::clone::Clone for aya_obj::Program
 pub fn aya_obj::Program::clone(&self) -> aya_obj::Program
 impl core::fmt::Debug for aya_obj::Program
 pub fn aya_obj::Program::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for aya_obj::Program
 impl core::marker::Send for aya_obj::Program
 impl core::marker::Sync for aya_obj::Program
 impl core::marker::Unpin for aya_obj::Program
@@ -6040,6 +6189,7 @@ pub fn aya_obj::programs::cgroup_sock::CgroupSockAttachType::default() -> aya_ob
 impl core::fmt::Debug for aya_obj::programs::cgroup_sock::CgroupSockAttachType
 pub fn aya_obj::programs::cgroup_sock::CgroupSockAttachType::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Copy for aya_obj::programs::cgroup_sock::CgroupSockAttachType
+impl core::marker::Freeze for aya_obj::programs::cgroup_sock::CgroupSockAttachType
 impl core::marker::Send for aya_obj::programs::cgroup_sock::CgroupSockAttachType
 impl core::marker::Sync for aya_obj::programs::cgroup_sock::CgroupSockAttachType
 impl core::marker::Unpin for aya_obj::programs::cgroup_sock::CgroupSockAttachType
@@ -6086,6 +6236,7 @@ pub fn aya_obj::generated::bpf_attach_type::from(s: aya_obj::programs::cgroup_so
 impl core::fmt::Debug for aya_obj::programs::cgroup_sock_addr::CgroupSockAddrAttachType
 pub fn aya_obj::programs::cgroup_sock_addr::CgroupSockAddrAttachType::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Copy for aya_obj::programs::cgroup_sock_addr::CgroupSockAddrAttachType
+impl core::marker::Freeze for aya_obj::programs::cgroup_sock_addr::CgroupSockAddrAttachType
 impl core::marker::Send for aya_obj::programs::cgroup_sock_addr::CgroupSockAddrAttachType
 impl core::marker::Sync for aya_obj::programs::cgroup_sock_addr::CgroupSockAddrAttachType
 impl core::marker::Unpin for aya_obj::programs::cgroup_sock_addr::CgroupSockAddrAttachType
@@ -6122,6 +6273,7 @@ pub fn aya_obj::generated::bpf_attach_type::from(s: aya_obj::programs::cgroup_so
 impl core::fmt::Debug for aya_obj::programs::cgroup_sockopt::CgroupSockoptAttachType
 pub fn aya_obj::programs::cgroup_sockopt::CgroupSockoptAttachType::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Copy for aya_obj::programs::cgroup_sockopt::CgroupSockoptAttachType
+impl core::marker::Freeze for aya_obj::programs::cgroup_sockopt::CgroupSockoptAttachType
 impl core::marker::Send for aya_obj::programs::cgroup_sockopt::CgroupSockoptAttachType
 impl core::marker::Sync for aya_obj::programs::cgroup_sockopt::CgroupSockoptAttachType
 impl core::marker::Unpin for aya_obj::programs::cgroup_sockopt::CgroupSockoptAttachType
@@ -6159,6 +6311,7 @@ pub fn aya_obj::generated::bpf_attach_type::from(value: aya_obj::programs::xdp::
 impl core::fmt::Debug for aya_obj::programs::xdp::XdpAttachType
 pub fn aya_obj::programs::xdp::XdpAttachType::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Copy for aya_obj::programs::xdp::XdpAttachType
+impl core::marker::Freeze for aya_obj::programs::xdp::XdpAttachType
 impl core::marker::Send for aya_obj::programs::xdp::XdpAttachType
 impl core::marker::Sync for aya_obj::programs::xdp::XdpAttachType
 impl core::marker::Unpin for aya_obj::programs::xdp::XdpAttachType
@@ -6204,6 +6357,7 @@ pub fn aya_obj::generated::bpf_attach_type::from(s: aya_obj::programs::cgroup_so
 impl core::fmt::Debug for aya_obj::programs::cgroup_sock_addr::CgroupSockAddrAttachType
 pub fn aya_obj::programs::cgroup_sock_addr::CgroupSockAddrAttachType::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Copy for aya_obj::programs::cgroup_sock_addr::CgroupSockAddrAttachType
+impl core::marker::Freeze for aya_obj::programs::cgroup_sock_addr::CgroupSockAddrAttachType
 impl core::marker::Send for aya_obj::programs::cgroup_sock_addr::CgroupSockAddrAttachType
 impl core::marker::Sync for aya_obj::programs::cgroup_sock_addr::CgroupSockAddrAttachType
 impl core::marker::Unpin for aya_obj::programs::cgroup_sock_addr::CgroupSockAddrAttachType
@@ -6243,6 +6397,7 @@ pub fn aya_obj::programs::cgroup_sock::CgroupSockAttachType::default() -> aya_ob
 impl core::fmt::Debug for aya_obj::programs::cgroup_sock::CgroupSockAttachType
 pub fn aya_obj::programs::cgroup_sock::CgroupSockAttachType::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Copy for aya_obj::programs::cgroup_sock::CgroupSockAttachType
+impl core::marker::Freeze for aya_obj::programs::cgroup_sock::CgroupSockAttachType
 impl core::marker::Send for aya_obj::programs::cgroup_sock::CgroupSockAttachType
 impl core::marker::Sync for aya_obj::programs::cgroup_sock::CgroupSockAttachType
 impl core::marker::Unpin for aya_obj::programs::cgroup_sock::CgroupSockAttachType
@@ -6278,6 +6433,7 @@ pub fn aya_obj::generated::bpf_attach_type::from(s: aya_obj::programs::cgroup_so
 impl core::fmt::Debug for aya_obj::programs::cgroup_sockopt::CgroupSockoptAttachType
 pub fn aya_obj::programs::cgroup_sockopt::CgroupSockoptAttachType::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Copy for aya_obj::programs::cgroup_sockopt::CgroupSockoptAttachType
+impl core::marker::Freeze for aya_obj::programs::cgroup_sockopt::CgroupSockoptAttachType
 impl core::marker::Send for aya_obj::programs::cgroup_sockopt::CgroupSockoptAttachType
 impl core::marker::Sync for aya_obj::programs::cgroup_sockopt::CgroupSockoptAttachType
 impl core::marker::Unpin for aya_obj::programs::cgroup_sockopt::CgroupSockoptAttachType
@@ -6314,6 +6470,7 @@ pub fn aya_obj::generated::bpf_attach_type::from(value: aya_obj::programs::xdp::
 impl core::fmt::Debug for aya_obj::programs::xdp::XdpAttachType
 pub fn aya_obj::programs::xdp::XdpAttachType::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Copy for aya_obj::programs::xdp::XdpAttachType
+impl core::marker::Freeze for aya_obj::programs::xdp::XdpAttachType
 impl core::marker::Send for aya_obj::programs::xdp::XdpAttachType
 impl core::marker::Sync for aya_obj::programs::xdp::XdpAttachType
 impl core::marker::Unpin for aya_obj::programs::xdp::XdpAttachType
@@ -6361,6 +6518,7 @@ impl core::fmt::Debug for aya_obj::relocation::RelocationError
 pub fn aya_obj::relocation::RelocationError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::fmt::Display for aya_obj::relocation::RelocationError
 pub fn aya_obj::relocation::RelocationError::fmt(&self, __formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for aya_obj::relocation::RelocationError
 impl core::marker::Send for aya_obj::relocation::RelocationError
 impl core::marker::Sync for aya_obj::relocation::RelocationError
 impl core::marker::Unpin for aya_obj::relocation::RelocationError
@@ -6391,6 +6549,7 @@ impl core::fmt::Debug for aya_obj::relocation::EbpfRelocationError
 pub fn aya_obj::relocation::EbpfRelocationError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::fmt::Display for aya_obj::relocation::EbpfRelocationError
 pub fn aya_obj::relocation::EbpfRelocationError::fmt(&self, __formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for aya_obj::relocation::EbpfRelocationError
 impl core::marker::Send for aya_obj::relocation::EbpfRelocationError
 impl core::marker::Sync for aya_obj::relocation::EbpfRelocationError
 impl core::marker::Unpin for aya_obj::relocation::EbpfRelocationError
@@ -6436,6 +6595,7 @@ impl core::fmt::Debug for aya_obj::EbpfSectionKind
 pub fn aya_obj::EbpfSectionKind::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Copy for aya_obj::EbpfSectionKind
 impl core::marker::StructuralPartialEq for aya_obj::EbpfSectionKind
+impl core::marker::Freeze for aya_obj::EbpfSectionKind
 impl core::marker::Send for aya_obj::EbpfSectionKind
 impl core::marker::Sync for aya_obj::EbpfSectionKind
 impl core::marker::Unpin for aya_obj::EbpfSectionKind
@@ -6482,6 +6642,7 @@ impl core::clone::Clone for aya_obj::maps::Map
 pub fn aya_obj::maps::Map::clone(&self) -> aya_obj::maps::Map
 impl core::fmt::Debug for aya_obj::maps::Map
 pub fn aya_obj::maps::Map::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for aya_obj::maps::Map
 impl core::marker::Send for aya_obj::maps::Map
 impl core::marker::Sync for aya_obj::maps::Map
 impl core::marker::Unpin for aya_obj::maps::Map
@@ -6555,6 +6716,7 @@ impl core::fmt::Debug for aya_obj::ParseError
 pub fn aya_obj::ParseError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::fmt::Display for aya_obj::ParseError
 pub fn aya_obj::ParseError::fmt(&self, __formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for aya_obj::ParseError
 impl core::marker::Send for aya_obj::ParseError
 impl core::marker::Sync for aya_obj::ParseError
 impl core::marker::Unpin for aya_obj::ParseError
@@ -6625,6 +6787,7 @@ pub fn aya_obj::ProgramSection::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> 
 impl core::str::traits::FromStr for aya_obj::ProgramSection
 pub type aya_obj::ProgramSection::Err = aya_obj::ParseError
 pub fn aya_obj::ProgramSection::from_str(section: &str) -> core::result::Result<aya_obj::ProgramSection, aya_obj::ParseError>
+impl core::marker::Freeze for aya_obj::ProgramSection
 impl core::marker::Send for aya_obj::ProgramSection
 impl core::marker::Sync for aya_obj::ProgramSection
 impl core::marker::Unpin for aya_obj::ProgramSection
@@ -6664,6 +6827,7 @@ impl core::default::Default for aya_obj::Features
 pub fn aya_obj::Features::default() -> aya_obj::Features
 impl core::fmt::Debug for aya_obj::Features
 pub fn aya_obj::Features::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for aya_obj::Features
 impl core::marker::Send for aya_obj::Features
 impl core::marker::Sync for aya_obj::Features
 impl core::marker::Unpin for aya_obj::Features
@@ -6699,6 +6863,7 @@ impl core::clone::Clone for aya_obj::Function
 pub fn aya_obj::Function::clone(&self) -> aya_obj::Function
 impl core::fmt::Debug for aya_obj::Function
 pub fn aya_obj::Function::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for aya_obj::Function
 impl core::marker::Send for aya_obj::Function
 impl core::marker::Sync for aya_obj::Function
 impl core::marker::Unpin for aya_obj::Function
@@ -6748,6 +6913,7 @@ impl core::clone::Clone for aya_obj::Object
 pub fn aya_obj::Object::clone(&self) -> aya_obj::Object
 impl core::fmt::Debug for aya_obj::Object
 pub fn aya_obj::Object::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for aya_obj::Object
 impl core::marker::Send for aya_obj::Object
 impl core::marker::Sync for aya_obj::Object
 impl core::marker::Unpin for aya_obj::Object
@@ -6785,6 +6951,7 @@ impl core::clone::Clone for aya_obj::Program
 pub fn aya_obj::Program::clone(&self) -> aya_obj::Program
 impl core::fmt::Debug for aya_obj::Program
 pub fn aya_obj::Program::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for aya_obj::Program
 impl core::marker::Send for aya_obj::Program
 impl core::marker::Sync for aya_obj::Program
 impl core::marker::Unpin for aya_obj::Program
@@ -6817,6 +6984,7 @@ impl core::fmt::Debug for aya_obj::VerifierLog
 pub fn aya_obj::VerifierLog::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::fmt::Display for aya_obj::VerifierLog
 pub fn aya_obj::VerifierLog::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for aya_obj::VerifierLog
 impl core::marker::Send for aya_obj::VerifierLog
 impl core::marker::Sync for aya_obj::VerifierLog
 impl core::marker::Unpin for aya_obj::VerifierLog

--- a/xtask/public-api/aya-tool.txt
+++ b/xtask/public-api/aya-tool.txt
@@ -20,6 +20,7 @@ impl core::fmt::Debug for aya_tool::generate::Error
 pub fn aya_tool::generate::Error::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::fmt::Display for aya_tool::generate::Error
 pub fn aya_tool::generate::Error::fmt(&self, __formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for aya_tool::generate::Error
 impl core::marker::Send for aya_tool::generate::Error
 impl core::marker::Sync for aya_tool::generate::Error
 impl core::marker::Unpin for aya_tool::generate::Error
@@ -46,6 +47,7 @@ pub fn aya_tool::generate::Error::from(t: T) -> T
 pub enum aya_tool::generate::InputFile
 pub aya_tool::generate::InputFile::Btf(std::path::PathBuf)
 pub aya_tool::generate::InputFile::Header(std::path::PathBuf)
+impl core::marker::Freeze for aya_tool::generate::InputFile
 impl core::marker::Send for aya_tool::generate::InputFile
 impl core::marker::Sync for aya_tool::generate::InputFile
 impl core::marker::Unpin for aya_tool::generate::InputFile
@@ -73,6 +75,7 @@ pub fn aya_tool::rustfmt::format(code: &str) -> core::result::Result<alloc::stri
 pub enum aya_tool::InputFile
 pub aya_tool::InputFile::Btf(std::path::PathBuf)
 pub aya_tool::InputFile::Header(std::path::PathBuf)
+impl core::marker::Freeze for aya_tool::generate::InputFile
 impl core::marker::Send for aya_tool::generate::InputFile
 impl core::marker::Sync for aya_tool::generate::InputFile
 impl core::marker::Unpin for aya_tool::generate::InputFile

--- a/xtask/public-api/aya.txt
+++ b/xtask/public-api/aya.txt
@@ -27,6 +27,7 @@ pub fn aya::maps::array::Array<T, V>::map(&self) -> &aya::maps::MapData
 impl<V: aya::Pod> core::convert::TryFrom<aya::maps::Map> for aya::maps::array::Array<aya::maps::MapData, V>
 pub type aya::maps::array::Array<aya::maps::MapData, V>::Error = aya::maps::MapError
 pub fn aya::maps::array::Array<aya::maps::MapData, V>::try_from(map: aya::maps::Map) -> core::result::Result<Self, Self::Error>
+impl<T, V> core::marker::Freeze for aya::maps::array::Array<T, V> where T: core::marker::Freeze
 impl<T, V> core::marker::Send for aya::maps::array::Array<T, V> where T: core::marker::Send, V: core::marker::Send
 impl<T, V> core::marker::Sync for aya::maps::array::Array<T, V> where T: core::marker::Sync, V: core::marker::Sync
 impl<T, V> core::marker::Unpin for aya::maps::array::Array<T, V> where T: core::marker::Unpin, V: core::marker::Unpin
@@ -69,6 +70,7 @@ pub fn aya::maps::PerCpuArray<T, V>::map(&self) -> &aya::maps::MapData
 impl<V: aya::Pod> core::convert::TryFrom<aya::maps::Map> for aya::maps::PerCpuArray<aya::maps::MapData, V>
 pub type aya::maps::PerCpuArray<aya::maps::MapData, V>::Error = aya::maps::MapError
 pub fn aya::maps::PerCpuArray<aya::maps::MapData, V>::try_from(map: aya::maps::Map) -> core::result::Result<Self, Self::Error>
+impl<T, V> core::marker::Freeze for aya::maps::PerCpuArray<T, V> where T: core::marker::Freeze
 impl<T, V> core::marker::Send for aya::maps::PerCpuArray<T, V> where T: core::marker::Send, V: core::marker::Send
 impl<T, V> core::marker::Sync for aya::maps::PerCpuArray<T, V> where T: core::marker::Sync, V: core::marker::Sync
 impl<T, V> core::marker::Unpin for aya::maps::PerCpuArray<T, V> where T: core::marker::Unpin, V: core::marker::Unpin
@@ -107,6 +109,7 @@ pub fn aya::maps::ProgramArray<&'a aya::maps::MapData>::try_from(map: &'a aya::m
 impl<'a> core::convert::TryFrom<&'a mut aya::maps::Map> for aya::maps::ProgramArray<&'a mut aya::maps::MapData>
 pub type aya::maps::ProgramArray<&'a mut aya::maps::MapData>::Error = aya::maps::MapError
 pub fn aya::maps::ProgramArray<&'a mut aya::maps::MapData>::try_from(map: &'a mut aya::maps::Map) -> core::result::Result<Self, Self::Error>
+impl<T> core::marker::Freeze for aya::maps::ProgramArray<T> where T: core::marker::Freeze
 impl<T> core::marker::Send for aya::maps::ProgramArray<T> where T: core::marker::Send
 impl<T> core::marker::Sync for aya::maps::ProgramArray<T> where T: core::marker::Sync
 impl<T> core::marker::Unpin for aya::maps::ProgramArray<T> where T: core::marker::Unpin
@@ -147,6 +150,7 @@ pub fn aya::maps::bloom_filter::BloomFilter<T, V>::fmt(&self, f: &mut core::fmt:
 impl<V: aya::Pod> core::convert::TryFrom<aya::maps::Map> for aya::maps::bloom_filter::BloomFilter<aya::maps::MapData, V>
 pub type aya::maps::bloom_filter::BloomFilter<aya::maps::MapData, V>::Error = aya::maps::MapError
 pub fn aya::maps::bloom_filter::BloomFilter<aya::maps::MapData, V>::try_from(map: aya::maps::Map) -> core::result::Result<Self, Self::Error>
+impl<T, V> core::marker::Freeze for aya::maps::bloom_filter::BloomFilter<T, V> where T: core::marker::Freeze
 impl<T, V> core::marker::Send for aya::maps::bloom_filter::BloomFilter<T, V> where T: core::marker::Send, V: core::marker::Send
 impl<T, V> core::marker::Sync for aya::maps::bloom_filter::BloomFilter<T, V> where T: core::marker::Sync, V: core::marker::Sync
 impl<T, V> core::marker::Unpin for aya::maps::bloom_filter::BloomFilter<T, V> where T: core::marker::Unpin, V: core::marker::Unpin
@@ -193,6 +197,7 @@ pub fn aya::maps::hash_map::HashMap<T, K, V>::get(&self, key: &K) -> core::resul
 pub fn aya::maps::hash_map::HashMap<T, K, V>::map(&self) -> &aya::maps::MapData
 impl<T: core::fmt::Debug, K: core::fmt::Debug, V: core::fmt::Debug> core::fmt::Debug for aya::maps::hash_map::HashMap<T, K, V>
 pub fn aya::maps::hash_map::HashMap<T, K, V>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl<T, K, V> core::marker::Freeze for aya::maps::hash_map::HashMap<T, K, V> where T: core::marker::Freeze
 impl<T, K, V> core::marker::Send for aya::maps::hash_map::HashMap<T, K, V> where K: core::marker::Send, T: core::marker::Send, V: core::marker::Send
 impl<T, K, V> core::marker::Sync for aya::maps::hash_map::HashMap<T, K, V> where K: core::marker::Sync, T: core::marker::Sync, V: core::marker::Sync
 impl<T, K, V> core::marker::Unpin for aya::maps::hash_map::HashMap<T, K, V> where K: core::marker::Unpin, T: core::marker::Unpin, V: core::marker::Unpin
@@ -236,6 +241,7 @@ pub fn aya::maps::hash_map::PerCpuHashMap<aya::maps::MapData, K, V>::try_from(ma
 impl<T: core::borrow::Borrow<aya::maps::MapData>, K: aya::Pod, V: aya::Pod> aya::maps::IterableMap<K, aya::maps::PerCpuValues<V>> for aya::maps::hash_map::PerCpuHashMap<T, K, V>
 pub fn aya::maps::hash_map::PerCpuHashMap<T, K, V>::get(&self, key: &K) -> core::result::Result<aya::maps::PerCpuValues<V>, aya::maps::MapError>
 pub fn aya::maps::hash_map::PerCpuHashMap<T, K, V>::map(&self) -> &aya::maps::MapData
+impl<T, K, V> core::marker::Freeze for aya::maps::hash_map::PerCpuHashMap<T, K, V> where T: core::marker::Freeze
 impl<T, K, V> core::marker::Send for aya::maps::hash_map::PerCpuHashMap<T, K, V> where K: core::marker::Send, T: core::marker::Send, V: core::marker::Send
 impl<T, K, V> core::marker::Sync for aya::maps::hash_map::PerCpuHashMap<T, K, V> where K: core::marker::Sync, T: core::marker::Sync, V: core::marker::Sync
 impl<T, K, V> core::marker::Unpin for aya::maps::hash_map::PerCpuHashMap<T, K, V> where K: core::marker::Unpin, T: core::marker::Unpin, V: core::marker::Unpin
@@ -270,6 +276,7 @@ impl<K: aya::Pod> core::marker::Copy for aya::maps::lpm_trie::Key<K>
 impl<T: core::borrow::Borrow<aya::maps::MapData>, K: aya::Pod, V: aya::Pod> aya::maps::IterableMap<aya::maps::lpm_trie::Key<K>, V> for aya::maps::lpm_trie::LpmTrie<T, K, V>
 pub fn aya::maps::lpm_trie::LpmTrie<T, K, V>::get(&self, key: &aya::maps::lpm_trie::Key<K>) -> core::result::Result<V, aya::maps::MapError>
 pub fn aya::maps::lpm_trie::LpmTrie<T, K, V>::map(&self) -> &aya::maps::MapData
+impl<K> core::marker::Freeze for aya::maps::lpm_trie::Key<K> where K: core::marker::Freeze
 impl<K> core::marker::Send for aya::maps::lpm_trie::Key<K> where K: core::marker::Send
 impl<K> core::marker::Sync for aya::maps::lpm_trie::Key<K> where K: core::marker::Sync
 impl<K> core::marker::Unpin for aya::maps::lpm_trie::Key<K> where K: core::marker::Unpin
@@ -319,6 +326,7 @@ pub fn aya::maps::lpm_trie::LpmTrie<T, K, V>::get(&self, key: &aya::maps::lpm_tr
 pub fn aya::maps::lpm_trie::LpmTrie<T, K, V>::map(&self) -> &aya::maps::MapData
 impl<T: core::fmt::Debug, K: core::fmt::Debug, V: core::fmt::Debug> core::fmt::Debug for aya::maps::lpm_trie::LpmTrie<T, K, V>
 pub fn aya::maps::lpm_trie::LpmTrie<T, K, V>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl<T, K, V> core::marker::Freeze for aya::maps::lpm_trie::LpmTrie<T, K, V> where T: core::marker::Freeze
 impl<T, K, V> core::marker::Send for aya::maps::lpm_trie::LpmTrie<T, K, V> where K: core::marker::Send, T: core::marker::Send, V: core::marker::Send
 impl<T, K, V> core::marker::Sync for aya::maps::lpm_trie::LpmTrie<T, K, V> where K: core::marker::Sync, T: core::marker::Sync, V: core::marker::Sync
 impl<T, K, V> core::marker::Unpin for aya::maps::lpm_trie::LpmTrie<T, K, V> where K: core::marker::Unpin, T: core::marker::Unpin, V: core::marker::Unpin
@@ -362,6 +370,7 @@ impl core::fmt::Debug for aya::maps::perf::PerfBufferError
 pub fn aya::maps::perf::PerfBufferError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::fmt::Display for aya::maps::perf::PerfBufferError
 pub fn aya::maps::perf::PerfBufferError::fmt(&self, __formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for aya::maps::perf::PerfBufferError
 impl core::marker::Send for aya::maps::perf::PerfBufferError
 impl core::marker::Sync for aya::maps::perf::PerfBufferError
 impl core::marker::Unpin for aya::maps::perf::PerfBufferError
@@ -398,6 +407,7 @@ pub fn aya::maps::perf::AsyncPerfEventArray<&'a aya::maps::MapData>::try_from(ma
 impl<'a> core::convert::TryFrom<&'a mut aya::maps::Map> for aya::maps::perf::AsyncPerfEventArray<&'a mut aya::maps::MapData>
 pub type aya::maps::perf::AsyncPerfEventArray<&'a mut aya::maps::MapData>::Error = aya::maps::MapError
 pub fn aya::maps::perf::AsyncPerfEventArray<&'a mut aya::maps::MapData>::try_from(map: &'a mut aya::maps::Map) -> core::result::Result<Self, Self::Error>
+impl<T> core::marker::Freeze for aya::maps::perf::AsyncPerfEventArray<T>
 impl<T> core::marker::Send for aya::maps::perf::AsyncPerfEventArray<T> where T: core::marker::Sync + core::marker::Send
 impl<T> core::marker::Sync for aya::maps::perf::AsyncPerfEventArray<T> where T: core::marker::Sync + core::marker::Send
 impl<T> core::marker::Unpin for aya::maps::perf::AsyncPerfEventArray<T>
@@ -422,6 +432,7 @@ pub fn aya::maps::perf::AsyncPerfEventArray<T>::from(t: T) -> T
 pub struct aya::maps::perf::AsyncPerfEventArrayBuffer<T: core::borrow::BorrowMut<aya::maps::MapData>>
 impl<T: core::borrow::BorrowMut<aya::maps::MapData>> aya::maps::perf::AsyncPerfEventArrayBuffer<T>
 pub async fn aya::maps::perf::AsyncPerfEventArrayBuffer<T>::read_events(&mut self, buffers: &mut [bytes::bytes_mut::BytesMut]) -> core::result::Result<aya::maps::perf::Events, aya::maps::perf::PerfBufferError>
+impl<T> !core::marker::Freeze for aya::maps::perf::AsyncPerfEventArrayBuffer<T>
 impl<T> core::marker::Send for aya::maps::perf::AsyncPerfEventArrayBuffer<T> where T: core::marker::Sync + core::marker::Send
 impl<T> core::marker::Sync for aya::maps::perf::AsyncPerfEventArrayBuffer<T> where T: core::marker::Sync + core::marker::Send
 impl<T> core::marker::Unpin for aya::maps::perf::AsyncPerfEventArrayBuffer<T>
@@ -452,6 +463,7 @@ pub fn aya::maps::perf::Events::eq(&self, other: &aya::maps::perf::Events) -> bo
 impl core::fmt::Debug for aya::maps::perf::Events
 pub fn aya::maps::perf::Events::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::StructuralPartialEq for aya::maps::perf::Events
+impl core::marker::Freeze for aya::maps::perf::Events
 impl core::marker::Send for aya::maps::perf::Events
 impl core::marker::Sync for aya::maps::perf::Events
 impl core::marker::Unpin for aya::maps::perf::Events
@@ -487,6 +499,7 @@ pub fn aya::maps::perf::PerfEventArray<&'a aya::maps::MapData>::try_from(map: &'
 impl<'a> core::convert::TryFrom<&'a mut aya::maps::Map> for aya::maps::perf::PerfEventArray<&'a mut aya::maps::MapData>
 pub type aya::maps::perf::PerfEventArray<&'a mut aya::maps::MapData>::Error = aya::maps::MapError
 pub fn aya::maps::perf::PerfEventArray<&'a mut aya::maps::MapData>::try_from(map: &'a mut aya::maps::Map) -> core::result::Result<Self, Self::Error>
+impl<T> core::marker::Freeze for aya::maps::perf::PerfEventArray<T>
 impl<T> core::marker::Send for aya::maps::perf::PerfEventArray<T> where T: core::marker::Sync + core::marker::Send
 impl<T> core::marker::Sync for aya::maps::perf::PerfEventArray<T> where T: core::marker::Sync + core::marker::Send
 impl<T> core::marker::Unpin for aya::maps::perf::PerfEventArray<T>
@@ -516,6 +529,7 @@ impl<T: core::borrow::BorrowMut<aya::maps::MapData>> std::os::fd::owned::AsFd fo
 pub fn aya::maps::perf::PerfEventArrayBuffer<T>::as_fd(&self) -> std::os::fd::owned::BorrowedFd<'_>
 impl<T: core::borrow::BorrowMut<aya::maps::MapData>> std::os::fd::raw::AsRawFd for aya::maps::perf::PerfEventArrayBuffer<T>
 pub fn aya::maps::perf::PerfEventArrayBuffer<T>::as_raw_fd(&self) -> std::os::fd::raw::RawFd
+impl<T> !core::marker::Freeze for aya::maps::perf::PerfEventArrayBuffer<T>
 impl<T> core::marker::Send for aya::maps::perf::PerfEventArrayBuffer<T> where T: core::marker::Sync + core::marker::Send
 impl<T> core::marker::Sync for aya::maps::perf::PerfEventArrayBuffer<T> where T: core::marker::Sync + core::marker::Send
 impl<T> core::marker::Unpin for aya::maps::perf::PerfEventArrayBuffer<T>
@@ -555,6 +569,7 @@ pub fn aya::maps::queue::Queue<&'a mut aya::maps::MapData, V>::try_from(map: &'a
 impl<V: aya::Pod> core::convert::TryFrom<aya::maps::Map> for aya::maps::queue::Queue<aya::maps::MapData, V>
 pub type aya::maps::queue::Queue<aya::maps::MapData, V>::Error = aya::maps::MapError
 pub fn aya::maps::queue::Queue<aya::maps::MapData, V>::try_from(map: aya::maps::Map) -> core::result::Result<Self, Self::Error>
+impl<T, V> core::marker::Freeze for aya::maps::queue::Queue<T, V> where T: core::marker::Freeze
 impl<T, V> core::marker::Send for aya::maps::queue::Queue<T, V> where T: core::marker::Send, V: core::marker::Send
 impl<T, V> core::marker::Sync for aya::maps::queue::Queue<T, V> where T: core::marker::Sync, V: core::marker::Sync
 impl<T, V> core::marker::Unpin for aya::maps::queue::Queue<T, V> where T: core::marker::Unpin, V: core::marker::Unpin
@@ -591,6 +606,7 @@ pub type aya::maps::ring_buf::RingBuf<&'a mut aya::maps::MapData>::Error = aya::
 pub fn aya::maps::ring_buf::RingBuf<&'a mut aya::maps::MapData>::try_from(map: &'a mut aya::maps::Map) -> core::result::Result<Self, Self::Error>
 impl<T: core::borrow::Borrow<aya::maps::MapData>> std::os::fd::raw::AsRawFd for aya::maps::ring_buf::RingBuf<T>
 pub fn aya::maps::ring_buf::RingBuf<T>::as_raw_fd(&self) -> std::os::fd::raw::RawFd
+impl<T> core::marker::Freeze for aya::maps::ring_buf::RingBuf<T> where T: core::marker::Freeze
 impl<T> core::marker::Send for aya::maps::ring_buf::RingBuf<T> where T: core::marker::Send
 impl<T> core::marker::Sync for aya::maps::ring_buf::RingBuf<T> where T: core::marker::Sync
 impl<T> core::marker::Unpin for aya::maps::ring_buf::RingBuf<T> where T: core::marker::Unpin
@@ -620,6 +636,7 @@ pub type aya::maps::ring_buf::RingBufItem<'_>::Target = [u8]
 pub fn aya::maps::ring_buf::RingBufItem<'_>::deref(&self) -> &Self::Target
 impl core::ops::drop::Drop for aya::maps::ring_buf::RingBufItem<'_>
 pub fn aya::maps::ring_buf::RingBufItem<'_>::drop(&mut self)
+impl<'a> core::marker::Freeze for aya::maps::ring_buf::RingBufItem<'a>
 impl<'a> core::marker::Send for aya::maps::ring_buf::RingBufItem<'a>
 impl<'a> core::marker::Sync for aya::maps::ring_buf::RingBufItem<'a>
 impl<'a> core::marker::Unpin for aya::maps::ring_buf::RingBufItem<'a>
@@ -665,6 +682,7 @@ pub fn aya::maps::SockHash<T, K>::map(&self) -> &aya::maps::MapData
 impl<V: aya::Pod> core::convert::TryFrom<aya::maps::Map> for aya::maps::SockHash<aya::maps::MapData, V>
 pub type aya::maps::SockHash<aya::maps::MapData, V>::Error = aya::maps::MapError
 pub fn aya::maps::SockHash<aya::maps::MapData, V>::try_from(map: aya::maps::Map) -> core::result::Result<Self, Self::Error>
+impl<T, K> core::marker::Freeze for aya::maps::SockHash<T, K> where T: core::marker::Freeze
 impl<T, K> core::marker::Send for aya::maps::SockHash<T, K> where K: core::marker::Send, T: core::marker::Send
 impl<T, K> core::marker::Sync for aya::maps::SockHash<T, K> where K: core::marker::Sync, T: core::marker::Sync
 impl<T, K> core::marker::Unpin for aya::maps::SockHash<T, K> where K: core::marker::Unpin, T: core::marker::Unpin
@@ -704,6 +722,7 @@ pub fn aya::maps::SockMap<&'a aya::maps::MapData>::try_from(map: &'a aya::maps::
 impl<'a> core::convert::TryFrom<&'a mut aya::maps::Map> for aya::maps::SockMap<&'a mut aya::maps::MapData>
 pub type aya::maps::SockMap<&'a mut aya::maps::MapData>::Error = aya::maps::MapError
 pub fn aya::maps::SockMap<&'a mut aya::maps::MapData>::try_from(map: &'a mut aya::maps::Map) -> core::result::Result<Self, Self::Error>
+impl<T> core::marker::Freeze for aya::maps::SockMap<T> where T: core::marker::Freeze
 impl<T> core::marker::Send for aya::maps::SockMap<T> where T: core::marker::Send
 impl<T> core::marker::Sync for aya::maps::SockMap<T> where T: core::marker::Sync
 impl<T> core::marker::Unpin for aya::maps::SockMap<T> where T: core::marker::Unpin
@@ -730,6 +749,7 @@ impl aya::maps::sock::SockMapFd
 pub fn aya::maps::sock::SockMapFd::try_clone(&self) -> std::io::error::Result<Self>
 impl std::os::fd::owned::AsFd for aya::maps::sock::SockMapFd
 pub fn aya::maps::sock::SockMapFd::as_fd(&self) -> std::os::fd::owned::BorrowedFd<'_>
+impl core::marker::Freeze for aya::maps::sock::SockMapFd
 impl core::marker::Send for aya::maps::sock::SockMapFd
 impl core::marker::Sync for aya::maps::sock::SockMapFd
 impl core::marker::Unpin for aya::maps::sock::SockMapFd
@@ -769,6 +789,7 @@ pub fn aya::maps::stack::Stack<&'a mut aya::maps::MapData, V>::try_from(map: &'a
 impl<V: aya::Pod> core::convert::TryFrom<aya::maps::Map> for aya::maps::stack::Stack<aya::maps::MapData, V>
 pub type aya::maps::stack::Stack<aya::maps::MapData, V>::Error = aya::maps::MapError
 pub fn aya::maps::stack::Stack<aya::maps::MapData, V>::try_from(map: aya::maps::Map) -> core::result::Result<Self, Self::Error>
+impl<T, V> core::marker::Freeze for aya::maps::stack::Stack<T, V> where T: core::marker::Freeze
 impl<T, V> core::marker::Send for aya::maps::stack::Stack<T, V> where T: core::marker::Send, V: core::marker::Send
 impl<T, V> core::marker::Sync for aya::maps::stack::Stack<T, V> where T: core::marker::Sync, V: core::marker::Sync
 impl<T, V> core::marker::Unpin for aya::maps::stack::Stack<T, V> where T: core::marker::Unpin, V: core::marker::Unpin
@@ -793,6 +814,7 @@ pub fn aya::maps::stack::Stack<T, V>::from(t: T) -> T
 pub mod aya::maps::stack_trace
 pub struct aya::maps::stack_trace::StackFrame
 pub aya::maps::stack_trace::StackFrame::ip: u64
+impl core::marker::Freeze for aya::maps::stack_trace::StackFrame
 impl core::marker::Send for aya::maps::stack_trace::StackFrame
 impl core::marker::Sync for aya::maps::stack_trace::StackFrame
 impl core::marker::Unpin for aya::maps::stack_trace::StackFrame
@@ -821,6 +843,7 @@ pub fn aya::maps::stack_trace::StackTrace::frames(&self) -> &[aya::maps::stack_t
 impl<T: core::borrow::Borrow<aya::maps::MapData>> aya::maps::IterableMap<u32, aya::maps::stack_trace::StackTrace> for aya::maps::stack_trace::StackTraceMap<T>
 pub fn aya::maps::stack_trace::StackTraceMap<T>::get(&self, index: &u32) -> core::result::Result<aya::maps::stack_trace::StackTrace, aya::maps::MapError>
 pub fn aya::maps::stack_trace::StackTraceMap<T>::map(&self) -> &aya::maps::MapData
+impl core::marker::Freeze for aya::maps::stack_trace::StackTrace
 impl core::marker::Send for aya::maps::stack_trace::StackTrace
 impl core::marker::Sync for aya::maps::stack_trace::StackTrace
 impl core::marker::Unpin for aya::maps::stack_trace::StackTrace
@@ -869,6 +892,7 @@ pub fn aya::maps::stack_trace::StackTraceMap<T>::get(&self, index: &u32) -> core
 pub fn aya::maps::stack_trace::StackTraceMap<T>::map(&self) -> &aya::maps::MapData
 impl<T: core::fmt::Debug> core::fmt::Debug for aya::maps::stack_trace::StackTraceMap<T>
 pub fn aya::maps::stack_trace::StackTraceMap<T>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl<T> core::marker::Freeze for aya::maps::stack_trace::StackTraceMap<T> where T: core::marker::Freeze
 impl<T> core::marker::Send for aya::maps::stack_trace::StackTraceMap<T> where T: core::marker::Send
 impl<T> core::marker::Sync for aya::maps::stack_trace::StackTraceMap<T> where T: core::marker::Sync
 impl<T> core::marker::Unpin for aya::maps::stack_trace::StackTraceMap<T> where T: core::marker::Unpin
@@ -902,6 +926,7 @@ impl core::fmt::Debug for aya::maps::xdp::XdpMapError
 pub fn aya::maps::xdp::XdpMapError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::fmt::Display for aya::maps::xdp::XdpMapError
 pub fn aya::maps::xdp::XdpMapError::fmt(&self, __formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for aya::maps::xdp::XdpMapError
 impl core::marker::Send for aya::maps::xdp::XdpMapError
 impl core::marker::Sync for aya::maps::xdp::XdpMapError
 impl core::marker::Unpin for aya::maps::xdp::XdpMapError
@@ -943,6 +968,7 @@ pub fn aya::maps::CpuMap<&'a aya::maps::MapData>::try_from(map: &'a aya::maps::M
 impl<'a> core::convert::TryFrom<&'a mut aya::maps::Map> for aya::maps::CpuMap<&'a mut aya::maps::MapData>
 pub type aya::maps::CpuMap<&'a mut aya::maps::MapData>::Error = aya::maps::MapError
 pub fn aya::maps::CpuMap<&'a mut aya::maps::MapData>::try_from(map: &'a mut aya::maps::Map) -> core::result::Result<Self, Self::Error>
+impl<T> core::marker::Freeze for aya::maps::CpuMap<T> where T: core::marker::Freeze
 impl<T> core::marker::Send for aya::maps::CpuMap<T> where T: core::marker::Send
 impl<T> core::marker::Sync for aya::maps::CpuMap<T> where T: core::marker::Sync
 impl<T> core::marker::Unpin for aya::maps::CpuMap<T> where T: core::marker::Unpin
@@ -982,6 +1008,7 @@ pub fn aya::maps::DevMap<&'a aya::maps::MapData>::try_from(map: &'a aya::maps::M
 impl<'a> core::convert::TryFrom<&'a mut aya::maps::Map> for aya::maps::DevMap<&'a mut aya::maps::MapData>
 pub type aya::maps::DevMap<&'a mut aya::maps::MapData>::Error = aya::maps::MapError
 pub fn aya::maps::DevMap<&'a mut aya::maps::MapData>::try_from(map: &'a mut aya::maps::Map) -> core::result::Result<Self, Self::Error>
+impl<T> core::marker::Freeze for aya::maps::DevMap<T> where T: core::marker::Freeze
 impl<T> core::marker::Send for aya::maps::DevMap<T> where T: core::marker::Send
 impl<T> core::marker::Sync for aya::maps::DevMap<T> where T: core::marker::Sync
 impl<T> core::marker::Unpin for aya::maps::DevMap<T> where T: core::marker::Unpin
@@ -1022,6 +1049,7 @@ pub fn aya::maps::DevMapHash<&'a aya::maps::MapData>::try_from(map: &'a aya::map
 impl<'a> core::convert::TryFrom<&'a mut aya::maps::Map> for aya::maps::DevMapHash<&'a mut aya::maps::MapData>
 pub type aya::maps::DevMapHash<&'a mut aya::maps::MapData>::Error = aya::maps::MapError
 pub fn aya::maps::DevMapHash<&'a mut aya::maps::MapData>::try_from(map: &'a mut aya::maps::Map) -> core::result::Result<Self, Self::Error>
+impl<T> core::marker::Freeze for aya::maps::DevMapHash<T> where T: core::marker::Freeze
 impl<T> core::marker::Send for aya::maps::DevMapHash<T> where T: core::marker::Send
 impl<T> core::marker::Sync for aya::maps::DevMapHash<T> where T: core::marker::Sync
 impl<T> core::marker::Unpin for aya::maps::DevMapHash<T> where T: core::marker::Unpin
@@ -1059,6 +1087,7 @@ pub fn aya::maps::XskMap<&'a aya::maps::MapData>::try_from(map: &'a aya::maps::M
 impl<'a> core::convert::TryFrom<&'a mut aya::maps::Map> for aya::maps::XskMap<&'a mut aya::maps::MapData>
 pub type aya::maps::XskMap<&'a mut aya::maps::MapData>::Error = aya::maps::MapError
 pub fn aya::maps::XskMap<&'a mut aya::maps::MapData>::try_from(map: &'a mut aya::maps::Map) -> core::result::Result<Self, Self::Error>
+impl<T> core::marker::Freeze for aya::maps::XskMap<T> where T: core::marker::Freeze
 impl<T> core::marker::Send for aya::maps::XskMap<T> where T: core::marker::Send
 impl<T> core::marker::Sync for aya::maps::XskMap<T> where T: core::marker::Sync
 impl<T> core::marker::Unpin for aya::maps::XskMap<T> where T: core::marker::Unpin
@@ -1277,6 +1306,7 @@ pub fn aya::maps::queue::Queue<aya::maps::MapData, V>::try_from(map: aya::maps::
 impl<V: aya::Pod> core::convert::TryFrom<aya::maps::Map> for aya::maps::stack::Stack<aya::maps::MapData, V>
 pub type aya::maps::stack::Stack<aya::maps::MapData, V>::Error = aya::maps::MapError
 pub fn aya::maps::stack::Stack<aya::maps::MapData, V>::try_from(map: aya::maps::Map) -> core::result::Result<Self, Self::Error>
+impl core::marker::Freeze for aya::maps::Map
 impl core::marker::Send for aya::maps::Map
 impl core::marker::Sync for aya::maps::Map
 impl core::marker::Unpin for aya::maps::Map
@@ -1340,6 +1370,7 @@ impl core::fmt::Debug for aya::maps::MapError
 pub fn aya::maps::MapError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::fmt::Display for aya::maps::MapError
 pub fn aya::maps::MapError::fmt(&self, __formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for aya::maps::MapError
 impl core::marker::Send for aya::maps::MapError
 impl core::marker::Sync for aya::maps::MapError
 impl core::marker::Unpin for aya::maps::MapError
@@ -1384,6 +1415,7 @@ pub fn aya::maps::array::Array<T, V>::map(&self) -> &aya::maps::MapData
 impl<V: aya::Pod> core::convert::TryFrom<aya::maps::Map> for aya::maps::array::Array<aya::maps::MapData, V>
 pub type aya::maps::array::Array<aya::maps::MapData, V>::Error = aya::maps::MapError
 pub fn aya::maps::array::Array<aya::maps::MapData, V>::try_from(map: aya::maps::Map) -> core::result::Result<Self, Self::Error>
+impl<T, V> core::marker::Freeze for aya::maps::array::Array<T, V> where T: core::marker::Freeze
 impl<T, V> core::marker::Send for aya::maps::array::Array<T, V> where T: core::marker::Send, V: core::marker::Send
 impl<T, V> core::marker::Sync for aya::maps::array::Array<T, V> where T: core::marker::Sync, V: core::marker::Sync
 impl<T, V> core::marker::Unpin for aya::maps::array::Array<T, V> where T: core::marker::Unpin, V: core::marker::Unpin
@@ -1418,6 +1450,7 @@ pub fn aya::maps::perf::AsyncPerfEventArray<&'a aya::maps::MapData>::try_from(ma
 impl<'a> core::convert::TryFrom<&'a mut aya::maps::Map> for aya::maps::perf::AsyncPerfEventArray<&'a mut aya::maps::MapData>
 pub type aya::maps::perf::AsyncPerfEventArray<&'a mut aya::maps::MapData>::Error = aya::maps::MapError
 pub fn aya::maps::perf::AsyncPerfEventArray<&'a mut aya::maps::MapData>::try_from(map: &'a mut aya::maps::Map) -> core::result::Result<Self, Self::Error>
+impl<T> core::marker::Freeze for aya::maps::perf::AsyncPerfEventArray<T>
 impl<T> core::marker::Send for aya::maps::perf::AsyncPerfEventArray<T> where T: core::marker::Sync + core::marker::Send
 impl<T> core::marker::Sync for aya::maps::perf::AsyncPerfEventArray<T> where T: core::marker::Sync + core::marker::Send
 impl<T> core::marker::Unpin for aya::maps::perf::AsyncPerfEventArray<T>
@@ -1457,6 +1490,7 @@ pub fn aya::maps::bloom_filter::BloomFilter<T, V>::fmt(&self, f: &mut core::fmt:
 impl<V: aya::Pod> core::convert::TryFrom<aya::maps::Map> for aya::maps::bloom_filter::BloomFilter<aya::maps::MapData, V>
 pub type aya::maps::bloom_filter::BloomFilter<aya::maps::MapData, V>::Error = aya::maps::MapError
 pub fn aya::maps::bloom_filter::BloomFilter<aya::maps::MapData, V>::try_from(map: aya::maps::Map) -> core::result::Result<Self, Self::Error>
+impl<T, V> core::marker::Freeze for aya::maps::bloom_filter::BloomFilter<T, V> where T: core::marker::Freeze
 impl<T, V> core::marker::Send for aya::maps::bloom_filter::BloomFilter<T, V> where T: core::marker::Send, V: core::marker::Send
 impl<T, V> core::marker::Sync for aya::maps::bloom_filter::BloomFilter<T, V> where T: core::marker::Sync, V: core::marker::Sync
 impl<T, V> core::marker::Unpin for aya::maps::bloom_filter::BloomFilter<T, V> where T: core::marker::Unpin, V: core::marker::Unpin
@@ -1496,6 +1530,7 @@ pub fn aya::maps::CpuMap<&'a aya::maps::MapData>::try_from(map: &'a aya::maps::M
 impl<'a> core::convert::TryFrom<&'a mut aya::maps::Map> for aya::maps::CpuMap<&'a mut aya::maps::MapData>
 pub type aya::maps::CpuMap<&'a mut aya::maps::MapData>::Error = aya::maps::MapError
 pub fn aya::maps::CpuMap<&'a mut aya::maps::MapData>::try_from(map: &'a mut aya::maps::Map) -> core::result::Result<Self, Self::Error>
+impl<T> core::marker::Freeze for aya::maps::CpuMap<T> where T: core::marker::Freeze
 impl<T> core::marker::Send for aya::maps::CpuMap<T> where T: core::marker::Send
 impl<T> core::marker::Sync for aya::maps::CpuMap<T> where T: core::marker::Sync
 impl<T> core::marker::Unpin for aya::maps::CpuMap<T> where T: core::marker::Unpin
@@ -1535,6 +1570,7 @@ pub fn aya::maps::DevMap<&'a aya::maps::MapData>::try_from(map: &'a aya::maps::M
 impl<'a> core::convert::TryFrom<&'a mut aya::maps::Map> for aya::maps::DevMap<&'a mut aya::maps::MapData>
 pub type aya::maps::DevMap<&'a mut aya::maps::MapData>::Error = aya::maps::MapError
 pub fn aya::maps::DevMap<&'a mut aya::maps::MapData>::try_from(map: &'a mut aya::maps::Map) -> core::result::Result<Self, Self::Error>
+impl<T> core::marker::Freeze for aya::maps::DevMap<T> where T: core::marker::Freeze
 impl<T> core::marker::Send for aya::maps::DevMap<T> where T: core::marker::Send
 impl<T> core::marker::Sync for aya::maps::DevMap<T> where T: core::marker::Sync
 impl<T> core::marker::Unpin for aya::maps::DevMap<T> where T: core::marker::Unpin
@@ -1575,6 +1611,7 @@ pub fn aya::maps::DevMapHash<&'a aya::maps::MapData>::try_from(map: &'a aya::map
 impl<'a> core::convert::TryFrom<&'a mut aya::maps::Map> for aya::maps::DevMapHash<&'a mut aya::maps::MapData>
 pub type aya::maps::DevMapHash<&'a mut aya::maps::MapData>::Error = aya::maps::MapError
 pub fn aya::maps::DevMapHash<&'a mut aya::maps::MapData>::try_from(map: &'a mut aya::maps::Map) -> core::result::Result<Self, Self::Error>
+impl<T> core::marker::Freeze for aya::maps::DevMapHash<T> where T: core::marker::Freeze
 impl<T> core::marker::Send for aya::maps::DevMapHash<T> where T: core::marker::Send
 impl<T> core::marker::Sync for aya::maps::DevMapHash<T> where T: core::marker::Sync
 impl<T> core::marker::Unpin for aya::maps::DevMapHash<T> where T: core::marker::Unpin
@@ -1620,6 +1657,7 @@ pub fn aya::maps::hash_map::HashMap<T, K, V>::get(&self, key: &K) -> core::resul
 pub fn aya::maps::hash_map::HashMap<T, K, V>::map(&self) -> &aya::maps::MapData
 impl<T: core::fmt::Debug, K: core::fmt::Debug, V: core::fmt::Debug> core::fmt::Debug for aya::maps::hash_map::HashMap<T, K, V>
 pub fn aya::maps::hash_map::HashMap<T, K, V>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl<T, K, V> core::marker::Freeze for aya::maps::hash_map::HashMap<T, K, V> where T: core::marker::Freeze
 impl<T, K, V> core::marker::Send for aya::maps::hash_map::HashMap<T, K, V> where K: core::marker::Send, T: core::marker::Send, V: core::marker::Send
 impl<T, K, V> core::marker::Sync for aya::maps::hash_map::HashMap<T, K, V> where K: core::marker::Sync, T: core::marker::Sync, V: core::marker::Sync
 impl<T, K, V> core::marker::Unpin for aya::maps::hash_map::HashMap<T, K, V> where K: core::marker::Unpin, T: core::marker::Unpin, V: core::marker::Unpin
@@ -1665,6 +1703,7 @@ pub fn aya::maps::lpm_trie::LpmTrie<T, K, V>::get(&self, key: &aya::maps::lpm_tr
 pub fn aya::maps::lpm_trie::LpmTrie<T, K, V>::map(&self) -> &aya::maps::MapData
 impl<T: core::fmt::Debug, K: core::fmt::Debug, V: core::fmt::Debug> core::fmt::Debug for aya::maps::lpm_trie::LpmTrie<T, K, V>
 pub fn aya::maps::lpm_trie::LpmTrie<T, K, V>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl<T, K, V> core::marker::Freeze for aya::maps::lpm_trie::LpmTrie<T, K, V> where T: core::marker::Freeze
 impl<T, K, V> core::marker::Send for aya::maps::lpm_trie::LpmTrie<T, K, V> where K: core::marker::Send, T: core::marker::Send, V: core::marker::Send
 impl<T, K, V> core::marker::Sync for aya::maps::lpm_trie::LpmTrie<T, K, V> where K: core::marker::Sync, T: core::marker::Sync, V: core::marker::Sync
 impl<T, K, V> core::marker::Unpin for aya::maps::lpm_trie::LpmTrie<T, K, V> where K: core::marker::Unpin, T: core::marker::Unpin, V: core::marker::Unpin
@@ -1697,6 +1736,7 @@ pub fn aya::maps::MapData::info(&self) -> core::result::Result<aya::maps::MapInf
 pub fn aya::maps::MapData::pin<P: core::convert::AsRef<std::path::Path>>(&self, path: P) -> core::result::Result<(), aya::pin::PinError>
 impl core::fmt::Debug for aya::maps::MapData
 pub fn aya::maps::MapData::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for aya::maps::MapData
 impl core::marker::Send for aya::maps::MapData
 impl core::marker::Sync for aya::maps::MapData
 impl core::marker::Unpin for aya::maps::MapData
@@ -1723,6 +1763,7 @@ impl core::fmt::Debug for aya::maps::MapFd
 pub fn aya::maps::MapFd::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl std::os::fd::owned::AsFd for aya::maps::MapFd
 pub fn aya::maps::MapFd::as_fd(&self) -> std::os::fd::owned::BorrowedFd<'_>
+impl core::marker::Freeze for aya::maps::MapFd
 impl core::marker::Send for aya::maps::MapFd
 impl core::marker::Sync for aya::maps::MapFd
 impl core::marker::Unpin for aya::maps::MapFd
@@ -1759,6 +1800,7 @@ pub fn aya::maps::MapInfo::name_as_str(&self) -> core::option::Option<&str>
 pub fn aya::maps::MapInfo::value_size(&self) -> u32
 impl core::fmt::Debug for aya::maps::MapInfo
 pub fn aya::maps::MapInfo::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for aya::maps::MapInfo
 impl core::marker::Send for aya::maps::MapInfo
 impl core::marker::Sync for aya::maps::MapInfo
 impl core::marker::Unpin for aya::maps::MapInfo
@@ -1784,6 +1826,7 @@ pub struct aya::maps::MapIter<'coll, K: aya::Pod, V, I: aya::maps::IterableMap<K
 impl<K: aya::Pod, V, I: aya::maps::IterableMap<K, V>> core::iter::traits::iterator::Iterator for aya::maps::MapIter<'_, K, V, I>
 pub type aya::maps::MapIter<'_, K, V, I>::Item = core::result::Result<(K, V), aya::maps::MapError>
 pub fn aya::maps::MapIter<'_, K, V, I>::next(&mut self) -> core::option::Option<Self::Item>
+impl<'coll, K, V, I> core::marker::Freeze for aya::maps::MapIter<'coll, K, V, I> where K: core::marker::Freeze
 impl<'coll, K, V, I> core::marker::Send for aya::maps::MapIter<'coll, K, V, I> where I: core::marker::Sync, K: core::marker::Send, V: core::marker::Send
 impl<'coll, K, V, I> core::marker::Sync for aya::maps::MapIter<'coll, K, V, I> where I: core::marker::Sync, K: core::marker::Sync, V: core::marker::Sync
 impl<'coll, K, V, I> core::marker::Unpin for aya::maps::MapIter<'coll, K, V, I> where K: core::marker::Unpin, V: core::marker::Unpin
@@ -1813,6 +1856,7 @@ pub struct aya::maps::MapKeys<'coll, K: aya::Pod>
 impl<K: aya::Pod> core::iter::traits::iterator::Iterator for aya::maps::MapKeys<'_, K>
 pub type aya::maps::MapKeys<'_, K>::Item = core::result::Result<K, aya::maps::MapError>
 pub fn aya::maps::MapKeys<'_, K>::next(&mut self) -> core::option::Option<core::result::Result<K, aya::maps::MapError>>
+impl<'coll, K> core::marker::Freeze for aya::maps::MapKeys<'coll, K> where K: core::marker::Freeze
 impl<'coll, K> core::marker::Send for aya::maps::MapKeys<'coll, K> where K: core::marker::Send
 impl<'coll, K> core::marker::Sync for aya::maps::MapKeys<'coll, K> where K: core::marker::Sync
 impl<'coll, K> core::marker::Unpin for aya::maps::MapKeys<'coll, K> where K: core::marker::Unpin
@@ -1859,6 +1903,7 @@ pub fn aya::maps::PerCpuArray<T, V>::map(&self) -> &aya::maps::MapData
 impl<V: aya::Pod> core::convert::TryFrom<aya::maps::Map> for aya::maps::PerCpuArray<aya::maps::MapData, V>
 pub type aya::maps::PerCpuArray<aya::maps::MapData, V>::Error = aya::maps::MapError
 pub fn aya::maps::PerCpuArray<aya::maps::MapData, V>::try_from(map: aya::maps::Map) -> core::result::Result<Self, Self::Error>
+impl<T, V> core::marker::Freeze for aya::maps::PerCpuArray<T, V> where T: core::marker::Freeze
 impl<T, V> core::marker::Send for aya::maps::PerCpuArray<T, V> where T: core::marker::Send, V: core::marker::Send
 impl<T, V> core::marker::Sync for aya::maps::PerCpuArray<T, V> where T: core::marker::Sync, V: core::marker::Sync
 impl<T, V> core::marker::Unpin for aya::maps::PerCpuArray<T, V> where T: core::marker::Unpin, V: core::marker::Unpin
@@ -1902,6 +1947,7 @@ pub fn aya::maps::hash_map::PerCpuHashMap<aya::maps::MapData, K, V>::try_from(ma
 impl<T: core::borrow::Borrow<aya::maps::MapData>, K: aya::Pod, V: aya::Pod> aya::maps::IterableMap<K, aya::maps::PerCpuValues<V>> for aya::maps::hash_map::PerCpuHashMap<T, K, V>
 pub fn aya::maps::hash_map::PerCpuHashMap<T, K, V>::get(&self, key: &K) -> core::result::Result<aya::maps::PerCpuValues<V>, aya::maps::MapError>
 pub fn aya::maps::hash_map::PerCpuHashMap<T, K, V>::map(&self) -> &aya::maps::MapData
+impl<T, K, V> core::marker::Freeze for aya::maps::hash_map::PerCpuHashMap<T, K, V> where T: core::marker::Freeze
 impl<T, K, V> core::marker::Send for aya::maps::hash_map::PerCpuHashMap<T, K, V> where K: core::marker::Send, T: core::marker::Send, V: core::marker::Send
 impl<T, K, V> core::marker::Sync for aya::maps::hash_map::PerCpuHashMap<T, K, V> where K: core::marker::Sync, T: core::marker::Sync, V: core::marker::Sync
 impl<T, K, V> core::marker::Unpin for aya::maps::hash_map::PerCpuHashMap<T, K, V> where K: core::marker::Unpin, T: core::marker::Unpin, V: core::marker::Unpin
@@ -1938,6 +1984,7 @@ pub fn aya::maps::PerCpuArray<T, V>::get(&self, index: &u32) -> core::result::Re
 pub fn aya::maps::PerCpuArray<T, V>::map(&self) -> &aya::maps::MapData
 impl<T: core::fmt::Debug + aya::Pod> core::fmt::Debug for aya::maps::PerCpuValues<T>
 pub fn aya::maps::PerCpuValues<T>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl<T> core::marker::Freeze for aya::maps::PerCpuValues<T>
 impl<T> core::marker::Send for aya::maps::PerCpuValues<T> where T: core::marker::Send
 impl<T> core::marker::Sync for aya::maps::PerCpuValues<T> where T: core::marker::Sync
 impl<T> core::marker::Unpin for aya::maps::PerCpuValues<T>
@@ -1973,6 +2020,7 @@ pub fn aya::maps::perf::PerfEventArray<&'a aya::maps::MapData>::try_from(map: &'
 impl<'a> core::convert::TryFrom<&'a mut aya::maps::Map> for aya::maps::perf::PerfEventArray<&'a mut aya::maps::MapData>
 pub type aya::maps::perf::PerfEventArray<&'a mut aya::maps::MapData>::Error = aya::maps::MapError
 pub fn aya::maps::perf::PerfEventArray<&'a mut aya::maps::MapData>::try_from(map: &'a mut aya::maps::Map) -> core::result::Result<Self, Self::Error>
+impl<T> core::marker::Freeze for aya::maps::perf::PerfEventArray<T>
 impl<T> core::marker::Send for aya::maps::perf::PerfEventArray<T> where T: core::marker::Sync + core::marker::Send
 impl<T> core::marker::Sync for aya::maps::perf::PerfEventArray<T> where T: core::marker::Sync + core::marker::Send
 impl<T> core::marker::Unpin for aya::maps::perf::PerfEventArray<T>
@@ -2011,6 +2059,7 @@ pub fn aya::maps::ProgramArray<&'a aya::maps::MapData>::try_from(map: &'a aya::m
 impl<'a> core::convert::TryFrom<&'a mut aya::maps::Map> for aya::maps::ProgramArray<&'a mut aya::maps::MapData>
 pub type aya::maps::ProgramArray<&'a mut aya::maps::MapData>::Error = aya::maps::MapError
 pub fn aya::maps::ProgramArray<&'a mut aya::maps::MapData>::try_from(map: &'a mut aya::maps::Map) -> core::result::Result<Self, Self::Error>
+impl<T> core::marker::Freeze for aya::maps::ProgramArray<T> where T: core::marker::Freeze
 impl<T> core::marker::Send for aya::maps::ProgramArray<T> where T: core::marker::Send
 impl<T> core::marker::Sync for aya::maps::ProgramArray<T> where T: core::marker::Sync
 impl<T> core::marker::Unpin for aya::maps::ProgramArray<T> where T: core::marker::Unpin
@@ -2049,6 +2098,7 @@ pub fn aya::maps::queue::Queue<&'a mut aya::maps::MapData, V>::try_from(map: &'a
 impl<V: aya::Pod> core::convert::TryFrom<aya::maps::Map> for aya::maps::queue::Queue<aya::maps::MapData, V>
 pub type aya::maps::queue::Queue<aya::maps::MapData, V>::Error = aya::maps::MapError
 pub fn aya::maps::queue::Queue<aya::maps::MapData, V>::try_from(map: aya::maps::Map) -> core::result::Result<Self, Self::Error>
+impl<T, V> core::marker::Freeze for aya::maps::queue::Queue<T, V> where T: core::marker::Freeze
 impl<T, V> core::marker::Send for aya::maps::queue::Queue<T, V> where T: core::marker::Send, V: core::marker::Send
 impl<T, V> core::marker::Sync for aya::maps::queue::Queue<T, V> where T: core::marker::Sync, V: core::marker::Sync
 impl<T, V> core::marker::Unpin for aya::maps::queue::Queue<T, V> where T: core::marker::Unpin, V: core::marker::Unpin
@@ -2084,6 +2134,7 @@ pub type aya::maps::ring_buf::RingBuf<&'a mut aya::maps::MapData>::Error = aya::
 pub fn aya::maps::ring_buf::RingBuf<&'a mut aya::maps::MapData>::try_from(map: &'a mut aya::maps::Map) -> core::result::Result<Self, Self::Error>
 impl<T: core::borrow::Borrow<aya::maps::MapData>> std::os::fd::raw::AsRawFd for aya::maps::ring_buf::RingBuf<T>
 pub fn aya::maps::ring_buf::RingBuf<T>::as_raw_fd(&self) -> std::os::fd::raw::RawFd
+impl<T> core::marker::Freeze for aya::maps::ring_buf::RingBuf<T> where T: core::marker::Freeze
 impl<T> core::marker::Send for aya::maps::ring_buf::RingBuf<T> where T: core::marker::Send
 impl<T> core::marker::Sync for aya::maps::ring_buf::RingBuf<T> where T: core::marker::Sync
 impl<T> core::marker::Unpin for aya::maps::ring_buf::RingBuf<T> where T: core::marker::Unpin
@@ -2128,6 +2179,7 @@ pub fn aya::maps::SockHash<T, K>::map(&self) -> &aya::maps::MapData
 impl<V: aya::Pod> core::convert::TryFrom<aya::maps::Map> for aya::maps::SockHash<aya::maps::MapData, V>
 pub type aya::maps::SockHash<aya::maps::MapData, V>::Error = aya::maps::MapError
 pub fn aya::maps::SockHash<aya::maps::MapData, V>::try_from(map: aya::maps::Map) -> core::result::Result<Self, Self::Error>
+impl<T, K> core::marker::Freeze for aya::maps::SockHash<T, K> where T: core::marker::Freeze
 impl<T, K> core::marker::Send for aya::maps::SockHash<T, K> where K: core::marker::Send, T: core::marker::Send
 impl<T, K> core::marker::Sync for aya::maps::SockHash<T, K> where K: core::marker::Sync, T: core::marker::Sync
 impl<T, K> core::marker::Unpin for aya::maps::SockHash<T, K> where K: core::marker::Unpin, T: core::marker::Unpin
@@ -2167,6 +2219,7 @@ pub fn aya::maps::SockMap<&'a aya::maps::MapData>::try_from(map: &'a aya::maps::
 impl<'a> core::convert::TryFrom<&'a mut aya::maps::Map> for aya::maps::SockMap<&'a mut aya::maps::MapData>
 pub type aya::maps::SockMap<&'a mut aya::maps::MapData>::Error = aya::maps::MapError
 pub fn aya::maps::SockMap<&'a mut aya::maps::MapData>::try_from(map: &'a mut aya::maps::Map) -> core::result::Result<Self, Self::Error>
+impl<T> core::marker::Freeze for aya::maps::SockMap<T> where T: core::marker::Freeze
 impl<T> core::marker::Send for aya::maps::SockMap<T> where T: core::marker::Send
 impl<T> core::marker::Sync for aya::maps::SockMap<T> where T: core::marker::Sync
 impl<T> core::marker::Unpin for aya::maps::SockMap<T> where T: core::marker::Unpin
@@ -2205,6 +2258,7 @@ pub fn aya::maps::stack::Stack<&'a mut aya::maps::MapData, V>::try_from(map: &'a
 impl<V: aya::Pod> core::convert::TryFrom<aya::maps::Map> for aya::maps::stack::Stack<aya::maps::MapData, V>
 pub type aya::maps::stack::Stack<aya::maps::MapData, V>::Error = aya::maps::MapError
 pub fn aya::maps::stack::Stack<aya::maps::MapData, V>::try_from(map: aya::maps::Map) -> core::result::Result<Self, Self::Error>
+impl<T, V> core::marker::Freeze for aya::maps::stack::Stack<T, V> where T: core::marker::Freeze
 impl<T, V> core::marker::Send for aya::maps::stack::Stack<T, V> where T: core::marker::Send, V: core::marker::Send
 impl<T, V> core::marker::Sync for aya::maps::stack::Stack<T, V> where T: core::marker::Sync, V: core::marker::Sync
 impl<T, V> core::marker::Unpin for aya::maps::stack::Stack<T, V> where T: core::marker::Unpin, V: core::marker::Unpin
@@ -2253,6 +2307,7 @@ pub fn aya::maps::stack_trace::StackTraceMap<T>::get(&self, index: &u32) -> core
 pub fn aya::maps::stack_trace::StackTraceMap<T>::map(&self) -> &aya::maps::MapData
 impl<T: core::fmt::Debug> core::fmt::Debug for aya::maps::stack_trace::StackTraceMap<T>
 pub fn aya::maps::stack_trace::StackTraceMap<T>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl<T> core::marker::Freeze for aya::maps::stack_trace::StackTraceMap<T> where T: core::marker::Freeze
 impl<T> core::marker::Send for aya::maps::stack_trace::StackTraceMap<T> where T: core::marker::Send
 impl<T> core::marker::Sync for aya::maps::stack_trace::StackTraceMap<T> where T: core::marker::Sync
 impl<T> core::marker::Unpin for aya::maps::stack_trace::StackTraceMap<T> where T: core::marker::Unpin
@@ -2290,6 +2345,7 @@ pub fn aya::maps::XskMap<&'a aya::maps::MapData>::try_from(map: &'a aya::maps::M
 impl<'a> core::convert::TryFrom<&'a mut aya::maps::Map> for aya::maps::XskMap<&'a mut aya::maps::MapData>
 pub type aya::maps::XskMap<&'a mut aya::maps::MapData>::Error = aya::maps::MapError
 pub fn aya::maps::XskMap<&'a mut aya::maps::MapData>::try_from(map: &'a mut aya::maps::Map) -> core::result::Result<Self, Self::Error>
+impl<T> core::marker::Freeze for aya::maps::XskMap<T> where T: core::marker::Freeze
 impl<T> core::marker::Send for aya::maps::XskMap<T> where T: core::marker::Send
 impl<T> core::marker::Sync for aya::maps::XskMap<T> where T: core::marker::Sync
 impl<T> core::marker::Unpin for aya::maps::XskMap<T> where T: core::marker::Unpin
@@ -2350,6 +2406,7 @@ impl core::fmt::Debug for aya::pin::PinError
 pub fn aya::pin::PinError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::fmt::Display for aya::pin::PinError
 pub fn aya::pin::PinError::fmt(&self, __formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for aya::pin::PinError
 impl core::marker::Send for aya::pin::PinError
 impl core::marker::Sync for aya::pin::PinError
 impl core::marker::Unpin for aya::pin::PinError
@@ -2406,6 +2463,7 @@ pub fn &'a aya::programs::cgroup_device::CgroupDevice::try_from(program: &'a aya
 impl<'a> core::convert::TryFrom<&'a mut aya::programs::Program> for &'a mut aya::programs::cgroup_device::CgroupDevice
 pub type &'a mut aya::programs::cgroup_device::CgroupDevice::Error = aya::programs::ProgramError
 pub fn &'a mut aya::programs::cgroup_device::CgroupDevice::try_from(program: &'a mut aya::programs::Program) -> core::result::Result<&'a mut aya::programs::cgroup_device::CgroupDevice, aya::programs::ProgramError>
+impl core::marker::Freeze for aya::programs::cgroup_device::CgroupDevice
 impl core::marker::Send for aya::programs::cgroup_device::CgroupDevice
 impl core::marker::Sync for aya::programs::cgroup_device::CgroupDevice
 impl core::marker::Unpin for aya::programs::cgroup_device::CgroupDevice
@@ -2436,6 +2494,7 @@ impl core::fmt::Debug for aya::programs::cgroup_device::CgroupDeviceLink
 pub fn aya::programs::cgroup_device::CgroupDeviceLink::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::ops::drop::Drop for aya::programs::cgroup_device::CgroupDeviceLink
 pub fn aya::programs::cgroup_device::CgroupDeviceLink::drop(&mut self)
+impl core::marker::Freeze for aya::programs::cgroup_device::CgroupDeviceLink
 impl core::marker::Send for aya::programs::cgroup_device::CgroupDeviceLink
 impl core::marker::Sync for aya::programs::cgroup_device::CgroupDeviceLink
 impl core::marker::Unpin for aya::programs::cgroup_device::CgroupDeviceLink
@@ -2466,6 +2525,7 @@ pub fn aya::programs::cgroup_device::CgroupDeviceLinkId::fmt(&self, f: &mut core
 impl core::hash::Hash for aya::programs::cgroup_device::CgroupDeviceLinkId
 pub fn aya::programs::cgroup_device::CgroupDeviceLinkId::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
 impl core::marker::StructuralPartialEq for aya::programs::cgroup_device::CgroupDeviceLinkId
+impl core::marker::Freeze for aya::programs::cgroup_device::CgroupDeviceLinkId
 impl core::marker::Send for aya::programs::cgroup_device::CgroupDeviceLinkId
 impl core::marker::Sync for aya::programs::cgroup_device::CgroupDeviceLinkId
 impl core::marker::Unpin for aya::programs::cgroup_device::CgroupDeviceLinkId
@@ -2496,6 +2556,7 @@ pub fn aya::programs::cgroup_skb::CgroupSkbAttachType::clone(&self) -> aya::prog
 impl core::fmt::Debug for aya::programs::cgroup_skb::CgroupSkbAttachType
 pub fn aya::programs::cgroup_skb::CgroupSkbAttachType::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Copy for aya::programs::cgroup_skb::CgroupSkbAttachType
+impl core::marker::Freeze for aya::programs::cgroup_skb::CgroupSkbAttachType
 impl core::marker::Send for aya::programs::cgroup_skb::CgroupSkbAttachType
 impl core::marker::Sync for aya::programs::cgroup_skb::CgroupSkbAttachType
 impl core::marker::Unpin for aya::programs::cgroup_skb::CgroupSkbAttachType
@@ -2548,6 +2609,7 @@ pub fn &'a aya::programs::cgroup_skb::CgroupSkb::try_from(program: &'a aya::prog
 impl<'a> core::convert::TryFrom<&'a mut aya::programs::Program> for &'a mut aya::programs::cgroup_skb::CgroupSkb
 pub type &'a mut aya::programs::cgroup_skb::CgroupSkb::Error = aya::programs::ProgramError
 pub fn &'a mut aya::programs::cgroup_skb::CgroupSkb::try_from(program: &'a mut aya::programs::Program) -> core::result::Result<&'a mut aya::programs::cgroup_skb::CgroupSkb, aya::programs::ProgramError>
+impl core::marker::Freeze for aya::programs::cgroup_skb::CgroupSkb
 impl core::marker::Send for aya::programs::cgroup_skb::CgroupSkb
 impl core::marker::Sync for aya::programs::cgroup_skb::CgroupSkb
 impl core::marker::Unpin for aya::programs::cgroup_skb::CgroupSkb
@@ -2578,6 +2640,7 @@ impl core::fmt::Debug for aya::programs::cgroup_skb::CgroupSkbLink
 pub fn aya::programs::cgroup_skb::CgroupSkbLink::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::ops::drop::Drop for aya::programs::cgroup_skb::CgroupSkbLink
 pub fn aya::programs::cgroup_skb::CgroupSkbLink::drop(&mut self)
+impl core::marker::Freeze for aya::programs::cgroup_skb::CgroupSkbLink
 impl core::marker::Send for aya::programs::cgroup_skb::CgroupSkbLink
 impl core::marker::Sync for aya::programs::cgroup_skb::CgroupSkbLink
 impl core::marker::Unpin for aya::programs::cgroup_skb::CgroupSkbLink
@@ -2608,6 +2671,7 @@ pub fn aya::programs::cgroup_skb::CgroupSkbLinkId::fmt(&self, f: &mut core::fmt:
 impl core::hash::Hash for aya::programs::cgroup_skb::CgroupSkbLinkId
 pub fn aya::programs::cgroup_skb::CgroupSkbLinkId::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
 impl core::marker::StructuralPartialEq for aya::programs::cgroup_skb::CgroupSkbLinkId
+impl core::marker::Freeze for aya::programs::cgroup_skb::CgroupSkbLinkId
 impl core::marker::Send for aya::programs::cgroup_skb::CgroupSkbLinkId
 impl core::marker::Sync for aya::programs::cgroup_skb::CgroupSkbLinkId
 impl core::marker::Unpin for aya::programs::cgroup_skb::CgroupSkbLinkId
@@ -2657,6 +2721,7 @@ pub fn &'a aya::programs::cgroup_sock::CgroupSock::try_from(program: &'a aya::pr
 impl<'a> core::convert::TryFrom<&'a mut aya::programs::Program> for &'a mut aya::programs::cgroup_sock::CgroupSock
 pub type &'a mut aya::programs::cgroup_sock::CgroupSock::Error = aya::programs::ProgramError
 pub fn &'a mut aya::programs::cgroup_sock::CgroupSock::try_from(program: &'a mut aya::programs::Program) -> core::result::Result<&'a mut aya::programs::cgroup_sock::CgroupSock, aya::programs::ProgramError>
+impl core::marker::Freeze for aya::programs::cgroup_sock::CgroupSock
 impl core::marker::Send for aya::programs::cgroup_sock::CgroupSock
 impl core::marker::Sync for aya::programs::cgroup_sock::CgroupSock
 impl core::marker::Unpin for aya::programs::cgroup_sock::CgroupSock
@@ -2687,6 +2752,7 @@ impl core::fmt::Debug for aya::programs::cgroup_sock::CgroupSockLink
 pub fn aya::programs::cgroup_sock::CgroupSockLink::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::ops::drop::Drop for aya::programs::cgroup_sock::CgroupSockLink
 pub fn aya::programs::cgroup_sock::CgroupSockLink::drop(&mut self)
+impl core::marker::Freeze for aya::programs::cgroup_sock::CgroupSockLink
 impl core::marker::Send for aya::programs::cgroup_sock::CgroupSockLink
 impl core::marker::Sync for aya::programs::cgroup_sock::CgroupSockLink
 impl core::marker::Unpin for aya::programs::cgroup_sock::CgroupSockLink
@@ -2717,6 +2783,7 @@ pub fn aya::programs::cgroup_sock::CgroupSockLinkId::fmt(&self, f: &mut core::fm
 impl core::hash::Hash for aya::programs::cgroup_sock::CgroupSockLinkId
 pub fn aya::programs::cgroup_sock::CgroupSockLinkId::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
 impl core::marker::StructuralPartialEq for aya::programs::cgroup_sock::CgroupSockLinkId
+impl core::marker::Freeze for aya::programs::cgroup_sock::CgroupSockLinkId
 impl core::marker::Send for aya::programs::cgroup_sock::CgroupSockLinkId
 impl core::marker::Sync for aya::programs::cgroup_sock::CgroupSockLinkId
 impl core::marker::Unpin for aya::programs::cgroup_sock::CgroupSockLinkId
@@ -2766,6 +2833,7 @@ pub fn &'a aya::programs::cgroup_sock_addr::CgroupSockAddr::try_from(program: &'
 impl<'a> core::convert::TryFrom<&'a mut aya::programs::Program> for &'a mut aya::programs::cgroup_sock_addr::CgroupSockAddr
 pub type &'a mut aya::programs::cgroup_sock_addr::CgroupSockAddr::Error = aya::programs::ProgramError
 pub fn &'a mut aya::programs::cgroup_sock_addr::CgroupSockAddr::try_from(program: &'a mut aya::programs::Program) -> core::result::Result<&'a mut aya::programs::cgroup_sock_addr::CgroupSockAddr, aya::programs::ProgramError>
+impl core::marker::Freeze for aya::programs::cgroup_sock_addr::CgroupSockAddr
 impl core::marker::Send for aya::programs::cgroup_sock_addr::CgroupSockAddr
 impl core::marker::Sync for aya::programs::cgroup_sock_addr::CgroupSockAddr
 impl core::marker::Unpin for aya::programs::cgroup_sock_addr::CgroupSockAddr
@@ -2796,6 +2864,7 @@ impl core::fmt::Debug for aya::programs::cgroup_sock_addr::CgroupSockAddrLink
 pub fn aya::programs::cgroup_sock_addr::CgroupSockAddrLink::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::ops::drop::Drop for aya::programs::cgroup_sock_addr::CgroupSockAddrLink
 pub fn aya::programs::cgroup_sock_addr::CgroupSockAddrLink::drop(&mut self)
+impl core::marker::Freeze for aya::programs::cgroup_sock_addr::CgroupSockAddrLink
 impl core::marker::Send for aya::programs::cgroup_sock_addr::CgroupSockAddrLink
 impl core::marker::Sync for aya::programs::cgroup_sock_addr::CgroupSockAddrLink
 impl core::marker::Unpin for aya::programs::cgroup_sock_addr::CgroupSockAddrLink
@@ -2826,6 +2895,7 @@ pub fn aya::programs::cgroup_sock_addr::CgroupSockAddrLinkId::fmt(&self, f: &mut
 impl core::hash::Hash for aya::programs::cgroup_sock_addr::CgroupSockAddrLinkId
 pub fn aya::programs::cgroup_sock_addr::CgroupSockAddrLinkId::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
 impl core::marker::StructuralPartialEq for aya::programs::cgroup_sock_addr::CgroupSockAddrLinkId
+impl core::marker::Freeze for aya::programs::cgroup_sock_addr::CgroupSockAddrLinkId
 impl core::marker::Send for aya::programs::cgroup_sock_addr::CgroupSockAddrLinkId
 impl core::marker::Sync for aya::programs::cgroup_sock_addr::CgroupSockAddrLinkId
 impl core::marker::Unpin for aya::programs::cgroup_sock_addr::CgroupSockAddrLinkId
@@ -2875,6 +2945,7 @@ pub fn &'a aya::programs::cgroup_sockopt::CgroupSockopt::try_from(program: &'a a
 impl<'a> core::convert::TryFrom<&'a mut aya::programs::Program> for &'a mut aya::programs::cgroup_sockopt::CgroupSockopt
 pub type &'a mut aya::programs::cgroup_sockopt::CgroupSockopt::Error = aya::programs::ProgramError
 pub fn &'a mut aya::programs::cgroup_sockopt::CgroupSockopt::try_from(program: &'a mut aya::programs::Program) -> core::result::Result<&'a mut aya::programs::cgroup_sockopt::CgroupSockopt, aya::programs::ProgramError>
+impl core::marker::Freeze for aya::programs::cgroup_sockopt::CgroupSockopt
 impl core::marker::Send for aya::programs::cgroup_sockopt::CgroupSockopt
 impl core::marker::Sync for aya::programs::cgroup_sockopt::CgroupSockopt
 impl core::marker::Unpin for aya::programs::cgroup_sockopt::CgroupSockopt
@@ -2905,6 +2976,7 @@ impl core::fmt::Debug for aya::programs::cgroup_sockopt::CgroupSockoptLink
 pub fn aya::programs::cgroup_sockopt::CgroupSockoptLink::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::ops::drop::Drop for aya::programs::cgroup_sockopt::CgroupSockoptLink
 pub fn aya::programs::cgroup_sockopt::CgroupSockoptLink::drop(&mut self)
+impl core::marker::Freeze for aya::programs::cgroup_sockopt::CgroupSockoptLink
 impl core::marker::Send for aya::programs::cgroup_sockopt::CgroupSockoptLink
 impl core::marker::Sync for aya::programs::cgroup_sockopt::CgroupSockoptLink
 impl core::marker::Unpin for aya::programs::cgroup_sockopt::CgroupSockoptLink
@@ -2935,6 +3007,7 @@ pub fn aya::programs::cgroup_sockopt::CgroupSockoptLinkId::fmt(&self, f: &mut co
 impl core::hash::Hash for aya::programs::cgroup_sockopt::CgroupSockoptLinkId
 pub fn aya::programs::cgroup_sockopt::CgroupSockoptLinkId::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
 impl core::marker::StructuralPartialEq for aya::programs::cgroup_sockopt::CgroupSockoptLinkId
+impl core::marker::Freeze for aya::programs::cgroup_sockopt::CgroupSockoptLinkId
 impl core::marker::Send for aya::programs::cgroup_sockopt::CgroupSockoptLinkId
 impl core::marker::Sync for aya::programs::cgroup_sockopt::CgroupSockoptLinkId
 impl core::marker::Unpin for aya::programs::cgroup_sockopt::CgroupSockoptLinkId
@@ -2984,6 +3057,7 @@ pub fn &'a aya::programs::cgroup_sysctl::CgroupSysctl::try_from(program: &'a aya
 impl<'a> core::convert::TryFrom<&'a mut aya::programs::Program> for &'a mut aya::programs::cgroup_sysctl::CgroupSysctl
 pub type &'a mut aya::programs::cgroup_sysctl::CgroupSysctl::Error = aya::programs::ProgramError
 pub fn &'a mut aya::programs::cgroup_sysctl::CgroupSysctl::try_from(program: &'a mut aya::programs::Program) -> core::result::Result<&'a mut aya::programs::cgroup_sysctl::CgroupSysctl, aya::programs::ProgramError>
+impl core::marker::Freeze for aya::programs::cgroup_sysctl::CgroupSysctl
 impl core::marker::Send for aya::programs::cgroup_sysctl::CgroupSysctl
 impl core::marker::Sync for aya::programs::cgroup_sysctl::CgroupSysctl
 impl core::marker::Unpin for aya::programs::cgroup_sysctl::CgroupSysctl
@@ -3014,6 +3088,7 @@ impl core::fmt::Debug for aya::programs::cgroup_sysctl::CgroupSysctlLink
 pub fn aya::programs::cgroup_sysctl::CgroupSysctlLink::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::ops::drop::Drop for aya::programs::cgroup_sysctl::CgroupSysctlLink
 pub fn aya::programs::cgroup_sysctl::CgroupSysctlLink::drop(&mut self)
+impl core::marker::Freeze for aya::programs::cgroup_sysctl::CgroupSysctlLink
 impl core::marker::Send for aya::programs::cgroup_sysctl::CgroupSysctlLink
 impl core::marker::Sync for aya::programs::cgroup_sysctl::CgroupSysctlLink
 impl core::marker::Unpin for aya::programs::cgroup_sysctl::CgroupSysctlLink
@@ -3044,6 +3119,7 @@ pub fn aya::programs::cgroup_sysctl::CgroupSysctlLinkId::fmt(&self, f: &mut core
 impl core::hash::Hash for aya::programs::cgroup_sysctl::CgroupSysctlLinkId
 pub fn aya::programs::cgroup_sysctl::CgroupSysctlLinkId::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
 impl core::marker::StructuralPartialEq for aya::programs::cgroup_sysctl::CgroupSysctlLinkId
+impl core::marker::Freeze for aya::programs::cgroup_sysctl::CgroupSysctlLinkId
 impl core::marker::Send for aya::programs::cgroup_sysctl::CgroupSysctlLinkId
 impl core::marker::Sync for aya::programs::cgroup_sysctl::CgroupSysctlLinkId
 impl core::marker::Unpin for aya::programs::cgroup_sysctl::CgroupSysctlLinkId
@@ -3075,6 +3151,7 @@ impl core::fmt::Debug for aya::programs::extension::ExtensionError
 pub fn aya::programs::extension::ExtensionError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::fmt::Display for aya::programs::extension::ExtensionError
 pub fn aya::programs::extension::ExtensionError::fmt(&self, __formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for aya::programs::extension::ExtensionError
 impl core::marker::Send for aya::programs::extension::ExtensionError
 impl core::marker::Sync for aya::programs::extension::ExtensionError
 impl core::marker::Unpin for aya::programs::extension::ExtensionError
@@ -3126,6 +3203,7 @@ pub fn &'a aya::programs::extension::Extension::try_from(program: &'a aya::progr
 impl<'a> core::convert::TryFrom<&'a mut aya::programs::Program> for &'a mut aya::programs::extension::Extension
 pub type &'a mut aya::programs::extension::Extension::Error = aya::programs::ProgramError
 pub fn &'a mut aya::programs::extension::Extension::try_from(program: &'a mut aya::programs::Program) -> core::result::Result<&'a mut aya::programs::extension::Extension, aya::programs::ProgramError>
+impl core::marker::Freeze for aya::programs::extension::Extension
 impl core::marker::Send for aya::programs::extension::Extension
 impl core::marker::Sync for aya::programs::extension::Extension
 impl core::marker::Unpin for aya::programs::extension::Extension
@@ -3160,6 +3238,7 @@ impl core::fmt::Debug for aya::programs::extension::ExtensionLink
 pub fn aya::programs::extension::ExtensionLink::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::ops::drop::Drop for aya::programs::extension::ExtensionLink
 pub fn aya::programs::extension::ExtensionLink::drop(&mut self)
+impl core::marker::Freeze for aya::programs::extension::ExtensionLink
 impl core::marker::Send for aya::programs::extension::ExtensionLink
 impl core::marker::Sync for aya::programs::extension::ExtensionLink
 impl core::marker::Unpin for aya::programs::extension::ExtensionLink
@@ -3190,6 +3269,7 @@ pub fn aya::programs::extension::ExtensionLinkId::fmt(&self, f: &mut core::fmt::
 impl core::hash::Hash for aya::programs::extension::ExtensionLinkId
 pub fn aya::programs::extension::ExtensionLinkId::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
 impl core::marker::StructuralPartialEq for aya::programs::extension::ExtensionLinkId
+impl core::marker::Freeze for aya::programs::extension::ExtensionLinkId
 impl core::marker::Send for aya::programs::extension::ExtensionLinkId
 impl core::marker::Sync for aya::programs::extension::ExtensionLinkId
 impl core::marker::Unpin for aya::programs::extension::ExtensionLinkId
@@ -3239,6 +3319,7 @@ pub fn &'a aya::programs::fentry::FEntry::try_from(program: &'a aya::programs::P
 impl<'a> core::convert::TryFrom<&'a mut aya::programs::Program> for &'a mut aya::programs::fentry::FEntry
 pub type &'a mut aya::programs::fentry::FEntry::Error = aya::programs::ProgramError
 pub fn &'a mut aya::programs::fentry::FEntry::try_from(program: &'a mut aya::programs::Program) -> core::result::Result<&'a mut aya::programs::fentry::FEntry, aya::programs::ProgramError>
+impl core::marker::Freeze for aya::programs::fentry::FEntry
 impl core::marker::Send for aya::programs::fentry::FEntry
 impl core::marker::Sync for aya::programs::fentry::FEntry
 impl core::marker::Unpin for aya::programs::fentry::FEntry
@@ -3273,6 +3354,7 @@ impl core::fmt::Debug for aya::programs::fentry::FEntryLink
 pub fn aya::programs::fentry::FEntryLink::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::ops::drop::Drop for aya::programs::fentry::FEntryLink
 pub fn aya::programs::fentry::FEntryLink::drop(&mut self)
+impl core::marker::Freeze for aya::programs::fentry::FEntryLink
 impl core::marker::Send for aya::programs::fentry::FEntryLink
 impl core::marker::Sync for aya::programs::fentry::FEntryLink
 impl core::marker::Unpin for aya::programs::fentry::FEntryLink
@@ -3303,6 +3385,7 @@ pub fn aya::programs::fentry::FEntryLinkId::fmt(&self, f: &mut core::fmt::Format
 impl core::hash::Hash for aya::programs::fentry::FEntryLinkId
 pub fn aya::programs::fentry::FEntryLinkId::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
 impl core::marker::StructuralPartialEq for aya::programs::fentry::FEntryLinkId
+impl core::marker::Freeze for aya::programs::fentry::FEntryLinkId
 impl core::marker::Send for aya::programs::fentry::FEntryLinkId
 impl core::marker::Sync for aya::programs::fentry::FEntryLinkId
 impl core::marker::Unpin for aya::programs::fentry::FEntryLinkId
@@ -3352,6 +3435,7 @@ pub fn &'a aya::programs::fexit::FExit::try_from(program: &'a aya::programs::Pro
 impl<'a> core::convert::TryFrom<&'a mut aya::programs::Program> for &'a mut aya::programs::fexit::FExit
 pub type &'a mut aya::programs::fexit::FExit::Error = aya::programs::ProgramError
 pub fn &'a mut aya::programs::fexit::FExit::try_from(program: &'a mut aya::programs::Program) -> core::result::Result<&'a mut aya::programs::fexit::FExit, aya::programs::ProgramError>
+impl core::marker::Freeze for aya::programs::fexit::FExit
 impl core::marker::Send for aya::programs::fexit::FExit
 impl core::marker::Sync for aya::programs::fexit::FExit
 impl core::marker::Unpin for aya::programs::fexit::FExit
@@ -3386,6 +3470,7 @@ impl core::fmt::Debug for aya::programs::fexit::FExitLink
 pub fn aya::programs::fexit::FExitLink::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::ops::drop::Drop for aya::programs::fexit::FExitLink
 pub fn aya::programs::fexit::FExitLink::drop(&mut self)
+impl core::marker::Freeze for aya::programs::fexit::FExitLink
 impl core::marker::Send for aya::programs::fexit::FExitLink
 impl core::marker::Sync for aya::programs::fexit::FExitLink
 impl core::marker::Unpin for aya::programs::fexit::FExitLink
@@ -3416,6 +3501,7 @@ pub fn aya::programs::fexit::FExitLinkId::fmt(&self, f: &mut core::fmt::Formatte
 impl core::hash::Hash for aya::programs::fexit::FExitLinkId
 pub fn aya::programs::fexit::FExitLinkId::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
 impl core::marker::StructuralPartialEq for aya::programs::fexit::FExitLinkId
+impl core::marker::Freeze for aya::programs::fexit::FExitLinkId
 impl core::marker::Send for aya::programs::fexit::FExitLinkId
 impl core::marker::Sync for aya::programs::fexit::FExitLinkId
 impl core::marker::Unpin for aya::programs::fexit::FExitLinkId
@@ -3450,6 +3536,7 @@ impl core::fmt::Debug for aya::programs::kprobe::KProbeError
 pub fn aya::programs::kprobe::KProbeError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::fmt::Display for aya::programs::kprobe::KProbeError
 pub fn aya::programs::kprobe::KProbeError::fmt(&self, __formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for aya::programs::kprobe::KProbeError
 impl core::marker::Send for aya::programs::kprobe::KProbeError
 impl core::marker::Sync for aya::programs::kprobe::KProbeError
 impl core::marker::Unpin for aya::programs::kprobe::KProbeError
@@ -3500,6 +3587,7 @@ pub fn &'a aya::programs::kprobe::KProbe::try_from(program: &'a aya::programs::P
 impl<'a> core::convert::TryFrom<&'a mut aya::programs::Program> for &'a mut aya::programs::kprobe::KProbe
 pub type &'a mut aya::programs::kprobe::KProbe::Error = aya::programs::ProgramError
 pub fn &'a mut aya::programs::kprobe::KProbe::try_from(program: &'a mut aya::programs::Program) -> core::result::Result<&'a mut aya::programs::kprobe::KProbe, aya::programs::ProgramError>
+impl core::marker::Freeze for aya::programs::kprobe::KProbe
 impl core::marker::Send for aya::programs::kprobe::KProbe
 impl core::marker::Sync for aya::programs::kprobe::KProbe
 impl core::marker::Unpin for aya::programs::kprobe::KProbe
@@ -3536,6 +3624,7 @@ impl core::fmt::Debug for aya::programs::kprobe::KProbeLink
 pub fn aya::programs::kprobe::KProbeLink::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::ops::drop::Drop for aya::programs::kprobe::KProbeLink
 pub fn aya::programs::kprobe::KProbeLink::drop(&mut self)
+impl core::marker::Freeze for aya::programs::kprobe::KProbeLink
 impl core::marker::Send for aya::programs::kprobe::KProbeLink
 impl core::marker::Sync for aya::programs::kprobe::KProbeLink
 impl core::marker::Unpin for aya::programs::kprobe::KProbeLink
@@ -3566,6 +3655,7 @@ pub fn aya::programs::kprobe::KProbeLinkId::fmt(&self, f: &mut core::fmt::Format
 impl core::hash::Hash for aya::programs::kprobe::KProbeLinkId
 pub fn aya::programs::kprobe::KProbeLinkId::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
 impl core::marker::StructuralPartialEq for aya::programs::kprobe::KProbeLinkId
+impl core::marker::Freeze for aya::programs::kprobe::KProbeLinkId
 impl core::marker::Send for aya::programs::kprobe::KProbeLinkId
 impl core::marker::Sync for aya::programs::kprobe::KProbeLinkId
 impl core::marker::Unpin for aya::programs::kprobe::KProbeLinkId
@@ -3597,6 +3687,7 @@ impl core::fmt::Debug for aya::programs::links::LinkError
 pub fn aya::programs::links::LinkError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::fmt::Display for aya::programs::links::LinkError
 pub fn aya::programs::links::LinkError::fmt(&self, __formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for aya::programs::links::LinkError
 impl core::marker::Send for aya::programs::links::LinkError
 impl core::marker::Sync for aya::programs::links::LinkError
 impl core::marker::Unpin for aya::programs::links::LinkError
@@ -3689,6 +3780,7 @@ pub type aya::programs::links::FdLink::Error = aya::programs::links::LinkError
 pub fn aya::programs::links::FdLink::try_from(value: aya::programs::xdp::XdpLink) -> core::result::Result<Self, Self::Error>
 impl core::fmt::Debug for aya::programs::links::FdLink
 pub fn aya::programs::links::FdLink::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for aya::programs::links::FdLink
 impl core::marker::Send for aya::programs::links::FdLink
 impl core::marker::Sync for aya::programs::links::FdLink
 impl core::marker::Unpin for aya::programs::links::FdLink
@@ -3719,6 +3811,7 @@ pub fn aya::programs::links::FdLinkId::fmt(&self, f: &mut core::fmt::Formatter<'
 impl core::hash::Hash for aya::programs::links::FdLinkId
 pub fn aya::programs::links::FdLinkId::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
 impl core::marker::StructuralPartialEq for aya::programs::links::FdLinkId
+impl core::marker::Freeze for aya::programs::links::FdLinkId
 impl core::marker::Send for aya::programs::links::FdLinkId
 impl core::marker::Sync for aya::programs::links::FdLinkId
 impl core::marker::Unpin for aya::programs::links::FdLinkId
@@ -3748,6 +3841,7 @@ impl core::convert::From<aya::programs::links::PinnedLink> for aya::programs::li
 pub fn aya::programs::links::FdLink::from(p: aya::programs::links::PinnedLink) -> Self
 impl core::fmt::Debug for aya::programs::links::PinnedLink
 pub fn aya::programs::links::PinnedLink::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for aya::programs::links::PinnedLink
 impl core::marker::Send for aya::programs::links::PinnedLink
 impl core::marker::Sync for aya::programs::links::PinnedLink
 impl core::marker::Unpin for aya::programs::links::PinnedLink
@@ -3788,6 +3882,7 @@ impl core::convert::From<aya::programs::sock_ops::SockOpsLink> for aya::programs
 pub fn aya::programs::links::ProgAttachLink::from(w: aya::programs::sock_ops::SockOpsLink) -> aya::programs::links::ProgAttachLink
 impl core::fmt::Debug for aya::programs::links::ProgAttachLink
 pub fn aya::programs::links::ProgAttachLink::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for aya::programs::links::ProgAttachLink
 impl core::marker::Send for aya::programs::links::ProgAttachLink
 impl core::marker::Sync for aya::programs::links::ProgAttachLink
 impl core::marker::Unpin for aya::programs::links::ProgAttachLink
@@ -3818,6 +3913,7 @@ pub fn aya::programs::links::ProgAttachLinkId::fmt(&self, f: &mut core::fmt::For
 impl core::hash::Hash for aya::programs::links::ProgAttachLinkId
 pub fn aya::programs::links::ProgAttachLinkId::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
 impl core::marker::StructuralPartialEq for aya::programs::links::ProgAttachLinkId
+impl core::marker::Freeze for aya::programs::links::ProgAttachLinkId
 impl core::marker::Send for aya::programs::links::ProgAttachLinkId
 impl core::marker::Sync for aya::programs::links::ProgAttachLinkId
 impl core::marker::Unpin for aya::programs::links::ProgAttachLinkId
@@ -3961,6 +4057,7 @@ pub fn aya::programs::lirc_mode2::LircLink::detach(self) -> core::result::Result
 pub fn aya::programs::lirc_mode2::LircLink::id(&self) -> Self::Id
 impl core::fmt::Debug for aya::programs::lirc_mode2::LircLink
 pub fn aya::programs::lirc_mode2::LircLink::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for aya::programs::lirc_mode2::LircLink
 impl core::marker::Send for aya::programs::lirc_mode2::LircLink
 impl core::marker::Sync for aya::programs::lirc_mode2::LircLink
 impl core::marker::Unpin for aya::programs::lirc_mode2::LircLink
@@ -3991,6 +4088,7 @@ pub fn aya::programs::lirc_mode2::LircLinkId::fmt(&self, f: &mut core::fmt::Form
 impl core::hash::Hash for aya::programs::lirc_mode2::LircLinkId
 pub fn aya::programs::lirc_mode2::LircLinkId::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
 impl core::marker::StructuralPartialEq for aya::programs::lirc_mode2::LircLinkId
+impl core::marker::Freeze for aya::programs::lirc_mode2::LircLinkId
 impl core::marker::Send for aya::programs::lirc_mode2::LircLinkId
 impl core::marker::Sync for aya::programs::lirc_mode2::LircLinkId
 impl core::marker::Unpin for aya::programs::lirc_mode2::LircLinkId
@@ -4040,6 +4138,7 @@ pub fn &'a aya::programs::lirc_mode2::LircMode2::try_from(program: &'a aya::prog
 impl<'a> core::convert::TryFrom<&'a mut aya::programs::Program> for &'a mut aya::programs::lirc_mode2::LircMode2
 pub type &'a mut aya::programs::lirc_mode2::LircMode2::Error = aya::programs::ProgramError
 pub fn &'a mut aya::programs::lirc_mode2::LircMode2::try_from(program: &'a mut aya::programs::Program) -> core::result::Result<&'a mut aya::programs::lirc_mode2::LircMode2, aya::programs::ProgramError>
+impl core::marker::Freeze for aya::programs::lirc_mode2::LircMode2
 impl core::marker::Send for aya::programs::lirc_mode2::LircMode2
 impl core::marker::Sync for aya::programs::lirc_mode2::LircMode2
 impl core::marker::Unpin for aya::programs::lirc_mode2::LircMode2
@@ -4089,6 +4188,7 @@ pub fn &'a aya::programs::lsm::Lsm::try_from(program: &'a aya::programs::Program
 impl<'a> core::convert::TryFrom<&'a mut aya::programs::Program> for &'a mut aya::programs::lsm::Lsm
 pub type &'a mut aya::programs::lsm::Lsm::Error = aya::programs::ProgramError
 pub fn &'a mut aya::programs::lsm::Lsm::try_from(program: &'a mut aya::programs::Program) -> core::result::Result<&'a mut aya::programs::lsm::Lsm, aya::programs::ProgramError>
+impl core::marker::Freeze for aya::programs::lsm::Lsm
 impl core::marker::Send for aya::programs::lsm::Lsm
 impl core::marker::Sync for aya::programs::lsm::Lsm
 impl core::marker::Unpin for aya::programs::lsm::Lsm
@@ -4123,6 +4223,7 @@ impl core::fmt::Debug for aya::programs::lsm::LsmLink
 pub fn aya::programs::lsm::LsmLink::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::ops::drop::Drop for aya::programs::lsm::LsmLink
 pub fn aya::programs::lsm::LsmLink::drop(&mut self)
+impl core::marker::Freeze for aya::programs::lsm::LsmLink
 impl core::marker::Send for aya::programs::lsm::LsmLink
 impl core::marker::Sync for aya::programs::lsm::LsmLink
 impl core::marker::Unpin for aya::programs::lsm::LsmLink
@@ -4153,6 +4254,7 @@ pub fn aya::programs::lsm::LsmLinkId::fmt(&self, f: &mut core::fmt::Formatter<'_
 impl core::hash::Hash for aya::programs::lsm::LsmLinkId
 pub fn aya::programs::lsm::LsmLinkId::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
 impl core::marker::StructuralPartialEq for aya::programs::lsm::LsmLinkId
+impl core::marker::Freeze for aya::programs::lsm::LsmLinkId
 impl core::marker::Send for aya::programs::lsm::LsmLinkId
 impl core::marker::Sync for aya::programs::lsm::LsmLinkId
 impl core::marker::Unpin for aya::programs::lsm::LsmLinkId
@@ -4182,6 +4284,7 @@ pub fn aya::programs::perf_attach::PerfLink::detach(self) -> core::result::Resul
 pub fn aya::programs::perf_attach::PerfLink::id(&self) -> Self::Id
 impl core::fmt::Debug for aya::programs::perf_attach::PerfLink
 pub fn aya::programs::perf_attach::PerfLink::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for aya::programs::perf_attach::PerfLink
 impl core::marker::Send for aya::programs::perf_attach::PerfLink
 impl core::marker::Sync for aya::programs::perf_attach::PerfLink
 impl core::marker::Unpin for aya::programs::perf_attach::PerfLink
@@ -4212,6 +4315,7 @@ pub fn aya::programs::perf_attach::PerfLinkId::fmt(&self, f: &mut core::fmt::For
 impl core::hash::Hash for aya::programs::perf_attach::PerfLinkId
 pub fn aya::programs::perf_attach::PerfLinkId::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
 impl core::marker::StructuralPartialEq for aya::programs::perf_attach::PerfLinkId
+impl core::marker::Freeze for aya::programs::perf_attach::PerfLinkId
 impl core::marker::Send for aya::programs::perf_attach::PerfLinkId
 impl core::marker::Sync for aya::programs::perf_attach::PerfLinkId
 impl core::marker::Unpin for aya::programs::perf_attach::PerfLinkId
@@ -4254,6 +4358,7 @@ impl core::clone::Clone for aya::programs::perf_event::PerfEventScope
 pub fn aya::programs::perf_event::PerfEventScope::clone(&self) -> aya::programs::perf_event::PerfEventScope
 impl core::fmt::Debug for aya::programs::perf_event::PerfEventScope
 pub fn aya::programs::perf_event::PerfEventScope::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for aya::programs::perf_event::PerfEventScope
 impl core::marker::Send for aya::programs::perf_event::PerfEventScope
 impl core::marker::Sync for aya::programs::perf_event::PerfEventScope
 impl core::marker::Unpin for aya::programs::perf_event::PerfEventScope
@@ -4290,6 +4395,7 @@ impl core::clone::Clone for aya::programs::perf_event::PerfTypeId
 pub fn aya::programs::perf_event::PerfTypeId::clone(&self) -> aya::programs::perf_event::PerfTypeId
 impl core::fmt::Debug for aya::programs::perf_event::PerfTypeId
 pub fn aya::programs::perf_event::PerfTypeId::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for aya::programs::perf_event::PerfTypeId
 impl core::marker::Send for aya::programs::perf_event::PerfTypeId
 impl core::marker::Sync for aya::programs::perf_event::PerfTypeId
 impl core::marker::Unpin for aya::programs::perf_event::PerfTypeId
@@ -4322,6 +4428,7 @@ impl core::clone::Clone for aya::programs::perf_event::SamplePolicy
 pub fn aya::programs::perf_event::SamplePolicy::clone(&self) -> aya::programs::perf_event::SamplePolicy
 impl core::fmt::Debug for aya::programs::perf_event::SamplePolicy
 pub fn aya::programs::perf_event::SamplePolicy::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for aya::programs::perf_event::SamplePolicy
 impl core::marker::Send for aya::programs::perf_event::SamplePolicy
 impl core::marker::Sync for aya::programs::perf_event::SamplePolicy
 impl core::marker::Unpin for aya::programs::perf_event::SamplePolicy
@@ -4374,6 +4481,7 @@ pub fn &'a aya::programs::perf_event::PerfEvent::try_from(program: &'a aya::prog
 impl<'a> core::convert::TryFrom<&'a mut aya::programs::Program> for &'a mut aya::programs::perf_event::PerfEvent
 pub type &'a mut aya::programs::perf_event::PerfEvent::Error = aya::programs::ProgramError
 pub fn &'a mut aya::programs::perf_event::PerfEvent::try_from(program: &'a mut aya::programs::Program) -> core::result::Result<&'a mut aya::programs::perf_event::PerfEvent, aya::programs::ProgramError>
+impl core::marker::Freeze for aya::programs::perf_event::PerfEvent
 impl core::marker::Send for aya::programs::perf_event::PerfEvent
 impl core::marker::Sync for aya::programs::perf_event::PerfEvent
 impl core::marker::Unpin for aya::programs::perf_event::PerfEvent
@@ -4410,6 +4518,7 @@ impl core::fmt::Debug for aya::programs::perf_event::PerfEventLink
 pub fn aya::programs::perf_event::PerfEventLink::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::ops::drop::Drop for aya::programs::perf_event::PerfEventLink
 pub fn aya::programs::perf_event::PerfEventLink::drop(&mut self)
+impl core::marker::Freeze for aya::programs::perf_event::PerfEventLink
 impl core::marker::Send for aya::programs::perf_event::PerfEventLink
 impl core::marker::Sync for aya::programs::perf_event::PerfEventLink
 impl core::marker::Unpin for aya::programs::perf_event::PerfEventLink
@@ -4440,6 +4549,7 @@ pub fn aya::programs::perf_event::PerfEventLinkId::fmt(&self, f: &mut core::fmt:
 impl core::hash::Hash for aya::programs::perf_event::PerfEventLinkId
 pub fn aya::programs::perf_event::PerfEventLinkId::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
 impl core::marker::StructuralPartialEq for aya::programs::perf_event::PerfEventLinkId
+impl core::marker::Freeze for aya::programs::perf_event::PerfEventLinkId
 impl core::marker::Send for aya::programs::perf_event::PerfEventLinkId
 impl core::marker::Sync for aya::programs::perf_event::PerfEventLinkId
 impl core::marker::Unpin for aya::programs::perf_event::PerfEventLinkId
@@ -4489,6 +4599,7 @@ pub fn &'a aya::programs::raw_trace_point::RawTracePoint::try_from(program: &'a 
 impl<'a> core::convert::TryFrom<&'a mut aya::programs::Program> for &'a mut aya::programs::raw_trace_point::RawTracePoint
 pub type &'a mut aya::programs::raw_trace_point::RawTracePoint::Error = aya::programs::ProgramError
 pub fn &'a mut aya::programs::raw_trace_point::RawTracePoint::try_from(program: &'a mut aya::programs::Program) -> core::result::Result<&'a mut aya::programs::raw_trace_point::RawTracePoint, aya::programs::ProgramError>
+impl core::marker::Freeze for aya::programs::raw_trace_point::RawTracePoint
 impl core::marker::Send for aya::programs::raw_trace_point::RawTracePoint
 impl core::marker::Sync for aya::programs::raw_trace_point::RawTracePoint
 impl core::marker::Unpin for aya::programs::raw_trace_point::RawTracePoint
@@ -4523,6 +4634,7 @@ impl core::fmt::Debug for aya::programs::raw_trace_point::RawTracePointLink
 pub fn aya::programs::raw_trace_point::RawTracePointLink::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::ops::drop::Drop for aya::programs::raw_trace_point::RawTracePointLink
 pub fn aya::programs::raw_trace_point::RawTracePointLink::drop(&mut self)
+impl core::marker::Freeze for aya::programs::raw_trace_point::RawTracePointLink
 impl core::marker::Send for aya::programs::raw_trace_point::RawTracePointLink
 impl core::marker::Sync for aya::programs::raw_trace_point::RawTracePointLink
 impl core::marker::Unpin for aya::programs::raw_trace_point::RawTracePointLink
@@ -4553,6 +4665,7 @@ pub fn aya::programs::raw_trace_point::RawTracePointLinkId::fmt(&self, f: &mut c
 impl core::hash::Hash for aya::programs::raw_trace_point::RawTracePointLinkId
 pub fn aya::programs::raw_trace_point::RawTracePointLinkId::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
 impl core::marker::StructuralPartialEq for aya::programs::raw_trace_point::RawTracePointLinkId
+impl core::marker::Freeze for aya::programs::raw_trace_point::RawTracePointLinkId
 impl core::marker::Send for aya::programs::raw_trace_point::RawTracePointLinkId
 impl core::marker::Sync for aya::programs::raw_trace_point::RawTracePointLinkId
 impl core::marker::Unpin for aya::programs::raw_trace_point::RawTracePointLinkId
@@ -4602,6 +4715,7 @@ pub fn &'a aya::programs::sk_lookup::SkLookup::try_from(program: &'a aya::progra
 impl<'a> core::convert::TryFrom<&'a mut aya::programs::Program> for &'a mut aya::programs::sk_lookup::SkLookup
 pub type &'a mut aya::programs::sk_lookup::SkLookup::Error = aya::programs::ProgramError
 pub fn &'a mut aya::programs::sk_lookup::SkLookup::try_from(program: &'a mut aya::programs::Program) -> core::result::Result<&'a mut aya::programs::sk_lookup::SkLookup, aya::programs::ProgramError>
+impl core::marker::Freeze for aya::programs::sk_lookup::SkLookup
 impl core::marker::Send for aya::programs::sk_lookup::SkLookup
 impl core::marker::Sync for aya::programs::sk_lookup::SkLookup
 impl core::marker::Unpin for aya::programs::sk_lookup::SkLookup
@@ -4636,6 +4750,7 @@ impl core::fmt::Debug for aya::programs::sk_lookup::SkLookupLink
 pub fn aya::programs::sk_lookup::SkLookupLink::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::ops::drop::Drop for aya::programs::sk_lookup::SkLookupLink
 pub fn aya::programs::sk_lookup::SkLookupLink::drop(&mut self)
+impl core::marker::Freeze for aya::programs::sk_lookup::SkLookupLink
 impl core::marker::Send for aya::programs::sk_lookup::SkLookupLink
 impl core::marker::Sync for aya::programs::sk_lookup::SkLookupLink
 impl core::marker::Unpin for aya::programs::sk_lookup::SkLookupLink
@@ -4666,6 +4781,7 @@ pub fn aya::programs::sk_lookup::SkLookupLinkId::fmt(&self, f: &mut core::fmt::F
 impl core::hash::Hash for aya::programs::sk_lookup::SkLookupLinkId
 pub fn aya::programs::sk_lookup::SkLookupLinkId::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
 impl core::marker::StructuralPartialEq for aya::programs::sk_lookup::SkLookupLinkId
+impl core::marker::Freeze for aya::programs::sk_lookup::SkLookupLinkId
 impl core::marker::Send for aya::programs::sk_lookup::SkLookupLinkId
 impl core::marker::Sync for aya::programs::sk_lookup::SkLookupLinkId
 impl core::marker::Unpin for aya::programs::sk_lookup::SkLookupLinkId
@@ -4715,6 +4831,7 @@ pub fn &'a aya::programs::sk_msg::SkMsg::try_from(program: &'a aya::programs::Pr
 impl<'a> core::convert::TryFrom<&'a mut aya::programs::Program> for &'a mut aya::programs::sk_msg::SkMsg
 pub type &'a mut aya::programs::sk_msg::SkMsg::Error = aya::programs::ProgramError
 pub fn &'a mut aya::programs::sk_msg::SkMsg::try_from(program: &'a mut aya::programs::Program) -> core::result::Result<&'a mut aya::programs::sk_msg::SkMsg, aya::programs::ProgramError>
+impl core::marker::Freeze for aya::programs::sk_msg::SkMsg
 impl core::marker::Send for aya::programs::sk_msg::SkMsg
 impl core::marker::Sync for aya::programs::sk_msg::SkMsg
 impl core::marker::Unpin for aya::programs::sk_msg::SkMsg
@@ -4749,6 +4866,7 @@ impl core::fmt::Debug for aya::programs::sk_msg::SkMsgLink
 pub fn aya::programs::sk_msg::SkMsgLink::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::ops::drop::Drop for aya::programs::sk_msg::SkMsgLink
 pub fn aya::programs::sk_msg::SkMsgLink::drop(&mut self)
+impl core::marker::Freeze for aya::programs::sk_msg::SkMsgLink
 impl core::marker::Send for aya::programs::sk_msg::SkMsgLink
 impl core::marker::Sync for aya::programs::sk_msg::SkMsgLink
 impl core::marker::Unpin for aya::programs::sk_msg::SkMsgLink
@@ -4779,6 +4897,7 @@ pub fn aya::programs::sk_msg::SkMsgLinkId::fmt(&self, f: &mut core::fmt::Formatt
 impl core::hash::Hash for aya::programs::sk_msg::SkMsgLinkId
 pub fn aya::programs::sk_msg::SkMsgLinkId::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
 impl core::marker::StructuralPartialEq for aya::programs::sk_msg::SkMsgLinkId
+impl core::marker::Freeze for aya::programs::sk_msg::SkMsgLinkId
 impl core::marker::Send for aya::programs::sk_msg::SkMsgLinkId
 impl core::marker::Sync for aya::programs::sk_msg::SkMsgLinkId
 impl core::marker::Unpin for aya::programs::sk_msg::SkMsgLinkId
@@ -4809,6 +4928,7 @@ pub fn aya::programs::sk_skb::SkSkbKind::clone(&self) -> aya::programs::sk_skb::
 impl core::fmt::Debug for aya::programs::sk_skb::SkSkbKind
 pub fn aya::programs::sk_skb::SkSkbKind::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Copy for aya::programs::sk_skb::SkSkbKind
+impl core::marker::Freeze for aya::programs::sk_skb::SkSkbKind
 impl core::marker::Send for aya::programs::sk_skb::SkSkbKind
 impl core::marker::Sync for aya::programs::sk_skb::SkSkbKind
 impl core::marker::Unpin for aya::programs::sk_skb::SkSkbKind
@@ -4860,6 +4980,7 @@ pub fn &'a aya::programs::sk_skb::SkSkb::try_from(program: &'a aya::programs::Pr
 impl<'a> core::convert::TryFrom<&'a mut aya::programs::Program> for &'a mut aya::programs::sk_skb::SkSkb
 pub type &'a mut aya::programs::sk_skb::SkSkb::Error = aya::programs::ProgramError
 pub fn &'a mut aya::programs::sk_skb::SkSkb::try_from(program: &'a mut aya::programs::Program) -> core::result::Result<&'a mut aya::programs::sk_skb::SkSkb, aya::programs::ProgramError>
+impl core::marker::Freeze for aya::programs::sk_skb::SkSkb
 impl core::marker::Send for aya::programs::sk_skb::SkSkb
 impl core::marker::Sync for aya::programs::sk_skb::SkSkb
 impl core::marker::Unpin for aya::programs::sk_skb::SkSkb
@@ -4894,6 +5015,7 @@ impl core::fmt::Debug for aya::programs::sk_skb::SkSkbLink
 pub fn aya::programs::sk_skb::SkSkbLink::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::ops::drop::Drop for aya::programs::sk_skb::SkSkbLink
 pub fn aya::programs::sk_skb::SkSkbLink::drop(&mut self)
+impl core::marker::Freeze for aya::programs::sk_skb::SkSkbLink
 impl core::marker::Send for aya::programs::sk_skb::SkSkbLink
 impl core::marker::Sync for aya::programs::sk_skb::SkSkbLink
 impl core::marker::Unpin for aya::programs::sk_skb::SkSkbLink
@@ -4924,6 +5046,7 @@ pub fn aya::programs::sk_skb::SkSkbLinkId::fmt(&self, f: &mut core::fmt::Formatt
 impl core::hash::Hash for aya::programs::sk_skb::SkSkbLinkId
 pub fn aya::programs::sk_skb::SkSkbLinkId::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
 impl core::marker::StructuralPartialEq for aya::programs::sk_skb::SkSkbLinkId
+impl core::marker::Freeze for aya::programs::sk_skb::SkSkbLinkId
 impl core::marker::Send for aya::programs::sk_skb::SkSkbLinkId
 impl core::marker::Sync for aya::programs::sk_skb::SkSkbLinkId
 impl core::marker::Unpin for aya::programs::sk_skb::SkSkbLinkId
@@ -4973,6 +5096,7 @@ pub fn &'a aya::programs::sock_ops::SockOps::try_from(program: &'a aya::programs
 impl<'a> core::convert::TryFrom<&'a mut aya::programs::Program> for &'a mut aya::programs::sock_ops::SockOps
 pub type &'a mut aya::programs::sock_ops::SockOps::Error = aya::programs::ProgramError
 pub fn &'a mut aya::programs::sock_ops::SockOps::try_from(program: &'a mut aya::programs::Program) -> core::result::Result<&'a mut aya::programs::sock_ops::SockOps, aya::programs::ProgramError>
+impl core::marker::Freeze for aya::programs::sock_ops::SockOps
 impl core::marker::Send for aya::programs::sock_ops::SockOps
 impl core::marker::Sync for aya::programs::sock_ops::SockOps
 impl core::marker::Unpin for aya::programs::sock_ops::SockOps
@@ -5007,6 +5131,7 @@ impl core::fmt::Debug for aya::programs::sock_ops::SockOpsLink
 pub fn aya::programs::sock_ops::SockOpsLink::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::ops::drop::Drop for aya::programs::sock_ops::SockOpsLink
 pub fn aya::programs::sock_ops::SockOpsLink::drop(&mut self)
+impl core::marker::Freeze for aya::programs::sock_ops::SockOpsLink
 impl core::marker::Send for aya::programs::sock_ops::SockOpsLink
 impl core::marker::Sync for aya::programs::sock_ops::SockOpsLink
 impl core::marker::Unpin for aya::programs::sock_ops::SockOpsLink
@@ -5037,6 +5162,7 @@ pub fn aya::programs::sock_ops::SockOpsLinkId::fmt(&self, f: &mut core::fmt::For
 impl core::hash::Hash for aya::programs::sock_ops::SockOpsLinkId
 pub fn aya::programs::sock_ops::SockOpsLinkId::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
 impl core::marker::StructuralPartialEq for aya::programs::sock_ops::SockOpsLinkId
+impl core::marker::Freeze for aya::programs::sock_ops::SockOpsLinkId
 impl core::marker::Send for aya::programs::sock_ops::SockOpsLinkId
 impl core::marker::Sync for aya::programs::sock_ops::SockOpsLinkId
 impl core::marker::Unpin for aya::programs::sock_ops::SockOpsLinkId
@@ -5070,6 +5196,7 @@ impl core::fmt::Debug for aya::programs::socket_filter::SocketFilterError
 pub fn aya::programs::socket_filter::SocketFilterError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::fmt::Display for aya::programs::socket_filter::SocketFilterError
 pub fn aya::programs::socket_filter::SocketFilterError::fmt(&self, __formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for aya::programs::socket_filter::SocketFilterError
 impl core::marker::Send for aya::programs::socket_filter::SocketFilterError
 impl core::marker::Sync for aya::programs::socket_filter::SocketFilterError
 impl core::marker::Unpin for aya::programs::socket_filter::SocketFilterError
@@ -5120,6 +5247,7 @@ pub fn &'a aya::programs::socket_filter::SocketFilter::try_from(program: &'a aya
 impl<'a> core::convert::TryFrom<&'a mut aya::programs::Program> for &'a mut aya::programs::socket_filter::SocketFilter
 pub type &'a mut aya::programs::socket_filter::SocketFilter::Error = aya::programs::ProgramError
 pub fn &'a mut aya::programs::socket_filter::SocketFilter::try_from(program: &'a mut aya::programs::Program) -> core::result::Result<&'a mut aya::programs::socket_filter::SocketFilter, aya::programs::ProgramError>
+impl core::marker::Freeze for aya::programs::socket_filter::SocketFilter
 impl core::marker::Send for aya::programs::socket_filter::SocketFilter
 impl core::marker::Sync for aya::programs::socket_filter::SocketFilter
 impl core::marker::Unpin for aya::programs::socket_filter::SocketFilter
@@ -5148,6 +5276,7 @@ pub fn aya::programs::socket_filter::SocketFilterLink::detach(self) -> core::res
 pub fn aya::programs::socket_filter::SocketFilterLink::id(&self) -> Self::Id
 impl core::fmt::Debug for aya::programs::socket_filter::SocketFilterLink
 pub fn aya::programs::socket_filter::SocketFilterLink::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for aya::programs::socket_filter::SocketFilterLink
 impl core::marker::Send for aya::programs::socket_filter::SocketFilterLink
 impl core::marker::Sync for aya::programs::socket_filter::SocketFilterLink
 impl core::marker::Unpin for aya::programs::socket_filter::SocketFilterLink
@@ -5178,6 +5307,7 @@ pub fn aya::programs::socket_filter::SocketFilterLinkId::fmt(&self, f: &mut core
 impl core::hash::Hash for aya::programs::socket_filter::SocketFilterLinkId
 pub fn aya::programs::socket_filter::SocketFilterLinkId::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
 impl core::marker::StructuralPartialEq for aya::programs::socket_filter::SocketFilterLinkId
+impl core::marker::Freeze for aya::programs::socket_filter::SocketFilterLinkId
 impl core::marker::Send for aya::programs::socket_filter::SocketFilterLinkId
 impl core::marker::Sync for aya::programs::socket_filter::SocketFilterLinkId
 impl core::marker::Unpin for aya::programs::socket_filter::SocketFilterLinkId
@@ -5215,6 +5345,7 @@ impl core::hash::Hash for aya::programs::tc::TcAttachType
 pub fn aya::programs::tc::TcAttachType::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
 impl core::marker::Copy for aya::programs::tc::TcAttachType
 impl core::marker::StructuralPartialEq for aya::programs::tc::TcAttachType
+impl core::marker::Freeze for aya::programs::tc::TcAttachType
 impl core::marker::Send for aya::programs::tc::TcAttachType
 impl core::marker::Sync for aya::programs::tc::TcAttachType
 impl core::marker::Unpin for aya::programs::tc::TcAttachType
@@ -5252,6 +5383,7 @@ impl core::fmt::Debug for aya::programs::tc::TcError
 pub fn aya::programs::tc::TcError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::fmt::Display for aya::programs::tc::TcError
 pub fn aya::programs::tc::TcError::fmt(&self, __formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for aya::programs::tc::TcError
 impl core::marker::Send for aya::programs::tc::TcError
 impl core::marker::Sync for aya::programs::tc::TcError
 impl core::marker::Unpin for aya::programs::tc::TcError
@@ -5303,6 +5435,7 @@ pub fn &'a aya::programs::tc::SchedClassifier::try_from(program: &'a aya::progra
 impl<'a> core::convert::TryFrom<&'a mut aya::programs::Program> for &'a mut aya::programs::tc::SchedClassifier
 pub type &'a mut aya::programs::tc::SchedClassifier::Error = aya::programs::ProgramError
 pub fn &'a mut aya::programs::tc::SchedClassifier::try_from(program: &'a mut aya::programs::Program) -> core::result::Result<&'a mut aya::programs::tc::SchedClassifier, aya::programs::ProgramError>
+impl core::marker::Freeze for aya::programs::tc::SchedClassifier
 impl core::marker::Send for aya::programs::tc::SchedClassifier
 impl core::marker::Sync for aya::programs::tc::SchedClassifier
 impl core::marker::Unpin for aya::programs::tc::SchedClassifier
@@ -5338,6 +5471,7 @@ impl core::fmt::Debug for aya::programs::tc::SchedClassifierLink
 pub fn aya::programs::tc::SchedClassifierLink::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::ops::drop::Drop for aya::programs::tc::SchedClassifierLink
 pub fn aya::programs::tc::SchedClassifierLink::drop(&mut self)
+impl core::marker::Freeze for aya::programs::tc::SchedClassifierLink
 impl core::marker::Send for aya::programs::tc::SchedClassifierLink
 impl core::marker::Sync for aya::programs::tc::SchedClassifierLink
 impl core::marker::Unpin for aya::programs::tc::SchedClassifierLink
@@ -5368,6 +5502,7 @@ pub fn aya::programs::tc::SchedClassifierLinkId::fmt(&self, f: &mut core::fmt::F
 impl core::hash::Hash for aya::programs::tc::SchedClassifierLinkId
 pub fn aya::programs::tc::SchedClassifierLinkId::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
 impl core::marker::StructuralPartialEq for aya::programs::tc::SchedClassifierLinkId
+impl core::marker::Freeze for aya::programs::tc::SchedClassifierLinkId
 impl core::marker::Send for aya::programs::tc::SchedClassifierLinkId
 impl core::marker::Sync for aya::programs::tc::SchedClassifierLinkId
 impl core::marker::Unpin for aya::programs::tc::SchedClassifierLinkId
@@ -5394,6 +5529,7 @@ pub aya::programs::tc::TcOptions::handle: u32
 pub aya::programs::tc::TcOptions::priority: u16
 impl core::default::Default for aya::programs::tc::TcOptions
 pub fn aya::programs::tc::TcOptions::default() -> aya::programs::tc::TcOptions
+impl core::marker::Freeze for aya::programs::tc::TcOptions
 impl core::marker::Send for aya::programs::tc::TcOptions
 impl core::marker::Sync for aya::programs::tc::TcOptions
 impl core::marker::Unpin for aya::programs::tc::TcOptions
@@ -5445,6 +5581,7 @@ pub fn &'a aya::programs::tp_btf::BtfTracePoint::try_from(program: &'a aya::prog
 impl<'a> core::convert::TryFrom<&'a mut aya::programs::Program> for &'a mut aya::programs::tp_btf::BtfTracePoint
 pub type &'a mut aya::programs::tp_btf::BtfTracePoint::Error = aya::programs::ProgramError
 pub fn &'a mut aya::programs::tp_btf::BtfTracePoint::try_from(program: &'a mut aya::programs::Program) -> core::result::Result<&'a mut aya::programs::tp_btf::BtfTracePoint, aya::programs::ProgramError>
+impl core::marker::Freeze for aya::programs::tp_btf::BtfTracePoint
 impl core::marker::Send for aya::programs::tp_btf::BtfTracePoint
 impl core::marker::Sync for aya::programs::tp_btf::BtfTracePoint
 impl core::marker::Unpin for aya::programs::tp_btf::BtfTracePoint
@@ -5479,6 +5616,7 @@ impl core::fmt::Debug for aya::programs::tp_btf::BtfTracePointLink
 pub fn aya::programs::tp_btf::BtfTracePointLink::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::ops::drop::Drop for aya::programs::tp_btf::BtfTracePointLink
 pub fn aya::programs::tp_btf::BtfTracePointLink::drop(&mut self)
+impl core::marker::Freeze for aya::programs::tp_btf::BtfTracePointLink
 impl core::marker::Send for aya::programs::tp_btf::BtfTracePointLink
 impl core::marker::Sync for aya::programs::tp_btf::BtfTracePointLink
 impl core::marker::Unpin for aya::programs::tp_btf::BtfTracePointLink
@@ -5509,6 +5647,7 @@ pub fn aya::programs::tp_btf::BtfTracePointLinkId::fmt(&self, f: &mut core::fmt:
 impl core::hash::Hash for aya::programs::tp_btf::BtfTracePointLinkId
 pub fn aya::programs::tp_btf::BtfTracePointLinkId::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
 impl core::marker::StructuralPartialEq for aya::programs::tp_btf::BtfTracePointLinkId
+impl core::marker::Freeze for aya::programs::tp_btf::BtfTracePointLinkId
 impl core::marker::Send for aya::programs::tp_btf::BtfTracePointLinkId
 impl core::marker::Sync for aya::programs::tp_btf::BtfTracePointLinkId
 impl core::marker::Unpin for aya::programs::tp_btf::BtfTracePointLinkId
@@ -5543,6 +5682,7 @@ impl core::fmt::Debug for aya::programs::trace_point::TracePointError
 pub fn aya::programs::trace_point::TracePointError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::fmt::Display for aya::programs::trace_point::TracePointError
 pub fn aya::programs::trace_point::TracePointError::fmt(&self, __formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for aya::programs::trace_point::TracePointError
 impl core::marker::Send for aya::programs::trace_point::TracePointError
 impl core::marker::Sync for aya::programs::trace_point::TracePointError
 impl core::marker::Unpin for aya::programs::trace_point::TracePointError
@@ -5593,6 +5733,7 @@ pub fn &'a aya::programs::trace_point::TracePoint::try_from(program: &'a aya::pr
 impl<'a> core::convert::TryFrom<&'a mut aya::programs::Program> for &'a mut aya::programs::trace_point::TracePoint
 pub type &'a mut aya::programs::trace_point::TracePoint::Error = aya::programs::ProgramError
 pub fn &'a mut aya::programs::trace_point::TracePoint::try_from(program: &'a mut aya::programs::Program) -> core::result::Result<&'a mut aya::programs::trace_point::TracePoint, aya::programs::ProgramError>
+impl core::marker::Freeze for aya::programs::trace_point::TracePoint
 impl core::marker::Send for aya::programs::trace_point::TracePoint
 impl core::marker::Sync for aya::programs::trace_point::TracePoint
 impl core::marker::Unpin for aya::programs::trace_point::TracePoint
@@ -5629,6 +5770,7 @@ impl core::fmt::Debug for aya::programs::trace_point::TracePointLink
 pub fn aya::programs::trace_point::TracePointLink::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::ops::drop::Drop for aya::programs::trace_point::TracePointLink
 pub fn aya::programs::trace_point::TracePointLink::drop(&mut self)
+impl core::marker::Freeze for aya::programs::trace_point::TracePointLink
 impl core::marker::Send for aya::programs::trace_point::TracePointLink
 impl core::marker::Sync for aya::programs::trace_point::TracePointLink
 impl core::marker::Unpin for aya::programs::trace_point::TracePointLink
@@ -5659,6 +5801,7 @@ pub fn aya::programs::trace_point::TracePointLinkId::fmt(&self, f: &mut core::fm
 impl core::hash::Hash for aya::programs::trace_point::TracePointLinkId
 pub fn aya::programs::trace_point::TracePointLinkId::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
 impl core::marker::StructuralPartialEq for aya::programs::trace_point::TracePointLinkId
+impl core::marker::Freeze for aya::programs::trace_point::TracePointLinkId
 impl core::marker::Send for aya::programs::trace_point::TracePointLinkId
 impl core::marker::Sync for aya::programs::trace_point::TracePointLinkId
 impl core::marker::Unpin for aya::programs::trace_point::TracePointLinkId
@@ -5700,6 +5843,7 @@ impl core::fmt::Debug for aya::programs::uprobe::UProbeError
 pub fn aya::programs::uprobe::UProbeError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::fmt::Display for aya::programs::uprobe::UProbeError
 pub fn aya::programs::uprobe::UProbeError::fmt(&self, __formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for aya::programs::uprobe::UProbeError
 impl core::marker::Send for aya::programs::uprobe::UProbeError
 impl core::marker::Sync for aya::programs::uprobe::UProbeError
 impl core::marker::Unpin for aya::programs::uprobe::UProbeError
@@ -5750,6 +5894,7 @@ pub fn &'a aya::programs::uprobe::UProbe::try_from(program: &'a aya::programs::P
 impl<'a> core::convert::TryFrom<&'a mut aya::programs::Program> for &'a mut aya::programs::uprobe::UProbe
 pub type &'a mut aya::programs::uprobe::UProbe::Error = aya::programs::ProgramError
 pub fn &'a mut aya::programs::uprobe::UProbe::try_from(program: &'a mut aya::programs::Program) -> core::result::Result<&'a mut aya::programs::uprobe::UProbe, aya::programs::ProgramError>
+impl core::marker::Freeze for aya::programs::uprobe::UProbe
 impl core::marker::Send for aya::programs::uprobe::UProbe
 impl core::marker::Sync for aya::programs::uprobe::UProbe
 impl core::marker::Unpin for aya::programs::uprobe::UProbe
@@ -5786,6 +5931,7 @@ impl core::fmt::Debug for aya::programs::uprobe::UProbeLink
 pub fn aya::programs::uprobe::UProbeLink::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::ops::drop::Drop for aya::programs::uprobe::UProbeLink
 pub fn aya::programs::uprobe::UProbeLink::drop(&mut self)
+impl core::marker::Freeze for aya::programs::uprobe::UProbeLink
 impl core::marker::Send for aya::programs::uprobe::UProbeLink
 impl core::marker::Sync for aya::programs::uprobe::UProbeLink
 impl core::marker::Unpin for aya::programs::uprobe::UProbeLink
@@ -5816,6 +5962,7 @@ pub fn aya::programs::uprobe::UProbeLinkId::fmt(&self, f: &mut core::fmt::Format
 impl core::hash::Hash for aya::programs::uprobe::UProbeLinkId
 pub fn aya::programs::uprobe::UProbeLinkId::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
 impl core::marker::StructuralPartialEq for aya::programs::uprobe::UProbeLinkId
+impl core::marker::Freeze for aya::programs::uprobe::UProbeLinkId
 impl core::marker::Send for aya::programs::uprobe::UProbeLinkId
 impl core::marker::Sync for aya::programs::uprobe::UProbeLinkId
 impl core::marker::Unpin for aya::programs::uprobe::UProbeLinkId
@@ -5849,6 +5996,7 @@ impl core::fmt::Debug for aya::programs::xdp::XdpError
 pub fn aya::programs::xdp::XdpError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::fmt::Display for aya::programs::xdp::XdpError
 pub fn aya::programs::xdp::XdpError::fmt(&self, __formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for aya::programs::xdp::XdpError
 impl core::marker::Send for aya::programs::xdp::XdpError
 impl core::marker::Sync for aya::programs::xdp::XdpError
 impl core::marker::Unpin for aya::programs::xdp::XdpError
@@ -5900,6 +6048,7 @@ pub fn &'a aya::programs::xdp::Xdp::try_from(program: &'a aya::programs::Program
 impl<'a> core::convert::TryFrom<&'a mut aya::programs::Program> for &'a mut aya::programs::xdp::Xdp
 pub type &'a mut aya::programs::xdp::Xdp::Error = aya::programs::ProgramError
 pub fn &'a mut aya::programs::xdp::Xdp::try_from(program: &'a mut aya::programs::Program) -> core::result::Result<&'a mut aya::programs::xdp::Xdp, aya::programs::ProgramError>
+impl core::marker::Freeze for aya::programs::xdp::Xdp
 impl core::marker::Send for aya::programs::xdp::Xdp
 impl core::marker::Sync for aya::programs::xdp::Xdp
 impl core::marker::Unpin for aya::programs::xdp::Xdp
@@ -6006,6 +6155,7 @@ pub fn aya::programs::xdp::XdpFlags::bitxor_assign(&mut self, other: Self)
 impl core::ops::bit::Not for aya::programs::xdp::XdpFlags
 pub type aya::programs::xdp::XdpFlags::Output = aya::programs::xdp::XdpFlags
 pub fn aya::programs::xdp::XdpFlags::not(self) -> Self
+impl core::marker::Freeze for aya::programs::xdp::XdpFlags
 impl core::marker::Send for aya::programs::xdp::XdpFlags
 impl core::marker::Sync for aya::programs::xdp::XdpFlags
 impl core::marker::Unpin for aya::programs::xdp::XdpFlags
@@ -6046,6 +6196,7 @@ impl core::fmt::Debug for aya::programs::xdp::XdpLink
 pub fn aya::programs::xdp::XdpLink::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::ops::drop::Drop for aya::programs::xdp::XdpLink
 pub fn aya::programs::xdp::XdpLink::drop(&mut self)
+impl core::marker::Freeze for aya::programs::xdp::XdpLink
 impl core::marker::Send for aya::programs::xdp::XdpLink
 impl core::marker::Sync for aya::programs::xdp::XdpLink
 impl core::marker::Unpin for aya::programs::xdp::XdpLink
@@ -6076,6 +6227,7 @@ pub fn aya::programs::xdp::XdpLinkId::fmt(&self, f: &mut core::fmt::Formatter<'_
 impl core::hash::Hash for aya::programs::xdp::XdpLinkId
 pub fn aya::programs::xdp::XdpLinkId::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
 impl core::marker::StructuralPartialEq for aya::programs::xdp::XdpLinkId
+impl core::marker::Freeze for aya::programs::xdp::XdpLinkId
 impl core::marker::Send for aya::programs::xdp::XdpLinkId
 impl core::marker::Sync for aya::programs::xdp::XdpLinkId
 impl core::marker::Unpin for aya::programs::xdp::XdpLinkId
@@ -6105,6 +6257,7 @@ pub fn aya::programs::cgroup_skb::CgroupSkbAttachType::clone(&self) -> aya::prog
 impl core::fmt::Debug for aya::programs::cgroup_skb::CgroupSkbAttachType
 pub fn aya::programs::cgroup_skb::CgroupSkbAttachType::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Copy for aya::programs::cgroup_skb::CgroupSkbAttachType
+impl core::marker::Freeze for aya::programs::cgroup_skb::CgroupSkbAttachType
 impl core::marker::Send for aya::programs::cgroup_skb::CgroupSkbAttachType
 impl core::marker::Sync for aya::programs::cgroup_skb::CgroupSkbAttachType
 impl core::marker::Unpin for aya::programs::cgroup_skb::CgroupSkbAttachType
@@ -6139,6 +6292,7 @@ impl core::fmt::Debug for aya::programs::extension::ExtensionError
 pub fn aya::programs::extension::ExtensionError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::fmt::Display for aya::programs::extension::ExtensionError
 pub fn aya::programs::extension::ExtensionError::fmt(&self, __formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for aya::programs::extension::ExtensionError
 impl core::marker::Send for aya::programs::extension::ExtensionError
 impl core::marker::Sync for aya::programs::extension::ExtensionError
 impl core::marker::Unpin for aya::programs::extension::ExtensionError
@@ -6174,6 +6328,7 @@ impl core::fmt::Debug for aya::programs::kprobe::KProbeError
 pub fn aya::programs::kprobe::KProbeError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::fmt::Display for aya::programs::kprobe::KProbeError
 pub fn aya::programs::kprobe::KProbeError::fmt(&self, __formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for aya::programs::kprobe::KProbeError
 impl core::marker::Send for aya::programs::kprobe::KProbeError
 impl core::marker::Sync for aya::programs::kprobe::KProbeError
 impl core::marker::Unpin for aya::programs::kprobe::KProbeError
@@ -6212,6 +6367,7 @@ impl core::clone::Clone for aya::programs::perf_event::PerfEventScope
 pub fn aya::programs::perf_event::PerfEventScope::clone(&self) -> aya::programs::perf_event::PerfEventScope
 impl core::fmt::Debug for aya::programs::perf_event::PerfEventScope
 pub fn aya::programs::perf_event::PerfEventScope::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for aya::programs::perf_event::PerfEventScope
 impl core::marker::Send for aya::programs::perf_event::PerfEventScope
 impl core::marker::Sync for aya::programs::perf_event::PerfEventScope
 impl core::marker::Unpin for aya::programs::perf_event::PerfEventScope
@@ -6248,6 +6404,7 @@ impl core::clone::Clone for aya::programs::perf_event::PerfTypeId
 pub fn aya::programs::perf_event::PerfTypeId::clone(&self) -> aya::programs::perf_event::PerfTypeId
 impl core::fmt::Debug for aya::programs::perf_event::PerfTypeId
 pub fn aya::programs::perf_event::PerfTypeId::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for aya::programs::perf_event::PerfTypeId
 impl core::marker::Send for aya::programs::perf_event::PerfTypeId
 impl core::marker::Sync for aya::programs::perf_event::PerfTypeId
 impl core::marker::Unpin for aya::programs::perf_event::PerfTypeId
@@ -6283,6 +6440,7 @@ pub fn aya::programs::ProbeKind::clone(&self) -> aya::programs::ProbeKind
 impl core::fmt::Debug for aya::programs::ProbeKind
 pub fn aya::programs::ProbeKind::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Copy for aya::programs::ProbeKind
+impl core::marker::Freeze for aya::programs::ProbeKind
 impl core::marker::Send for aya::programs::ProbeKind
 impl core::marker::Sync for aya::programs::ProbeKind
 impl core::marker::Unpin for aya::programs::ProbeKind
@@ -6485,6 +6643,7 @@ pub fn &'a mut aya::programs::uprobe::UProbe::try_from(program: &'a mut aya::pro
 impl<'a> core::convert::TryFrom<&'a mut aya::programs::Program> for &'a mut aya::programs::xdp::Xdp
 pub type &'a mut aya::programs::xdp::Xdp::Error = aya::programs::ProgramError
 pub fn &'a mut aya::programs::xdp::Xdp::try_from(program: &'a mut aya::programs::Program) -> core::result::Result<&'a mut aya::programs::xdp::Xdp, aya::programs::ProgramError>
+impl core::marker::Freeze for aya::programs::Program
 impl core::marker::Send for aya::programs::Program
 impl core::marker::Sync for aya::programs::Program
 impl core::marker::Unpin for aya::programs::Program
@@ -6558,6 +6717,7 @@ impl core::fmt::Debug for aya::programs::ProgramError
 pub fn aya::programs::ProgramError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::fmt::Display for aya::programs::ProgramError
 pub fn aya::programs::ProgramError::fmt(&self, __formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for aya::programs::ProgramError
 impl core::marker::Send for aya::programs::ProgramError
 impl core::marker::Sync for aya::programs::ProgramError
 impl core::marker::Unpin for aya::programs::ProgramError
@@ -6588,6 +6748,7 @@ impl core::clone::Clone for aya::programs::perf_event::SamplePolicy
 pub fn aya::programs::perf_event::SamplePolicy::clone(&self) -> aya::programs::perf_event::SamplePolicy
 impl core::fmt::Debug for aya::programs::perf_event::SamplePolicy
 pub fn aya::programs::perf_event::SamplePolicy::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for aya::programs::perf_event::SamplePolicy
 impl core::marker::Send for aya::programs::perf_event::SamplePolicy
 impl core::marker::Sync for aya::programs::perf_event::SamplePolicy
 impl core::marker::Unpin for aya::programs::perf_event::SamplePolicy
@@ -6621,6 +6782,7 @@ pub fn aya::programs::sk_skb::SkSkbKind::clone(&self) -> aya::programs::sk_skb::
 impl core::fmt::Debug for aya::programs::sk_skb::SkSkbKind
 pub fn aya::programs::sk_skb::SkSkbKind::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Copy for aya::programs::sk_skb::SkSkbKind
+impl core::marker::Freeze for aya::programs::sk_skb::SkSkbKind
 impl core::marker::Send for aya::programs::sk_skb::SkSkbKind
 impl core::marker::Sync for aya::programs::sk_skb::SkSkbKind
 impl core::marker::Unpin for aya::programs::sk_skb::SkSkbKind
@@ -6657,6 +6819,7 @@ impl core::fmt::Debug for aya::programs::socket_filter::SocketFilterError
 pub fn aya::programs::socket_filter::SocketFilterError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::fmt::Display for aya::programs::socket_filter::SocketFilterError
 pub fn aya::programs::socket_filter::SocketFilterError::fmt(&self, __formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for aya::programs::socket_filter::SocketFilterError
 impl core::marker::Send for aya::programs::socket_filter::SocketFilterError
 impl core::marker::Sync for aya::programs::socket_filter::SocketFilterError
 impl core::marker::Unpin for aya::programs::socket_filter::SocketFilterError
@@ -6695,6 +6858,7 @@ impl core::hash::Hash for aya::programs::tc::TcAttachType
 pub fn aya::programs::tc::TcAttachType::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
 impl core::marker::Copy for aya::programs::tc::TcAttachType
 impl core::marker::StructuralPartialEq for aya::programs::tc::TcAttachType
+impl core::marker::Freeze for aya::programs::tc::TcAttachType
 impl core::marker::Send for aya::programs::tc::TcAttachType
 impl core::marker::Sync for aya::programs::tc::TcAttachType
 impl core::marker::Unpin for aya::programs::tc::TcAttachType
@@ -6732,6 +6896,7 @@ impl core::fmt::Debug for aya::programs::tc::TcError
 pub fn aya::programs::tc::TcError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::fmt::Display for aya::programs::tc::TcError
 pub fn aya::programs::tc::TcError::fmt(&self, __formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for aya::programs::tc::TcError
 impl core::marker::Send for aya::programs::tc::TcError
 impl core::marker::Sync for aya::programs::tc::TcError
 impl core::marker::Unpin for aya::programs::tc::TcError
@@ -6767,6 +6932,7 @@ impl core::fmt::Debug for aya::programs::trace_point::TracePointError
 pub fn aya::programs::trace_point::TracePointError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::fmt::Display for aya::programs::trace_point::TracePointError
 pub fn aya::programs::trace_point::TracePointError::fmt(&self, __formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for aya::programs::trace_point::TracePointError
 impl core::marker::Send for aya::programs::trace_point::TracePointError
 impl core::marker::Sync for aya::programs::trace_point::TracePointError
 impl core::marker::Unpin for aya::programs::trace_point::TracePointError
@@ -6809,6 +6975,7 @@ impl core::fmt::Debug for aya::programs::uprobe::UProbeError
 pub fn aya::programs::uprobe::UProbeError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::fmt::Display for aya::programs::uprobe::UProbeError
 pub fn aya::programs::uprobe::UProbeError::fmt(&self, __formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for aya::programs::uprobe::UProbeError
 impl core::marker::Send for aya::programs::uprobe::UProbeError
 impl core::marker::Sync for aya::programs::uprobe::UProbeError
 impl core::marker::Unpin for aya::programs::uprobe::UProbeError
@@ -6843,6 +7010,7 @@ impl core::fmt::Debug for aya::programs::xdp::XdpError
 pub fn aya::programs::xdp::XdpError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::fmt::Display for aya::programs::xdp::XdpError
 pub fn aya::programs::xdp::XdpError::fmt(&self, __formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for aya::programs::xdp::XdpError
 impl core::marker::Send for aya::programs::xdp::XdpError
 impl core::marker::Sync for aya::programs::xdp::XdpError
 impl core::marker::Unpin for aya::programs::xdp::XdpError
@@ -6893,6 +7061,7 @@ pub fn &'a aya::programs::tp_btf::BtfTracePoint::try_from(program: &'a aya::prog
 impl<'a> core::convert::TryFrom<&'a mut aya::programs::Program> for &'a mut aya::programs::tp_btf::BtfTracePoint
 pub type &'a mut aya::programs::tp_btf::BtfTracePoint::Error = aya::programs::ProgramError
 pub fn &'a mut aya::programs::tp_btf::BtfTracePoint::try_from(program: &'a mut aya::programs::Program) -> core::result::Result<&'a mut aya::programs::tp_btf::BtfTracePoint, aya::programs::ProgramError>
+impl core::marker::Freeze for aya::programs::tp_btf::BtfTracePoint
 impl core::marker::Send for aya::programs::tp_btf::BtfTracePoint
 impl core::marker::Sync for aya::programs::tp_btf::BtfTracePoint
 impl core::marker::Unpin for aya::programs::tp_btf::BtfTracePoint
@@ -6942,6 +7111,7 @@ pub fn &'a aya::programs::cgroup_device::CgroupDevice::try_from(program: &'a aya
 impl<'a> core::convert::TryFrom<&'a mut aya::programs::Program> for &'a mut aya::programs::cgroup_device::CgroupDevice
 pub type &'a mut aya::programs::cgroup_device::CgroupDevice::Error = aya::programs::ProgramError
 pub fn &'a mut aya::programs::cgroup_device::CgroupDevice::try_from(program: &'a mut aya::programs::Program) -> core::result::Result<&'a mut aya::programs::cgroup_device::CgroupDevice, aya::programs::ProgramError>
+impl core::marker::Freeze for aya::programs::cgroup_device::CgroupDevice
 impl core::marker::Send for aya::programs::cgroup_device::CgroupDevice
 impl core::marker::Sync for aya::programs::cgroup_device::CgroupDevice
 impl core::marker::Unpin for aya::programs::cgroup_device::CgroupDevice
@@ -6990,6 +7160,7 @@ pub fn &'a aya::programs::cgroup_skb::CgroupSkb::try_from(program: &'a aya::prog
 impl<'a> core::convert::TryFrom<&'a mut aya::programs::Program> for &'a mut aya::programs::cgroup_skb::CgroupSkb
 pub type &'a mut aya::programs::cgroup_skb::CgroupSkb::Error = aya::programs::ProgramError
 pub fn &'a mut aya::programs::cgroup_skb::CgroupSkb::try_from(program: &'a mut aya::programs::Program) -> core::result::Result<&'a mut aya::programs::cgroup_skb::CgroupSkb, aya::programs::ProgramError>
+impl core::marker::Freeze for aya::programs::cgroup_skb::CgroupSkb
 impl core::marker::Send for aya::programs::cgroup_skb::CgroupSkb
 impl core::marker::Sync for aya::programs::cgroup_skb::CgroupSkb
 impl core::marker::Unpin for aya::programs::cgroup_skb::CgroupSkb
@@ -7037,6 +7208,7 @@ pub fn &'a aya::programs::cgroup_sock::CgroupSock::try_from(program: &'a aya::pr
 impl<'a> core::convert::TryFrom<&'a mut aya::programs::Program> for &'a mut aya::programs::cgroup_sock::CgroupSock
 pub type &'a mut aya::programs::cgroup_sock::CgroupSock::Error = aya::programs::ProgramError
 pub fn &'a mut aya::programs::cgroup_sock::CgroupSock::try_from(program: &'a mut aya::programs::Program) -> core::result::Result<&'a mut aya::programs::cgroup_sock::CgroupSock, aya::programs::ProgramError>
+impl core::marker::Freeze for aya::programs::cgroup_sock::CgroupSock
 impl core::marker::Send for aya::programs::cgroup_sock::CgroupSock
 impl core::marker::Sync for aya::programs::cgroup_sock::CgroupSock
 impl core::marker::Unpin for aya::programs::cgroup_sock::CgroupSock
@@ -7084,6 +7256,7 @@ pub fn &'a aya::programs::cgroup_sock_addr::CgroupSockAddr::try_from(program: &'
 impl<'a> core::convert::TryFrom<&'a mut aya::programs::Program> for &'a mut aya::programs::cgroup_sock_addr::CgroupSockAddr
 pub type &'a mut aya::programs::cgroup_sock_addr::CgroupSockAddr::Error = aya::programs::ProgramError
 pub fn &'a mut aya::programs::cgroup_sock_addr::CgroupSockAddr::try_from(program: &'a mut aya::programs::Program) -> core::result::Result<&'a mut aya::programs::cgroup_sock_addr::CgroupSockAddr, aya::programs::ProgramError>
+impl core::marker::Freeze for aya::programs::cgroup_sock_addr::CgroupSockAddr
 impl core::marker::Send for aya::programs::cgroup_sock_addr::CgroupSockAddr
 impl core::marker::Sync for aya::programs::cgroup_sock_addr::CgroupSockAddr
 impl core::marker::Unpin for aya::programs::cgroup_sock_addr::CgroupSockAddr
@@ -7131,6 +7304,7 @@ pub fn &'a aya::programs::cgroup_sockopt::CgroupSockopt::try_from(program: &'a a
 impl<'a> core::convert::TryFrom<&'a mut aya::programs::Program> for &'a mut aya::programs::cgroup_sockopt::CgroupSockopt
 pub type &'a mut aya::programs::cgroup_sockopt::CgroupSockopt::Error = aya::programs::ProgramError
 pub fn &'a mut aya::programs::cgroup_sockopt::CgroupSockopt::try_from(program: &'a mut aya::programs::Program) -> core::result::Result<&'a mut aya::programs::cgroup_sockopt::CgroupSockopt, aya::programs::ProgramError>
+impl core::marker::Freeze for aya::programs::cgroup_sockopt::CgroupSockopt
 impl core::marker::Send for aya::programs::cgroup_sockopt::CgroupSockopt
 impl core::marker::Sync for aya::programs::cgroup_sockopt::CgroupSockopt
 impl core::marker::Unpin for aya::programs::cgroup_sockopt::CgroupSockopt
@@ -7179,6 +7353,7 @@ pub fn &'a aya::programs::cgroup_sysctl::CgroupSysctl::try_from(program: &'a aya
 impl<'a> core::convert::TryFrom<&'a mut aya::programs::Program> for &'a mut aya::programs::cgroup_sysctl::CgroupSysctl
 pub type &'a mut aya::programs::cgroup_sysctl::CgroupSysctl::Error = aya::programs::ProgramError
 pub fn &'a mut aya::programs::cgroup_sysctl::CgroupSysctl::try_from(program: &'a mut aya::programs::Program) -> core::result::Result<&'a mut aya::programs::cgroup_sysctl::CgroupSysctl, aya::programs::ProgramError>
+impl core::marker::Freeze for aya::programs::cgroup_sysctl::CgroupSysctl
 impl core::marker::Send for aya::programs::cgroup_sysctl::CgroupSysctl
 impl core::marker::Sync for aya::programs::cgroup_sysctl::CgroupSysctl
 impl core::marker::Unpin for aya::programs::cgroup_sysctl::CgroupSysctl
@@ -7228,6 +7403,7 @@ pub fn &'a aya::programs::extension::Extension::try_from(program: &'a aya::progr
 impl<'a> core::convert::TryFrom<&'a mut aya::programs::Program> for &'a mut aya::programs::extension::Extension
 pub type &'a mut aya::programs::extension::Extension::Error = aya::programs::ProgramError
 pub fn &'a mut aya::programs::extension::Extension::try_from(program: &'a mut aya::programs::Program) -> core::result::Result<&'a mut aya::programs::extension::Extension, aya::programs::ProgramError>
+impl core::marker::Freeze for aya::programs::extension::Extension
 impl core::marker::Send for aya::programs::extension::Extension
 impl core::marker::Sync for aya::programs::extension::Extension
 impl core::marker::Unpin for aya::programs::extension::Extension
@@ -7276,6 +7452,7 @@ pub fn &'a aya::programs::fentry::FEntry::try_from(program: &'a aya::programs::P
 impl<'a> core::convert::TryFrom<&'a mut aya::programs::Program> for &'a mut aya::programs::fentry::FEntry
 pub type &'a mut aya::programs::fentry::FEntry::Error = aya::programs::ProgramError
 pub fn &'a mut aya::programs::fentry::FEntry::try_from(program: &'a mut aya::programs::Program) -> core::result::Result<&'a mut aya::programs::fentry::FEntry, aya::programs::ProgramError>
+impl core::marker::Freeze for aya::programs::fentry::FEntry
 impl core::marker::Send for aya::programs::fentry::FEntry
 impl core::marker::Sync for aya::programs::fentry::FEntry
 impl core::marker::Unpin for aya::programs::fentry::FEntry
@@ -7324,6 +7501,7 @@ pub fn &'a aya::programs::fexit::FExit::try_from(program: &'a aya::programs::Pro
 impl<'a> core::convert::TryFrom<&'a mut aya::programs::Program> for &'a mut aya::programs::fexit::FExit
 pub type &'a mut aya::programs::fexit::FExit::Error = aya::programs::ProgramError
 pub fn &'a mut aya::programs::fexit::FExit::try_from(program: &'a mut aya::programs::Program) -> core::result::Result<&'a mut aya::programs::fexit::FExit, aya::programs::ProgramError>
+impl core::marker::Freeze for aya::programs::fexit::FExit
 impl core::marker::Send for aya::programs::fexit::FExit
 impl core::marker::Sync for aya::programs::fexit::FExit
 impl core::marker::Unpin for aya::programs::fexit::FExit
@@ -7372,6 +7550,7 @@ pub fn &'a aya::programs::kprobe::KProbe::try_from(program: &'a aya::programs::P
 impl<'a> core::convert::TryFrom<&'a mut aya::programs::Program> for &'a mut aya::programs::kprobe::KProbe
 pub type &'a mut aya::programs::kprobe::KProbe::Error = aya::programs::ProgramError
 pub fn &'a mut aya::programs::kprobe::KProbe::try_from(program: &'a mut aya::programs::Program) -> core::result::Result<&'a mut aya::programs::kprobe::KProbe, aya::programs::ProgramError>
+impl core::marker::Freeze for aya::programs::kprobe::KProbe
 impl core::marker::Send for aya::programs::kprobe::KProbe
 impl core::marker::Sync for aya::programs::kprobe::KProbe
 impl core::marker::Unpin for aya::programs::kprobe::KProbe
@@ -7421,6 +7600,7 @@ pub fn &'a aya::programs::lirc_mode2::LircMode2::try_from(program: &'a aya::prog
 impl<'a> core::convert::TryFrom<&'a mut aya::programs::Program> for &'a mut aya::programs::lirc_mode2::LircMode2
 pub type &'a mut aya::programs::lirc_mode2::LircMode2::Error = aya::programs::ProgramError
 pub fn &'a mut aya::programs::lirc_mode2::LircMode2::try_from(program: &'a mut aya::programs::Program) -> core::result::Result<&'a mut aya::programs::lirc_mode2::LircMode2, aya::programs::ProgramError>
+impl core::marker::Freeze for aya::programs::lirc_mode2::LircMode2
 impl core::marker::Send for aya::programs::lirc_mode2::LircMode2
 impl core::marker::Sync for aya::programs::lirc_mode2::LircMode2
 impl core::marker::Unpin for aya::programs::lirc_mode2::LircMode2
@@ -7469,6 +7649,7 @@ pub fn &'a aya::programs::lsm::Lsm::try_from(program: &'a aya::programs::Program
 impl<'a> core::convert::TryFrom<&'a mut aya::programs::Program> for &'a mut aya::programs::lsm::Lsm
 pub type &'a mut aya::programs::lsm::Lsm::Error = aya::programs::ProgramError
 pub fn &'a mut aya::programs::lsm::Lsm::try_from(program: &'a mut aya::programs::Program) -> core::result::Result<&'a mut aya::programs::lsm::Lsm, aya::programs::ProgramError>
+impl core::marker::Freeze for aya::programs::lsm::Lsm
 impl core::marker::Send for aya::programs::lsm::Lsm
 impl core::marker::Sync for aya::programs::lsm::Lsm
 impl core::marker::Unpin for aya::programs::lsm::Lsm
@@ -7517,6 +7698,7 @@ pub fn &'a aya::programs::perf_event::PerfEvent::try_from(program: &'a aya::prog
 impl<'a> core::convert::TryFrom<&'a mut aya::programs::Program> for &'a mut aya::programs::perf_event::PerfEvent
 pub type &'a mut aya::programs::perf_event::PerfEvent::Error = aya::programs::ProgramError
 pub fn &'a mut aya::programs::perf_event::PerfEvent::try_from(program: &'a mut aya::programs::Program) -> core::result::Result<&'a mut aya::programs::perf_event::PerfEvent, aya::programs::ProgramError>
+impl core::marker::Freeze for aya::programs::perf_event::PerfEvent
 impl core::marker::Send for aya::programs::perf_event::PerfEvent
 impl core::marker::Sync for aya::programs::perf_event::PerfEvent
 impl core::marker::Unpin for aya::programs::perf_event::PerfEvent
@@ -7545,6 +7727,7 @@ impl core::fmt::Debug for aya::programs::ProgramFd
 pub fn aya::programs::ProgramFd::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl std::os::fd::owned::AsFd for aya::programs::ProgramFd
 pub fn aya::programs::ProgramFd::as_fd(&self) -> std::os::fd::owned::BorrowedFd<'_>
+impl core::marker::Freeze for aya::programs::ProgramFd
 impl core::marker::Send for aya::programs::ProgramFd
 impl core::marker::Sync for aya::programs::ProgramFd
 impl core::marker::Unpin for aya::programs::ProgramFd
@@ -7585,6 +7768,7 @@ pub fn aya::programs::ProgramInfo::tag(&self) -> u64
 pub fn aya::programs::ProgramInfo::verified_instruction_count(&self) -> u32
 impl core::fmt::Debug for aya::programs::ProgramInfo
 pub fn aya::programs::ProgramInfo::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for aya::programs::ProgramInfo
 impl core::marker::Send for aya::programs::ProgramInfo
 impl core::marker::Sync for aya::programs::ProgramInfo
 impl core::marker::Unpin for aya::programs::ProgramInfo
@@ -7633,6 +7817,7 @@ pub fn &'a aya::programs::raw_trace_point::RawTracePoint::try_from(program: &'a 
 impl<'a> core::convert::TryFrom<&'a mut aya::programs::Program> for &'a mut aya::programs::raw_trace_point::RawTracePoint
 pub type &'a mut aya::programs::raw_trace_point::RawTracePoint::Error = aya::programs::ProgramError
 pub fn &'a mut aya::programs::raw_trace_point::RawTracePoint::try_from(program: &'a mut aya::programs::Program) -> core::result::Result<&'a mut aya::programs::raw_trace_point::RawTracePoint, aya::programs::ProgramError>
+impl core::marker::Freeze for aya::programs::raw_trace_point::RawTracePoint
 impl core::marker::Send for aya::programs::raw_trace_point::RawTracePoint
 impl core::marker::Sync for aya::programs::raw_trace_point::RawTracePoint
 impl core::marker::Unpin for aya::programs::raw_trace_point::RawTracePoint
@@ -7682,6 +7867,7 @@ pub fn &'a aya::programs::tc::SchedClassifier::try_from(program: &'a aya::progra
 impl<'a> core::convert::TryFrom<&'a mut aya::programs::Program> for &'a mut aya::programs::tc::SchedClassifier
 pub type &'a mut aya::programs::tc::SchedClassifier::Error = aya::programs::ProgramError
 pub fn &'a mut aya::programs::tc::SchedClassifier::try_from(program: &'a mut aya::programs::Program) -> core::result::Result<&'a mut aya::programs::tc::SchedClassifier, aya::programs::ProgramError>
+impl core::marker::Freeze for aya::programs::tc::SchedClassifier
 impl core::marker::Send for aya::programs::tc::SchedClassifier
 impl core::marker::Sync for aya::programs::tc::SchedClassifier
 impl core::marker::Unpin for aya::programs::tc::SchedClassifier
@@ -7730,6 +7916,7 @@ pub fn &'a aya::programs::sk_lookup::SkLookup::try_from(program: &'a aya::progra
 impl<'a> core::convert::TryFrom<&'a mut aya::programs::Program> for &'a mut aya::programs::sk_lookup::SkLookup
 pub type &'a mut aya::programs::sk_lookup::SkLookup::Error = aya::programs::ProgramError
 pub fn &'a mut aya::programs::sk_lookup::SkLookup::try_from(program: &'a mut aya::programs::Program) -> core::result::Result<&'a mut aya::programs::sk_lookup::SkLookup, aya::programs::ProgramError>
+impl core::marker::Freeze for aya::programs::sk_lookup::SkLookup
 impl core::marker::Send for aya::programs::sk_lookup::SkLookup
 impl core::marker::Sync for aya::programs::sk_lookup::SkLookup
 impl core::marker::Unpin for aya::programs::sk_lookup::SkLookup
@@ -7778,6 +7965,7 @@ pub fn &'a aya::programs::sk_msg::SkMsg::try_from(program: &'a aya::programs::Pr
 impl<'a> core::convert::TryFrom<&'a mut aya::programs::Program> for &'a mut aya::programs::sk_msg::SkMsg
 pub type &'a mut aya::programs::sk_msg::SkMsg::Error = aya::programs::ProgramError
 pub fn &'a mut aya::programs::sk_msg::SkMsg::try_from(program: &'a mut aya::programs::Program) -> core::result::Result<&'a mut aya::programs::sk_msg::SkMsg, aya::programs::ProgramError>
+impl core::marker::Freeze for aya::programs::sk_msg::SkMsg
 impl core::marker::Send for aya::programs::sk_msg::SkMsg
 impl core::marker::Sync for aya::programs::sk_msg::SkMsg
 impl core::marker::Unpin for aya::programs::sk_msg::SkMsg
@@ -7825,6 +8013,7 @@ pub fn &'a aya::programs::sk_skb::SkSkb::try_from(program: &'a aya::programs::Pr
 impl<'a> core::convert::TryFrom<&'a mut aya::programs::Program> for &'a mut aya::programs::sk_skb::SkSkb
 pub type &'a mut aya::programs::sk_skb::SkSkb::Error = aya::programs::ProgramError
 pub fn &'a mut aya::programs::sk_skb::SkSkb::try_from(program: &'a mut aya::programs::Program) -> core::result::Result<&'a mut aya::programs::sk_skb::SkSkb, aya::programs::ProgramError>
+impl core::marker::Freeze for aya::programs::sk_skb::SkSkb
 impl core::marker::Send for aya::programs::sk_skb::SkSkb
 impl core::marker::Sync for aya::programs::sk_skb::SkSkb
 impl core::marker::Unpin for aya::programs::sk_skb::SkSkb
@@ -7873,6 +8062,7 @@ pub fn &'a aya::programs::sock_ops::SockOps::try_from(program: &'a aya::programs
 impl<'a> core::convert::TryFrom<&'a mut aya::programs::Program> for &'a mut aya::programs::sock_ops::SockOps
 pub type &'a mut aya::programs::sock_ops::SockOps::Error = aya::programs::ProgramError
 pub fn &'a mut aya::programs::sock_ops::SockOps::try_from(program: &'a mut aya::programs::Program) -> core::result::Result<&'a mut aya::programs::sock_ops::SockOps, aya::programs::ProgramError>
+impl core::marker::Freeze for aya::programs::sock_ops::SockOps
 impl core::marker::Send for aya::programs::sock_ops::SockOps
 impl core::marker::Sync for aya::programs::sock_ops::SockOps
 impl core::marker::Unpin for aya::programs::sock_ops::SockOps
@@ -7921,6 +8111,7 @@ pub fn &'a aya::programs::socket_filter::SocketFilter::try_from(program: &'a aya
 impl<'a> core::convert::TryFrom<&'a mut aya::programs::Program> for &'a mut aya::programs::socket_filter::SocketFilter
 pub type &'a mut aya::programs::socket_filter::SocketFilter::Error = aya::programs::ProgramError
 pub fn &'a mut aya::programs::socket_filter::SocketFilter::try_from(program: &'a mut aya::programs::Program) -> core::result::Result<&'a mut aya::programs::socket_filter::SocketFilter, aya::programs::ProgramError>
+impl core::marker::Freeze for aya::programs::socket_filter::SocketFilter
 impl core::marker::Send for aya::programs::socket_filter::SocketFilter
 impl core::marker::Sync for aya::programs::socket_filter::SocketFilter
 impl core::marker::Unpin for aya::programs::socket_filter::SocketFilter
@@ -7969,6 +8160,7 @@ pub fn &'a aya::programs::trace_point::TracePoint::try_from(program: &'a aya::pr
 impl<'a> core::convert::TryFrom<&'a mut aya::programs::Program> for &'a mut aya::programs::trace_point::TracePoint
 pub type &'a mut aya::programs::trace_point::TracePoint::Error = aya::programs::ProgramError
 pub fn &'a mut aya::programs::trace_point::TracePoint::try_from(program: &'a mut aya::programs::Program) -> core::result::Result<&'a mut aya::programs::trace_point::TracePoint, aya::programs::ProgramError>
+impl core::marker::Freeze for aya::programs::trace_point::TracePoint
 impl core::marker::Send for aya::programs::trace_point::TracePoint
 impl core::marker::Sync for aya::programs::trace_point::TracePoint
 impl core::marker::Unpin for aya::programs::trace_point::TracePoint
@@ -8017,6 +8209,7 @@ pub fn &'a aya::programs::uprobe::UProbe::try_from(program: &'a aya::programs::P
 impl<'a> core::convert::TryFrom<&'a mut aya::programs::Program> for &'a mut aya::programs::uprobe::UProbe
 pub type &'a mut aya::programs::uprobe::UProbe::Error = aya::programs::ProgramError
 pub fn &'a mut aya::programs::uprobe::UProbe::try_from(program: &'a mut aya::programs::Program) -> core::result::Result<&'a mut aya::programs::uprobe::UProbe, aya::programs::ProgramError>
+impl core::marker::Freeze for aya::programs::uprobe::UProbe
 impl core::marker::Send for aya::programs::uprobe::UProbe
 impl core::marker::Sync for aya::programs::uprobe::UProbe
 impl core::marker::Unpin for aya::programs::uprobe::UProbe
@@ -8066,6 +8259,7 @@ pub fn &'a aya::programs::xdp::Xdp::try_from(program: &'a aya::programs::Program
 impl<'a> core::convert::TryFrom<&'a mut aya::programs::Program> for &'a mut aya::programs::xdp::Xdp
 pub type &'a mut aya::programs::xdp::Xdp::Error = aya::programs::ProgramError
 pub fn &'a mut aya::programs::xdp::Xdp::try_from(program: &'a mut aya::programs::Program) -> core::result::Result<&'a mut aya::programs::xdp::Xdp, aya::programs::ProgramError>
+impl core::marker::Freeze for aya::programs::xdp::Xdp
 impl core::marker::Send for aya::programs::xdp::Xdp
 impl core::marker::Sync for aya::programs::xdp::Xdp
 impl core::marker::Unpin for aya::programs::xdp::Xdp
@@ -8172,6 +8366,7 @@ pub fn aya::programs::xdp::XdpFlags::bitxor_assign(&mut self, other: Self)
 impl core::ops::bit::Not for aya::programs::xdp::XdpFlags
 pub type aya::programs::xdp::XdpFlags::Output = aya::programs::xdp::XdpFlags
 pub fn aya::programs::xdp::XdpFlags::not(self) -> Self
+impl core::marker::Freeze for aya::programs::xdp::XdpFlags
 impl core::marker::Send for aya::programs::xdp::XdpFlags
 impl core::marker::Sync for aya::programs::xdp::XdpFlags
 impl core::marker::Unpin for aya::programs::xdp::XdpFlags
@@ -8327,6 +8522,7 @@ impl core::fmt::Debug for aya::util::KernelVersion
 pub fn aya::util::KernelVersion::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Copy for aya::util::KernelVersion
 impl core::marker::StructuralPartialEq for aya::util::KernelVersion
+impl core::marker::Freeze for aya::util::KernelVersion
 impl core::marker::Send for aya::util::KernelVersion
 impl core::marker::Sync for aya::util::KernelVersion
 impl core::marker::Unpin for aya::util::KernelVersion
@@ -8388,6 +8584,7 @@ impl core::fmt::Debug for aya::EbpfError
 pub fn aya::EbpfError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::fmt::Display for aya::EbpfError
 pub fn aya::EbpfError::fmt(&self, __formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for aya::EbpfError
 impl core::marker::Send for aya::EbpfError
 impl core::marker::Sync for aya::EbpfError
 impl core::marker::Unpin for aya::EbpfError
@@ -8426,6 +8623,7 @@ pub fn aya::Ebpf::programs_mut(&mut self) -> impl core::iter::traits::iterator::
 pub fn aya::Ebpf::take_map(&mut self, name: &str) -> core::option::Option<aya::maps::Map>
 impl core::fmt::Debug for aya::Ebpf
 pub fn aya::Ebpf::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for aya::Ebpf
 impl core::marker::Send for aya::Ebpf
 impl core::marker::Sync for aya::Ebpf
 impl core::marker::Unpin for aya::Ebpf
@@ -8463,6 +8661,7 @@ impl core::default::Default for aya::EbpfLoader<'_>
 pub fn aya::EbpfLoader<'_>::default() -> Self
 impl<'a> core::fmt::Debug for aya::EbpfLoader<'a>
 pub fn aya::EbpfLoader<'a>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl<'a> core::marker::Freeze for aya::EbpfLoader<'a>
 impl<'a> core::marker::Send for aya::EbpfLoader<'a>
 impl<'a> core::marker::Sync for aya::EbpfLoader<'a>
 impl<'a> core::marker::Unpin for aya::EbpfLoader<'a>
@@ -8489,6 +8688,7 @@ impl<'a, T: aya::Pod> core::convert::From<&'a T> for aya::GlobalData<'a>
 pub fn aya::GlobalData<'a>::from(v: &'a T) -> Self
 impl<'a, T: aya::Pod> core::convert::From<&'a [T]> for aya::GlobalData<'a>
 pub fn aya::GlobalData<'a>::from(s: &'a [T]) -> Self
+impl<'a> core::marker::Freeze for aya::GlobalData<'a>
 impl<'a> core::marker::Send for aya::GlobalData<'a>
 impl<'a> core::marker::Sync for aya::GlobalData<'a>
 impl<'a> core::marker::Unpin for aya::GlobalData<'a>
@@ -8594,6 +8794,7 @@ pub fn aya::VerifierLogLevel::bitxor_assign(&mut self, other: Self)
 impl core::ops::bit::Not for aya::VerifierLogLevel
 pub type aya::VerifierLogLevel::Output = aya::VerifierLogLevel
 pub fn aya::VerifierLogLevel::not(self) -> Self
+impl core::marker::Freeze for aya::VerifierLogLevel
 impl core::marker::Send for aya::VerifierLogLevel
 impl core::marker::Sync for aya::VerifierLogLevel
 impl core::marker::Unpin for aya::VerifierLogLevel


### PR DESCRIPTION
Nightly now exposes `core::marker::Freeze`.

https://github.com/rust-lang/rust/pull/121840
