### PR TITLE
aya,aya-obj: conversion from `u32` to prog, map, and link type

### DIFF
--- a/aya-obj/src/generated/linux_bindings_aarch64.rs
+++ b/aya-obj/src/generated/linux_bindings_aarch64.rs
@@ -476,6 +476,11 @@ pub const BPF_F_TOKEN_FD: _bindgen_ty_5 = 65536;
 pub const BPF_F_SEGV_ON_FAULT: _bindgen_ty_5 = 131072;
 pub const BPF_F_NO_USER_CONV: _bindgen_ty_5 = 262144;
 pub type _bindgen_ty_5 = ::core::ffi::c_uint;
+#[repr(u32)]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum bpf_stats_type {
+    BPF_STATS_RUN_TIME = 0,
+}
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub union bpf_attr {

--- a/aya-obj/src/generated/linux_bindings_armv7.rs
+++ b/aya-obj/src/generated/linux_bindings_armv7.rs
@@ -476,6 +476,11 @@ pub const BPF_F_TOKEN_FD: _bindgen_ty_5 = 65536;
 pub const BPF_F_SEGV_ON_FAULT: _bindgen_ty_5 = 131072;
 pub const BPF_F_NO_USER_CONV: _bindgen_ty_5 = 262144;
 pub type _bindgen_ty_5 = ::core::ffi::c_uint;
+#[repr(u32)]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum bpf_stats_type {
+    BPF_STATS_RUN_TIME = 0,
+}
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub union bpf_attr {

--- a/aya-obj/src/generated/linux_bindings_riscv64.rs
+++ b/aya-obj/src/generated/linux_bindings_riscv64.rs
@@ -476,6 +476,11 @@ pub const BPF_F_TOKEN_FD: _bindgen_ty_5 = 65536;
 pub const BPF_F_SEGV_ON_FAULT: _bindgen_ty_5 = 131072;
 pub const BPF_F_NO_USER_CONV: _bindgen_ty_5 = 262144;
 pub type _bindgen_ty_5 = ::core::ffi::c_uint;
+#[repr(u32)]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum bpf_stats_type {
+    BPF_STATS_RUN_TIME = 0,
+}
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub union bpf_attr {

--- a/aya-obj/src/generated/linux_bindings_x86_64.rs
+++ b/aya-obj/src/generated/linux_bindings_x86_64.rs
@@ -476,6 +476,11 @@ pub const BPF_F_TOKEN_FD: _bindgen_ty_5 = 65536;
 pub const BPF_F_SEGV_ON_FAULT: _bindgen_ty_5 = 131072;
 pub const BPF_F_NO_USER_CONV: _bindgen_ty_5 = 262144;
 pub type _bindgen_ty_5 = ::core::ffi::c_uint;
+#[repr(u32)]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum bpf_stats_type {
+    BPF_STATS_RUN_TIME = 0,
+}
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub union bpf_attr {

--- a/aya-obj/src/lib.rs
+++ b/aya-obj/src/lib.rs
@@ -87,6 +87,7 @@ mod std {
 
 pub mod btf;
 pub mod generated;
+pub mod links;
 pub mod maps;
 pub mod obj;
 pub mod programs;

--- a/aya-obj/src/lib.rs
+++ b/aya-obj/src/lib.rs
@@ -92,10 +92,12 @@ pub mod maps;
 pub mod obj;
 pub mod programs;
 pub mod relocation;
+pub mod stats;
 mod util;
 
 pub use maps::Map;
 pub use obj::*;
+pub use stats::BpfStatsType;
 
 /// An error returned from the verifier.
 ///

--- a/aya-obj/src/links.rs
+++ b/aya-obj/src/links.rs
@@ -1,0 +1,53 @@
+//! Link struct and type bindings.
+
+use core::fmt::Display;
+
+use crate::generated::bpf_link_type::{self, *};
+
+impl From<u32> for bpf_link_type {
+    fn from(link_type: u32) -> Self {
+        match link_type {
+            x if x == BPF_LINK_TYPE_UNSPEC as u32 => BPF_LINK_TYPE_UNSPEC,
+            x if x == BPF_LINK_TYPE_RAW_TRACEPOINT as u32 => BPF_LINK_TYPE_RAW_TRACEPOINT,
+            x if x == BPF_LINK_TYPE_TRACING as u32 => BPF_LINK_TYPE_TRACING,
+            x if x == BPF_LINK_TYPE_CGROUP as u32 => BPF_LINK_TYPE_CGROUP,
+            x if x == BPF_LINK_TYPE_ITER as u32 => BPF_LINK_TYPE_ITER,
+            x if x == BPF_LINK_TYPE_NETNS as u32 => BPF_LINK_TYPE_NETNS,
+            x if x == BPF_LINK_TYPE_XDP as u32 => BPF_LINK_TYPE_XDP,
+            x if x == BPF_LINK_TYPE_PERF_EVENT as u32 => BPF_LINK_TYPE_PERF_EVENT,
+            x if x == BPF_LINK_TYPE_KPROBE_MULTI as u32 => BPF_LINK_TYPE_KPROBE_MULTI,
+            x if x == BPF_LINK_TYPE_STRUCT_OPS as u32 => BPF_LINK_TYPE_STRUCT_OPS,
+            x if x == BPF_LINK_TYPE_NETFILTER as u32 => BPF_LINK_TYPE_NETFILTER,
+            x if x == BPF_LINK_TYPE_TCX as u32 => BPF_LINK_TYPE_TCX,
+            x if x == BPF_LINK_TYPE_UPROBE_MULTI as u32 => BPF_LINK_TYPE_UPROBE_MULTI,
+            x if x == BPF_LINK_TYPE_NETKIT as u32 => BPF_LINK_TYPE_NETKIT,
+            _ => __MAX_BPF_LINK_TYPE,
+        }
+    }
+}
+
+impl Display for bpf_link_type {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(
+            f,
+            "{}",
+            match self {
+                BPF_LINK_TYPE_UNSPEC => "Unspec",
+                BPF_LINK_TYPE_RAW_TRACEPOINT => "RawTracePoint",
+                BPF_LINK_TYPE_TRACING => "Tracing",
+                BPF_LINK_TYPE_CGROUP => "Cgroup",
+                BPF_LINK_TYPE_ITER => "Iter",
+                BPF_LINK_TYPE_NETNS => "NetNs",
+                BPF_LINK_TYPE_XDP => "Xdp",
+                BPF_LINK_TYPE_PERF_EVENT => "PerfEvent",
+                BPF_LINK_TYPE_KPROBE_MULTI => "KProbeMulti",
+                BPF_LINK_TYPE_STRUCT_OPS => "StructOps",
+                BPF_LINK_TYPE_NETFILTER => "Netfilter",
+                BPF_LINK_TYPE_TCX => "Tcx",
+                BPF_LINK_TYPE_UPROBE_MULTI => "UProbeMulti",
+                BPF_LINK_TYPE_NETKIT => "NetKit",
+                __MAX_BPF_LINK_TYPE => "MaxLinkType",
+            }
+        )
+    }
+}

--- a/aya-obj/src/maps.rs
+++ b/aya-obj/src/maps.rs
@@ -5,7 +5,7 @@ use core::mem;
 
 #[cfg(not(feature = "std"))]
 use crate::std;
-use crate::EbpfSectionKind;
+use crate::{generated::bpf_map_type::*, EbpfSectionKind};
 
 /// Invalid map type encontered
 pub struct InvalidMapTypeError {
@@ -17,7 +17,6 @@ impl TryFrom<u32> for crate::generated::bpf_map_type {
     type Error = InvalidMapTypeError;
 
     fn try_from(map_type: u32) -> Result<Self, Self::Error> {
-        use crate::generated::bpf_map_type::*;
         Ok(match map_type {
             x if x == BPF_MAP_TYPE_UNSPEC as u32 => BPF_MAP_TYPE_UNSPEC,
             x if x == BPF_MAP_TYPE_HASH as u32 => BPF_MAP_TYPE_HASH,
@@ -31,7 +30,6 @@ impl TryFrom<u32> for crate::generated::bpf_map_type {
             x if x == BPF_MAP_TYPE_LRU_HASH as u32 => BPF_MAP_TYPE_LRU_HASH,
             x if x == BPF_MAP_TYPE_LRU_PERCPU_HASH as u32 => BPF_MAP_TYPE_LRU_PERCPU_HASH,
             x if x == BPF_MAP_TYPE_LPM_TRIE as u32 => BPF_MAP_TYPE_LPM_TRIE,
-            x if x == BPF_MAP_TYPE_BLOOM_FILTER as u32 => BPF_MAP_TYPE_BLOOM_FILTER,
             x if x == BPF_MAP_TYPE_ARRAY_OF_MAPS as u32 => BPF_MAP_TYPE_ARRAY_OF_MAPS,
             x if x == BPF_MAP_TYPE_HASH_OF_MAPS as u32 => BPF_MAP_TYPE_HASH_OF_MAPS,
             x if x == BPF_MAP_TYPE_DEVMAP as u32 => BPF_MAP_TYPE_DEVMAP,
@@ -42,7 +40,6 @@ impl TryFrom<u32> for crate::generated::bpf_map_type {
             x if x == BPF_MAP_TYPE_CGROUP_STORAGE_DEPRECATED as u32 => {
                 BPF_MAP_TYPE_CGROUP_STORAGE_DEPRECATED
             }
-            x if x == BPF_MAP_TYPE_CGRP_STORAGE as u32 => BPF_MAP_TYPE_CGRP_STORAGE,
             x if x == BPF_MAP_TYPE_REUSEPORT_SOCKARRAY as u32 => BPF_MAP_TYPE_REUSEPORT_SOCKARRAY,
             x if x == BPF_MAP_TYPE_PERCPU_CGROUP_STORAGE_DEPRECATED as u32 => {
                 BPF_MAP_TYPE_PERCPU_CGROUP_STORAGE_DEPRECATED
@@ -58,6 +55,7 @@ impl TryFrom<u32> for crate::generated::bpf_map_type {
             x if x == BPF_MAP_TYPE_BLOOM_FILTER as u32 => BPF_MAP_TYPE_BLOOM_FILTER,
             x if x == BPF_MAP_TYPE_USER_RINGBUF as u32 => BPF_MAP_TYPE_USER_RINGBUF,
             x if x == BPF_MAP_TYPE_CGRP_STORAGE as u32 => BPF_MAP_TYPE_CGRP_STORAGE,
+            x if x == BPF_MAP_TYPE_ARENA as u32 => BPF_MAP_TYPE_ARENA,
             _ => return Err(InvalidMapTypeError { map_type }),
         })
     }
@@ -289,4 +287,50 @@ pub struct BtfMap {
     pub(crate) section_index: usize,
     pub(crate) symbol_index: usize,
     pub(crate) data: Vec<u8>,
+}
+
+impl core::fmt::Display for crate::generated::bpf_map_type {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(
+            f,
+            "{}",
+            match self {
+                BPF_MAP_TYPE_UNSPEC => "Unspec",
+                BPF_MAP_TYPE_HASH => "Hash",
+                BPF_MAP_TYPE_ARRAY => "Array",
+                BPF_MAP_TYPE_PROG_ARRAY => "ProgArray",
+                BPF_MAP_TYPE_PERF_EVENT_ARRAY => "PerfEventArray",
+                BPF_MAP_TYPE_PERCPU_HASH => "PerCpuHash",
+                BPF_MAP_TYPE_PERCPU_ARRAY => "PerCpuArray",
+                BPF_MAP_TYPE_STACK_TRACE => "StackTrace",
+                BPF_MAP_TYPE_CGROUP_ARRAY => "CgroupArray",
+                BPF_MAP_TYPE_LRU_HASH => "LruHash",
+                BPF_MAP_TYPE_LRU_PERCPU_HASH => "LruPerCpuHash",
+                BPF_MAP_TYPE_LPM_TRIE => "LpmTrie",
+                BPF_MAP_TYPE_ARRAY_OF_MAPS => "ArrayOfMaps",
+                BPF_MAP_TYPE_HASH_OF_MAPS => "HashOfMaps",
+                BPF_MAP_TYPE_DEVMAP => "DevMap",
+                BPF_MAP_TYPE_SOCKMAP => "SockMap",
+                BPF_MAP_TYPE_CPUMAP => "CpuMap",
+                BPF_MAP_TYPE_XSKMAP => "XskMap",
+                BPF_MAP_TYPE_SOCKHASH => "SockHash",
+                BPF_MAP_TYPE_CGROUP_STORAGE_DEPRECATED => "CgroupStorageDeprecated",
+                BPF_MAP_TYPE_REUSEPORT_SOCKARRAY => "ReusePortSockArray",
+                BPF_MAP_TYPE_PERCPU_CGROUP_STORAGE_DEPRECATED => "PerCpuCgroupStorageDeprecated",
+                BPF_MAP_TYPE_QUEUE => "Queue",
+                BPF_MAP_TYPE_STACK => "Stack",
+                BPF_MAP_TYPE_SK_STORAGE => "SkStorage",
+                BPF_MAP_TYPE_DEVMAP_HASH => "DevMapHash",
+                BPF_MAP_TYPE_STRUCT_OPS => "StructOps",
+                BPF_MAP_TYPE_RINGBUF => "RingBuf",
+                BPF_MAP_TYPE_INODE_STORAGE => "InodeStorage",
+                BPF_MAP_TYPE_TASK_STORAGE => "TaskStorage",
+                BPF_MAP_TYPE_BLOOM_FILTER => "BloomFilter",
+                BPF_MAP_TYPE_USER_RINGBUF => "UserRingBuf",
+                BPF_MAP_TYPE_CGRP_STORAGE => "CgrpStorage",
+                BPF_MAP_TYPE_ARENA => "Arena",
+                __MAX_BPF_MAP_TYPE => "MaxMapType",
+            }
+        )
+    }
 }

--- a/aya-obj/src/programs/mod.rs
+++ b/aya-obj/src/programs/mod.rs
@@ -3,6 +3,7 @@
 pub mod cgroup_sock;
 pub mod cgroup_sock_addr;
 pub mod cgroup_sockopt;
+pub mod prog_type;
 pub mod xdp;
 
 pub use cgroup_sock::CgroupSockAttachType;

--- a/aya-obj/src/programs/prog_type.rs
+++ b/aya-obj/src/programs/prog_type.rs
@@ -1,0 +1,93 @@
+//! Program type bindings.
+
+use core::fmt::Display;
+
+use crate::generated::bpf_prog_type::{self, *};
+
+impl From<u32> for bpf_prog_type {
+    fn from(prog_type: u32) -> Self {
+        match prog_type {
+            x if x == BPF_PROG_TYPE_UNSPEC as u32 => BPF_PROG_TYPE_UNSPEC,
+            x if x == BPF_PROG_TYPE_SOCKET_FILTER as u32 => BPF_PROG_TYPE_SOCKET_FILTER,
+            x if x == BPF_PROG_TYPE_KPROBE as u32 => BPF_PROG_TYPE_KPROBE,
+            x if x == BPF_PROG_TYPE_SCHED_CLS as u32 => BPF_PROG_TYPE_SCHED_CLS,
+            x if x == BPF_PROG_TYPE_SCHED_ACT as u32 => BPF_PROG_TYPE_SCHED_ACT,
+            x if x == BPF_PROG_TYPE_TRACEPOINT as u32 => BPF_PROG_TYPE_TRACEPOINT,
+            x if x == BPF_PROG_TYPE_XDP as u32 => BPF_PROG_TYPE_XDP,
+            x if x == BPF_PROG_TYPE_PERF_EVENT as u32 => BPF_PROG_TYPE_PERF_EVENT,
+            x if x == BPF_PROG_TYPE_CGROUP_SKB as u32 => BPF_PROG_TYPE_CGROUP_SKB,
+            x if x == BPF_PROG_TYPE_CGROUP_SOCK as u32 => BPF_PROG_TYPE_CGROUP_SOCK,
+            x if x == BPF_PROG_TYPE_LWT_IN as u32 => BPF_PROG_TYPE_LWT_IN,
+            x if x == BPF_PROG_TYPE_LWT_OUT as u32 => BPF_PROG_TYPE_LWT_OUT,
+            x if x == BPF_PROG_TYPE_LWT_XMIT as u32 => BPF_PROG_TYPE_LWT_XMIT,
+            x if x == BPF_PROG_TYPE_SOCK_OPS as u32 => BPF_PROG_TYPE_SOCK_OPS,
+            x if x == BPF_PROG_TYPE_SK_SKB as u32 => BPF_PROG_TYPE_SK_SKB,
+            x if x == BPF_PROG_TYPE_CGROUP_DEVICE as u32 => BPF_PROG_TYPE_CGROUP_DEVICE,
+            x if x == BPF_PROG_TYPE_SK_MSG as u32 => BPF_PROG_TYPE_SK_MSG,
+            x if x == BPF_PROG_TYPE_RAW_TRACEPOINT as u32 => BPF_PROG_TYPE_RAW_TRACEPOINT,
+            x if x == BPF_PROG_TYPE_CGROUP_SOCK_ADDR as u32 => BPF_PROG_TYPE_CGROUP_SOCK_ADDR,
+            x if x == BPF_PROG_TYPE_LWT_SEG6LOCAL as u32 => BPF_PROG_TYPE_LWT_SEG6LOCAL,
+            x if x == BPF_PROG_TYPE_LIRC_MODE2 as u32 => BPF_PROG_TYPE_LIRC_MODE2,
+            x if x == BPF_PROG_TYPE_SK_REUSEPORT as u32 => BPF_PROG_TYPE_SK_REUSEPORT,
+            x if x == BPF_PROG_TYPE_FLOW_DISSECTOR as u32 => BPF_PROG_TYPE_FLOW_DISSECTOR,
+            x if x == BPF_PROG_TYPE_CGROUP_SYSCTL as u32 => BPF_PROG_TYPE_CGROUP_SYSCTL,
+            x if x == BPF_PROG_TYPE_RAW_TRACEPOINT_WRITABLE as u32 => {
+                BPF_PROG_TYPE_RAW_TRACEPOINT_WRITABLE
+            }
+            x if x == BPF_PROG_TYPE_CGROUP_SOCKOPT as u32 => BPF_PROG_TYPE_CGROUP_SOCKOPT,
+            x if x == BPF_PROG_TYPE_TRACING as u32 => BPF_PROG_TYPE_TRACING,
+            x if x == BPF_PROG_TYPE_STRUCT_OPS as u32 => BPF_PROG_TYPE_STRUCT_OPS,
+            x if x == BPF_PROG_TYPE_EXT as u32 => BPF_PROG_TYPE_EXT,
+            x if x == BPF_PROG_TYPE_LSM as u32 => BPF_PROG_TYPE_LSM,
+            x if x == BPF_PROG_TYPE_SK_LOOKUP as u32 => BPF_PROG_TYPE_SK_LOOKUP,
+            x if x == BPF_PROG_TYPE_SYSCALL as u32 => BPF_PROG_TYPE_SYSCALL,
+            x if x == BPF_PROG_TYPE_NETFILTER as u32 => BPF_PROG_TYPE_NETFILTER,
+            _ => __MAX_BPF_PROG_TYPE,
+        }
+    }
+}
+
+impl Display for bpf_prog_type {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(
+            f,
+            "{}",
+            match self {
+                BPF_PROG_TYPE_UNSPEC => "Unspec",
+                BPF_PROG_TYPE_SOCKET_FILTER => "SocketFilter",
+                BPF_PROG_TYPE_KPROBE => "KProbe",
+                BPF_PROG_TYPE_SCHED_CLS => "SchedCls",
+                BPF_PROG_TYPE_SCHED_ACT => "SchedAct",
+                BPF_PROG_TYPE_TRACEPOINT => "TracePoint",
+                BPF_PROG_TYPE_XDP => "Xdp",
+                BPF_PROG_TYPE_PERF_EVENT => "PerfEvent",
+                BPF_PROG_TYPE_CGROUP_SKB => "CgroupSkb",
+                BPF_PROG_TYPE_CGROUP_SOCK => "CgroupSock",
+                BPF_PROG_TYPE_LWT_IN => "LwtIn",
+                BPF_PROG_TYPE_LWT_OUT => "LwtOut",
+                BPF_PROG_TYPE_LWT_XMIT => "LwtXmit",
+                BPF_PROG_TYPE_SOCK_OPS => "SockOps",
+                BPF_PROG_TYPE_SK_SKB => "SkSkb",
+                BPF_PROG_TYPE_CGROUP_DEVICE => "CgroupDevice",
+                BPF_PROG_TYPE_SK_MSG => "SkMsg",
+                BPF_PROG_TYPE_RAW_TRACEPOINT => "RawTracePoint",
+                BPF_PROG_TYPE_CGROUP_SOCK_ADDR => "CgroupSockAddr",
+                BPF_PROG_TYPE_LWT_SEG6LOCAL => "LwtSeg6local",
+                BPF_PROG_TYPE_LIRC_MODE2 => "LircMode2",
+                BPF_PROG_TYPE_SK_REUSEPORT => "SkReusePort",
+                BPF_PROG_TYPE_FLOW_DISSECTOR => "FlowDissector",
+                BPF_PROG_TYPE_CGROUP_SYSCTL => "CgroupSysctl",
+                BPF_PROG_TYPE_RAW_TRACEPOINT_WRITABLE => "RawTracePointWritable",
+                BPF_PROG_TYPE_CGROUP_SOCKOPT => "CgroupSockOpt",
+                BPF_PROG_TYPE_TRACING => "Tracing",
+                BPF_PROG_TYPE_STRUCT_OPS => "StructOps",
+                BPF_PROG_TYPE_EXT => "Ext",
+                BPF_PROG_TYPE_LSM => "Lsm",
+                BPF_PROG_TYPE_SK_LOOKUP => "SkLookup",
+                BPF_PROG_TYPE_SYSCALL => "Syscall",
+                BPF_PROG_TYPE_NETFILTER => "Netfilter",
+                __MAX_BPF_PROG_TYPE => "MaxProgType",
+            }
+        )
+    }
+}

--- a/aya-obj/src/stats.rs
+++ b/aya-obj/src/stats.rs
@@ -1,0 +1,18 @@
+//! BPF stats type for `BPF_ENABLE_STATS`
+
+use crate::generated::bpf_stats_type;
+
+/// The type of BPF statistic to enable.
+#[derive(Copy, Clone, Debug)]
+pub enum BpfStatsType {
+    /// Metrics for `run_time_ns` and `run_cnt`.
+    RunTime,
+}
+
+impl From<BpfStatsType> for bpf_stats_type {
+    fn from(value: BpfStatsType) -> Self {
+        match value {
+            BpfStatsType::RunTime => bpf_stats_type::BPF_STATS_RUN_TIME,
+        }
+    }
+}

--- a/aya/src/maps/mod.rs
+++ b/aya/src/maps/mod.rs
@@ -59,6 +59,7 @@ use std::{
     ptr,
 };
 
+use aya_obj::generated::bpf_map_type;
 use libc::{getrlimit, rlim_t, rlimit, RLIMIT_MEMLOCK, RLIM_INFINITY};
 use log::warn;
 use obj::maps::InvalidMapTypeError;
@@ -960,6 +961,12 @@ impl MapInfo {
     /// [`bpf_map_type`](https://elixir.bootlin.com/linux/v6.4.4/source/include/uapi/linux/bpf.h#L905).
     pub fn map_type(&self) -> u32 {
         self.0.type_
+    }
+
+    /// The map type as defined by the linux kernel enum
+    /// [`bpf_map_type`](https://elixir.bootlin.com/linux/v6.4.4/source/include/uapi/linux/bpf.h#L905).
+    pub fn map_type_enum(&self) -> bpf_map_type {
+        bpf_map_type::try_from(self.0.type_).unwrap_or(bpf_map_type::__MAX_BPF_MAP_TYPE)
     }
 
     /// The key size for this map.

--- a/aya/src/programs/mod.rs
+++ b/aya/src/programs/mod.rs
@@ -1039,6 +1039,12 @@ impl ProgramInfo {
         self.0.type_
     }
 
+    /// The program type as the linux kernel enum
+    /// [`bpf_prog_type`](https://elixir.bootlin.com/linux/v6.4.4/source/include/uapi/linux/bpf.h#L948).
+    pub fn program_type_enum(&self) -> bpf_prog_type {
+        bpf_prog_type::from(self.0.type_)
+    }
+
     /// Returns true if the program is defined with a GPL-compatible license.
     pub fn gpl_compatible(&self) -> bool {
         self.0.gpl_compatible() != 0

--- a/aya/src/programs/mod.rs
+++ b/aya/src/programs/mod.rs
@@ -1105,6 +1105,22 @@ impl ProgramInfo {
         Ok(ProgramFd(fd))
     }
 
+    /// The duration the program has been running, in nanoseconds.
+    ///
+    /// Note this field is only updated for as long as [`BPF_ENABLE_STATS`](crate::Ebpf::enable_stats_fd)
+    /// is enabled with [`BPF_STATS_RUN_TIME`](aya_obj::BpfStatsType::RunTime) type set.
+    pub fn run_time_ns(&self) -> u64 {
+        self.0.run_time_ns
+    }
+
+    /// The number of times the program has ran.
+    ///
+    /// Note this field is only updated for as long as [`BPF_ENABLE_STATS`](crate::Ebpf::enable_stats_fd)
+    /// is enabled with [`BPF_STATS_RUN_TIME`](aya_obj::BpfStatsType::RunTime) type set.
+    pub fn run_cnt(&self) -> u64 {
+        self.0.run_cnt
+    }
+
     /// Loads a program from a pinned path in bpffs.
     pub fn from_pin<P: AsRef<Path>>(path: P) -> Result<Self, ProgramError> {
         use std::os::unix::ffi::OsStrExt as _;

--- a/test/integration-test/src/tests/smoke.rs
+++ b/test/integration-test/src/tests/smoke.rs
@@ -98,6 +98,8 @@ fn list_loaded_programs() {
     prog.verified_instruction_count();
     prog.loaded_at();
     prog.fd().unwrap();
+    prog.run_time_ns();
+    prog.run_cnt();
 }
 
 #[test]

--- a/xtask/public-api/aya-ebpf-bindings.txt
+++ b/xtask/public-api/aya-ebpf-bindings.txt
@@ -539,10 +539,6 @@ impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::__sk_buff__bind
 pub fn aya_ebpf_bindings::bindings::__sk_buff__bindgen_ty_1::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::__sk_buff__bindgen_ty_1 where T: core::marker::Sized
 pub fn aya_ebpf_bindings::bindings::__sk_buff__bindgen_ty_1::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::__sk_buff__bindgen_ty_1 where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::__sk_buff__bindgen_ty_1::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::__sk_buff__bindgen_ty_1 where T: core::marker::Copy
-pub unsafe fn aya_ebpf_bindings::bindings::__sk_buff__bindgen_ty_1::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::__sk_buff__bindgen_ty_1
 pub fn aya_ebpf_bindings::bindings::__sk_buff__bindgen_ty_1::from(t: T) -> T
 #[repr(C)] pub union aya_ebpf_bindings::bindings::__sk_buff__bindgen_ty_2
@@ -574,10 +570,6 @@ impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::__sk_buff__bind
 pub fn aya_ebpf_bindings::bindings::__sk_buff__bindgen_ty_2::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::__sk_buff__bindgen_ty_2 where T: core::marker::Sized
 pub fn aya_ebpf_bindings::bindings::__sk_buff__bindgen_ty_2::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::__sk_buff__bindgen_ty_2 where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::__sk_buff__bindgen_ty_2::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::__sk_buff__bindgen_ty_2 where T: core::marker::Copy
-pub unsafe fn aya_ebpf_bindings::bindings::__sk_buff__bindgen_ty_2::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::__sk_buff__bindgen_ty_2
 pub fn aya_ebpf_bindings::bindings::__sk_buff__bindgen_ty_2::from(t: T) -> T
 #[repr(C)] pub union aya_ebpf_bindings::bindings::bpf_attr
@@ -624,10 +616,6 @@ impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_attr where 
 pub fn aya_ebpf_bindings::bindings::bpf_attr::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_attr where T: core::marker::Sized
 pub fn aya_ebpf_bindings::bindings::bpf_attr::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_attr where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_attr::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_attr where T: core::marker::Copy
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_attr::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_attr
 pub fn aya_ebpf_bindings::bindings::bpf_attr::from(t: T) -> T
 #[repr(C)] pub union aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_10__bindgen_ty_1
@@ -656,10 +644,6 @@ impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_attr__bindg
 pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_10__bindgen_ty_1::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_10__bindgen_ty_1 where T: core::marker::Sized
 pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_10__bindgen_ty_1::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_10__bindgen_ty_1 where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_10__bindgen_ty_1::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_10__bindgen_ty_1 where T: core::marker::Copy
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_10__bindgen_ty_1::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_10__bindgen_ty_1
 pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_10__bindgen_ty_1::from(t: T) -> T
 #[repr(C)] pub union aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_10__bindgen_ty_2
@@ -688,10 +672,6 @@ impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_attr__bindg
 pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_10__bindgen_ty_2::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_10__bindgen_ty_2 where T: core::marker::Sized
 pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_10__bindgen_ty_2::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_10__bindgen_ty_2 where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_10__bindgen_ty_2::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_10__bindgen_ty_2 where T: core::marker::Copy
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_10__bindgen_ty_2::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_10__bindgen_ty_2
 pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_10__bindgen_ty_2::from(t: T) -> T
 #[repr(C)] pub union aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_1
@@ -720,10 +700,6 @@ impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_attr__bindg
 pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_1::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_1 where T: core::marker::Sized
 pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_1::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_1 where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_1::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_1 where T: core::marker::Copy
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_1::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_1
 pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_1::from(t: T) -> T
 #[repr(C)] pub union aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_2
@@ -752,10 +728,6 @@ impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_attr__bindg
 pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_2::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_2 where T: core::marker::Sized
 pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_2::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_2 where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_2::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_2 where T: core::marker::Copy
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_2::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_2
 pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_2::from(t: T) -> T
 #[repr(C)] pub union aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3
@@ -791,10 +763,6 @@ impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_attr__bindg
 pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3 where T: core::marker::Sized
 pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3 where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3 where T: core::marker::Copy
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3
 pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3::from(t: T) -> T
 #[repr(C)] pub union aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_6__bindgen_ty_1
@@ -823,10 +791,6 @@ impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_attr__bindg
 pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_6__bindgen_ty_1::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_6__bindgen_ty_1 where T: core::marker::Sized
 pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_6__bindgen_ty_1::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_6__bindgen_ty_1 where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_6__bindgen_ty_1::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_6__bindgen_ty_1 where T: core::marker::Copy
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_6__bindgen_ty_1::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_6__bindgen_ty_1
 pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_6__bindgen_ty_1::from(t: T) -> T
 #[repr(C)] pub union aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_8__bindgen_ty_1
@@ -855,10 +819,6 @@ impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_attr__bindg
 pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_8__bindgen_ty_1::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_8__bindgen_ty_1 where T: core::marker::Sized
 pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_8__bindgen_ty_1::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_8__bindgen_ty_1 where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_8__bindgen_ty_1::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_8__bindgen_ty_1 where T: core::marker::Copy
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_8__bindgen_ty_1::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_8__bindgen_ty_1
 pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_8__bindgen_ty_1::from(t: T) -> T
 #[repr(C)] pub union aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_15__bindgen_ty_1
@@ -887,10 +847,6 @@ impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_attr__bindg
 pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_15__bindgen_ty_1::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_15__bindgen_ty_1 where T: core::marker::Sized
 pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_15__bindgen_ty_1::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_15__bindgen_ty_1 where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_15__bindgen_ty_1::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_15__bindgen_ty_1 where T: core::marker::Copy
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_15__bindgen_ty_1::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_15__bindgen_ty_1
 pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_15__bindgen_ty_1::from(t: T) -> T
 #[repr(C)] pub union aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_15__bindgen_ty_2
@@ -919,10 +875,6 @@ impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_attr__bindg
 pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_15__bindgen_ty_2::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_15__bindgen_ty_2 where T: core::marker::Sized
 pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_15__bindgen_ty_2::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_15__bindgen_ty_2 where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_15__bindgen_ty_2::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_15__bindgen_ty_2 where T: core::marker::Copy
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_15__bindgen_ty_2::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_15__bindgen_ty_2
 pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_15__bindgen_ty_2::from(t: T) -> T
 #[repr(C)] pub union aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_2__bindgen_ty_1
@@ -951,10 +903,6 @@ impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_attr__bindg
 pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_2__bindgen_ty_1::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_2__bindgen_ty_1 where T: core::marker::Sized
 pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_2__bindgen_ty_1::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_2__bindgen_ty_1 where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_2__bindgen_ty_1::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_2__bindgen_ty_1 where T: core::marker::Copy
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_2__bindgen_ty_1::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_2__bindgen_ty_1
 pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_2__bindgen_ty_1::from(t: T) -> T
 #[repr(C)] pub union aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_4__bindgen_ty_1
@@ -983,10 +931,6 @@ impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_attr__bindg
 pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_4__bindgen_ty_1::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_4__bindgen_ty_1 where T: core::marker::Sized
 pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_4__bindgen_ty_1::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_4__bindgen_ty_1 where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_4__bindgen_ty_1::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_4__bindgen_ty_1 where T: core::marker::Copy
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_4__bindgen_ty_1::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_4__bindgen_ty_1
 pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_4__bindgen_ty_1::from(t: T) -> T
 #[repr(C)] pub union aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_6__bindgen_ty_1
@@ -1015,10 +959,6 @@ impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_attr__bindg
 pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_6__bindgen_ty_1::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_6__bindgen_ty_1 where T: core::marker::Sized
 pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_6__bindgen_ty_1::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_6__bindgen_ty_1 where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_6__bindgen_ty_1::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_6__bindgen_ty_1 where T: core::marker::Copy
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_6__bindgen_ty_1::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_6__bindgen_ty_1
 pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_6__bindgen_ty_1::from(t: T) -> T
 #[repr(C)] pub union aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_6__bindgen_ty_2
@@ -1047,10 +987,6 @@ impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_attr__bindg
 pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_6__bindgen_ty_2::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_6__bindgen_ty_2 where T: core::marker::Sized
 pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_6__bindgen_ty_2::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_6__bindgen_ty_2 where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_6__bindgen_ty_2::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_6__bindgen_ty_2 where T: core::marker::Copy
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_6__bindgen_ty_2::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_6__bindgen_ty_2
 pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_6__bindgen_ty_2::from(t: T) -> T
 #[repr(C)] pub union aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_8__bindgen_ty_1
@@ -1082,10 +1018,6 @@ impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_attr__bindg
 pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_8__bindgen_ty_1::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_8__bindgen_ty_1 where T: core::marker::Sized
 pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_8__bindgen_ty_1::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_8__bindgen_ty_1 where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_8__bindgen_ty_1::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_8__bindgen_ty_1 where T: core::marker::Copy
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_8__bindgen_ty_1::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_8__bindgen_ty_1
 pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_8__bindgen_ty_1::from(t: T) -> T
 #[repr(C)] pub union aya_ebpf_bindings::bindings::bpf_cpumap_val__bindgen_ty_1
@@ -1114,10 +1046,6 @@ impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_cpumap_val_
 pub fn aya_ebpf_bindings::bindings::bpf_cpumap_val__bindgen_ty_1::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_cpumap_val__bindgen_ty_1 where T: core::marker::Sized
 pub fn aya_ebpf_bindings::bindings::bpf_cpumap_val__bindgen_ty_1::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_cpumap_val__bindgen_ty_1 where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_cpumap_val__bindgen_ty_1::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_cpumap_val__bindgen_ty_1 where T: core::marker::Copy
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_cpumap_val__bindgen_ty_1::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_cpumap_val__bindgen_ty_1
 pub fn aya_ebpf_bindings::bindings::bpf_cpumap_val__bindgen_ty_1::from(t: T) -> T
 #[repr(C)] pub union aya_ebpf_bindings::bindings::bpf_devmap_val__bindgen_ty_1
@@ -1146,10 +1074,6 @@ impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_devmap_val_
 pub fn aya_ebpf_bindings::bindings::bpf_devmap_val__bindgen_ty_1::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_devmap_val__bindgen_ty_1 where T: core::marker::Sized
 pub fn aya_ebpf_bindings::bindings::bpf_devmap_val__bindgen_ty_1::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_devmap_val__bindgen_ty_1 where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_devmap_val__bindgen_ty_1::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_devmap_val__bindgen_ty_1 where T: core::marker::Copy
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_devmap_val__bindgen_ty_1::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_devmap_val__bindgen_ty_1
 pub fn aya_ebpf_bindings::bindings::bpf_devmap_val__bindgen_ty_1::from(t: T) -> T
 #[repr(C)] pub union aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_1
@@ -1178,10 +1102,6 @@ impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_fib_lookup_
 pub fn aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_1::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_1 where T: core::marker::Sized
 pub fn aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_1::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_1 where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_1::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_1 where T: core::marker::Copy
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_1::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_1
 pub fn aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_1::from(t: T) -> T
 #[repr(C)] pub union aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_2
@@ -1211,10 +1131,6 @@ impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_fib_lookup_
 pub fn aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_2::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_2 where T: core::marker::Sized
 pub fn aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_2::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_2 where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_2::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_2 where T: core::marker::Copy
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_2::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_2
 pub fn aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_2::from(t: T) -> T
 #[repr(C)] pub union aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_3
@@ -1243,10 +1159,6 @@ impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_fib_lookup_
 pub fn aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_3::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_3 where T: core::marker::Sized
 pub fn aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_3::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_3 where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_3::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_3 where T: core::marker::Copy
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_3::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_3
 pub fn aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_3::from(t: T) -> T
 #[repr(C)] pub union aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_4
@@ -1275,10 +1187,6 @@ impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_fib_lookup_
 pub fn aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_4::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_4 where T: core::marker::Sized
 pub fn aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_4::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_4 where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_4::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_4 where T: core::marker::Copy
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_4::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_4
 pub fn aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_4::from(t: T) -> T
 #[repr(C)] pub union aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_5
@@ -1307,10 +1215,6 @@ impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_fib_lookup_
 pub fn aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_5::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_5 where T: core::marker::Sized
 pub fn aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_5::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_5 where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_5::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_5 where T: core::marker::Copy
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_5::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_5
 pub fn aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_5::from(t: T) -> T
 #[repr(C)] pub union aya_ebpf_bindings::bindings::bpf_flow_keys__bindgen_ty_1
@@ -1339,10 +1243,6 @@ impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_flow_keys__
 pub fn aya_ebpf_bindings::bindings::bpf_flow_keys__bindgen_ty_1::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_flow_keys__bindgen_ty_1 where T: core::marker::Sized
 pub fn aya_ebpf_bindings::bindings::bpf_flow_keys__bindgen_ty_1::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_flow_keys__bindgen_ty_1 where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_flow_keys__bindgen_ty_1::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_flow_keys__bindgen_ty_1 where T: core::marker::Copy
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_flow_keys__bindgen_ty_1::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_flow_keys__bindgen_ty_1
 pub fn aya_ebpf_bindings::bindings::bpf_flow_keys__bindgen_ty_1::from(t: T) -> T
 #[repr(C)] pub union aya_ebpf_bindings::bindings::bpf_iter_link_info
@@ -1372,10 +1272,6 @@ impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_iter_link_i
 pub fn aya_ebpf_bindings::bindings::bpf_iter_link_info::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_iter_link_info where T: core::marker::Sized
 pub fn aya_ebpf_bindings::bindings::bpf_iter_link_info::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_iter_link_info where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_iter_link_info::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_iter_link_info where T: core::marker::Copy
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_iter_link_info::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_iter_link_info
 pub fn aya_ebpf_bindings::bindings::bpf_iter_link_info::from(t: T) -> T
 #[repr(C)] pub union aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1
@@ -1415,10 +1311,6 @@ impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_link_info__
 pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1 where T: core::marker::Sized
 pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1 where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1 where T: core::marker::Copy
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1
 pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1::from(t: T) -> T
 #[repr(C)] pub union aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1
@@ -1449,10 +1341,6 @@ impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_link_info__
 pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1 where T: core::marker::Sized
 pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1 where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1 where T: core::marker::Copy
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1
 pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1::from(t: T) -> T
 #[repr(C)] pub union aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_1
@@ -1480,10 +1368,6 @@ impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_link_info__
 pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_1::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_1 where T: core::marker::Sized
 pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_1::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_1 where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_1::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_1 where T: core::marker::Copy
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_1::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_1
 pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_1::from(t: T) -> T
 #[repr(C)] pub union aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2
@@ -1512,10 +1396,6 @@ impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_link_info__
 pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2 where T: core::marker::Sized
 pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2 where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2 where T: core::marker::Copy
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2
 pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2::from(t: T) -> T
 #[repr(C)] pub union aya_ebpf_bindings::bindings::bpf_lpm_trie_key_u8__bindgen_ty_1
@@ -1544,10 +1424,6 @@ impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_lpm_trie_ke
 pub fn aya_ebpf_bindings::bindings::bpf_lpm_trie_key_u8__bindgen_ty_1::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_lpm_trie_key_u8__bindgen_ty_1 where T: core::marker::Sized
 pub fn aya_ebpf_bindings::bindings::bpf_lpm_trie_key_u8__bindgen_ty_1::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_lpm_trie_key_u8__bindgen_ty_1 where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_lpm_trie_key_u8__bindgen_ty_1::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_lpm_trie_key_u8__bindgen_ty_1 where T: core::marker::Copy
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_lpm_trie_key_u8__bindgen_ty_1::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_lpm_trie_key_u8__bindgen_ty_1
 pub fn aya_ebpf_bindings::bindings::bpf_lpm_trie_key_u8__bindgen_ty_1::from(t: T) -> T
 #[repr(C)] pub union aya_ebpf_bindings::bindings::bpf_redir_neigh__bindgen_ty_1
@@ -1576,10 +1452,6 @@ impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_redir_neigh
 pub fn aya_ebpf_bindings::bindings::bpf_redir_neigh__bindgen_ty_1::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_redir_neigh__bindgen_ty_1 where T: core::marker::Sized
 pub fn aya_ebpf_bindings::bindings::bpf_redir_neigh__bindgen_ty_1::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_redir_neigh__bindgen_ty_1 where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_redir_neigh__bindgen_ty_1::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_redir_neigh__bindgen_ty_1 where T: core::marker::Copy
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_redir_neigh__bindgen_ty_1::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_redir_neigh__bindgen_ty_1
 pub fn aya_ebpf_bindings::bindings::bpf_redir_neigh__bindgen_ty_1::from(t: T) -> T
 #[repr(C)] pub union aya_ebpf_bindings::bindings::bpf_sk_lookup__bindgen_ty_1
@@ -1608,10 +1480,6 @@ impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_sk_lookup__
 pub fn aya_ebpf_bindings::bindings::bpf_sk_lookup__bindgen_ty_1::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_sk_lookup__bindgen_ty_1 where T: core::marker::Sized
 pub fn aya_ebpf_bindings::bindings::bpf_sk_lookup__bindgen_ty_1::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_sk_lookup__bindgen_ty_1 where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_sk_lookup__bindgen_ty_1::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_sk_lookup__bindgen_ty_1 where T: core::marker::Copy
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_sk_lookup__bindgen_ty_1::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_sk_lookup__bindgen_ty_1
 pub fn aya_ebpf_bindings::bindings::bpf_sk_lookup__bindgen_ty_1::from(t: T) -> T
 #[repr(C)] pub union aya_ebpf_bindings::bindings::bpf_sk_lookup__bindgen_ty_1__bindgen_ty_1
@@ -1643,10 +1511,6 @@ impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_sk_lookup__
 pub fn aya_ebpf_bindings::bindings::bpf_sk_lookup__bindgen_ty_1__bindgen_ty_1::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_sk_lookup__bindgen_ty_1__bindgen_ty_1 where T: core::marker::Sized
 pub fn aya_ebpf_bindings::bindings::bpf_sk_lookup__bindgen_ty_1__bindgen_ty_1::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_sk_lookup__bindgen_ty_1__bindgen_ty_1 where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_sk_lookup__bindgen_ty_1__bindgen_ty_1::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_sk_lookup__bindgen_ty_1__bindgen_ty_1 where T: core::marker::Copy
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_sk_lookup__bindgen_ty_1__bindgen_ty_1::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_sk_lookup__bindgen_ty_1__bindgen_ty_1
 pub fn aya_ebpf_bindings::bindings::bpf_sk_lookup__bindgen_ty_1__bindgen_ty_1::from(t: T) -> T
 #[repr(C)] pub union aya_ebpf_bindings::bindings::bpf_sock_addr__bindgen_ty_1
@@ -1678,10 +1542,6 @@ impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_sock_addr__
 pub fn aya_ebpf_bindings::bindings::bpf_sock_addr__bindgen_ty_1::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_sock_addr__bindgen_ty_1 where T: core::marker::Sized
 pub fn aya_ebpf_bindings::bindings::bpf_sock_addr__bindgen_ty_1::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_sock_addr__bindgen_ty_1 where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_sock_addr__bindgen_ty_1::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_sock_addr__bindgen_ty_1 where T: core::marker::Copy
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_sock_addr__bindgen_ty_1::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_sock_addr__bindgen_ty_1
 pub fn aya_ebpf_bindings::bindings::bpf_sock_addr__bindgen_ty_1::from(t: T) -> T
 #[repr(C)] pub union aya_ebpf_bindings::bindings::bpf_sock_ops__bindgen_ty_1
@@ -1711,10 +1571,6 @@ impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_sock_ops__b
 pub fn aya_ebpf_bindings::bindings::bpf_sock_ops__bindgen_ty_1::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_sock_ops__bindgen_ty_1 where T: core::marker::Sized
 pub fn aya_ebpf_bindings::bindings::bpf_sock_ops__bindgen_ty_1::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_sock_ops__bindgen_ty_1 where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_sock_ops__bindgen_ty_1::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_sock_ops__bindgen_ty_1 where T: core::marker::Copy
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_sock_ops__bindgen_ty_1::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_sock_ops__bindgen_ty_1
 pub fn aya_ebpf_bindings::bindings::bpf_sock_ops__bindgen_ty_1::from(t: T) -> T
 #[repr(C)] pub union aya_ebpf_bindings::bindings::bpf_sock_ops__bindgen_ty_2
@@ -1746,10 +1602,6 @@ impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_sock_ops__b
 pub fn aya_ebpf_bindings::bindings::bpf_sock_ops__bindgen_ty_2::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_sock_ops__bindgen_ty_2 where T: core::marker::Sized
 pub fn aya_ebpf_bindings::bindings::bpf_sock_ops__bindgen_ty_2::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_sock_ops__bindgen_ty_2 where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_sock_ops__bindgen_ty_2::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_sock_ops__bindgen_ty_2 where T: core::marker::Copy
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_sock_ops__bindgen_ty_2::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_sock_ops__bindgen_ty_2
 pub fn aya_ebpf_bindings::bindings::bpf_sock_ops__bindgen_ty_2::from(t: T) -> T
 #[repr(C)] pub union aya_ebpf_bindings::bindings::bpf_sock_ops__bindgen_ty_3
@@ -1781,10 +1633,6 @@ impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_sock_ops__b
 pub fn aya_ebpf_bindings::bindings::bpf_sock_ops__bindgen_ty_3::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_sock_ops__bindgen_ty_3 where T: core::marker::Sized
 pub fn aya_ebpf_bindings::bindings::bpf_sock_ops__bindgen_ty_3::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_sock_ops__bindgen_ty_3 where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_sock_ops__bindgen_ty_3::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_sock_ops__bindgen_ty_3 where T: core::marker::Copy
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_sock_ops__bindgen_ty_3::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_sock_ops__bindgen_ty_3
 pub fn aya_ebpf_bindings::bindings::bpf_sock_ops__bindgen_ty_3::from(t: T) -> T
 #[repr(C)] pub union aya_ebpf_bindings::bindings::bpf_sock_ops__bindgen_ty_4
@@ -1816,10 +1664,6 @@ impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_sock_ops__b
 pub fn aya_ebpf_bindings::bindings::bpf_sock_ops__bindgen_ty_4::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_sock_ops__bindgen_ty_4 where T: core::marker::Sized
 pub fn aya_ebpf_bindings::bindings::bpf_sock_ops__bindgen_ty_4::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_sock_ops__bindgen_ty_4 where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_sock_ops__bindgen_ty_4::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_sock_ops__bindgen_ty_4 where T: core::marker::Copy
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_sock_ops__bindgen_ty_4::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_sock_ops__bindgen_ty_4
 pub fn aya_ebpf_bindings::bindings::bpf_sock_ops__bindgen_ty_4::from(t: T) -> T
 #[repr(C)] pub union aya_ebpf_bindings::bindings::bpf_sock_tuple__bindgen_ty_1
@@ -1848,10 +1692,6 @@ impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_sock_tuple_
 pub fn aya_ebpf_bindings::bindings::bpf_sock_tuple__bindgen_ty_1::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_sock_tuple__bindgen_ty_1 where T: core::marker::Sized
 pub fn aya_ebpf_bindings::bindings::bpf_sock_tuple__bindgen_ty_1::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_sock_tuple__bindgen_ty_1 where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_sock_tuple__bindgen_ty_1::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_sock_tuple__bindgen_ty_1 where T: core::marker::Copy
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_sock_tuple__bindgen_ty_1::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_sock_tuple__bindgen_ty_1
 pub fn aya_ebpf_bindings::bindings::bpf_sock_tuple__bindgen_ty_1::from(t: T) -> T
 #[repr(C)] pub union aya_ebpf_bindings::bindings::bpf_sockopt__bindgen_ty_1
@@ -1883,10 +1723,6 @@ impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_sockopt__bi
 pub fn aya_ebpf_bindings::bindings::bpf_sockopt__bindgen_ty_1::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_sockopt__bindgen_ty_1 where T: core::marker::Sized
 pub fn aya_ebpf_bindings::bindings::bpf_sockopt__bindgen_ty_1::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_sockopt__bindgen_ty_1 where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_sockopt__bindgen_ty_1::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_sockopt__bindgen_ty_1 where T: core::marker::Copy
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_sockopt__bindgen_ty_1::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_sockopt__bindgen_ty_1
 pub fn aya_ebpf_bindings::bindings::bpf_sockopt__bindgen_ty_1::from(t: T) -> T
 #[repr(C)] pub union aya_ebpf_bindings::bindings::bpf_sockopt__bindgen_ty_2
@@ -1918,10 +1754,6 @@ impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_sockopt__bi
 pub fn aya_ebpf_bindings::bindings::bpf_sockopt__bindgen_ty_2::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_sockopt__bindgen_ty_2 where T: core::marker::Sized
 pub fn aya_ebpf_bindings::bindings::bpf_sockopt__bindgen_ty_2::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_sockopt__bindgen_ty_2 where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_sockopt__bindgen_ty_2::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_sockopt__bindgen_ty_2 where T: core::marker::Copy
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_sockopt__bindgen_ty_2::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_sockopt__bindgen_ty_2
 pub fn aya_ebpf_bindings::bindings::bpf_sockopt__bindgen_ty_2::from(t: T) -> T
 #[repr(C)] pub union aya_ebpf_bindings::bindings::bpf_sockopt__bindgen_ty_3
@@ -1953,10 +1785,6 @@ impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_sockopt__bi
 pub fn aya_ebpf_bindings::bindings::bpf_sockopt__bindgen_ty_3::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_sockopt__bindgen_ty_3 where T: core::marker::Sized
 pub fn aya_ebpf_bindings::bindings::bpf_sockopt__bindgen_ty_3::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_sockopt__bindgen_ty_3 where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_sockopt__bindgen_ty_3::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_sockopt__bindgen_ty_3 where T: core::marker::Copy
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_sockopt__bindgen_ty_3::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_sockopt__bindgen_ty_3
 pub fn aya_ebpf_bindings::bindings::bpf_sockopt__bindgen_ty_3::from(t: T) -> T
 #[repr(C)] pub union aya_ebpf_bindings::bindings::bpf_stack_build_id__bindgen_ty_1
@@ -1985,10 +1813,6 @@ impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_stack_build
 pub fn aya_ebpf_bindings::bindings::bpf_stack_build_id__bindgen_ty_1::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_stack_build_id__bindgen_ty_1 where T: core::marker::Sized
 pub fn aya_ebpf_bindings::bindings::bpf_stack_build_id__bindgen_ty_1::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_stack_build_id__bindgen_ty_1 where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_stack_build_id__bindgen_ty_1::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_stack_build_id__bindgen_ty_1 where T: core::marker::Copy
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_stack_build_id__bindgen_ty_1::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_stack_build_id__bindgen_ty_1
 pub fn aya_ebpf_bindings::bindings::bpf_stack_build_id__bindgen_ty_1::from(t: T) -> T
 #[repr(C)] pub union aya_ebpf_bindings::bindings::bpf_tunnel_key__bindgen_ty_1
@@ -2017,10 +1841,6 @@ impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_tunnel_key_
 pub fn aya_ebpf_bindings::bindings::bpf_tunnel_key__bindgen_ty_1::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_tunnel_key__bindgen_ty_1 where T: core::marker::Sized
 pub fn aya_ebpf_bindings::bindings::bpf_tunnel_key__bindgen_ty_1::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_tunnel_key__bindgen_ty_1 where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_tunnel_key__bindgen_ty_1::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_tunnel_key__bindgen_ty_1 where T: core::marker::Copy
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_tunnel_key__bindgen_ty_1::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_tunnel_key__bindgen_ty_1
 pub fn aya_ebpf_bindings::bindings::bpf_tunnel_key__bindgen_ty_1::from(t: T) -> T
 #[repr(C)] pub union aya_ebpf_bindings::bindings::bpf_tunnel_key__bindgen_ty_2
@@ -2049,10 +1869,6 @@ impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_tunnel_key_
 pub fn aya_ebpf_bindings::bindings::bpf_tunnel_key__bindgen_ty_2::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_tunnel_key__bindgen_ty_2 where T: core::marker::Sized
 pub fn aya_ebpf_bindings::bindings::bpf_tunnel_key__bindgen_ty_2::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_tunnel_key__bindgen_ty_2 where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_tunnel_key__bindgen_ty_2::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_tunnel_key__bindgen_ty_2 where T: core::marker::Copy
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_tunnel_key__bindgen_ty_2::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_tunnel_key__bindgen_ty_2
 pub fn aya_ebpf_bindings::bindings::bpf_tunnel_key__bindgen_ty_2::from(t: T) -> T
 #[repr(C)] pub union aya_ebpf_bindings::bindings::bpf_tunnel_key__bindgen_ty_3
@@ -2081,10 +1897,6 @@ impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_tunnel_key_
 pub fn aya_ebpf_bindings::bindings::bpf_tunnel_key__bindgen_ty_3::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_tunnel_key__bindgen_ty_3 where T: core::marker::Sized
 pub fn aya_ebpf_bindings::bindings::bpf_tunnel_key__bindgen_ty_3::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_tunnel_key__bindgen_ty_3 where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_tunnel_key__bindgen_ty_3::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_tunnel_key__bindgen_ty_3 where T: core::marker::Copy
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_tunnel_key__bindgen_ty_3::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_tunnel_key__bindgen_ty_3
 pub fn aya_ebpf_bindings::bindings::bpf_tunnel_key__bindgen_ty_3::from(t: T) -> T
 #[repr(C)] pub union aya_ebpf_bindings::bindings::bpf_xfrm_state__bindgen_ty_1
@@ -2113,10 +1925,6 @@ impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_xfrm_state_
 pub fn aya_ebpf_bindings::bindings::bpf_xfrm_state__bindgen_ty_1::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_xfrm_state__bindgen_ty_1 where T: core::marker::Sized
 pub fn aya_ebpf_bindings::bindings::bpf_xfrm_state__bindgen_ty_1::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_xfrm_state__bindgen_ty_1 where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_xfrm_state__bindgen_ty_1::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_xfrm_state__bindgen_ty_1 where T: core::marker::Copy
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_xfrm_state__bindgen_ty_1::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_xfrm_state__bindgen_ty_1
 pub fn aya_ebpf_bindings::bindings::bpf_xfrm_state__bindgen_ty_1::from(t: T) -> T
 #[repr(C)] pub union aya_ebpf_bindings::bindings::sk_msg_md__bindgen_ty_1
@@ -2148,10 +1956,6 @@ impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::sk_msg_md__bind
 pub fn aya_ebpf_bindings::bindings::sk_msg_md__bindgen_ty_1::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::sk_msg_md__bindgen_ty_1 where T: core::marker::Sized
 pub fn aya_ebpf_bindings::bindings::sk_msg_md__bindgen_ty_1::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::sk_msg_md__bindgen_ty_1 where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::sk_msg_md__bindgen_ty_1::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::sk_msg_md__bindgen_ty_1 where T: core::marker::Copy
-pub unsafe fn aya_ebpf_bindings::bindings::sk_msg_md__bindgen_ty_1::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::sk_msg_md__bindgen_ty_1
 pub fn aya_ebpf_bindings::bindings::sk_msg_md__bindgen_ty_1::from(t: T) -> T
 #[repr(C)] pub union aya_ebpf_bindings::bindings::sk_msg_md__bindgen_ty_2
@@ -2183,10 +1987,6 @@ impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::sk_msg_md__bind
 pub fn aya_ebpf_bindings::bindings::sk_msg_md__bindgen_ty_2::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::sk_msg_md__bindgen_ty_2 where T: core::marker::Sized
 pub fn aya_ebpf_bindings::bindings::sk_msg_md__bindgen_ty_2::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::sk_msg_md__bindgen_ty_2 where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::sk_msg_md__bindgen_ty_2::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::sk_msg_md__bindgen_ty_2 where T: core::marker::Copy
-pub unsafe fn aya_ebpf_bindings::bindings::sk_msg_md__bindgen_ty_2::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::sk_msg_md__bindgen_ty_2
 pub fn aya_ebpf_bindings::bindings::sk_msg_md__bindgen_ty_2::from(t: T) -> T
 #[repr(C)] pub union aya_ebpf_bindings::bindings::sk_msg_md__bindgen_ty_3
@@ -2218,10 +2018,6 @@ impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::sk_msg_md__bind
 pub fn aya_ebpf_bindings::bindings::sk_msg_md__bindgen_ty_3::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::sk_msg_md__bindgen_ty_3 where T: core::marker::Sized
 pub fn aya_ebpf_bindings::bindings::sk_msg_md__bindgen_ty_3::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::sk_msg_md__bindgen_ty_3 where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::sk_msg_md__bindgen_ty_3::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::sk_msg_md__bindgen_ty_3 where T: core::marker::Copy
-pub unsafe fn aya_ebpf_bindings::bindings::sk_msg_md__bindgen_ty_3::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::sk_msg_md__bindgen_ty_3
 pub fn aya_ebpf_bindings::bindings::sk_msg_md__bindgen_ty_3::from(t: T) -> T
 #[repr(C)] pub union aya_ebpf_bindings::bindings::sk_reuseport_md__bindgen_ty_1
@@ -2253,10 +2049,6 @@ impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::sk_reuseport_md
 pub fn aya_ebpf_bindings::bindings::sk_reuseport_md__bindgen_ty_1::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::sk_reuseport_md__bindgen_ty_1 where T: core::marker::Sized
 pub fn aya_ebpf_bindings::bindings::sk_reuseport_md__bindgen_ty_1::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::sk_reuseport_md__bindgen_ty_1 where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::sk_reuseport_md__bindgen_ty_1::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::sk_reuseport_md__bindgen_ty_1 where T: core::marker::Copy
-pub unsafe fn aya_ebpf_bindings::bindings::sk_reuseport_md__bindgen_ty_1::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::sk_reuseport_md__bindgen_ty_1
 pub fn aya_ebpf_bindings::bindings::sk_reuseport_md__bindgen_ty_1::from(t: T) -> T
 #[repr(C)] pub union aya_ebpf_bindings::bindings::sk_reuseport_md__bindgen_ty_2
@@ -2288,10 +2080,6 @@ impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::sk_reuseport_md
 pub fn aya_ebpf_bindings::bindings::sk_reuseport_md__bindgen_ty_2::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::sk_reuseport_md__bindgen_ty_2 where T: core::marker::Sized
 pub fn aya_ebpf_bindings::bindings::sk_reuseport_md__bindgen_ty_2::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::sk_reuseport_md__bindgen_ty_2 where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::sk_reuseport_md__bindgen_ty_2::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::sk_reuseport_md__bindgen_ty_2 where T: core::marker::Copy
-pub unsafe fn aya_ebpf_bindings::bindings::sk_reuseport_md__bindgen_ty_2::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::sk_reuseport_md__bindgen_ty_2
 pub fn aya_ebpf_bindings::bindings::sk_reuseport_md__bindgen_ty_2::from(t: T) -> T
 #[repr(C)] pub union aya_ebpf_bindings::bindings::sk_reuseport_md__bindgen_ty_3
@@ -2323,10 +2111,6 @@ impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::sk_reuseport_md
 pub fn aya_ebpf_bindings::bindings::sk_reuseport_md__bindgen_ty_3::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::sk_reuseport_md__bindgen_ty_3 where T: core::marker::Sized
 pub fn aya_ebpf_bindings::bindings::sk_reuseport_md__bindgen_ty_3::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::sk_reuseport_md__bindgen_ty_3 where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::sk_reuseport_md__bindgen_ty_3::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::sk_reuseport_md__bindgen_ty_3 where T: core::marker::Copy
-pub unsafe fn aya_ebpf_bindings::bindings::sk_reuseport_md__bindgen_ty_3::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::sk_reuseport_md__bindgen_ty_3
 pub fn aya_ebpf_bindings::bindings::sk_reuseport_md__bindgen_ty_3::from(t: T) -> T
 #[repr(C)] pub union aya_ebpf_bindings::bindings::sk_reuseport_md__bindgen_ty_4
@@ -2358,10 +2142,6 @@ impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::sk_reuseport_md
 pub fn aya_ebpf_bindings::bindings::sk_reuseport_md__bindgen_ty_4::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::sk_reuseport_md__bindgen_ty_4 where T: core::marker::Sized
 pub fn aya_ebpf_bindings::bindings::sk_reuseport_md__bindgen_ty_4::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::sk_reuseport_md__bindgen_ty_4 where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::sk_reuseport_md__bindgen_ty_4::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::sk_reuseport_md__bindgen_ty_4 where T: core::marker::Copy
-pub unsafe fn aya_ebpf_bindings::bindings::sk_reuseport_md__bindgen_ty_4::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::sk_reuseport_md__bindgen_ty_4
 pub fn aya_ebpf_bindings::bindings::sk_reuseport_md__bindgen_ty_4::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::__BindgenBitfieldUnit<Storage>
@@ -2409,10 +2189,6 @@ impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::__BindgenBitfie
 pub fn aya_ebpf_bindings::bindings::__BindgenBitfieldUnit<Storage>::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::__BindgenBitfieldUnit<Storage> where T: core::marker::Sized
 pub fn aya_ebpf_bindings::bindings::__BindgenBitfieldUnit<Storage>::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::__BindgenBitfieldUnit<Storage> where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::__BindgenBitfieldUnit<Storage>::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::__BindgenBitfieldUnit<Storage> where T: core::marker::Copy
-pub unsafe fn aya_ebpf_bindings::bindings::__BindgenBitfieldUnit<Storage>::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::__BindgenBitfieldUnit<Storage>
 pub fn aya_ebpf_bindings::bindings::__BindgenBitfieldUnit<Storage>::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::__IncompleteArrayField<T>(_, _)
@@ -2510,10 +2286,6 @@ impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::__sk_buff where
 pub fn aya_ebpf_bindings::bindings::__sk_buff::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::__sk_buff where T: core::marker::Sized
 pub fn aya_ebpf_bindings::bindings::__sk_buff::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::__sk_buff where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::__sk_buff::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::__sk_buff where T: core::marker::Copy
-pub unsafe fn aya_ebpf_bindings::bindings::__sk_buff::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::__sk_buff
 pub fn aya_ebpf_bindings::bindings::__sk_buff::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_1
@@ -2558,10 +2330,6 @@ impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_attr__bindg
 pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_1::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_1 where T: core::marker::Sized
 pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_1::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_1 where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_1::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_1 where T: core::marker::Copy
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_1::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_1
 pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_1::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_10
@@ -2602,10 +2370,6 @@ impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_attr__bindg
 pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_10::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_10 where T: core::marker::Sized
 pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_10::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_10 where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_10::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_10 where T: core::marker::Copy
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_10::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_10
 pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_10::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_11
@@ -2641,10 +2405,6 @@ impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_attr__bindg
 pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_11::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_11 where T: core::marker::Sized
 pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_11::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_11 where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_11::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_11 where T: core::marker::Copy
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_11::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_11
 pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_11::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_12
@@ -2681,10 +2441,6 @@ impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_attr__bindg
 pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_12::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_12 where T: core::marker::Sized
 pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_12::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_12 where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_12::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_12 where T: core::marker::Copy
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_12::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_12
 pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_12::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_13
@@ -2722,10 +2478,6 @@ impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_attr__bindg
 pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_13::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_13 where T: core::marker::Sized
 pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_13::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_13 where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_13::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_13 where T: core::marker::Copy
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_13::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_13
 pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_13::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14
@@ -2757,10 +2509,6 @@ impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_attr__bindg
 pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14 where T: core::marker::Sized
 pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14 where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14 where T: core::marker::Copy
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14
 pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_1
@@ -2791,10 +2539,6 @@ impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_attr__bindg
 pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_1::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_1 where T: core::marker::Sized
 pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_1::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_1 where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_1::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_1 where T: core::marker::Copy
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_1::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_1
 pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_1::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_2
@@ -2824,10 +2568,6 @@ impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_attr__bindg
 pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_2::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_2 where T: core::marker::Sized
 pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_2::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_2 where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_2::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_2 where T: core::marker::Copy
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_2::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_2
 pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_2::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_3
@@ -2861,10 +2601,6 @@ impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_attr__bindg
 pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_3::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_3 where T: core::marker::Sized
 pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_3::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_3 where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_3::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_3 where T: core::marker::Copy
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_3::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_3
 pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_3::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_4
@@ -2895,10 +2631,6 @@ impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_attr__bindg
 pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_4::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_4 where T: core::marker::Sized
 pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_4::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_4 where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_4::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_4 where T: core::marker::Copy
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_4::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_4
 pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_4::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_5
@@ -2931,10 +2663,6 @@ impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_attr__bindg
 pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_5::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_5 where T: core::marker::Sized
 pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_5::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_5 where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_5::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_5 where T: core::marker::Copy
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_5::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_5
 pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_5::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_6
@@ -2963,10 +2691,6 @@ impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_attr__bindg
 pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_6::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_6 where T: core::marker::Sized
 pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_6::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_6 where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_6::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_6 where T: core::marker::Copy
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_6::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_6
 pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_6::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_7
@@ -3002,10 +2726,6 @@ impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_attr__bindg
 pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_7::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_7 where T: core::marker::Sized
 pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_7::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_7 where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_7::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_7 where T: core::marker::Copy
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_7::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_7
 pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_7::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_8
@@ -3034,10 +2754,6 @@ impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_attr__bindg
 pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_8::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_8 where T: core::marker::Sized
 pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_8::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_8 where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_8::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_8 where T: core::marker::Copy
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_8::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_8
 pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_8::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_15
@@ -3068,10 +2784,6 @@ impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_attr__bindg
 pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_15::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_15 where T: core::marker::Sized
 pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_15::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_15 where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_15::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_15 where T: core::marker::Copy
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_15::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_15
 pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_15::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_16
@@ -3101,10 +2813,6 @@ impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_attr__bindg
 pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_16::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_16 where T: core::marker::Sized
 pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_16::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_16 where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_16::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_16 where T: core::marker::Copy
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_16::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_16
 pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_16::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_17
@@ -3134,10 +2842,6 @@ impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_attr__bindg
 pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_17::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_17 where T: core::marker::Sized
 pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_17::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_17 where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_17::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_17 where T: core::marker::Copy
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_17::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_17
 pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_17::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_18
@@ -3168,10 +2872,6 @@ impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_attr__bindg
 pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_18::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_18 where T: core::marker::Sized
 pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_18::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_18 where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_18::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_18 where T: core::marker::Copy
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_18::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_18
 pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_18::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_19
@@ -3203,10 +2903,6 @@ impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_attr__bindg
 pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_19::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_19 where T: core::marker::Sized
 pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_19::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_19 where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_19::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_19 where T: core::marker::Copy
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_19::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_19
 pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_19::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_2
@@ -3237,10 +2933,6 @@ impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_attr__bindg
 pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_2::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_2 where T: core::marker::Sized
 pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_2::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_2 where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_2::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_2 where T: core::marker::Copy
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_2::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_2
 pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_2::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_20
@@ -3271,10 +2963,6 @@ impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_attr__bindg
 pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_20::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_20 where T: core::marker::Sized
 pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_20::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_20 where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_20::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_20 where T: core::marker::Copy
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_20::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_20
 pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_20::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_3
@@ -3311,10 +2999,6 @@ impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_attr__bindg
 pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_3::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_3 where T: core::marker::Sized
 pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_3::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_3 where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_3::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_3 where T: core::marker::Copy
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_3::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_3
 pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_3::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_4
@@ -3368,10 +3052,6 @@ impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_attr__bindg
 pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_4::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_4 where T: core::marker::Sized
 pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_4::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_4 where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_4::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_4 where T: core::marker::Copy
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_4::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_4
 pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_4::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_5
@@ -3404,10 +3084,6 @@ impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_attr__bindg
 pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_5::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_5 where T: core::marker::Sized
 pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_5::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_5 where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_5::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_5 where T: core::marker::Copy
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_5::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_5
 pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_5::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_6
@@ -3441,10 +3117,6 @@ impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_attr__bindg
 pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_6::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_6 where T: core::marker::Sized
 pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_6::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_6 where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_6::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_6 where T: core::marker::Copy
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_6::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_6
 pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_6::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_7
@@ -3488,10 +3160,6 @@ impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_attr__bindg
 pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_7::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_7 where T: core::marker::Sized
 pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_7::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_7 where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_7::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_7 where T: core::marker::Copy
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_7::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_7
 pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_7::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_8
@@ -3521,10 +3189,6 @@ impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_attr__bindg
 pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_8::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_8 where T: core::marker::Sized
 pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_8::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_8 where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_8::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_8 where T: core::marker::Copy
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_8::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_8
 pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_8::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_9
@@ -3556,10 +3220,6 @@ impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_attr__bindg
 pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_9::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_9 where T: core::marker::Sized
 pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_9::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_9 where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_9::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_9 where T: core::marker::Copy
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_9::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_9
 pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_9::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::bpf_btf_info
@@ -3594,10 +3254,6 @@ impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_btf_info wh
 pub fn aya_ebpf_bindings::bindings::bpf_btf_info::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_btf_info where T: core::marker::Sized
 pub fn aya_ebpf_bindings::bindings::bpf_btf_info::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_btf_info where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_btf_info::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_btf_info where T: core::marker::Copy
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_btf_info::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_btf_info
 pub fn aya_ebpf_bindings::bindings::bpf_btf_info::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::bpf_cgroup_dev_ctx
@@ -3629,10 +3285,6 @@ impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_cgroup_dev_
 pub fn aya_ebpf_bindings::bindings::bpf_cgroup_dev_ctx::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_cgroup_dev_ctx where T: core::marker::Sized
 pub fn aya_ebpf_bindings::bindings::bpf_cgroup_dev_ctx::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_cgroup_dev_ctx where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_cgroup_dev_ctx::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_cgroup_dev_ctx where T: core::marker::Copy
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_cgroup_dev_ctx::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_cgroup_dev_ctx
 pub fn aya_ebpf_bindings::bindings::bpf_cgroup_dev_ctx::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::bpf_cgroup_storage_key
@@ -3663,10 +3315,6 @@ impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_cgroup_stor
 pub fn aya_ebpf_bindings::bindings::bpf_cgroup_storage_key::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_cgroup_storage_key where T: core::marker::Sized
 pub fn aya_ebpf_bindings::bindings::bpf_cgroup_storage_key::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_cgroup_storage_key where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_cgroup_storage_key::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_cgroup_storage_key where T: core::marker::Copy
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_cgroup_storage_key::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_cgroup_storage_key
 pub fn aya_ebpf_bindings::bindings::bpf_cgroup_storage_key::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::bpf_core_relo
@@ -3699,10 +3347,6 @@ impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_core_relo w
 pub fn aya_ebpf_bindings::bindings::bpf_core_relo::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_core_relo where T: core::marker::Sized
 pub fn aya_ebpf_bindings::bindings::bpf_core_relo::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_core_relo where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_core_relo::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_core_relo where T: core::marker::Copy
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_core_relo::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_core_relo
 pub fn aya_ebpf_bindings::bindings::bpf_core_relo::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::bpf_cpumap_val
@@ -3731,10 +3375,6 @@ impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_cpumap_val 
 pub fn aya_ebpf_bindings::bindings::bpf_cpumap_val::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_cpumap_val where T: core::marker::Sized
 pub fn aya_ebpf_bindings::bindings::bpf_cpumap_val::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_cpumap_val where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_cpumap_val::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_cpumap_val where T: core::marker::Copy
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_cpumap_val::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_cpumap_val
 pub fn aya_ebpf_bindings::bindings::bpf_cpumap_val::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::bpf_devmap_val
@@ -3763,10 +3403,6 @@ impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_devmap_val 
 pub fn aya_ebpf_bindings::bindings::bpf_devmap_val::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_devmap_val where T: core::marker::Sized
 pub fn aya_ebpf_bindings::bindings::bpf_devmap_val::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_devmap_val where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_devmap_val::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_devmap_val where T: core::marker::Copy
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_devmap_val::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_devmap_val
 pub fn aya_ebpf_bindings::bindings::bpf_devmap_val::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::bpf_dynptr
@@ -3796,10 +3432,6 @@ impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_dynptr wher
 pub fn aya_ebpf_bindings::bindings::bpf_dynptr::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_dynptr where T: core::marker::Sized
 pub fn aya_ebpf_bindings::bindings::bpf_dynptr::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_dynptr where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_dynptr::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_dynptr where T: core::marker::Copy
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_dynptr::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_dynptr
 pub fn aya_ebpf_bindings::bindings::bpf_dynptr::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::bpf_fib_lookup
@@ -3838,10 +3470,6 @@ impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_fib_lookup 
 pub fn aya_ebpf_bindings::bindings::bpf_fib_lookup::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_fib_lookup where T: core::marker::Sized
 pub fn aya_ebpf_bindings::bindings::bpf_fib_lookup::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_fib_lookup where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_fib_lookup::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_fib_lookup where T: core::marker::Copy
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_fib_lookup::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_fib_lookup
 pub fn aya_ebpf_bindings::bindings::bpf_fib_lookup::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_5__bindgen_ty_1
@@ -3872,10 +3500,6 @@ impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_fib_lookup_
 pub fn aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_5__bindgen_ty_1::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_5__bindgen_ty_1 where T: core::marker::Sized
 pub fn aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_5__bindgen_ty_1::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_5__bindgen_ty_1 where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_5__bindgen_ty_1::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_5__bindgen_ty_1 where T: core::marker::Copy
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_5__bindgen_ty_1::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_5__bindgen_ty_1
 pub fn aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_5__bindgen_ty_1::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::bpf_flow_keys
@@ -3915,10 +3539,6 @@ impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_flow_keys w
 pub fn aya_ebpf_bindings::bindings::bpf_flow_keys::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_flow_keys where T: core::marker::Sized
 pub fn aya_ebpf_bindings::bindings::bpf_flow_keys::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_flow_keys where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_flow_keys::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_flow_keys where T: core::marker::Copy
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_flow_keys::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_flow_keys
 pub fn aya_ebpf_bindings::bindings::bpf_flow_keys::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::bpf_flow_keys__bindgen_ty_1__bindgen_ty_1
@@ -3949,10 +3569,6 @@ impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_flow_keys__
 pub fn aya_ebpf_bindings::bindings::bpf_flow_keys__bindgen_ty_1__bindgen_ty_1::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_flow_keys__bindgen_ty_1__bindgen_ty_1 where T: core::marker::Sized
 pub fn aya_ebpf_bindings::bindings::bpf_flow_keys__bindgen_ty_1__bindgen_ty_1::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_flow_keys__bindgen_ty_1__bindgen_ty_1 where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_flow_keys__bindgen_ty_1__bindgen_ty_1::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_flow_keys__bindgen_ty_1__bindgen_ty_1 where T: core::marker::Copy
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_flow_keys__bindgen_ty_1__bindgen_ty_1::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_flow_keys__bindgen_ty_1__bindgen_ty_1
 pub fn aya_ebpf_bindings::bindings::bpf_flow_keys__bindgen_ty_1__bindgen_ty_1::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::bpf_flow_keys__bindgen_ty_1__bindgen_ty_2
@@ -3983,10 +3599,6 @@ impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_flow_keys__
 pub fn aya_ebpf_bindings::bindings::bpf_flow_keys__bindgen_ty_1__bindgen_ty_2::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_flow_keys__bindgen_ty_1__bindgen_ty_2 where T: core::marker::Sized
 pub fn aya_ebpf_bindings::bindings::bpf_flow_keys__bindgen_ty_1__bindgen_ty_2::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_flow_keys__bindgen_ty_1__bindgen_ty_2 where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_flow_keys__bindgen_ty_1__bindgen_ty_2::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_flow_keys__bindgen_ty_1__bindgen_ty_2 where T: core::marker::Copy
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_flow_keys__bindgen_ty_1__bindgen_ty_2::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_flow_keys__bindgen_ty_1__bindgen_ty_2
 pub fn aya_ebpf_bindings::bindings::bpf_flow_keys__bindgen_ty_1__bindgen_ty_2::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::bpf_func_info
@@ -4017,10 +3629,6 @@ impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_func_info w
 pub fn aya_ebpf_bindings::bindings::bpf_func_info::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_func_info where T: core::marker::Sized
 pub fn aya_ebpf_bindings::bindings::bpf_func_info::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_func_info where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_func_info::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_func_info where T: core::marker::Copy
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_func_info::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_func_info
 pub fn aya_ebpf_bindings::bindings::bpf_func_info::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::bpf_insn
@@ -4060,10 +3668,6 @@ impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_insn where 
 pub fn aya_ebpf_bindings::bindings::bpf_insn::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_insn where T: core::marker::Sized
 pub fn aya_ebpf_bindings::bindings::bpf_insn::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_insn where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_insn::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_insn where T: core::marker::Copy
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_insn::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_insn
 pub fn aya_ebpf_bindings::bindings::bpf_insn::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::bpf_iter_link_info__bindgen_ty_1
@@ -4093,10 +3697,6 @@ impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_iter_link_i
 pub fn aya_ebpf_bindings::bindings::bpf_iter_link_info__bindgen_ty_1::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_iter_link_info__bindgen_ty_1 where T: core::marker::Sized
 pub fn aya_ebpf_bindings::bindings::bpf_iter_link_info__bindgen_ty_1::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_iter_link_info__bindgen_ty_1 where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_iter_link_info__bindgen_ty_1::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_iter_link_info__bindgen_ty_1 where T: core::marker::Copy
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_iter_link_info__bindgen_ty_1::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_iter_link_info__bindgen_ty_1
 pub fn aya_ebpf_bindings::bindings::bpf_iter_link_info__bindgen_ty_1::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::bpf_iter_link_info__bindgen_ty_2
@@ -4128,10 +3728,6 @@ impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_iter_link_i
 pub fn aya_ebpf_bindings::bindings::bpf_iter_link_info__bindgen_ty_2::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_iter_link_info__bindgen_ty_2 where T: core::marker::Sized
 pub fn aya_ebpf_bindings::bindings::bpf_iter_link_info__bindgen_ty_2::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_iter_link_info__bindgen_ty_2 where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_iter_link_info__bindgen_ty_2::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_iter_link_info__bindgen_ty_2 where T: core::marker::Copy
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_iter_link_info__bindgen_ty_2::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_iter_link_info__bindgen_ty_2
 pub fn aya_ebpf_bindings::bindings::bpf_iter_link_info__bindgen_ty_2::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::bpf_iter_link_info__bindgen_ty_3
@@ -4163,10 +3759,6 @@ impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_iter_link_i
 pub fn aya_ebpf_bindings::bindings::bpf_iter_link_info__bindgen_ty_3::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_iter_link_info__bindgen_ty_3 where T: core::marker::Sized
 pub fn aya_ebpf_bindings::bindings::bpf_iter_link_info__bindgen_ty_3::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_iter_link_info__bindgen_ty_3 where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_iter_link_info__bindgen_ty_3::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_iter_link_info__bindgen_ty_3 where T: core::marker::Copy
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_iter_link_info__bindgen_ty_3::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_iter_link_info__bindgen_ty_3
 pub fn aya_ebpf_bindings::bindings::bpf_iter_link_info__bindgen_ty_3::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::bpf_iter_num
@@ -4196,10 +3788,6 @@ impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_iter_num wh
 pub fn aya_ebpf_bindings::bindings::bpf_iter_num::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_iter_num where T: core::marker::Sized
 pub fn aya_ebpf_bindings::bindings::bpf_iter_num::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_iter_num where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_iter_num::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_iter_num where T: core::marker::Copy
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_iter_num::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_iter_num
 pub fn aya_ebpf_bindings::bindings::bpf_iter_num::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::bpf_line_info
@@ -4232,10 +3820,6 @@ impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_line_info w
 pub fn aya_ebpf_bindings::bindings::bpf_line_info::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_line_info where T: core::marker::Sized
 pub fn aya_ebpf_bindings::bindings::bpf_line_info::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_line_info where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_line_info::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_line_info where T: core::marker::Copy
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_line_info::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_line_info
 pub fn aya_ebpf_bindings::bindings::bpf_line_info::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::bpf_link_info
@@ -4266,10 +3850,6 @@ impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_link_info w
 pub fn aya_ebpf_bindings::bindings::bpf_link_info::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_link_info where T: core::marker::Sized
 pub fn aya_ebpf_bindings::bindings::bpf_link_info::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_link_info where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_link_info::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_link_info where T: core::marker::Copy
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_link_info::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_link_info
 pub fn aya_ebpf_bindings::bindings::bpf_link_info::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_1
@@ -4300,10 +3880,6 @@ impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_link_info__
 pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_1::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_1 where T: core::marker::Sized
 pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_1::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_1 where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_1::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_1 where T: core::marker::Copy
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_1::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_1
 pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_1::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_10
@@ -4340,10 +3916,6 @@ impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_link_info__
 pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_10::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_10 where T: core::marker::Sized
 pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_10::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_10 where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_10::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_10 where T: core::marker::Copy
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_10::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_10
 pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_10::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_11
@@ -4376,10 +3948,6 @@ impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_link_info__
 pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_11::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_11 where T: core::marker::Sized
 pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_11::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_11 where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_11::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_11 where T: core::marker::Copy
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_11::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_11
 pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_11::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_1
@@ -4412,10 +3980,6 @@ impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_link_info__
 pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_1::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_1 where T: core::marker::Sized
 pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_1::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_1 where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_1::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_1 where T: core::marker::Copy
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_1::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_1
 pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_1::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_2
@@ -4450,10 +4014,6 @@ impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_link_info__
 pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_2::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_2 where T: core::marker::Sized
 pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_2::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_2 where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_2::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_2 where T: core::marker::Copy
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_2::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_2
 pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_2::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_3
@@ -4489,10 +4049,6 @@ impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_link_info__
 pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_3::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_3 where T: core::marker::Sized
 pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_3::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_3 where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_3::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_3 where T: core::marker::Copy
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_3::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_3
 pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_3::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_4
@@ -4528,10 +4084,6 @@ impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_link_info__
 pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_4::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_4 where T: core::marker::Sized
 pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_4::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_4 where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_4::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_4 where T: core::marker::Copy
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_4::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_4
 pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_4::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_12
@@ -4562,10 +4114,6 @@ impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_link_info__
 pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_12::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_12 where T: core::marker::Sized
 pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_12::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_12 where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_12::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_12 where T: core::marker::Copy
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_12::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_12
 pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_12::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_13
@@ -4596,10 +4144,6 @@ impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_link_info__
 pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_13::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_13 where T: core::marker::Sized
 pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_13::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_13 where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_13::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_13 where T: core::marker::Copy
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_13::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_13
 pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_13::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_2
@@ -4631,10 +4175,6 @@ impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_link_info__
 pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_2::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_2 where T: core::marker::Sized
 pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_2::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_2 where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_2::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_2 where T: core::marker::Copy
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_2::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_2
 pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_2::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_3
@@ -4665,10 +4205,6 @@ impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_link_info__
 pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_3::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_3 where T: core::marker::Sized
 pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_3::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_3 where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_3::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_3 where T: core::marker::Copy
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_3::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_3
 pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_3::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4
@@ -4699,10 +4235,6 @@ impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_link_info__
 pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4 where T: core::marker::Sized
 pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4 where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4 where T: core::marker::Copy
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4
 pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_1__bindgen_ty_1
@@ -4732,10 +4264,6 @@ impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_link_info__
 pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_1__bindgen_ty_1::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_1__bindgen_ty_1 where T: core::marker::Sized
 pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_1__bindgen_ty_1::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_1__bindgen_ty_1 where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_1__bindgen_ty_1::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_1__bindgen_ty_1 where T: core::marker::Copy
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_1__bindgen_ty_1::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_1__bindgen_ty_1
 pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_1__bindgen_ty_1::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2__bindgen_ty_1
@@ -4766,10 +4294,6 @@ impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_link_info__
 pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2__bindgen_ty_1::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2__bindgen_ty_1 where T: core::marker::Sized
 pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2__bindgen_ty_1::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2__bindgen_ty_1 where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2__bindgen_ty_1::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2__bindgen_ty_1 where T: core::marker::Copy
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2__bindgen_ty_1::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2__bindgen_ty_1
 pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2__bindgen_ty_1::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2__bindgen_ty_2
@@ -4800,10 +4324,6 @@ impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_link_info__
 pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2__bindgen_ty_2::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2__bindgen_ty_2 where T: core::marker::Sized
 pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2__bindgen_ty_2::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2__bindgen_ty_2 where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2__bindgen_ty_2::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2__bindgen_ty_2 where T: core::marker::Copy
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2__bindgen_ty_2::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2__bindgen_ty_2
 pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2__bindgen_ty_2::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_5
@@ -4834,10 +4354,6 @@ impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_link_info__
 pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_5::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_5 where T: core::marker::Sized
 pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_5::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_5 where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_5::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_5 where T: core::marker::Copy
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_5::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_5
 pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_5::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_6
@@ -4867,10 +4383,6 @@ impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_link_info__
 pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_6::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_6 where T: core::marker::Sized
 pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_6::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_6 where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_6::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_6 where T: core::marker::Copy
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_6::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_6
 pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_6::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_7
@@ -4900,10 +4412,6 @@ impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_link_info__
 pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_7::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_7 where T: core::marker::Sized
 pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_7::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_7 where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_7::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_7 where T: core::marker::Copy
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_7::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_7
 pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_7::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_8
@@ -4936,10 +4444,6 @@ impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_link_info__
 pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_8::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_8 where T: core::marker::Sized
 pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_8::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_8 where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_8::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_8 where T: core::marker::Copy
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_8::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_8
 pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_8::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_9
@@ -4973,10 +4477,6 @@ impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_link_info__
 pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_9::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_9 where T: core::marker::Sized
 pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_9::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_9 where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_9::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_9 where T: core::marker::Copy
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_9::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_9
 pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_9::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::bpf_list_head
@@ -5006,10 +4506,6 @@ impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_list_head w
 pub fn aya_ebpf_bindings::bindings::bpf_list_head::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_list_head where T: core::marker::Sized
 pub fn aya_ebpf_bindings::bindings::bpf_list_head::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_list_head where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_list_head::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_list_head where T: core::marker::Copy
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_list_head::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_list_head
 pub fn aya_ebpf_bindings::bindings::bpf_list_head::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::bpf_list_node
@@ -5039,10 +4535,6 @@ impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_list_node w
 pub fn aya_ebpf_bindings::bindings::bpf_list_node::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_list_node where T: core::marker::Sized
 pub fn aya_ebpf_bindings::bindings::bpf_list_node::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_list_node where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_list_node::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_list_node where T: core::marker::Copy
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_list_node::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_list_node
 pub fn aya_ebpf_bindings::bindings::bpf_list_node::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::bpf_lpm_trie_key
@@ -5099,10 +4591,6 @@ impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_lpm_trie_ke
 pub fn aya_ebpf_bindings::bindings::bpf_lpm_trie_key_hdr::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_lpm_trie_key_hdr where T: core::marker::Sized
 pub fn aya_ebpf_bindings::bindings::bpf_lpm_trie_key_hdr::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_lpm_trie_key_hdr where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_lpm_trie_key_hdr::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_lpm_trie_key_hdr where T: core::marker::Copy
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_lpm_trie_key_hdr::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_lpm_trie_key_hdr
 pub fn aya_ebpf_bindings::bindings::bpf_lpm_trie_key_hdr::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::bpf_lpm_trie_key_u8
@@ -5163,10 +4651,6 @@ impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_map_def whe
 pub fn aya_ebpf_bindings::bindings::bpf_map_def::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_map_def where T: core::marker::Sized
 pub fn aya_ebpf_bindings::bindings::bpf_map_def::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_map_def where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_map_def::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_map_def where T: core::marker::Copy
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_map_def::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_map_def
 pub fn aya_ebpf_bindings::bindings::bpf_map_def::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::bpf_map_info
@@ -5211,10 +4695,6 @@ impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_map_info wh
 pub fn aya_ebpf_bindings::bindings::bpf_map_info::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_map_info where T: core::marker::Sized
 pub fn aya_ebpf_bindings::bindings::bpf_map_info::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_map_info where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_map_info::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_map_info where T: core::marker::Copy
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_map_info::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_map_info
 pub fn aya_ebpf_bindings::bindings::bpf_map_info::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::bpf_perf_event_data
@@ -5243,10 +4723,6 @@ impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_perf_event_
 pub fn aya_ebpf_bindings::bindings::bpf_perf_event_data::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_perf_event_data where T: core::marker::Sized
 pub fn aya_ebpf_bindings::bindings::bpf_perf_event_data::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_perf_event_data where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_perf_event_data::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_perf_event_data where T: core::marker::Copy
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_perf_event_data::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_perf_event_data
 pub fn aya_ebpf_bindings::bindings::bpf_perf_event_data::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::bpf_perf_event_value
@@ -5278,10 +4754,6 @@ impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_perf_event_
 pub fn aya_ebpf_bindings::bindings::bpf_perf_event_value::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_perf_event_value where T: core::marker::Sized
 pub fn aya_ebpf_bindings::bindings::bpf_perf_event_value::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_perf_event_value where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_perf_event_value::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_perf_event_value where T: core::marker::Copy
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_perf_event_value::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_perf_event_value
 pub fn aya_ebpf_bindings::bindings::bpf_perf_event_value::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::bpf_pidns_info
@@ -5312,10 +4784,6 @@ impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_pidns_info 
 pub fn aya_ebpf_bindings::bindings::bpf_pidns_info::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_pidns_info where T: core::marker::Sized
 pub fn aya_ebpf_bindings::bindings::bpf_pidns_info::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_pidns_info where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_pidns_info::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_pidns_info where T: core::marker::Copy
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_pidns_info::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_pidns_info
 pub fn aya_ebpf_bindings::bindings::bpf_pidns_info::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::bpf_prog_info
@@ -5387,10 +4855,6 @@ impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_prog_info w
 pub fn aya_ebpf_bindings::bindings::bpf_prog_info::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_prog_info where T: core::marker::Sized
 pub fn aya_ebpf_bindings::bindings::bpf_prog_info::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_prog_info where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_prog_info::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_prog_info where T: core::marker::Copy
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_prog_info::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_prog_info
 pub fn aya_ebpf_bindings::bindings::bpf_prog_info::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::bpf_raw_tracepoint_args
@@ -5446,10 +4910,6 @@ impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_rb_node whe
 pub fn aya_ebpf_bindings::bindings::bpf_rb_node::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_rb_node where T: core::marker::Sized
 pub fn aya_ebpf_bindings::bindings::bpf_rb_node::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_rb_node where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_rb_node::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_rb_node where T: core::marker::Copy
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_rb_node::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_rb_node
 pub fn aya_ebpf_bindings::bindings::bpf_rb_node::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::bpf_rb_root
@@ -5479,10 +4939,6 @@ impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_rb_root whe
 pub fn aya_ebpf_bindings::bindings::bpf_rb_root::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_rb_root where T: core::marker::Sized
 pub fn aya_ebpf_bindings::bindings::bpf_rb_root::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_rb_root where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_rb_root::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_rb_root where T: core::marker::Copy
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_rb_root::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_rb_root
 pub fn aya_ebpf_bindings::bindings::bpf_rb_root::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::bpf_redir_neigh
@@ -5511,10 +4967,6 @@ impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_redir_neigh
 pub fn aya_ebpf_bindings::bindings::bpf_redir_neigh::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_redir_neigh where T: core::marker::Sized
 pub fn aya_ebpf_bindings::bindings::bpf_redir_neigh::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_redir_neigh where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_redir_neigh::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_redir_neigh where T: core::marker::Copy
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_redir_neigh::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_redir_neigh
 pub fn aya_ebpf_bindings::bindings::bpf_redir_neigh::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::bpf_refcount
@@ -5544,10 +4996,6 @@ impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_refcount wh
 pub fn aya_ebpf_bindings::bindings::bpf_refcount::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_refcount where T: core::marker::Sized
 pub fn aya_ebpf_bindings::bindings::bpf_refcount::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_refcount where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_refcount::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_refcount where T: core::marker::Copy
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_refcount::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_refcount
 pub fn aya_ebpf_bindings::bindings::bpf_refcount::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::bpf_sk_lookup
@@ -5588,10 +5036,6 @@ impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_sk_lookup w
 pub fn aya_ebpf_bindings::bindings::bpf_sk_lookup::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_sk_lookup where T: core::marker::Sized
 pub fn aya_ebpf_bindings::bindings::bpf_sk_lookup::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_sk_lookup where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_sk_lookup::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_sk_lookup where T: core::marker::Copy
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_sk_lookup::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_sk_lookup
 pub fn aya_ebpf_bindings::bindings::bpf_sk_lookup::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::bpf_sock
@@ -5638,10 +5082,6 @@ impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_sock where 
 pub fn aya_ebpf_bindings::bindings::bpf_sock::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_sock where T: core::marker::Sized
 pub fn aya_ebpf_bindings::bindings::bpf_sock::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_sock where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_sock::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_sock where T: core::marker::Copy
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_sock::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_sock
 pub fn aya_ebpf_bindings::bindings::bpf_sock::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::bpf_sock_addr
@@ -5678,10 +5118,6 @@ impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_sock_addr w
 pub fn aya_ebpf_bindings::bindings::bpf_sock_addr::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_sock_addr where T: core::marker::Sized
 pub fn aya_ebpf_bindings::bindings::bpf_sock_addr::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_sock_addr where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_sock_addr::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_sock_addr where T: core::marker::Copy
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_sock_addr::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_sock_addr
 pub fn aya_ebpf_bindings::bindings::bpf_sock_addr::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::bpf_sock_ops
@@ -5749,10 +5185,6 @@ impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_sock_ops wh
 pub fn aya_ebpf_bindings::bindings::bpf_sock_ops::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_sock_ops where T: core::marker::Sized
 pub fn aya_ebpf_bindings::bindings::bpf_sock_ops::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_sock_ops where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_sock_ops::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_sock_ops where T: core::marker::Copy
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_sock_ops::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_sock_ops
 pub fn aya_ebpf_bindings::bindings::bpf_sock_ops::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::bpf_sock_tuple
@@ -5780,10 +5212,6 @@ impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_sock_tuple 
 pub fn aya_ebpf_bindings::bindings::bpf_sock_tuple::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_sock_tuple where T: core::marker::Sized
 pub fn aya_ebpf_bindings::bindings::bpf_sock_tuple::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_sock_tuple where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_sock_tuple::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_sock_tuple where T: core::marker::Copy
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_sock_tuple::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_sock_tuple
 pub fn aya_ebpf_bindings::bindings::bpf_sock_tuple::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::bpf_sock_tuple__bindgen_ty_1__bindgen_ty_1
@@ -5816,10 +5244,6 @@ impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_sock_tuple_
 pub fn aya_ebpf_bindings::bindings::bpf_sock_tuple__bindgen_ty_1__bindgen_ty_1::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_sock_tuple__bindgen_ty_1__bindgen_ty_1 where T: core::marker::Sized
 pub fn aya_ebpf_bindings::bindings::bpf_sock_tuple__bindgen_ty_1__bindgen_ty_1::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_sock_tuple__bindgen_ty_1__bindgen_ty_1 where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_sock_tuple__bindgen_ty_1__bindgen_ty_1::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_sock_tuple__bindgen_ty_1__bindgen_ty_1 where T: core::marker::Copy
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_sock_tuple__bindgen_ty_1__bindgen_ty_1::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_sock_tuple__bindgen_ty_1__bindgen_ty_1
 pub fn aya_ebpf_bindings::bindings::bpf_sock_tuple__bindgen_ty_1__bindgen_ty_1::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::bpf_sock_tuple__bindgen_ty_1__bindgen_ty_2
@@ -5852,10 +5276,6 @@ impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_sock_tuple_
 pub fn aya_ebpf_bindings::bindings::bpf_sock_tuple__bindgen_ty_1__bindgen_ty_2::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_sock_tuple__bindgen_ty_1__bindgen_ty_2 where T: core::marker::Sized
 pub fn aya_ebpf_bindings::bindings::bpf_sock_tuple__bindgen_ty_1__bindgen_ty_2::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_sock_tuple__bindgen_ty_1__bindgen_ty_2 where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_sock_tuple__bindgen_ty_1__bindgen_ty_2::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_sock_tuple__bindgen_ty_1__bindgen_ty_2 where T: core::marker::Copy
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_sock_tuple__bindgen_ty_1__bindgen_ty_2::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_sock_tuple__bindgen_ty_1__bindgen_ty_2
 pub fn aya_ebpf_bindings::bindings::bpf_sock_tuple__bindgen_ty_1__bindgen_ty_2::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::bpf_sockopt
@@ -5889,10 +5309,6 @@ impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_sockopt whe
 pub fn aya_ebpf_bindings::bindings::bpf_sockopt::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_sockopt where T: core::marker::Sized
 pub fn aya_ebpf_bindings::bindings::bpf_sockopt::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_sockopt where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_sockopt::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_sockopt where T: core::marker::Copy
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_sockopt::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_sockopt
 pub fn aya_ebpf_bindings::bindings::bpf_sockopt::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::bpf_spin_lock
@@ -5922,10 +5338,6 @@ impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_spin_lock w
 pub fn aya_ebpf_bindings::bindings::bpf_spin_lock::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_spin_lock where T: core::marker::Sized
 pub fn aya_ebpf_bindings::bindings::bpf_spin_lock::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_spin_lock where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_spin_lock::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_spin_lock where T: core::marker::Copy
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_spin_lock::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_spin_lock
 pub fn aya_ebpf_bindings::bindings::bpf_spin_lock::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::bpf_stack_build_id
@@ -5955,10 +5367,6 @@ impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_stack_build
 pub fn aya_ebpf_bindings::bindings::bpf_stack_build_id::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_stack_build_id where T: core::marker::Sized
 pub fn aya_ebpf_bindings::bindings::bpf_stack_build_id::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_stack_build_id where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_stack_build_id::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_stack_build_id where T: core::marker::Copy
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_stack_build_id::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_stack_build_id
 pub fn aya_ebpf_bindings::bindings::bpf_stack_build_id::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::bpf_sysctl
@@ -5989,10 +5397,6 @@ impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_sysctl wher
 pub fn aya_ebpf_bindings::bindings::bpf_sysctl::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_sysctl where T: core::marker::Sized
 pub fn aya_ebpf_bindings::bindings::bpf_sysctl::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_sysctl where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_sysctl::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_sysctl where T: core::marker::Copy
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_sysctl::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_sysctl
 pub fn aya_ebpf_bindings::bindings::bpf_sysctl::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::bpf_tcp_sock
@@ -6047,10 +5451,6 @@ impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_tcp_sock wh
 pub fn aya_ebpf_bindings::bindings::bpf_tcp_sock::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_tcp_sock where T: core::marker::Sized
 pub fn aya_ebpf_bindings::bindings::bpf_tcp_sock::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_tcp_sock where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_tcp_sock::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_tcp_sock where T: core::marker::Copy
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_tcp_sock::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_tcp_sock
 pub fn aya_ebpf_bindings::bindings::bpf_tcp_sock::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::bpf_timer
@@ -6080,10 +5480,6 @@ impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_timer where
 pub fn aya_ebpf_bindings::bindings::bpf_timer::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_timer where T: core::marker::Sized
 pub fn aya_ebpf_bindings::bindings::bpf_timer::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_timer where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_timer::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_timer where T: core::marker::Copy
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_timer::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_timer
 pub fn aya_ebpf_bindings::bindings::bpf_timer::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::bpf_tunnel_key
@@ -6117,10 +5513,6 @@ impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_tunnel_key 
 pub fn aya_ebpf_bindings::bindings::bpf_tunnel_key::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_tunnel_key where T: core::marker::Sized
 pub fn aya_ebpf_bindings::bindings::bpf_tunnel_key::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_tunnel_key where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_tunnel_key::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_tunnel_key where T: core::marker::Copy
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_tunnel_key::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_tunnel_key
 pub fn aya_ebpf_bindings::bindings::bpf_tunnel_key::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::bpf_xdp_sock
@@ -6150,10 +5542,6 @@ impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_xdp_sock wh
 pub fn aya_ebpf_bindings::bindings::bpf_xdp_sock::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_xdp_sock where T: core::marker::Sized
 pub fn aya_ebpf_bindings::bindings::bpf_xdp_sock::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_xdp_sock where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_xdp_sock::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_xdp_sock where T: core::marker::Copy
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_xdp_sock::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_xdp_sock
 pub fn aya_ebpf_bindings::bindings::bpf_xdp_sock::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::bpf_xfrm_state
@@ -6185,10 +5573,6 @@ impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_xfrm_state 
 pub fn aya_ebpf_bindings::bindings::bpf_xfrm_state::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_xfrm_state where T: core::marker::Sized
 pub fn aya_ebpf_bindings::bindings::bpf_xfrm_state::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_xfrm_state where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_xfrm_state::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_xfrm_state where T: core::marker::Copy
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_xfrm_state::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_xfrm_state
 pub fn aya_ebpf_bindings::bindings::bpf_xfrm_state::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::btf_ptr
@@ -6220,10 +5604,6 @@ impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::btf_ptr where T
 pub fn aya_ebpf_bindings::bindings::btf_ptr::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::btf_ptr where T: core::marker::Sized
 pub fn aya_ebpf_bindings::bindings::btf_ptr::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::btf_ptr where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::btf_ptr::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::btf_ptr where T: core::marker::Copy
-pub unsafe fn aya_ebpf_bindings::bindings::btf_ptr::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::btf_ptr
 pub fn aya_ebpf_bindings::bindings::btf_ptr::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::cgroup
@@ -6252,10 +5632,6 @@ impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::cgroup where T:
 pub fn aya_ebpf_bindings::bindings::cgroup::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::cgroup where T: core::marker::Sized
 pub fn aya_ebpf_bindings::bindings::cgroup::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::cgroup where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::cgroup::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::cgroup where T: core::marker::Copy
-pub unsafe fn aya_ebpf_bindings::bindings::cgroup::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::cgroup
 pub fn aya_ebpf_bindings::bindings::cgroup::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::file
@@ -6284,10 +5660,6 @@ impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::file where T: c
 pub fn aya_ebpf_bindings::bindings::file::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::file where T: core::marker::Sized
 pub fn aya_ebpf_bindings::bindings::file::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::file where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::file::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::file where T: core::marker::Copy
-pub unsafe fn aya_ebpf_bindings::bindings::file::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::file
 pub fn aya_ebpf_bindings::bindings::file::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::inode
@@ -6316,10 +5688,6 @@ impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::inode where T: 
 pub fn aya_ebpf_bindings::bindings::inode::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::inode where T: core::marker::Sized
 pub fn aya_ebpf_bindings::bindings::inode::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::inode where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::inode::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::inode where T: core::marker::Copy
-pub unsafe fn aya_ebpf_bindings::bindings::inode::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::inode
 pub fn aya_ebpf_bindings::bindings::inode::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::iphdr
@@ -6348,10 +5716,6 @@ impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::iphdr where T: 
 pub fn aya_ebpf_bindings::bindings::iphdr::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::iphdr where T: core::marker::Sized
 pub fn aya_ebpf_bindings::bindings::iphdr::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::iphdr where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::iphdr::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::iphdr where T: core::marker::Copy
-pub unsafe fn aya_ebpf_bindings::bindings::iphdr::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::iphdr
 pub fn aya_ebpf_bindings::bindings::iphdr::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::ipv6hdr
@@ -6380,10 +5744,6 @@ impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::ipv6hdr where T
 pub fn aya_ebpf_bindings::bindings::ipv6hdr::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::ipv6hdr where T: core::marker::Sized
 pub fn aya_ebpf_bindings::bindings::ipv6hdr::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::ipv6hdr where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::ipv6hdr::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::ipv6hdr where T: core::marker::Copy
-pub unsafe fn aya_ebpf_bindings::bindings::ipv6hdr::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::ipv6hdr
 pub fn aya_ebpf_bindings::bindings::ipv6hdr::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::linux_binprm
@@ -6412,10 +5772,6 @@ impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::linux_binprm wh
 pub fn aya_ebpf_bindings::bindings::linux_binprm::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::linux_binprm where T: core::marker::Sized
 pub fn aya_ebpf_bindings::bindings::linux_binprm::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::linux_binprm where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::linux_binprm::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::linux_binprm where T: core::marker::Copy
-pub unsafe fn aya_ebpf_bindings::bindings::linux_binprm::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::linux_binprm
 pub fn aya_ebpf_bindings::bindings::linux_binprm::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::mptcp_sock
@@ -6444,10 +5800,6 @@ impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::mptcp_sock wher
 pub fn aya_ebpf_bindings::bindings::mptcp_sock::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::mptcp_sock where T: core::marker::Sized
 pub fn aya_ebpf_bindings::bindings::mptcp_sock::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::mptcp_sock where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::mptcp_sock::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::mptcp_sock where T: core::marker::Copy
-pub unsafe fn aya_ebpf_bindings::bindings::mptcp_sock::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::mptcp_sock
 pub fn aya_ebpf_bindings::bindings::mptcp_sock::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::path
@@ -6476,10 +5828,6 @@ impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::path where T: c
 pub fn aya_ebpf_bindings::bindings::path::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::path where T: core::marker::Sized
 pub fn aya_ebpf_bindings::bindings::path::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::path where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::path::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::path where T: core::marker::Copy
-pub unsafe fn aya_ebpf_bindings::bindings::path::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::path
 pub fn aya_ebpf_bindings::bindings::path::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::pt_regs
@@ -6529,10 +5877,6 @@ impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::pt_regs where T
 pub fn aya_ebpf_bindings::bindings::pt_regs::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::pt_regs where T: core::marker::Sized
 pub fn aya_ebpf_bindings::bindings::pt_regs::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::pt_regs where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::pt_regs::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::pt_regs where T: core::marker::Copy
-pub unsafe fn aya_ebpf_bindings::bindings::pt_regs::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::pt_regs
 pub fn aya_ebpf_bindings::bindings::pt_regs::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::seq_file
@@ -6561,10 +5905,6 @@ impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::seq_file where 
 pub fn aya_ebpf_bindings::bindings::seq_file::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::seq_file where T: core::marker::Sized
 pub fn aya_ebpf_bindings::bindings::seq_file::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::seq_file where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::seq_file::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::seq_file where T: core::marker::Copy
-pub unsafe fn aya_ebpf_bindings::bindings::seq_file::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::seq_file
 pub fn aya_ebpf_bindings::bindings::seq_file::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::sk_msg_md
@@ -6602,10 +5942,6 @@ impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::sk_msg_md where
 pub fn aya_ebpf_bindings::bindings::sk_msg_md::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::sk_msg_md where T: core::marker::Sized
 pub fn aya_ebpf_bindings::bindings::sk_msg_md::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::sk_msg_md where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::sk_msg_md::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::sk_msg_md where T: core::marker::Copy
-pub unsafe fn aya_ebpf_bindings::bindings::sk_msg_md::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::sk_msg_md
 pub fn aya_ebpf_bindings::bindings::sk_msg_md::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::sk_reuseport_md
@@ -6641,10 +5977,6 @@ impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::sk_reuseport_md
 pub fn aya_ebpf_bindings::bindings::sk_reuseport_md::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::sk_reuseport_md where T: core::marker::Sized
 pub fn aya_ebpf_bindings::bindings::sk_reuseport_md::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::sk_reuseport_md where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::sk_reuseport_md::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::sk_reuseport_md where T: core::marker::Copy
-pub unsafe fn aya_ebpf_bindings::bindings::sk_reuseport_md::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::sk_reuseport_md
 pub fn aya_ebpf_bindings::bindings::sk_reuseport_md::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::sockaddr
@@ -6675,10 +6007,6 @@ impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::sockaddr where 
 pub fn aya_ebpf_bindings::bindings::sockaddr::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::sockaddr where T: core::marker::Sized
 pub fn aya_ebpf_bindings::bindings::sockaddr::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::sockaddr where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::sockaddr::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::sockaddr where T: core::marker::Copy
-pub unsafe fn aya_ebpf_bindings::bindings::sockaddr::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::sockaddr
 pub fn aya_ebpf_bindings::bindings::sockaddr::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::socket
@@ -6707,10 +6035,6 @@ impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::socket where T:
 pub fn aya_ebpf_bindings::bindings::socket::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::socket where T: core::marker::Sized
 pub fn aya_ebpf_bindings::bindings::socket::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::socket where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::socket::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::socket where T: core::marker::Copy
-pub unsafe fn aya_ebpf_bindings::bindings::socket::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::socket
 pub fn aya_ebpf_bindings::bindings::socket::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::task_struct
@@ -6739,10 +6063,6 @@ impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::task_struct whe
 pub fn aya_ebpf_bindings::bindings::task_struct::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::task_struct where T: core::marker::Sized
 pub fn aya_ebpf_bindings::bindings::task_struct::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::task_struct where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::task_struct::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::task_struct where T: core::marker::Copy
-pub unsafe fn aya_ebpf_bindings::bindings::task_struct::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::task_struct
 pub fn aya_ebpf_bindings::bindings::task_struct::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::tcp6_sock
@@ -6771,10 +6091,6 @@ impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::tcp6_sock where
 pub fn aya_ebpf_bindings::bindings::tcp6_sock::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::tcp6_sock where T: core::marker::Sized
 pub fn aya_ebpf_bindings::bindings::tcp6_sock::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::tcp6_sock where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::tcp6_sock::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::tcp6_sock where T: core::marker::Copy
-pub unsafe fn aya_ebpf_bindings::bindings::tcp6_sock::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::tcp6_sock
 pub fn aya_ebpf_bindings::bindings::tcp6_sock::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::tcp_request_sock
@@ -6803,10 +6119,6 @@ impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::tcp_request_soc
 pub fn aya_ebpf_bindings::bindings::tcp_request_sock::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::tcp_request_sock where T: core::marker::Sized
 pub fn aya_ebpf_bindings::bindings::tcp_request_sock::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::tcp_request_sock where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::tcp_request_sock::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::tcp_request_sock where T: core::marker::Copy
-pub unsafe fn aya_ebpf_bindings::bindings::tcp_request_sock::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::tcp_request_sock
 pub fn aya_ebpf_bindings::bindings::tcp_request_sock::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::tcp_sock
@@ -6835,10 +6147,6 @@ impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::tcp_sock where 
 pub fn aya_ebpf_bindings::bindings::tcp_sock::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::tcp_sock where T: core::marker::Sized
 pub fn aya_ebpf_bindings::bindings::tcp_sock::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::tcp_sock where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::tcp_sock::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::tcp_sock where T: core::marker::Copy
-pub unsafe fn aya_ebpf_bindings::bindings::tcp_sock::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::tcp_sock
 pub fn aya_ebpf_bindings::bindings::tcp_sock::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::tcp_timewait_sock
@@ -6867,10 +6175,6 @@ impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::tcp_timewait_so
 pub fn aya_ebpf_bindings::bindings::tcp_timewait_sock::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::tcp_timewait_sock where T: core::marker::Sized
 pub fn aya_ebpf_bindings::bindings::tcp_timewait_sock::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::tcp_timewait_sock where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::tcp_timewait_sock::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::tcp_timewait_sock where T: core::marker::Copy
-pub unsafe fn aya_ebpf_bindings::bindings::tcp_timewait_sock::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::tcp_timewait_sock
 pub fn aya_ebpf_bindings::bindings::tcp_timewait_sock::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::tcphdr
@@ -6899,10 +6203,6 @@ impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::tcphdr where T:
 pub fn aya_ebpf_bindings::bindings::tcphdr::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::tcphdr where T: core::marker::Sized
 pub fn aya_ebpf_bindings::bindings::tcphdr::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::tcphdr where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::tcphdr::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::tcphdr where T: core::marker::Copy
-pub unsafe fn aya_ebpf_bindings::bindings::tcphdr::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::tcphdr
 pub fn aya_ebpf_bindings::bindings::tcphdr::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::udp6_sock
@@ -6931,10 +6231,6 @@ impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::udp6_sock where
 pub fn aya_ebpf_bindings::bindings::udp6_sock::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::udp6_sock where T: core::marker::Sized
 pub fn aya_ebpf_bindings::bindings::udp6_sock::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::udp6_sock where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::udp6_sock::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::udp6_sock where T: core::marker::Copy
-pub unsafe fn aya_ebpf_bindings::bindings::udp6_sock::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::udp6_sock
 pub fn aya_ebpf_bindings::bindings::udp6_sock::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::unix_sock
@@ -6963,10 +6259,6 @@ impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::unix_sock where
 pub fn aya_ebpf_bindings::bindings::unix_sock::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::unix_sock where T: core::marker::Sized
 pub fn aya_ebpf_bindings::bindings::unix_sock::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::unix_sock where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::unix_sock::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::unix_sock where T: core::marker::Copy
-pub unsafe fn aya_ebpf_bindings::bindings::unix_sock::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::unix_sock
 pub fn aya_ebpf_bindings::bindings::unix_sock::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::xdp_md
@@ -7001,10 +6293,6 @@ impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::xdp_md where T:
 pub fn aya_ebpf_bindings::bindings::xdp_md::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::xdp_md where T: core::marker::Sized
 pub fn aya_ebpf_bindings::bindings::xdp_md::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::xdp_md where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::xdp_md::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::xdp_md where T: core::marker::Copy
-pub unsafe fn aya_ebpf_bindings::bindings::xdp_md::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::xdp_md
 pub fn aya_ebpf_bindings::bindings::xdp_md::from(t: T) -> T
 pub const aya_ebpf_bindings::bindings::BPF_ABS: u32

--- a/xtask/public-api/aya-ebpf.txt
+++ b/xtask/public-api/aya-ebpf.txt
@@ -57,10 +57,6 @@ impl<T> core::borrow::Borrow<T> for aya_ebpf::helpers::PrintkArg where T: core::
 pub fn aya_ebpf::helpers::PrintkArg::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_ebpf::helpers::PrintkArg where T: core::marker::Sized
 pub fn aya_ebpf::helpers::PrintkArg::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf::helpers::PrintkArg where T: core::clone::Clone
-pub unsafe fn aya_ebpf::helpers::PrintkArg::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_ebpf::helpers::PrintkArg where T: core::marker::Copy
-pub unsafe fn aya_ebpf::helpers::PrintkArg::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_ebpf::helpers::PrintkArg
 pub fn aya_ebpf::helpers::PrintkArg::from(t: T) -> T
 pub fn aya_ebpf::helpers::bpf_get_current_comm() -> core::result::Result<[u8; 16], aya_ebpf_cty::od::c_long>

--- a/xtask/public-api/aya-log-common.txt
+++ b/xtask/public-api/aya-log-common.txt
@@ -45,10 +45,6 @@ impl<T> core::borrow::Borrow<T> for aya_log_common::Argument where T: core::mark
 pub fn aya_log_common::Argument::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_log_common::Argument where T: core::marker::Sized
 pub fn aya_log_common::Argument::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_log_common::Argument where T: core::clone::Clone
-pub unsafe fn aya_log_common::Argument::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_log_common::Argument where T: core::marker::Copy
-pub unsafe fn aya_log_common::Argument::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_log_common::Argument
 pub fn aya_log_common::Argument::from(t: T) -> T
 #[repr(u8)] pub enum aya_log_common::DisplayHint
@@ -91,10 +87,6 @@ impl<T> core::borrow::Borrow<T> for aya_log_common::DisplayHint where T: core::m
 pub fn aya_log_common::DisplayHint::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_log_common::DisplayHint where T: core::marker::Sized
 pub fn aya_log_common::DisplayHint::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_log_common::DisplayHint where T: core::clone::Clone
-pub unsafe fn aya_log_common::DisplayHint::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_log_common::DisplayHint where T: core::marker::Copy
-pub unsafe fn aya_log_common::DisplayHint::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_log_common::DisplayHint
 pub fn aya_log_common::DisplayHint::from(t: T) -> T
 #[repr(u8)] pub enum aya_log_common::Level
@@ -136,10 +128,6 @@ impl<T> core::borrow::Borrow<T> for aya_log_common::Level where T: core::marker:
 pub fn aya_log_common::Level::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_log_common::Level where T: core::marker::Sized
 pub fn aya_log_common::Level::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_log_common::Level where T: core::clone::Clone
-pub unsafe fn aya_log_common::Level::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_log_common::Level where T: core::marker::Copy
-pub unsafe fn aya_log_common::Level::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_log_common::Level
 pub fn aya_log_common::Level::from(t: T) -> T
 #[repr(u8)] pub enum aya_log_common::RecordField
@@ -176,10 +164,6 @@ impl<T> core::borrow::Borrow<T> for aya_log_common::RecordField where T: core::m
 pub fn aya_log_common::RecordField::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_log_common::RecordField where T: core::marker::Sized
 pub fn aya_log_common::RecordField::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_log_common::RecordField where T: core::clone::Clone
-pub unsafe fn aya_log_common::RecordField::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_log_common::RecordField where T: core::marker::Copy
-pub unsafe fn aya_log_common::RecordField::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_log_common::RecordField
 pub fn aya_log_common::RecordField::from(t: T) -> T
 pub const aya_log_common::LOG_BUF_CAPACITY: usize

--- a/xtask/public-api/aya-log-parser.txt
+++ b/xtask/public-api/aya-log-parser.txt
@@ -34,8 +34,6 @@ impl<T> core::borrow::Borrow<T> for aya_log_parser::Fragment where T: core::mark
 pub fn aya_log_parser::Fragment::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_log_parser::Fragment where T: core::marker::Sized
 pub fn aya_log_parser::Fragment::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_log_parser::Fragment where T: core::clone::Clone
-pub unsafe fn aya_log_parser::Fragment::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_log_parser::Fragment
 pub fn aya_log_parser::Fragment::from(t: T) -> T
 pub struct aya_log_parser::Parameter
@@ -72,8 +70,6 @@ impl<T> core::borrow::Borrow<T> for aya_log_parser::Parameter where T: core::mar
 pub fn aya_log_parser::Parameter::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_log_parser::Parameter where T: core::marker::Sized
 pub fn aya_log_parser::Parameter::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_log_parser::Parameter where T: core::clone::Clone
-pub unsafe fn aya_log_parser::Parameter::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_log_parser::Parameter
 pub fn aya_log_parser::Parameter::from(t: T) -> T
 pub fn aya_log_parser::parse(format_string: &str) -> core::result::Result<alloc::vec::Vec<aya_log_parser::Fragment>, alloc::string::String>

--- a/xtask/public-api/aya-obj.txt
+++ b/xtask/public-api/aya-obj.txt
@@ -1723,6 +1723,47 @@ impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::bpf_prog_type where T
 pub fn aya_obj::generated::bpf_prog_type::borrow_mut(&mut self) -> &mut T
 impl<T> core::convert::From<T> for aya_obj::generated::bpf_prog_type
 pub fn aya_obj::generated::bpf_prog_type::from(t: T) -> T
+#[repr(u32)] pub enum aya_obj::generated::bpf_stats_type
+pub aya_obj::generated::bpf_stats_type::BPF_STATS_RUN_TIME = 0
+impl core::clone::Clone for aya_obj::generated::bpf_stats_type
+pub fn aya_obj::generated::bpf_stats_type::clone(&self) -> aya_obj::generated::bpf_stats_type
+impl core::cmp::Eq for aya_obj::generated::bpf_stats_type
+impl core::cmp::PartialEq for aya_obj::generated::bpf_stats_type
+pub fn aya_obj::generated::bpf_stats_type::eq(&self, other: &aya_obj::generated::bpf_stats_type) -> bool
+impl core::convert::From<aya_obj::stats::BpfStatsType> for aya_obj::generated::bpf_stats_type
+pub fn aya_obj::generated::bpf_stats_type::from(value: aya_obj::stats::BpfStatsType) -> Self
+impl core::fmt::Debug for aya_obj::generated::bpf_stats_type
+pub fn aya_obj::generated::bpf_stats_type::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::hash::Hash for aya_obj::generated::bpf_stats_type
+pub fn aya_obj::generated::bpf_stats_type::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+impl core::marker::Copy for aya_obj::generated::bpf_stats_type
+impl core::marker::StructuralPartialEq for aya_obj::generated::bpf_stats_type
+impl core::marker::Freeze for aya_obj::generated::bpf_stats_type
+impl core::marker::Send for aya_obj::generated::bpf_stats_type
+impl core::marker::Sync for aya_obj::generated::bpf_stats_type
+impl core::marker::Unpin for aya_obj::generated::bpf_stats_type
+impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::generated::bpf_stats_type
+impl core::panic::unwind_safe::UnwindSafe for aya_obj::generated::bpf_stats_type
+impl<T, U> core::convert::Into<U> for aya_obj::generated::bpf_stats_type where U: core::convert::From<T>
+pub fn aya_obj::generated::bpf_stats_type::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for aya_obj::generated::bpf_stats_type where U: core::convert::Into<T>
+pub type aya_obj::generated::bpf_stats_type::Error = core::convert::Infallible
+pub fn aya_obj::generated::bpf_stats_type::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for aya_obj::generated::bpf_stats_type where U: core::convert::TryFrom<T>
+pub type aya_obj::generated::bpf_stats_type::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn aya_obj::generated::bpf_stats_type::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for aya_obj::generated::bpf_stats_type where T: core::clone::Clone
+pub type aya_obj::generated::bpf_stats_type::Owned = T
+pub fn aya_obj::generated::bpf_stats_type::clone_into(&self, target: &mut T)
+pub fn aya_obj::generated::bpf_stats_type::to_owned(&self) -> T
+impl<T> core::any::Any for aya_obj::generated::bpf_stats_type where T: 'static + core::marker::Sized
+pub fn aya_obj::generated::bpf_stats_type::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for aya_obj::generated::bpf_stats_type where T: core::marker::Sized
+pub fn aya_obj::generated::bpf_stats_type::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::bpf_stats_type where T: core::marker::Sized
+pub fn aya_obj::generated::bpf_stats_type::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for aya_obj::generated::bpf_stats_type
+pub fn aya_obj::generated::bpf_stats_type::from(t: T) -> T
 #[repr(u32)] pub enum aya_obj::generated::btf_func_linkage
 pub aya_obj::generated::btf_func_linkage::BTF_FUNC_EXTERN = 2
 pub aya_obj::generated::btf_func_linkage::BTF_FUNC_GLOBAL = 1
@@ -7342,6 +7383,77 @@ impl<T> core::borrow::BorrowMut<T> for aya_obj::relocation::EbpfRelocationError 
 pub fn aya_obj::relocation::EbpfRelocationError::borrow_mut(&mut self) -> &mut T
 impl<T> core::convert::From<T> for aya_obj::relocation::EbpfRelocationError
 pub fn aya_obj::relocation::EbpfRelocationError::from(t: T) -> T
+pub mod aya_obj::stats
+pub enum aya_obj::stats::BpfStatsType
+pub aya_obj::stats::BpfStatsType::RunTime
+impl core::clone::Clone for aya_obj::stats::BpfStatsType
+pub fn aya_obj::stats::BpfStatsType::clone(&self) -> aya_obj::stats::BpfStatsType
+impl core::convert::From<aya_obj::stats::BpfStatsType> for aya_obj::generated::bpf_stats_type
+pub fn aya_obj::generated::bpf_stats_type::from(value: aya_obj::stats::BpfStatsType) -> Self
+impl core::fmt::Debug for aya_obj::stats::BpfStatsType
+pub fn aya_obj::stats::BpfStatsType::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Copy for aya_obj::stats::BpfStatsType
+impl core::marker::Freeze for aya_obj::stats::BpfStatsType
+impl core::marker::Send for aya_obj::stats::BpfStatsType
+impl core::marker::Sync for aya_obj::stats::BpfStatsType
+impl core::marker::Unpin for aya_obj::stats::BpfStatsType
+impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::stats::BpfStatsType
+impl core::panic::unwind_safe::UnwindSafe for aya_obj::stats::BpfStatsType
+impl<T, U> core::convert::Into<U> for aya_obj::stats::BpfStatsType where U: core::convert::From<T>
+pub fn aya_obj::stats::BpfStatsType::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for aya_obj::stats::BpfStatsType where U: core::convert::Into<T>
+pub type aya_obj::stats::BpfStatsType::Error = core::convert::Infallible
+pub fn aya_obj::stats::BpfStatsType::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for aya_obj::stats::BpfStatsType where U: core::convert::TryFrom<T>
+pub type aya_obj::stats::BpfStatsType::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn aya_obj::stats::BpfStatsType::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for aya_obj::stats::BpfStatsType where T: core::clone::Clone
+pub type aya_obj::stats::BpfStatsType::Owned = T
+pub fn aya_obj::stats::BpfStatsType::clone_into(&self, target: &mut T)
+pub fn aya_obj::stats::BpfStatsType::to_owned(&self) -> T
+impl<T> core::any::Any for aya_obj::stats::BpfStatsType where T: 'static + core::marker::Sized
+pub fn aya_obj::stats::BpfStatsType::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for aya_obj::stats::BpfStatsType where T: core::marker::Sized
+pub fn aya_obj::stats::BpfStatsType::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for aya_obj::stats::BpfStatsType where T: core::marker::Sized
+pub fn aya_obj::stats::BpfStatsType::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for aya_obj::stats::BpfStatsType
+pub fn aya_obj::stats::BpfStatsType::from(t: T) -> T
+pub enum aya_obj::BpfStatsType
+pub aya_obj::BpfStatsType::RunTime
+impl core::clone::Clone for aya_obj::stats::BpfStatsType
+pub fn aya_obj::stats::BpfStatsType::clone(&self) -> aya_obj::stats::BpfStatsType
+impl core::convert::From<aya_obj::stats::BpfStatsType> for aya_obj::generated::bpf_stats_type
+pub fn aya_obj::generated::bpf_stats_type::from(value: aya_obj::stats::BpfStatsType) -> Self
+impl core::fmt::Debug for aya_obj::stats::BpfStatsType
+pub fn aya_obj::stats::BpfStatsType::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Copy for aya_obj::stats::BpfStatsType
+impl core::marker::Freeze for aya_obj::stats::BpfStatsType
+impl core::marker::Send for aya_obj::stats::BpfStatsType
+impl core::marker::Sync for aya_obj::stats::BpfStatsType
+impl core::marker::Unpin for aya_obj::stats::BpfStatsType
+impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::stats::BpfStatsType
+impl core::panic::unwind_safe::UnwindSafe for aya_obj::stats::BpfStatsType
+impl<T, U> core::convert::Into<U> for aya_obj::stats::BpfStatsType where U: core::convert::From<T>
+pub fn aya_obj::stats::BpfStatsType::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for aya_obj::stats::BpfStatsType where U: core::convert::Into<T>
+pub type aya_obj::stats::BpfStatsType::Error = core::convert::Infallible
+pub fn aya_obj::stats::BpfStatsType::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for aya_obj::stats::BpfStatsType where U: core::convert::TryFrom<T>
+pub type aya_obj::stats::BpfStatsType::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn aya_obj::stats::BpfStatsType::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for aya_obj::stats::BpfStatsType where T: core::clone::Clone
+pub type aya_obj::stats::BpfStatsType::Owned = T
+pub fn aya_obj::stats::BpfStatsType::clone_into(&self, target: &mut T)
+pub fn aya_obj::stats::BpfStatsType::to_owned(&self) -> T
+impl<T> core::any::Any for aya_obj::stats::BpfStatsType where T: 'static + core::marker::Sized
+pub fn aya_obj::stats::BpfStatsType::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for aya_obj::stats::BpfStatsType where T: core::marker::Sized
+pub fn aya_obj::stats::BpfStatsType::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for aya_obj::stats::BpfStatsType where T: core::marker::Sized
+pub fn aya_obj::stats::BpfStatsType::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for aya_obj::stats::BpfStatsType
+pub fn aya_obj::stats::BpfStatsType::from(t: T) -> T
 pub enum aya_obj::EbpfSectionKind
 pub aya_obj::EbpfSectionKind::Bss
 pub aya_obj::EbpfSectionKind::Btf

--- a/xtask/public-api/aya-obj.txt
+++ b/xtask/public-api/aya-obj.txt
@@ -133,10 +133,6 @@ impl<T> core::borrow::Borrow<T> for aya_obj::btf::BtfKind where T: core::marker:
 pub fn aya_obj::btf::BtfKind::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_obj::btf::BtfKind where T: core::marker::Sized
 pub fn aya_obj::btf::BtfKind::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::btf::BtfKind where T: core::clone::Clone
-pub unsafe fn aya_obj::btf::BtfKind::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_obj::btf::BtfKind where T: core::marker::Copy
-pub unsafe fn aya_obj::btf::BtfKind::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_obj::btf::BtfKind
 pub fn aya_obj::btf::BtfKind::from(t: T) -> T
 pub enum aya_obj::btf::BtfType
@@ -188,8 +184,6 @@ impl<T> core::borrow::Borrow<T> for aya_obj::btf::BtfType where T: core::marker:
 pub fn aya_obj::btf::BtfType::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_obj::btf::BtfType where T: core::marker::Sized
 pub fn aya_obj::btf::BtfType::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::btf::BtfType where T: core::clone::Clone
-pub unsafe fn aya_obj::btf::BtfType::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_obj::btf::BtfType
 pub fn aya_obj::btf::BtfType::from(t: T) -> T
 #[repr(u32)] pub enum aya_obj::btf::FuncLinkage
@@ -231,8 +225,6 @@ impl<T> core::borrow::Borrow<T> for aya_obj::btf::FuncLinkage where T: core::mar
 pub fn aya_obj::btf::FuncLinkage::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_obj::btf::FuncLinkage where T: core::marker::Sized
 pub fn aya_obj::btf::FuncLinkage::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::btf::FuncLinkage where T: core::clone::Clone
-pub unsafe fn aya_obj::btf::FuncLinkage::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_obj::btf::FuncLinkage
 pub fn aya_obj::btf::FuncLinkage::from(t: T) -> T
 #[repr(u32)] pub enum aya_obj::btf::IntEncoding
@@ -275,8 +267,6 @@ impl<T> core::borrow::Borrow<T> for aya_obj::btf::IntEncoding where T: core::mar
 pub fn aya_obj::btf::IntEncoding::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_obj::btf::IntEncoding where T: core::marker::Sized
 pub fn aya_obj::btf::IntEncoding::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::btf::IntEncoding where T: core::clone::Clone
-pub unsafe fn aya_obj::btf::IntEncoding::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_obj::btf::IntEncoding
 pub fn aya_obj::btf::IntEncoding::from(t: T) -> T
 #[repr(u32)] pub enum aya_obj::btf::VarLinkage
@@ -318,8 +308,6 @@ impl<T> core::borrow::Borrow<T> for aya_obj::btf::VarLinkage where T: core::mark
 pub fn aya_obj::btf::VarLinkage::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_obj::btf::VarLinkage where T: core::marker::Sized
 pub fn aya_obj::btf::VarLinkage::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::btf::VarLinkage where T: core::clone::Clone
-pub unsafe fn aya_obj::btf::VarLinkage::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_obj::btf::VarLinkage
 pub fn aya_obj::btf::VarLinkage::from(t: T) -> T
 #[repr(C)] pub struct aya_obj::btf::Array
@@ -351,8 +339,6 @@ impl<T> core::borrow::Borrow<T> for aya_obj::btf::Array where T: core::marker::S
 pub fn aya_obj::btf::Array::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_obj::btf::Array where T: core::marker::Sized
 pub fn aya_obj::btf::Array::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::btf::Array where T: core::clone::Clone
-pub unsafe fn aya_obj::btf::Array::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_obj::btf::Array
 pub fn aya_obj::btf::Array::from(t: T) -> T
 pub struct aya_obj::btf::Btf
@@ -395,8 +381,6 @@ impl<T> core::borrow::Borrow<T> for aya_obj::btf::Btf where T: core::marker::Siz
 pub fn aya_obj::btf::Btf::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_obj::btf::Btf where T: core::marker::Sized
 pub fn aya_obj::btf::Btf::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::btf::Btf where T: core::clone::Clone
-pub unsafe fn aya_obj::btf::Btf::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_obj::btf::Btf
 pub fn aya_obj::btf::Btf::from(t: T) -> T
 #[repr(C)] pub struct aya_obj::btf::BtfEnum
@@ -432,8 +416,6 @@ impl<T> core::borrow::Borrow<T> for aya_obj::btf::BtfEnum where T: core::marker:
 pub fn aya_obj::btf::BtfEnum::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_obj::btf::BtfEnum where T: core::marker::Sized
 pub fn aya_obj::btf::BtfEnum::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::btf::BtfEnum where T: core::clone::Clone
-pub unsafe fn aya_obj::btf::BtfEnum::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_obj::btf::BtfEnum
 pub fn aya_obj::btf::BtfEnum::from(t: T) -> T
 #[repr(C)] pub struct aya_obj::btf::BtfEnum64
@@ -467,8 +449,6 @@ impl<T> core::borrow::Borrow<T> for aya_obj::btf::BtfEnum64 where T: core::marke
 pub fn aya_obj::btf::BtfEnum64::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_obj::btf::BtfEnum64 where T: core::marker::Sized
 pub fn aya_obj::btf::BtfEnum64::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::btf::BtfEnum64 where T: core::clone::Clone
-pub unsafe fn aya_obj::btf::BtfEnum64::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_obj::btf::BtfEnum64
 pub fn aya_obj::btf::BtfEnum64::from(t: T) -> T
 pub struct aya_obj::btf::BtfExt
@@ -500,8 +480,6 @@ impl<T> core::borrow::Borrow<T> for aya_obj::btf::BtfExt where T: core::marker::
 pub fn aya_obj::btf::BtfExt::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_obj::btf::BtfExt where T: core::marker::Sized
 pub fn aya_obj::btf::BtfExt::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::btf::BtfExt where T: core::clone::Clone
-pub unsafe fn aya_obj::btf::BtfExt::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_obj::btf::BtfExt
 pub fn aya_obj::btf::BtfExt::from(t: T) -> T
 pub struct aya_obj::btf::BtfFeatures
@@ -571,8 +549,6 @@ impl<T> core::borrow::Borrow<T> for aya_obj::btf::BtfParam where T: core::marker
 pub fn aya_obj::btf::BtfParam::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_obj::btf::BtfParam where T: core::marker::Sized
 pub fn aya_obj::btf::BtfParam::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::btf::BtfParam where T: core::clone::Clone
-pub unsafe fn aya_obj::btf::BtfParam::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_obj::btf::BtfParam
 pub fn aya_obj::btf::BtfParam::from(t: T) -> T
 pub struct aya_obj::btf::BtfRelocationError
@@ -636,8 +612,6 @@ impl<T> core::borrow::Borrow<T> for aya_obj::btf::Const where T: core::marker::S
 pub fn aya_obj::btf::Const::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_obj::btf::Const where T: core::marker::Sized
 pub fn aya_obj::btf::Const::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::btf::Const where T: core::clone::Clone
-pub unsafe fn aya_obj::btf::Const::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_obj::btf::Const
 pub fn aya_obj::btf::Const::from(t: T) -> T
 #[repr(C)] pub struct aya_obj::btf::DataSec
@@ -671,8 +645,6 @@ impl<T> core::borrow::Borrow<T> for aya_obj::btf::DataSec where T: core::marker:
 pub fn aya_obj::btf::DataSec::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_obj::btf::DataSec where T: core::marker::Sized
 pub fn aya_obj::btf::DataSec::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::btf::DataSec where T: core::clone::Clone
-pub unsafe fn aya_obj::btf::DataSec::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_obj::btf::DataSec
 pub fn aya_obj::btf::DataSec::from(t: T) -> T
 #[repr(C)] pub struct aya_obj::btf::DataSecEntry
@@ -707,8 +679,6 @@ impl<T> core::borrow::Borrow<T> for aya_obj::btf::DataSecEntry where T: core::ma
 pub fn aya_obj::btf::DataSecEntry::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_obj::btf::DataSecEntry where T: core::marker::Sized
 pub fn aya_obj::btf::DataSecEntry::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::btf::DataSecEntry where T: core::clone::Clone
-pub unsafe fn aya_obj::btf::DataSecEntry::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_obj::btf::DataSecEntry
 pub fn aya_obj::btf::DataSecEntry::from(t: T) -> T
 #[repr(C)] pub struct aya_obj::btf::DeclTag
@@ -742,8 +712,6 @@ impl<T> core::borrow::Borrow<T> for aya_obj::btf::DeclTag where T: core::marker:
 pub fn aya_obj::btf::DeclTag::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_obj::btf::DeclTag where T: core::marker::Sized
 pub fn aya_obj::btf::DeclTag::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::btf::DeclTag where T: core::clone::Clone
-pub unsafe fn aya_obj::btf::DeclTag::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_obj::btf::DeclTag
 pub fn aya_obj::btf::DeclTag::from(t: T) -> T
 #[repr(C)] pub struct aya_obj::btf::Enum
@@ -777,8 +745,6 @@ impl<T> core::borrow::Borrow<T> for aya_obj::btf::Enum where T: core::marker::Si
 pub fn aya_obj::btf::Enum::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_obj::btf::Enum where T: core::marker::Sized
 pub fn aya_obj::btf::Enum::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::btf::Enum where T: core::clone::Clone
-pub unsafe fn aya_obj::btf::Enum::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_obj::btf::Enum
 pub fn aya_obj::btf::Enum::from(t: T) -> T
 #[repr(C)] pub struct aya_obj::btf::Enum64
@@ -812,8 +778,6 @@ impl<T> core::borrow::Borrow<T> for aya_obj::btf::Enum64 where T: core::marker::
 pub fn aya_obj::btf::Enum64::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_obj::btf::Enum64 where T: core::marker::Sized
 pub fn aya_obj::btf::Enum64::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::btf::Enum64 where T: core::clone::Clone
-pub unsafe fn aya_obj::btf::Enum64::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_obj::btf::Enum64
 pub fn aya_obj::btf::Enum64::from(t: T) -> T
 #[repr(C)] pub struct aya_obj::btf::Float
@@ -847,8 +811,6 @@ impl<T> core::borrow::Borrow<T> for aya_obj::btf::Float where T: core::marker::S
 pub fn aya_obj::btf::Float::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_obj::btf::Float where T: core::marker::Sized
 pub fn aya_obj::btf::Float::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::btf::Float where T: core::clone::Clone
-pub unsafe fn aya_obj::btf::Float::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_obj::btf::Float
 pub fn aya_obj::btf::Float::from(t: T) -> T
 #[repr(C)] pub struct aya_obj::btf::Func
@@ -882,8 +844,6 @@ impl<T> core::borrow::Borrow<T> for aya_obj::btf::Func where T: core::marker::Si
 pub fn aya_obj::btf::Func::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_obj::btf::Func where T: core::marker::Sized
 pub fn aya_obj::btf::Func::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::btf::Func where T: core::clone::Clone
-pub unsafe fn aya_obj::btf::Func::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_obj::btf::Func
 pub fn aya_obj::btf::Func::from(t: T) -> T
 pub struct aya_obj::btf::FuncInfo
@@ -916,8 +876,6 @@ impl<T> core::borrow::Borrow<T> for aya_obj::btf::FuncInfo where T: core::marker
 pub fn aya_obj::btf::FuncInfo::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_obj::btf::FuncInfo where T: core::marker::Sized
 pub fn aya_obj::btf::FuncInfo::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::btf::FuncInfo where T: core::clone::Clone
-pub unsafe fn aya_obj::btf::FuncInfo::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_obj::btf::FuncInfo
 pub fn aya_obj::btf::FuncInfo::from(t: T) -> T
 #[repr(C)] pub struct aya_obj::btf::FuncProto
@@ -951,8 +909,6 @@ impl<T> core::borrow::Borrow<T> for aya_obj::btf::FuncProto where T: core::marke
 pub fn aya_obj::btf::FuncProto::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_obj::btf::FuncProto where T: core::marker::Sized
 pub fn aya_obj::btf::FuncProto::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::btf::FuncProto where T: core::clone::Clone
-pub unsafe fn aya_obj::btf::FuncProto::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_obj::btf::FuncProto
 pub fn aya_obj::btf::FuncProto::from(t: T) -> T
 pub struct aya_obj::btf::FuncSecInfo
@@ -991,8 +947,6 @@ impl<T> core::borrow::Borrow<T> for aya_obj::btf::FuncSecInfo where T: core::mar
 pub fn aya_obj::btf::FuncSecInfo::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_obj::btf::FuncSecInfo where T: core::marker::Sized
 pub fn aya_obj::btf::FuncSecInfo::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::btf::FuncSecInfo where T: core::clone::Clone
-pub unsafe fn aya_obj::btf::FuncSecInfo::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_obj::btf::FuncSecInfo
 pub fn aya_obj::btf::FuncSecInfo::from(t: T) -> T
 #[repr(C)] pub struct aya_obj::btf::Fwd
@@ -1024,8 +978,6 @@ impl<T> core::borrow::Borrow<T> for aya_obj::btf::Fwd where T: core::marker::Siz
 pub fn aya_obj::btf::Fwd::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_obj::btf::Fwd where T: core::marker::Sized
 pub fn aya_obj::btf::Fwd::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::btf::Fwd where T: core::clone::Clone
-pub unsafe fn aya_obj::btf::Fwd::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_obj::btf::Fwd
 pub fn aya_obj::btf::Fwd::from(t: T) -> T
 #[repr(C)] pub struct aya_obj::btf::Int
@@ -1059,8 +1011,6 @@ impl<T> core::borrow::Borrow<T> for aya_obj::btf::Int where T: core::marker::Siz
 pub fn aya_obj::btf::Int::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_obj::btf::Int where T: core::marker::Sized
 pub fn aya_obj::btf::Int::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::btf::Int where T: core::clone::Clone
-pub unsafe fn aya_obj::btf::Int::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_obj::btf::Int
 pub fn aya_obj::btf::Int::from(t: T) -> T
 pub struct aya_obj::btf::LineSecInfo
@@ -1099,8 +1049,6 @@ impl<T> core::borrow::Borrow<T> for aya_obj::btf::LineSecInfo where T: core::mar
 pub fn aya_obj::btf::LineSecInfo::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_obj::btf::LineSecInfo where T: core::marker::Sized
 pub fn aya_obj::btf::LineSecInfo::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::btf::LineSecInfo where T: core::clone::Clone
-pub unsafe fn aya_obj::btf::LineSecInfo::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_obj::btf::LineSecInfo
 pub fn aya_obj::btf::LineSecInfo::from(t: T) -> T
 #[repr(C)] pub struct aya_obj::btf::Ptr
@@ -1134,8 +1082,6 @@ impl<T> core::borrow::Borrow<T> for aya_obj::btf::Ptr where T: core::marker::Siz
 pub fn aya_obj::btf::Ptr::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_obj::btf::Ptr where T: core::marker::Sized
 pub fn aya_obj::btf::Ptr::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::btf::Ptr where T: core::clone::Clone
-pub unsafe fn aya_obj::btf::Ptr::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_obj::btf::Ptr
 pub fn aya_obj::btf::Ptr::from(t: T) -> T
 pub struct aya_obj::btf::Restrict
@@ -1167,8 +1113,6 @@ impl<T> core::borrow::Borrow<T> for aya_obj::btf::Restrict where T: core::marker
 pub fn aya_obj::btf::Restrict::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_obj::btf::Restrict where T: core::marker::Sized
 pub fn aya_obj::btf::Restrict::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::btf::Restrict where T: core::clone::Clone
-pub unsafe fn aya_obj::btf::Restrict::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_obj::btf::Restrict
 pub fn aya_obj::btf::Restrict::from(t: T) -> T
 #[repr(C)] pub struct aya_obj::btf::Struct
@@ -1200,8 +1144,6 @@ impl<T> core::borrow::Borrow<T> for aya_obj::btf::Struct where T: core::marker::
 pub fn aya_obj::btf::Struct::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_obj::btf::Struct where T: core::marker::Sized
 pub fn aya_obj::btf::Struct::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::btf::Struct where T: core::clone::Clone
-pub unsafe fn aya_obj::btf::Struct::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_obj::btf::Struct
 pub fn aya_obj::btf::Struct::from(t: T) -> T
 #[repr(C)] pub struct aya_obj::btf::TypeTag
@@ -1235,8 +1177,6 @@ impl<T> core::borrow::Borrow<T> for aya_obj::btf::TypeTag where T: core::marker:
 pub fn aya_obj::btf::TypeTag::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_obj::btf::TypeTag where T: core::marker::Sized
 pub fn aya_obj::btf::TypeTag::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::btf::TypeTag where T: core::clone::Clone
-pub unsafe fn aya_obj::btf::TypeTag::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_obj::btf::TypeTag
 pub fn aya_obj::btf::TypeTag::from(t: T) -> T
 #[repr(C)] pub struct aya_obj::btf::Typedef
@@ -1268,8 +1208,6 @@ impl<T> core::borrow::Borrow<T> for aya_obj::btf::Typedef where T: core::marker:
 pub fn aya_obj::btf::Typedef::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_obj::btf::Typedef where T: core::marker::Sized
 pub fn aya_obj::btf::Typedef::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::btf::Typedef where T: core::clone::Clone
-pub unsafe fn aya_obj::btf::Typedef::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_obj::btf::Typedef
 pub fn aya_obj::btf::Typedef::from(t: T) -> T
 #[repr(C)] pub struct aya_obj::btf::Union
@@ -1301,8 +1239,6 @@ impl<T> core::borrow::Borrow<T> for aya_obj::btf::Union where T: core::marker::S
 pub fn aya_obj::btf::Union::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_obj::btf::Union where T: core::marker::Sized
 pub fn aya_obj::btf::Union::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::btf::Union where T: core::clone::Clone
-pub unsafe fn aya_obj::btf::Union::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_obj::btf::Union
 pub fn aya_obj::btf::Union::from(t: T) -> T
 #[repr(C)] pub struct aya_obj::btf::Var
@@ -1336,8 +1272,6 @@ impl<T> core::borrow::Borrow<T> for aya_obj::btf::Var where T: core::marker::Siz
 pub fn aya_obj::btf::Var::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_obj::btf::Var where T: core::marker::Sized
 pub fn aya_obj::btf::Var::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::btf::Var where T: core::clone::Clone
-pub unsafe fn aya_obj::btf::Var::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_obj::btf::Var
 pub fn aya_obj::btf::Var::from(t: T) -> T
 #[repr(C)] pub struct aya_obj::btf::Volatile
@@ -1369,8 +1303,6 @@ impl<T> core::borrow::Borrow<T> for aya_obj::btf::Volatile where T: core::marker
 pub fn aya_obj::btf::Volatile::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_obj::btf::Volatile where T: core::marker::Sized
 pub fn aya_obj::btf::Volatile::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::btf::Volatile where T: core::clone::Clone
-pub unsafe fn aya_obj::btf::Volatile::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_obj::btf::Volatile
 pub fn aya_obj::btf::Volatile::from(t: T) -> T
 pub mod aya_obj::generated
@@ -1490,10 +1422,6 @@ impl<T> core::borrow::Borrow<T> for aya_obj::generated::bpf_attach_type where T:
 pub fn aya_obj::generated::bpf_attach_type::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::bpf_attach_type where T: core::marker::Sized
 pub fn aya_obj::generated::bpf_attach_type::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_attach_type where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::bpf_attach_type::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_attach_type where T: core::marker::Copy
-pub unsafe fn aya_obj::generated::bpf_attach_type::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_obj::generated::bpf_attach_type
 pub fn aya_obj::generated::bpf_attach_type::from(t: T) -> T
 #[repr(u32)] pub enum aya_obj::generated::bpf_cmd
@@ -1572,10 +1500,6 @@ impl<T> core::borrow::Borrow<T> for aya_obj::generated::bpf_cmd where T: core::m
 pub fn aya_obj::generated::bpf_cmd::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::bpf_cmd where T: core::marker::Sized
 pub fn aya_obj::generated::bpf_cmd::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_cmd where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::bpf_cmd::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_cmd where T: core::marker::Copy
-pub unsafe fn aya_obj::generated::bpf_cmd::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_obj::generated::bpf_cmd
 pub fn aya_obj::generated::bpf_cmd::from(t: T) -> T
 #[repr(u32)] pub enum aya_obj::generated::bpf_link_type
@@ -1629,10 +1553,6 @@ impl<T> core::borrow::Borrow<T> for aya_obj::generated::bpf_link_type where T: c
 pub fn aya_obj::generated::bpf_link_type::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::bpf_link_type where T: core::marker::Sized
 pub fn aya_obj::generated::bpf_link_type::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_link_type where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::bpf_link_type::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_link_type where T: core::marker::Copy
-pub unsafe fn aya_obj::generated::bpf_link_type::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_obj::generated::bpf_link_type
 pub fn aya_obj::generated::bpf_link_type::from(t: T) -> T
 #[repr(u32)] pub enum aya_obj::generated::bpf_map_type
@@ -1713,10 +1633,6 @@ impl<T> core::borrow::Borrow<T> for aya_obj::generated::bpf_map_type where T: co
 pub fn aya_obj::generated::bpf_map_type::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::bpf_map_type where T: core::marker::Sized
 pub fn aya_obj::generated::bpf_map_type::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_map_type where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::bpf_map_type::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_map_type where T: core::marker::Copy
-pub unsafe fn aya_obj::generated::bpf_map_type::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_obj::generated::bpf_map_type
 pub fn aya_obj::generated::bpf_map_type::from(t: T) -> T
 #[repr(u32)] pub enum aya_obj::generated::bpf_prog_type
@@ -1759,7 +1675,11 @@ pub fn aya_obj::generated::bpf_prog_type::clone(&self) -> aya_obj::generated::bp
 impl core::cmp::Eq for aya_obj::generated::bpf_prog_type
 impl core::cmp::PartialEq for aya_obj::generated::bpf_prog_type
 pub fn aya_obj::generated::bpf_prog_type::eq(&self, other: &aya_obj::generated::bpf_prog_type) -> bool
+impl core::convert::From<u32> for aya_obj::generated::bpf_prog_type
+pub fn aya_obj::generated::bpf_prog_type::from(prog_type: u32) -> Self
 impl core::fmt::Debug for aya_obj::generated::bpf_prog_type
+pub fn aya_obj::generated::bpf_prog_type::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::fmt::Display for aya_obj::generated::bpf_prog_type
 pub fn aya_obj::generated::bpf_prog_type::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::hash::Hash for aya_obj::generated::bpf_prog_type
 pub fn aya_obj::generated::bpf_prog_type::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
@@ -1783,16 +1703,14 @@ impl<T> alloc::borrow::ToOwned for aya_obj::generated::bpf_prog_type where T: co
 pub type aya_obj::generated::bpf_prog_type::Owned = T
 pub fn aya_obj::generated::bpf_prog_type::clone_into(&self, target: &mut T)
 pub fn aya_obj::generated::bpf_prog_type::to_owned(&self) -> T
+impl<T> alloc::string::ToString for aya_obj::generated::bpf_prog_type where T: core::fmt::Display + core::marker::Sized
+pub fn aya_obj::generated::bpf_prog_type::to_string(&self) -> alloc::string::String
 impl<T> core::any::Any for aya_obj::generated::bpf_prog_type where T: 'static + core::marker::Sized
 pub fn aya_obj::generated::bpf_prog_type::type_id(&self) -> core::any::TypeId
 impl<T> core::borrow::Borrow<T> for aya_obj::generated::bpf_prog_type where T: core::marker::Sized
 pub fn aya_obj::generated::bpf_prog_type::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::bpf_prog_type where T: core::marker::Sized
 pub fn aya_obj::generated::bpf_prog_type::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_prog_type where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::bpf_prog_type::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_prog_type where T: core::marker::Copy
-pub unsafe fn aya_obj::generated::bpf_prog_type::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_obj::generated::bpf_prog_type
 pub fn aya_obj::generated::bpf_prog_type::from(t: T) -> T
 #[repr(u32)] pub enum aya_obj::generated::btf_func_linkage
@@ -1834,10 +1752,6 @@ impl<T> core::borrow::Borrow<T> for aya_obj::generated::btf_func_linkage where T
 pub fn aya_obj::generated::btf_func_linkage::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::btf_func_linkage where T: core::marker::Sized
 pub fn aya_obj::generated::btf_func_linkage::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::btf_func_linkage where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::btf_func_linkage::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_obj::generated::btf_func_linkage where T: core::marker::Copy
-pub unsafe fn aya_obj::generated::btf_func_linkage::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_obj::generated::btf_func_linkage
 pub fn aya_obj::generated::btf_func_linkage::from(t: T) -> T
 #[repr(u32)] pub enum aya_obj::generated::perf_event_sample_format
@@ -1902,10 +1816,6 @@ impl<T> core::borrow::Borrow<T> for aya_obj::generated::perf_event_sample_format
 pub fn aya_obj::generated::perf_event_sample_format::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::perf_event_sample_format where T: core::marker::Sized
 pub fn aya_obj::generated::perf_event_sample_format::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::perf_event_sample_format where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::perf_event_sample_format::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_obj::generated::perf_event_sample_format where T: core::marker::Copy
-pub unsafe fn aya_obj::generated::perf_event_sample_format::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_obj::generated::perf_event_sample_format
 pub fn aya_obj::generated::perf_event_sample_format::from(t: T) -> T
 #[repr(u32)] pub enum aya_obj::generated::perf_event_type
@@ -1966,10 +1876,6 @@ impl<T> core::borrow::Borrow<T> for aya_obj::generated::perf_event_type where T:
 pub fn aya_obj::generated::perf_event_type::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::perf_event_type where T: core::marker::Sized
 pub fn aya_obj::generated::perf_event_type::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::perf_event_type where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::perf_event_type::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_obj::generated::perf_event_type where T: core::marker::Copy
-pub unsafe fn aya_obj::generated::perf_event_type::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_obj::generated::perf_event_type
 pub fn aya_obj::generated::perf_event_type::from(t: T) -> T
 #[repr(u32)] pub enum aya_obj::generated::perf_hw_cache_id
@@ -2016,10 +1922,6 @@ impl<T> core::borrow::Borrow<T> for aya_obj::generated::perf_hw_cache_id where T
 pub fn aya_obj::generated::perf_hw_cache_id::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::perf_hw_cache_id where T: core::marker::Sized
 pub fn aya_obj::generated::perf_hw_cache_id::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::perf_hw_cache_id where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::perf_hw_cache_id::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_obj::generated::perf_hw_cache_id where T: core::marker::Copy
-pub unsafe fn aya_obj::generated::perf_hw_cache_id::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_obj::generated::perf_hw_cache_id
 pub fn aya_obj::generated::perf_hw_cache_id::from(t: T) -> T
 #[repr(u32)] pub enum aya_obj::generated::perf_hw_cache_op_id
@@ -2062,10 +1964,6 @@ impl<T> core::borrow::Borrow<T> for aya_obj::generated::perf_hw_cache_op_id wher
 pub fn aya_obj::generated::perf_hw_cache_op_id::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::perf_hw_cache_op_id where T: core::marker::Sized
 pub fn aya_obj::generated::perf_hw_cache_op_id::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::perf_hw_cache_op_id where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::perf_hw_cache_op_id::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_obj::generated::perf_hw_cache_op_id where T: core::marker::Copy
-pub unsafe fn aya_obj::generated::perf_hw_cache_op_id::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_obj::generated::perf_hw_cache_op_id
 pub fn aya_obj::generated::perf_hw_cache_op_id::from(t: T) -> T
 #[repr(u32)] pub enum aya_obj::generated::perf_hw_cache_op_result_id
@@ -2107,10 +2005,6 @@ impl<T> core::borrow::Borrow<T> for aya_obj::generated::perf_hw_cache_op_result_
 pub fn aya_obj::generated::perf_hw_cache_op_result_id::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::perf_hw_cache_op_result_id where T: core::marker::Sized
 pub fn aya_obj::generated::perf_hw_cache_op_result_id::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::perf_hw_cache_op_result_id where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::perf_hw_cache_op_result_id::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_obj::generated::perf_hw_cache_op_result_id where T: core::marker::Copy
-pub unsafe fn aya_obj::generated::perf_hw_cache_op_result_id::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_obj::generated::perf_hw_cache_op_result_id
 pub fn aya_obj::generated::perf_hw_cache_op_result_id::from(t: T) -> T
 #[repr(u32)] pub enum aya_obj::generated::perf_hw_id
@@ -2160,10 +2054,6 @@ impl<T> core::borrow::Borrow<T> for aya_obj::generated::perf_hw_id where T: core
 pub fn aya_obj::generated::perf_hw_id::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::perf_hw_id where T: core::marker::Sized
 pub fn aya_obj::generated::perf_hw_id::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::perf_hw_id where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::perf_hw_id::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_obj::generated::perf_hw_id where T: core::marker::Copy
-pub unsafe fn aya_obj::generated::perf_hw_id::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_obj::generated::perf_hw_id
 pub fn aya_obj::generated::perf_hw_id::from(t: T) -> T
 #[repr(u32)] pub enum aya_obj::generated::perf_sw_ids
@@ -2215,10 +2105,6 @@ impl<T> core::borrow::Borrow<T> for aya_obj::generated::perf_sw_ids where T: cor
 pub fn aya_obj::generated::perf_sw_ids::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::perf_sw_ids where T: core::marker::Sized
 pub fn aya_obj::generated::perf_sw_ids::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::perf_sw_ids where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::perf_sw_ids::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_obj::generated::perf_sw_ids where T: core::marker::Copy
-pub unsafe fn aya_obj::generated::perf_sw_ids::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_obj::generated::perf_sw_ids
 pub fn aya_obj::generated::perf_sw_ids::from(t: T) -> T
 #[repr(u32)] pub enum aya_obj::generated::perf_type_id
@@ -2264,10 +2150,6 @@ impl<T> core::borrow::Borrow<T> for aya_obj::generated::perf_type_id where T: co
 pub fn aya_obj::generated::perf_type_id::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::perf_type_id where T: core::marker::Sized
 pub fn aya_obj::generated::perf_type_id::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::perf_type_id where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::perf_type_id::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_obj::generated::perf_type_id where T: core::marker::Copy
-pub unsafe fn aya_obj::generated::perf_type_id::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_obj::generated::perf_type_id
 pub fn aya_obj::generated::perf_type_id::from(t: T) -> T
 #[repr(C)] pub union aya_obj::generated::bpf_attr
@@ -2318,10 +2200,6 @@ impl<T> core::borrow::Borrow<T> for aya_obj::generated::bpf_attr where T: core::
 pub fn aya_obj::generated::bpf_attr::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::bpf_attr where T: core::marker::Sized
 pub fn aya_obj::generated::bpf_attr::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_attr where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::bpf_attr::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_attr where T: core::marker::Copy
-pub unsafe fn aya_obj::generated::bpf_attr::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_obj::generated::bpf_attr
 pub fn aya_obj::generated::bpf_attr::from(t: T) -> T
 #[repr(C)] pub union aya_obj::generated::bpf_attr__bindgen_ty_10__bindgen_ty_1
@@ -2354,10 +2232,6 @@ impl<T> core::borrow::Borrow<T> for aya_obj::generated::bpf_attr__bindgen_ty_10_
 pub fn aya_obj::generated::bpf_attr__bindgen_ty_10__bindgen_ty_1::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::bpf_attr__bindgen_ty_10__bindgen_ty_1 where T: core::marker::Sized
 pub fn aya_obj::generated::bpf_attr__bindgen_ty_10__bindgen_ty_1::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_attr__bindgen_ty_10__bindgen_ty_1 where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::bpf_attr__bindgen_ty_10__bindgen_ty_1::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_attr__bindgen_ty_10__bindgen_ty_1 where T: core::marker::Copy
-pub unsafe fn aya_obj::generated::bpf_attr__bindgen_ty_10__bindgen_ty_1::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_obj::generated::bpf_attr__bindgen_ty_10__bindgen_ty_1
 pub fn aya_obj::generated::bpf_attr__bindgen_ty_10__bindgen_ty_1::from(t: T) -> T
 #[repr(C)] pub union aya_obj::generated::bpf_attr__bindgen_ty_10__bindgen_ty_2
@@ -2390,10 +2264,6 @@ impl<T> core::borrow::Borrow<T> for aya_obj::generated::bpf_attr__bindgen_ty_10_
 pub fn aya_obj::generated::bpf_attr__bindgen_ty_10__bindgen_ty_2::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::bpf_attr__bindgen_ty_10__bindgen_ty_2 where T: core::marker::Sized
 pub fn aya_obj::generated::bpf_attr__bindgen_ty_10__bindgen_ty_2::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_attr__bindgen_ty_10__bindgen_ty_2 where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::bpf_attr__bindgen_ty_10__bindgen_ty_2::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_attr__bindgen_ty_10__bindgen_ty_2 where T: core::marker::Copy
-pub unsafe fn aya_obj::generated::bpf_attr__bindgen_ty_10__bindgen_ty_2::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_obj::generated::bpf_attr__bindgen_ty_10__bindgen_ty_2
 pub fn aya_obj::generated::bpf_attr__bindgen_ty_10__bindgen_ty_2::from(t: T) -> T
 #[repr(C)] pub union aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_1
@@ -2426,10 +2296,6 @@ impl<T> core::borrow::Borrow<T> for aya_obj::generated::bpf_attr__bindgen_ty_14_
 pub fn aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_1::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_1 where T: core::marker::Sized
 pub fn aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_1::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_1 where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_1::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_1 where T: core::marker::Copy
-pub unsafe fn aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_1::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_1
 pub fn aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_1::from(t: T) -> T
 #[repr(C)] pub union aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_2
@@ -2462,10 +2328,6 @@ impl<T> core::borrow::Borrow<T> for aya_obj::generated::bpf_attr__bindgen_ty_14_
 pub fn aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_2::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_2 where T: core::marker::Sized
 pub fn aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_2::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_2 where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_2::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_2 where T: core::marker::Copy
-pub unsafe fn aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_2::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_2
 pub fn aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_2::from(t: T) -> T
 #[repr(C)] pub union aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3
@@ -2505,10 +2367,6 @@ impl<T> core::borrow::Borrow<T> for aya_obj::generated::bpf_attr__bindgen_ty_14_
 pub fn aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3 where T: core::marker::Sized
 pub fn aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3 where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3 where T: core::marker::Copy
-pub unsafe fn aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3
 pub fn aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3::from(t: T) -> T
 #[repr(C)] pub union aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_6__bindgen_ty_1
@@ -2541,10 +2399,6 @@ impl<T> core::borrow::Borrow<T> for aya_obj::generated::bpf_attr__bindgen_ty_14_
 pub fn aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_6__bindgen_ty_1::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_6__bindgen_ty_1 where T: core::marker::Sized
 pub fn aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_6__bindgen_ty_1::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_6__bindgen_ty_1 where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_6__bindgen_ty_1::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_6__bindgen_ty_1 where T: core::marker::Copy
-pub unsafe fn aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_6__bindgen_ty_1::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_6__bindgen_ty_1
 pub fn aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_6__bindgen_ty_1::from(t: T) -> T
 #[repr(C)] pub union aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_8__bindgen_ty_1
@@ -2577,10 +2431,6 @@ impl<T> core::borrow::Borrow<T> for aya_obj::generated::bpf_attr__bindgen_ty_14_
 pub fn aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_8__bindgen_ty_1::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_8__bindgen_ty_1 where T: core::marker::Sized
 pub fn aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_8__bindgen_ty_1::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_8__bindgen_ty_1 where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_8__bindgen_ty_1::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_8__bindgen_ty_1 where T: core::marker::Copy
-pub unsafe fn aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_8__bindgen_ty_1::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_8__bindgen_ty_1
 pub fn aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_8__bindgen_ty_1::from(t: T) -> T
 #[repr(C)] pub union aya_obj::generated::bpf_attr__bindgen_ty_15__bindgen_ty_1
@@ -2613,10 +2463,6 @@ impl<T> core::borrow::Borrow<T> for aya_obj::generated::bpf_attr__bindgen_ty_15_
 pub fn aya_obj::generated::bpf_attr__bindgen_ty_15__bindgen_ty_1::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::bpf_attr__bindgen_ty_15__bindgen_ty_1 where T: core::marker::Sized
 pub fn aya_obj::generated::bpf_attr__bindgen_ty_15__bindgen_ty_1::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_attr__bindgen_ty_15__bindgen_ty_1 where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::bpf_attr__bindgen_ty_15__bindgen_ty_1::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_attr__bindgen_ty_15__bindgen_ty_1 where T: core::marker::Copy
-pub unsafe fn aya_obj::generated::bpf_attr__bindgen_ty_15__bindgen_ty_1::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_obj::generated::bpf_attr__bindgen_ty_15__bindgen_ty_1
 pub fn aya_obj::generated::bpf_attr__bindgen_ty_15__bindgen_ty_1::from(t: T) -> T
 #[repr(C)] pub union aya_obj::generated::bpf_attr__bindgen_ty_15__bindgen_ty_2
@@ -2649,10 +2495,6 @@ impl<T> core::borrow::Borrow<T> for aya_obj::generated::bpf_attr__bindgen_ty_15_
 pub fn aya_obj::generated::bpf_attr__bindgen_ty_15__bindgen_ty_2::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::bpf_attr__bindgen_ty_15__bindgen_ty_2 where T: core::marker::Sized
 pub fn aya_obj::generated::bpf_attr__bindgen_ty_15__bindgen_ty_2::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_attr__bindgen_ty_15__bindgen_ty_2 where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::bpf_attr__bindgen_ty_15__bindgen_ty_2::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_attr__bindgen_ty_15__bindgen_ty_2 where T: core::marker::Copy
-pub unsafe fn aya_obj::generated::bpf_attr__bindgen_ty_15__bindgen_ty_2::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_obj::generated::bpf_attr__bindgen_ty_15__bindgen_ty_2
 pub fn aya_obj::generated::bpf_attr__bindgen_ty_15__bindgen_ty_2::from(t: T) -> T
 #[repr(C)] pub union aya_obj::generated::bpf_attr__bindgen_ty_2__bindgen_ty_1
@@ -2685,10 +2527,6 @@ impl<T> core::borrow::Borrow<T> for aya_obj::generated::bpf_attr__bindgen_ty_2__
 pub fn aya_obj::generated::bpf_attr__bindgen_ty_2__bindgen_ty_1::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::bpf_attr__bindgen_ty_2__bindgen_ty_1 where T: core::marker::Sized
 pub fn aya_obj::generated::bpf_attr__bindgen_ty_2__bindgen_ty_1::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_attr__bindgen_ty_2__bindgen_ty_1 where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::bpf_attr__bindgen_ty_2__bindgen_ty_1::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_attr__bindgen_ty_2__bindgen_ty_1 where T: core::marker::Copy
-pub unsafe fn aya_obj::generated::bpf_attr__bindgen_ty_2__bindgen_ty_1::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_obj::generated::bpf_attr__bindgen_ty_2__bindgen_ty_1
 pub fn aya_obj::generated::bpf_attr__bindgen_ty_2__bindgen_ty_1::from(t: T) -> T
 #[repr(C)] pub union aya_obj::generated::bpf_attr__bindgen_ty_4__bindgen_ty_1
@@ -2721,10 +2559,6 @@ impl<T> core::borrow::Borrow<T> for aya_obj::generated::bpf_attr__bindgen_ty_4__
 pub fn aya_obj::generated::bpf_attr__bindgen_ty_4__bindgen_ty_1::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::bpf_attr__bindgen_ty_4__bindgen_ty_1 where T: core::marker::Sized
 pub fn aya_obj::generated::bpf_attr__bindgen_ty_4__bindgen_ty_1::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_attr__bindgen_ty_4__bindgen_ty_1 where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::bpf_attr__bindgen_ty_4__bindgen_ty_1::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_attr__bindgen_ty_4__bindgen_ty_1 where T: core::marker::Copy
-pub unsafe fn aya_obj::generated::bpf_attr__bindgen_ty_4__bindgen_ty_1::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_obj::generated::bpf_attr__bindgen_ty_4__bindgen_ty_1
 pub fn aya_obj::generated::bpf_attr__bindgen_ty_4__bindgen_ty_1::from(t: T) -> T
 #[repr(C)] pub union aya_obj::generated::bpf_attr__bindgen_ty_6__bindgen_ty_1
@@ -2757,10 +2591,6 @@ impl<T> core::borrow::Borrow<T> for aya_obj::generated::bpf_attr__bindgen_ty_6__
 pub fn aya_obj::generated::bpf_attr__bindgen_ty_6__bindgen_ty_1::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::bpf_attr__bindgen_ty_6__bindgen_ty_1 where T: core::marker::Sized
 pub fn aya_obj::generated::bpf_attr__bindgen_ty_6__bindgen_ty_1::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_attr__bindgen_ty_6__bindgen_ty_1 where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::bpf_attr__bindgen_ty_6__bindgen_ty_1::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_attr__bindgen_ty_6__bindgen_ty_1 where T: core::marker::Copy
-pub unsafe fn aya_obj::generated::bpf_attr__bindgen_ty_6__bindgen_ty_1::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_obj::generated::bpf_attr__bindgen_ty_6__bindgen_ty_1
 pub fn aya_obj::generated::bpf_attr__bindgen_ty_6__bindgen_ty_1::from(t: T) -> T
 #[repr(C)] pub union aya_obj::generated::bpf_attr__bindgen_ty_6__bindgen_ty_2
@@ -2793,10 +2623,6 @@ impl<T> core::borrow::Borrow<T> for aya_obj::generated::bpf_attr__bindgen_ty_6__
 pub fn aya_obj::generated::bpf_attr__bindgen_ty_6__bindgen_ty_2::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::bpf_attr__bindgen_ty_6__bindgen_ty_2 where T: core::marker::Sized
 pub fn aya_obj::generated::bpf_attr__bindgen_ty_6__bindgen_ty_2::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_attr__bindgen_ty_6__bindgen_ty_2 where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::bpf_attr__bindgen_ty_6__bindgen_ty_2::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_attr__bindgen_ty_6__bindgen_ty_2 where T: core::marker::Copy
-pub unsafe fn aya_obj::generated::bpf_attr__bindgen_ty_6__bindgen_ty_2::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_obj::generated::bpf_attr__bindgen_ty_6__bindgen_ty_2
 pub fn aya_obj::generated::bpf_attr__bindgen_ty_6__bindgen_ty_2::from(t: T) -> T
 #[repr(C)] pub union aya_obj::generated::bpf_attr__bindgen_ty_8__bindgen_ty_1
@@ -2832,10 +2658,6 @@ impl<T> core::borrow::Borrow<T> for aya_obj::generated::bpf_attr__bindgen_ty_8__
 pub fn aya_obj::generated::bpf_attr__bindgen_ty_8__bindgen_ty_1::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::bpf_attr__bindgen_ty_8__bindgen_ty_1 where T: core::marker::Sized
 pub fn aya_obj::generated::bpf_attr__bindgen_ty_8__bindgen_ty_1::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_attr__bindgen_ty_8__bindgen_ty_1 where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::bpf_attr__bindgen_ty_8__bindgen_ty_1::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_attr__bindgen_ty_8__bindgen_ty_1 where T: core::marker::Copy
-pub unsafe fn aya_obj::generated::bpf_attr__bindgen_ty_8__bindgen_ty_1::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_obj::generated::bpf_attr__bindgen_ty_8__bindgen_ty_1
 pub fn aya_obj::generated::bpf_attr__bindgen_ty_8__bindgen_ty_1::from(t: T) -> T
 #[repr(C)] pub union aya_obj::generated::bpf_cpumap_val__bindgen_ty_1
@@ -2868,10 +2690,6 @@ impl<T> core::borrow::Borrow<T> for aya_obj::generated::bpf_cpumap_val__bindgen_
 pub fn aya_obj::generated::bpf_cpumap_val__bindgen_ty_1::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::bpf_cpumap_val__bindgen_ty_1 where T: core::marker::Sized
 pub fn aya_obj::generated::bpf_cpumap_val__bindgen_ty_1::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_cpumap_val__bindgen_ty_1 where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::bpf_cpumap_val__bindgen_ty_1::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_cpumap_val__bindgen_ty_1 where T: core::marker::Copy
-pub unsafe fn aya_obj::generated::bpf_cpumap_val__bindgen_ty_1::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_obj::generated::bpf_cpumap_val__bindgen_ty_1
 pub fn aya_obj::generated::bpf_cpumap_val__bindgen_ty_1::from(t: T) -> T
 #[repr(C)] pub union aya_obj::generated::bpf_devmap_val__bindgen_ty_1
@@ -2904,10 +2722,6 @@ impl<T> core::borrow::Borrow<T> for aya_obj::generated::bpf_devmap_val__bindgen_
 pub fn aya_obj::generated::bpf_devmap_val__bindgen_ty_1::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::bpf_devmap_val__bindgen_ty_1 where T: core::marker::Sized
 pub fn aya_obj::generated::bpf_devmap_val__bindgen_ty_1::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_devmap_val__bindgen_ty_1 where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::bpf_devmap_val__bindgen_ty_1::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_devmap_val__bindgen_ty_1 where T: core::marker::Copy
-pub unsafe fn aya_obj::generated::bpf_devmap_val__bindgen_ty_1::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_obj::generated::bpf_devmap_val__bindgen_ty_1
 pub fn aya_obj::generated::bpf_devmap_val__bindgen_ty_1::from(t: T) -> T
 #[repr(C)] pub union aya_obj::generated::bpf_link_info__bindgen_ty_1
@@ -2951,10 +2765,6 @@ impl<T> core::borrow::Borrow<T> for aya_obj::generated::bpf_link_info__bindgen_t
 pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::bpf_link_info__bindgen_ty_1 where T: core::marker::Sized
 pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_link_info__bindgen_ty_1 where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::bpf_link_info__bindgen_ty_1::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_link_info__bindgen_ty_1 where T: core::marker::Copy
-pub unsafe fn aya_obj::generated::bpf_link_info__bindgen_ty_1::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_obj::generated::bpf_link_info__bindgen_ty_1
 pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1::from(t: T) -> T
 #[repr(C)] pub union aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1
@@ -2989,10 +2799,6 @@ impl<T> core::borrow::Borrow<T> for aya_obj::generated::bpf_link_info__bindgen_t
 pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1 where T: core::marker::Sized
 pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1 where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1 where T: core::marker::Copy
-pub unsafe fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1
 pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1::from(t: T) -> T
 #[repr(C)] pub union aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_1
@@ -3024,10 +2830,6 @@ impl<T> core::borrow::Borrow<T> for aya_obj::generated::bpf_link_info__bindgen_t
 pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_1::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_1 where T: core::marker::Sized
 pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_1::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_1 where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_1::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_1 where T: core::marker::Copy
-pub unsafe fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_1::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_1
 pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_1::from(t: T) -> T
 #[repr(C)] pub union aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2
@@ -3060,10 +2862,6 @@ impl<T> core::borrow::Borrow<T> for aya_obj::generated::bpf_link_info__bindgen_t
 pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2 where T: core::marker::Sized
 pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2 where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2 where T: core::marker::Copy
-pub unsafe fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2
 pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2::from(t: T) -> T
 #[repr(C)] pub union aya_obj::generated::btf_type__bindgen_ty_1
@@ -3096,10 +2894,6 @@ impl<T> core::borrow::Borrow<T> for aya_obj::generated::btf_type__bindgen_ty_1 w
 pub fn aya_obj::generated::btf_type__bindgen_ty_1::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::btf_type__bindgen_ty_1 where T: core::marker::Sized
 pub fn aya_obj::generated::btf_type__bindgen_ty_1::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::btf_type__bindgen_ty_1 where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::btf_type__bindgen_ty_1::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_obj::generated::btf_type__bindgen_ty_1 where T: core::marker::Copy
-pub unsafe fn aya_obj::generated::btf_type__bindgen_ty_1::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_obj::generated::btf_type__bindgen_ty_1
 pub fn aya_obj::generated::btf_type__bindgen_ty_1::from(t: T) -> T
 #[repr(C)] pub union aya_obj::generated::perf_event_attr__bindgen_ty_1
@@ -3132,10 +2926,6 @@ impl<T> core::borrow::Borrow<T> for aya_obj::generated::perf_event_attr__bindgen
 pub fn aya_obj::generated::perf_event_attr__bindgen_ty_1::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::perf_event_attr__bindgen_ty_1 where T: core::marker::Sized
 pub fn aya_obj::generated::perf_event_attr__bindgen_ty_1::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::perf_event_attr__bindgen_ty_1 where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::perf_event_attr__bindgen_ty_1::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_obj::generated::perf_event_attr__bindgen_ty_1 where T: core::marker::Copy
-pub unsafe fn aya_obj::generated::perf_event_attr__bindgen_ty_1::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_obj::generated::perf_event_attr__bindgen_ty_1
 pub fn aya_obj::generated::perf_event_attr__bindgen_ty_1::from(t: T) -> T
 #[repr(C)] pub union aya_obj::generated::perf_event_attr__bindgen_ty_2
@@ -3168,10 +2958,6 @@ impl<T> core::borrow::Borrow<T> for aya_obj::generated::perf_event_attr__bindgen
 pub fn aya_obj::generated::perf_event_attr__bindgen_ty_2::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::perf_event_attr__bindgen_ty_2 where T: core::marker::Sized
 pub fn aya_obj::generated::perf_event_attr__bindgen_ty_2::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::perf_event_attr__bindgen_ty_2 where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::perf_event_attr__bindgen_ty_2::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_obj::generated::perf_event_attr__bindgen_ty_2 where T: core::marker::Copy
-pub unsafe fn aya_obj::generated::perf_event_attr__bindgen_ty_2::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_obj::generated::perf_event_attr__bindgen_ty_2
 pub fn aya_obj::generated::perf_event_attr__bindgen_ty_2::from(t: T) -> T
 #[repr(C)] pub union aya_obj::generated::perf_event_attr__bindgen_ty_3
@@ -3206,10 +2992,6 @@ impl<T> core::borrow::Borrow<T> for aya_obj::generated::perf_event_attr__bindgen
 pub fn aya_obj::generated::perf_event_attr__bindgen_ty_3::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::perf_event_attr__bindgen_ty_3 where T: core::marker::Sized
 pub fn aya_obj::generated::perf_event_attr__bindgen_ty_3::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::perf_event_attr__bindgen_ty_3 where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::perf_event_attr__bindgen_ty_3::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_obj::generated::perf_event_attr__bindgen_ty_3 where T: core::marker::Copy
-pub unsafe fn aya_obj::generated::perf_event_attr__bindgen_ty_3::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_obj::generated::perf_event_attr__bindgen_ty_3
 pub fn aya_obj::generated::perf_event_attr__bindgen_ty_3::from(t: T) -> T
 #[repr(C)] pub union aya_obj::generated::perf_event_attr__bindgen_ty_4
@@ -3244,10 +3026,6 @@ impl<T> core::borrow::Borrow<T> for aya_obj::generated::perf_event_attr__bindgen
 pub fn aya_obj::generated::perf_event_attr__bindgen_ty_4::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::perf_event_attr__bindgen_ty_4 where T: core::marker::Sized
 pub fn aya_obj::generated::perf_event_attr__bindgen_ty_4::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::perf_event_attr__bindgen_ty_4 where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::perf_event_attr__bindgen_ty_4::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_obj::generated::perf_event_attr__bindgen_ty_4 where T: core::marker::Copy
-pub unsafe fn aya_obj::generated::perf_event_attr__bindgen_ty_4::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_obj::generated::perf_event_attr__bindgen_ty_4
 pub fn aya_obj::generated::perf_event_attr__bindgen_ty_4::from(t: T) -> T
 #[repr(C)] pub union aya_obj::generated::perf_event_mmap_page__bindgen_ty_1
@@ -3280,10 +3058,6 @@ impl<T> core::borrow::Borrow<T> for aya_obj::generated::perf_event_mmap_page__bi
 pub fn aya_obj::generated::perf_event_mmap_page__bindgen_ty_1::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::perf_event_mmap_page__bindgen_ty_1 where T: core::marker::Sized
 pub fn aya_obj::generated::perf_event_mmap_page__bindgen_ty_1::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::perf_event_mmap_page__bindgen_ty_1 where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::perf_event_mmap_page__bindgen_ty_1::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_obj::generated::perf_event_mmap_page__bindgen_ty_1 where T: core::marker::Copy
-pub unsafe fn aya_obj::generated::perf_event_mmap_page__bindgen_ty_1::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_obj::generated::perf_event_mmap_page__bindgen_ty_1
 pub fn aya_obj::generated::perf_event_mmap_page__bindgen_ty_1::from(t: T) -> T
 #[repr(C)] pub struct aya_obj::generated::__BindgenBitfieldUnit<Storage>
@@ -3335,10 +3109,6 @@ impl<T> core::borrow::Borrow<T> for aya_obj::generated::__BindgenBitfieldUnit<St
 pub fn aya_obj::generated::__BindgenBitfieldUnit<Storage>::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::__BindgenBitfieldUnit<Storage> where T: core::marker::Sized
 pub fn aya_obj::generated::__BindgenBitfieldUnit<Storage>::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::__BindgenBitfieldUnit<Storage> where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::__BindgenBitfieldUnit<Storage>::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_obj::generated::__BindgenBitfieldUnit<Storage> where T: core::marker::Copy
-pub unsafe fn aya_obj::generated::__BindgenBitfieldUnit<Storage>::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_obj::generated::__BindgenBitfieldUnit<Storage>
 pub fn aya_obj::generated::__BindgenBitfieldUnit<Storage>::from(t: T) -> T
 #[repr(C)] pub struct aya_obj::generated::__IncompleteArrayField<T>(_, _)
@@ -3420,10 +3190,6 @@ impl<T> core::borrow::Borrow<T> for aya_obj::generated::bpf_attr__bindgen_ty_1 w
 pub fn aya_obj::generated::bpf_attr__bindgen_ty_1::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::bpf_attr__bindgen_ty_1 where T: core::marker::Sized
 pub fn aya_obj::generated::bpf_attr__bindgen_ty_1::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_attr__bindgen_ty_1 where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::bpf_attr__bindgen_ty_1::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_attr__bindgen_ty_1 where T: core::marker::Copy
-pub unsafe fn aya_obj::generated::bpf_attr__bindgen_ty_1::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_obj::generated::bpf_attr__bindgen_ty_1
 pub fn aya_obj::generated::bpf_attr__bindgen_ty_1::from(t: T) -> T
 #[repr(C)] pub struct aya_obj::generated::bpf_attr__bindgen_ty_10
@@ -3468,10 +3234,6 @@ impl<T> core::borrow::Borrow<T> for aya_obj::generated::bpf_attr__bindgen_ty_10 
 pub fn aya_obj::generated::bpf_attr__bindgen_ty_10::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::bpf_attr__bindgen_ty_10 where T: core::marker::Sized
 pub fn aya_obj::generated::bpf_attr__bindgen_ty_10::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_attr__bindgen_ty_10 where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::bpf_attr__bindgen_ty_10::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_attr__bindgen_ty_10 where T: core::marker::Copy
-pub unsafe fn aya_obj::generated::bpf_attr__bindgen_ty_10::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_obj::generated::bpf_attr__bindgen_ty_10
 pub fn aya_obj::generated::bpf_attr__bindgen_ty_10::from(t: T) -> T
 #[repr(C)] pub struct aya_obj::generated::bpf_attr__bindgen_ty_11
@@ -3511,10 +3273,6 @@ impl<T> core::borrow::Borrow<T> for aya_obj::generated::bpf_attr__bindgen_ty_11 
 pub fn aya_obj::generated::bpf_attr__bindgen_ty_11::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::bpf_attr__bindgen_ty_11 where T: core::marker::Sized
 pub fn aya_obj::generated::bpf_attr__bindgen_ty_11::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_attr__bindgen_ty_11 where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::bpf_attr__bindgen_ty_11::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_attr__bindgen_ty_11 where T: core::marker::Copy
-pub unsafe fn aya_obj::generated::bpf_attr__bindgen_ty_11::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_obj::generated::bpf_attr__bindgen_ty_11
 pub fn aya_obj::generated::bpf_attr__bindgen_ty_11::from(t: T) -> T
 #[repr(C)] pub struct aya_obj::generated::bpf_attr__bindgen_ty_12
@@ -3555,10 +3313,6 @@ impl<T> core::borrow::Borrow<T> for aya_obj::generated::bpf_attr__bindgen_ty_12 
 pub fn aya_obj::generated::bpf_attr__bindgen_ty_12::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::bpf_attr__bindgen_ty_12 where T: core::marker::Sized
 pub fn aya_obj::generated::bpf_attr__bindgen_ty_12::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_attr__bindgen_ty_12 where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::bpf_attr__bindgen_ty_12::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_attr__bindgen_ty_12 where T: core::marker::Copy
-pub unsafe fn aya_obj::generated::bpf_attr__bindgen_ty_12::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_obj::generated::bpf_attr__bindgen_ty_12
 pub fn aya_obj::generated::bpf_attr__bindgen_ty_12::from(t: T) -> T
 #[repr(C)] pub struct aya_obj::generated::bpf_attr__bindgen_ty_13
@@ -3600,10 +3354,6 @@ impl<T> core::borrow::Borrow<T> for aya_obj::generated::bpf_attr__bindgen_ty_13 
 pub fn aya_obj::generated::bpf_attr__bindgen_ty_13::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::bpf_attr__bindgen_ty_13 where T: core::marker::Sized
 pub fn aya_obj::generated::bpf_attr__bindgen_ty_13::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_attr__bindgen_ty_13 where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::bpf_attr__bindgen_ty_13::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_attr__bindgen_ty_13 where T: core::marker::Copy
-pub unsafe fn aya_obj::generated::bpf_attr__bindgen_ty_13::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_obj::generated::bpf_attr__bindgen_ty_13
 pub fn aya_obj::generated::bpf_attr__bindgen_ty_13::from(t: T) -> T
 #[repr(C)] pub struct aya_obj::generated::bpf_attr__bindgen_ty_14
@@ -3639,10 +3389,6 @@ impl<T> core::borrow::Borrow<T> for aya_obj::generated::bpf_attr__bindgen_ty_14 
 pub fn aya_obj::generated::bpf_attr__bindgen_ty_14::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::bpf_attr__bindgen_ty_14 where T: core::marker::Sized
 pub fn aya_obj::generated::bpf_attr__bindgen_ty_14::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_attr__bindgen_ty_14 where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::bpf_attr__bindgen_ty_14::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_attr__bindgen_ty_14 where T: core::marker::Copy
-pub unsafe fn aya_obj::generated::bpf_attr__bindgen_ty_14::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_obj::generated::bpf_attr__bindgen_ty_14
 pub fn aya_obj::generated::bpf_attr__bindgen_ty_14::from(t: T) -> T
 #[repr(C)] pub struct aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_1
@@ -3677,10 +3423,6 @@ impl<T> core::borrow::Borrow<T> for aya_obj::generated::bpf_attr__bindgen_ty_14_
 pub fn aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_1::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_1 where T: core::marker::Sized
 pub fn aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_1::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_1 where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_1::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_1 where T: core::marker::Copy
-pub unsafe fn aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_1::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_1
 pub fn aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_1::from(t: T) -> T
 #[repr(C)] pub struct aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_2
@@ -3714,10 +3456,6 @@ impl<T> core::borrow::Borrow<T> for aya_obj::generated::bpf_attr__bindgen_ty_14_
 pub fn aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_2::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_2 where T: core::marker::Sized
 pub fn aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_2::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_2 where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_2::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_2 where T: core::marker::Copy
-pub unsafe fn aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_2::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_2
 pub fn aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_2::from(t: T) -> T
 #[repr(C)] pub struct aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_3
@@ -3755,10 +3493,6 @@ impl<T> core::borrow::Borrow<T> for aya_obj::generated::bpf_attr__bindgen_ty_14_
 pub fn aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_3::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_3 where T: core::marker::Sized
 pub fn aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_3::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_3 where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_3::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_3 where T: core::marker::Copy
-pub unsafe fn aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_3::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_3
 pub fn aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_3::from(t: T) -> T
 #[repr(C)] pub struct aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_4
@@ -3793,10 +3527,6 @@ impl<T> core::borrow::Borrow<T> for aya_obj::generated::bpf_attr__bindgen_ty_14_
 pub fn aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_4::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_4 where T: core::marker::Sized
 pub fn aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_4::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_4 where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_4::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_4 where T: core::marker::Copy
-pub unsafe fn aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_4::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_4
 pub fn aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_4::from(t: T) -> T
 #[repr(C)] pub struct aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_5
@@ -3833,10 +3563,6 @@ impl<T> core::borrow::Borrow<T> for aya_obj::generated::bpf_attr__bindgen_ty_14_
 pub fn aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_5::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_5 where T: core::marker::Sized
 pub fn aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_5::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_5 where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_5::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_5 where T: core::marker::Copy
-pub unsafe fn aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_5::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_5
 pub fn aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_5::from(t: T) -> T
 #[repr(C)] pub struct aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_6
@@ -3869,10 +3595,6 @@ impl<T> core::borrow::Borrow<T> for aya_obj::generated::bpf_attr__bindgen_ty_14_
 pub fn aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_6::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_6 where T: core::marker::Sized
 pub fn aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_6::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_6 where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_6::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_6 where T: core::marker::Copy
-pub unsafe fn aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_6::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_6
 pub fn aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_6::from(t: T) -> T
 #[repr(C)] pub struct aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_7
@@ -3912,10 +3634,6 @@ impl<T> core::borrow::Borrow<T> for aya_obj::generated::bpf_attr__bindgen_ty_14_
 pub fn aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_7::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_7 where T: core::marker::Sized
 pub fn aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_7::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_7 where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_7::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_7 where T: core::marker::Copy
-pub unsafe fn aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_7::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_7
 pub fn aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_7::from(t: T) -> T
 #[repr(C)] pub struct aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_8
@@ -3948,10 +3666,6 @@ impl<T> core::borrow::Borrow<T> for aya_obj::generated::bpf_attr__bindgen_ty_14_
 pub fn aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_8::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_8 where T: core::marker::Sized
 pub fn aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_8::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_8 where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_8::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_8 where T: core::marker::Copy
-pub unsafe fn aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_8::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_8
 pub fn aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_8::from(t: T) -> T
 #[repr(C)] pub struct aya_obj::generated::bpf_attr__bindgen_ty_15
@@ -3986,10 +3700,6 @@ impl<T> core::borrow::Borrow<T> for aya_obj::generated::bpf_attr__bindgen_ty_15 
 pub fn aya_obj::generated::bpf_attr__bindgen_ty_15::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::bpf_attr__bindgen_ty_15 where T: core::marker::Sized
 pub fn aya_obj::generated::bpf_attr__bindgen_ty_15::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_attr__bindgen_ty_15 where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::bpf_attr__bindgen_ty_15::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_attr__bindgen_ty_15 where T: core::marker::Copy
-pub unsafe fn aya_obj::generated::bpf_attr__bindgen_ty_15::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_obj::generated::bpf_attr__bindgen_ty_15
 pub fn aya_obj::generated::bpf_attr__bindgen_ty_15::from(t: T) -> T
 #[repr(C)] pub struct aya_obj::generated::bpf_attr__bindgen_ty_16
@@ -4023,10 +3733,6 @@ impl<T> core::borrow::Borrow<T> for aya_obj::generated::bpf_attr__bindgen_ty_16 
 pub fn aya_obj::generated::bpf_attr__bindgen_ty_16::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::bpf_attr__bindgen_ty_16 where T: core::marker::Sized
 pub fn aya_obj::generated::bpf_attr__bindgen_ty_16::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_attr__bindgen_ty_16 where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::bpf_attr__bindgen_ty_16::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_attr__bindgen_ty_16 where T: core::marker::Copy
-pub unsafe fn aya_obj::generated::bpf_attr__bindgen_ty_16::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_obj::generated::bpf_attr__bindgen_ty_16
 pub fn aya_obj::generated::bpf_attr__bindgen_ty_16::from(t: T) -> T
 #[repr(C)] pub struct aya_obj::generated::bpf_attr__bindgen_ty_17
@@ -4060,10 +3766,6 @@ impl<T> core::borrow::Borrow<T> for aya_obj::generated::bpf_attr__bindgen_ty_17 
 pub fn aya_obj::generated::bpf_attr__bindgen_ty_17::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::bpf_attr__bindgen_ty_17 where T: core::marker::Sized
 pub fn aya_obj::generated::bpf_attr__bindgen_ty_17::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_attr__bindgen_ty_17 where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::bpf_attr__bindgen_ty_17::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_attr__bindgen_ty_17 where T: core::marker::Copy
-pub unsafe fn aya_obj::generated::bpf_attr__bindgen_ty_17::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_obj::generated::bpf_attr__bindgen_ty_17
 pub fn aya_obj::generated::bpf_attr__bindgen_ty_17::from(t: T) -> T
 #[repr(C)] pub struct aya_obj::generated::bpf_attr__bindgen_ty_18
@@ -4098,10 +3800,6 @@ impl<T> core::borrow::Borrow<T> for aya_obj::generated::bpf_attr__bindgen_ty_18 
 pub fn aya_obj::generated::bpf_attr__bindgen_ty_18::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::bpf_attr__bindgen_ty_18 where T: core::marker::Sized
 pub fn aya_obj::generated::bpf_attr__bindgen_ty_18::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_attr__bindgen_ty_18 where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::bpf_attr__bindgen_ty_18::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_attr__bindgen_ty_18 where T: core::marker::Copy
-pub unsafe fn aya_obj::generated::bpf_attr__bindgen_ty_18::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_obj::generated::bpf_attr__bindgen_ty_18
 pub fn aya_obj::generated::bpf_attr__bindgen_ty_18::from(t: T) -> T
 #[repr(C)] pub struct aya_obj::generated::bpf_attr__bindgen_ty_19
@@ -4137,10 +3835,6 @@ impl<T> core::borrow::Borrow<T> for aya_obj::generated::bpf_attr__bindgen_ty_19 
 pub fn aya_obj::generated::bpf_attr__bindgen_ty_19::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::bpf_attr__bindgen_ty_19 where T: core::marker::Sized
 pub fn aya_obj::generated::bpf_attr__bindgen_ty_19::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_attr__bindgen_ty_19 where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::bpf_attr__bindgen_ty_19::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_attr__bindgen_ty_19 where T: core::marker::Copy
-pub unsafe fn aya_obj::generated::bpf_attr__bindgen_ty_19::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_obj::generated::bpf_attr__bindgen_ty_19
 pub fn aya_obj::generated::bpf_attr__bindgen_ty_19::from(t: T) -> T
 #[repr(C)] pub struct aya_obj::generated::bpf_attr__bindgen_ty_2
@@ -4175,10 +3869,6 @@ impl<T> core::borrow::Borrow<T> for aya_obj::generated::bpf_attr__bindgen_ty_2 w
 pub fn aya_obj::generated::bpf_attr__bindgen_ty_2::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::bpf_attr__bindgen_ty_2 where T: core::marker::Sized
 pub fn aya_obj::generated::bpf_attr__bindgen_ty_2::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_attr__bindgen_ty_2 where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::bpf_attr__bindgen_ty_2::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_attr__bindgen_ty_2 where T: core::marker::Copy
-pub unsafe fn aya_obj::generated::bpf_attr__bindgen_ty_2::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_obj::generated::bpf_attr__bindgen_ty_2
 pub fn aya_obj::generated::bpf_attr__bindgen_ty_2::from(t: T) -> T
 #[repr(C)] pub struct aya_obj::generated::bpf_attr__bindgen_ty_20
@@ -4213,10 +3903,6 @@ impl<T> core::borrow::Borrow<T> for aya_obj::generated::bpf_attr__bindgen_ty_20 
 pub fn aya_obj::generated::bpf_attr__bindgen_ty_20::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::bpf_attr__bindgen_ty_20 where T: core::marker::Sized
 pub fn aya_obj::generated::bpf_attr__bindgen_ty_20::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_attr__bindgen_ty_20 where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::bpf_attr__bindgen_ty_20::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_attr__bindgen_ty_20 where T: core::marker::Copy
-pub unsafe fn aya_obj::generated::bpf_attr__bindgen_ty_20::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_obj::generated::bpf_attr__bindgen_ty_20
 pub fn aya_obj::generated::bpf_attr__bindgen_ty_20::from(t: T) -> T
 #[repr(C)] pub struct aya_obj::generated::bpf_attr__bindgen_ty_3
@@ -4257,10 +3943,6 @@ impl<T> core::borrow::Borrow<T> for aya_obj::generated::bpf_attr__bindgen_ty_3 w
 pub fn aya_obj::generated::bpf_attr__bindgen_ty_3::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::bpf_attr__bindgen_ty_3 where T: core::marker::Sized
 pub fn aya_obj::generated::bpf_attr__bindgen_ty_3::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_attr__bindgen_ty_3 where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::bpf_attr__bindgen_ty_3::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_attr__bindgen_ty_3 where T: core::marker::Copy
-pub unsafe fn aya_obj::generated::bpf_attr__bindgen_ty_3::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_obj::generated::bpf_attr__bindgen_ty_3
 pub fn aya_obj::generated::bpf_attr__bindgen_ty_3::from(t: T) -> T
 #[repr(C)] pub struct aya_obj::generated::bpf_attr__bindgen_ty_4
@@ -4318,10 +4000,6 @@ impl<T> core::borrow::Borrow<T> for aya_obj::generated::bpf_attr__bindgen_ty_4 w
 pub fn aya_obj::generated::bpf_attr__bindgen_ty_4::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::bpf_attr__bindgen_ty_4 where T: core::marker::Sized
 pub fn aya_obj::generated::bpf_attr__bindgen_ty_4::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_attr__bindgen_ty_4 where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::bpf_attr__bindgen_ty_4::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_attr__bindgen_ty_4 where T: core::marker::Copy
-pub unsafe fn aya_obj::generated::bpf_attr__bindgen_ty_4::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_obj::generated::bpf_attr__bindgen_ty_4
 pub fn aya_obj::generated::bpf_attr__bindgen_ty_4::from(t: T) -> T
 #[repr(C)] pub struct aya_obj::generated::bpf_attr__bindgen_ty_5
@@ -4358,10 +4036,6 @@ impl<T> core::borrow::Borrow<T> for aya_obj::generated::bpf_attr__bindgen_ty_5 w
 pub fn aya_obj::generated::bpf_attr__bindgen_ty_5::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::bpf_attr__bindgen_ty_5 where T: core::marker::Sized
 pub fn aya_obj::generated::bpf_attr__bindgen_ty_5::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_attr__bindgen_ty_5 where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::bpf_attr__bindgen_ty_5::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_attr__bindgen_ty_5 where T: core::marker::Copy
-pub unsafe fn aya_obj::generated::bpf_attr__bindgen_ty_5::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_obj::generated::bpf_attr__bindgen_ty_5
 pub fn aya_obj::generated::bpf_attr__bindgen_ty_5::from(t: T) -> T
 #[repr(C)] pub struct aya_obj::generated::bpf_attr__bindgen_ty_6
@@ -4399,10 +4073,6 @@ impl<T> core::borrow::Borrow<T> for aya_obj::generated::bpf_attr__bindgen_ty_6 w
 pub fn aya_obj::generated::bpf_attr__bindgen_ty_6::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::bpf_attr__bindgen_ty_6 where T: core::marker::Sized
 pub fn aya_obj::generated::bpf_attr__bindgen_ty_6::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_attr__bindgen_ty_6 where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::bpf_attr__bindgen_ty_6::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_attr__bindgen_ty_6 where T: core::marker::Copy
-pub unsafe fn aya_obj::generated::bpf_attr__bindgen_ty_6::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_obj::generated::bpf_attr__bindgen_ty_6
 pub fn aya_obj::generated::bpf_attr__bindgen_ty_6::from(t: T) -> T
 #[repr(C)] pub struct aya_obj::generated::bpf_attr__bindgen_ty_7
@@ -4450,10 +4120,6 @@ impl<T> core::borrow::Borrow<T> for aya_obj::generated::bpf_attr__bindgen_ty_7 w
 pub fn aya_obj::generated::bpf_attr__bindgen_ty_7::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::bpf_attr__bindgen_ty_7 where T: core::marker::Sized
 pub fn aya_obj::generated::bpf_attr__bindgen_ty_7::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_attr__bindgen_ty_7 where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::bpf_attr__bindgen_ty_7::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_attr__bindgen_ty_7 where T: core::marker::Copy
-pub unsafe fn aya_obj::generated::bpf_attr__bindgen_ty_7::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_obj::generated::bpf_attr__bindgen_ty_7
 pub fn aya_obj::generated::bpf_attr__bindgen_ty_7::from(t: T) -> T
 #[repr(C)] pub struct aya_obj::generated::bpf_attr__bindgen_ty_8
@@ -4487,10 +4153,6 @@ impl<T> core::borrow::Borrow<T> for aya_obj::generated::bpf_attr__bindgen_ty_8 w
 pub fn aya_obj::generated::bpf_attr__bindgen_ty_8::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::bpf_attr__bindgen_ty_8 where T: core::marker::Sized
 pub fn aya_obj::generated::bpf_attr__bindgen_ty_8::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_attr__bindgen_ty_8 where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::bpf_attr__bindgen_ty_8::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_attr__bindgen_ty_8 where T: core::marker::Copy
-pub unsafe fn aya_obj::generated::bpf_attr__bindgen_ty_8::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_obj::generated::bpf_attr__bindgen_ty_8
 pub fn aya_obj::generated::bpf_attr__bindgen_ty_8::from(t: T) -> T
 #[repr(C)] pub struct aya_obj::generated::bpf_attr__bindgen_ty_9
@@ -4526,10 +4188,6 @@ impl<T> core::borrow::Borrow<T> for aya_obj::generated::bpf_attr__bindgen_ty_9 w
 pub fn aya_obj::generated::bpf_attr__bindgen_ty_9::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::bpf_attr__bindgen_ty_9 where T: core::marker::Sized
 pub fn aya_obj::generated::bpf_attr__bindgen_ty_9::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_attr__bindgen_ty_9 where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::bpf_attr__bindgen_ty_9::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_attr__bindgen_ty_9 where T: core::marker::Copy
-pub unsafe fn aya_obj::generated::bpf_attr__bindgen_ty_9::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_obj::generated::bpf_attr__bindgen_ty_9
 pub fn aya_obj::generated::bpf_attr__bindgen_ty_9::from(t: T) -> T
 #[repr(C)] pub struct aya_obj::generated::bpf_btf_info
@@ -4568,10 +4226,6 @@ impl<T> core::borrow::Borrow<T> for aya_obj::generated::bpf_btf_info where T: co
 pub fn aya_obj::generated::bpf_btf_info::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::bpf_btf_info where T: core::marker::Sized
 pub fn aya_obj::generated::bpf_btf_info::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_btf_info where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::bpf_btf_info::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_btf_info where T: core::marker::Copy
-pub unsafe fn aya_obj::generated::bpf_btf_info::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_obj::generated::bpf_btf_info
 pub fn aya_obj::generated::bpf_btf_info::from(t: T) -> T
 #[repr(C)] pub struct aya_obj::generated::bpf_core_relo
@@ -4608,10 +4262,6 @@ impl<T> core::borrow::Borrow<T> for aya_obj::generated::bpf_core_relo where T: c
 pub fn aya_obj::generated::bpf_core_relo::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::bpf_core_relo where T: core::marker::Sized
 pub fn aya_obj::generated::bpf_core_relo::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_core_relo where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::bpf_core_relo::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_core_relo where T: core::marker::Copy
-pub unsafe fn aya_obj::generated::bpf_core_relo::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_obj::generated::bpf_core_relo
 pub fn aya_obj::generated::bpf_core_relo::from(t: T) -> T
 #[repr(C)] pub struct aya_obj::generated::bpf_cpumap_val
@@ -4644,10 +4294,6 @@ impl<T> core::borrow::Borrow<T> for aya_obj::generated::bpf_cpumap_val where T: 
 pub fn aya_obj::generated::bpf_cpumap_val::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::bpf_cpumap_val where T: core::marker::Sized
 pub fn aya_obj::generated::bpf_cpumap_val::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_cpumap_val where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::bpf_cpumap_val::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_cpumap_val where T: core::marker::Copy
-pub unsafe fn aya_obj::generated::bpf_cpumap_val::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_obj::generated::bpf_cpumap_val
 pub fn aya_obj::generated::bpf_cpumap_val::from(t: T) -> T
 #[repr(C)] pub struct aya_obj::generated::bpf_devmap_val
@@ -4680,10 +4326,6 @@ impl<T> core::borrow::Borrow<T> for aya_obj::generated::bpf_devmap_val where T: 
 pub fn aya_obj::generated::bpf_devmap_val::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::bpf_devmap_val where T: core::marker::Sized
 pub fn aya_obj::generated::bpf_devmap_val::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_devmap_val where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::bpf_devmap_val::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_devmap_val where T: core::marker::Copy
-pub unsafe fn aya_obj::generated::bpf_devmap_val::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_obj::generated::bpf_devmap_val
 pub fn aya_obj::generated::bpf_devmap_val::from(t: T) -> T
 #[repr(C)] pub struct aya_obj::generated::bpf_func_info
@@ -4718,10 +4360,6 @@ impl<T> core::borrow::Borrow<T> for aya_obj::generated::bpf_func_info where T: c
 pub fn aya_obj::generated::bpf_func_info::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::bpf_func_info where T: core::marker::Sized
 pub fn aya_obj::generated::bpf_func_info::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_func_info where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::bpf_func_info::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_func_info where T: core::marker::Copy
-pub unsafe fn aya_obj::generated::bpf_func_info::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_obj::generated::bpf_func_info
 pub fn aya_obj::generated::bpf_func_info::from(t: T) -> T
 #[repr(C)] pub struct aya_obj::generated::bpf_insn
@@ -4765,10 +4403,6 @@ impl<T> core::borrow::Borrow<T> for aya_obj::generated::bpf_insn where T: core::
 pub fn aya_obj::generated::bpf_insn::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::bpf_insn where T: core::marker::Sized
 pub fn aya_obj::generated::bpf_insn::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_insn where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::bpf_insn::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_insn where T: core::marker::Copy
-pub unsafe fn aya_obj::generated::bpf_insn::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_obj::generated::bpf_insn
 pub fn aya_obj::generated::bpf_insn::from(t: T) -> T
 #[repr(C)] pub struct aya_obj::generated::bpf_line_info
@@ -4805,10 +4439,6 @@ impl<T> core::borrow::Borrow<T> for aya_obj::generated::bpf_line_info where T: c
 pub fn aya_obj::generated::bpf_line_info::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::bpf_line_info where T: core::marker::Sized
 pub fn aya_obj::generated::bpf_line_info::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_line_info where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::bpf_line_info::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_line_info where T: core::marker::Copy
-pub unsafe fn aya_obj::generated::bpf_line_info::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_obj::generated::bpf_line_info
 pub fn aya_obj::generated::bpf_line_info::from(t: T) -> T
 #[repr(C)] pub struct aya_obj::generated::bpf_link_info
@@ -4843,10 +4473,6 @@ impl<T> core::borrow::Borrow<T> for aya_obj::generated::bpf_link_info where T: c
 pub fn aya_obj::generated::bpf_link_info::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::bpf_link_info where T: core::marker::Sized
 pub fn aya_obj::generated::bpf_link_info::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_link_info where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::bpf_link_info::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_link_info where T: core::marker::Copy
-pub unsafe fn aya_obj::generated::bpf_link_info::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_obj::generated::bpf_link_info
 pub fn aya_obj::generated::bpf_link_info::from(t: T) -> T
 #[repr(C)] pub struct aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_1
@@ -4881,10 +4507,6 @@ impl<T> core::borrow::Borrow<T> for aya_obj::generated::bpf_link_info__bindgen_t
 pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_1::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_1 where T: core::marker::Sized
 pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_1::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_1 where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_1::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_1 where T: core::marker::Copy
-pub unsafe fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_1::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_1
 pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_1::from(t: T) -> T
 #[repr(C)] pub struct aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_10
@@ -4925,10 +4547,6 @@ impl<T> core::borrow::Borrow<T> for aya_obj::generated::bpf_link_info__bindgen_t
 pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_10::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_10 where T: core::marker::Sized
 pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_10::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_10 where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_10::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_10 where T: core::marker::Copy
-pub unsafe fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_10::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_10
 pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_10::from(t: T) -> T
 #[repr(C)] pub struct aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11
@@ -4965,10 +4583,6 @@ impl<T> core::borrow::Borrow<T> for aya_obj::generated::bpf_link_info__bindgen_t
 pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11 where T: core::marker::Sized
 pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11 where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11 where T: core::marker::Copy
-pub unsafe fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11
 pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11::from(t: T) -> T
 #[repr(C)] pub struct aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_1
@@ -5005,10 +4619,6 @@ impl<T> core::borrow::Borrow<T> for aya_obj::generated::bpf_link_info__bindgen_t
 pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_1::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_1 where T: core::marker::Sized
 pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_1::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_1 where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_1::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_1 where T: core::marker::Copy
-pub unsafe fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_1::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_1
 pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_1::from(t: T) -> T
 #[repr(C)] pub struct aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_2
@@ -5047,10 +4657,6 @@ impl<T> core::borrow::Borrow<T> for aya_obj::generated::bpf_link_info__bindgen_t
 pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_2::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_2 where T: core::marker::Sized
 pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_2::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_2 where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_2::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_2 where T: core::marker::Copy
-pub unsafe fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_2::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_2
 pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_2::from(t: T) -> T
 #[repr(C)] pub struct aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_3
@@ -5090,10 +4696,6 @@ impl<T> core::borrow::Borrow<T> for aya_obj::generated::bpf_link_info__bindgen_t
 pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_3::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_3 where T: core::marker::Sized
 pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_3::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_3 where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_3::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_3 where T: core::marker::Copy
-pub unsafe fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_3::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_3
 pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_3::from(t: T) -> T
 #[repr(C)] pub struct aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_4
@@ -5133,10 +4735,6 @@ impl<T> core::borrow::Borrow<T> for aya_obj::generated::bpf_link_info__bindgen_t
 pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_4::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_4 where T: core::marker::Sized
 pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_4::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_4 where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_4::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_4 where T: core::marker::Copy
-pub unsafe fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_4::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_4
 pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_4::from(t: T) -> T
 #[repr(C)] pub struct aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_12
@@ -5171,10 +4769,6 @@ impl<T> core::borrow::Borrow<T> for aya_obj::generated::bpf_link_info__bindgen_t
 pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_12::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_12 where T: core::marker::Sized
 pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_12::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_12 where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_12::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_12 where T: core::marker::Copy
-pub unsafe fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_12::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_12
 pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_12::from(t: T) -> T
 #[repr(C)] pub struct aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_13
@@ -5209,10 +4803,6 @@ impl<T> core::borrow::Borrow<T> for aya_obj::generated::bpf_link_info__bindgen_t
 pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_13::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_13 where T: core::marker::Sized
 pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_13::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_13 where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_13::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_13 where T: core::marker::Copy
-pub unsafe fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_13::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_13
 pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_13::from(t: T) -> T
 #[repr(C)] pub struct aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_2
@@ -5248,10 +4838,6 @@ impl<T> core::borrow::Borrow<T> for aya_obj::generated::bpf_link_info__bindgen_t
 pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_2::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_2 where T: core::marker::Sized
 pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_2::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_2 where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_2::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_2 where T: core::marker::Copy
-pub unsafe fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_2::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_2
 pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_2::from(t: T) -> T
 #[repr(C)] pub struct aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_3
@@ -5286,10 +4872,6 @@ impl<T> core::borrow::Borrow<T> for aya_obj::generated::bpf_link_info__bindgen_t
 pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_3::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_3 where T: core::marker::Sized
 pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_3::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_3 where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_3::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_3 where T: core::marker::Copy
-pub unsafe fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_3::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_3
 pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_3::from(t: T) -> T
 #[repr(C)] pub struct aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4
@@ -5324,10 +4906,6 @@ impl<T> core::borrow::Borrow<T> for aya_obj::generated::bpf_link_info__bindgen_t
 pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4 where T: core::marker::Sized
 pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4 where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4 where T: core::marker::Copy
-pub unsafe fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4
 pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4::from(t: T) -> T
 #[repr(C)] pub struct aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_1__bindgen_ty_1
@@ -5361,10 +4939,6 @@ impl<T> core::borrow::Borrow<T> for aya_obj::generated::bpf_link_info__bindgen_t
 pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_1__bindgen_ty_1::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_1__bindgen_ty_1 where T: core::marker::Sized
 pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_1__bindgen_ty_1::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_1__bindgen_ty_1 where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_1__bindgen_ty_1::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_1__bindgen_ty_1 where T: core::marker::Copy
-pub unsafe fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_1__bindgen_ty_1::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_1__bindgen_ty_1
 pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_1__bindgen_ty_1::from(t: T) -> T
 #[repr(C)] pub struct aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2__bindgen_ty_1
@@ -5399,10 +4973,6 @@ impl<T> core::borrow::Borrow<T> for aya_obj::generated::bpf_link_info__bindgen_t
 pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2__bindgen_ty_1::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2__bindgen_ty_1 where T: core::marker::Sized
 pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2__bindgen_ty_1::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2__bindgen_ty_1 where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2__bindgen_ty_1::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2__bindgen_ty_1 where T: core::marker::Copy
-pub unsafe fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2__bindgen_ty_1::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2__bindgen_ty_1
 pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2__bindgen_ty_1::from(t: T) -> T
 #[repr(C)] pub struct aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2__bindgen_ty_2
@@ -5437,10 +5007,6 @@ impl<T> core::borrow::Borrow<T> for aya_obj::generated::bpf_link_info__bindgen_t
 pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2__bindgen_ty_2::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2__bindgen_ty_2 where T: core::marker::Sized
 pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2__bindgen_ty_2::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2__bindgen_ty_2 where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2__bindgen_ty_2::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2__bindgen_ty_2 where T: core::marker::Copy
-pub unsafe fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2__bindgen_ty_2::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2__bindgen_ty_2
 pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2__bindgen_ty_2::from(t: T) -> T
 #[repr(C)] pub struct aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_5
@@ -5475,10 +5041,6 @@ impl<T> core::borrow::Borrow<T> for aya_obj::generated::bpf_link_info__bindgen_t
 pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_5::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_5 where T: core::marker::Sized
 pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_5::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_5 where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_5::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_5 where T: core::marker::Copy
-pub unsafe fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_5::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_5
 pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_5::from(t: T) -> T
 #[repr(C)] pub struct aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_6
@@ -5512,10 +5074,6 @@ impl<T> core::borrow::Borrow<T> for aya_obj::generated::bpf_link_info__bindgen_t
 pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_6::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_6 where T: core::marker::Sized
 pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_6::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_6 where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_6::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_6 where T: core::marker::Copy
-pub unsafe fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_6::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_6
 pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_6::from(t: T) -> T
 #[repr(C)] pub struct aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_7
@@ -5549,10 +5107,6 @@ impl<T> core::borrow::Borrow<T> for aya_obj::generated::bpf_link_info__bindgen_t
 pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_7::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_7 where T: core::marker::Sized
 pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_7::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_7 where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_7::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_7 where T: core::marker::Copy
-pub unsafe fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_7::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_7
 pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_7::from(t: T) -> T
 #[repr(C)] pub struct aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_8
@@ -5589,10 +5143,6 @@ impl<T> core::borrow::Borrow<T> for aya_obj::generated::bpf_link_info__bindgen_t
 pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_8::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_8 where T: core::marker::Sized
 pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_8::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_8 where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_8::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_8 where T: core::marker::Copy
-pub unsafe fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_8::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_8
 pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_8::from(t: T) -> T
 #[repr(C)] pub struct aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_9
@@ -5630,10 +5180,6 @@ impl<T> core::borrow::Borrow<T> for aya_obj::generated::bpf_link_info__bindgen_t
 pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_9::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_9 where T: core::marker::Sized
 pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_9::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_9 where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_9::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_9 where T: core::marker::Copy
-pub unsafe fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_9::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_9
 pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_9::from(t: T) -> T
 #[repr(C)] pub struct aya_obj::generated::bpf_lpm_trie_key
@@ -5709,10 +5255,6 @@ impl<T> core::borrow::Borrow<T> for aya_obj::generated::bpf_map_info where T: co
 pub fn aya_obj::generated::bpf_map_info::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::bpf_map_info where T: core::marker::Sized
 pub fn aya_obj::generated::bpf_map_info::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_map_info where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::bpf_map_info::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_map_info where T: core::marker::Copy
-pub unsafe fn aya_obj::generated::bpf_map_info::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_obj::generated::bpf_map_info
 pub fn aya_obj::generated::bpf_map_info::from(t: T) -> T
 #[repr(C)] pub struct aya_obj::generated::bpf_prog_info
@@ -5788,10 +5330,6 @@ impl<T> core::borrow::Borrow<T> for aya_obj::generated::bpf_prog_info where T: c
 pub fn aya_obj::generated::bpf_prog_info::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::bpf_prog_info where T: core::marker::Sized
 pub fn aya_obj::generated::bpf_prog_info::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_prog_info where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::bpf_prog_info::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_prog_info where T: core::marker::Copy
-pub unsafe fn aya_obj::generated::bpf_prog_info::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_obj::generated::bpf_prog_info
 pub fn aya_obj::generated::bpf_prog_info::from(t: T) -> T
 #[repr(C)] pub struct aya_obj::generated::btf_array
@@ -5827,10 +5365,6 @@ impl<T> core::borrow::Borrow<T> for aya_obj::generated::btf_array where T: core:
 pub fn aya_obj::generated::btf_array::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::btf_array where T: core::marker::Sized
 pub fn aya_obj::generated::btf_array::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::btf_array where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::btf_array::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_obj::generated::btf_array where T: core::marker::Copy
-pub unsafe fn aya_obj::generated::btf_array::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_obj::generated::btf_array
 pub fn aya_obj::generated::btf_array::from(t: T) -> T
 #[repr(C)] pub struct aya_obj::generated::btf_decl_tag
@@ -5864,10 +5398,6 @@ impl<T> core::borrow::Borrow<T> for aya_obj::generated::btf_decl_tag where T: co
 pub fn aya_obj::generated::btf_decl_tag::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::btf_decl_tag where T: core::marker::Sized
 pub fn aya_obj::generated::btf_decl_tag::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::btf_decl_tag where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::btf_decl_tag::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_obj::generated::btf_decl_tag where T: core::marker::Copy
-pub unsafe fn aya_obj::generated::btf_decl_tag::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_obj::generated::btf_decl_tag
 pub fn aya_obj::generated::btf_decl_tag::from(t: T) -> T
 #[repr(C)] pub struct aya_obj::generated::btf_enum
@@ -5902,10 +5432,6 @@ impl<T> core::borrow::Borrow<T> for aya_obj::generated::btf_enum where T: core::
 pub fn aya_obj::generated::btf_enum::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::btf_enum where T: core::marker::Sized
 pub fn aya_obj::generated::btf_enum::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::btf_enum where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::btf_enum::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_obj::generated::btf_enum where T: core::marker::Copy
-pub unsafe fn aya_obj::generated::btf_enum::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_obj::generated::btf_enum
 pub fn aya_obj::generated::btf_enum::from(t: T) -> T
 #[repr(C)] pub struct aya_obj::generated::btf_ext_header
@@ -5948,10 +5474,6 @@ impl<T> core::borrow::Borrow<T> for aya_obj::generated::btf_ext_header where T: 
 pub fn aya_obj::generated::btf_ext_header::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::btf_ext_header where T: core::marker::Sized
 pub fn aya_obj::generated::btf_ext_header::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::btf_ext_header where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::btf_ext_header::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_obj::generated::btf_ext_header where T: core::marker::Copy
-pub unsafe fn aya_obj::generated::btf_ext_header::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_obj::generated::btf_ext_header
 pub fn aya_obj::generated::btf_ext_header::from(t: T) -> T
 #[repr(C)] pub struct aya_obj::generated::btf_header
@@ -5992,10 +5514,6 @@ impl<T> core::borrow::Borrow<T> for aya_obj::generated::btf_header where T: core
 pub fn aya_obj::generated::btf_header::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::btf_header where T: core::marker::Sized
 pub fn aya_obj::generated::btf_header::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::btf_header where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::btf_header::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_obj::generated::btf_header where T: core::marker::Copy
-pub unsafe fn aya_obj::generated::btf_header::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_obj::generated::btf_header
 pub fn aya_obj::generated::btf_header::from(t: T) -> T
 #[repr(C)] pub struct aya_obj::generated::btf_member
@@ -6031,10 +5549,6 @@ impl<T> core::borrow::Borrow<T> for aya_obj::generated::btf_member where T: core
 pub fn aya_obj::generated::btf_member::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::btf_member where T: core::marker::Sized
 pub fn aya_obj::generated::btf_member::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::btf_member where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::btf_member::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_obj::generated::btf_member where T: core::marker::Copy
-pub unsafe fn aya_obj::generated::btf_member::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_obj::generated::btf_member
 pub fn aya_obj::generated::btf_member::from(t: T) -> T
 #[repr(C)] pub struct aya_obj::generated::btf_param
@@ -6069,10 +5583,6 @@ impl<T> core::borrow::Borrow<T> for aya_obj::generated::btf_param where T: core:
 pub fn aya_obj::generated::btf_param::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::btf_param where T: core::marker::Sized
 pub fn aya_obj::generated::btf_param::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::btf_param where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::btf_param::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_obj::generated::btf_param where T: core::marker::Copy
-pub unsafe fn aya_obj::generated::btf_param::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_obj::generated::btf_param
 pub fn aya_obj::generated::btf_param::from(t: T) -> T
 #[repr(C)] pub struct aya_obj::generated::btf_type
@@ -6106,10 +5616,6 @@ impl<T> core::borrow::Borrow<T> for aya_obj::generated::btf_type where T: core::
 pub fn aya_obj::generated::btf_type::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::btf_type where T: core::marker::Sized
 pub fn aya_obj::generated::btf_type::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::btf_type where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::btf_type::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_obj::generated::btf_type where T: core::marker::Copy
-pub unsafe fn aya_obj::generated::btf_type::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_obj::generated::btf_type
 pub fn aya_obj::generated::btf_type::from(t: T) -> T
 #[repr(C)] pub struct aya_obj::generated::btf_var
@@ -6143,10 +5649,6 @@ impl<T> core::borrow::Borrow<T> for aya_obj::generated::btf_var where T: core::m
 pub fn aya_obj::generated::btf_var::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::btf_var where T: core::marker::Sized
 pub fn aya_obj::generated::btf_var::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::btf_var where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::btf_var::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_obj::generated::btf_var where T: core::marker::Copy
-pub unsafe fn aya_obj::generated::btf_var::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_obj::generated::btf_var
 pub fn aya_obj::generated::btf_var::from(t: T) -> T
 #[repr(C)] pub struct aya_obj::generated::btf_var_secinfo
@@ -6182,10 +5684,6 @@ impl<T> core::borrow::Borrow<T> for aya_obj::generated::btf_var_secinfo where T:
 pub fn aya_obj::generated::btf_var_secinfo::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::btf_var_secinfo where T: core::marker::Sized
 pub fn aya_obj::generated::btf_var_secinfo::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::btf_var_secinfo where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::btf_var_secinfo::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_obj::generated::btf_var_secinfo where T: core::marker::Copy
-pub unsafe fn aya_obj::generated::btf_var_secinfo::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_obj::generated::btf_var_secinfo
 pub fn aya_obj::generated::btf_var_secinfo::from(t: T) -> T
 #[repr(C)] pub struct aya_obj::generated::ifinfomsg
@@ -6224,10 +5722,6 @@ impl<T> core::borrow::Borrow<T> for aya_obj::generated::ifinfomsg where T: core:
 pub fn aya_obj::generated::ifinfomsg::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::ifinfomsg where T: core::marker::Sized
 pub fn aya_obj::generated::ifinfomsg::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::ifinfomsg where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::ifinfomsg::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_obj::generated::ifinfomsg where T: core::marker::Copy
-pub unsafe fn aya_obj::generated::ifinfomsg::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_obj::generated::ifinfomsg
 pub fn aya_obj::generated::ifinfomsg::from(t: T) -> T
 #[repr(C)] pub struct aya_obj::generated::perf_event_attr
@@ -6360,10 +5854,6 @@ impl<T> core::borrow::Borrow<T> for aya_obj::generated::perf_event_attr where T:
 pub fn aya_obj::generated::perf_event_attr::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::perf_event_attr where T: core::marker::Sized
 pub fn aya_obj::generated::perf_event_attr::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::perf_event_attr where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::perf_event_attr::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_obj::generated::perf_event_attr where T: core::marker::Copy
-pub unsafe fn aya_obj::generated::perf_event_attr::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_obj::generated::perf_event_attr
 pub fn aya_obj::generated::perf_event_attr::from(t: T) -> T
 #[repr(C)] pub struct aya_obj::generated::perf_event_header
@@ -6399,10 +5889,6 @@ impl<T> core::borrow::Borrow<T> for aya_obj::generated::perf_event_header where 
 pub fn aya_obj::generated::perf_event_header::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::perf_event_header where T: core::marker::Sized
 pub fn aya_obj::generated::perf_event_header::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::perf_event_header where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::perf_event_header::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_obj::generated::perf_event_header where T: core::marker::Copy
-pub unsafe fn aya_obj::generated::perf_event_header::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_obj::generated::perf_event_header
 pub fn aya_obj::generated::perf_event_header::from(t: T) -> T
 #[repr(C)] pub struct aya_obj::generated::perf_event_mmap_page
@@ -6459,10 +5945,6 @@ impl<T> core::borrow::Borrow<T> for aya_obj::generated::perf_event_mmap_page whe
 pub fn aya_obj::generated::perf_event_mmap_page::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::perf_event_mmap_page where T: core::marker::Sized
 pub fn aya_obj::generated::perf_event_mmap_page::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::perf_event_mmap_page where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::perf_event_mmap_page::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_obj::generated::perf_event_mmap_page where T: core::marker::Copy
-pub unsafe fn aya_obj::generated::perf_event_mmap_page::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_obj::generated::perf_event_mmap_page
 pub fn aya_obj::generated::perf_event_mmap_page::from(t: T) -> T
 #[repr(C)] pub struct aya_obj::generated::perf_event_mmap_page__bindgen_ty_1__bindgen_ty_1
@@ -6513,10 +5995,6 @@ impl<T> core::borrow::Borrow<T> for aya_obj::generated::perf_event_mmap_page__bi
 pub fn aya_obj::generated::perf_event_mmap_page__bindgen_ty_1__bindgen_ty_1::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::perf_event_mmap_page__bindgen_ty_1__bindgen_ty_1 where T: core::marker::Sized
 pub fn aya_obj::generated::perf_event_mmap_page__bindgen_ty_1__bindgen_ty_1::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::perf_event_mmap_page__bindgen_ty_1__bindgen_ty_1 where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::perf_event_mmap_page__bindgen_ty_1__bindgen_ty_1::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_obj::generated::perf_event_mmap_page__bindgen_ty_1__bindgen_ty_1 where T: core::marker::Copy
-pub unsafe fn aya_obj::generated::perf_event_mmap_page__bindgen_ty_1__bindgen_ty_1::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_obj::generated::perf_event_mmap_page__bindgen_ty_1__bindgen_ty_1
 pub fn aya_obj::generated::perf_event_mmap_page__bindgen_ty_1__bindgen_ty_1::from(t: T) -> T
 #[repr(C)] pub struct aya_obj::generated::tcmsg
@@ -6556,10 +6034,6 @@ impl<T> core::borrow::Borrow<T> for aya_obj::generated::tcmsg where T: core::mar
 pub fn aya_obj::generated::tcmsg::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::tcmsg where T: core::marker::Sized
 pub fn aya_obj::generated::tcmsg::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::tcmsg where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::tcmsg::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_obj::generated::tcmsg where T: core::marker::Copy
-pub unsafe fn aya_obj::generated::tcmsg::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_obj::generated::tcmsg
 pub fn aya_obj::generated::tcmsg::from(t: T) -> T
 pub const aya_obj::generated::AYA_PERF_EVENT_IOC_DISABLE: core::ffi::c_int
@@ -6842,8 +6316,6 @@ impl<T> core::borrow::Borrow<T> for aya_obj::maps::Map where T: core::marker::Si
 pub fn aya_obj::maps::Map::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_obj::maps::Map where T: core::marker::Sized
 pub fn aya_obj::maps::Map::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::maps::Map where T: core::clone::Clone
-pub unsafe fn aya_obj::maps::Map::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_obj::maps::Map
 pub fn aya_obj::maps::Map::from(t: T) -> T
 pub enum aya_obj::maps::PinningError
@@ -6919,10 +6391,6 @@ impl<T> core::borrow::Borrow<T> for aya_obj::maps::PinningType where T: core::ma
 pub fn aya_obj::maps::PinningType::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_obj::maps::PinningType where T: core::marker::Sized
 pub fn aya_obj::maps::PinningType::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::maps::PinningType where T: core::clone::Clone
-pub unsafe fn aya_obj::maps::PinningType::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_obj::maps::PinningType where T: core::marker::Copy
-pub unsafe fn aya_obj::maps::PinningType::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_obj::maps::PinningType
 pub fn aya_obj::maps::PinningType::from(t: T) -> T
 pub struct aya_obj::maps::BtfMap
@@ -6955,8 +6423,6 @@ impl<T> core::borrow::Borrow<T> for aya_obj::maps::BtfMap where T: core::marker:
 pub fn aya_obj::maps::BtfMap::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_obj::maps::BtfMap where T: core::marker::Sized
 pub fn aya_obj::maps::BtfMap::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::maps::BtfMap where T: core::clone::Clone
-pub unsafe fn aya_obj::maps::BtfMap::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_obj::maps::BtfMap
 pub fn aya_obj::maps::BtfMap::from(t: T) -> T
 pub struct aya_obj::maps::BtfMapDef
@@ -6997,10 +6463,6 @@ impl<T> core::borrow::Borrow<T> for aya_obj::maps::BtfMapDef where T: core::mark
 pub fn aya_obj::maps::BtfMapDef::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_obj::maps::BtfMapDef where T: core::marker::Sized
 pub fn aya_obj::maps::BtfMapDef::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::maps::BtfMapDef where T: core::clone::Clone
-pub unsafe fn aya_obj::maps::BtfMapDef::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_obj::maps::BtfMapDef where T: core::marker::Copy
-pub unsafe fn aya_obj::maps::BtfMapDef::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_obj::maps::BtfMapDef
 pub fn aya_obj::maps::BtfMapDef::from(t: T) -> T
 pub struct aya_obj::maps::InvalidMapTypeError
@@ -7061,8 +6523,6 @@ impl<T> core::borrow::Borrow<T> for aya_obj::maps::LegacyMap where T: core::mark
 pub fn aya_obj::maps::LegacyMap::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_obj::maps::LegacyMap where T: core::marker::Sized
 pub fn aya_obj::maps::LegacyMap::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::maps::LegacyMap where T: core::clone::Clone
-pub unsafe fn aya_obj::maps::LegacyMap::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_obj::maps::LegacyMap
 pub fn aya_obj::maps::LegacyMap::from(t: T) -> T
 #[repr(C)] pub struct aya_obj::maps::bpf_map_def
@@ -7108,10 +6568,6 @@ impl<T> core::borrow::Borrow<T> for aya_obj::maps::bpf_map_def where T: core::ma
 pub fn aya_obj::maps::bpf_map_def::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_obj::maps::bpf_map_def where T: core::marker::Sized
 pub fn aya_obj::maps::bpf_map_def::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::maps::bpf_map_def where T: core::clone::Clone
-pub unsafe fn aya_obj::maps::bpf_map_def::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_obj::maps::bpf_map_def where T: core::marker::Copy
-pub unsafe fn aya_obj::maps::bpf_map_def::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_obj::maps::bpf_map_def
 pub fn aya_obj::maps::bpf_map_def::from(t: T) -> T
 pub mod aya_obj::obj
@@ -7161,10 +6617,6 @@ impl<T> core::borrow::Borrow<T> for aya_obj::EbpfSectionKind where T: core::mark
 pub fn aya_obj::EbpfSectionKind::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_obj::EbpfSectionKind where T: core::marker::Sized
 pub fn aya_obj::EbpfSectionKind::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::EbpfSectionKind where T: core::clone::Clone
-pub unsafe fn aya_obj::EbpfSectionKind::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_obj::EbpfSectionKind where T: core::marker::Copy
-pub unsafe fn aya_obj::EbpfSectionKind::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_obj::EbpfSectionKind
 pub fn aya_obj::EbpfSectionKind::from(t: T) -> T
 pub enum aya_obj::obj::ParseError
@@ -7310,8 +6762,6 @@ impl<T> core::borrow::Borrow<T> for aya_obj::ProgramSection where T: core::marke
 pub fn aya_obj::ProgramSection::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_obj::ProgramSection where T: core::marker::Sized
 pub fn aya_obj::ProgramSection::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::ProgramSection where T: core::clone::Clone
-pub unsafe fn aya_obj::ProgramSection::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_obj::ProgramSection
 pub fn aya_obj::ProgramSection::from(t: T) -> T
 pub struct aya_obj::obj::Features
@@ -7388,8 +6838,6 @@ impl<T> core::borrow::Borrow<T> for aya_obj::Function where T: core::marker::Siz
 pub fn aya_obj::Function::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_obj::Function where T: core::marker::Sized
 pub fn aya_obj::Function::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::Function where T: core::clone::Clone
-pub unsafe fn aya_obj::Function::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_obj::Function
 pub fn aya_obj::Function::from(t: T) -> T
 pub struct aya_obj::obj::Object
@@ -7440,8 +6888,6 @@ impl<T> core::borrow::Borrow<T> for aya_obj::Object where T: core::marker::Sized
 pub fn aya_obj::Object::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_obj::Object where T: core::marker::Sized
 pub fn aya_obj::Object::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::Object where T: core::clone::Clone
-pub unsafe fn aya_obj::Object::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_obj::Object
 pub fn aya_obj::Object::from(t: T) -> T
 pub struct aya_obj::obj::Program
@@ -7480,8 +6926,6 @@ impl<T> core::borrow::Borrow<T> for aya_obj::Program where T: core::marker::Size
 pub fn aya_obj::Program::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_obj::Program where T: core::marker::Sized
 pub fn aya_obj::Program::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::Program where T: core::clone::Clone
-pub unsafe fn aya_obj::Program::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_obj::Program
 pub fn aya_obj::Program::from(t: T) -> T
 pub fn aya_obj::obj::copy_instructions(data: &[u8]) -> core::result::Result<alloc::vec::Vec<aya_obj::generated::bpf_insn>, aya_obj::ParseError>
@@ -7526,10 +6970,6 @@ impl<T> core::borrow::Borrow<T> for aya_obj::programs::cgroup_sock::CgroupSockAt
 pub fn aya_obj::programs::cgroup_sock::CgroupSockAttachType::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_obj::programs::cgroup_sock::CgroupSockAttachType where T: core::marker::Sized
 pub fn aya_obj::programs::cgroup_sock::CgroupSockAttachType::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::programs::cgroup_sock::CgroupSockAttachType where T: core::clone::Clone
-pub unsafe fn aya_obj::programs::cgroup_sock::CgroupSockAttachType::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_obj::programs::cgroup_sock::CgroupSockAttachType where T: core::marker::Copy
-pub unsafe fn aya_obj::programs::cgroup_sock::CgroupSockAttachType::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_obj::programs::cgroup_sock::CgroupSockAttachType
 pub fn aya_obj::programs::cgroup_sock::CgroupSockAttachType::from(t: T) -> T
 pub mod aya_obj::programs::cgroup_sock_addr
@@ -7577,10 +7017,6 @@ impl<T> core::borrow::Borrow<T> for aya_obj::programs::cgroup_sock_addr::CgroupS
 pub fn aya_obj::programs::cgroup_sock_addr::CgroupSockAddrAttachType::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_obj::programs::cgroup_sock_addr::CgroupSockAddrAttachType where T: core::marker::Sized
 pub fn aya_obj::programs::cgroup_sock_addr::CgroupSockAddrAttachType::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::programs::cgroup_sock_addr::CgroupSockAddrAttachType where T: core::clone::Clone
-pub unsafe fn aya_obj::programs::cgroup_sock_addr::CgroupSockAddrAttachType::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_obj::programs::cgroup_sock_addr::CgroupSockAddrAttachType where T: core::marker::Copy
-pub unsafe fn aya_obj::programs::cgroup_sock_addr::CgroupSockAddrAttachType::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_obj::programs::cgroup_sock_addr::CgroupSockAddrAttachType
 pub fn aya_obj::programs::cgroup_sock_addr::CgroupSockAddrAttachType::from(t: T) -> T
 pub mod aya_obj::programs::cgroup_sockopt
@@ -7618,12 +7054,9 @@ impl<T> core::borrow::Borrow<T> for aya_obj::programs::cgroup_sockopt::CgroupSoc
 pub fn aya_obj::programs::cgroup_sockopt::CgroupSockoptAttachType::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_obj::programs::cgroup_sockopt::CgroupSockoptAttachType where T: core::marker::Sized
 pub fn aya_obj::programs::cgroup_sockopt::CgroupSockoptAttachType::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::programs::cgroup_sockopt::CgroupSockoptAttachType where T: core::clone::Clone
-pub unsafe fn aya_obj::programs::cgroup_sockopt::CgroupSockoptAttachType::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_obj::programs::cgroup_sockopt::CgroupSockoptAttachType where T: core::marker::Copy
-pub unsafe fn aya_obj::programs::cgroup_sockopt::CgroupSockoptAttachType::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_obj::programs::cgroup_sockopt::CgroupSockoptAttachType
 pub fn aya_obj::programs::cgroup_sockopt::CgroupSockoptAttachType::from(t: T) -> T
+pub mod aya_obj::programs::prog_type
 pub mod aya_obj::programs::xdp
 pub enum aya_obj::programs::xdp::XdpAttachType
 pub aya_obj::programs::xdp::XdpAttachType::CpuMap
@@ -7660,10 +7093,6 @@ impl<T> core::borrow::Borrow<T> for aya_obj::programs::xdp::XdpAttachType where 
 pub fn aya_obj::programs::xdp::XdpAttachType::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_obj::programs::xdp::XdpAttachType where T: core::marker::Sized
 pub fn aya_obj::programs::xdp::XdpAttachType::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::programs::xdp::XdpAttachType where T: core::clone::Clone
-pub unsafe fn aya_obj::programs::xdp::XdpAttachType::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_obj::programs::xdp::XdpAttachType where T: core::marker::Copy
-pub unsafe fn aya_obj::programs::xdp::XdpAttachType::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_obj::programs::xdp::XdpAttachType
 pub fn aya_obj::programs::xdp::XdpAttachType::from(t: T) -> T
 pub enum aya_obj::programs::CgroupSockAddrAttachType
@@ -7710,10 +7139,6 @@ impl<T> core::borrow::Borrow<T> for aya_obj::programs::cgroup_sock_addr::CgroupS
 pub fn aya_obj::programs::cgroup_sock_addr::CgroupSockAddrAttachType::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_obj::programs::cgroup_sock_addr::CgroupSockAddrAttachType where T: core::marker::Sized
 pub fn aya_obj::programs::cgroup_sock_addr::CgroupSockAddrAttachType::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::programs::cgroup_sock_addr::CgroupSockAddrAttachType where T: core::clone::Clone
-pub unsafe fn aya_obj::programs::cgroup_sock_addr::CgroupSockAddrAttachType::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_obj::programs::cgroup_sock_addr::CgroupSockAddrAttachType where T: core::marker::Copy
-pub unsafe fn aya_obj::programs::cgroup_sock_addr::CgroupSockAddrAttachType::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_obj::programs::cgroup_sock_addr::CgroupSockAddrAttachType
 pub fn aya_obj::programs::cgroup_sock_addr::CgroupSockAddrAttachType::from(t: T) -> T
 pub enum aya_obj::programs::CgroupSockAttachType
@@ -7754,10 +7179,6 @@ impl<T> core::borrow::Borrow<T> for aya_obj::programs::cgroup_sock::CgroupSockAt
 pub fn aya_obj::programs::cgroup_sock::CgroupSockAttachType::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_obj::programs::cgroup_sock::CgroupSockAttachType where T: core::marker::Sized
 pub fn aya_obj::programs::cgroup_sock::CgroupSockAttachType::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::programs::cgroup_sock::CgroupSockAttachType where T: core::clone::Clone
-pub unsafe fn aya_obj::programs::cgroup_sock::CgroupSockAttachType::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_obj::programs::cgroup_sock::CgroupSockAttachType where T: core::marker::Copy
-pub unsafe fn aya_obj::programs::cgroup_sock::CgroupSockAttachType::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_obj::programs::cgroup_sock::CgroupSockAttachType
 pub fn aya_obj::programs::cgroup_sock::CgroupSockAttachType::from(t: T) -> T
 pub enum aya_obj::programs::CgroupSockoptAttachType
@@ -7794,10 +7215,6 @@ impl<T> core::borrow::Borrow<T> for aya_obj::programs::cgroup_sockopt::CgroupSoc
 pub fn aya_obj::programs::cgroup_sockopt::CgroupSockoptAttachType::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_obj::programs::cgroup_sockopt::CgroupSockoptAttachType where T: core::marker::Sized
 pub fn aya_obj::programs::cgroup_sockopt::CgroupSockoptAttachType::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::programs::cgroup_sockopt::CgroupSockoptAttachType where T: core::clone::Clone
-pub unsafe fn aya_obj::programs::cgroup_sockopt::CgroupSockoptAttachType::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_obj::programs::cgroup_sockopt::CgroupSockoptAttachType where T: core::marker::Copy
-pub unsafe fn aya_obj::programs::cgroup_sockopt::CgroupSockoptAttachType::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_obj::programs::cgroup_sockopt::CgroupSockoptAttachType
 pub fn aya_obj::programs::cgroup_sockopt::CgroupSockoptAttachType::from(t: T) -> T
 pub enum aya_obj::programs::XdpAttachType
@@ -7835,10 +7252,6 @@ impl<T> core::borrow::Borrow<T> for aya_obj::programs::xdp::XdpAttachType where 
 pub fn aya_obj::programs::xdp::XdpAttachType::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_obj::programs::xdp::XdpAttachType where T: core::marker::Sized
 pub fn aya_obj::programs::xdp::XdpAttachType::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::programs::xdp::XdpAttachType where T: core::clone::Clone
-pub unsafe fn aya_obj::programs::xdp::XdpAttachType::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_obj::programs::xdp::XdpAttachType where T: core::marker::Copy
-pub unsafe fn aya_obj::programs::xdp::XdpAttachType::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_obj::programs::xdp::XdpAttachType
 pub fn aya_obj::programs::xdp::XdpAttachType::from(t: T) -> T
 pub mod aya_obj::relocation
@@ -7964,10 +7377,6 @@ impl<T> core::borrow::Borrow<T> for aya_obj::EbpfSectionKind where T: core::mark
 pub fn aya_obj::EbpfSectionKind::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_obj::EbpfSectionKind where T: core::marker::Sized
 pub fn aya_obj::EbpfSectionKind::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::EbpfSectionKind where T: core::clone::Clone
-pub unsafe fn aya_obj::EbpfSectionKind::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya_obj::EbpfSectionKind where T: core::marker::Copy
-pub unsafe fn aya_obj::EbpfSectionKind::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_obj::EbpfSectionKind
 pub fn aya_obj::EbpfSectionKind::from(t: T) -> T
 pub enum aya_obj::Map
@@ -8015,8 +7424,6 @@ impl<T> core::borrow::Borrow<T> for aya_obj::maps::Map where T: core::marker::Si
 pub fn aya_obj::maps::Map::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_obj::maps::Map where T: core::marker::Sized
 pub fn aya_obj::maps::Map::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::maps::Map where T: core::clone::Clone
-pub unsafe fn aya_obj::maps::Map::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_obj::maps::Map
 pub fn aya_obj::maps::Map::from(t: T) -> T
 pub enum aya_obj::ParseError
@@ -8162,8 +7569,6 @@ impl<T> core::borrow::Borrow<T> for aya_obj::ProgramSection where T: core::marke
 pub fn aya_obj::ProgramSection::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_obj::ProgramSection where T: core::marker::Sized
 pub fn aya_obj::ProgramSection::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::ProgramSection where T: core::clone::Clone
-pub unsafe fn aya_obj::ProgramSection::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_obj::ProgramSection
 pub fn aya_obj::ProgramSection::from(t: T) -> T
 pub struct aya_obj::Features
@@ -8240,8 +7645,6 @@ impl<T> core::borrow::Borrow<T> for aya_obj::Function where T: core::marker::Siz
 pub fn aya_obj::Function::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_obj::Function where T: core::marker::Sized
 pub fn aya_obj::Function::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::Function where T: core::clone::Clone
-pub unsafe fn aya_obj::Function::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_obj::Function
 pub fn aya_obj::Function::from(t: T) -> T
 pub struct aya_obj::Object
@@ -8292,8 +7695,6 @@ impl<T> core::borrow::Borrow<T> for aya_obj::Object where T: core::marker::Sized
 pub fn aya_obj::Object::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_obj::Object where T: core::marker::Sized
 pub fn aya_obj::Object::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::Object where T: core::clone::Clone
-pub unsafe fn aya_obj::Object::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_obj::Object
 pub fn aya_obj::Object::from(t: T) -> T
 pub struct aya_obj::Program
@@ -8332,8 +7733,6 @@ impl<T> core::borrow::Borrow<T> for aya_obj::Program where T: core::marker::Size
 pub fn aya_obj::Program::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya_obj::Program where T: core::marker::Sized
 pub fn aya_obj::Program::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::Program where T: core::clone::Clone
-pub unsafe fn aya_obj::Program::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya_obj::Program
 pub fn aya_obj::Program::from(t: T) -> T
 pub struct aya_obj::VerifierLog(_)

--- a/xtask/public-api/aya-obj.txt
+++ b/xtask/public-api/aya-obj.txt
@@ -1523,7 +1523,11 @@ pub fn aya_obj::generated::bpf_link_type::clone(&self) -> aya_obj::generated::bp
 impl core::cmp::Eq for aya_obj::generated::bpf_link_type
 impl core::cmp::PartialEq for aya_obj::generated::bpf_link_type
 pub fn aya_obj::generated::bpf_link_type::eq(&self, other: &aya_obj::generated::bpf_link_type) -> bool
+impl core::convert::From<u32> for aya_obj::generated::bpf_link_type
+pub fn aya_obj::generated::bpf_link_type::from(link_type: u32) -> Self
 impl core::fmt::Debug for aya_obj::generated::bpf_link_type
+pub fn aya_obj::generated::bpf_link_type::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::fmt::Display for aya_obj::generated::bpf_link_type
 pub fn aya_obj::generated::bpf_link_type::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::hash::Hash for aya_obj::generated::bpf_link_type
 pub fn aya_obj::generated::bpf_link_type::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
@@ -1547,6 +1551,8 @@ impl<T> alloc::borrow::ToOwned for aya_obj::generated::bpf_link_type where T: co
 pub type aya_obj::generated::bpf_link_type::Owned = T
 pub fn aya_obj::generated::bpf_link_type::clone_into(&self, target: &mut T)
 pub fn aya_obj::generated::bpf_link_type::to_owned(&self) -> T
+impl<T> alloc::string::ToString for aya_obj::generated::bpf_link_type where T: core::fmt::Display + core::marker::Sized
+pub fn aya_obj::generated::bpf_link_type::to_string(&self) -> alloc::string::String
 impl<T> core::any::Any for aya_obj::generated::bpf_link_type where T: 'static + core::marker::Sized
 pub fn aya_obj::generated::bpf_link_type::type_id(&self) -> core::any::TypeId
 impl<T> core::borrow::Borrow<T> for aya_obj::generated::bpf_link_type where T: core::marker::Sized
@@ -1605,6 +1611,8 @@ pub type aya_obj::generated::bpf_map_type::Error = aya_obj::maps::InvalidMapType
 pub fn aya_obj::generated::bpf_map_type::try_from(map_type: u32) -> core::result::Result<Self, Self::Error>
 impl core::fmt::Debug for aya_obj::generated::bpf_map_type
 pub fn aya_obj::generated::bpf_map_type::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::fmt::Display for aya_obj::generated::bpf_map_type
+pub fn aya_obj::generated::bpf_map_type::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::hash::Hash for aya_obj::generated::bpf_map_type
 pub fn aya_obj::generated::bpf_map_type::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
 impl core::marker::Copy for aya_obj::generated::bpf_map_type
@@ -1627,6 +1635,8 @@ impl<T> alloc::borrow::ToOwned for aya_obj::generated::bpf_map_type where T: cor
 pub type aya_obj::generated::bpf_map_type::Owned = T
 pub fn aya_obj::generated::bpf_map_type::clone_into(&self, target: &mut T)
 pub fn aya_obj::generated::bpf_map_type::to_owned(&self) -> T
+impl<T> alloc::string::ToString for aya_obj::generated::bpf_map_type where T: core::fmt::Display + core::marker::Sized
+pub fn aya_obj::generated::bpf_map_type::to_string(&self) -> alloc::string::String
 impl<T> core::any::Any for aya_obj::generated::bpf_map_type where T: 'static + core::marker::Sized
 pub fn aya_obj::generated::bpf_map_type::type_id(&self) -> core::any::TypeId
 impl<T> core::borrow::Borrow<T> for aya_obj::generated::bpf_map_type where T: core::marker::Sized
@@ -6270,6 +6280,7 @@ pub type aya_obj::generated::_bindgen_ty_7 = core::ffi::c_uint
 pub type aya_obj::generated::_bindgen_ty_8 = core::ffi::c_uint
 pub type aya_obj::generated::_bindgen_ty_9 = core::ffi::c_uint
 pub type aya_obj::generated::_bindgen_ty_92 = core::ffi::c_uint
+pub mod aya_obj::links
 pub mod aya_obj::maps
 pub enum aya_obj::maps::Map
 pub aya_obj::maps::Map::Btf(aya_obj::maps::BtfMap)

--- a/xtask/public-api/aya.txt
+++ b/xtask/public-api/aya.txt
@@ -1798,6 +1798,7 @@ pub fn aya::maps::MapInfo::id(&self) -> u32
 pub fn aya::maps::MapInfo::key_size(&self) -> u32
 pub fn aya::maps::MapInfo::map_flags(&self) -> u32
 pub fn aya::maps::MapInfo::map_type(&self) -> u32
+pub fn aya::maps::MapInfo::map_type_enum(&self) -> aya_obj::generated::linux_bindings_x86_64::bpf_map_type
 pub fn aya::maps::MapInfo::max_entries(&self) -> u32
 pub fn aya::maps::MapInfo::name(&self) -> &[u8]
 pub fn aya::maps::MapInfo::name_as_str(&self) -> core::option::Option<&str>

--- a/xtask/public-api/aya.txt
+++ b/xtask/public-api/aya.txt
@@ -300,10 +300,6 @@ impl<T> core::borrow::Borrow<T> for aya::maps::lpm_trie::Key<K> where T: core::m
 pub fn aya::maps::lpm_trie::Key<K>::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya::maps::lpm_trie::Key<K> where T: core::marker::Sized
 pub fn aya::maps::lpm_trie::Key<K>::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya::maps::lpm_trie::Key<K> where T: core::clone::Clone
-pub unsafe fn aya::maps::lpm_trie::Key<K>::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya::maps::lpm_trie::Key<K> where T: core::marker::Copy
-pub unsafe fn aya::maps::lpm_trie::Key<K>::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya::maps::lpm_trie::Key<K>
 pub fn aya::maps::lpm_trie::Key<K>::from(t: T) -> T
 pub struct aya::maps::lpm_trie::LpmTrie<T, K, V>
@@ -2592,10 +2588,6 @@ impl<T> core::borrow::Borrow<T> for aya::programs::cgroup_skb::CgroupSkbAttachTy
 pub fn aya::programs::cgroup_skb::CgroupSkbAttachType::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya::programs::cgroup_skb::CgroupSkbAttachType where T: core::marker::Sized
 pub fn aya::programs::cgroup_skb::CgroupSkbAttachType::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya::programs::cgroup_skb::CgroupSkbAttachType where T: core::clone::Clone
-pub unsafe fn aya::programs::cgroup_skb::CgroupSkbAttachType::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya::programs::cgroup_skb::CgroupSkbAttachType where T: core::marker::Copy
-pub unsafe fn aya::programs::cgroup_skb::CgroupSkbAttachType::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya::programs::cgroup_skb::CgroupSkbAttachType
 pub fn aya::programs::cgroup_skb::CgroupSkbAttachType::from(t: T) -> T
 pub struct aya::programs::cgroup_skb::CgroupSkb
@@ -4454,8 +4446,6 @@ impl<T> core::borrow::Borrow<T> for aya::programs::perf_event::PerfEventScope wh
 pub fn aya::programs::perf_event::PerfEventScope::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya::programs::perf_event::PerfEventScope where T: core::marker::Sized
 pub fn aya::programs::perf_event::PerfEventScope::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya::programs::perf_event::PerfEventScope where T: core::clone::Clone
-pub unsafe fn aya::programs::perf_event::PerfEventScope::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya::programs::perf_event::PerfEventScope
 pub fn aya::programs::perf_event::PerfEventScope::from(t: T) -> T
 #[repr(u32)] pub enum aya::programs::perf_event::PerfTypeId
@@ -4493,8 +4483,6 @@ impl<T> core::borrow::Borrow<T> for aya::programs::perf_event::PerfTypeId where 
 pub fn aya::programs::perf_event::PerfTypeId::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya::programs::perf_event::PerfTypeId where T: core::marker::Sized
 pub fn aya::programs::perf_event::PerfTypeId::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya::programs::perf_event::PerfTypeId where T: core::clone::Clone
-pub unsafe fn aya::programs::perf_event::PerfTypeId::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya::programs::perf_event::PerfTypeId
 pub fn aya::programs::perf_event::PerfTypeId::from(t: T) -> T
 pub enum aya::programs::perf_event::SamplePolicy
@@ -4528,8 +4516,6 @@ impl<T> core::borrow::Borrow<T> for aya::programs::perf_event::SamplePolicy wher
 pub fn aya::programs::perf_event::SamplePolicy::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya::programs::perf_event::SamplePolicy where T: core::marker::Sized
 pub fn aya::programs::perf_event::SamplePolicy::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya::programs::perf_event::SamplePolicy where T: core::clone::Clone
-pub unsafe fn aya::programs::perf_event::SamplePolicy::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya::programs::perf_event::SamplePolicy
 pub fn aya::programs::perf_event::SamplePolicy::from(t: T) -> T
 pub struct aya::programs::perf_event::PerfEvent
@@ -5046,10 +5032,6 @@ impl<T> core::borrow::Borrow<T> for aya::programs::sk_skb::SkSkbKind where T: co
 pub fn aya::programs::sk_skb::SkSkbKind::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya::programs::sk_skb::SkSkbKind where T: core::marker::Sized
 pub fn aya::programs::sk_skb::SkSkbKind::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya::programs::sk_skb::SkSkbKind where T: core::clone::Clone
-pub unsafe fn aya::programs::sk_skb::SkSkbKind::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya::programs::sk_skb::SkSkbKind where T: core::marker::Copy
-pub unsafe fn aya::programs::sk_skb::SkSkbKind::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya::programs::sk_skb::SkSkbKind
 pub fn aya::programs::sk_skb::SkSkbKind::from(t: T) -> T
 pub struct aya::programs::sk_skb::SkSkb
@@ -5483,10 +5465,6 @@ impl<T> core::borrow::Borrow<T> for aya::programs::tc::TcAttachType where T: cor
 pub fn aya::programs::tc::TcAttachType::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya::programs::tc::TcAttachType where T: core::marker::Sized
 pub fn aya::programs::tc::TcAttachType::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya::programs::tc::TcAttachType where T: core::clone::Clone
-pub unsafe fn aya::programs::tc::TcAttachType::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya::programs::tc::TcAttachType where T: core::marker::Copy
-pub unsafe fn aya::programs::tc::TcAttachType::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya::programs::tc::TcAttachType
 pub fn aya::programs::tc::TcAttachType::from(t: T) -> T
 pub enum aya::programs::tc::TcError
@@ -6313,10 +6291,6 @@ impl<T> core::borrow::Borrow<T> for aya::programs::xdp::XdpFlags where T: core::
 pub fn aya::programs::xdp::XdpFlags::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya::programs::xdp::XdpFlags where T: core::marker::Sized
 pub fn aya::programs::xdp::XdpFlags::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya::programs::xdp::XdpFlags where T: core::clone::Clone
-pub unsafe fn aya::programs::xdp::XdpFlags::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya::programs::xdp::XdpFlags where T: core::marker::Copy
-pub unsafe fn aya::programs::xdp::XdpFlags::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya::programs::xdp::XdpFlags
 pub fn aya::programs::xdp::XdpFlags::from(t: T) -> T
 pub struct aya::programs::xdp::XdpLink(_)
@@ -6423,10 +6397,6 @@ impl<T> core::borrow::Borrow<T> for aya::programs::cgroup_skb::CgroupSkbAttachTy
 pub fn aya::programs::cgroup_skb::CgroupSkbAttachType::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya::programs::cgroup_skb::CgroupSkbAttachType where T: core::marker::Sized
 pub fn aya::programs::cgroup_skb::CgroupSkbAttachType::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya::programs::cgroup_skb::CgroupSkbAttachType where T: core::clone::Clone
-pub unsafe fn aya::programs::cgroup_skb::CgroupSkbAttachType::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya::programs::cgroup_skb::CgroupSkbAttachType where T: core::marker::Copy
-pub unsafe fn aya::programs::cgroup_skb::CgroupSkbAttachType::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya::programs::cgroup_skb::CgroupSkbAttachType
 pub fn aya::programs::cgroup_skb::CgroupSkbAttachType::from(t: T) -> T
 pub enum aya::programs::ExtensionError
@@ -6537,8 +6507,6 @@ impl<T> core::borrow::Borrow<T> for aya::programs::perf_event::PerfEventScope wh
 pub fn aya::programs::perf_event::PerfEventScope::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya::programs::perf_event::PerfEventScope where T: core::marker::Sized
 pub fn aya::programs::perf_event::PerfEventScope::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya::programs::perf_event::PerfEventScope where T: core::clone::Clone
-pub unsafe fn aya::programs::perf_event::PerfEventScope::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya::programs::perf_event::PerfEventScope
 pub fn aya::programs::perf_event::PerfEventScope::from(t: T) -> T
 #[repr(u32)] pub enum aya::programs::PerfTypeId
@@ -6576,8 +6544,6 @@ impl<T> core::borrow::Borrow<T> for aya::programs::perf_event::PerfTypeId where 
 pub fn aya::programs::perf_event::PerfTypeId::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya::programs::perf_event::PerfTypeId where T: core::marker::Sized
 pub fn aya::programs::perf_event::PerfTypeId::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya::programs::perf_event::PerfTypeId where T: core::clone::Clone
-pub unsafe fn aya::programs::perf_event::PerfTypeId::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya::programs::perf_event::PerfTypeId
 pub fn aya::programs::perf_event::PerfTypeId::from(t: T) -> T
 pub enum aya::programs::ProbeKind
@@ -6614,10 +6580,6 @@ impl<T> core::borrow::Borrow<T> for aya::programs::ProbeKind where T: core::mark
 pub fn aya::programs::ProbeKind::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya::programs::ProbeKind where T: core::marker::Sized
 pub fn aya::programs::ProbeKind::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya::programs::ProbeKind where T: core::clone::Clone
-pub unsafe fn aya::programs::ProbeKind::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya::programs::ProbeKind where T: core::marker::Copy
-pub unsafe fn aya::programs::ProbeKind::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya::programs::ProbeKind
 pub fn aya::programs::ProbeKind::from(t: T) -> T
 pub enum aya::programs::Program
@@ -6926,8 +6888,6 @@ impl<T> core::borrow::Borrow<T> for aya::programs::perf_event::SamplePolicy wher
 pub fn aya::programs::perf_event::SamplePolicy::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya::programs::perf_event::SamplePolicy where T: core::marker::Sized
 pub fn aya::programs::perf_event::SamplePolicy::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya::programs::perf_event::SamplePolicy where T: core::clone::Clone
-pub unsafe fn aya::programs::perf_event::SamplePolicy::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya::programs::perf_event::SamplePolicy
 pub fn aya::programs::perf_event::SamplePolicy::from(t: T) -> T
 pub enum aya::programs::SkSkbKind
@@ -6962,10 +6922,6 @@ impl<T> core::borrow::Borrow<T> for aya::programs::sk_skb::SkSkbKind where T: co
 pub fn aya::programs::sk_skb::SkSkbKind::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya::programs::sk_skb::SkSkbKind where T: core::marker::Sized
 pub fn aya::programs::sk_skb::SkSkbKind::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya::programs::sk_skb::SkSkbKind where T: core::clone::Clone
-pub unsafe fn aya::programs::sk_skb::SkSkbKind::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya::programs::sk_skb::SkSkbKind where T: core::marker::Copy
-pub unsafe fn aya::programs::sk_skb::SkSkbKind::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya::programs::sk_skb::SkSkbKind
 pub fn aya::programs::sk_skb::SkSkbKind::from(t: T) -> T
 pub enum aya::programs::SocketFilterError
@@ -7046,10 +7002,6 @@ impl<T> core::borrow::Borrow<T> for aya::programs::tc::TcAttachType where T: cor
 pub fn aya::programs::tc::TcAttachType::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya::programs::tc::TcAttachType where T: core::marker::Sized
 pub fn aya::programs::tc::TcAttachType::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya::programs::tc::TcAttachType where T: core::clone::Clone
-pub unsafe fn aya::programs::tc::TcAttachType::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya::programs::tc::TcAttachType where T: core::marker::Copy
-pub unsafe fn aya::programs::tc::TcAttachType::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya::programs::tc::TcAttachType
 pub fn aya::programs::tc::TcAttachType::from(t: T) -> T
 pub enum aya::programs::TcError
@@ -7930,6 +7882,7 @@ pub fn aya::programs::ProgramInfo::memory_locked(&self) -> core::result::Result<
 pub fn aya::programs::ProgramInfo::name(&self) -> &[u8]
 pub fn aya::programs::ProgramInfo::name_as_str(&self) -> core::option::Option<&str>
 pub fn aya::programs::ProgramInfo::program_type(&self) -> u32
+pub fn aya::programs::ProgramInfo::program_type_enum(&self) -> aya_obj::generated::linux_bindings_x86_64::bpf_prog_type
 pub fn aya::programs::ProgramInfo::size_jitted(&self) -> u32
 pub fn aya::programs::ProgramInfo::size_translated(&self) -> u32
 pub fn aya::programs::ProgramInfo::tag(&self) -> u64
@@ -8558,10 +8511,6 @@ impl<T> core::borrow::Borrow<T> for aya::programs::xdp::XdpFlags where T: core::
 pub fn aya::programs::xdp::XdpFlags::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya::programs::xdp::XdpFlags where T: core::marker::Sized
 pub fn aya::programs::xdp::XdpFlags::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya::programs::xdp::XdpFlags where T: core::clone::Clone
-pub unsafe fn aya::programs::xdp::XdpFlags::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya::programs::xdp::XdpFlags where T: core::marker::Copy
-pub unsafe fn aya::programs::xdp::XdpFlags::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya::programs::xdp::XdpFlags
 pub fn aya::programs::xdp::XdpFlags::from(t: T) -> T
 pub trait aya::programs::Link: core::fmt::Debug + 'static
@@ -8722,10 +8671,6 @@ impl<T> core::borrow::Borrow<T> for aya::util::KernelVersion where T: core::mark
 pub fn aya::util::KernelVersion::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya::util::KernelVersion where T: core::marker::Sized
 pub fn aya::util::KernelVersion::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya::util::KernelVersion where T: core::clone::Clone
-pub unsafe fn aya::util::KernelVersion::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya::util::KernelVersion where T: core::marker::Copy
-pub unsafe fn aya::util::KernelVersion::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya::util::KernelVersion
 pub fn aya::util::KernelVersion::from(t: T) -> T
 pub fn aya::util::kernel_symbols() -> core::result::Result<alloc::collections::btree::map::BTreeMap<u64, alloc::string::String>, std::io::error::Error>
@@ -8998,10 +8943,6 @@ impl<T> core::borrow::Borrow<T> for aya::VerifierLogLevel where T: core::marker:
 pub fn aya::VerifierLogLevel::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for aya::VerifierLogLevel where T: core::marker::Sized
 pub fn aya::VerifierLogLevel::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya::VerifierLogLevel where T: core::clone::Clone
-pub unsafe fn aya::VerifierLogLevel::clone_to_uninit(&self, dst: *mut T)
-impl<T> core::clone::CloneToUninit for aya::VerifierLogLevel where T: core::marker::Copy
-pub unsafe fn aya::VerifierLogLevel::clone_to_uninit(&self, dst: *mut T)
 impl<T> core::convert::From<T> for aya::VerifierLogLevel
 pub fn aya::VerifierLogLevel::from(t: T) -> T
 pub unsafe trait aya::Pod: core::marker::Copy + 'static

--- a/xtask/public-api/aya.txt
+++ b/xtask/public-api/aya.txt
@@ -7884,6 +7884,8 @@ pub fn aya::programs::ProgramInfo::name(&self) -> &[u8]
 pub fn aya::programs::ProgramInfo::name_as_str(&self) -> core::option::Option<&str>
 pub fn aya::programs::ProgramInfo::program_type(&self) -> u32
 pub fn aya::programs::ProgramInfo::program_type_enum(&self) -> aya_obj::generated::linux_bindings_x86_64::bpf_prog_type
+pub fn aya::programs::ProgramInfo::run_cnt(&self) -> u64
+pub fn aya::programs::ProgramInfo::run_time_ns(&self) -> u64
 pub fn aya::programs::ProgramInfo::size_jitted(&self) -> u32
 pub fn aya::programs::ProgramInfo::size_translated(&self) -> u32
 pub fn aya::programs::ProgramInfo::tag(&self) -> u64
@@ -8690,6 +8692,7 @@ pub aya::EbpfError::NoBTF
 pub aya::EbpfError::ParseError(aya_obj::obj::ParseError)
 pub aya::EbpfError::ProgramError(aya::programs::ProgramError)
 pub aya::EbpfError::RelocationError(aya_obj::relocation::EbpfRelocationError)
+pub aya::EbpfError::SyscallError(crate::sys::SyscallError)
 pub aya::EbpfError::UnexpectedPinningType
 pub aya::EbpfError::UnexpectedPinningType::name: u32
 impl core::convert::From<aya::maps::MapError> for aya::EbpfError
@@ -8736,6 +8739,7 @@ impl<T> core::convert::From<T> for aya::EbpfError
 pub fn aya::EbpfError::from(t: T) -> T
 pub struct aya::Ebpf
 impl aya::Ebpf
+pub fn aya::Ebpf::enable_stats_fd(stats_type: aya_obj::stats::BpfStatsType) -> core::result::Result<std::os::fd::owned::OwnedFd, SyscallError>
 pub fn aya::Ebpf::load(data: &[u8]) -> core::result::Result<Self, aya::EbpfError>
 pub fn aya::Ebpf::load_file<P: core::convert::AsRef<std::path::Path>>(path: P) -> core::result::Result<Self, aya::EbpfError>
 pub fn aya::Ebpf::map(&self, name: &str) -> core::option::Option<&aya::maps::Map>

--- a/xtask/src/codegen/aya.rs
+++ b/xtask/src/codegen/aya.rs
@@ -79,6 +79,7 @@ fn codegen_bindings(opts: &SysrootOptions, libbpf_dir: &Path) -> Result<(), anyh
         "bpf_lpm_trie_key",
         "bpf_cpumap_val",
         "bpf_devmap_val",
+        "bpf_stats_type",
         // BTF
         "btf_header",
         "btf_ext_info",


### PR DESCRIPTION
I have a usecase that extracts program type information from from `bpf_prog_info`. 😺

This PR adds conversion from `u32` to `bpf_prog_type` so that the `type_` field in `bpf_prog_info` can map to the program type enum. This also implements Display for `bpf_prog_type` for condensed output format. 😺 

Also, `codegen` and `public-api` appears to be acting a little funky for me.