### PR TITLE
docs: update docs for load to mention include_bytes_aligned

### DIFF
--- a/aya/src/bpf.rs
+++ b/aya/src/bpf.rs
@@ -375,9 +375,9 @@ impl<'a> EbpfLoader<'a> {
 
     /// Loads eBPF bytecode from a buffer.
     ///
-    /// The buffer will need to be aligned to 4 bytes.
-    /// If you are bundling this statically into your binary, it is recommended that you do so
-    /// using [`include_bytes_aligned`](crate::include_bytes_aligned).
+    /// The buffer needs to be 4-bytes aligned. If you are bundling the bytecode statically
+    /// into your binary, it is recommended that you do so using
+    /// [`include_bytes_aligned`](crate::include_bytes_aligned).
     ///
     /// # Examples
     ///
@@ -902,9 +902,9 @@ impl Ebpf {
     /// [maps](crate::maps) defined in it. If the kernel supports [BTF](Btf)
     /// debug info, it is automatically loaded from `/sys/kernel/btf/vmlinux`.
     ///
-    /// The buffer will need to be aligned to 4 bytes.
-    /// If you are bundling this statically into your binary, it is recommended that you do so
-    /// using [`include_bytes_aligned`](crate::include_bytes_aligned).
+    /// The buffer needs to be 4-bytes aligned. If you are bundling the bytecode statically
+    /// into your binary, it is recommended that you do so using
+    /// [`include_bytes_aligned`](crate::include_bytes_aligned).
     ///
     /// For more loading options, see [EbpfLoader].
     ///

--- a/aya/src/bpf.rs
+++ b/aya/src/bpf.rs
@@ -375,7 +375,7 @@ impl<'a> EbpfLoader<'a> {
 
     /// Loads eBPF bytecode from a buffer.
     ///
-    /// The program will need to be aligned properly for you to use it.
+    /// The buffer will need to be aligned to 4 bytes.
     /// If you are bundling this statically into your binary, it is recommended that you do so
     /// using [`include_bytes_aligned`](crate::include_bytes_aligned).
     ///
@@ -902,7 +902,7 @@ impl Ebpf {
     /// [maps](crate::maps) defined in it. If the kernel supports [BTF](Btf)
     /// debug info, it is automatically loaded from `/sys/kernel/btf/vmlinux`.
     ///
-    /// The program will need to be aligned properly for you to use it.
+    /// The buffer will need to be aligned to 4 bytes.
     /// If you are bundling this statically into your binary, it is recommended that you do so
     /// using [`include_bytes_aligned`](crate::include_bytes_aligned).
     ///

--- a/aya/src/bpf.rs
+++ b/aya/src/bpf.rs
@@ -375,6 +375,10 @@ impl<'a> EbpfLoader<'a> {
 
     /// Loads eBPF bytecode from a buffer.
     ///
+    /// The program will need to be aligned properly for you to use it.
+    /// If you are bundling this statically into your binary, it is recommended that you do so
+    /// using [`include_bytes_aligned`](crate::include_bytes_aligned).
+    ///
     /// # Examples
     ///
     /// ```no_run
@@ -897,6 +901,10 @@ impl Ebpf {
     /// Parses the object code contained in `data` and initializes the
     /// [maps](crate::maps) defined in it. If the kernel supports [BTF](Btf)
     /// debug info, it is automatically loaded from `/sys/kernel/btf/vmlinux`.
+    ///
+    /// The program will need to be aligned properly for you to use it.
+    /// If you are bundling this statically into your binary, it is recommended that you do so
+    /// using [`include_bytes_aligned`](crate::include_bytes_aligned).
     ///
     /// For more loading options, see [EbpfLoader].
     ///


### PR DESCRIPTION
This macro is required if you are bundling programs statically into your binary, which is not an uncommon thing to do.

This change updates the documentation for the load function to mention this macro and the need for alignment.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aya-rs/aya/1119)
<!-- Reviewable:end -->
