### PR TITLE
Bump kernel image revision

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -256,7 +256,7 @@ jobs:
           # TODO: enable tests on kernels before 6.0.
           # linux-image-5.10.0-23-cloud-arm64-unsigned_5.10.179-3_arm64.deb \
           printf '%s\0' \
-            linux-image-6.1.0-15-cloud-arm64-unsigned_6.1.66-1_arm64.deb \
+            linux-image-6.1.0-16-cloud-arm64-unsigned_6.1.67-1_arm64.deb \
           | xargs -0 -t -P0 -I {} wget -nd -nv -P test/.tmp/debian-kernels/arm64 ftp://ftp.us.debian.org/debian/pool/main/l/linux/{}
 
       - name: Download debian kernels
@@ -268,7 +268,7 @@ jobs:
           # linux-image-4.19.0-21-cloud-amd64-unsigned_4.19.249-2_amd64.deb \
           # linux-image-5.10.0-23-cloud-amd64-unsigned_5.10.179-3_amd64.deb \
           printf '%s\0' \
-            linux-image-6.1.0-15-cloud-amd64-unsigned_6.1.66-1_amd64.deb \
+            linux-image-6.1.0-16-cloud-amd64-unsigned_6.1.67-1_amd64.deb \
           | xargs -0 -t -P0 -I {} wget -nd -nv -P test/.tmp/debian-kernels/amd64 ftp://ftp.us.debian.org/debian/pool/main/l/linux/{}
 
       - name: Extract debian kernels


### PR DESCRIPTION
6.1.0-15 seems to have been pulled.
