### PR TITLE
aya-ebpf: Add set_reply accessor to SockOpsContext

### DIFF
--- a/ebpf/aya-ebpf/src/programs/sock_ops.rs
+++ b/ebpf/aya-ebpf/src/programs/sock_ops.rs
@@ -61,6 +61,10 @@ impl SockOpsContext {
     pub fn arg(&self, n: usize) -> u32 {
         unsafe { (*self.ops).__bindgen_anon_1.args[n] }
     }
+
+    pub fn set_reply(&mut self, reply: u32) {
+        unsafe { (*self.ops).__bindgen_anon_1.reply = reply }
+    }
 }
 
 impl EbpfContext for SockOpsContext {

--- a/xtask/public-api/aya-ebpf.txt
+++ b/xtask/public-api/aya-ebpf.txt
@@ -1821,6 +1821,7 @@ pub fn aya_ebpf::programs::sock_ops::SockOpsContext::remote_ip4(&self) -> u32
 pub fn aya_ebpf::programs::sock_ops::SockOpsContext::remote_ip6(&self) -> [u32; 4]
 pub fn aya_ebpf::programs::sock_ops::SockOpsContext::remote_port(&self) -> u32
 pub fn aya_ebpf::programs::sock_ops::SockOpsContext::set_cb_flags(&self, flags: i32) -> core::result::Result<(), i64>
+pub fn aya_ebpf::programs::sock_ops::SockOpsContext::set_reply(&mut self, reply: u32)
 impl aya_ebpf::EbpfContext for aya_ebpf::programs::sock_ops::SockOpsContext
 pub fn aya_ebpf::programs::sock_ops::SockOpsContext::as_ptr(&self) -> *mut core::ffi::c_void
 impl core::marker::Freeze for aya_ebpf::programs::sock_ops::SockOpsContext
@@ -2466,6 +2467,7 @@ pub fn aya_ebpf::programs::sock_ops::SockOpsContext::remote_ip4(&self) -> u32
 pub fn aya_ebpf::programs::sock_ops::SockOpsContext::remote_ip6(&self) -> [u32; 4]
 pub fn aya_ebpf::programs::sock_ops::SockOpsContext::remote_port(&self) -> u32
 pub fn aya_ebpf::programs::sock_ops::SockOpsContext::set_cb_flags(&self, flags: i32) -> core::result::Result<(), i64>
+pub fn aya_ebpf::programs::sock_ops::SockOpsContext::set_reply(&mut self, reply: u32)
 impl aya_ebpf::EbpfContext for aya_ebpf::programs::sock_ops::SockOpsContext
 pub fn aya_ebpf::programs::sock_ops::SockOpsContext::as_ptr(&self) -> *mut core::ffi::c_void
 impl core::marker::Freeze for aya_ebpf::programs::sock_ops::SockOpsContext


### PR DESCRIPTION
A sock_ops program should always return 1 on success, otherwise [`__cgroup_bpf_run_filter_sock_ops()`](https://github.com/torvalds/linux/commit/40304b2a1567fecc321f640ee4239556dd0f3ee0#diff-c3fa9a9d1fb31882db807c25992de189916efb3439621ccd625dcf22a8c953bf) would return `-EPERM`.

The reply fields of the `bpf_sock_ops` struct are there in case a bpf program needs to return a value. For example, [BPF_SOCK_OPS_TIMEOUT_INIT](https://github.com/torvalds/linux/commit/8550f328f45db6d37981eb2041bc465810245c03) and [BPF_SOCK_OPS_RWND_INIT](https://github.com/torvalds/linux/commit/13d3b1ebe28762c79e981931a41914fae5d04386) are invoked via [`tcp_call_bpf()`](https://github.com/torvalds/linux/commit/40304b2a1567fecc321f640ee4239556dd0f3ee0#diff-ff57716b18eaf625ed142c9cb45d80319f37663be3c35ef3001de8f614737111), which returns `sock_ops.reply` on success.

This follows up commit 3f6b2507b6c5c0da19b3a7fe3145240c3bab3c69 to cover all common accessors.