### PR TITLE
codegen: add `tcx_action_base` enum to bindings

### DIFF
--- a/xtask/src/codegen/aya_ebpf_bindings.rs
+++ b/xtask/src/codegen/aya_ebpf_bindings.rs
@@ -57,6 +57,7 @@ pub fn codegen(opts: &SysrootOptions, libbpf_dir: &Path) -> Result<(), anyhow::E
             "user_pt_regs",
             "user_regs_struct",
             "xdp_action",
+            "tcx_action_base",
         ];
         let vars = ["BPF_.*", "bpf_.*", "TC_ACT_.*", "SOL_SOCKET", "SO_.*"];
 


### PR DESCRIPTION
Add tcx_action_base to pick up new TCX return codes, follow this pr up with a manual codegen actions run 

Relates to #918 and needed for #921

cc @dave-tucker 



