### PR TITLE
codegen: add `bpf_perf_event_type` enum bindings

### DIFF
--- a/xtask/src/codegen/aya.rs
+++ b/xtask/src/codegen/aya.rs
@@ -80,6 +80,7 @@ fn codegen_bindings(opts: &SysrootOptions, libbpf_dir: &Path) -> Result<(), anyh
         "bpf_cpumap_val",
         "bpf_devmap_val",
         "bpf_stats_type",
+        "bpf_perf_event_type",
         // BTF
         "btf_header",
         "btf_ext_info",


### PR DESCRIPTION
Adds the `bpf_perf_event_type` enum to Rust FFI bindings.
This enum is used in `perf_event.type` field in `bpf_link_info` (https://elixir.bootlin.com/linux/v6.6/source/include/uapi/linux/bpf.h#L6530).

I plan to use it in another PR (coming soon) that implements `LinkInfo` for `bpf_link_info`.