### PR TITLE
Appease clippy

### DIFF
--- a/aya-obj/src/obj.rs
+++ b/aya-obj/src/obj.rs
@@ -1080,7 +1080,7 @@ struct Section<'a> {
     relocations: Vec<Relocation>,
 }
 
-impl<'data, 'file, 'a> TryFrom<&'a ObjSection<'data, 'file>> for Section<'a> {
+impl<'a> TryFrom<&'a ObjSection<'_, '_>> for Section<'a> {
     type Error = ParseError;
 
     fn try_from(section: &'a ObjSection) -> Result<Section<'a>, ParseError> {


### PR DESCRIPTION
```
error: the following explicit lifetimes could be elided: 'data, 'file
    --> aya-obj/src/obj.rs:1083:6
     |
1083 | impl<'data, 'file, 'a> TryFrom<&'a ObjSection<'data, 'file>> for Section<'a> {
     |      ^^^^^  ^^^^^                             ^^^^^  ^^^^^
     |
     = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_lifetimes
```
