### PR TITLE
Revert "Remove unused `allow(dead_code)`"

### DIFF
--- a/aya-log/src/lib.rs
+++ b/aya-log/src/lib.rs
@@ -76,9 +76,11 @@ use bytes::BytesMut;
 use log::{error, Log, Record};
 use thiserror::Error;
 
+#[allow(dead_code)] // TODO(https://github.com/rust-lang/rust/issues/120770): Remove when false positive is fixed.
 #[derive(Copy, Clone)]
 #[repr(transparent)]
 struct RecordFieldWrapper(RecordField);
+#[allow(dead_code)] // TODO(https://github.com/rust-lang/rust/issues/120770): Remove when false positive is fixed.
 #[derive(Copy, Clone)]
 #[repr(transparent)]
 struct ArgumentWrapper(Argument);


### PR DESCRIPTION
Reverts aya-rs/aya#994. Upstream reverted dead_code changes.