### PR TITLE
feat(aya): Add is_program_type_supported

### DIFF
--- a/aya/src/bpf.rs
+++ b/aya/src/bpf.rs
@@ -30,8 +30,9 @@ use crate::{
     programs::{
         BtfTracePoint, CgroupDevice, CgroupSkb, CgroupSkbAttachType, CgroupSock, CgroupSockAddr,
         CgroupSockopt, CgroupSysctl, Extension, FEntry, FExit, Iter, KProbe, LircMode2, Lsm,
-        PerfEvent, ProbeKind, Program, ProgramData, ProgramError, RawTracePoint, SchedClassifier,
-        SkLookup, SkMsg, SkSkb, SkSkbKind, SockOps, SocketFilter, TracePoint, UProbe, Xdp,
+        PerfEvent, ProbeKind, Program, ProgramData, ProgramError, ProgramType, RawTracePoint,
+        SchedClassifier, SkLookup, SkMsg, SkSkb, SkSkbKind, SockOps, SocketFilter, TracePoint,
+        UProbe, Xdp,
     },
     sys::{
         bpf_load_btf, is_bpf_cookie_supported, is_bpf_global_data_supported,
@@ -39,7 +40,8 @@ use crate::{
         is_btf_float_supported, is_btf_func_global_supported, is_btf_func_supported,
         is_btf_supported, is_btf_type_tag_supported, is_info_gpl_compatible_supported,
         is_info_map_ids_supported, is_perf_link_supported, is_probe_read_kernel_supported,
-        is_prog_id_supported, is_prog_name_supported, retry_with_verifier_logs,
+        is_prog_id_supported, is_prog_name_supported, is_prog_type_supported,
+        retry_with_verifier_logs,
     },
     util::{bytes_of, bytes_of_slice, nr_cpus, page_size},
 };
@@ -103,6 +105,26 @@ fn detect_features() -> Features {
 /// Returns a reference to the detected BPF features.
 pub fn features() -> &'static Features {
     &FEATURES
+}
+
+/// Returns whether a program type is supported by the running kernel.
+///
+/// # Errors
+///
+/// Returns an error if an unexpected error occurs while checking the program
+/// type support.
+///
+/// # Example
+///
+/// ```no_run
+/// use aya::{is_program_type_supported, programs::ProgramType};
+///
+/// let supported = is_program_type_supported(ProgramType::Xdp)?;
+/// # Ok::<(), aya::EbpfError>(())
+/// ```
+pub fn is_program_type_supported(program_type: ProgramType) -> Result<bool, EbpfError> {
+    is_prog_type_supported(program_type.into())
+        .map_err(|e| EbpfError::ProgramError(ProgramError::from(e)))
 }
 
 /// Builder style API for advanced loading of eBPF programs.

--- a/aya/src/programs/info.rs
+++ b/aya/src/programs/info.rs
@@ -475,6 +475,46 @@ pub enum ProgramType {
     Netfilter = bpf_prog_type::BPF_PROG_TYPE_NETFILTER as isize,
 }
 
+impl From<ProgramType> for bpf_prog_type {
+    fn from(value: ProgramType) -> Self {
+        match value {
+            ProgramType::Unspecified => Self::BPF_PROG_TYPE_UNSPEC,
+            ProgramType::SocketFilter => Self::BPF_PROG_TYPE_SOCKET_FILTER,
+            ProgramType::KProbe => Self::BPF_PROG_TYPE_KPROBE,
+            ProgramType::SchedClassifier => Self::BPF_PROG_TYPE_SCHED_CLS,
+            ProgramType::SchedAction => Self::BPF_PROG_TYPE_SCHED_ACT,
+            ProgramType::TracePoint => Self::BPF_PROG_TYPE_TRACEPOINT,
+            ProgramType::Xdp => Self::BPF_PROG_TYPE_XDP,
+            ProgramType::PerfEvent => Self::BPF_PROG_TYPE_PERF_EVENT,
+            ProgramType::CgroupSkb => Self::BPF_PROG_TYPE_CGROUP_SKB,
+            ProgramType::CgroupSock => Self::BPF_PROG_TYPE_CGROUP_SOCK,
+            ProgramType::LwtInput => Self::BPF_PROG_TYPE_LWT_IN,
+            ProgramType::LwtOutput => Self::BPF_PROG_TYPE_LWT_OUT,
+            ProgramType::LwtXmit => Self::BPF_PROG_TYPE_LWT_XMIT,
+            ProgramType::SockOps => Self::BPF_PROG_TYPE_SOCK_OPS,
+            ProgramType::SkSkb => Self::BPF_PROG_TYPE_SK_SKB,
+            ProgramType::CgroupDevice => Self::BPF_PROG_TYPE_CGROUP_DEVICE,
+            ProgramType::SkMsg => Self::BPF_PROG_TYPE_SK_MSG,
+            ProgramType::RawTracePoint => Self::BPF_PROG_TYPE_RAW_TRACEPOINT,
+            ProgramType::CgroupSockAddr => Self::BPF_PROG_TYPE_CGROUP_SOCK_ADDR,
+            ProgramType::LwtSeg6local => Self::BPF_PROG_TYPE_LWT_SEG6LOCAL,
+            ProgramType::LircMode2 => Self::BPF_PROG_TYPE_LIRC_MODE2,
+            ProgramType::SkReuseport => Self::BPF_PROG_TYPE_SK_REUSEPORT,
+            ProgramType::FlowDissector => Self::BPF_PROG_TYPE_FLOW_DISSECTOR,
+            ProgramType::CgroupSysctl => Self::BPF_PROG_TYPE_CGROUP_SYSCTL,
+            ProgramType::RawTracePointWritable => Self::BPF_PROG_TYPE_RAW_TRACEPOINT_WRITABLE,
+            ProgramType::CgroupSockopt => Self::BPF_PROG_TYPE_CGROUP_SOCKOPT,
+            ProgramType::Tracing => Self::BPF_PROG_TYPE_TRACING,
+            ProgramType::StructOps => Self::BPF_PROG_TYPE_STRUCT_OPS,
+            ProgramType::Extension => Self::BPF_PROG_TYPE_EXT,
+            ProgramType::Lsm => Self::BPF_PROG_TYPE_LSM,
+            ProgramType::SkLookup => Self::BPF_PROG_TYPE_SK_LOOKUP,
+            ProgramType::Syscall => Self::BPF_PROG_TYPE_SYSCALL,
+            ProgramType::Netfilter => Self::BPF_PROG_TYPE_NETFILTER,
+        }
+    }
+}
+
 impl TryFrom<bpf_prog_type> for ProgramType {
     type Error = ProgramError;
 

--- a/test/integration-test/src/tests/smoke.rs
+++ b/test/integration-test/src/tests/smoke.rs
@@ -1,11 +1,24 @@
 use aya::{
-    programs::{Extension, TracePoint, Xdp, XdpFlags},
+    is_program_type_supported,
+    programs::{Extension, ProgramType, TracePoint, Xdp, XdpFlags},
     util::KernelVersion,
     Ebpf, EbpfLoader,
 };
 use test_log::test;
 
 use crate::utils::NetNsGuard;
+
+#[test]
+fn progam_is_supported() {
+    // All of these program types have been supported for a long time and are
+    // used in our tests without any special checks.
+
+    assert!(is_program_type_supported(ProgramType::Xdp).unwrap());
+    assert!(is_program_type_supported(ProgramType::TracePoint).unwrap());
+    // Kprobe and uprobe are the same program type
+    assert!(is_program_type_supported(ProgramType::KProbe).unwrap());
+    assert!(is_program_type_supported(ProgramType::SchedClassifier).unwrap());
+}
 
 #[test]
 fn xdp() {

--- a/xtask/public-api/aya.txt
+++ b/xtask/public-api/aya.txt
@@ -7651,6 +7651,8 @@ impl core::clone::Clone for aya::programs::ProgramType
 pub fn aya::programs::ProgramType::clone(&self) -> aya::programs::ProgramType
 impl core::cmp::PartialEq for aya::programs::ProgramType
 pub fn aya::programs::ProgramType::eq(&self, other: &aya::programs::ProgramType) -> bool
+impl core::convert::From<aya::programs::ProgramType> for aya_obj::generated::linux_bindings_x86_64::bpf_prog_type
+pub fn aya_obj::generated::linux_bindings_x86_64::bpf_prog_type::from(value: aya::programs::ProgramType) -> Self
 impl core::convert::TryFrom<aya_obj::generated::linux_bindings_x86_64::bpf_prog_type> for aya::programs::ProgramType
 pub type aya::programs::ProgramType::Error = aya::programs::ProgramError
 pub fn aya::programs::ProgramType::try_from(prog_type: aya_obj::generated::linux_bindings_x86_64::bpf_prog_type) -> core::result::Result<Self, Self::Error>
@@ -10034,6 +10036,7 @@ impl aya::Pod for u8
 impl<K: aya::Pod> aya::Pod for aya::maps::lpm_trie::Key<K>
 impl<T: aya::Pod, const N: usize> aya::Pod for [T; N]
 pub fn aya::features() -> &'static aya_obj::obj::Features
+pub fn aya::is_program_type_supported(program_type: aya::programs::ProgramType) -> core::result::Result<bool, aya::EbpfError>
 pub type aya::Bpf = aya::Ebpf
 pub type aya::BpfError = aya::EbpfError
 pub type aya::BpfLoader<'a> = aya::EbpfLoader<'a>


### PR DESCRIPTION
This adds a new API to test whether a given program type is supported.

This is to support 3 usecases:

1. A project like bpfman (which uses Aya) may wish to prevent users with a list of program types that are supported on the target system
2. A user of Aya may wish to test whether Fentry/Fexit programs are supported and code their own behaviour to fallback to Kprobes
3. Our own integration tests can be made to skip certain program tests when kernel features are missing.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aya-rs/aya/1145)
<!-- Reviewable:end -->
