### PR TITLE
Appease clippy

### DIFF
--- a/test/integration-test/build.rs
+++ b/test/integration-test/build.rs
@@ -14,9 +14,11 @@ use xtask::{exec, AYA_BUILD_INTEGRATION_BPF, LIBBPF_DIR};
 
 /// This crate has a runtime dependency on artifacts produced by the `integration-ebpf` crate. This
 /// would be better expressed as one or more [artifact-dependencies][bindeps] but issues such as:
+///
 /// * https://github.com/rust-lang/cargo/issues/12374
 /// * https://github.com/rust-lang/cargo/issues/12375
 /// * https://github.com/rust-lang/cargo/issues/12385
+///
 /// prevent their use for the time being.
 ///
 /// This file, along with the xtask crate, allows analysis tools such as `cargo check`, `cargo


### PR DESCRIPTION
```
warning: doc list item missing indentation
  --> test/integration-test/build.rs:20:5
   |
20 | /// prevent their use for the time being.
   |     ^
   |
   = help: if this is supposed to be its own paragraph, add a blank line
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#doc_lazy_continuation
   = note: `#[warn(clippy::doc_lazy_continuation)]` on by default
help: indent this line
   |
20 | ///   prevent their use for the time being.
   |     ++
```