### PR TITLE
handle unwrap while getting current kernel version

### DIFF
--- a/aya/src/programs/cgroup_device.rs
+++ b/aya/src/programs/cgroup_device.rs
@@ -1,7 +1,8 @@
 //! Cgroup device programs.
 
-use log::warn;
 use std::os::fd::AsFd;
+
+use log::warn;
 
 use crate::{
     generated::{bpf_attach_type::BPF_CGROUP_DEVICE, bpf_prog_type::BPF_PROG_TYPE_CGROUP_DEVICE},

--- a/aya/src/programs/cgroup_sock_addr.rs
+++ b/aya/src/programs/cgroup_sock_addr.rs
@@ -3,6 +3,7 @@
 use std::{hash::Hash, os::fd::AsFd, path::Path};
 
 pub use aya_obj::programs::CgroupSockAddrAttachType;
+use log::warn;
 
 use crate::{
     generated::bpf_prog_type::BPF_PROG_TYPE_CGROUP_SOCK_ADDR,
@@ -77,29 +78,42 @@ impl CgroupSockAddr {
         let prog_fd = prog_fd.as_fd();
         let cgroup_fd = cgroup.as_fd();
         let attach_type = self.data.expected_attach_type.unwrap();
-        if KernelVersion::current().unwrap() >= KernelVersion::new(5, 7, 0) {
-            let link_fd = bpf_link_create(
-                prog_fd,
-                LinkTarget::Fd(cgroup_fd),
-                attach_type,
-                None,
-                mode.into(),
-            )
-            .map_err(|(_, io_error)| SyscallError {
-                call: "bpf_link_create",
-                io_error,
-            })?;
-            self.data
-                .links
-                .insert(CgroupSockAddrLink::new(CgroupSockAddrLinkInner::Fd(
-                    FdLink::new(link_fd),
-                )))
-        } else {
-            let link = ProgAttachLink::attach(prog_fd, cgroup_fd, attach_type, mode)?;
 
-            self.data.links.insert(CgroupSockAddrLink::new(
-                CgroupSockAddrLinkInner::ProgAttach(link),
-            ))
+        match KernelVersion::current() {
+            Ok(version) => {
+                if version >= KernelVersion::new(5, 7, 0) {
+                    let link_fd = bpf_link_create(
+                        prog_fd,
+                        LinkTarget::Fd(cgroup_fd),
+                        attach_type,
+                        None,
+                        mode.into(),
+                    )
+                    .map_err(|(_, io_error)| SyscallError {
+                        call: "bpf_link_create",
+                        io_error,
+                    })?;
+                    self.data
+                        .links
+                        .insert(CgroupSockAddrLink::new(CgroupSockAddrLinkInner::Fd(
+                            FdLink::new(link_fd),
+                        )))
+                } else {
+                    let link = ProgAttachLink::attach(prog_fd, cgroup_fd, attach_type, mode)?;
+
+                    self.data.links.insert(CgroupSockAddrLink::new(
+                        CgroupSockAddrLinkInner::ProgAttach(link),
+                    ))
+                }
+            }
+            Err(_) => {
+                warn!("Warning: Can not get the current kernel version");
+                let link = ProgAttachLink::attach(prog_fd, cgroup_fd, attach_type, mode)?;
+
+                self.data.links.insert(CgroupSockAddrLink::new(
+                    CgroupSockAddrLinkInner::ProgAttach(link),
+                ))
+            }
         }
     }
 

--- a/aya/src/programs/cgroup_sockopt.rs
+++ b/aya/src/programs/cgroup_sockopt.rs
@@ -3,6 +3,7 @@
 use std::{hash::Hash, os::fd::AsFd, path::Path};
 
 pub use aya_obj::programs::CgroupSockoptAttachType;
+use log::warn;
 
 use crate::{
     generated::bpf_prog_type::BPF_PROG_TYPE_CGROUP_SOCKOPT,
@@ -74,31 +75,43 @@ impl CgroupSockopt {
         let prog_fd = prog_fd.as_fd();
         let cgroup_fd = cgroup.as_fd();
         let attach_type = self.data.expected_attach_type.unwrap();
-        if KernelVersion::current().unwrap() >= KernelVersion::new(5, 7, 0) {
-            let link_fd = bpf_link_create(
-                prog_fd,
-                LinkTarget::Fd(cgroup_fd),
-                attach_type,
-                None,
-                mode.into(),
-            )
-            .map_err(|(_, io_error)| SyscallError {
-                call: "bpf_link_create",
-                io_error,
-            })?;
-            self.data
-                .links
-                .insert(CgroupSockoptLink::new(CgroupSockoptLinkInner::Fd(
-                    FdLink::new(link_fd),
-                )))
-        } else {
-            let link = ProgAttachLink::attach(prog_fd, cgroup_fd, attach_type, mode)?;
+        match KernelVersion::current() {
+            Ok(version) => {
+                if version >= KernelVersion::new(5, 7, 0) {
+                    let link_fd = bpf_link_create(
+                        prog_fd,
+                        LinkTarget::Fd(cgroup_fd),
+                        attach_type,
+                        None,
+                        mode.into(),
+                    )
+                    .map_err(|(_, io_error)| SyscallError {
+                        call: "bpf_link_create",
+                        io_error,
+                    })?;
+                    self.data
+                        .links
+                        .insert(CgroupSockoptLink::new(CgroupSockoptLinkInner::Fd(
+                            FdLink::new(link_fd),
+                        )))
+                } else {
+                    let link = ProgAttachLink::attach(prog_fd, cgroup_fd, attach_type, mode)?;
 
-            self.data
-                .links
-                .insert(CgroupSockoptLink::new(CgroupSockoptLinkInner::ProgAttach(
-                    link,
-                )))
+                    self.data.links.insert(CgroupSockoptLink::new(
+                        CgroupSockoptLinkInner::ProgAttach(link),
+                    ))
+                }
+            }
+            Err(_) => {
+                warn!("Warning: Can not get the current kernel version");
+                let link = ProgAttachLink::attach(prog_fd, cgroup_fd, attach_type, mode)?;
+
+                self.data
+                    .links
+                    .insert(CgroupSockoptLink::new(CgroupSockoptLinkInner::ProgAttach(
+                        link,
+                    )))
+            }
         }
     }
 


### PR DESCRIPTION
Closes https://github.com/aya-rs/aya/issues/1024 

There is still 2 places where we still `unwrap` though. To handle it there might require changes to some functions that I am not sure if they should be part of this PR

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aya-rs/aya/1042)
<!-- Reviewable:end -->
