### PR TITLE
fix(aya): BSS Sections must be filled with zeros

### DIFF
--- a/aya/src/maps/mod.rs
+++ b/aya/src/maps/mod.rs
@@ -637,7 +637,7 @@ impl MapData {
 
     pub(crate) fn finalize(&mut self) -> Result<(), MapError> {
         let Self { obj, fd } = self;
-        if !obj.data().is_empty() && obj.section_kind() != EbpfSectionKind::Bss {
+        if !obj.data().is_empty() {
             bpf_map_update_elem_ptr(fd.as_fd(), &0 as *const _, obj.data_mut().as_mut_ptr(), 0)
                 .map_err(|(_, io_error)| SyscallError {
                     call: "bpf_map_update_elem",

--- a/init/src/main.rs
+++ b/init/src/main.rs
@@ -128,6 +128,7 @@ fn run() -> anyhow::Result<()> {
             let path = entry.path();
             let status = std::process::Command::new(&path)
                 .args(&args)
+                .env("RUST_LOG", "debug")
                 .status()
                 .with_context(|| format!("failed to execute {}", path.display()))?;
 

--- a/test/integration-test/bpf/variables_reloc.bpf.c
+++ b/test/integration-test/bpf/variables_reloc.bpf.c
@@ -1,0 +1,21 @@
+// clang-format off
+#include <vmlinux.h>
+#include <bpf/bpf_helpers.h>
+// clang-format on
+
+volatile unsigned int key1 = 0;       // .bss
+volatile unsigned int key2 = 1;       // .data
+volatile const unsigned int key3 = 2; // .rodata
+
+SEC("xdp")
+int variables_reloc(struct xdp_md *ctx) {
+  if (key1 == 0 && key2 != 1 && key3 != 2) {
+    key1 += 1;
+    key2 += 1;
+    return XDP_DROP;
+  } else {
+    return XDP_PASS;
+  }
+}
+
+char _license[] SEC("license") = "GPL";

--- a/test/integration-test/build.rs
+++ b/test/integration-test/build.rs
@@ -71,6 +71,7 @@ fn main() {
         ("multimap-btf.bpf.c", false),
         ("reloc.bpf.c", true),
         ("text_64_64_reloc.c", false),
+        ("variables_reloc.bpf.c", false),
     ];
 
     if build_integration_bpf {

--- a/test/integration-test/src/lib.rs
+++ b/test/integration-test/src/lib.rs
@@ -9,6 +9,8 @@ pub const RELOC_BTF: &[u8] =
     include_bytes_aligned!(concat!(env!("OUT_DIR"), "/reloc.bpf.target.o"));
 pub const TEXT_64_64_RELOC: &[u8] =
     include_bytes_aligned!(concat!(env!("OUT_DIR"), "/text_64_64_reloc.o"));
+pub const VARIABLES_RELOC: &[u8] =
+    include_bytes_aligned!(concat!(env!("OUT_DIR"), "/variables_reloc.bpf.o"));
 
 pub const LOG: &[u8] = include_bytes_aligned!(concat!(env!("OUT_DIR"), "/log"));
 pub const MAP_TEST: &[u8] = include_bytes_aligned!(concat!(env!("OUT_DIR"), "/map_test"));

--- a/test/integration-test/src/tests/relocations.rs
+++ b/test/integration-test/src/tests/relocations.rs
@@ -1,4 +1,8 @@
-use aya::{programs::UProbe, util::KernelVersion, Ebpf};
+use aya::{
+    programs::{UProbe, Xdp},
+    util::KernelVersion,
+    Ebpf,
+};
 use test_log::test;
 
 #[test]
@@ -31,6 +35,17 @@ fn text_64_64_reloc() {
 
     assert_eq!(m.get(&0, 0).unwrap(), 2);
     assert_eq!(m.get(&1, 0).unwrap(), 3);
+}
+
+#[test]
+fn variables_reloc() {
+    let mut bpf = Ebpf::load(crate::VARIABLES_RELOC).unwrap();
+    let prog: &mut Xdp = bpf
+        .program_mut("variables_reloc")
+        .unwrap()
+        .try_into()
+        .unwrap();
+    prog.load().unwrap();
 }
 
 fn load_and_attach(name: &str, bytes: &[u8]) -> Ebpf {


### PR DESCRIPTION
See individual commits.

In summary, we need to fill BSS sections with 0's up to the size of the ELF section.
Otherwise access to these variables will fail with the following verifier error:

```
cannot access ptr member ops with moff 0 in struct bpf_map with off 0 size 4
```

Fixes: #1002 