### PR TITLE
Fix aya-ebpf-* riscv64 build

### DIFF
--- a/ebpf/aya-ebpf-bindings/build.rs
+++ b/ebpf/aya-ebpf-bindings/build.rs
@@ -6,7 +6,10 @@ fn main() {
         println!("cargo:rustc-cfg=bpf_target_arch=\"{arch}\"");
     } else {
         let arch = env::var("HOST").unwrap();
-        let arch = arch.split_once('-').map_or(&*arch, |x| x.0);
+        let mut arch = arch.split_once('-').map_or(&*arch, |x| x.0);
+        if arch.starts_with("riscv64") {
+            arch = "riscv64";
+        }
         println!("cargo:rustc-cfg=bpf_target_arch=\"{arch}\"");
     }
     println!("cargo::rustc-check-cfg=cfg(bpf_target_arch, values(\"x86_64\",\"arm\",\"aarch64\",\"riscv64\",\"powerpc64\",\"s390x\"))");

--- a/ebpf/aya-ebpf-cty/build.rs
+++ b/ebpf/aya-ebpf-cty/build.rs
@@ -6,7 +6,10 @@ fn main() {
         println!("cargo:rustc-cfg=bpf_target_arch=\"{arch}\"");
     } else {
         let arch = env::var("HOST").unwrap();
-        let arch = arch.split_once('-').map_or(&*arch, |x| x.0);
+        let mut arch = arch.split_once('-').map_or(&*arch, |x| x.0);
+        if arch.starts_with("riscv64") {
+            arch = "riscv64";
+        }
         println!("cargo:rustc-cfg=bpf_target_arch=\"{arch}\"");
     }
     println!("cargo::rustc-check-cfg=cfg(bpf_target_arch, values(\"x86_64\",\"arm\",\"aarch64\",\"riscv64\",\"powerpc64\",\"s390x\"))");

--- a/ebpf/aya-ebpf/build.rs
+++ b/ebpf/aya-ebpf/build.rs
@@ -7,7 +7,10 @@ fn main() {
         println!("cargo:rustc-cfg=bpf_target_arch=\"{arch}\"");
     } else {
         let arch = env::var("HOST").unwrap();
-        let arch = arch.split_once('-').map_or(&*arch, |x| x.0);
+        let mut arch = arch.split_once('-').map_or(&*arch, |x| x.0);
+        if arch.starts_with("riscv64") {
+            arch = "riscv64";
+        }
         println!("cargo:rustc-cfg=bpf_target_arch=\"{arch}\"");
     }
     println!("cargo::rustc-check-cfg=cfg(bpf_target_arch, values(\"x86_64\",\"arm\",\"aarch64\",\"riscv64\",\"powerpc64\",\"s390x\"))");


### PR DESCRIPTION
bpf_target_arch should be riscv64, but target triple starts with riscv64gc (and possibly riscv64 followed by any combination of extensions).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aya-rs/aya/1139)
<!-- Reviewable:end -->
