### PR TITLE
fix CI failures on macos

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -256,9 +256,10 @@ jobs:
 
       - name: bpf-linker
         if: runner.os == 'macOS'
-        # NB: rustc doesn't ship libLLVM.so on macOS, so disable proxying (default feature).
+        # NB: rustc doesn't ship libLLVM.so on macOS, so disable proxying (default feature). We also
+        # --force so that bpf-linker gets always relinked against the latest LLVM installed by brew.
         # Remove --rev when LLVM18 is released.
-        run: cargo install bpf-linker --git https://github.com/aya-rs/bpf-linker.git --rev 821f92990074cb7e950e25129dcd55e20424cede --no-default-features
+        run: cargo install --force bpf-linker --git https://github.com/aya-rs/bpf-linker.git --rev 821f92990074cb7e950e25129dcd55e20424cede --no-default-features
 
       - name: Download debian kernels
         if: runner.arch == 'ARM64'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -187,24 +187,11 @@ jobs:
         with:
           submodules: recursive
 
-      - if: runner.os == 'Linux'
-        uses: dtolnay/rust-toolchain@master
+      - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: nightly
           components: rust-src
           targets: aarch64-unknown-linux-musl,x86_64-unknown-linux-musl
-
-      #### Temporary workaround for LLVM 18 not being released yet.
-      - if: runner.os == 'macOS'
-        uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: nightly-2024-02-12
-          components: rust-src
-          targets: aarch64-unknown-linux-musl,x86_64-unknown-linux-musl
-
-      - if: runner.os == 'macOS'
-        run: sed -i '' 's/nightly/nightly-2024-02-12/' test/integration-ebpf/rust-toolchain.toml
-      #### End of temporary workaround.
 
       - uses: Swatinem/rust-cache@v2
 
@@ -258,8 +245,7 @@ jobs:
         if: runner.os == 'macOS'
         # NB: rustc doesn't ship libLLVM.so on macOS, so disable proxying (default feature). We also
         # --force so that bpf-linker gets always relinked against the latest LLVM installed by brew.
-        # Remove --rev when LLVM18 is released.
-        run: cargo install --force bpf-linker --git https://github.com/aya-rs/bpf-linker.git --rev 821f92990074cb7e950e25129dcd55e20424cede --no-default-features
+        run: cargo install --force bpf-linker --git https://github.com/aya-rs/bpf-linker.git --no-default-features
 
       - name: Download debian kernels
         if: runner.arch == 'ARM64'


### PR DESCRIPTION
This fixes the current CI failures we're seeing on macos https://github.com/aya-rs/aya/actions/runs/8810405556/job/24182725423

The fix is to make sure bpf-linker is always rebuilt/relinked against the latest llvm installed via brew.