### PR TITLE
fix(docs): rustdoc flag correction to `-D warnings`

### DIFF
--- a/.taplo.toml
+++ b/.taplo.toml
@@ -2,4 +2,3 @@
 
 [rule.formatting]
 indent_string = "    "
-reorder_arrays = true

--- a/aya/Cargo.toml
+++ b/aya/Cargo.toml
@@ -35,4 +35,4 @@ async_std = ["dep:async-io"]
 
 [package.metadata.docs.rs]
 all-features = true
-rustdoc-args = ["--cfg", "-D", "docsrs", "warnings"]
+rustdoc-args = ["--cfg", "docsrs", "-D", "warnings"]


### PR DESCRIPTION
This fixes the current rustdoc build error by correcting the ordering of `rustdoc-args` to `-D warnings`. Additionally, this also removes the `recorder_arrays` field (defaults to false) so that the order is not modified, which is what caused the error in the first place. 😺