### PR TITLE
chore(xtask): Add s390x and powerpc64 to codegen

### DIFF
--- a/xtask/src/codegen/aya.rs
+++ b/xtask/src/codegen/aya.rs
@@ -57,6 +57,8 @@ fn codegen_bindings(opts: &SysrootOptions, libbpf_dir: &Path) -> Result<(), anyh
         aarch64_sysroot,
         armv7_sysroot,
         riscv64_sysroot,
+        powerpc64_sysroot,
+        s390x_sysroot,
     } = opts;
     let types = [
         // BPF
@@ -179,6 +181,8 @@ fn codegen_bindings(opts: &SysrootOptions, libbpf_dir: &Path) -> Result<(), anyh
             Architecture::ARMv7 => "armv7-unknown-linux-gnu",
             Architecture::AArch64 => "aarch64-unknown-linux-gnu",
             Architecture::RISCV64 => "riscv64-unknown-linux-gnu",
+            Architecture::PowerPC64 => "powerpc64le-unknown-linux-gnu",
+            Architecture::S390X => "s390x-unknown-linux-gnu",
         };
         bindgen = bindgen.clang_args(&["-target", target]);
 
@@ -189,6 +193,8 @@ fn codegen_bindings(opts: &SysrootOptions, libbpf_dir: &Path) -> Result<(), anyh
             Architecture::ARMv7 => armv7_sysroot,
             Architecture::AArch64 => aarch64_sysroot,
             Architecture::RISCV64 => riscv64_sysroot,
+            Architecture::PowerPC64 => powerpc64_sysroot,
+            Architecture::S390X => s390x_sysroot,
         };
         bindgen = bindgen.clang_args(&["-I", &*sysroot.to_string_lossy()]);
 

--- a/xtask/src/codegen/aya_ebpf_bindings.rs
+++ b/xtask/src/codegen/aya_ebpf_bindings.rs
@@ -17,6 +17,8 @@ pub fn codegen(opts: &SysrootOptions, libbpf_dir: &Path) -> Result<(), anyhow::E
         aarch64_sysroot,
         armv7_sysroot,
         riscv64_sysroot,
+        powerpc64_sysroot,
+        s390x_sysroot,
     } = opts;
 
     let dir = PathBuf::from("ebpf/aya-ebpf-bindings");
@@ -80,6 +82,8 @@ pub fn codegen(opts: &SysrootOptions, libbpf_dir: &Path) -> Result<(), anyhow::E
             Architecture::ARMv7 => "armv7-unknown-linux-gnu",
             Architecture::AArch64 => "aarch64-unknown-linux-gnu",
             Architecture::RISCV64 => "riscv64-unknown-linux-gnu",
+            Architecture::PowerPC64 => "powerpc64le-unknown-linux-gnu",
+            Architecture::S390X => "s390x-unknown-linux-gnu",
         };
         bindgen = bindgen.clang_args(&["-target", target]);
 
@@ -90,6 +94,8 @@ pub fn codegen(opts: &SysrootOptions, libbpf_dir: &Path) -> Result<(), anyhow::E
             Architecture::ARMv7 => armv7_sysroot,
             Architecture::AArch64 => aarch64_sysroot,
             Architecture::RISCV64 => riscv64_sysroot,
+            Architecture::PowerPC64 => powerpc64_sysroot,
+            Architecture::S390X => s390x_sysroot,
         };
         bindgen = bindgen.clang_args(&["-I", &*sysroot.to_string_lossy()]);
 

--- a/xtask/src/codegen/mod.rs
+++ b/xtask/src/codegen/mod.rs
@@ -11,6 +11,8 @@ const SUPPORTED_ARCHS: &[Architecture] = &[
     Architecture::ARMv7,
     Architecture::AArch64,
     Architecture::RISCV64,
+    Architecture::PowerPC64,
+    Architecture::S390X,
 ];
 
 #[derive(Debug, Copy, Clone)]
@@ -19,6 +21,8 @@ pub enum Architecture {
     ARMv7,
     AArch64,
     RISCV64,
+    PowerPC64,
+    S390X,
 }
 
 impl Architecture {
@@ -36,6 +40,8 @@ impl std::str::FromStr for Architecture {
             "armv7" => Architecture::ARMv7,
             "aarch64" => Architecture::AArch64,
             "riscv64" => Architecture::RISCV64,
+            "powerpc64" => Architecture::PowerPC64,
+            "s390x" => Architecture::S390X,
             _ => return Err("invalid architecture"),
         })
     }
@@ -48,6 +54,8 @@ impl std::fmt::Display for Architecture {
             Architecture::ARMv7 => "armv7",
             Architecture::AArch64 => "aarch64",
             Architecture::RISCV64 => "riscv64",
+            Architecture::PowerPC64 => "powerpc64",
+            Architecture::S390X => "s390x",
         })
     }
 }
@@ -67,6 +75,12 @@ pub struct SysrootOptions {
 
     #[arg(long, default_value = "/usr/riscv64-linux-gnu/include", action)]
     riscv64_sysroot: PathBuf,
+
+    #[arg(long, default_value = "/usr/powerpc64le-linux-gnu/include", action)]
+    powerpc64_sysroot: PathBuf,
+
+    #[arg(long, default_value = "/usr/s390x-linux-gnu/include", action)]
+    s390x_sysroot: PathBuf,
 }
 
 #[derive(Parser)]


### PR DESCRIPTION
This commit adds the s390x and powerpc architectures to codegen.
This will enable an upcoming PR to add support for aya to support theses architectures in both aya and aya-ebpf.