### PR TITLE
aya-ebpf: ProbeContext: rewrite the implement of FromPtRegs trait.

### DIFF
--- a/ebpf/aya-ebpf/src/programs/probe.rs
+++ b/ebpf/aya-ebpf/src/programs/probe.rs
@@ -41,7 +41,7 @@ impl ProbeContext {
     /// }
     /// ```
     pub fn arg<T: FromPtRegs>(&self, n: usize) -> Option<T> {
-        T::from_argument(unsafe { &*self.regs }, n)
+        T::from_argument(self.regs, n)
     }
 }
 

--- a/ebpf/aya-ebpf/src/programs/retprobe.rs
+++ b/ebpf/aya-ebpf/src/programs/retprobe.rs
@@ -35,7 +35,7 @@ impl RetProbeContext {
     /// }
     /// ```
     pub fn ret<T: FromPtRegs>(&self) -> Option<T> {
-        T::from_retval(unsafe { &*self.regs })
+        T::from_retval(self.regs)
     }
 }
 


### PR DESCRIPTION
The original implementation of the  trait is unable to correctly retrieve the arguments of a function, necessitating a rewrite. This includes two interfaces: `from_argument` and `from_retval`.

To access a function's argument, it is necessary to accurately identify the register address where the argument is stored. Subsequently, we can use the  function to read
the contents at this register address.
This allows us to correctly retrieve the argument of the function.

Fixes: #587