### PR TITLE
Appease nightly clippy

### DIFF
--- a/aya/src/programs/raw_trace_point.rs
+++ b/aya/src/programs/raw_trace_point.rs
@@ -9,9 +9,10 @@ use crate::{
     },
 };
 
-/// A program that can be attached at a pre-defined kernel trace point, but also
-/// has an access to kernel internal arguments of trace points, which
-/// differentiates them from traditional tracepoint eBPF programs.
+/// A program that can be attached at a pre-defined kernel trace point.
+///
+/// Unlike [`TracePoint`](super::TracePoint), the kernel does not pre-process
+/// the arguments before calling the program.
 ///
 /// The kernel provides a set of pre-defined trace points that eBPF programs can
 /// be attached to. See`/sys/kernel/debug/tracing/events` for a list of which

--- a/aya/src/programs/raw_trace_point.rs
+++ b/aya/src/programs/raw_trace_point.rs
@@ -25,8 +25,8 @@ use crate::{
 /// # Examples
 ///
 /// ```no_run
-/// # let mut bpf = Ebpf::load_file("ebpf_programs.o")?;
-/// use aya::{Ebpf, programs::RawTracePoint};
+/// # let mut bpf = aya::Ebpf::load(&[])?;
+/// use aya::programs::RawTracePoint;
 ///
 /// let program: &mut RawTracePoint = bpf.program_mut("sys_enter").unwrap().try_into()?;
 /// program.load()?;

--- a/aya/src/programs/trace_point.rs
+++ b/aya/src/programs/trace_point.rs
@@ -41,24 +41,13 @@ pub enum TracePointError {
 /// # Examples
 ///
 /// ```no_run
-/// # #[derive(Debug, thiserror::Error)]
-/// # enum Error {
-/// #     #[error(transparent)]
-/// #     IO(#[from] std::io::Error),
-/// #     #[error(transparent)]
-/// #     Map(#[from] aya::maps::MapError),
-/// #     #[error(transparent)]
-/// #     Program(#[from] aya::programs::ProgramError),
-/// #     #[error(transparent)]
-/// #     Ebpf(#[from] aya::EbpfError)
-/// # }
 /// # let mut bpf = aya::Ebpf::load(&[])?;
 /// use aya::programs::TracePoint;
 ///
 /// let prog: &mut TracePoint = bpf.program_mut("trace_context_switch").unwrap().try_into()?;
 /// prog.load()?;
 /// prog.attach("sched", "sched_switch")?;
-/// # Ok::<(), Error>(())
+/// # Ok::<(), aya::EbpfError>(())
 /// ```
 #[derive(Debug)]
 #[doc(alias = "BPF_PROG_TYPE_TRACEPOINT")]

--- a/ebpf/aya-ebpf/src/helpers.rs
+++ b/ebpf/aya-ebpf/src/helpers.rs
@@ -1,11 +1,13 @@
-//! This module contains kernel helper functions that may be exposed to specific BPF
-//! program types. These helpers can be used to perform common tasks, query and operate on
-//! data exposed by the kernel, and perform some operations that would normally be denied
-//! by the BPF verifier.
+//! This module contains kernel helper functions that may be exposed to specific
+//! BPF program types.
 //!
-//! Here, we provide some higher-level wrappers around the underlying kernel helpers, but
-//! also expose bindings to the underlying helpers as a fall-back in case of a missing
-//! implementation.
+//! These helpers can be used to perform common tasks, query and operate on data
+//! exposed by the kernel, and perform some operations that would normally be
+//! denied by the BPF verifier.
+//!
+//! Here, we provide some higher-level wrappers around the underlying kernel
+//! helpers, but also expose bindings to the underlying helpers as a fall-back
+//! in case of a missing implementation.
 
 use core::mem::{self, MaybeUninit};
 


### PR DESCRIPTION
```
error: first doc comment paragraph is too long
  --> aya/src/programs/raw_trace_point.rs:12:1
   |
12 | / /// A program that can be attached at a pre-defined kernel trace point, but also
13 | | /// has an access to kernel internal arguments of trace points, which
14 | | /// differentiates them from traditional tracepoint eBPF programs.
15 | | ///
16 | | /// The kernel provides a set of pre-defined trace points that eBPF programs can
   | |_
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#too_long_first_doc_paragraph

error: first doc comment paragraph is too long
  --> ebpf/aya-ebpf/src/helpers.rs:1:1
   |
1  | / //! This module contains kernel helper functions that may be exposed to specific BPF
2  | | //! program types. These helpers can be used to perform common tasks, query and operate on
3  | | //! data exposed by the kernel, and perform some operations that would normally be denied
4  | | //! by the BPF verifier.
5  | | //!
6  | | //! Here, we provide some higher-level wrappers around the underlying kernel helpers, but
   | |_
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#too_long_first_doc_paragraph
```
