### PR TITLE
integration-test: Use veth pair instead of lo

### DIFF
--- a/aya-obj/include/linux_wrapper.h
+++ b/aya-obj/include/linux_wrapper.h
@@ -6,6 +6,7 @@
 #include <linux/pkt_cls.h>
 #include <linux/pkt_sched.h>
 #include <linux/rtnetlink.h>
+#include <linux/veth.h>
 
 /* workaround the fact that bindgen can't parse the IOC macros */
 int AYA_PERF_EVENT_IOC_ENABLE = PERF_EVENT_IOC_ENABLE;

--- a/aya-obj/src/generated/linux_bindings_aarch64.rs
+++ b/aya-obj/src/generated/linux_bindings_aarch64.rs
@@ -2384,6 +2384,15 @@ pub const __TCA_BPF_MAX: _bindgen_ty_152 = 12;
 pub type _bindgen_ty_152 = ::core::ffi::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+pub struct ifaddrmsg {
+    pub ifa_family: __u8,
+    pub ifa_prefixlen: __u8,
+    pub ifa_flags: __u8,
+    pub ifa_scope: __u8,
+    pub ifa_index: __u32,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct ifinfomsg {
     pub ifi_family: ::core::ffi::c_uchar,
     pub __ifi_pad: ::core::ffi::c_uchar,
@@ -2421,6 +2430,16 @@ pub const TCA_EGRESS_BLOCK: _bindgen_ty_172 = 14;
 pub const TCA_DUMP_FLAGS: _bindgen_ty_172 = 15;
 pub const __TCA_MAX: _bindgen_ty_172 = 16;
 pub type _bindgen_ty_172 = ::core::ffi::c_uint;
+pub const VETH_INFO_UNSPEC: _bindgen_ty_175 = _bindgen_ty_175::VETH_INFO_UNSPEC;
+pub const VETH_INFO_PEER: _bindgen_ty_175 = _bindgen_ty_175::VETH_INFO_PEER;
+pub const __VETH_INFO_MAX: _bindgen_ty_175 = _bindgen_ty_175::__VETH_INFO_MAX;
+#[repr(u32)]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum _bindgen_ty_175 {
+    VETH_INFO_UNSPEC = 0,
+    VETH_INFO_PEER = 1,
+    __VETH_INFO_MAX = 2,
+}
 pub const AYA_PERF_EVENT_IOC_ENABLE: ::core::ffi::c_int = 9216;
 pub const AYA_PERF_EVENT_IOC_DISABLE: ::core::ffi::c_int = 9217;
 pub const AYA_PERF_EVENT_IOC_SET_BPF: ::core::ffi::c_int = 1074013192;

--- a/aya-obj/src/generated/linux_bindings_armv7.rs
+++ b/aya-obj/src/generated/linux_bindings_armv7.rs
@@ -2384,6 +2384,15 @@ pub const __TCA_BPF_MAX: _bindgen_ty_152 = 12;
 pub type _bindgen_ty_152 = ::core::ffi::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+pub struct ifaddrmsg {
+    pub ifa_family: __u8,
+    pub ifa_prefixlen: __u8,
+    pub ifa_flags: __u8,
+    pub ifa_scope: __u8,
+    pub ifa_index: __u32,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct ifinfomsg {
     pub ifi_family: ::core::ffi::c_uchar,
     pub __ifi_pad: ::core::ffi::c_uchar,
@@ -2421,6 +2430,16 @@ pub const TCA_EGRESS_BLOCK: _bindgen_ty_172 = 14;
 pub const TCA_DUMP_FLAGS: _bindgen_ty_172 = 15;
 pub const __TCA_MAX: _bindgen_ty_172 = 16;
 pub type _bindgen_ty_172 = ::core::ffi::c_uint;
+pub const VETH_INFO_UNSPEC: _bindgen_ty_175 = _bindgen_ty_175::VETH_INFO_UNSPEC;
+pub const VETH_INFO_PEER: _bindgen_ty_175 = _bindgen_ty_175::VETH_INFO_PEER;
+pub const __VETH_INFO_MAX: _bindgen_ty_175 = _bindgen_ty_175::__VETH_INFO_MAX;
+#[repr(u32)]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum _bindgen_ty_175 {
+    VETH_INFO_UNSPEC = 0,
+    VETH_INFO_PEER = 1,
+    __VETH_INFO_MAX = 2,
+}
 pub const AYA_PERF_EVENT_IOC_ENABLE: ::core::ffi::c_int = 9216;
 pub const AYA_PERF_EVENT_IOC_DISABLE: ::core::ffi::c_int = 9217;
 pub const AYA_PERF_EVENT_IOC_SET_BPF: ::core::ffi::c_int = 1074013192;

--- a/aya-obj/src/generated/linux_bindings_riscv64.rs
+++ b/aya-obj/src/generated/linux_bindings_riscv64.rs
@@ -2384,6 +2384,15 @@ pub const __TCA_BPF_MAX: _bindgen_ty_152 = 12;
 pub type _bindgen_ty_152 = ::core::ffi::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+pub struct ifaddrmsg {
+    pub ifa_family: __u8,
+    pub ifa_prefixlen: __u8,
+    pub ifa_flags: __u8,
+    pub ifa_scope: __u8,
+    pub ifa_index: __u32,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct ifinfomsg {
     pub ifi_family: ::core::ffi::c_uchar,
     pub __ifi_pad: ::core::ffi::c_uchar,
@@ -2421,6 +2430,16 @@ pub const TCA_EGRESS_BLOCK: _bindgen_ty_172 = 14;
 pub const TCA_DUMP_FLAGS: _bindgen_ty_172 = 15;
 pub const __TCA_MAX: _bindgen_ty_172 = 16;
 pub type _bindgen_ty_172 = ::core::ffi::c_uint;
+pub const VETH_INFO_UNSPEC: _bindgen_ty_175 = _bindgen_ty_175::VETH_INFO_UNSPEC;
+pub const VETH_INFO_PEER: _bindgen_ty_175 = _bindgen_ty_175::VETH_INFO_PEER;
+pub const __VETH_INFO_MAX: _bindgen_ty_175 = _bindgen_ty_175::__VETH_INFO_MAX;
+#[repr(u32)]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum _bindgen_ty_175 {
+    VETH_INFO_UNSPEC = 0,
+    VETH_INFO_PEER = 1,
+    __VETH_INFO_MAX = 2,
+}
 pub const AYA_PERF_EVENT_IOC_ENABLE: ::core::ffi::c_int = 9216;
 pub const AYA_PERF_EVENT_IOC_DISABLE: ::core::ffi::c_int = 9217;
 pub const AYA_PERF_EVENT_IOC_SET_BPF: ::core::ffi::c_int = 1074013192;

--- a/aya-obj/src/generated/linux_bindings_x86_64.rs
+++ b/aya-obj/src/generated/linux_bindings_x86_64.rs
@@ -2384,6 +2384,15 @@ pub const __TCA_BPF_MAX: _bindgen_ty_152 = 12;
 pub type _bindgen_ty_152 = ::core::ffi::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+pub struct ifaddrmsg {
+    pub ifa_family: __u8,
+    pub ifa_prefixlen: __u8,
+    pub ifa_flags: __u8,
+    pub ifa_scope: __u8,
+    pub ifa_index: __u32,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct ifinfomsg {
     pub ifi_family: ::core::ffi::c_uchar,
     pub __ifi_pad: ::core::ffi::c_uchar,
@@ -2421,6 +2430,16 @@ pub const TCA_EGRESS_BLOCK: _bindgen_ty_172 = 14;
 pub const TCA_DUMP_FLAGS: _bindgen_ty_172 = 15;
 pub const __TCA_MAX: _bindgen_ty_172 = 16;
 pub type _bindgen_ty_172 = ::core::ffi::c_uint;
+pub const VETH_INFO_UNSPEC: _bindgen_ty_175 = _bindgen_ty_175::VETH_INFO_UNSPEC;
+pub const VETH_INFO_PEER: _bindgen_ty_175 = _bindgen_ty_175::VETH_INFO_PEER;
+pub const __VETH_INFO_MAX: _bindgen_ty_175 = _bindgen_ty_175::__VETH_INFO_MAX;
+#[repr(u32)]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum _bindgen_ty_175 {
+    VETH_INFO_UNSPEC = 0,
+    VETH_INFO_PEER = 1,
+    __VETH_INFO_MAX = 2,
+}
 pub const AYA_PERF_EVENT_IOC_ENABLE: ::core::ffi::c_int = 9216;
 pub const AYA_PERF_EVENT_IOC_DISABLE: ::core::ffi::c_int = 9217;
 pub const AYA_PERF_EVENT_IOC_SET_BPF: ::core::ffi::c_int = 1074013192;

--- a/aya/src/lib.rs
+++ b/aya/src/lib.rs
@@ -92,4 +92,7 @@ pub use bpf::*;
 pub use obj::btf::{Btf, BtfError};
 pub use object::Endianness;
 #[doc(hidden)]
-pub use sys::netlink_set_link_up;
+pub use sys::{
+    netlink_add_ip_addr, netlink_add_veth_pair, netlink_delete_link, netlink_set_link_down,
+    netlink_set_link_up,
+};

--- a/aya/src/sys/mod.rs
+++ b/aya/src/sys/mod.rs
@@ -15,9 +15,12 @@ pub(crate) use bpf::*;
 #[cfg(test)]
 pub(crate) use fake::*;
 use libc::{pid_t, SYS_bpf, SYS_perf_event_open};
-#[doc(hidden)]
-pub use netlink::netlink_set_link_up;
 pub(crate) use netlink::*;
+#[doc(hidden)]
+pub use netlink::{
+    netlink_add_ip_addr, netlink_add_veth_pair, netlink_delete_link, netlink_set_link_down,
+    netlink_set_link_up,
+};
 pub(crate) use perf_event::*;
 use thiserror::Error;
 

--- a/test/integration-test/src/utils.rs
+++ b/test/integration-test/src/utils.rs
@@ -1,19 +1,42 @@
 //! Utilities to run tests
 
 use std::{
-    ffi::CString,
-    io, process,
+    ffi::CStr,
+    io,
+    net::Ipv4Addr,
+    process,
     sync::atomic::{AtomicU64, Ordering},
 };
 
-use aya::netlink_set_link_up;
+use aya::{
+    netlink_add_ip_addr, netlink_add_veth_pair, netlink_delete_link, netlink_set_link_down,
+    netlink_set_link_up,
+};
 use libc::if_nametoindex;
 use netns_rs::{get_from_current_thread, NetNs};
+
+pub const IF_NAME_1: &CStr = c"aya-test-1";
+pub const IF_NAME_2: &CStr = c"aya-test-2";
+pub const IP_ADDR_1: Ipv4Addr = Ipv4Addr::new(10, 0, 0, 1);
+pub const IP_ADDR_2: Ipv4Addr = Ipv4Addr::new(10, 0, 0, 2);
+pub const IP_PREFIX: u8 = 24;
+
+pub fn setup_test_veth_pair() {
+    unsafe { netlink_add_veth_pair(IF_NAME_1, IF_NAME_2) }.unwrap_or_else(|e| {
+        panic!(
+            "Failed to set up veth pair ({}, {}): {e}",
+            IF_NAME_1.to_string_lossy(),
+            IF_NAME_2.to_string_lossy()
+        )
+    })
+}
 
 pub struct NetNsGuard {
     name: String,
     old_ns: NetNs,
     ns: Option<NetNs>,
+    pub if_idx1: u32,
+    pub if_idx2: u32,
 }
 
 impl NetNsGuard {
@@ -26,39 +49,116 @@ impl NetNsGuard {
 
         // Create and enter netns
         let ns = NetNs::new(&name).unwrap_or_else(|e| panic!("Failed to create netns {name}: {e}"));
-        let netns = Self {
+
+        ns.enter()
+            .unwrap_or_else(|e| panic!("Failed to enter network namespace {}: {e}", name));
+        println!("Entered network namespace {}", name);
+
+        // By default, the loopback in a new netns is down. Set it up.
+        let lo_idx = unsafe { if_nametoindex(c"lo".as_ptr()) };
+        if lo_idx == 0 {
+            panic!(
+                "Interface `lo` not found in netns {}: {}",
+                name,
+                io::Error::last_os_error()
+            );
+        }
+
+        unsafe { netlink_set_link_up(lo_idx as i32) }
+            .unwrap_or_else(|e| panic!("Failed to set `lo` up in netns {}: {e}", name));
+
+        setup_test_veth_pair();
+
+        let if_idx1 = unsafe { if_nametoindex(IF_NAME_1.as_ptr()) };
+        if if_idx1 == 0 {
+            panic!(
+                "Interface `{}` not found in netns {}: {}",
+                IF_NAME_1.to_string_lossy(),
+                name,
+                io::Error::last_os_error()
+            );
+        }
+
+        let if_idx2 = unsafe { if_nametoindex(IF_NAME_2.as_ptr()) };
+        if if_idx2 == 0 {
+            panic!(
+                "Interface `{}` not found in netns {}: {}",
+                IF_NAME_2.to_string_lossy(),
+                name,
+                io::Error::last_os_error()
+            );
+        }
+
+        unsafe { netlink_add_ip_addr(if_idx1, IP_ADDR_1, IP_PREFIX) }.unwrap_or_else(|e| {
+            panic!(
+                "Failed to add IP `{}` to `{}` in netns {}: {e}",
+                IP_ADDR_1,
+                IF_NAME_1.to_string_lossy(),
+                name
+            )
+        });
+
+        unsafe { netlink_add_ip_addr(if_idx2, IP_ADDR_2, IP_PREFIX) }.unwrap_or_else(|e| {
+            panic!(
+                "Failed to add IP `{}` to `{}` in netns {}: {e}",
+                IP_ADDR_2,
+                IF_NAME_2.to_string_lossy(),
+                name
+            )
+        });
+
+        unsafe { netlink_set_link_up(if_idx1 as i32) }.unwrap_or_else(|e| {
+            panic!(
+                "Failed to set `{}` up in netns {}: {e}",
+                IF_NAME_1.to_string_lossy(),
+                name
+            )
+        });
+
+        unsafe { netlink_set_link_up(if_idx2 as i32) }.unwrap_or_else(|e| {
+            panic!(
+                "Failed to set `{}` up in netns {}: {e}",
+                IF_NAME_2.to_string_lossy(),
+                name
+            )
+        });
+
+        Self {
             old_ns,
             ns: Some(ns),
             name,
-        };
-
-        let ns = netns.ns.as_ref().unwrap();
-        ns.enter()
-            .unwrap_or_else(|e| panic!("Failed to enter network namespace {}: {e}", netns.name));
-        println!("Entered network namespace {}", netns.name);
-
-        // By default, the loopback in a new netns is down. Set it up.
-        let lo = CString::new("lo").unwrap();
-        unsafe {
-            let idx = if_nametoindex(lo.as_ptr());
-            if idx == 0 {
-                panic!(
-                    "Interface `lo` not found in netns {}: {}",
-                    netns.name,
-                    io::Error::last_os_error()
-                );
-            }
-            netlink_set_link_up(idx as i32)
-                .unwrap_or_else(|e| panic!("Failed to set `lo` up in netns {}: {e}", netns.name));
+            if_idx1,
+            if_idx2,
         }
-
-        netns
     }
 }
 
 impl Drop for NetNsGuard {
     fn drop(&mut self) {
         // Avoid panic in panic
+        if let Err(e) = unsafe { netlink_set_link_down(self.if_idx1 as i32) } {
+            eprintln!(
+                "Failed to set `{}` down in netns {}: {e}",
+                IF_NAME_1.to_string_lossy(),
+                self.name
+            )
+        }
+        if let Err(e) = unsafe { netlink_set_link_down(self.if_idx2 as i32) } {
+            eprintln!(
+                "Failed to set `{}` down in netns {}: {e}",
+                IF_NAME_2.to_string_lossy(),
+                self.name
+            )
+        }
+
+        if let Err(e) = unsafe { netlink_delete_link(self.if_idx1 as i32) } {
+            eprintln!(
+                "Failed to delete `{}` in netns {}: {e}",
+                IF_NAME_1.to_string_lossy(),
+                self.name
+            )
+        }
+
         if let Err(e) = self.old_ns.enter() {
             eprintln!("Failed to return to original netns: {e}");
         }

--- a/xtask/check-config.sh
+++ b/xtask/check-config.sh
@@ -1,0 +1,419 @@
+#!/usr/bin/env sh
+set -e
+
+EXITCODE=0
+
+# bits of this were adapted from lxc-checkconfig
+# see also https://github.com/lxc/lxc/blob/lxc-1.0.2/src/lxc/lxc-checkconfig.in
+
+possibleConfigs="
+	/proc/config.gz
+	/boot/config-$(uname -r)
+	/usr/src/linux-$(uname -r)/.config
+	/usr/src/linux/.config
+"
+
+if [ $# -gt 0 ]; then
+	CONFIG="$1"
+else
+	: "${CONFIG:=/proc/config.gz}"
+fi
+
+if ! command -v zgrep > /dev/null 2>&1; then
+	zgrep() {
+		zcat "$2" | grep "$1"
+	}
+fi
+
+useColor=true
+if [ "$NO_COLOR" = "1" ] || [ ! -t 1 ]; then
+	useColor=false
+fi
+kernelVersion="$(uname -r)"
+kernelMajor="${kernelVersion%%.*}"
+kernelMinor="${kernelVersion#$kernelMajor.}"
+kernelMinor="${kernelMinor%%.*}"
+
+is_set() {
+	zgrep "CONFIG_$1=[y|m]" "$CONFIG" > /dev/null
+}
+is_set_in_kernel() {
+	zgrep "CONFIG_$1=y" "$CONFIG" > /dev/null
+}
+is_set_as_module() {
+	zgrep "CONFIG_$1=m" "$CONFIG" > /dev/null
+}
+
+color() {
+	# if stdout is not a terminal, then don't do color codes.
+	if [ "$useColor" = "false" ]; then
+		return 0
+	fi
+	codes=
+	if [ "$1" = 'bold' ]; then
+		codes='1'
+		shift
+	fi
+	if [ "$#" -gt 0 ]; then
+		code=
+		case "$1" in
+			# see https://en.wikipedia.org/wiki/ANSI_escape_code#Colors
+			black) code=30 ;;
+			red) code=31 ;;
+			green) code=32 ;;
+			yellow) code=33 ;;
+			blue) code=34 ;;
+			magenta) code=35 ;;
+			cyan) code=36 ;;
+			white) code=37 ;;
+		esac
+		if [ "$code" ]; then
+			codes="${codes:+$codes;}$code"
+		fi
+	fi
+	printf '\033[%sm' "$codes"
+}
+wrap_color() {
+	text="$1"
+	shift
+	color "$@"
+	printf '%s' "$text"
+	color reset
+	echo
+}
+
+wrap_good() {
+	echo "$(wrap_color "$1" white): $(wrap_color "$2" green)"
+}
+wrap_bad() {
+	echo "$(wrap_color "$1" bold): $(wrap_color "$2" bold red)"
+}
+wrap_warning() {
+	wrap_color >&2 "$*" red
+}
+
+check_flag() {
+	if is_set_in_kernel "$1"; then
+		wrap_good "CONFIG_$1" 'enabled'
+	elif is_set_as_module "$1"; then
+		wrap_good "CONFIG_$1" 'enabled (as module)'
+	else
+		wrap_bad "CONFIG_$1" 'missing'
+		EXITCODE=1
+	fi
+}
+
+check_flags() {
+	for flag in "$@"; do
+		printf -- '- '
+		check_flag "$flag"
+	done
+}
+
+check_command() {
+	if command -v "$1" > /dev/null 2>&1; then
+		wrap_good "$1 command" 'available'
+	else
+		wrap_bad "$1 command" 'missing'
+		EXITCODE=1
+	fi
+}
+
+check_device() {
+	if [ -c "$1" ]; then
+		wrap_good "$1" 'present'
+	else
+		wrap_bad "$1" 'missing'
+		EXITCODE=1
+	fi
+}
+
+check_distro_userns() {
+	if [ ! -e /etc/os-release ]; then
+		return
+	fi
+	. /etc/os-release 2> /dev/null || /bin/true
+	case "$ID" in
+		centos | rhel)
+			case "$VERSION_ID" in
+				7*)
+					# this is a CentOS7 or RHEL7 system
+					grep -q 'user_namespace.enable=1' /proc/cmdline || {
+						# no user namespace support enabled
+						wrap_bad "  (RHEL7/CentOS7" "User namespaces disabled; add 'user_namespace.enable=1' to boot command line)"
+						EXITCODE=1
+					}
+					;;
+			esac
+			;;
+	esac
+}
+
+if [ ! -e "$CONFIG" ]; then
+	wrap_warning "warning: $CONFIG does not exist, searching other paths for kernel config ..."
+	for tryConfig in $possibleConfigs; do
+		if [ -e "$tryConfig" ]; then
+			CONFIG="$tryConfig"
+			break
+		fi
+	done
+	if [ ! -e "$CONFIG" ]; then
+		wrap_warning "error: cannot find kernel config"
+		wrap_warning "  try running this script again, specifying the kernel config:"
+		wrap_warning "    CONFIG=/path/to/kernel/.config $0 or $0 /path/to/kernel/.config"
+		exit 1
+	fi
+fi
+
+wrap_color "info: reading kernel config from $CONFIG ..." white
+echo
+
+echo 'Generally Necessary:'
+
+printf -- '- '
+if [ "$(stat -f -c %t /sys/fs/cgroup 2> /dev/null)" = '63677270' ]; then
+	wrap_good 'cgroup hierarchy' 'cgroupv2'
+	cgroupv2ControllerFile='/sys/fs/cgroup/cgroup.controllers'
+	if [ -f "$cgroupv2ControllerFile" ]; then
+		echo '  Controllers:'
+		for controller in cpu cpuset io memory pids; do
+			if grep -qE '(^| )'"$controller"'($| )' "$cgroupv2ControllerFile"; then
+				echo "  - $(wrap_good "$controller" 'available')"
+			else
+				echo "  - $(wrap_bad "$controller" 'missing')"
+			fi
+		done
+	else
+		wrap_bad "$cgroupv2ControllerFile" 'nonexistent??'
+	fi
+	# TODO find an efficient way to check if cgroup.freeze exists in subdir
+else
+	cgroupSubsystemDir="$(sed -rne '/^[^ ]+ ([^ ]+) cgroup ([^ ]*,)?(cpu|cpuacct|cpuset|devices|freezer|memory)[, ].*$/ { s//\1/p; q }' /proc/mounts)"
+	cgroupDir="$(dirname "$cgroupSubsystemDir")"
+	if [ -d "$cgroupDir/cpu" ] || [ -d "$cgroupDir/cpuacct" ] || [ -d "$cgroupDir/cpuset" ] || [ -d "$cgroupDir/devices" ] || [ -d "$cgroupDir/freezer" ] || [ -d "$cgroupDir/memory" ]; then
+		echo "$(wrap_good 'cgroup hierarchy' 'properly mounted') [$cgroupDir]"
+	else
+		if [ "$cgroupSubsystemDir" ]; then
+			echo "$(wrap_bad 'cgroup hierarchy' 'single mountpoint!') [$cgroupSubsystemDir]"
+		else
+			wrap_bad 'cgroup hierarchy' 'nonexistent??'
+		fi
+		EXITCODE=1
+		echo "    $(wrap_color '(see https://github.com/tianon/cgroupfs-mount)' yellow)"
+	fi
+fi
+
+if [ "$(cat /sys/module/apparmor/parameters/enabled 2> /dev/null)" = 'Y' ]; then
+	printf -- '- '
+	if command -v apparmor_parser > /dev/null 2>&1; then
+		wrap_good 'apparmor' 'enabled and tools installed'
+	else
+		wrap_bad 'apparmor' 'enabled, but apparmor_parser missing'
+		printf '    '
+		if command -v apt-get > /dev/null 2>&1; then
+			wrap_color '(use "apt-get install apparmor" to fix this)'
+		elif command -v yum > /dev/null 2>&1; then
+			wrap_color '(your best bet is "yum install apparmor-parser")'
+		else
+			wrap_color '(look for an "apparmor" package for your distribution)'
+		fi
+		EXITCODE=1
+	fi
+fi
+
+check_flags \
+	NAMESPACES NET_NS PID_NS IPC_NS UTS_NS \
+	CGROUPS CGROUP_CPUACCT CGROUP_DEVICE CGROUP_FREEZER CGROUP_SCHED CPUSETS MEMCG \
+	KEYS \
+	VETH BRIDGE BRIDGE_NETFILTER \
+	IP_NF_FILTER IP_NF_MANGLE IP_NF_TARGET_MASQUERADE \
+	NETFILTER_XT_MATCH_ADDRTYPE \
+	NETFILTER_XT_MATCH_CONNTRACK \
+	NETFILTER_XT_MATCH_IPVS \
+	NETFILTER_XT_MARK \
+	IP_NF_NAT NF_NAT \
+	POSIX_MQUEUE
+# (POSIX_MQUEUE is required for bind-mounting /dev/mqueue into containers)
+
+if [ "$kernelMajor" -lt 4 ] || ([ "$kernelMajor" -eq 4 ] && [ "$kernelMinor" -lt 8 ]); then
+	check_flags DEVPTS_MULTIPLE_INSTANCES
+fi
+
+if [ "$kernelMajor" -lt 5 ] || [ "$kernelMajor" -eq 5 -a "$kernelMinor" -le 1 ]; then
+	check_flags NF_NAT_IPV4
+fi
+
+if [ "$kernelMajor" -lt 5 ] || [ "$kernelMajor" -eq 5 -a "$kernelMinor" -le 2 ]; then
+	check_flags NF_NAT_NEEDED
+fi
+# check availability of BPF_CGROUP_DEVICE support
+if [ "$kernelMajor" -ge 5 ] || ([ "$kernelMajor" -eq 4 ] && [ "$kernelMinor" -ge 15 ]); then
+	check_flags CGROUP_BPF
+fi
+
+echo
+
+echo 'Optional Features:'
+{
+	check_flags USER_NS
+	check_distro_userns
+}
+{
+	check_flags SECCOMP
+	check_flags SECCOMP_FILTER
+}
+{
+	check_flags CGROUP_PIDS
+}
+{
+	check_flags MEMCG_SWAP
+	# Kernel v5.8+ removes MEMCG_SWAP_ENABLED.
+	if [ "$kernelMajor" -lt 5 ] || [ "$kernelMajor" -eq 5 -a "$kernelMinor" -le 8 ]; then
+		CODE=${EXITCODE}
+		check_flags MEMCG_SWAP_ENABLED
+		# FIXME this check is cgroupv1-specific
+		if [ -e /sys/fs/cgroup/memory/memory.memsw.limit_in_bytes ]; then
+			echo "    $(wrap_color '(cgroup swap accounting is currently enabled)' bold black)"
+			EXITCODE=${CODE}
+		elif is_set MEMCG_SWAP && ! is_set MEMCG_SWAP_ENABLED; then
+			echo "    $(wrap_color '(cgroup swap accounting is currently not enabled, you can enable it by setting boot option "swapaccount=1")' bold black)"
+		fi
+	else
+		# Kernel v5.8+ enables swap accounting by default.
+		echo "    $(wrap_color '(cgroup swap accounting is currently enabled)' bold black)"
+	fi
+}
+{
+	if is_set LEGACY_VSYSCALL_NATIVE; then
+		printf -- '- '
+		wrap_bad "CONFIG_LEGACY_VSYSCALL_NATIVE" 'enabled'
+		echo "    $(wrap_color '(dangerous, provides an ASLR-bypassing target with usable ROP gadgets.)' bold black)"
+	elif is_set LEGACY_VSYSCALL_EMULATE; then
+		printf -- '- '
+		wrap_good "CONFIG_LEGACY_VSYSCALL_EMULATE" 'enabled'
+	elif is_set LEGACY_VSYSCALL_NONE; then
+		printf -- '- '
+		wrap_bad "CONFIG_LEGACY_VSYSCALL_NONE" 'enabled'
+		echo "    $(wrap_color '(containers using eglibc <= 2.13 will not work. Switch to' bold black)"
+		echo "    $(wrap_color ' "CONFIG_VSYSCALL_[NATIVE|EMULATE]" or use "vsyscall=[native|emulate]"' bold black)"
+		echo "    $(wrap_color ' on kernel command line. Note that this will disable ASLR for the,' bold black)"
+		echo "    $(wrap_color ' VDSO which may assist in exploiting security vulnerabilities.)' bold black)"
+	# else Older kernels (prior to 3dc33bd30f3e, released in v4.40-rc1) do
+	#      not have these LEGACY_VSYSCALL options and are effectively
+	#      LEGACY_VSYSCALL_EMULATE. Even older kernels are presumably
+	#      effectively LEGACY_VSYSCALL_NATIVE.
+	fi
+}
+
+if [ "$kernelMajor" -lt 4 ] || ([ "$kernelMajor" -eq 4 ] && [ "$kernelMinor" -le 5 ]); then
+	check_flags MEMCG_KMEM
+fi
+
+if [ "$kernelMajor" -lt 3 ] || ([ "$kernelMajor" -eq 3 ] && [ "$kernelMinor" -le 18 ]); then
+	check_flags RESOURCE_COUNTERS
+fi
+
+if [ "$kernelMajor" -lt 3 ] || ([ "$kernelMajor" -eq 3 ] && [ "$kernelMinor" -le 13 ]); then
+	netprio=NETPRIO_CGROUP
+else
+	netprio=CGROUP_NET_PRIO
+fi
+
+if [ "$kernelMajor" -lt 5 ]; then
+	check_flags IOSCHED_CFQ CFQ_GROUP_IOSCHED
+fi
+
+check_flags \
+	BLK_CGROUP BLK_DEV_THROTTLING \
+	CGROUP_PERF \
+	CGROUP_HUGETLB \
+	NET_CLS_CGROUP $netprio \
+	CFS_BANDWIDTH FAIR_GROUP_SCHED \
+	IP_NF_TARGET_REDIRECT \
+	IP_VS \
+	IP_VS_NFCT \
+	IP_VS_PROTO_TCP \
+	IP_VS_PROTO_UDP \
+	IP_VS_RR \
+	SECURITY_SELINUX \
+	SECURITY_APPARMOR
+
+if ! is_set EXT4_USE_FOR_EXT2; then
+	check_flags EXT3_FS EXT3_FS_XATTR EXT3_FS_POSIX_ACL EXT3_FS_SECURITY
+	if ! is_set EXT3_FS || ! is_set EXT3_FS_XATTR || ! is_set EXT3_FS_POSIX_ACL || ! is_set EXT3_FS_SECURITY; then
+		echo "    $(wrap_color '(enable these ext3 configs if you are using ext3 as backing filesystem)' bold black)"
+	fi
+fi
+
+check_flags EXT4_FS EXT4_FS_POSIX_ACL EXT4_FS_SECURITY
+if ! is_set EXT4_FS || ! is_set EXT4_FS_POSIX_ACL || ! is_set EXT4_FS_SECURITY; then
+	if is_set EXT4_USE_FOR_EXT2; then
+		echo "    $(wrap_color 'enable these ext4 configs if you are using ext3 or ext4 as backing filesystem' bold black)"
+	else
+		echo "    $(wrap_color 'enable these ext4 configs if you are using ext4 as backing filesystem' bold black)"
+	fi
+fi
+
+echo '- Network Drivers:'
+echo "  - \"$(wrap_color 'overlay' blue)\":"
+check_flags VXLAN BRIDGE_VLAN_FILTERING | sed 's/^/    /'
+echo '      Optional (for encrypted networks):'
+check_flags CRYPTO CRYPTO_AEAD CRYPTO_GCM CRYPTO_SEQIV CRYPTO_GHASH \
+	XFRM XFRM_USER XFRM_ALGO INET_ESP NETFILTER_XT_MATCH_BPF | sed 's/^/      /'
+if [ "$kernelMajor" -lt 5 ] || [ "$kernelMajor" -eq 5 -a "$kernelMinor" -le 3 ]; then
+	check_flags INET_XFRM_MODE_TRANSPORT | sed 's/^/      /'
+fi
+echo "  - \"$(wrap_color 'ipvlan' blue)\":"
+check_flags IPVLAN | sed 's/^/    /'
+echo "  - \"$(wrap_color 'macvlan' blue)\":"
+check_flags MACVLAN DUMMY | sed 's/^/    /'
+echo "  - \"$(wrap_color 'ftp,tftp client in container' blue)\":"
+check_flags NF_NAT_FTP NF_CONNTRACK_FTP NF_NAT_TFTP NF_CONNTRACK_TFTP | sed 's/^/    /'
+
+# only fail if no storage drivers available
+CODE=${EXITCODE}
+EXITCODE=0
+STORAGE=1
+
+echo '- Storage Drivers:'
+echo "  - \"$(wrap_color 'btrfs' blue)\":"
+check_flags BTRFS_FS | sed 's/^/    /'
+check_flags BTRFS_FS_POSIX_ACL | sed 's/^/    /'
+[ "$EXITCODE" = 0 ] && STORAGE=0
+EXITCODE=0
+
+echo "  - \"$(wrap_color 'overlay' blue)\":"
+check_flags OVERLAY_FS | sed 's/^/    /'
+[ "$EXITCODE" = 0 ] && STORAGE=0
+EXITCODE=0
+
+echo "  - \"$(wrap_color 'zfs' blue)\":"
+printf '    - '
+check_device /dev/zfs
+printf '    - '
+check_command zfs
+printf '    - '
+check_command zpool
+[ "$EXITCODE" = 0 ] && STORAGE=0
+EXITCODE=0
+
+EXITCODE=$CODE
+[ "$STORAGE" = 1 ] && EXITCODE=1
+
+echo
+
+check_limit_over() {
+	if [ "$(cat "$1")" -le "$2" ]; then
+		wrap_bad "- $1" "$(cat "$1")"
+		wrap_color "    This should be set to at least $2, for example set: sysctl -w kernel/keys/root_maxkeys=1000000" bold black
+		EXITCODE=1
+	else
+		wrap_good "- $1" "$(cat "$1")"
+	fi
+}
+
+echo 'Limits:'
+check_limit_over /proc/sys/kernel/keys/root_maxkeys 10000
+echo
+
+exit $EXITCODE

--- a/xtask/public-api/aya-obj.txt
+++ b/xtask/public-api/aya-obj.txt
@@ -1321,6 +1321,47 @@ pub const aya_obj::generated::bpf_core_relo_kind::BPF_CORE_TYPE_ID_TARGET: aya_o
 pub const aya_obj::generated::bpf_core_relo_kind::BPF_CORE_TYPE_MATCHES: aya_obj::generated::bpf_core_relo_kind::Type = 12u32
 pub const aya_obj::generated::bpf_core_relo_kind::BPF_CORE_TYPE_SIZE: aya_obj::generated::bpf_core_relo_kind::Type = 9u32
 pub type aya_obj::generated::bpf_core_relo_kind::Type = core::ffi::c_uint
+#[repr(u32)] pub enum aya_obj::generated::_bindgen_ty_175
+pub aya_obj::generated::_bindgen_ty_175::VETH_INFO_PEER = 1
+pub aya_obj::generated::_bindgen_ty_175::VETH_INFO_UNSPEC = 0
+pub aya_obj::generated::_bindgen_ty_175::__VETH_INFO_MAX = 2
+impl core::clone::Clone for aya_obj::generated::_bindgen_ty_175
+pub fn aya_obj::generated::_bindgen_ty_175::clone(&self) -> aya_obj::generated::_bindgen_ty_175
+impl core::cmp::Eq for aya_obj::generated::_bindgen_ty_175
+impl core::cmp::PartialEq for aya_obj::generated::_bindgen_ty_175
+pub fn aya_obj::generated::_bindgen_ty_175::eq(&self, other: &aya_obj::generated::_bindgen_ty_175) -> bool
+impl core::fmt::Debug for aya_obj::generated::_bindgen_ty_175
+pub fn aya_obj::generated::_bindgen_ty_175::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::hash::Hash for aya_obj::generated::_bindgen_ty_175
+pub fn aya_obj::generated::_bindgen_ty_175::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+impl core::marker::Copy for aya_obj::generated::_bindgen_ty_175
+impl core::marker::StructuralPartialEq for aya_obj::generated::_bindgen_ty_175
+impl core::marker::Freeze for aya_obj::generated::_bindgen_ty_175
+impl core::marker::Send for aya_obj::generated::_bindgen_ty_175
+impl core::marker::Sync for aya_obj::generated::_bindgen_ty_175
+impl core::marker::Unpin for aya_obj::generated::_bindgen_ty_175
+impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::generated::_bindgen_ty_175
+impl core::panic::unwind_safe::UnwindSafe for aya_obj::generated::_bindgen_ty_175
+impl<T, U> core::convert::Into<U> for aya_obj::generated::_bindgen_ty_175 where U: core::convert::From<T>
+pub fn aya_obj::generated::_bindgen_ty_175::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for aya_obj::generated::_bindgen_ty_175 where U: core::convert::Into<T>
+pub type aya_obj::generated::_bindgen_ty_175::Error = core::convert::Infallible
+pub fn aya_obj::generated::_bindgen_ty_175::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for aya_obj::generated::_bindgen_ty_175 where U: core::convert::TryFrom<T>
+pub type aya_obj::generated::_bindgen_ty_175::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn aya_obj::generated::_bindgen_ty_175::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for aya_obj::generated::_bindgen_ty_175 where T: core::clone::Clone
+pub type aya_obj::generated::_bindgen_ty_175::Owned = T
+pub fn aya_obj::generated::_bindgen_ty_175::clone_into(&self, target: &mut T)
+pub fn aya_obj::generated::_bindgen_ty_175::to_owned(&self) -> T
+impl<T> core::any::Any for aya_obj::generated::_bindgen_ty_175 where T: 'static + core::marker::Sized
+pub fn aya_obj::generated::_bindgen_ty_175::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for aya_obj::generated::_bindgen_ty_175 where T: core::marker::Sized
+pub fn aya_obj::generated::_bindgen_ty_175::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::_bindgen_ty_175 where T: core::marker::Sized
+pub fn aya_obj::generated::_bindgen_ty_175::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for aya_obj::generated::_bindgen_ty_175
+pub fn aya_obj::generated::_bindgen_ty_175::from(t: T) -> T
 #[repr(u32)] pub enum aya_obj::generated::bpf_attach_type
 pub aya_obj::generated::bpf_attach_type::BPF_CGROUP_DEVICE = 6
 pub aya_obj::generated::bpf_attach_type::BPF_CGROUP_GETSOCKOPT = 21
@@ -5680,6 +5721,43 @@ impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::btf_var_secinfo where
 pub fn aya_obj::generated::btf_var_secinfo::borrow_mut(&mut self) -> &mut T
 impl<T> core::convert::From<T> for aya_obj::generated::btf_var_secinfo
 pub fn aya_obj::generated::btf_var_secinfo::from(t: T) -> T
+#[repr(C)] pub struct aya_obj::generated::ifaddrmsg
+pub aya_obj::generated::ifaddrmsg::ifa_family: aya_obj::generated::__u8
+pub aya_obj::generated::ifaddrmsg::ifa_flags: aya_obj::generated::__u8
+pub aya_obj::generated::ifaddrmsg::ifa_index: aya_obj::generated::__u32
+pub aya_obj::generated::ifaddrmsg::ifa_prefixlen: aya_obj::generated::__u8
+pub aya_obj::generated::ifaddrmsg::ifa_scope: aya_obj::generated::__u8
+impl core::clone::Clone for aya_obj::generated::ifaddrmsg
+pub fn aya_obj::generated::ifaddrmsg::clone(&self) -> aya_obj::generated::ifaddrmsg
+impl core::fmt::Debug for aya_obj::generated::ifaddrmsg
+pub fn aya_obj::generated::ifaddrmsg::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Copy for aya_obj::generated::ifaddrmsg
+impl core::marker::Freeze for aya_obj::generated::ifaddrmsg
+impl core::marker::Send for aya_obj::generated::ifaddrmsg
+impl core::marker::Sync for aya_obj::generated::ifaddrmsg
+impl core::marker::Unpin for aya_obj::generated::ifaddrmsg
+impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::generated::ifaddrmsg
+impl core::panic::unwind_safe::UnwindSafe for aya_obj::generated::ifaddrmsg
+impl<T, U> core::convert::Into<U> for aya_obj::generated::ifaddrmsg where U: core::convert::From<T>
+pub fn aya_obj::generated::ifaddrmsg::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for aya_obj::generated::ifaddrmsg where U: core::convert::Into<T>
+pub type aya_obj::generated::ifaddrmsg::Error = core::convert::Infallible
+pub fn aya_obj::generated::ifaddrmsg::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for aya_obj::generated::ifaddrmsg where U: core::convert::TryFrom<T>
+pub type aya_obj::generated::ifaddrmsg::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn aya_obj::generated::ifaddrmsg::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for aya_obj::generated::ifaddrmsg where T: core::clone::Clone
+pub type aya_obj::generated::ifaddrmsg::Owned = T
+pub fn aya_obj::generated::ifaddrmsg::clone_into(&self, target: &mut T)
+pub fn aya_obj::generated::ifaddrmsg::to_owned(&self) -> T
+impl<T> core::any::Any for aya_obj::generated::ifaddrmsg where T: 'static + core::marker::Sized
+pub fn aya_obj::generated::ifaddrmsg::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for aya_obj::generated::ifaddrmsg where T: core::marker::Sized
+pub fn aya_obj::generated::ifaddrmsg::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::ifaddrmsg where T: core::marker::Sized
+pub fn aya_obj::generated::ifaddrmsg::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for aya_obj::generated::ifaddrmsg
+pub fn aya_obj::generated::ifaddrmsg::from(t: T) -> T
 #[repr(C)] pub struct aya_obj::generated::ifinfomsg
 pub aya_obj::generated::ifinfomsg::__ifi_pad: core::ffi::c_uchar
 pub aya_obj::generated::ifinfomsg::ifi_change: core::ffi::c_uint
@@ -6222,6 +6300,8 @@ pub const aya_obj::generated::TC_H_MIN_MASK: u32 = 65_535u32
 pub const aya_obj::generated::TC_H_MIN_PRIORITY: u32 = 65_504u32
 pub const aya_obj::generated::TC_H_ROOT: u32 = 4_294_967_295u32
 pub const aya_obj::generated::TC_H_UNSPEC: u32 = 0u32
+pub const aya_obj::generated::VETH_INFO_PEER: _bindgen_ty_175::VETH_INFO_PEER
+pub const aya_obj::generated::VETH_INFO_UNSPEC: _bindgen_ty_175::VETH_INFO_UNSPEC
 pub const aya_obj::generated::XDP_FLAGS_DRV_MODE: u32 = 4u32
 pub const aya_obj::generated::XDP_FLAGS_HW_MODE: u32 = 8u32
 pub const aya_obj::generated::XDP_FLAGS_MASK: u32 = 31u32
@@ -6232,6 +6312,7 @@ pub const aya_obj::generated::XDP_FLAGS_UPDATE_IF_NOEXIST: u32 = 1u32
 pub const aya_obj::generated::__IFLA_XDP_MAX: aya_obj::generated::_bindgen_ty_92 = 9u32
 pub const aya_obj::generated::__TCA_BPF_MAX: aya_obj::generated::_bindgen_ty_152 = 12u32
 pub const aya_obj::generated::__TCA_MAX: aya_obj::generated::_bindgen_ty_172 = 16u32
+pub const aya_obj::generated::__VETH_INFO_MAX: _bindgen_ty_175::__VETH_INFO_MAX
 pub type aya_obj::generated::__s16 = core::ffi::c_short
 pub type aya_obj::generated::__s32 = core::ffi::c_int
 pub type aya_obj::generated::__s64 = core::ffi::c_longlong

--- a/xtask/src/codegen/aya.rs
+++ b/xtask/src/codegen/aya.rs
@@ -103,6 +103,7 @@ fn codegen_bindings(opts: &SysrootOptions, libbpf_dir: &Path) -> Result<(), anyh
         "perf_type_id",
         "perf_event_type",
         // NETLINK
+        "ifaddrmsg",
         "ifinfomsg",
         "tcmsg",
     ];
@@ -155,6 +156,7 @@ fn codegen_bindings(opts: &SysrootOptions, libbpf_dir: &Path) -> Result<(), anyh
         "TC_H_MIN_PRIORITY",
         "TC_H_MIN_INGRESS",
         "TC_H_MIN_EGRESS",
+        "VETH_INFO_PEER",
         // Ringbuf
         "BPF_RINGBUF_.*",
     ];


### PR DESCRIPTION
Fixes #422. I split the initial codegen commit out to #919 to clean this PR up.

I would like some help debugging the last 4 test failures:
```
---- tests::smoke::list_loaded_maps stdout ----
Entered network namespace aya-test-404672-4
thread 'tests::smoke::list_loaded_maps' panicked at test/integration-test/src/tests/smoke.rs:117:23:
called `Result::unwrap()` on an `Err` value: LoadError { io_error: Os { code: 22, kind: InvalidInput, message: "Invalid argument" }, verifier_log:  }
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
Exited network namespace aya-test-404672-4

---- tests::smoke::list_loaded_programs stdout ----
Entered network namespace aya-test-404672-5
thread 'tests::smoke::list_loaded_programs' panicked at test/integration-test/src/tests/smoke.rs:84:23:
called `Result::unwrap()` on an `Err` value: LoadError { io_error: Os { code: 22, kind: InvalidInput, message: "Invalid argument" }, verifier_log:  }
Exited network namespace aya-test-404672-5

---- tests::xdp::af_xdp stdout ----
Entered network namespace aya-test-404672-6
thread 'tests::xdp::af_xdp' panicked at test/integration-test/src/tests/xdp.rs:57:22:
called `Result::unwrap()` on an `Err` value: Errno(19: No such device)
Exited network namespace aya-test-404672-6

---- tests::xdp::cpumap_chain stdout ----
Entered network namespace aya-test-404672-7
thread 'tests::xdp::cpumap_chain' panicked at test/integration-test/src/tests/xdp.rs:182:5:
assertion `left == right` failed
  left: 0
 right: 1
Exited network namespace aya-test-404672-7
```

I'm not sure if introducing the network namespace caused behavior to now be different.