### PR TITLE
lsm-cgroup: attachment type support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,7 +78,7 @@ indoc = { version = "2.0", default-features = false }
 libc = { version = "0.2.105", default-features = false }
 log = { version = "0.4", default-features = false }
 netns-rs = { version = "0.1", default-features = false }
-nix = { version = "0.29.0", default-features = false }
+nix = { version = "0.29.0", default-features = true }
 num_enum = { version = "0.7", default-features = false }
 object = { version = "0.36", default-features = false }
 octorust = { version = "0.9.0", default-features = false }

--- a/aya-ebpf-macros/src/lsm.rs
+++ b/aya-ebpf-macros/src/lsm.rs
@@ -9,6 +9,7 @@ use crate::args::{err_on_unknown_args, pop_bool_arg, pop_string_arg};
 pub(crate) struct Lsm {
     item: ItemFn,
     hook: Option<String>,
+    cgroup: bool,
     sleepable: bool,
 }
 
@@ -18,46 +19,64 @@ impl Lsm {
         let mut args = syn::parse2(attrs)?;
         let hook = pop_string_arg(&mut args, "hook");
         let sleepable = pop_bool_arg(&mut args, "sleepable");
+        let cgroup = pop_bool_arg(&mut args, "cgroup");
         err_on_unknown_args(&args)?;
+
         Ok(Self {
             item,
             hook,
+            cgroup,
             sleepable,
         })
     }
 
     pub(crate) fn expand(&self) -> TokenStream {
-        let Self {
-            item,
-            hook,
-            sleepable,
-        } = self;
-        let ItemFn {
-            attrs: _,
-            vis,
-            sig,
-            block: _,
-        } = item;
-        let section_prefix = if *sleepable { "lsm.s" } else { "lsm" };
-        let section_name: Cow<'_, _> = if let Some(hook) = hook {
-            format!("{}/{}", section_prefix, hook).into()
-        } else {
-            section_prefix.into()
-        };
-        // LSM probes need to return an integer corresponding to the correct
-        // policy decision. Therefore we do not simply default to a return value
-        // of 0 as in other program types.
-        let fn_name = &sig.ident;
-        quote! {
-            #[no_mangle]
-            #[link_section = #section_name]
-            #vis fn #fn_name(ctx: *mut ::core::ffi::c_void) -> i32 {
-                return #fn_name(::aya_ebpf::programs::LsmContext::new(ctx));
+        if self.cgroup{
+            let section_name = if let Some(name) = &self.hook{
+                format!("lsm_cgroup/{}", name)
+            } else {
+                ("lsm_cgroup").to_owned()
+            };
+                
+            let fn_name = &self.item.sig.ident;
+            let item = &self.item;
 
-                #item
+            quote! {
+                #[no_mangle]
+                #[link_section = #section_name]
+                fn #fn_name(ctx: *mut ::core::ffi::c_void) -> i32 {
+                    return #fn_name(::aya_ebpf::programs::LsmContext::new(ctx));
+    
+                    #item
+                }
+            }
+        } else {
+            let section_prefix = if self.sleepable { "lsm.s" } else { "lsm" };
+            let section_name: Cow<'_, _> = if let Some(hook) = &self.hook {
+                format!("{}/{}", section_prefix, hook).into()
+            } else {
+                section_prefix.into()
+            };
+
+            let fn_vis = &self.item.vis;
+            let fn_name = self.item.sig.ident.clone();
+            let item = &self.item;
+
+            quote! {
+                #[no_mangle]
+                #[link_section = #section_name]
+                #fn_vis fn #fn_name(ctx: *mut ::core::ffi::c_void) -> i32 {
+                    return #fn_name(::aya_ebpf::programs::LsmContext::new(ctx));
+    
+                    #item
+                }
             }
         }
     }
+
+    // LSM probes need to return an integer corresponding to the correct
+    // policy decision. Therefore we do not simply default to a return value
+    // of 0 as in other program types.
 }
 
 #[cfg(test)]
@@ -112,6 +131,35 @@ mod tests {
         let expected = quote! {
             #[no_mangle]
             #[link_section = "lsm/bprm_committed_creds"]
+            fn bprm_committed_creds(ctx: *mut ::core::ffi::c_void) -> i32 {
+                return bprm_committed_creds(::aya_ebpf::programs::LsmContext::new(ctx));
+
+                fn bprm_committed_creds(ctx: &mut ::aya_ebpf::programs::LsmContext) -> i32 {
+                    0
+                }
+            }
+        };
+        assert_eq!(expected.to_string(), expanded.to_string());
+    }
+
+    #[test]
+    fn test_lsm_cgroup() {
+        let prog = Lsm::parse(
+            parse_quote! {
+                hook = "bprm_committed_creds",
+                cgroup
+            },
+            parse_quote! {
+                fn bprm_committed_creds(ctx: &mut ::aya_ebpf::programs::LsmContext) -> i32 {
+                    0
+                }
+            },
+        )
+        .unwrap();
+        let expanded = prog.expand();
+        let expected = quote! {
+            #[no_mangle]
+            #[link_section = "lsm_cgroup/bprm_committed_creds"]
             fn bprm_committed_creds(ctx: *mut ::core::ffi::c_void) -> i32 {
                 return bprm_committed_creds(::aya_ebpf::programs::LsmContext::new(ctx));
 

--- a/aya-obj/src/obj.rs
+++ b/aya-obj/src/obj.rs
@@ -27,7 +27,7 @@ use crate::{
     },
     maps::{bpf_map_def, BtfMap, BtfMapDef, LegacyMap, Map, PinningType, MINIMUM_MAP_SIZE},
     programs::{
-        CgroupSockAddrAttachType, CgroupSockAttachType, CgroupSockoptAttachType, XdpAttachType,
+        CgroupSockAddrAttachType, CgroupSockAttachType, CgroupSockoptAttachType, LsmAttachType, XdpAttachType
     },
     relocation::*,
     util::HashMap,
@@ -274,6 +274,7 @@ pub enum ProgramSection {
     RawTracePoint,
     Lsm {
         sleepable: bool,
+        attach_type: LsmAttachType,
     },
     BtfTracePoint,
     FEntry {
@@ -434,8 +435,9 @@ impl FromStr for ProgramSection {
             "lirc_mode2" => LircMode2,
             "perf_event" => PerfEvent,
             "raw_tp" | "raw_tracepoint" => RawTracePoint,
-            "lsm" => Lsm { sleepable: false },
-            "lsm.s" => Lsm { sleepable: true },
+            "lsm" => Lsm { sleepable: false, attach_type: LsmAttachType::Mac},
+            "lsm.s" => Lsm { sleepable: true, attach_type: LsmAttachType::Mac },
+            "lsm_cgroup" => Lsm { sleepable: false, attach_type: LsmAttachType::Cgroup },
             "fentry" => FEntry { sleepable: false },
             "fentry.s" => FEntry { sleepable: true },
             "fexit" => FExit { sleepable: false },
@@ -2190,7 +2192,7 @@ mod tests {
             Some(Program {
                 section: ProgramSection::Lsm {
                     sleepable: false,
-                    ..
+                    attach_type: LsmAttachType::Mac
                 },
                 ..
             })
@@ -2217,6 +2219,32 @@ mod tests {
                 section: ProgramSection::Lsm {
                     sleepable: true,
                     ..
+                },
+                ..
+            })
+        );
+    }
+
+    #[test]
+    fn test_parse_section_lsm_cgroup() {
+        let mut obj = fake_obj();
+        fake_sym(&mut obj, 0, 0, "foo", FAKE_INS_LEN);
+
+        assert_matches!(
+            obj.parse_section(fake_section(
+                EbpfSectionKind::Program,
+                "lsm_cgroup/foo",
+                bytes_of(&fake_ins()),
+                None
+            )),
+            Ok(())
+        );
+        assert_matches!(
+            obj.programs.get("foo"),
+            Some(Program {
+                section: ProgramSection::Lsm {
+                    sleepable: false,
+                    attach_type: LsmAttachType::Cgroup
                 },
                 ..
             })

--- a/aya-obj/src/programs/lsm.rs
+++ b/aya-obj/src/programs/lsm.rs
@@ -1,0 +1,21 @@
+//! XDP programs.
+
+use crate::generated::bpf_attach_type;
+
+/// Defines where to attach an `XDP` program.
+#[derive(Copy, Clone, Debug)]
+pub enum LsmAttachType {
+    /// Cgroup based LSM program
+    Cgroup,
+    /// MAC based LSM program
+    Mac,
+}
+
+impl From<LsmAttachType> for bpf_attach_type {
+    fn from(value: LsmAttachType) -> Self {
+        match value {
+            LsmAttachType::Cgroup => bpf_attach_type::BPF_LSM_CGROUP,
+            LsmAttachType::Mac => bpf_attach_type::BPF_LSM_MAC,
+        }
+    }
+}

--- a/aya-obj/src/programs/mod.rs
+++ b/aya-obj/src/programs/mod.rs
@@ -5,8 +5,10 @@ pub mod cgroup_sock_addr;
 pub mod cgroup_sockopt;
 mod types;
 pub mod xdp;
+pub mod lsm;
 
 pub use cgroup_sock::CgroupSockAttachType;
 pub use cgroup_sock_addr::CgroupSockAddrAttachType;
 pub use cgroup_sockopt::CgroupSockoptAttachType;
 pub use xdp::XdpAttachType;
+pub use lsm::LsmAttachType;

--- a/aya/src/bpf.rs
+++ b/aya/src/bpf.rs
@@ -411,7 +411,7 @@ impl<'a> EbpfLoader<'a> {
                                 ProgramSection::Extension
                                 | ProgramSection::FEntry { sleepable: _ }
                                 | ProgramSection::FExit { sleepable: _ }
-                                | ProgramSection::Lsm { sleepable: _ }
+                                | ProgramSection::Lsm { sleepable: _, attach_type: _ }
                                 | ProgramSection::BtfTracePoint
                                 | ProgramSection::Iter { sleepable: _ } => {
                                     return Err(EbpfError::BtfError(err))
@@ -649,13 +649,16 @@ impl<'a> EbpfLoader<'a> {
                         ProgramSection::RawTracePoint => Program::RawTracePoint(RawTracePoint {
                             data: ProgramData::new(prog_name, obj, btf_fd, *verifier_log_level),
                         }),
-                        ProgramSection::Lsm { sleepable } => {
+                        ProgramSection::Lsm { sleepable , attach_type} => {
                             let mut data =
                                 ProgramData::new(prog_name, obj, btf_fd, *verifier_log_level);
                             if *sleepable {
                                 data.flags = BPF_F_SLEEPABLE;
                             }
-                            Program::Lsm(Lsm { data })
+                            Program::Lsm(Lsm { 
+                                data,
+                                attach_type: *attach_type,
+                            })  
                         }
                         ProgramSection::BtfTracePoint => Program::BtfTracePoint(BtfTracePoint {
                             data: ProgramData::new(prog_name, obj, btf_fd, *verifier_log_level),

--- a/aya/src/programs/mod.rs
+++ b/aya/src/programs/mod.rs
@@ -963,7 +963,6 @@ impl_from_pin!(
     CgroupSysctl,
     LircMode2,
     PerfEvent,
-    Lsm,
     RawTracePoint,
     BtfTracePoint,
     FEntry,

--- a/test/integration-ebpf/src/test.rs
+++ b/test/integration-ebpf/src/test.rs
@@ -2,9 +2,7 @@
 #![no_main]
 
 use aya_ebpf::{
-    bindings::xdp_action,
-    macros::{kprobe, kretprobe, tracepoint, uprobe, uretprobe, xdp},
-    programs::{ProbeContext, RetProbeContext, TracePointContext, XdpContext},
+    bindings::xdp_action, helpers::{bpf_get_current_cgroup_id, bpf_get_current_pid_tgid}, macros::{kprobe, kretprobe, lsm, tracepoint, uprobe, uretprobe, xdp}, programs::{LsmContext, ProbeContext, RetProbeContext, TracePointContext, XdpContext}
 };
 
 #[xdp]
@@ -41,6 +39,11 @@ pub fn test_uprobe(_ctx: ProbeContext) -> u32 {
 
 #[uretprobe]
 pub fn test_uretprobe(_ctx: RetProbeContext) -> u32 {
+    0
+}
+
+#[lsm(hook="socket_bind", cgroup)]
+pub fn test_lsmcgroup(_ctx: LsmContext) -> i32 {
     0
 }
 

--- a/test/integration-test/Cargo.toml
+++ b/test/integration-test/Cargo.toml
@@ -28,6 +28,7 @@ test-case = { workspace = true }
 test-log = { workspace = true, features = ["log"] }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread", "time"] }
 xdpilone = { workspace = true }
+nix = { workspace = true, features = ["process"]}
 
 [build-dependencies]
 anyhow = { workspace = true }

--- a/test/integration-test/src/tests.rs
+++ b/test/integration-test/src/tests.rs
@@ -13,3 +13,4 @@ mod smoke;
 mod strncmp;
 mod tcx;
 mod xdp;
+mod lsm;

--- a/test/integration-test/src/tests/lsm.rs
+++ b/test/integration-test/src/tests/lsm.rs
@@ -1,0 +1,54 @@
+use std::{fs::File, io::{ErrorKind, Write}, path::Path};
+use aya::{programs::Lsm, util::KernelVersion, Btf, Ebpf};
+use std::net::{Ipv4Addr, SocketAddr, SocketAddrV4, TcpListener};
+use nix::{
+    sys::wait::waitpid,
+    unistd::{fork, getpid, ForkResult},
+};
+
+#[test]
+fn lsm_cgroup() {
+    let kernel_version = KernelVersion::current().unwrap();
+    if kernel_version < KernelVersion::new(6, 0, 0) {
+        eprintln!("skipping lsm_cgroup test on kernel {kernel_version:?}");
+        return;
+    }
+
+    let mut bpf: Ebpf = Ebpf::load(crate::TEST).unwrap();
+    let prog: &mut Lsm = bpf.program_mut("test_lsmcgroup").unwrap().try_into().unwrap();
+    let btf = Btf::from_sys_fs().expect("could not get btf from sys");
+    if let Err(err) = prog.load("socket_bind", &btf) {
+        panic!("{err}");
+    }
+
+    let cgroup_path = Path::new(".").join("/sys/fs/cgroup/").join("lsm_cgroup_test");
+
+    let _ = std::fs::create_dir_all( cgroup_path.clone()).expect("could not create the cgroup dir");
+
+    let p = prog.attach(
+        Some(File::open(cgroup_path.clone()).unwrap()),
+    )
+    .unwrap();
+
+    unsafe {
+        match fork().expect("Failed to fork process") {
+            ForkResult::Parent { child } => {
+                waitpid(Some(child), None).unwrap();
+
+                let pid = getpid();
+
+                let mut f = File::create(cgroup_path.join("cgroup.procs")).expect("could not open cgroup procs");
+                f.write_fmt(format_args!("{}",pid.as_raw() as u64)).expect("could not write into procs file");
+                
+                assert_matches::assert_matches!(TcpListener::bind("127.0.0.1:12345"), Err(e) => assert_eq!(
+                    e.kind(), ErrorKind::PermissionDenied)
+                );
+            }
+            ForkResult::Child => {
+                assert_matches::assert_matches!(TcpListener::bind("127.0.0.1:12345"), Ok(listener) => assert_eq!(
+                    listener.local_addr().unwrap(), SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::new(127, 0, 0, 1), 12345)))
+                );
+            }
+        }
+    }
+}


### PR DESCRIPTION

I have followed up on the work from this [PR](https://github.com/aya-rs/aya/pull/439/files#diff-792650682d4fc9f2b2074750a52da94fe53ab86c6cd53b418268dc7337aa7fbd), which has been more than 2 years since the initial commit for lsm_cgroup support created,

so i basically re-implemented it so it would be using the latest aya infrastructure and we will have a single LSM program type that would support both attachment types, instead of creating a different program type for each attachment type. I thought this would make it more consistent with the relevant BPF API provided by the OS.

@vadorovsky @dave-tucker i would really appreciate your review on this, and let me know if there is anything needs to be done before merging this into upstream.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aya-rs/aya/1131)
<!-- Reviewable:end -->
