### PR TITLE
Appease clippy

### DIFF
--- a/aya-log-common/src/lib.rs
+++ b/aya-log-common/src/lib.rs
@@ -165,6 +165,9 @@ pub enum DisplayHint {
 // llvm: <unknown>:0:0: in function _ZN14aya_log_common5write17hc9ed05433e23a663E { i64, i64 } (i8, ptr, i64, ptr, i64): only integer returns supported
 #[inline(always)]
 pub(crate) fn write(tag: u8, value: &[u8], buf: &mut [u8]) -> Option<NonZeroUsize> {
+    // TODO(https://github.com/rust-lang/rust-clippy/issues/14112): Remove this allowance when the
+    // lint behaves more sensibly.
+    #[allow(clippy::manual_ok_err)]
     let wire_len: LogValueLength = match value.len().try_into() {
         Ok(wire_len) => Some(wire_len),
         Err(TryFromIntError { .. }) => None,

--- a/aya-obj/src/obj.rs
+++ b/aya-obj/src/obj.rs
@@ -1702,7 +1702,7 @@ mod tests {
         assert_matches!(prog_foo, Program {
             license,
             kernel_version: None,
-            section: ProgramSection::KProbe { .. },
+            section: ProgramSection::KProbe,
             ..
         } => assert_eq!(license.to_str().unwrap(), "GPL"));
 
@@ -1766,7 +1766,7 @@ mod tests {
         assert_matches!(prog_foo, Program {
             license,
             kernel_version: None,
-            section: ProgramSection::KProbe { .. },
+            section: ProgramSection::KProbe,
             ..
         } => assert_eq!(license.to_str().unwrap(), "GPL"));
         assert_matches!(
@@ -1784,7 +1784,7 @@ mod tests {
         assert_matches!(prog_bar, Program {
             license,
             kernel_version: None,
-            section: ProgramSection::KProbe { .. },
+            section: ProgramSection::KProbe ,
             ..
         } => assert_eq!(license.to_str().unwrap(), "GPL"));
         assert_matches!(
@@ -1916,7 +1916,7 @@ mod tests {
         assert_matches!(
             obj.programs.get("foo"),
             Some(Program {
-                section: ProgramSection::KProbe { .. },
+                section: ProgramSection::KProbe,
                 ..
             })
         );
@@ -2038,7 +2038,7 @@ mod tests {
         assert_matches!(
             obj.programs.get("foo"),
             Some(Program {
-                section: ProgramSection::TracePoint { .. },
+                section: ProgramSection::TracePoint,
                 ..
             })
         );
@@ -2055,7 +2055,7 @@ mod tests {
         assert_matches!(
             obj.programs.get("bar"),
             Some(Program {
-                section: ProgramSection::TracePoint { .. },
+                section: ProgramSection::TracePoint,
                 ..
             })
         );
@@ -2078,7 +2078,7 @@ mod tests {
         assert_matches!(
             obj.programs.get("foo"),
             Some(Program {
-                section: ProgramSection::SocketFilter { .. },
+                section: ProgramSection::SocketFilter,
                 ..
             })
         );
@@ -2148,7 +2148,7 @@ mod tests {
         assert_matches!(
             obj.programs.get("foo"),
             Some(Program {
-                section: ProgramSection::RawTracePoint { .. },
+                section: ProgramSection::RawTracePoint,
                 ..
             })
         );
@@ -2165,7 +2165,7 @@ mod tests {
         assert_matches!(
             obj.programs.get("bar"),
             Some(Program {
-                section: ProgramSection::RawTracePoint { .. },
+                section: ProgramSection::RawTracePoint,
                 ..
             })
         );
@@ -2240,7 +2240,7 @@ mod tests {
         assert_matches!(
             obj.programs.get("foo"),
             Some(Program {
-                section: ProgramSection::BtfTracePoint { .. },
+                section: ProgramSection::BtfTracePoint,
                 ..
             })
         );
@@ -2263,7 +2263,7 @@ mod tests {
         assert_matches!(
             obj.programs.get("stream_parser"),
             Some(Program {
-                section: ProgramSection::SkSkbStreamParser { .. },
+                section: ProgramSection::SkSkbStreamParser,
                 ..
             })
         );
@@ -2286,7 +2286,7 @@ mod tests {
         assert_matches!(
             obj.programs.get("my_parser"),
             Some(Program {
-                section: ProgramSection::SkSkbStreamParser { .. },
+                section: ProgramSection::SkSkbStreamParser,
                 ..
             })
         );
@@ -2407,7 +2407,7 @@ mod tests {
         assert_matches!(
             obj.programs.get("ingress"),
             Some(Program {
-                section: ProgramSection::CgroupSkbIngress { .. },
+                section: ProgramSection::CgroupSkbIngress,
                 ..
             })
         );
@@ -2430,7 +2430,7 @@ mod tests {
         assert_matches!(
             obj.programs.get("foo"),
             Some(Program {
-                section: ProgramSection::CgroupSkbIngress { .. },
+                section: ProgramSection::CgroupSkbIngress,
                 ..
             })
         );
@@ -2453,7 +2453,7 @@ mod tests {
         assert_matches!(
             obj.programs.get("skb"),
             Some(Program {
-                section: ProgramSection::CgroupSkb { .. },
+                section: ProgramSection::CgroupSkb,
                 ..
             })
         );
@@ -2476,7 +2476,7 @@ mod tests {
         assert_matches!(
             obj.programs.get("foo"),
             Some(Program {
-                section: ProgramSection::CgroupSkb { .. },
+                section: ProgramSection::CgroupSkb,
                 ..
             })
         );

--- a/aya/src/util.rs
+++ b/aya/src/util.rs
@@ -258,6 +258,9 @@ fn parse_kernel_symbols(reader: impl BufRead) -> Result<BTreeMap<u64, String>, i
                 let addr = parts.next()?;
                 let _kind = parts.next()?;
                 let name = parts.next()?;
+                // TODO(https://github.com/rust-lang/rust-clippy/issues/14112): Remove this
+                // allowance when the lint behaves more sensibly.
+                #[allow(clippy::manual_ok_err)]
                 let addr = match u64::from_str_radix(addr, 16) {
                     Ok(addr) => Some(addr),
                     Err(ParseIntError { .. }) => None,

--- a/init/src/main.rs
+++ b/init/src/main.rs
@@ -138,9 +138,14 @@ fn run() -> anyhow::Result<()> {
                 Err(anyhow::anyhow!("{} failed: {status:?}", path.display()))
             }
         })
-        .filter_map(|result| match result {
-            Ok(()) => None,
-            Err(err) => Some(err),
+        .filter_map(|result| {
+            // TODO(https://github.com/rust-lang/rust-clippy/issues/14112): Remove this allowance
+            // when the lint behaves more sensibly.
+            #[allow(clippy::manual_ok_err)]
+            match result {
+                Ok(()) => None,
+                Err(err) => Some(err),
+            }
         })
         .collect::<Vec<_>>();
     if errors.is_empty() {

--- a/xtask/src/public_api.rs
+++ b/xtask/src/public_api.rs
@@ -77,9 +77,14 @@ pub fn public_api(options: Options, metadata: Metadata) -> Result<()> {
                 }
             },
         )
-        .filter_map(|result| match result {
-            Ok(()) => None,
-            Err(err) => Some(err),
+        .filter_map(|result| {
+            // TODO(https://github.com/rust-lang/rust-clippy/issues/14112): Remove this allowance
+            // when the lint behaves more sensibly.
+            #[allow(clippy::manual_ok_err)]
+            match result {
+                Ok(()) => None,
+                Err(err) => Some(err),
+            }
         })
         .collect();
 


### PR DESCRIPTION
```
error: manual implementation of `ok`
   --> aya/src/util.rs:261:28
    |
261 |                   let addr = match u64::from_str_radix(addr, 16) {
    |  ____________________________^
262 | |                     Ok(addr) => Some(addr),
263 | |                     Err(ParseIntError { .. }) => None,
264 | |                 }?;
    | |_________________^ help: replace with: `u64::from_str_radix(addr, 16).ok()`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#manual_ok_err

error: struct pattern is not needed for a unit variant
    --> aya-obj/src/obj.rs:1705:44
     |
1705 |             section: ProgramSection::KProbe { .. },
     |                                            ^^^^^^^ help: remove the struct pattern
     |
     = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unneeded_struct_pattern
note: the lint level is defined here
    --> aya-obj/src/lib.rs:68:9
     |
68   | #![deny(clippy::all, missing_docs)]
     |         ^^^^^^^^^^^
     = note: `#[deny(clippy::unneeded_struct_pattern)]` implied by `#[deny(clippy::all)]`

error: struct pattern is not needed for a unit variant
    --> aya-obj/src/obj.rs:1769:44
     |
1769 |             section: ProgramSection::KProbe { .. },
     |                                            ^^^^^^^ help: remove the struct pattern
     |
     = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unneeded_struct_pattern

error: struct pattern is not needed for a unit variant
    --> aya-obj/src/obj.rs:1787:44
     |
1787 |             section: ProgramSection::KProbe { .. },
     |                                            ^^^^^^^ help: remove the struct pattern
     |
     = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unneeded_struct_pattern

error: struct pattern is not needed for a unit variant
    --> aya-obj/src/obj.rs:1919:48
     |
1919 |                 section: ProgramSection::KProbe { .. },
     |                                                ^^^^^^^ help: remove the struct pattern
     |
     = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unneeded_struct_pattern

error: struct pattern is not needed for a unit variant
    --> aya-obj/src/obj.rs:2041:52
     |
2041 |                 section: ProgramSection::TracePoint { .. },
     |                                                    ^^^^^^^ help: remove the struct pattern
     |
     = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unneeded_struct_pattern

error: struct pattern is not needed for a unit variant
    --> aya-obj/src/obj.rs:2058:52
     |
2058 |                 section: ProgramSection::TracePoint { .. },
     |                                                    ^^^^^^^ help: remove the struct pattern
     |
     = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unneeded_struct_pattern

error: struct pattern is not needed for a unit variant
    --> aya-obj/src/obj.rs:2081:54
     |
2081 |                 section: ProgramSection::SocketFilter { .. },
     |                                                      ^^^^^^^ help: remove the struct pattern
     |
     = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unneeded_struct_pattern

error: struct pattern is not needed for a unit variant
    --> aya-obj/src/obj.rs:2151:55
     |
2151 |                 section: ProgramSection::RawTracePoint { .. },
     |                                                       ^^^^^^^ help: remove the struct pattern
     |
     = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unneeded_struct_pattern

error: struct pattern is not needed for a unit variant
    --> aya-obj/src/obj.rs:2168:55
     |
2168 |                 section: ProgramSection::RawTracePoint { .. },
     |                                                       ^^^^^^^ help: remove the struct pattern
     |
     = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unneeded_struct_pattern

error: struct pattern is not needed for a unit variant
    --> aya-obj/src/obj.rs:2243:55
     |
2243 |                 section: ProgramSection::BtfTracePoint { .. },
     |                                                       ^^^^^^^ help: remove the struct pattern
     |
     = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unneeded_struct_pattern

error: struct pattern is not needed for a unit variant
    --> aya-obj/src/obj.rs:2266:59
     |
2266 |                 section: ProgramSection::SkSkbStreamParser { .. },
     |                                                           ^^^^^^^ help: remove the struct pattern
     |
     = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unneeded_struct_pattern

error: struct pattern is not needed for a unit variant
    --> aya-obj/src/obj.rs:2289:59
     |
2289 |                 section: ProgramSection::SkSkbStreamParser { .. },
     |                                                           ^^^^^^^ help: remove the struct pattern
     |
     = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unneeded_struct_pattern

error: struct pattern is not needed for a unit variant
    --> aya-obj/src/obj.rs:2410:58
     |
2410 |                 section: ProgramSection::CgroupSkbIngress { .. },
     |                                                          ^^^^^^^ help: remove the struct pattern
     |
     = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unneeded_struct_pattern

error: struct pattern is not needed for a unit variant
    --> aya-obj/src/obj.rs:2433:58
     |
2433 |                 section: ProgramSection::CgroupSkbIngress { .. },
     |                                                          ^^^^^^^ help: remove the struct pattern
     |
     = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unneeded_struct_pattern

error: struct pattern is not needed for a unit variant
    --> aya-obj/src/obj.rs:2456:51
     |
2456 |                 section: ProgramSection::CgroupSkb { .. },
     |                                                   ^^^^^^^ help: remove the struct pattern
     |
     = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unneeded_struct_pattern

error: struct pattern is not needed for a unit variant
    --> aya-obj/src/obj.rs:2479:51
     |
2479 |                 section: ProgramSection::CgroupSkb { .. },
     |                                                   ^^^^^^^ help: remove the struct pattern
     |
     = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unneeded_struct_pattern

error: manual implementation of `ok`
   --> aya-log-common/src/lib.rs:168:36
    |
168 |       let wire_len: LogValueLength = match value.len().try_into() {
    |  ____________________________________^
169 | |         Ok(wire_len) => Some(wire_len),
170 | |         Err(TryFromIntError { .. }) => None,
171 | |     }?;
    | |_____^ help: replace with: `value.len().try_into().ok()`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#manual_ok_err

error: manual implementation of `err`
   --> init/src/main.rs:141:30
    |
141 |           .filter_map(|result| match result {
    |  ______________________________^
142 | |             Ok(()) => None,
143 | |             Err(err) => Some(err),
144 | |         })
    | |_________^ help: replace with: `result.err()`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#manual_ok_err

error: manual implementation of `err`
  --> xtask/src/public_api.rs:80:30
   |
80 |           .filter_map(|result| match result {
   |  ______________________________^
81 | |             Ok(()) => None,
82 | |             Err(err) => Some(err),
83 | |         })
   | |_________^ help: replace with: `result.err()`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#manual_ok_err
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aya-rs/aya/1149)
<!-- Reviewable:end -->
