### PR TITLE
Allow `+bpo` kernels

### DIFF
--- a/.github/scripts/download_kernel_images.sh
+++ b/.github/scripts/download_kernel_images.sh
@@ -19,14 +19,12 @@ readonly URLS
 # Find the latest revision of each kernel version.
 FILES=()
 for VERSION in "${VERSIONS[@]}"; do
-  while read -r line; do
-    FILES+=("$line")
-  done <<< "$(
-    printf '%s\n' "$URLS" \
-    | grep -E "linux-image-${VERSION//./\\.}\\.[0-9]+(-[0-9]+)?-cloud-${ARCHITECTURE}-unsigned_.*\\.deb" \
-    | sort -V \
-    | tail -n1
-  )"
+  REGEX="linux-image-${VERSION//./\\.}\\.[0-9]+(-[0-9]+)?(\+bpo)?-cloud-${ARCHITECTURE}-unsigned_.*\\.deb"
+  match=$(printf '%s\n' "$URLS" | grep -E "$REGEX" | sort -V | tail -n1) || {
+    printf '%s\nVERSION=%s\nREGEX=%s\n' "$URLS" "$VERSION" "$REGEX" >&2
+    exit 1
+  }
+  FILES+=("$match")
 done
 
 # TODO(https://github.com/curl/curl/issues/15729): restore --parallel here if and when it properly


### PR DESCRIPTION
Seems 6.10 is now being marked `+bpo`.

Improve error handling while I'm here.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aya-rs/aya/1127)
<!-- Reviewable:end -->
