### PR TITLE
HashMap: Impl. safe get_corrupt_u32()

### DIFF
--- a/ebpf/aya-ebpf/src/maps/hash_map.rs
+++ b/ebpf/aya-ebpf/src/maps/hash_map.rs
@@ -85,6 +85,16 @@ impl<K, V> HashMap<K, V> {
     }
 }
 
+impl<K> HashMap<K, u32> {
+    /// Retrieve the value associate with `key` from the map. This can not lead
+    /// to memory/type-safety bugs because a corrupt scalar can only lead to
+    /// logic bugs.
+    #[inline]
+    pub fn get_corrupt_u32(&self, key: &K) -> Option<&u32> {
+        unsafe { get(self.def.get(), key) }
+    }
+}
+
 #[repr(transparent)]
 pub struct LruHashMap<K, V> {
     def: UnsafeCell<bpf_map_def>,


### PR DESCRIPTION
Just a minimal patch to see if there is any need for discussion here. If needed and if you agree with this approach, similar safe functions could likely be implemented for other collections / scalar types.