### PR TITLE
Fix CI on macOS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -238,8 +238,6 @@ jobs:
           echo /usr/local/opt/findutils/libexec/gnubin >> $GITHUB_PATH
           echo /usr/local/opt/gnu-tar/libexec/gnubin >> $GITHUB_PATH
           echo /usr/local/opt/llvm/bin >> $GITHUB_PATH
-          # https://github.com/Homebrew/homebrew-core/issues/140244
-          codesign --verify $(which qemu-system-x86_64) || brew reinstall qemu --build-from-source
 
       - name: bpf-linker
         if: runner.os == 'macOS'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -239,9 +239,9 @@ jobs:
           | grep -q ^/Library/Frameworks/Python.framework/Versions/' _ {} \; -exec rm -v {} \;
           HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK=1 \
           brew install dpkg findutils gnu-tar llvm pkg-config qemu
-          echo /usr/local/opt/findutils/libexec/gnubin >> $GITHUB_PATH
-          echo /usr/local/opt/gnu-tar/libexec/gnubin >> $GITHUB_PATH
-          echo /usr/local/opt/llvm/bin >> $GITHUB_PATH
+          echo $(brew --prefix)/opt/findutils/libexec/gnubin >> $GITHUB_PATH
+          echo $(brew --prefix)/opt/gnu-tar/libexec/gnubin >> $GITHUB_PATH
+          echo $(brew --prefix)/opt/llvm/bin >> $GITHUB_PATH
 
       - name: bpf-linker
         if: runner.os == 'macOS'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -179,7 +179,11 @@ jobs:
       fail-fast: false
       matrix:
         runner:
-          - macos-12
+          # macos-14 is arm64 per
+          # https://github.com/actions/runner-images#available-images which
+          # doesn't support nested virtualization per
+          # https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#limitations-for-arm64-macos-runners
+          - macos-13
           - ubuntu-22.04
     runs-on: ${{ matrix.runner }}
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -191,14 +191,6 @@ jobs:
         with:
           submodules: recursive
 
-      - uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: nightly
-          components: rust-src
-          targets: aarch64-unknown-linux-musl,x86_64-unknown-linux-musl
-
-      - uses: Swatinem/rust-cache@v2
-
       - name: Install prerequisites
         if: runner.os == 'Linux'
         # ubuntu-22.04 comes with clang 14[0] which doesn't include support for signed and 64bit
@@ -242,6 +234,14 @@ jobs:
           echo $(brew --prefix)/opt/findutils/libexec/gnubin >> $GITHUB_PATH
           echo $(brew --prefix)/opt/gnu-tar/libexec/gnubin >> $GITHUB_PATH
           echo $(brew --prefix)/opt/llvm/bin >> $GITHUB_PATH
+
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: nightly
+          components: rust-src
+          targets: aarch64-unknown-linux-musl,x86_64-unknown-linux-musl
+
+      - uses: Swatinem/rust-cache@v2
 
       - name: bpf-linker
         if: runner.os == 'macOS'


### PR DESCRIPTION
A naive attempt to resolve recent CI issues: `cargo: command not found`.
