### PR TITLE
fix(xtask): corrected bpf to ebpf for path to aya-ebpf-bindings in codegen

### DIFF
--- a/xtask/src/codegen/aya.rs
+++ b/xtask/src/codegen/aya.rs
@@ -42,7 +42,7 @@ fn codegen_internal_btf_bindings(libbpf_dir: &Path) -> Result<(), anyhow::Error>
 
     let bindings = bindgen
         .generate()
-        .map_err(|_| anyhow!("bindgen failed"))?
+        .map_err(|op| anyhow!("bindgen failed - {op}"))?
         .to_string();
 
     // write the bindings, with the original helpers removed
@@ -216,7 +216,7 @@ fn codegen_bindings(opts: &SysrootOptions, libbpf_dir: &Path) -> Result<(), anyh
 
         let bindings = bindgen
             .generate()
-            .map_err(|_| anyhow!("bindgen failed"))?
+            .map_err(|op| anyhow!("bindgen failed - {op}"))?
             .to_string();
 
         // write the bindings, with the original helpers removed

--- a/xtask/src/codegen/aya_ebpf_bindings.rs
+++ b/xtask/src/codegen/aya_ebpf_bindings.rs
@@ -19,7 +19,7 @@ pub fn codegen(opts: &SysrootOptions, libbpf_dir: &Path) -> Result<(), anyhow::E
         riscv64_sysroot,
     } = opts;
 
-    let dir = PathBuf::from("bpf/aya-ebpf-bindings");
+    let dir = PathBuf::from("ebpf/aya-ebpf-bindings");
 
     let builder = || {
         let mut bindgen = bindgen::bpf_builder()
@@ -95,7 +95,7 @@ pub fn codegen(opts: &SysrootOptions, libbpf_dir: &Path) -> Result<(), anyhow::E
 
         let bindings = bindgen
             .generate()
-            .map_err(|_| anyhow!("bindgen failed"))?
+            .map_err(|op| anyhow!("bindgen failed - {op}"))?
             .to_string();
 
         let mut tree = parse_str::<syn::File>(&bindings).unwrap();


### PR DESCRIPTION
Currently, when running `cargo +nightly xtask codegen` locally and in the codegen GHA workflow, an error occurs with only "Error: bindgen failed" displayed.

This was due to a path using "bpf/..." instead of "ebpf/...". It is now corrected to "ebpf", so the codegen command and GHA workflow shouldn't fail. Additionally, any bindgen fails should now display a more direct message on why it failed.

Fixes: #914