### PR TITLE
Expose io_error in SyscallError

### DIFF
--- a/aya/src/sys/mod.rs
+++ b/aya/src/sys/mod.rs
@@ -48,10 +48,10 @@ pub(crate) enum Syscall<'a> {
 #[error("`{call}` failed")]
 pub struct SyscallError {
     /// The name of the syscall which failed.
-    pub(crate) call: &'static str,
+    pub call: &'static str,
     /// The [`io::Error`] returned by the syscall.
     #[source]
-    pub(crate) io_error: io::Error,
+    pub io_error: io::Error,
 }
 
 impl std::fmt::Debug for Syscall<'_> {


### PR DESCRIPTION
If a bpf syscall fails, it would be useful to know if this is due to not having enough permissions or that the kernel does not have BPF support.

Ubuntu kernels are compiled without `CONFIG_BPF_LIRC_MODE2` so this is important for https://github.com/seanyoung/cir/ : I would like to present a useful error saying your kernel does not support BPF IR decoders, go fix your kernel.

Also, when removing all BPF programs using `cir config --clear` then if there is no support for BPF, there is nothing to clear and the syscall error can be ignored.