### PR TITLE
codegen: add `bpfcgroup_iter_order` `NFPROTO*` `nf_inet_hooks`

### DIFF
--- a/aya-obj/include/linux_wrapper.h
+++ b/aya-obj/include/linux_wrapper.h
@@ -2,6 +2,7 @@
 #include <linux/bpf.h>
 #include <linux/btf.h>
 #include <linux/if_link.h>
+#include <linux/netfilter.h>
 #include <linux/perf_event.h>
 #include <linux/pkt_cls.h>
 #include <linux/pkt_sched.h>

--- a/xtask/src/codegen/aya.rs
+++ b/xtask/src/codegen/aya.rs
@@ -109,6 +109,10 @@ fn codegen_bindings(opts: &SysrootOptions, libbpf_dir: &Path) -> Result<(), anyh
         // NETLINK
         "ifinfomsg",
         "tcmsg",
+        // ITER
+        "bpf_cgroup_iter_order",
+        // NETFILTER
+        "nf_inet_hooks",
     ];
 
     let vars = [
@@ -161,6 +165,8 @@ fn codegen_bindings(opts: &SysrootOptions, libbpf_dir: &Path) -> Result<(), anyh
         "TC_H_MIN_EGRESS",
         // Ringbuf
         "BPF_RINGBUF_.*",
+        // NETFILTER
+        "NFPROTO_.*",
     ];
 
     let dir = PathBuf::from("aya-obj");
@@ -211,7 +217,9 @@ fn codegen_bindings(opts: &SysrootOptions, libbpf_dir: &Path) -> Result<(), anyh
                 .constified_enum("BTF_VAR_.*")
                 .constified_enum("IFLA_.*")
                 .constified_enum("TCA_.*")
-                .constified_enum("BPF_RINGBUF_.*");
+                .constified_enum("BPF_RINGBUF_.*")
+                // NETFILTER
+                .constified_enum("NFPROTO_.*");
         }
 
         for x in &types {


### PR DESCRIPTION
Adds the following to codegen:
- `bpf_cgroup_iter_order`: used in `bpf_link_info.iter.group.order`
- `NFPROTO_*`: used in `bpf_link_info.netfilter.pf`
- `nf_inet_hooks`: used in `bpf_link_info.netfilter.hooknum`

`linux/netfilter.h` is included in `aya-obj/include/linux_wrapper.h` for `NFPROTO_.*` and `nf_inet_hooks` to generate.

This is all that's left for `bpf_link_info`. 🙃