### PR TITLE
aya::programs::uprobe: fix bad variable name

### DIFF
--- a/aya/src/programs/uprobe.rs
+++ b/aya/src/programs/uprobe.rs
@@ -95,8 +95,8 @@ impl UProbe {
             0
         };
 
-        let fn_name = path.as_os_str();
-        attach(&mut self.data, self.kind, fn_name, sym_offset + offset, pid)
+        let path = path.as_os_str();
+        attach(&mut self.data, self.kind, path, sym_offset + offset, pid)
     }
 
     /// Detaches the program.


### PR DESCRIPTION
The variable fn_name was very much *not* the fn_name, but rather the object file path.