### PR TITLE
Appease clippy

### DIFF
--- a/aya-log-common/src/lib.rs
+++ b/aya-log-common/src/lib.rs
@@ -217,7 +217,7 @@ impl WriteToBuf for [u16; 8] {
     // compile-time constant.
     #[inline(never)]
     fn write(self, buf: &mut [u8]) -> Option<NonZeroUsize> {
-        let bytes = unsafe { core::mem::transmute::<_, [u8; 16]>(self) };
+        let bytes = unsafe { core::mem::transmute::<[u16; 8], [u8; 16]>(self) };
         write(Argument::ArrU16Len8.into(), &bytes, buf)
     }
 }

--- a/aya/src/maps/mod.rs
+++ b/aya/src/maps/mod.rs
@@ -1025,7 +1025,7 @@ mod tests {
     use std::os::fd::AsRawFd as _;
 
     use assert_matches::assert_matches;
-    use libc::EFAULT;
+    use libc::{c_char, EFAULT};
 
     use super::*;
     use crate::{
@@ -1126,8 +1126,9 @@ mod tests {
                     mem::size_of::<bpf_map_info>() as u32
                 );
                 let map_info = unsafe { &mut *(attr.info.info as *mut bpf_map_info) };
-                map_info.name[..TEST_NAME.len()]
-                    .copy_from_slice(unsafe { mem::transmute(TEST_NAME) });
+                map_info.name[..TEST_NAME.len()].copy_from_slice(unsafe {
+                    mem::transmute::<&[u8], &[c_char]>(TEST_NAME.as_bytes())
+                });
                 Ok(0)
             }
             _ => Err((-1, io::Error::from_raw_os_error(EFAULT))),


### PR DESCRIPTION
```
  warning: transmute used without annotations
     --> aya-log-common/src/lib.rs:220:41
      |
  220 |         let bytes = unsafe { core::mem::transmute::<_, [u8; 16]>(self) };
      |                                         ^^^^^^^^^^^^^^^^^^^^^^^^ help: consider adding missing annotations: `transmute::<[u16; 8], [u8; 16]>`
      |
      = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#missing_transmute_annotations
      = note: `#[warn(clippy::missing_transmute_annotations)]` on by default

  error: transmute used without annotations
      --> aya/src/maps/mod.rs:1130:52
       |
  1130 |                     .copy_from_slice(unsafe { mem::transmute(TEST_NAME) });
       |                                                    ^^^^^^^^^ help: consider adding missing annotations: `transmute::<&str, &[i8]>`
       |
       = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#missing_transmute_annotations
  note: the lint level is defined here
      --> aya/src/lib.rs:41:5
       |
  41   |     clippy::all,
       |     ^^^^^^^^^^^
       = note: `#[deny(clippy::missing_transmute_annotations)]` implied by `#[deny(clippy::all)]`
```
