### PR TITLE
Fix kernel version parsing failed too early.

### DIFF
--- a/aya/src/util.rs
+++ b/aya/src/util.rs
@@ -130,7 +130,7 @@ impl KernelVersion {
     }
 
     fn get_kernel_version() -> Result<Self, CurrentKernelVersionError> {
-        if let Some(v) = Self::get_ubuntu_kernel_version()? {
+        if let Ok(Some(v)) = Self::get_ubuntu_kernel_version() {
             return Ok(v);
         }
 
@@ -139,7 +139,7 @@ impl KernelVersion {
             return Err(io::Error::last_os_error().into());
         }
 
-        if let Some(v) = Self::get_debian_kernel_version(&info)? {
+        if let Ok(Some(v)) = Self::get_debian_kernel_version(&info) {
             return Ok(v);
         }
 


### PR DESCRIPTION
libbpf does not fail that early when `get_{OS}_kernel_version()` failed to scan kernel version strings from either `/proc/version_signature` or from `utsname::version`

https://github.com/libbpf/libbpf/blob/855bf91055a6250642dff1390231387cc5540711/src/libbpf_probes.c#L80-L100

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aya-rs/aya/923)
<!-- Reviewable:end -->
