### PR TITLE
aya-ebpf: `XdpContext` adjust_{head|tail|meta} API

### DIFF
--- a/ebpf/aya-ebpf/src/programs/xdp.rs
+++ b/ebpf/aya-ebpf/src/programs/xdp.rs
@@ -1,6 +1,10 @@
 use core::ffi::c_void;
 
-use crate::{bindings::xdp_md, EbpfContext};
+use crate::{
+    bindings::xdp_md,
+    helpers::{bpf_xdp_adjust_head, bpf_xdp_adjust_meta, bpf_xdp_adjust_tail},
+    EbpfContext,
+};
 
 pub struct XdpContext {
     pub ctx: *mut xdp_md,
@@ -31,6 +35,42 @@ impl XdpContext {
     #[inline(always)]
     pub fn metadata_end(&self) -> usize {
         self.data()
+    }
+
+    /// Adjusts the head of the Packet by given 'delta' (both positive and negative values are
+    /// possible.)
+    #[inline(always)]
+    pub fn adjust_head(&mut self, delta: crate::cty::c_int) -> Result<(), ()> {
+        unsafe {
+            match bpf_xdp_adjust_head(self.ctx, delta) {
+                0 => Ok(()),
+                _ => Err(()),
+            }
+        }
+    }
+
+    /// Adjusts the tail of the Packet by given 'delta' (both positive and negative values are
+    /// possible.)
+    #[inline(always)]
+    pub fn adjust_tail(&mut self, delta: crate::cty::c_int) -> Result<(), ()> {
+        unsafe {
+            match bpf_xdp_adjust_tail(self.ctx, delta) {
+                0 => Ok(()),
+                _ => Err(()),
+            }
+        }
+    }
+
+    /// Adjusts the tail of the Packet by given 'delta' (both positive and negative values are
+    /// possible.)
+    #[inline(always)]
+    pub fn adjust_metadata(&mut self, delta: crate::cty::c_int) -> Result<(), ()> {
+        unsafe {
+            match bpf_xdp_adjust_meta(self.ctx, delta) {
+                0 => Ok(()),
+                _ => Err(()),
+            }
+        }
     }
 }
 

--- a/xtask/public-api/aya-ebpf.txt
+++ b/xtask/public-api/aya-ebpf.txt
@@ -2013,6 +2013,9 @@ pub mod aya_ebpf::programs::xdp
 pub struct aya_ebpf::programs::xdp::XdpContext
 pub aya_ebpf::programs::xdp::XdpContext::ctx: *mut aya_ebpf_bindings::x86_64::bindings::xdp_md
 impl aya_ebpf::programs::xdp::XdpContext
+pub fn aya_ebpf::programs::xdp::XdpContext::adjust_head(&mut self, delta: aya_ebpf_cty::ad::c_int) -> core::result::Result<(), ()>
+pub fn aya_ebpf::programs::xdp::XdpContext::adjust_metadata(&mut self, delta: aya_ebpf_cty::ad::c_int) -> core::result::Result<(), ()>
+pub fn aya_ebpf::programs::xdp::XdpContext::adjust_tail(&mut self, delta: aya_ebpf_cty::ad::c_int) -> core::result::Result<(), ()>
 pub fn aya_ebpf::programs::xdp::XdpContext::data(&self) -> usize
 pub fn aya_ebpf::programs::xdp::XdpContext::data_end(&self) -> usize
 pub fn aya_ebpf::programs::xdp::XdpContext::metadata(&self) -> usize
@@ -2624,6 +2627,9 @@ pub fn aya_ebpf::programs::tracepoint::TracePointContext::from(t: T) -> T
 pub struct aya_ebpf::programs::XdpContext
 pub aya_ebpf::programs::XdpContext::ctx: *mut aya_ebpf_bindings::x86_64::bindings::xdp_md
 impl aya_ebpf::programs::xdp::XdpContext
+pub fn aya_ebpf::programs::xdp::XdpContext::adjust_head(&mut self, delta: aya_ebpf_cty::ad::c_int) -> core::result::Result<(), ()>
+pub fn aya_ebpf::programs::xdp::XdpContext::adjust_metadata(&mut self, delta: aya_ebpf_cty::ad::c_int) -> core::result::Result<(), ()>
+pub fn aya_ebpf::programs::xdp::XdpContext::adjust_tail(&mut self, delta: aya_ebpf_cty::ad::c_int) -> core::result::Result<(), ()>
 pub fn aya_ebpf::programs::xdp::XdpContext::data(&self) -> usize
 pub fn aya_ebpf::programs::xdp::XdpContext::data_end(&self) -> usize
 pub fn aya_ebpf::programs::xdp::XdpContext::metadata(&self) -> usize


### PR DESCRIPTION
Added new public API for the `XdpContext`:
- `adjust_head` : To grow the packet buffer at the beginning
- `adjist_tail` : To grow the packet buffer at the end
- `adjust_meta` : To grow metadata area

These API are handy for packet processing when additional headers etc. are to be pushed to the packet.

Also added these APIs using `cargo xtask public-api --bless`

Refs: #948