### PR TITLE
fix unsupported maps warning message

### DIFF
--- a/aya/src/maps/mod.rs
+++ b/aya/src/maps/mod.rs
@@ -195,10 +195,12 @@ pub enum MapError {
     ProgIdNotSupported,
 
     /// Unsupported Map type
-    #[error("Unsupported map type found {map_type}")]
+    #[error("type of {name} ({map_type:?}) is unsupported; see `EbpfLoader::allow_unsupported_maps`")]
     Unsupported {
+        /// Map name
+        name: String,
         /// The map type
-        map_type: u32,
+        map_type: bpf_map_type,
     },
 }
 

--- a/xtask/public-api/aya.txt
+++ b/xtask/public-api/aya.txt
@@ -1362,7 +1362,8 @@ pub aya::maps::MapError::ProgIdNotSupported
 pub aya::maps::MapError::ProgramNotLoaded
 pub aya::maps::MapError::SyscallError(aya::sys::SyscallError)
 pub aya::maps::MapError::Unsupported
-pub aya::maps::MapError::Unsupported::map_type: u32
+pub aya::maps::MapError::Unsupported::map_type: aya_obj::generated::linux_bindings_x86_64::bpf_map_type
+pub aya::maps::MapError::Unsupported::name: alloc::string::String
 impl core::convert::From<aya::maps::MapError> for aya::EbpfError
 pub fn aya::EbpfError::from(source: aya::maps::MapError) -> Self
 impl core::convert::From<aya::maps::MapError> for aya::maps::xdp::XdpMapError


### PR DESCRIPTION
fix #1081 

the proposed solution is to remove the warning log and instead provide more meaningful information directly within the error itself.

without considering the issue, right now we have just a warning log (which contains the important information), but this is misleading since it actually leads to an error. I believe this can cause confusion because the critical details should be part of the error itself. For this reason I consolidated all the relevant information into the error message.

Additionally, I updated the `map_type` field type in `Unsupported` error from`u32` to `bpf_map_type`, as an unsupported map has a specific map type, which is distinct from a generic `u32` used in cases like the `InvalidMapType` error.

PS: Regarding `InvalidMapType` and other map-related errors, I believe they should also include the names of the maps.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aya-rs/aya/1092)
<!-- Reviewable:end -->
