### PR TITLE
Appease clippy

### DIFF
--- a/aya/src/programs/uprobe.rs
+++ b/aya/src/programs/uprobe.rs
@@ -279,7 +279,7 @@ fn proc_maps_libs(pid: pid_t) -> Result<Vec<(OsString, PathBuf)>, io::Error> {
                 }
                 break;
             }
-            let path = line.split(|b| b.is_ascii_whitespace()).last()?;
+            let path = line.split(|b| b.is_ascii_whitespace()).next_back()?;
             let path = Path::new(OsStr::from_bytes(path));
             path.is_absolute()
                 .then(|| {


### PR DESCRIPTION
```
error: called `Iterator::last` on a `DoubleEndedIterator`; this will needlessly iterate the entire iterator
   --> aya/src/programs/uprobe.rs:282:64
    |
282 |             let path = line.split(|b| b.is_ascii_whitespace()).last()?;
    |                                                                ^^^^^^ help: try: `next_back()`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#double_ended_iterator_last
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aya-rs/aya/1134)
<!-- Reviewable:end -->
