### PR TITLE
fix(aya): Fix PerfEventArray resize logic

### DIFF
--- a/aya/src/maps/bloom_filter.rs
+++ b/aya/src/maps/bloom_filter.rs
@@ -120,8 +120,7 @@ mod tests {
 
     #[test]
     fn test_try_from_wrong_map() {
-        // This is necessary to stop miri tripping over the PERF_EVENT_ARRAY
-        // logic and attempting to open a file to read number of online CPUs.
+        // Use any map type here other than BPF_MAP_TYPE_PERF_EVENT_ARRAY as it will trip miri
         let map = new_map(test_utils::new_obj_map::<u32>(BPF_MAP_TYPE_ARRAY));
         let map = Map::Array(map);
 

--- a/aya/src/maps/lpm_trie.rs
+++ b/aya/src/maps/lpm_trie.rs
@@ -249,8 +249,7 @@ mod tests {
 
     #[test]
     fn test_try_from_wrong_map() {
-        // This is necessary to stop miri tripping over the PERF_EVENT_ARRAY
-        // logic and attempting to open a file to read number of online CPUs.
+        // Use any map type here other than BPF_MAP_TYPE_PERF_EVENT_ARRAY as it will trip miri
         let map = new_map(test_utils::new_obj_map::<u32>(BPF_MAP_TYPE_ARRAY));
         let map = Map::Array(map);
 

--- a/aya/src/sys/bpf.rs
+++ b/aya/src/sys/bpf.rs
@@ -30,7 +30,7 @@ use crate::{
         copy_instructions,
     },
     sys::{syscall, SysResult, Syscall, SyscallError},
-    util::{nr_cpus, KernelVersion},
+    util::KernelVersion,
     Btf, Pod, VerifierLogLevel, BPF_OBJ_NAME_LEN,
 };
 
@@ -46,26 +46,6 @@ pub(crate) fn bpf_create_map(
     u.map_type = def.map_type();
     u.key_size = def.key_size();
     u.value_size = def.value_size();
-    u.max_entries = def.max_entries();
-
-    // BPF_MAP_TYPE_PERF_EVENT_ARRAY's max_entries should not exceed the number of
-    // CPUs.
-    //
-    // By default, the newest versions of Aya, libbpf and cilium/ebpf define `max_entries` of
-    // `PerfEventArray` as `0`, with an intention to get it replaced with a correct value
-    // by the loader.
-    //
-    // We allow custom values (potentially coming either from older versions of aya-ebpf or
-    // programs written in C) as long as they don't exceed the number of CPUs.
-    //
-    // Otherwise, when the value is `0` or too large, we set it to the number of CPUs.
-    if def.map_type() == bpf_map_type::BPF_MAP_TYPE_PERF_EVENT_ARRAY as u32 {
-        let ncpus = nr_cpus().map_err(|e| (-1i64, e))? as u32;
-        if u.max_entries == 0 || u.max_entries > ncpus {
-            u.max_entries = ncpus;
-        }
-    };
-
     u.max_entries = def.max_entries();
     u.map_flags = def.map_flags();
 

--- a/xtask/public-api/aya.txt
+++ b/xtask/public-api/aya.txt
@@ -1352,6 +1352,7 @@ pub aya::maps::MapError::InvalidName::name: alloc::string::String
 pub aya::maps::MapError::InvalidValueSize
 pub aya::maps::MapError::InvalidValueSize::expected: usize
 pub aya::maps::MapError::InvalidValueSize::size: usize
+pub aya::maps::MapError::IoError(std::io::error::Error)
 pub aya::maps::MapError::KeyNotFound
 pub aya::maps::MapError::OutOfBounds
 pub aya::maps::MapError::OutOfBounds::index: u32
@@ -1372,6 +1373,8 @@ impl core::convert::From<aya::maps::MapError> for aya::programs::ProgramError
 pub fn aya::programs::ProgramError::from(source: aya::maps::MapError) -> Self
 impl core::convert::From<aya_obj::maps::InvalidMapTypeError> for aya::maps::MapError
 pub fn aya::maps::MapError::from(e: aya_obj::maps::InvalidMapTypeError) -> Self
+impl core::convert::From<std::io::error::Error> for aya::maps::MapError
+pub fn aya::maps::MapError::from(source: std::io::error::Error) -> Self
 impl core::error::Error for aya::maps::MapError
 pub fn aya::maps::MapError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
 impl core::fmt::Debug for aya::maps::MapError


### PR DESCRIPTION
There was a logic bug in the previously merged patch where we set the correctly calculated max_entries size with the original.

To fix this and prevent regressions a unit test was added. This highlighted that the original map definition needs to be mutated in order for the max_entries change to be properly applied.

As such, this resize logic moved out of aya::sys into aya::maps