### PR TITLE
Appease `static_mut_refs`

### DIFF
--- a/test/integration-ebpf/src/redirect.rs
+++ b/test/integration-ebpf/src/redirect.rs
@@ -22,7 +22,7 @@ static CPUS: CpuMap = CpuMap::with_max_entries(1, 0);
 /// counts how many times the map programs got executed.
 /// This allows the test harness to assert that a specific step got executed.
 #[map]
-static mut HITS: Array<u32> = Array::with_max_entries(2, 0);
+static HITS: Array<u32> = Array::with_max_entries(2, 0);
 
 #[xdp]
 pub fn redirect_sock(_ctx: XdpContext) -> u32 {
@@ -61,7 +61,7 @@ pub fn redirect_dev_chain(_ctx: XdpContext) -> u32 {
 
 #[inline(always)]
 fn inc_hit(index: u32) {
-    if let Some(hit) = unsafe { HITS.get_ptr_mut(index) } {
+    if let Some(hit) = HITS.get_ptr_mut(index) {
         unsafe { *hit += 1 };
     }
 }

--- a/test/integration-ebpf/src/relocations.rs
+++ b/test/integration-ebpf/src/relocations.rs
@@ -10,7 +10,7 @@ use aya_ebpf::{
 };
 
 #[map]
-static mut RESULTS: Array<u64> = Array::with_max_entries(3, 0);
+static RESULTS: Array<u64> = Array::with_max_entries(3, 0);
 
 #[uprobe]
 pub fn test_64_32_call_relocs(_ctx: ProbeContext) {

--- a/test/integration-test/src/tests/rbpf.rs
+++ b/test/integration-test/src/tests/rbpf.rs
@@ -53,6 +53,9 @@ fn use_map_with_rbpf() {
     //   so we keeps the pointers to our maps in MULTIMAP_MAPS, to be used in helpers.
     let mut maps = HashMap::new();
     let mut map_instances = vec![vec![0u64], vec![0u64], vec![0u64]];
+    unsafe {
+        MULTIMAP_MAPS = [null_mut(); 3];
+    }
     for (name, map) in object.maps.iter() {
         assert_eq!(map.key_size(), size_of::<u32>() as u32);
         assert_eq!(map.value_size(), size_of::<u64>() as u32);
@@ -110,10 +113,6 @@ fn use_map_with_rbpf() {
     assert_eq!(vm.execute_program().unwrap(), 0);
 
     assert_eq!(map_instances, [[24], [42], [44]]);
-
-    unsafe {
-        MULTIMAP_MAPS.iter_mut().for_each(|v| *v = null_mut());
-    }
 }
 
 #[track_caller]


### PR DESCRIPTION
Made stricter in https://github.com/rust-lang/rust/commit/5ba6db1b648d9.

I'm pretty sure our doctests still contain patterns that offend this lint but I couldn't figure out how to make them complain.
