### PR TITLE
Remove deny(pointer_structural_match)

### DIFF
--- a/aya/src/lib.rs
+++ b/aya/src/lib.rs
@@ -54,7 +54,6 @@
     missing_docs,
     non_ascii_idents,
     noop_method_call,
-    pointer_structural_match,
     rust_2021_incompatible_closure_captures,
     rust_2021_incompatible_or_patterns,
     rust_2021_prefixes_incompatible_syntax,


### PR DESCRIPTION
```
warning: lint `pointer_structural_match` has been removed: converted into hard error, see RFC #3535 <https://rust-lang.github.io/rfcs/3535-constants-in-patterns.html> for more information
  --> aya/src/lib.rs:57:5
   |
57 |     pointer_structural_match,
   |     ^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = note: `#[warn(renamed_and_removed_lints)]` on by default
```
