### PR TITLE
aya-ebpf-macros: remove aya-ebpf version

### DIFF
--- a/aya-ebpf-macros/Cargo.toml
+++ b/aya-ebpf-macros/Cargo.toml
@@ -18,4 +18,4 @@ quote = { workspace = true }
 syn = { workspace = true, default-features = true, features = ["full"] }
 
 [dev-dependencies]
-aya-ebpf = { path = "../ebpf/aya-ebpf", version = "^0.1.1", default-features = false }
+aya-ebpf = { path = "../ebpf/aya-ebpf", default-features = false }


### PR DESCRIPTION
The presence of this version specification causes cargo-smart-release to
trip on the circular dependency.

Fixes #1050.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aya-rs/aya/1106)
<!-- Reviewable:end -->
