### PR TITLE
ci: Fix codegen and prep for s390/ppc64el

### DIFF
--- a/.github/workflows/gen.yml
+++ b/.github/workflows/gen.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Install headers
         run: |
           sudo apt -y update
-          sudo apt -y install libc6-dev libc6-dev-{arm64,armel,riscv64}-cross
+          sudo apt -y install libelf-dev libc6-dev libc6-dev-{arm64,armel,riscv64,ppc64el,s390x}-cross
 
       - name: Run codegen
         run: |


### PR DESCRIPTION
Adds missing libelf headers that are now included
as part of libbpf-internal.h. Adds ppc64el and
s390x to the cross environment.