### PR TITLE
Appease clippy

### DIFF
--- a/aya/src/maps/bloom_filter.rs
+++ b/aya/src/maps/bloom_filter.rs
@@ -32,7 +32,6 @@ use crate::{
 ///
 /// # Ok::<(), aya::EbpfError>(())
 /// ```
-
 #[doc(alias = "BPF_MAP_TYPE_BLOOM_FILTER")]
 #[derive(Debug)]
 pub struct BloomFilter<T, V: Pod> {

--- a/aya/src/maps/lpm_trie.rs
+++ b/aya/src/maps/lpm_trie.rs
@@ -44,7 +44,6 @@ use crate::{
 /// assert_eq!(value, 2);
 /// # Ok::<(), aya::EbpfError>(())
 /// ```
-
 #[doc(alias = "BPF_MAP_TYPE_LPM_TRIE")]
 #[derive(Debug)]
 pub struct LpmTrie<T, K, V> {

--- a/test/integration-ebpf/build.rs
+++ b/test/integration-ebpf/build.rs
@@ -14,7 +14,6 @@ use xtask::AYA_BUILD_INTEGRATION_BPF;
 /// which would likely mean far too much cache invalidation.
 ///
 /// [bindeps]: https://doc.rust-lang.org/nightly/cargo/reference/unstable.html?highlight=feature#artifact-dependencies
-
 fn main() {
     println!("cargo:rerun-if-env-changed={}", AYA_BUILD_INTEGRATION_BPF);
 

--- a/test/integration-test/build.rs
+++ b/test/integration-test/build.rs
@@ -36,7 +36,6 @@ use xtask::{exec, AYA_BUILD_INTEGRATION_BPF, LIBBPF_DIR};
 /// runtime because the stubs are inadequate for actually running the tests.
 ///
 /// [bindeps]: https://doc.rust-lang.org/nightly/cargo/reference/unstable.html?highlight=feature#artifact-dependencies
-
 fn main() {
     println!("cargo:rerun-if-env-changed={}", AYA_BUILD_INTEGRATION_BPF);
 

--- a/test/integration-test/src/tests/xdp.rs
+++ b/test/integration-test/src/tests/xdp.rs
@@ -1,4 +1,4 @@
-use std::{ffi::CStr, mem::MaybeUninit, net::UdpSocket, num::NonZeroU32, time::Duration};
+use std::{mem::MaybeUninit, net::UdpSocket, num::NonZeroU32, time::Duration};
 
 use aya::{
     maps::{Array, CpuMap, XskMap},
@@ -41,9 +41,7 @@ fn af_xdp() {
     };
 
     let mut iface = IfInfo::invalid();
-    iface
-        .from_name(CStr::from_bytes_with_nul(b"lo\0").unwrap())
-        .unwrap();
+    iface.from_name(c"lo").unwrap();
     let sock = Socket::with_shared(&iface, &umem).unwrap();
 
     let mut fq_cq = umem.fq_cq(&sock).unwrap(); // Fill Queue / Completion Queue


### PR DESCRIPTION
See https://github.com/rust-lang/rust/pull/130778.

```
warning: empty line after doc comment
  --> test/integration-ebpf/build.rs:16:1
   |
16 | / /// [bindeps]: https://doc.rust-lang.org/nightly/cargo/reference/unstable.html?highlight=feature#artifact-dependencies
17 | |
   | |_
18 |   fn main() {
   |   --------- the comment documents this function
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#empty_line_after_doc_comments
   = note: `#[warn(clippy::empty_line_after_doc_comments)]` on by default
   = help: if the empty line is unintentional remove it

error: empty line after doc comment
  --> aya/src/maps/bloom_filter.rs:34:1
   |
34 | / /// ```
35 | |
   | |_
...
38 |   pub struct BloomFilter<T, V: Pod> {
   |   --------------------------------- the comment documents this struct
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#empty_line_after_doc_comments
note: the lint level is defined here
  --> aya/src/lib.rs:41:5
   |
41 |     clippy::all,
   |     ^^^^^^^^^^^
   = note: `#[deny(clippy::empty_line_after_doc_comments)]` implied by `#[deny(clippy::all)]`
   = help: if the empty line is unintentional remove it

error: empty line after doc comment
  --> aya/src/maps/lpm_trie.rs:46:1
   |
46 | / /// ```
47 | |
   | |_
...
50 |   pub struct LpmTrie<T, K, V> {
   |   --------------------------- the comment documents this struct
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#empty_line_after_doc_comments
   = help: if the empty line is unintentional remove it

warning: empty line after doc comment
  --> test/integration-test/build.rs:38:1
   |
38 | / /// [bindeps]: https://doc.rust-lang.org/nightly/cargo/reference/unstable.html?highlight=feature#artifact-dependencies
39 | |
   | |_
40 |   fn main() {
   |   --------- the comment documents this function
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#empty_line_after_doc_comments
   = note: `#[warn(clippy::empty_line_after_doc_comments)]` on by default
   = help: if the empty line is unintentional remove it

warning: calling `CStr::new` with a byte string literal
  --> test/integration-test/src/tests/xdp.rs:45:20
   |
45 |         .from_name(CStr::from_bytes_with_nul(b"lo\0").unwrap())
   |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use a `c""` literal: `c"lo"`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#manual_c_str_literals
   = note: `#[warn(clippy::manual_c_str_literals)]` on by default
```
