### PR TITLE
aya-ebpf: add ifindex support to XdpContext

### DIFF
--- a/ebpf/aya-ebpf/src/programs/xdp.rs
+++ b/ebpf/aya-ebpf/src/programs/xdp.rs
@@ -21,6 +21,12 @@ impl XdpContext {
         unsafe { (*self.ctx).data_end as usize }
     }
 
+    /// Return the interface of the index as determined by the OS.
+    #[inline]
+    pub fn ingress_ifindex(&self) -> usize {
+        unsafe { (*self.ctx).ingress_ifindex as usize }
+    }
+
     /// Return the raw address of the XdpContext metadata.
     #[inline(always)]
     pub fn metadata(&self) -> usize {

--- a/xtask/public-api/aya-ebpf.txt
+++ b/xtask/public-api/aya-ebpf.txt
@@ -2018,6 +2018,7 @@ pub aya_ebpf::programs::xdp::XdpContext::ctx: *mut aya_ebpf_bindings::x86_64::bi
 impl aya_ebpf::programs::xdp::XdpContext
 pub fn aya_ebpf::programs::xdp::XdpContext::data(&self) -> usize
 pub fn aya_ebpf::programs::xdp::XdpContext::data_end(&self) -> usize
+pub fn aya_ebpf::programs::xdp::XdpContext::ingress_ifindex(&self) -> usize
 pub fn aya_ebpf::programs::xdp::XdpContext::metadata(&self) -> usize
 pub fn aya_ebpf::programs::xdp::XdpContext::metadata_end(&self) -> usize
 pub fn aya_ebpf::programs::xdp::XdpContext::new(ctx: *mut aya_ebpf_bindings::x86_64::bindings::xdp_md) -> aya_ebpf::programs::xdp::XdpContext
@@ -2631,6 +2632,7 @@ pub aya_ebpf::programs::XdpContext::ctx: *mut aya_ebpf_bindings::x86_64::binding
 impl aya_ebpf::programs::xdp::XdpContext
 pub fn aya_ebpf::programs::xdp::XdpContext::data(&self) -> usize
 pub fn aya_ebpf::programs::xdp::XdpContext::data_end(&self) -> usize
+pub fn aya_ebpf::programs::xdp::XdpContext::ingress_ifindex(&self) -> usize
 pub fn aya_ebpf::programs::xdp::XdpContext::metadata(&self) -> usize
 pub fn aya_ebpf::programs::xdp::XdpContext::metadata_end(&self) -> usize
 pub fn aya_ebpf::programs::xdp::XdpContext::new(ctx: *mut aya_ebpf_bindings::x86_64::bindings::xdp_md) -> aya_ebpf::programs::xdp::XdpContext


### PR DESCRIPTION
This change exposes the ifindex field from the underlying xdp_md data structure to the XdpContext in Aya. The ifindex represents the unique OS-provided index for a network interface.

Fixes #1140

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aya-rs/aya/1141)
<!-- Reviewable:end -->
