### PR TITLE
feat(aya-ebpf): Implement memmove

### DIFF
--- a/test/integration-ebpf/Cargo.toml
+++ b/test/integration-ebpf/Cargo.toml
@@ -11,6 +11,7 @@ edition.workspace = true
 [dependencies]
 aya-ebpf = { path = "../../ebpf/aya-ebpf" }
 aya-log-ebpf = { path = "../../ebpf/aya-log-ebpf" }
+network-types = "0.0.6"
 
 [build-dependencies]
 which = { workspace = true }
@@ -59,3 +60,7 @@ path = "src/xdp_sec.rs"
 [[bin]]
 name = "ring_buf"
 path = "src/ring_buf.rs"
+
+[[bin]]
+name = "memmove_test"
+path = "src/memmove_test.rs"

--- a/test/integration-ebpf/src/memmove_test.rs
+++ b/test/integration-ebpf/src/memmove_test.rs
@@ -1,0 +1,61 @@
+#![no_std]
+#![no_main]
+
+use core::mem;
+
+use aya_ebpf::{
+    bindings::{xdp_action, BPF_F_NO_PREALLOC},
+    macros::{map, xdp},
+    maps::HashMap,
+    programs::XdpContext,
+};
+use network_types::{
+    eth::{EthHdr, EtherType},
+    ip::Ipv6Hdr,
+};
+
+#[inline(always)]
+fn ptr_at<T>(ctx: &XdpContext, offset: usize) -> Result<*const T, ()> {
+    let start = ctx.data();
+    let end = ctx.data_end();
+    let len = mem::size_of::<T>();
+
+    if start + offset + len > end {
+        return Err(());
+    }
+
+    Ok((start + offset) as *const T)
+}
+
+struct Value {
+    pub orig_ip: [u8; 16],
+}
+
+#[map]
+static RULES: HashMap<u8, Value> = HashMap::<u8, Value>::with_max_entries(1, BPF_F_NO_PREALLOC);
+
+#[xdp]
+pub fn do_dnat(ctx: XdpContext) -> u32 {
+    try_do_dnat(ctx).unwrap_or(xdp_action::XDP_DROP)
+}
+
+fn try_do_dnat(ctx: XdpContext) -> Result<u32, ()> {
+    let index = 0;
+    if let Some(nat) = unsafe { RULES.get(&index) } {
+        let hproto: *const EtherType = ptr_at(&ctx, mem::offset_of!(EthHdr, ether_type))?;
+        match unsafe { *hproto } {
+            EtherType::Ipv6 => {
+                let ip_hdr: *const Ipv6Hdr = ptr_at(&ctx, EthHdr::LEN)?;
+                unsafe { (*ip_hdr.cast_mut()).dst_addr.in6_u.u6_addr8 = nat.orig_ip };
+            }
+            _ => return Ok(xdp_action::XDP_PASS),
+        }
+    }
+    Ok(xdp_action::XDP_PASS)
+}
+
+#[cfg(not(test))]
+#[panic_handler]
+fn panic(_info: &core::panic::PanicInfo) -> ! {
+    loop {}
+}

--- a/test/integration-test/src/lib.rs
+++ b/test/integration-test/src/lib.rs
@@ -22,6 +22,7 @@ pub const BPF_PROBE_READ: &[u8] =
 pub const REDIRECT: &[u8] = include_bytes_aligned!(concat!(env!("OUT_DIR"), "/redirect"));
 pub const XDP_SEC: &[u8] = include_bytes_aligned!(concat!(env!("OUT_DIR"), "/xdp_sec"));
 pub const RING_BUF: &[u8] = include_bytes_aligned!(concat!(env!("OUT_DIR"), "/ring_buf"));
+pub const MEMMOVE_TEST: &[u8] = include_bytes_aligned!(concat!(env!("OUT_DIR"), "/memmove_test"));
 
 #[cfg(test)]
 mod tests;

--- a/test/integration-test/src/tests/load.rs
+++ b/test/integration-test/src/tests/load.rs
@@ -283,6 +283,15 @@ fn unload_kprobe() {
 }
 
 #[test]
+fn memmove() {
+    let mut bpf = Ebpf::load(crate::MEMMOVE_TEST).unwrap();
+    let prog: &mut Xdp = bpf.program_mut("do_dnat").unwrap().try_into().unwrap();
+
+    prog.load().unwrap();
+    assert_loaded("do_dnat");
+}
+
+#[test]
 fn basic_tracepoint() {
     let mut bpf = Ebpf::load(crate::TEST).unwrap();
     let prog: &mut TracePoint = bpf

--- a/xtask/public-api/aya-ebpf.txt
+++ b/xtask/public-api/aya-ebpf.txt
@@ -2736,4 +2736,5 @@ impl aya_ebpf::EbpfContext for aya_ebpf::programs::xdp::XdpContext
 pub fn aya_ebpf::programs::xdp::XdpContext::as_ptr(&self) -> *mut core::ffi::c_void
 pub fn aya_ebpf::check_bounds_signed(value: i64, lower: i64, upper: i64) -> bool
 #[no_mangle] pub unsafe c fn aya_ebpf::memcpy(dest: *mut u8, src: *mut u8, n: usize)
+#[no_mangle] pub unsafe c fn aya_ebpf::memmove(dest: *mut u8, src: *mut u8, n: usize)
 #[no_mangle] pub unsafe c fn aya_ebpf::memset(s: *mut u8, c: aya_ebpf_cty::ad::c_int, n: usize)


### PR DESCRIPTION
The compiler will emit this function for certain operations, but aya currently does not provide an implementation.
This leads to ebpf loading failures as the kernel can't find the symbol when loading the program.

The implementation is based on https://github.com/rust-lang/compiler-builtins/blob/master/src/mem/mod.rs#L29-L40 and https://github.com/rust-lang/compiler-builtins/blob/master/src/mem/impls.rs#L128-L135 Only the simplest case has been implemented, none of the word optimizations, since memcpy also doesn't seem to have them.