### PR TITLE
integration-test: Set `rust-lld` as a linker only on macOS 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -202,18 +202,68 @@ jobs:
           - target: x86_64-unknown-linux-gnu
             # We don't use ubuntu-latest because we care about the apt packages available.
             os: ubuntu-22.04
+          - target: x86_64-unknown-linux-musl
+            os: ubuntu-22.04
+            container:
+              image: docker.io/alpine:3.20
+              options: --privileged -v /sys/fs/bpf:/sys/fs/bpf -v /sys/kernel:/sys/kernel
     runs-on: ${{ matrix.os }}
+    container: ${{ matrix.container }}
     steps:
-      - uses: actions/checkout@v4
-        with:
-          submodules: recursive
+      - name: Install prerequisites
+        if: runner.os == 'Linux' && contains(matrix.container.image, 'alpine')
+        # bash is used in the `rust-toolchain` action.
+        #
+        # clang and make are needed for building the C eBPF programs, which are
+        # part of the integration tests.
+        #
+        # curl, file and jq are used in the steps below.
+        #
+        # dpkg is used to unpack the kernel images from .deb packages, which we
+        # use for virtualized tests. lynx is used to download them.
+        #
+        # gcc is needed as a linker, it also provides the runtime library, both
+        # needed by Rust.
+        #
+        # git is needed for the `checkout` action.
+        #
+        # libstdc++ is a dependency of llvm-sys, which is a dependency of
+        # bpf-linker.
+        #
+        # musl-dev provides CRT objects, which are linked by Rust.
+        #
+        # QEMU is used to run virtualized integration tests.
+        #
+        # sudo is needed by integration tests.
+        run: |
+          set -euxo pipefail
+          apk add \
+            bash \
+            clang \
+            curl \
+            dpkg \
+            file \
+            gcc \
+            git \
+            jq \
+            libstdc++-dev \
+            lynx \
+            make \
+            musl-dev \
+            qemu-system-arm \
+            qemu-system-x86_64 \
+            sudo
 
       - name: Install prerequisites
-        if: runner.os == 'Linux'
+        if: runner.os == 'Linux' && matrix.container == ''
         # ubuntu-22.04 comes with clang 13-15[0]; support for signed and 64bit
         # enum values was added in clang 15[1] which isn't in `$PATH`.
         #
         # gcc-multilib provides at least <asm/types.h> which is referenced by libbpf.
+        #
+        # lynx is used to download kernel images.
+        #
+        # QEMU is used to run virtualized integration tests.
         #
         # [0] https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2204-Readme.md
         #
@@ -223,6 +273,26 @@ jobs:
           sudo apt update
           sudo apt -y install gcc-multilib lynx qemu-system-{arm,x86}
           echo /usr/lib/llvm-15/bin >> $GITHUB_PATH
+
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      # When running in a container as root, git throws the following error:
+      #
+      # fatal: detected dubious ownership in repository at '/__w/aya/aya'
+      #
+      # Which makes a lot of sense, not running regular git commands as root is
+      # a good thing. However, using a container image with a regular user
+      # results in permission errors thrown by the runner binary.[0] It's most
+      # likely because of a host volume mount which is owned by root. It would
+      # be great to make it work, but it's not going to be trivial and might
+      # require changes in the runner code itself.
+      #
+      # [0] https://github.com/aya-rs/aya/actions/runs/12034434029/job/33550963904
+      - name: Mark the directory as safe for git
+        if: matrix.container != ''
+        run: git config --global --add safe.directory /__w/aya/aya
 
       - name: Install prerequisites
         if: runner.os == 'macOS'

--- a/test/integration-test/src/tests/iter.rs
+++ b/test/integration-test/src/tests/iter.rs
@@ -1,4 +1,4 @@
-use std::io::BufRead;
+use std::{env, io::BufRead, path::Path};
 
 use aya::{programs::Iter, Btf, Ebpf};
 use test_log::test;
@@ -20,11 +20,15 @@ fn iter_task() {
     let line_init = lines.next().unwrap().unwrap();
 
     assert_eq!(line_title, "tgid     pid      name");
-    let expected_values = ["1        1        init", "1        1        systemd"];
-    assert!(
-        expected_values.contains(&line_init.as_str()),
-        "Unexpected line_init value: '{}', expected one of: {:?}",
-        line_init,
-        expected_values
-    );
+    // It's hard to predict what's the PID of the first process in a container.
+    // Use this assertion only on non-containerized systems.
+    if !Path::new("/.dockerenv").exists() && env::var_os("container").is_none() {
+        let expected_values = ["1        1        init", "1        1        systemd"];
+        assert!(
+            expected_values.contains(&line_init.as_str()),
+            "Unexpected line_init value: '{}', expected one of: {:?}",
+            line_init,
+            expected_values
+        );
+    }
 }


### PR DESCRIPTION
The recommendation (coming from rust-lang/rust#130062) for Linux hosts
is using C compiler driver as a linker, which is able to find
system-wide libraries. Using linker binaries directly in `-C linker`
(e.g. `-C linker=rust-lld`) often results in errors like:

```
cargo:warning=error: linking with `rust-lld` failed: exit status: 1ger, ppv-lite86, libc...
cargo:warning=  |
cargo:warning=  = note: LC_ALL="C" PATH="/home/vadorovsky/.rustup/toolchains/stable-x86_64-un
cargo:warning=  = note: rust-lld: error: unable to find library -lgcc_s
cargo:warning=          rust-lld: error: unable to find library -lc
cargo:warning=
cargo:warning=
cargo:warning=
cargo:warning=error: aborting due to 1 previous error
```

Not touching the linker settings is usually the best approach for Linux
systems. Native builds pick up the default C toolchain. Cross builds
default to GCC cross wrapper, but that's easy to supress with clang
and lld using RUSTFLAGS.

However, `-C linker=rust-lld` still works the best on macOS, where
Rust toolchains come with unwinder and runtime and there is usually no
need to link system libraries. Keep setting it only for macOS.

Fixes #907

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aya-rs/aya/908)
<!-- Reviewable:end -->
