### PR TITLE
chore(xtask): Add mips to codegen

### DIFF
--- a/aya-tool/src/lib.rs
+++ b/aya-tool/src/lib.rs
@@ -1,5 +1,5 @@
 use std::{
-    fs::File,
+    fs::{create_dir_all, File},
     io::{self, Write},
     path::Path,
 };
@@ -11,6 +11,13 @@ pub mod rustfmt;
 pub use generate::{generate, InputFile};
 
 pub fn write_to_file<T: AsRef<Path>>(path: T, code: &str) -> Result<(), io::Error> {
+    // Create parent directories if they don't exist already
+    if let Some(parent) = path.as_ref().parent() {
+        if !parent.exists() {
+            create_dir_all(parent)?;
+        }
+    }
+
     let mut file = File::create(path)?;
     file.write_all(code.as_bytes())
 }

--- a/xtask/src/codegen/aya.rs
+++ b/xtask/src/codegen/aya.rs
@@ -59,6 +59,7 @@ fn codegen_bindings(opts: &SysrootOptions, libbpf_dir: &Path) -> Result<(), anyh
         riscv64_sysroot,
         powerpc64_sysroot,
         s390x_sysroot,
+        mips_sysroot,
     } = opts;
     let types = [
         // BPF
@@ -191,6 +192,7 @@ fn codegen_bindings(opts: &SysrootOptions, libbpf_dir: &Path) -> Result<(), anyh
             Architecture::RISCV64 => "riscv64-unknown-linux-gnu",
             Architecture::PowerPC64 => "powerpc64le-unknown-linux-gnu",
             Architecture::S390X => "s390x-unknown-linux-gnu",
+            Architecture::Mips => "mips-unknown-linux-gnu",
         };
         bindgen = bindgen.clang_args(&["-target", target]);
 
@@ -203,6 +205,7 @@ fn codegen_bindings(opts: &SysrootOptions, libbpf_dir: &Path) -> Result<(), anyh
             Architecture::RISCV64 => riscv64_sysroot,
             Architecture::PowerPC64 => powerpc64_sysroot,
             Architecture::S390X => s390x_sysroot,
+            Architecture::Mips => mips_sysroot,
         };
         bindgen = bindgen.clang_args(&["-I", &*sysroot.to_string_lossy()]);
 

--- a/xtask/src/codegen/aya_ebpf_bindings.rs
+++ b/xtask/src/codegen/aya_ebpf_bindings.rs
@@ -22,6 +22,7 @@ pub fn codegen(opts: &SysrootOptions, libbpf_dir: &Path) -> Result<(), anyhow::E
         riscv64_sysroot,
         powerpc64_sysroot,
         s390x_sysroot,
+        mips_sysroot,
     } = opts;
 
     let dir = PathBuf::from("ebpf/aya-ebpf-bindings");
@@ -88,6 +89,7 @@ pub fn codegen(opts: &SysrootOptions, libbpf_dir: &Path) -> Result<(), anyhow::E
             Architecture::RISCV64 => "riscv64-unknown-linux-gnu",
             Architecture::PowerPC64 => "powerpc64le-unknown-linux-gnu",
             Architecture::S390X => "s390x-unknown-linux-gnu",
+            Architecture::Mips => "mips-unknown-linux-gnu",
         };
         bindgen = bindgen.clang_args(&["-target", target]);
 
@@ -100,6 +102,7 @@ pub fn codegen(opts: &SysrootOptions, libbpf_dir: &Path) -> Result<(), anyhow::E
             Architecture::RISCV64 => riscv64_sysroot,
             Architecture::PowerPC64 => powerpc64_sysroot,
             Architecture::S390X => s390x_sysroot,
+            Architecture::Mips => mips_sysroot,
         };
         bindgen = bindgen.clang_args(&["-I", &*sysroot.to_string_lossy()]);
 
@@ -109,6 +112,7 @@ pub fn codegen(opts: &SysrootOptions, libbpf_dir: &Path) -> Result<(), anyhow::E
             .to_string();
 
         let mut tree = parse_str::<syn::File>(&bindings).unwrap();
+
         let (indexes, helpers) = extract_helpers(&tree.items);
         let helpers = expand_helpers(&helpers);
         for index in indexes {

--- a/xtask/src/codegen/mod.rs
+++ b/xtask/src/codegen/mod.rs
@@ -7,6 +7,7 @@ use std::path::{Path, PathBuf};
 use clap::Parser;
 
 const SUPPORTED_ARCHS: &[Architecture] = &[
+    Architecture::Mips,
     Architecture::X86_64,
     Architecture::ARMv7,
     Architecture::AArch64,
@@ -23,6 +24,7 @@ pub enum Architecture {
     RISCV64,
     PowerPC64,
     S390X,
+    Mips,
 }
 
 impl Architecture {
@@ -36,6 +38,7 @@ impl std::str::FromStr for Architecture {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         Ok(match s {
+            "mips" => Architecture::Mips,
             "x86_64" => Architecture::X86_64,
             "armv7" => Architecture::ARMv7,
             "aarch64" => Architecture::AArch64,
@@ -50,6 +53,7 @@ impl std::str::FromStr for Architecture {
 impl std::fmt::Display for Architecture {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.write_str(match self {
+            Architecture::Mips => "mips",
             Architecture::X86_64 => "x86_64",
             Architecture::ARMv7 => "armv7",
             Architecture::AArch64 => "aarch64",
@@ -81,6 +85,9 @@ pub struct SysrootOptions {
 
     #[arg(long, default_value = "/usr/s390x-linux-gnu/include", action)]
     s390x_sysroot: PathBuf,
+
+    #[arg(long, default_value = "/usr/mips-linux-gnu/include", action)]
+    mips_sysroot: PathBuf,
 }
 
 #[derive(Parser)]


### PR DESCRIPTION
This will generate bindings for mips the next time that the codegen job is run.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aya-rs/aya/1150)
<!-- Reviewable:end -->
