### PR TITLE
ci: pin rust to nightly-2024-09-09 until public-api fixed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: nightly
+          toolchain: nightly-2024-09-09
           components: rustfmt, clippy, miri, rust-src
 
       - uses: Swatinem/rust-cache@v2
@@ -55,7 +55,7 @@ jobs:
       - name: Run miri
         run: |
           set -euxo pipefail
-          cargo hack miri test --all-targets --feature-powerset \
+          cargo +nightly-2024-09-09 hack miri test --all-targets --feature-powerset \
             --exclude aya-ebpf \
             --exclude aya-ebpf-bindings \
             --exclude aya-log-ebpf \
@@ -149,7 +149,7 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: nightly
+          toolchain: nightly-2024-09-09
           components: rust-src
 
       - uses: Swatinem/rust-cache@v2
@@ -243,7 +243,7 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: nightly
+          toolchain: nightly-2024-09-09
           components: rust-src
           targets: aarch64-unknown-linux-musl,x86_64-unknown-linux-musl
 

--- a/.github/workflows/gen.yml
+++ b/.github/workflows/gen.yml
@@ -21,7 +21,7 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: nightly
+          toolchain: nightly-2024-09-09
           components: rustfmt, clippy
 
       - uses: Swatinem/rust-cache@v2

--- a/ebpf/rust-toolchain.toml
+++ b/ebpf/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "nightly"
+channel = "nightly-2024-09-09"

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,3 +1,3 @@
 [build]
 publish = "site"
-command = "rustup toolchain install nightly -c rust-src && cargo xtask docs"
+command = "rustup toolchain install nightly-2024-09-09 -c rust-src && cargo xtask docs"

--- a/test/integration-ebpf/rust-toolchain.toml
+++ b/test/integration-ebpf/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "nightly"
+channel = "nightly-2024-09-09"

--- a/xtask/src/docs.rs
+++ b/xtask/src/docs.rs
@@ -44,7 +44,7 @@ pub fn docs(metadata: Metadata) -> Result<()> {
         Command::new("cargo")
             .current_dir(&workspace_root)
             .env("RUSTDOCFLAGS", rustdocflags)
-            .args(["+nightly", "doc", "--no-deps", "--all-features"])
+            .args(["+nightly-2024-09-09", "doc", "--no-deps", "--all-features"])
             .args(
                 PACKAGE_TO_DESCRIPTION
                     .iter()

--- a/xtask/src/public_api.rs
+++ b/xtask/src/public_api.rs
@@ -24,7 +24,7 @@ pub struct Options {
 }
 
 pub fn public_api(options: Options, metadata: Metadata) -> Result<()> {
-    let toolchain = "nightly";
+    let toolchain = "nightly-2024-09-09";
     let Options { bless, target } = options;
 
     if !rustup_toolchain::is_installed(toolchain)? {


### PR DESCRIPTION
The public-api (cargo xtask public-api) is failing with the latest rust nightly package. Temporarily pin nightly to last known working version until the issue can be resolved.