### PR TITLE
Use MockableFd everywhere

### DIFF
--- a/aya/src/bpf.rs
+++ b/aya/src/bpf.rs
@@ -3,7 +3,7 @@ use std::{
     collections::{HashMap, HashSet},
     fs, io,
     os::{
-        fd::{AsFd as _, AsRawFd as _, OwnedFd},
+        fd::{AsFd as _, AsRawFd as _},
         raw::c_int,
     },
     path::{Path, PathBuf},
@@ -1123,7 +1123,10 @@ pub enum EbpfError {
 #[deprecated(since = "0.13.0", note = "use `EbpfError` instead")]
 pub type BpfError = EbpfError;
 
-fn load_btf(raw_btf: Vec<u8>, verifier_log_level: VerifierLogLevel) -> Result<OwnedFd, BtfError> {
+fn load_btf(
+    raw_btf: Vec<u8>,
+    verifier_log_level: VerifierLogLevel,
+) -> Result<crate::MockableFd, BtfError> {
     let (ret, verifier_log) = retry_with_verifier_logs(10, |logger| {
         bpf_load_btf(raw_btf.as_slice(), logger, verifier_log_level)
     });

--- a/aya/src/maps/perf/perf_buffer.rs
+++ b/aya/src/maps/perf/perf_buffer.rs
@@ -120,7 +120,6 @@ impl PerfBuffer {
             });
         }
 
-        let fd = crate::MockableFd::from_fd(fd);
         let perf_buf = Self {
             buf: AtomicPtr::new(buf as *mut perf_event_mmap_page),
             size,

--- a/aya/src/programs/cgroup_device.rs
+++ b/aya/src/programs/cgroup_device.rs
@@ -122,6 +122,7 @@ impl CgroupDevice {
             .map(|prog_id| {
                 let prog_fd = bpf_prog_get_fd_by_id(prog_id)?;
                 let target_fd = target_fd.try_clone_to_owned()?;
+                let target_fd = crate::MockableFd::from_fd(target_fd);
                 let prog_fd = ProgramFd(prog_fd);
                 Ok(CgroupDeviceLink::new(CgroupDeviceLinkInner::ProgAttach(
                     ProgAttachLink::new(prog_fd, target_fd, BPF_CGROUP_DEVICE),

--- a/aya/src/programs/extension.rs
+++ b/aya/src/programs/extension.rs
@@ -1,6 +1,6 @@
 //! Extension programs.
 
-use std::os::fd::{AsFd as _, BorrowedFd, OwnedFd};
+use std::os::fd::{AsFd as _, BorrowedFd};
 
 use object::Endianness;
 use thiserror::Error;
@@ -169,7 +169,10 @@ impl Extension {
 
 /// Retrieves the FD of the BTF object for the provided `prog_fd` and the BTF ID of the function
 /// with the name `func_name` within that BTF object.
-fn get_btf_info(prog_fd: BorrowedFd<'_>, func_name: &str) -> Result<(OwnedFd, u32), ProgramError> {
+fn get_btf_info(
+    prog_fd: BorrowedFd<'_>,
+    func_name: &str,
+) -> Result<(crate::MockableFd, u32), ProgramError> {
     // retrieve program information
     let info = sys::bpf_prog_get_info_by_fd(prog_fd, &mut [])?;
 

--- a/aya/src/programs/mod.rs
+++ b/aya/src/programs/mod.rs
@@ -72,7 +72,7 @@ use std::{
     ffi::CString,
     io,
     num::NonZeroU32,
-    os::fd::{AsFd, AsRawFd, BorrowedFd, OwnedFd},
+    os::fd::{AsFd, AsRawFd, BorrowedFd},
     path::{Path, PathBuf},
     sync::Arc,
     time::{Duration, SystemTime},
@@ -224,7 +224,7 @@ pub enum ProgramError {
 
 /// A [`Program`] file descriptor.
 #[derive(Debug)]
-pub struct ProgramFd(OwnedFd);
+pub struct ProgramFd(crate::MockableFd);
 
 impl ProgramFd {
     /// Creates a new instance that shares the same underlying file description as [`self`].
@@ -460,10 +460,10 @@ pub(crate) struct ProgramData<T: Link> {
     pub(crate) fd: Option<ProgramFd>,
     pub(crate) links: LinkMap<T>,
     pub(crate) expected_attach_type: Option<bpf_attach_type>,
-    pub(crate) attach_btf_obj_fd: Option<OwnedFd>,
+    pub(crate) attach_btf_obj_fd: Option<crate::MockableFd>,
     pub(crate) attach_btf_id: Option<u32>,
     pub(crate) attach_prog_fd: Option<ProgramFd>,
-    pub(crate) btf_fd: Option<Arc<OwnedFd>>,
+    pub(crate) btf_fd: Option<Arc<crate::MockableFd>>,
     pub(crate) verifier_log_level: VerifierLogLevel,
     pub(crate) path: Option<PathBuf>,
     pub(crate) flags: u32,
@@ -473,7 +473,7 @@ impl<T: Link> ProgramData<T> {
     pub(crate) fn new(
         name: Option<String>,
         obj: (obj::Program, obj::Function),
-        btf_fd: Option<Arc<OwnedFd>>,
+        btf_fd: Option<Arc<crate::MockableFd>>,
         verifier_log_level: VerifierLogLevel,
     ) -> Self {
         Self {
@@ -494,7 +494,7 @@ impl<T: Link> ProgramData<T> {
 
     pub(crate) fn from_bpf_prog_info(
         name: Option<String>,
-        fd: OwnedFd,
+        fd: crate::MockableFd,
         path: &Path,
         info: bpf_prog_info,
         verifier_log_level: VerifierLogLevel,

--- a/aya/src/programs/perf_attach.rs
+++ b/aya/src/programs/perf_attach.rs
@@ -1,5 +1,5 @@
 //! Perf attach links.
-use std::os::fd::{AsFd as _, AsRawFd as _, BorrowedFd, OwnedFd, RawFd};
+use std::os::fd::{AsFd as _, AsRawFd as _, BorrowedFd, RawFd};
 
 use crate::{
     generated::bpf_attach_type::BPF_PERF_EVENT,
@@ -48,7 +48,7 @@ pub struct PerfLinkId(RawFd);
 /// The attachment type of PerfEvent programs.
 #[derive(Debug)]
 pub struct PerfLink {
-    perf_fd: OwnedFd,
+    perf_fd: crate::MockableFd,
     event: Option<ProbeEvent>,
 }
 
@@ -72,7 +72,7 @@ impl Link for PerfLink {
 
 pub(crate) fn perf_attach(
     prog_fd: BorrowedFd<'_>,
-    fd: OwnedFd,
+    fd: crate::MockableFd,
 ) -> Result<PerfLinkInner, ProgramError> {
     if FEATURES.bpf_perf_link() {
         let link_fd = bpf_link_create(prog_fd, LinkTarget::Fd(fd.as_fd()), BPF_PERF_EVENT, None, 0)
@@ -88,7 +88,7 @@ pub(crate) fn perf_attach(
 
 pub(crate) fn perf_attach_debugfs(
     prog_fd: BorrowedFd<'_>,
-    fd: OwnedFd,
+    fd: crate::MockableFd,
     event: ProbeEvent,
 ) -> Result<PerfLinkInner, ProgramError> {
     perf_attach_either(prog_fd, fd, Some(event))
@@ -96,7 +96,7 @@ pub(crate) fn perf_attach_debugfs(
 
 fn perf_attach_either(
     prog_fd: BorrowedFd<'_>,
-    fd: OwnedFd,
+    fd: crate::MockableFd,
     event: Option<ProbeEvent>,
 ) -> Result<PerfLinkInner, ProgramError> {
     perf_event_ioctl(fd.as_fd(), PERF_EVENT_IOC_SET_BPF, prog_fd.as_raw_fd()).map_err(

--- a/aya/src/programs/probe.rs
+++ b/aya/src/programs/probe.rs
@@ -3,7 +3,7 @@ use std::{
     fmt::Write as _,
     fs::{self, OpenOptions},
     io::{self, Write},
-    os::fd::{AsFd as _, OwnedFd},
+    os::fd::AsFd as _,
     path::{Path, PathBuf},
     process,
     sync::atomic::{AtomicUsize, Ordering},
@@ -150,7 +150,7 @@ fn create_as_probe(
     fn_name: &OsStr,
     offset: u64,
     pid: Option<pid_t>,
-) -> Result<OwnedFd, ProgramError> {
+) -> Result<crate::MockableFd, ProgramError> {
     use ProbeKind::*;
 
     let perf_ty = match kind {
@@ -186,7 +186,7 @@ fn create_as_trace_point(
     name: &OsStr,
     offset: u64,
     pid: Option<pid_t>,
-) -> Result<(OwnedFd, OsString), ProgramError> {
+) -> Result<(crate::MockableFd, OsString), ProgramError> {
     use ProbeKind::*;
 
     let tracefs = find_tracefs_path()?;

--- a/aya/src/sys/netlink.rs
+++ b/aya/src/sys/netlink.rs
@@ -2,7 +2,7 @@ use std::{
     collections::HashMap,
     ffi::CStr,
     io, mem,
-    os::fd::{AsRawFd as _, BorrowedFd, FromRawFd as _, OwnedFd},
+    os::fd::{AsRawFd as _, BorrowedFd, FromRawFd as _},
     ptr, slice,
 };
 
@@ -307,7 +307,7 @@ struct TcRequest {
 }
 
 struct NetlinkSocket {
-    sock: OwnedFd,
+    sock: crate::MockableFd,
     _nl_pid: u32,
 }
 
@@ -319,7 +319,7 @@ impl NetlinkSocket {
             return Err(io::Error::last_os_error());
         }
         // SAFETY: `socket` returns a file descriptor.
-        let sock = unsafe { OwnedFd::from_raw_fd(sock) };
+        let sock = unsafe { crate::MockableFd::from_raw_fd(sock) };
 
         let enable = 1i32;
         // Safety: libc wrapper


### PR DESCRIPTION
Rust 1.80 contains https://github.com/rust-lang/rust/pull/124210,
causing tests which we skip under miri to segfault.
