### PR TITLE
codegen: add `bpf_stats_type` to codegen

### DIFF
--- a/xtask/src/codegen/aya.rs
+++ b/xtask/src/codegen/aya.rs
@@ -79,6 +79,7 @@ fn codegen_bindings(opts: &SysrootOptions, libbpf_dir: &Path) -> Result<(), anyh
         "bpf_lpm_trie_key",
         "bpf_cpumap_val",
         "bpf_devmap_val",
+        "bpf_stats_type",
         // BTF
         "btf_header",
         "btf_ext_info",


### PR DESCRIPTION
Adds the `bpf_stats_type` enum to codegen bindings.

Refs: #959