### PR TITLE
Automatically Size PerfEventArrays

### DIFF
--- a/aya/src/maps/bloom_filter.rs
+++ b/aya/src/maps/bloom_filter.rs
@@ -120,6 +120,8 @@ mod tests {
 
     #[test]
     fn test_try_from_wrong_map() {
+        // This is necessary to stop miri tripping over the PERF_EVENT_ARRAY
+        // logic and attempting to open a file to read number of online CPUs.
         let map = new_map(test_utils::new_obj_map::<u32>(BPF_MAP_TYPE_ARRAY));
         let map = Map::Array(map);
 

--- a/aya/src/maps/bloom_filter.rs
+++ b/aya/src/maps/bloom_filter.rs
@@ -88,7 +88,7 @@ mod tests {
     use crate::{
         generated::{
             bpf_cmd,
-            bpf_map_type::{BPF_MAP_TYPE_BLOOM_FILTER, BPF_MAP_TYPE_PERF_EVENT_ARRAY},
+            bpf_map_type::{BPF_MAP_TYPE_ARRAY, BPF_MAP_TYPE_BLOOM_FILTER},
         },
         maps::{
             test_utils::{self, new_map},
@@ -120,10 +120,8 @@ mod tests {
 
     #[test]
     fn test_try_from_wrong_map() {
-        let map = new_map(test_utils::new_obj_map::<u32>(
-            BPF_MAP_TYPE_PERF_EVENT_ARRAY,
-        ));
-        let map = Map::PerfEventArray(map);
+        let map = new_map(test_utils::new_obj_map::<u32>(BPF_MAP_TYPE_ARRAY));
+        let map = Map::Array(map);
 
         assert_matches!(
             BloomFilter::<_, u32>::try_from(&map),

--- a/aya/src/maps/lpm_trie.rs
+++ b/aya/src/maps/lpm_trie.rs
@@ -249,6 +249,8 @@ mod tests {
 
     #[test]
     fn test_try_from_wrong_map() {
+        // This is necessary to stop miri tripping over the PERF_EVENT_ARRAY
+        // logic and attempting to open a file to read number of online CPUs.
         let map = new_map(test_utils::new_obj_map::<u32>(BPF_MAP_TYPE_ARRAY));
         let map = Map::Array(map);
 

--- a/aya/src/maps/lpm_trie.rs
+++ b/aya/src/maps/lpm_trie.rs
@@ -205,7 +205,7 @@ mod tests {
     use crate::{
         generated::{
             bpf_cmd,
-            bpf_map_type::{BPF_MAP_TYPE_LPM_TRIE, BPF_MAP_TYPE_PERF_EVENT_ARRAY},
+            bpf_map_type::{BPF_MAP_TYPE_ARRAY, BPF_MAP_TYPE_LPM_TRIE},
         },
         maps::{
             test_utils::{self, new_map},
@@ -249,10 +249,8 @@ mod tests {
 
     #[test]
     fn test_try_from_wrong_map() {
-        let map = new_map(test_utils::new_obj_map::<u32>(
-            BPF_MAP_TYPE_PERF_EVENT_ARRAY,
-        ));
-        let map = Map::PerfEventArray(map);
+        let map = new_map(test_utils::new_obj_map::<u32>(BPF_MAP_TYPE_ARRAY));
+        let map = Map::Array(map);
 
         assert_matches!(
             LpmTrie::<_, u32, u32>::try_from(&map),

--- a/ebpf/aya-ebpf/src/maps/perf/perf_event_array.rs
+++ b/ebpf/aya-ebpf/src/maps/perf/perf_event_array.rs
@@ -17,16 +17,12 @@ unsafe impl<T: Sync> Sync for PerfEventArray<T> {}
 
 impl<T> PerfEventArray<T> {
     pub const fn new(flags: u32) -> PerfEventArray<T> {
-        PerfEventArray::with_max_entries(0, flags)
-    }
-
-    pub const fn with_max_entries(max_entries: u32, flags: u32) -> PerfEventArray<T> {
         PerfEventArray {
             def: UnsafeCell::new(bpf_map_def {
                 type_: BPF_MAP_TYPE_PERF_EVENT_ARRAY,
                 key_size: mem::size_of::<u32>() as u32,
                 value_size: mem::size_of::<u32>() as u32,
-                max_entries,
+                max_entries: 0,
                 map_flags: flags,
                 id: 0,
                 pinning: PinningType::None as u32,
@@ -35,13 +31,13 @@ impl<T> PerfEventArray<T> {
         }
     }
 
-    pub const fn pinned(max_entries: u32, flags: u32) -> PerfEventArray<T> {
+    pub const fn pinned(flags: u32) -> PerfEventArray<T> {
         PerfEventArray {
             def: UnsafeCell::new(bpf_map_def {
                 type_: BPF_MAP_TYPE_PERF_EVENT_ARRAY,
                 key_size: mem::size_of::<u32>() as u32,
                 value_size: mem::size_of::<u32>() as u32,
-                max_entries,
+                max_entries: 0,
                 map_flags: flags,
                 id: 0,
                 pinning: PinningType::ByName as u32,

--- a/ebpf/aya-ebpf/src/maps/perf/perf_event_byte_array.rs
+++ b/ebpf/aya-ebpf/src/maps/perf/perf_event_byte_array.rs
@@ -16,16 +16,12 @@ unsafe impl Sync for PerfEventByteArray {}
 
 impl PerfEventByteArray {
     pub const fn new(flags: u32) -> PerfEventByteArray {
-        PerfEventByteArray::with_max_entries(0, flags)
-    }
-
-    pub const fn with_max_entries(max_entries: u32, flags: u32) -> PerfEventByteArray {
         PerfEventByteArray {
             def: UnsafeCell::new(bpf_map_def {
                 type_: BPF_MAP_TYPE_PERF_EVENT_ARRAY,
                 key_size: mem::size_of::<u32>() as u32,
                 value_size: mem::size_of::<u32>() as u32,
-                max_entries,
+                max_entries: 0,
                 map_flags: flags,
                 id: 0,
                 pinning: PinningType::None as u32,
@@ -33,13 +29,13 @@ impl PerfEventByteArray {
         }
     }
 
-    pub const fn pinned(max_entries: u32, flags: u32) -> PerfEventByteArray {
+    pub const fn pinned(flags: u32) -> PerfEventByteArray {
         PerfEventByteArray {
             def: UnsafeCell::new(bpf_map_def {
                 type_: BPF_MAP_TYPE_PERF_EVENT_ARRAY,
                 key_size: mem::size_of::<u32>() as u32,
                 value_size: mem::size_of::<u32>() as u32,
-                max_entries,
+                max_entries: 0,
                 map_flags: flags,
                 id: 0,
                 pinning: PinningType::ByName as u32,

--- a/xtask/public-api/aya-ebpf.txt
+++ b/xtask/public-api/aya-ebpf.txt
@@ -356,8 +356,7 @@ impl<T> aya_ebpf::maps::PerfEventArray<T>
 pub const fn aya_ebpf::maps::PerfEventArray<T>::new(flags: u32) -> aya_ebpf::maps::PerfEventArray<T>
 pub fn aya_ebpf::maps::PerfEventArray<T>::output<C: aya_ebpf::EbpfContext>(&self, ctx: &C, data: &T, flags: u32)
 pub fn aya_ebpf::maps::PerfEventArray<T>::output_at_index<C: aya_ebpf::EbpfContext>(&self, ctx: &C, index: u32, data: &T, flags: u32)
-pub const fn aya_ebpf::maps::PerfEventArray<T>::pinned(max_entries: u32, flags: u32) -> aya_ebpf::maps::PerfEventArray<T>
-pub const fn aya_ebpf::maps::PerfEventArray<T>::with_max_entries(max_entries: u32, flags: u32) -> aya_ebpf::maps::PerfEventArray<T>
+pub const fn aya_ebpf::maps::PerfEventArray<T>::pinned(flags: u32) -> aya_ebpf::maps::PerfEventArray<T>
 impl<T: core::marker::Sync> core::marker::Sync for aya_ebpf::maps::PerfEventArray<T>
 impl<T> !core::marker::Freeze for aya_ebpf::maps::PerfEventArray<T>
 impl<T> core::marker::Send for aya_ebpf::maps::PerfEventArray<T> where T: core::marker::Send
@@ -385,8 +384,7 @@ impl aya_ebpf::maps::PerfEventByteArray
 pub const fn aya_ebpf::maps::PerfEventByteArray::new(flags: u32) -> aya_ebpf::maps::PerfEventByteArray
 pub fn aya_ebpf::maps::PerfEventByteArray::output<C: aya_ebpf::EbpfContext>(&self, ctx: &C, data: &[u8], flags: u32)
 pub fn aya_ebpf::maps::PerfEventByteArray::output_at_index<C: aya_ebpf::EbpfContext>(&self, ctx: &C, index: u32, data: &[u8], flags: u32)
-pub const fn aya_ebpf::maps::PerfEventByteArray::pinned(max_entries: u32, flags: u32) -> aya_ebpf::maps::PerfEventByteArray
-pub const fn aya_ebpf::maps::PerfEventByteArray::with_max_entries(max_entries: u32, flags: u32) -> aya_ebpf::maps::PerfEventByteArray
+pub const fn aya_ebpf::maps::PerfEventByteArray::pinned(flags: u32) -> aya_ebpf::maps::PerfEventByteArray
 impl core::marker::Sync for aya_ebpf::maps::PerfEventByteArray
 impl !core::marker::Freeze for aya_ebpf::maps::PerfEventByteArray
 impl core::marker::Send for aya_ebpf::maps::PerfEventByteArray
@@ -1085,8 +1083,7 @@ impl<T> aya_ebpf::maps::PerfEventArray<T>
 pub const fn aya_ebpf::maps::PerfEventArray<T>::new(flags: u32) -> aya_ebpf::maps::PerfEventArray<T>
 pub fn aya_ebpf::maps::PerfEventArray<T>::output<C: aya_ebpf::EbpfContext>(&self, ctx: &C, data: &T, flags: u32)
 pub fn aya_ebpf::maps::PerfEventArray<T>::output_at_index<C: aya_ebpf::EbpfContext>(&self, ctx: &C, index: u32, data: &T, flags: u32)
-pub const fn aya_ebpf::maps::PerfEventArray<T>::pinned(max_entries: u32, flags: u32) -> aya_ebpf::maps::PerfEventArray<T>
-pub const fn aya_ebpf::maps::PerfEventArray<T>::with_max_entries(max_entries: u32, flags: u32) -> aya_ebpf::maps::PerfEventArray<T>
+pub const fn aya_ebpf::maps::PerfEventArray<T>::pinned(flags: u32) -> aya_ebpf::maps::PerfEventArray<T>
 impl<T: core::marker::Sync> core::marker::Sync for aya_ebpf::maps::PerfEventArray<T>
 impl<T> !core::marker::Freeze for aya_ebpf::maps::PerfEventArray<T>
 impl<T> core::marker::Send for aya_ebpf::maps::PerfEventArray<T> where T: core::marker::Send
@@ -1114,8 +1111,7 @@ impl aya_ebpf::maps::PerfEventByteArray
 pub const fn aya_ebpf::maps::PerfEventByteArray::new(flags: u32) -> aya_ebpf::maps::PerfEventByteArray
 pub fn aya_ebpf::maps::PerfEventByteArray::output<C: aya_ebpf::EbpfContext>(&self, ctx: &C, data: &[u8], flags: u32)
 pub fn aya_ebpf::maps::PerfEventByteArray::output_at_index<C: aya_ebpf::EbpfContext>(&self, ctx: &C, index: u32, data: &[u8], flags: u32)
-pub const fn aya_ebpf::maps::PerfEventByteArray::pinned(max_entries: u32, flags: u32) -> aya_ebpf::maps::PerfEventByteArray
-pub const fn aya_ebpf::maps::PerfEventByteArray::with_max_entries(max_entries: u32, flags: u32) -> aya_ebpf::maps::PerfEventByteArray
+pub const fn aya_ebpf::maps::PerfEventByteArray::pinned(flags: u32) -> aya_ebpf::maps::PerfEventByteArray
 impl core::marker::Sync for aya_ebpf::maps::PerfEventByteArray
 impl !core::marker::Freeze for aya_ebpf::maps::PerfEventByteArray
 impl core::marker::Send for aya_ebpf::maps::PerfEventByteArray


### PR DESCRIPTION
This brings Aya into compliance with libbpf and other popular loaders.
PerfEventArray sizes should be set to 0 at compile time.
At load time, they are set to the number of online CPUs.

Fixes: #995