### PR TITLE
chore(codegen): Fix duplicate BPF_F_LINK

### DIFF
--- a/xtask/src/codegen/aya.rs
+++ b/xtask/src/codegen/aya.rs
@@ -216,6 +216,10 @@ fn codegen_bindings(opts: &SysrootOptions, libbpf_dir: &Path) -> Result<(), anyh
         for x in &vars {
             bindgen = bindgen
                 .allowlist_var(x)
+                // BPF_F_LINK is defined twice. Once in an anonymous enum
+                // which bindgen will constify, and once via #define macro
+                // which generates a duplicate const.
+                .blocklist_var("BPF_F_LINK")
                 .constified_enum("BPF_F_.*")
                 .constified_enum("BTF_KIND_.*")
                 .constified_enum("BTF_VAR_.*")

--- a/xtask/src/codegen/aya_ebpf_bindings.rs
+++ b/xtask/src/codegen/aya_ebpf_bindings.rs
@@ -36,6 +36,10 @@ pub fn codegen(opts: &SysrootOptions, libbpf_dir: &Path) -> Result<(), anyhow::E
             .clang_args(&["-I", &*libbpf_dir.join("include/uapi").to_string_lossy()])
             .clang_args(&["-I", &*libbpf_dir.join("include").to_string_lossy()])
             .clang_args(&["-I", &*libbpf_dir.join("src").to_string_lossy()])
+            // BPF_F_LINK is defined twice. Once in an anonymous enum
+            // which bindgen will constify, and once via #define macro
+            // which generates a duplicate const.
+            .blocklist_var("BPF_F_LINK")
             // open aya-ebpf-bindings/.../bindings.rs and look for mod
             // _bindgen, those are anonymous enums
             .constified_enum("BPF_F_.*")


### PR DESCRIPTION
Per the comment added in the code, there are 2 definitions of BPF_F_LINK in the kernel headers. Once is in an anonymous enum which bindgen will constify, and once is via a #define macro. The values are identical. The fix is to exclude BPF_F_LINK from the list of variables in bindgen removing one of the duplicate definitions.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aya-rs/aya/1154)
<!-- Reviewable:end -->
