### PR TITLE
Appease clippy

### DIFF
--- a/aya/src/bpf.rs
+++ b/aya/src/bpf.rs
@@ -195,7 +195,7 @@ impl<'a> EbpfLoader<'a> {
     ///
     /// # Ok::<(), aya::EbpfError>(())
     /// ```
-    pub fn btf(&mut self, btf: Option<&'a Btf>) -> &mut EbpfLoader<'a> {
+    pub fn btf(&mut self, btf: Option<&'a Btf>) -> &mut Self {
         self.btf = btf.map(Cow::Borrowed);
         self
     }
@@ -219,7 +219,7 @@ impl<'a> EbpfLoader<'a> {
     /// # Ok::<(), aya::EbpfError>(())
     /// ```
     ///
-    pub fn allow_unsupported_maps(&mut self) -> &mut EbpfLoader<'a> {
+    pub fn allow_unsupported_maps(&mut self) -> &mut Self {
         self.allow_unsupported_maps = true;
         self
     }
@@ -240,7 +240,7 @@ impl<'a> EbpfLoader<'a> {
     /// # Ok::<(), aya::EbpfError>(())
     /// ```
     ///
-    pub fn map_pin_path<P: AsRef<Path>>(&mut self, path: P) -> &mut EbpfLoader<'a> {
+    pub fn map_pin_path<P: AsRef<Path>>(&mut self, path: P) -> &mut Self {
         self.map_pin_path = Some(path.as_ref().to_owned());
         self
     }
@@ -289,7 +289,7 @@ impl<'a> EbpfLoader<'a> {
         name: &'a str,
         value: T,
         must_exist: bool,
-    ) -> &mut EbpfLoader<'a> {
+    ) -> &mut Self {
         self.globals.insert(name, (value.into().bytes, must_exist));
         self
     }
@@ -310,7 +310,7 @@ impl<'a> EbpfLoader<'a> {
     /// # Ok::<(), aya::EbpfError>(())
     /// ```
     ///
-    pub fn set_max_entries(&mut self, name: &'a str, size: u32) -> &mut EbpfLoader<'a> {
+    pub fn set_max_entries(&mut self, name: &'a str, size: u32) -> &mut Self {
         self.max_entries.insert(name, size);
         self
     }
@@ -332,7 +332,7 @@ impl<'a> EbpfLoader<'a> {
     /// # Ok::<(), aya::EbpfError>(())
     /// ```
     ///
-    pub fn extension(&mut self, name: &'a str) -> &mut EbpfLoader<'a> {
+    pub fn extension(&mut self, name: &'a str) -> &mut Self {
         self.extensions.insert(name);
         self
     }
@@ -350,7 +350,7 @@ impl<'a> EbpfLoader<'a> {
     /// # Ok::<(), aya::EbpfError>(())
     /// ```
     ///
-    pub fn verifier_log_level(&mut self, level: VerifierLogLevel) -> &mut EbpfLoader<'a> {
+    pub fn verifier_log_level(&mut self, level: VerifierLogLevel) -> &mut Self {
         self.verifier_log_level = level;
         self
     }

--- a/test/integration-test/src/tests/btf_relocations.rs
+++ b/test/integration-test/src/tests/btf_relocations.rs
@@ -1,6 +1,8 @@
 use aya::{maps::Array, programs::UProbe, util::KernelVersion, Btf, EbpfLoader, Endianness};
 use test_case::test_case;
 
+// False positive, see: https://github.com/rust-lang/rust-clippy/issues/12537.
+#[allow(clippy::duplicated_attributes)]
 #[test_case("enum_signed_32", false, Some((KernelVersion::new(6, 0, 0), "https://github.com/torvalds/linux/commit/6089fb3")), -0x7AAAAAAAi32 as u64)]
 #[test_case("enum_signed_32", true, Some((KernelVersion::new(6, 0, 0), "https://github.com/torvalds/linux/commit/6089fb3")), -0x7BBBBBBBi32 as u64)]
 #[test_case("enum_signed_32_checked_variants", false, Some((KernelVersion::new(6, 0, 0), "https://github.com/torvalds/linux/commit/6089fb3")), -0x7AAAAAAAi32 as u64)]

--- a/xtask/public-api/aya.txt
+++ b/xtask/public-api/aya.txt
@@ -8647,16 +8647,16 @@ impl<T> core::convert::From<T> for aya::Ebpf
 pub fn aya::Ebpf::from(t: T) -> T
 pub struct aya::EbpfLoader<'a>
 impl<'a> aya::EbpfLoader<'a>
-pub fn aya::EbpfLoader<'a>::allow_unsupported_maps(&mut self) -> &mut aya::EbpfLoader<'a>
-pub fn aya::EbpfLoader<'a>::btf(&mut self, btf: core::option::Option<&'a aya_obj::btf::btf::Btf>) -> &mut aya::EbpfLoader<'a>
-pub fn aya::EbpfLoader<'a>::extension(&mut self, name: &'a str) -> &mut aya::EbpfLoader<'a>
+pub fn aya::EbpfLoader<'a>::allow_unsupported_maps(&mut self) -> &mut Self
+pub fn aya::EbpfLoader<'a>::btf(&mut self, btf: core::option::Option<&'a aya_obj::btf::btf::Btf>) -> &mut Self
+pub fn aya::EbpfLoader<'a>::extension(&mut self, name: &'a str) -> &mut Self
 pub fn aya::EbpfLoader<'a>::load(&mut self, data: &[u8]) -> core::result::Result<aya::Ebpf, aya::EbpfError>
 pub fn aya::EbpfLoader<'a>::load_file<P: core::convert::AsRef<std::path::Path>>(&mut self, path: P) -> core::result::Result<aya::Ebpf, aya::EbpfError>
-pub fn aya::EbpfLoader<'a>::map_pin_path<P: core::convert::AsRef<std::path::Path>>(&mut self, path: P) -> &mut aya::EbpfLoader<'a>
+pub fn aya::EbpfLoader<'a>::map_pin_path<P: core::convert::AsRef<std::path::Path>>(&mut self, path: P) -> &mut Self
 pub fn aya::EbpfLoader<'a>::new() -> Self
-pub fn aya::EbpfLoader<'a>::set_global<T: core::convert::Into<aya::GlobalData<'a>>>(&mut self, name: &'a str, value: T, must_exist: bool) -> &mut aya::EbpfLoader<'a>
-pub fn aya::EbpfLoader<'a>::set_max_entries(&mut self, name: &'a str, size: u32) -> &mut aya::EbpfLoader<'a>
-pub fn aya::EbpfLoader<'a>::verifier_log_level(&mut self, level: aya::VerifierLogLevel) -> &mut aya::EbpfLoader<'a>
+pub fn aya::EbpfLoader<'a>::set_global<T: core::convert::Into<aya::GlobalData<'a>>>(&mut self, name: &'a str, value: T, must_exist: bool) -> &mut Self
+pub fn aya::EbpfLoader<'a>::set_max_entries(&mut self, name: &'a str, size: u32) -> &mut Self
+pub fn aya::EbpfLoader<'a>::verifier_log_level(&mut self, level: aya::VerifierLogLevel) -> &mut Self
 impl core::default::Default for aya::EbpfLoader<'_>
 pub fn aya::EbpfLoader<'_>::default() -> Self
 impl<'a> core::fmt::Debug for aya::EbpfLoader<'a>


### PR DESCRIPTION
```
  error: unnecessary structure name repetition
     --> aya/src/bpf.rs:198:57
      |
  198 |     pub fn btf(&mut self, btf: Option<&'a Btf>) -> &mut EbpfLoader<'a> {
      |                                                         ^^^^^^^^^^^^^^ help: use the applicable keyword: `Self`
      |
      = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#use_self
  note: the lint level is defined here
     --> aya/src/lib.rs:42:5
      |
  42  |     clippy::use_self,
      |     ^^^^^^^^^^^^^^^^

  error: unnecessary structure name repetition
     --> aya/src/bpf.rs:222:54
      |
  222 |     pub fn allow_unsupported_maps(&mut self) -> &mut EbpfLoader<'a> {
      |                                                      ^^^^^^^^^^^^^^ help: use the applicable keyword: `Self`
      |
      = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#use_self

  error: unnecessary structure name repetition
     --> aya/src/bpf.rs:243:69
      |
  243 |     pub fn map_pin_path<P: AsRef<Path>>(&mut self, path: P) -> &mut EbpfLoader<'a> {
      |                                                                     ^^^^^^^^^^^^^^ help: use the applicable keyword: `Self`
      |
      = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#use_self

  error: unnecessary structure name repetition
     --> aya/src/bpf.rs:292:15
      |
  292 |     ) -> &mut EbpfLoader<'a> {
      |               ^^^^^^^^^^^^^^ help: use the applicable keyword: `Self`
      |
      = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#use_self

  error: unnecessary structure name repetition
     --> aya/src/bpf.rs:313:73
      |
  313 |     pub fn set_max_entries(&mut self, name: &'a str, size: u32) -> &mut EbpfLoader<'a> {
      |                                                                         ^^^^^^^^^^^^^^ help: use the applicable keyword: `Self`
      |
      = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#use_self

  error: unnecessary structure name repetition
     --> aya/src/bpf.rs:335:56
      |
  335 |     pub fn extension(&mut self, name: &'a str) -> &mut EbpfLoader<'a> {
      |                                                        ^^^^^^^^^^^^^^ help: use the applicable keyword: `Self`
      |
      = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#use_self

  error: unnecessary structure name repetition
     --> aya/src/bpf.rs:353:75
      |
  353 |     pub fn verifier_log_level(&mut self, level: VerifierLogLevel) -> &mut EbpfLoader<'a> {
      |                                                                           ^^^^^^^^^^^^^^ help: use the applicable keyword: `Self`
      |
      = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#use_self
```

See https://github.com/rust-lang/rust-clippy/pull/12386.
