### PR TITLE
WIP: auto-attach tracepoints based on SEC() data

### DIFF
--- a/aya-obj/src/obj.rs
+++ b/aya-obj/src/obj.rs
@@ -249,7 +249,10 @@ pub enum ProgramSection {
     URetProbe {
         sleepable: bool,
     },
-    TracePoint,
+    TracePoint {
+        category: Option<String>,
+        name: Option<String>,
+    },
     SocketFilter,
     Xdp {
         frags: bool,
@@ -330,7 +333,11 @@ impl FromStr for ProgramSection {
                 },
             },
             "tp_btf" => BtfTracePoint,
-            "tracepoint" | "tp" => TracePoint,
+            "tracepoint" | "tp" => {
+                let category = pieces.next().map(|s| s.to_string());
+                let name = pieces.next().map(|s| s.to_string());
+                TracePoint { category, name }
+            }
             "socket" => SocketFilter,
             "sk_msg" => SkMsg,
             "sk_skb" => {
@@ -2014,7 +2021,7 @@ mod tests {
         assert_matches!(
             obj.parse_section(fake_section(
                 EbpfSectionKind::Program,
-                "tracepoint/foo",
+                "tracepoint/cat/name",
                 bytes_of(&fake_ins()),
                 None
             )),

--- a/aya/src/programs/mod.rs
+++ b/aya/src/programs/mod.rs
@@ -146,6 +146,10 @@ pub enum ProgramError {
     #[error("the program is not attached")]
     NotAttached,
 
+    /// The program cannot be auto attached.
+    #[error("the program cannot be auto attached")]
+    CannotAutoAttach,
+
     /// Loading the program failed.
     #[error("the BPF_PROG_LOAD syscall failed. Verifier output: {verifier_log}")]
     LoadError {
@@ -939,7 +943,6 @@ macro_rules! impl_from_pin {
 
 // Use impl_from_pin if the program doesn't require additional data
 impl_from_pin!(
-    TracePoint,
     SocketFilter,
     SkMsg,
     CgroupSysctl,


### PR DESCRIPTION
This is mostly a conversation starter. The work originated in me asking about this on Discord [1].

I can try to flesh this out to a full solution, but I have some questions on what the ideal solution looks like:

Question 1: Currently I am mostly seeing these `SEC()` annotations in C bpf programs. The automatic template generator of the aya-ebpf tracepoints does not seem to populate the fields (tough it looks like they are supported!). Should we populate those fields there too?
libbpf-tools generates those .skel.h headers that allow automating the attach. I find that a nice QoL improvement over manually having to attach all the probes.

Question 2: I assume we also want to expose public getters for these fields?

Question 3: Do we want to extend this to all of the other "well-known" `SEC()` annotations that libbpf-tools uses? This would allow us to have a central `auto_attach()` that simply iterates over all programs and attaches them all?

Open TODOs:
- tests
- better documentation
- review contribution guidelines in detail


[1] https://discord.com/channels/855676609003651072/855676609003651075/1288759816612741120