### PR TITLE
Add a 6.10 linux kernel to the virtualized testing in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -261,6 +261,7 @@ jobs:
           # linux-image-5.10.0-23-cloud-arm64-unsigned_5.10.179-3_arm64.deb \
           printf '%s\0' \
             linux-image-6.1.0-16-cloud-arm64-unsigned_6.1.67-1_arm64.deb \
+            linux-image-6.10.4-cloud-arm64-unsigned_6.10.4-1_arm64.deb \
           | xargs -0 -t -P0 -I {} wget -nd -nv -P test/.tmp/debian-kernels/arm64 ftp://ftp.us.debian.org/debian/pool/main/l/linux/{}
 
       - name: Download debian kernels
@@ -273,6 +274,7 @@ jobs:
           # linux-image-5.10.0-23-cloud-amd64-unsigned_5.10.179-3_amd64.deb \
           printf '%s\0' \
             linux-image-6.1.0-16-cloud-amd64-unsigned_6.1.67-1_amd64.deb \
+            linux-image-6.10.4-cloud-amd64-unsigned_6.10.4-1_amd64.deb \
           | xargs -0 -t -P0 -I {} wget -nd -nv -P test/.tmp/debian-kernels/amd64 ftp://ftp.us.debian.org/debian/pool/main/l/linux/{}
 
       - name: Extract debian kernels

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,7 +96,7 @@ testing_logger = { version = "0.1.1", default-features = false }
 thiserror = { version = "1", default-features = false }
 tokio = { version = "1.24.0", default-features = false }
 which = { version = "6.0.0", default-features = false }
-xdpilone = { version = "1.0", default-features = false }
+xdpilone = { version = "1.0.5", default-features = false }
 xtask = { path = "xtask", default-features = false }
 
 [profile.dev]


### PR DESCRIPTION
Ensure we run our integration tests against `linux-image-6.10.4-cloud-amd64-unsigned_6.10.4-1_amd64.deb` 
    
Bump xdpilone version to fix bug on latest kernel.

