### PR TITLE
aya-log: Allow logging `core::net::Ipv4Addr` and `core::net::Ipv6Addr`

### DIFF
--- a/test/integration-ebpf/src/log.rs
+++ b/test/integration-ebpf/src/log.rs
@@ -1,6 +1,8 @@
 #![no_std]
 #![no_main]
 
+use core::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+
 use aya_ebpf::{macros::uprobe, programs::ProbeContext};
 use aya_log_ebpf::{debug, error, info, trace, warn};
 
@@ -15,11 +17,43 @@ pub fn test_log(ctx: ProbeContext) {
         "wao",
         "wao".as_bytes()
     );
-    let ipv4 = 167772161u32; // 10.0.0.1
-    let ipv6 = [
-        32u8, 1u8, 13u8, 184u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 1u8,
-    ]; // 2001:db8::1
-    info!(&ctx, "ipv4: {:i}, ipv6: {:i}", ipv4, ipv6);
+
+    // 10.0.0.1
+    let ipv4 = Ipv4Addr::new(10, 0, 0, 1);
+    // 2001:db8::1
+    let ipv6 = Ipv6Addr::new(8193, 3512, 0, 0, 0, 0, 0, 1);
+    info!(
+        &ctx,
+        "ip structs, without format hint: ipv4: {}, ipv6: {}", ipv4, ipv6
+    );
+    info!(
+        &ctx,
+        "ip structs, with format hint: ipv4: {:i}, ipv6: {:i}", ipv4, ipv6
+    );
+
+    let ipv4_enum = IpAddr::V4(ipv4);
+    let ipv6_enum = IpAddr::V6(ipv6);
+    info!(
+        &ctx,
+        "ip enums, without format hint: ipv4: {}, ipv6: {}", ipv4_enum, ipv6_enum
+    );
+    info!(
+        &ctx,
+        "ip enums, with format hint: ipv4: {:i}, ipv6: {:i}", ipv4_enum, ipv6_enum
+    );
+
+    // We don't format `Ipv6Addr::to_bits`, because `u128` is not supported by
+    // eBPF. Even though Rust compiler does not complain, verifier would throw
+    // an error about returning values not fitting into 64-bit registers.
+    info!(&ctx, "ip as bits: ipv4: {:i}", ipv4.to_bits());
+
+    info!(
+        &ctx,
+        "ip as octets: ipv4: {:i}, ipv6: {:i}",
+        ipv4.octets(),
+        ipv6.octets()
+    );
+
     let mac = [4u8, 32u8, 6u8, 9u8, 0u8, 64u8];
     trace!(&ctx, "mac lc: {:mac}, mac uc: {:MAC}", mac, mac);
     let hex = 0x2f;

--- a/test/integration-test/src/tests/log.rs
+++ b/test/integration-test/src/tests/log.rs
@@ -106,7 +106,52 @@ async fn log() {
     assert_eq!(
         records.next(),
         Some(&CapturedLog {
-            body: "ipv4: 10.0.0.1, ipv6: 2001:db8::1".into(),
+            body: "ip structs, without format hint: ipv4: 10.0.0.1, ipv6: 2001:db8::1".into(),
+            level: Level::Info,
+            target: "log".into(),
+        })
+    );
+
+    assert_eq!(
+        records.next(),
+        Some(&CapturedLog {
+            body: "ip structs, with format hint: ipv4: 10.0.0.1, ipv6: 2001:db8::1".into(),
+            level: Level::Info,
+            target: "log".into(),
+        })
+    );
+
+    assert_eq!(
+        records.next(),
+        Some(&CapturedLog {
+            body: "ip enums, without format hint: ipv4: 10.0.0.1, ipv6: 2001:db8::1".into(),
+            level: Level::Info,
+            target: "log".into(),
+        })
+    );
+
+    assert_eq!(
+        records.next(),
+        Some(&CapturedLog {
+            body: "ip enums, with format hint: ipv4: 10.0.0.1, ipv6: 2001:db8::1".into(),
+            level: Level::Info,
+            target: "log".into(),
+        })
+    );
+
+    assert_eq!(
+        records.next(),
+        Some(&CapturedLog {
+            body: "ip as bits: ipv4: 10.0.0.1".into(),
+            level: Level::Info,
+            target: "log".into(),
+        })
+    );
+
+    assert_eq!(
+        records.next(),
+        Some(&CapturedLog {
+            body: "ip as octets: ipv4: 10.0.0.1, ipv6: 2001:db8::1".into(),
             level: Level::Info,
             target: "log".into(),
         })

--- a/xtask/public-api/aya-log-common.txt
+++ b/xtask/public-api/aya-log-common.txt
@@ -2,6 +2,7 @@ pub mod aya_log_common
 #[repr(u8)] pub enum aya_log_common::Argument
 pub aya_log_common::Argument::ArrU16Len8
 pub aya_log_common::Argument::ArrU8Len16
+pub aya_log_common::Argument::ArrU8Len4
 pub aya_log_common::Argument::ArrU8Len6
 pub aya_log_common::Argument::Bytes
 pub aya_log_common::Argument::DisplayHint
@@ -11,6 +12,8 @@ pub aya_log_common::Argument::I16
 pub aya_log_common::Argument::I32
 pub aya_log_common::Argument::I64
 pub aya_log_common::Argument::I8
+pub aya_log_common::Argument::Ipv4Addr
+pub aya_log_common::Argument::Ipv6Addr
 pub aya_log_common::Argument::Isize
 pub aya_log_common::Argument::Str
 pub aya_log_common::Argument::U16
@@ -188,6 +191,9 @@ pub trait aya_log_common::DefaultFormatter
 impl aya_log_common::DefaultFormatter for &str
 impl aya_log_common::DefaultFormatter for bool
 impl aya_log_common::DefaultFormatter for char
+impl aya_log_common::DefaultFormatter for core::net::ip_addr::IpAddr
+impl aya_log_common::DefaultFormatter for core::net::ip_addr::Ipv4Addr
+impl aya_log_common::DefaultFormatter for core::net::ip_addr::Ipv6Addr
 impl aya_log_common::DefaultFormatter for f32
 impl aya_log_common::DefaultFormatter for f64
 impl aya_log_common::DefaultFormatter for i16
@@ -204,6 +210,10 @@ impl aya_log_common::DefaultFormatter for usize
 pub trait aya_log_common::IpFormatter
 impl aya_log_common::IpFormatter for [u16; 8]
 impl aya_log_common::IpFormatter for [u8; 16]
+impl aya_log_common::IpFormatter for [u8; 4]
+impl aya_log_common::IpFormatter for core::net::ip_addr::IpAddr
+impl aya_log_common::IpFormatter for core::net::ip_addr::Ipv4Addr
+impl aya_log_common::IpFormatter for core::net::ip_addr::Ipv6Addr
 impl aya_log_common::IpFormatter for u32
 pub trait aya_log_common::LowerHexFormatter
 impl aya_log_common::LowerHexFormatter for &[u8]
@@ -243,10 +253,18 @@ impl aya_log_common::WriteToBuf for [u16; 8]
 pub fn [u16; 8]::write(self, buf: &mut [u8]) -> core::option::Option<core::num::nonzero::NonZeroUsize>
 impl aya_log_common::WriteToBuf for [u8; 16]
 pub fn [u8; 16]::write(self, buf: &mut [u8]) -> core::option::Option<core::num::nonzero::NonZeroUsize>
+impl aya_log_common::WriteToBuf for [u8; 4]
+pub fn [u8; 4]::write(self, buf: &mut [u8]) -> core::option::Option<core::num::nonzero::NonZeroUsize>
 impl aya_log_common::WriteToBuf for [u8; 6]
 pub fn [u8; 6]::write(self, buf: &mut [u8]) -> core::option::Option<core::num::nonzero::NonZeroUsize>
 impl aya_log_common::WriteToBuf for aya_log_common::DisplayHint
 pub fn aya_log_common::DisplayHint::write(self, buf: &mut [u8]) -> core::option::Option<core::num::nonzero::NonZeroUsize>
+impl aya_log_common::WriteToBuf for core::net::ip_addr::IpAddr
+pub fn core::net::ip_addr::IpAddr::write(self, buf: &mut [u8]) -> core::option::Option<core::num::nonzero::NonZeroUsize>
+impl aya_log_common::WriteToBuf for core::net::ip_addr::Ipv4Addr
+pub fn core::net::ip_addr::Ipv4Addr::write(self, buf: &mut [u8]) -> core::option::Option<core::num::nonzero::NonZeroUsize>
+impl aya_log_common::WriteToBuf for core::net::ip_addr::Ipv6Addr
+pub fn core::net::ip_addr::Ipv6Addr::write(self, buf: &mut [u8]) -> core::option::Option<core::num::nonzero::NonZeroUsize>
 impl aya_log_common::WriteToBuf for f32
 pub fn f32::write(self, buf: &mut [u8]) -> core::option::Option<core::num::nonzero::NonZeroUsize>
 impl aya_log_common::WriteToBuf for f64


### PR DESCRIPTION
IP address types are available in `core`, so they can be used also in eBPF programs. This change adds support of these types in aya-log.

* Add implementation of `WriteTuBuf` to these types.
* Support these types in `Ipv4Formatter` and `Ipv6Formatter`.
* Support them with `DisplayHint::Ip`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aya-rs/aya/966)
<!-- Reviewable:end -->
