### PR TITLE
ci: download gen_init_cpio with authentication

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -299,7 +299,10 @@ jobs:
         run: cargo xtask integration-test local
 
       - name: Run virtualized integration tests
-        run: find test/.tmp -name 'vmlinuz-*' | xargs -t cargo xtask integration-test vm
+        run: |
+          set -euxo pipefail
+          find test/.tmp -name 'vmlinuz-*' -print0 | xargs -t -0 \
+            cargo xtask integration-test vm --github-api-token ${{ secrets.GITHUB_TOKEN }}
 
   # Provides a single status check for the entire build workflow.
   # This is used for merge automation, like Mergify, since GH actions


### PR DESCRIPTION
API rate limiting seems broken - let's hope this gets around it.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aya-rs/aya/1116)
<!-- Reviewable:end -->
