### PR TITLE
Introducing Aya Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,8 @@
 [![Crates.io][crates-badge]][crates-url]
 ![License][license-badge]
 [![Build status][build-badge]][build-url]
-[![Book][book-badge]][book-url] [![Gurubase][gurubase-badge]][gurubase-url]
+[![Book][book-badge]][book-url]
+[![Gurubase][gurubase-badge]][gurubase-url]
 
 [crates-badge]: https://img.shields.io/crates/v/aya.svg?style=for-the-badge&logo=rust
 [crates-url]: https://crates.io/crates/aya

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Crates.io][crates-badge]][crates-url]
 ![License][license-badge]
 [![Build status][build-badge]][build-url]
-[![Book][book-badge]][book-url]
+[![Book][book-badge]][book-url] [![Gurubase][gurubase-badge]][gurubase-url]
 
 [crates-badge]: https://img.shields.io/crates/v/aya.svg?style=for-the-badge&logo=rust
 [crates-url]: https://crates.io/crates/aya
@@ -12,6 +12,8 @@
 [build-url]: https://github.com/aya-rs/aya/actions/workflows/ci.yml
 [book-badge]: https://img.shields.io/badge/read%20the-book-9cf.svg?style=for-the-badge&logo=mdbook
 [book-url]: https://aya-rs.dev/book
+[gurubase-badge]: https://img.shields.io/badge/Gurubase-Ask%20Aya%20Guru-006BFF?style=for-the-badge
+[gurubase-url]: https://gurubase.io/g/aya
 
 ## API Documentation
 


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [Aya Guru](https://gurubase.io/g/aya) to Gurubase. Aya Guru uses the data from this repo and data from the [docs](https://aya-rs.dev/) to answer questions by leveraging the LLM.

In this PR, I showcased the "Aya Guru", which highlights that Aya now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable Aya Guru in Gurubase, just let me know that's totally fine.
