### PR TITLE
chore: remove `aya_obj` -> `obj` alias

### DIFF
--- a/aya/src/bpf.rs
+++ b/aya/src/bpf.rs
@@ -9,24 +9,20 @@ use std::{
 };
 
 use aya_obj::{
-    btf::{BtfFeatures, BtfRelocationError},
-    generated::{BPF_F_SLEEPABLE, BPF_F_XDP_HAS_FRAGS},
+    btf::{Btf, BtfError, BtfFeatures, BtfRelocationError},
+    generated::{
+        bpf_map_type::{self, *},
+        AYA_PERF_EVENT_IOC_DISABLE, AYA_PERF_EVENT_IOC_ENABLE, AYA_PERF_EVENT_IOC_SET_BPF,
+        BPF_F_SLEEPABLE, BPF_F_XDP_HAS_FRAGS,
+    },
     relocation::EbpfRelocationError,
-    EbpfSectionKind, Features,
+    EbpfSectionKind, Features, Object, ParseError, ProgramSection,
 };
 use log::{debug, warn};
 use thiserror::Error;
 
 use crate::{
-    generated::{
-        bpf_map_type::{self, *},
-        AYA_PERF_EVENT_IOC_DISABLE, AYA_PERF_EVENT_IOC_ENABLE, AYA_PERF_EVENT_IOC_SET_BPF,
-    },
     maps::{Map, MapData, MapError},
-    obj::{
-        btf::{Btf, BtfError},
-        Object, ParseError, ProgramSection,
-    },
     programs::{
         BtfTracePoint, CgroupDevice, CgroupSkb, CgroupSkbAttachType, CgroupSock, CgroupSockAddr,
         CgroupSockopt, CgroupSysctl, Extension, FEntry, FExit, Iter, KProbe, LircMode2, Lsm,
@@ -801,7 +797,7 @@ fn adjust_to_page_size(byte_size: u32, page_size: u32) -> u32 {
 
 #[cfg(test)]
 mod tests {
-    use crate::generated::bpf_map_type::*;
+    use aya_obj::generated::bpf_map_type::*;
 
     const PAGE_SIZE: u32 = 4096;
     const NUM_CPUS: u32 = 4;

--- a/aya/src/lib.rs
+++ b/aya/src/lib.rs
@@ -86,10 +86,8 @@ pub mod util;
 
 use std::os::fd::{AsFd, AsRawFd, BorrowedFd, FromRawFd, OwnedFd, RawFd};
 
-use aya_obj as obj;
-use aya_obj::generated;
+pub use aya_obj::btf::{Btf, BtfError};
 pub use bpf::*;
-pub use obj::btf::{Btf, BtfError};
 pub use object::Endianness;
 #[doc(hidden)]
 pub use sys::netlink_set_link_up;

--- a/aya/src/maps/bloom_filter.rs
+++ b/aya/src/maps/bloom_filter.rs
@@ -81,23 +81,22 @@ mod tests {
     use std::{ffi::c_long, io};
 
     use assert_matches::assert_matches;
+    use aya_obj::generated::{
+        bpf_cmd,
+        bpf_map_type::{BPF_MAP_TYPE_ARRAY, BPF_MAP_TYPE_BLOOM_FILTER},
+    };
     use libc::{EFAULT, ENOENT};
 
     use super::*;
     use crate::{
-        generated::{
-            bpf_cmd,
-            bpf_map_type::{BPF_MAP_TYPE_ARRAY, BPF_MAP_TYPE_BLOOM_FILTER},
-        },
         maps::{
             test_utils::{self, new_map},
             Map,
         },
-        obj,
         sys::{override_syscall, SysResult, Syscall},
     };
 
-    fn new_obj_map() -> obj::Map {
+    fn new_obj_map() -> aya_obj::Map {
         test_utils::new_obj_map::<u32>(BPF_MAP_TYPE_BLOOM_FILTER)
     }
 

--- a/aya/src/maps/hash_map/hash_map.rs
+++ b/aya/src/maps/hash_map/hash_map.rs
@@ -106,23 +106,22 @@ mod tests {
     use std::{ffi::c_long, io};
 
     use assert_matches::assert_matches;
+    use aya_obj::generated::{
+        bpf_attr, bpf_cmd,
+        bpf_map_type::{BPF_MAP_TYPE_HASH, BPF_MAP_TYPE_LRU_HASH},
+    };
     use libc::{EFAULT, ENOENT};
 
     use super::*;
     use crate::{
-        generated::{
-            bpf_attr, bpf_cmd,
-            bpf_map_type::{BPF_MAP_TYPE_HASH, BPF_MAP_TYPE_LRU_HASH},
-        },
         maps::{
             test_utils::{self, new_map},
             Map,
         },
-        obj,
         sys::{override_syscall, SysResult, Syscall},
     };
 
-    fn new_obj_map() -> obj::Map {
+    fn new_obj_map() -> aya_obj::Map {
         test_utils::new_obj_map::<u32>(BPF_MAP_TYPE_HASH)
     }
 

--- a/aya/src/maps/hash_map/per_cpu_hash_map.rs
+++ b/aya/src/maps/hash_map/per_cpu_hash_map.rs
@@ -151,11 +151,12 @@ impl<T: Borrow<MapData>, K: Pod, V: Pod> IterableMap<K, PerCpuValues<V>>
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use crate::{
-        generated::bpf_map_type::{BPF_MAP_TYPE_LRU_PERCPU_HASH, BPF_MAP_TYPE_PERCPU_HASH},
-        maps::{test_utils, Map},
+    use aya_obj::generated::bpf_map_type::{
+        BPF_MAP_TYPE_LRU_PERCPU_HASH, BPF_MAP_TYPE_PERCPU_HASH,
     };
+
+    use super::*;
+    use crate::maps::{test_utils, Map};
 
     #[test]
     fn test_try_from_ok() {

--- a/aya/src/maps/lpm_trie.rs
+++ b/aya/src/maps/lpm_trie.rs
@@ -198,23 +198,22 @@ mod tests {
     use std::{ffi::c_long, io, net::Ipv4Addr};
 
     use assert_matches::assert_matches;
+    use aya_obj::generated::{
+        bpf_cmd,
+        bpf_map_type::{BPF_MAP_TYPE_ARRAY, BPF_MAP_TYPE_LPM_TRIE},
+    };
     use libc::{EFAULT, ENOENT};
 
     use super::*;
     use crate::{
-        generated::{
-            bpf_cmd,
-            bpf_map_type::{BPF_MAP_TYPE_ARRAY, BPF_MAP_TYPE_LPM_TRIE},
-        },
         maps::{
             test_utils::{self, new_map},
             Map,
         },
-        obj,
         sys::{override_syscall, SysResult, Syscall},
     };
 
-    fn new_obj_map() -> obj::Map {
+    fn new_obj_map() -> aya_obj::Map {
         test_utils::new_obj_map::<Key<u32>>(BPF_MAP_TYPE_LPM_TRIE)
     }
 

--- a/aya/src/maps/perf/perf_buffer.rs
+++ b/aya/src/maps/perf/perf_buffer.rs
@@ -6,15 +6,15 @@ use std::{
     sync::atomic::{self, AtomicPtr, Ordering},
 };
 
+use aya_obj::generated::{
+    perf_event_header, perf_event_mmap_page,
+    perf_event_type::{PERF_RECORD_LOST, PERF_RECORD_SAMPLE},
+};
 use bytes::BytesMut;
 use libc::{munmap, MAP_FAILED, MAP_SHARED, PROT_READ, PROT_WRITE};
 use thiserror::Error;
 
 use crate::{
-    generated::{
-        perf_event_header, perf_event_mmap_page,
-        perf_event_type::{PERF_RECORD_LOST, PERF_RECORD_SAMPLE},
-    },
     sys::{mmap, perf_event_ioctl, perf_event_open_bpf, SysResult},
     PERF_EVENT_IOC_DISABLE, PERF_EVENT_IOC_ENABLE,
 };

--- a/aya/src/maps/ring_buf.rs
+++ b/aya/src/maps/ring_buf.rs
@@ -17,10 +17,10 @@ use std::{
     sync::atomic::{AtomicU32, AtomicUsize, Ordering},
 };
 
+use aya_obj::generated::{BPF_RINGBUF_BUSY_BIT, BPF_RINGBUF_DISCARD_BIT, BPF_RINGBUF_HDR_SZ};
 use libc::{munmap, off_t, MAP_FAILED, MAP_SHARED, PROT_READ, PROT_WRITE};
 
 use crate::{
-    generated::{BPF_RINGBUF_BUSY_BIT, BPF_RINGBUF_DISCARD_BIT, BPF_RINGBUF_HDR_SZ},
     maps::{MapData, MapError},
     sys::{mmap, SyscallError},
     util::page_size,

--- a/aya/src/programs/cgroup_device.rs
+++ b/aya/src/programs/cgroup_device.rs
@@ -2,8 +2,11 @@
 
 use std::os::fd::AsFd;
 
+use aya_obj::generated::{
+    bpf_attach_type::BPF_CGROUP_DEVICE, bpf_prog_type::BPF_PROG_TYPE_CGROUP_DEVICE,
+};
+
 use crate::{
-    generated::{bpf_attach_type::BPF_CGROUP_DEVICE, bpf_prog_type::BPF_PROG_TYPE_CGROUP_DEVICE},
     programs::{
         bpf_prog_get_fd_by_id, define_link_wrapper, id_as_key, load_program, query,
         CgroupAttachMode, FdLink, Link, ProgAttachLink, ProgramData, ProgramError, ProgramFd,

--- a/aya/src/programs/cgroup_skb.rs
+++ b/aya/src/programs/cgroup_skb.rs
@@ -2,11 +2,12 @@
 
 use std::{hash::Hash, os::fd::AsFd, path::Path};
 
+use aya_obj::generated::{
+    bpf_attach_type::{BPF_CGROUP_INET_EGRESS, BPF_CGROUP_INET_INGRESS},
+    bpf_prog_type::BPF_PROG_TYPE_CGROUP_SKB,
+};
+
 use crate::{
-    generated::{
-        bpf_attach_type::{BPF_CGROUP_INET_EGRESS, BPF_CGROUP_INET_INGRESS},
-        bpf_prog_type::BPF_PROG_TYPE_CGROUP_SKB,
-    },
     programs::{
         define_link_wrapper, id_as_key, load_program, CgroupAttachMode, FdLink, Link,
         ProgAttachLink, ProgramData, ProgramError,

--- a/aya/src/programs/cgroup_sock.rs
+++ b/aya/src/programs/cgroup_sock.rs
@@ -2,10 +2,10 @@
 
 use std::{hash::Hash, os::fd::AsFd, path::Path};
 
+use aya_obj::generated::bpf_prog_type::BPF_PROG_TYPE_CGROUP_SOCK;
 pub use aya_obj::programs::CgroupSockAttachType;
 
 use crate::{
-    generated::bpf_prog_type::BPF_PROG_TYPE_CGROUP_SOCK,
     programs::{
         define_link_wrapper, id_as_key, load_program, CgroupAttachMode, FdLink, Link,
         ProgAttachLink, ProgramData, ProgramError,

--- a/aya/src/programs/cgroup_sock_addr.rs
+++ b/aya/src/programs/cgroup_sock_addr.rs
@@ -2,10 +2,10 @@
 
 use std::{hash::Hash, os::fd::AsFd, path::Path};
 
+use aya_obj::generated::bpf_prog_type::BPF_PROG_TYPE_CGROUP_SOCK_ADDR;
 pub use aya_obj::programs::CgroupSockAddrAttachType;
 
 use crate::{
-    generated::bpf_prog_type::BPF_PROG_TYPE_CGROUP_SOCK_ADDR,
     programs::{
         define_link_wrapper, id_as_key, load_program, CgroupAttachMode, FdLink, Link,
         ProgAttachLink, ProgramData, ProgramError,

--- a/aya/src/programs/cgroup_sockopt.rs
+++ b/aya/src/programs/cgroup_sockopt.rs
@@ -2,10 +2,10 @@
 
 use std::{hash::Hash, os::fd::AsFd, path::Path};
 
+use aya_obj::generated::bpf_prog_type::BPF_PROG_TYPE_CGROUP_SOCKOPT;
 pub use aya_obj::programs::CgroupSockoptAttachType;
 
 use crate::{
-    generated::bpf_prog_type::BPF_PROG_TYPE_CGROUP_SOCKOPT,
     programs::{
         define_link_wrapper, id_as_key, load_program, CgroupAttachMode, FdLink, Link,
         ProgAttachLink, ProgramData, ProgramError,

--- a/aya/src/programs/cgroup_sysctl.rs
+++ b/aya/src/programs/cgroup_sysctl.rs
@@ -2,8 +2,11 @@
 
 use std::{hash::Hash, os::fd::AsFd};
 
+use aya_obj::generated::{
+    bpf_attach_type::BPF_CGROUP_SYSCTL, bpf_prog_type::BPF_PROG_TYPE_CGROUP_SYSCTL,
+};
+
 use crate::{
-    generated::{bpf_attach_type::BPF_CGROUP_SYSCTL, bpf_prog_type::BPF_PROG_TYPE_CGROUP_SYSCTL},
     programs::{
         define_link_wrapper, id_as_key, load_program, CgroupAttachMode, FdLink, Link,
         ProgAttachLink, ProgramData, ProgramError,

--- a/aya/src/programs/extension.rs
+++ b/aya/src/programs/extension.rs
@@ -2,12 +2,14 @@
 
 use std::os::fd::{AsFd as _, BorrowedFd};
 
+use aya_obj::{
+    btf::BtfKind,
+    generated::{bpf_attach_type::BPF_CGROUP_INET_INGRESS, bpf_prog_type::BPF_PROG_TYPE_EXT},
+};
 use object::Endianness;
 use thiserror::Error;
 
 use crate::{
-    generated::{bpf_attach_type::BPF_CGROUP_INET_INGRESS, bpf_prog_type::BPF_PROG_TYPE_EXT},
-    obj::btf::BtfKind,
     programs::{
         define_link_wrapper, load_program, FdLink, FdLinkId, ProgramData, ProgramError, ProgramFd,
     },

--- a/aya/src/programs/fentry.rs
+++ b/aya/src/programs/fentry.rs
@@ -1,12 +1,13 @@
 //! Fentry programs.
 
-use crate::{
+use aya_obj::{
+    btf::{Btf, BtfKind},
     generated::{bpf_attach_type::BPF_TRACE_FENTRY, bpf_prog_type::BPF_PROG_TYPE_TRACING},
-    obj::btf::{Btf, BtfKind},
-    programs::{
-        define_link_wrapper, load_program, utils::attach_raw_tracepoint, FdLink, FdLinkId,
-        ProgramData, ProgramError,
-    },
+};
+
+use crate::programs::{
+    define_link_wrapper, load_program, utils::attach_raw_tracepoint, FdLink, FdLinkId, ProgramData,
+    ProgramError,
 };
 
 /// A program that can be attached to the entry point of (almost) any kernel

--- a/aya/src/programs/fexit.rs
+++ b/aya/src/programs/fexit.rs
@@ -1,12 +1,13 @@
 //! Fexit programs.
 
-use crate::{
+use aya_obj::{
+    btf::{Btf, BtfKind},
     generated::{bpf_attach_type::BPF_TRACE_FEXIT, bpf_prog_type::BPF_PROG_TYPE_TRACING},
-    obj::btf::{Btf, BtfKind},
-    programs::{
-        define_link_wrapper, load_program, utils::attach_raw_tracepoint, FdLink, FdLinkId,
-        ProgramData, ProgramError,
-    },
+};
+
+use crate::programs::{
+    define_link_wrapper, load_program, utils::attach_raw_tracepoint, FdLink, FdLinkId, ProgramData,
+    ProgramError,
 };
 
 /// A program that can be attached to the exit point of (almost) anny kernel

--- a/aya/src/programs/iter.rs
+++ b/aya/src/programs/iter.rs
@@ -4,12 +4,15 @@ use std::{
     os::fd::{AsFd, BorrowedFd},
 };
 
-use crate::{
+use aya_obj::{
+    btf::{Btf, BtfKind},
     generated::{
         bpf_attach_type::BPF_TRACE_ITER, bpf_link_type::BPF_LINK_TYPE_ITER,
         bpf_prog_type::BPF_PROG_TYPE_TRACING,
     },
-    obj::btf::{Btf, BtfKind},
+};
+
+use crate::{
     programs::{
         define_link_wrapper, load_program, FdLink, LinkError, PerfLinkIdInner, PerfLinkInner,
         ProgramData, ProgramError,

--- a/aya/src/programs/kprobe.rs
+++ b/aya/src/programs/kprobe.rs
@@ -6,10 +6,10 @@ use std::{
     path::{Path, PathBuf},
 };
 
+use aya_obj::generated::{bpf_link_type, bpf_prog_type::BPF_PROG_TYPE_KPROBE};
 use thiserror::Error;
 
 use crate::{
-    generated::{bpf_link_type, bpf_prog_type::BPF_PROG_TYPE_KPROBE},
     programs::{
         define_link_wrapper, load_program,
         perf_attach::{PerfLinkIdInner, PerfLinkInner},

--- a/aya/src/programs/links.rs
+++ b/aya/src/programs/links.rs
@@ -6,14 +6,14 @@ use std::{
     path::{Path, PathBuf},
 };
 
+use aya_obj::generated::{
+    bpf_attach_type, BPF_F_AFTER, BPF_F_ALLOW_MULTI, BPF_F_ALLOW_OVERRIDE, BPF_F_BEFORE, BPF_F_ID,
+    BPF_F_LINK, BPF_F_REPLACE,
+};
 use hashbrown::hash_set::{Entry, HashSet};
 use thiserror::Error;
 
 use crate::{
-    generated::{
-        bpf_attach_type, BPF_F_AFTER, BPF_F_ALLOW_MULTI, BPF_F_ALLOW_OVERRIDE, BPF_F_BEFORE,
-        BPF_F_ID, BPF_F_LINK, BPF_F_REPLACE,
-    },
     pin::PinError,
     programs::{MultiProgLink, MultiProgram, ProgramError, ProgramFd, ProgramId},
     sys::{bpf_get_object, bpf_pin_object, bpf_prog_attach, bpf_prog_detach, SyscallError},
@@ -578,11 +578,11 @@ mod tests {
     use std::{cell::RefCell, fs::File, rc::Rc};
 
     use assert_matches::assert_matches;
+    use aya_obj::generated::{BPF_F_ALLOW_MULTI, BPF_F_ALLOW_OVERRIDE};
     use tempfile::tempdir;
 
     use super::{FdLink, Link, Links};
     use crate::{
-        generated::{BPF_F_ALLOW_MULTI, BPF_F_ALLOW_OVERRIDE},
         programs::{CgroupAttachMode, ProgramError},
         sys::override_syscall,
     };

--- a/aya/src/programs/lirc_mode2.rs
+++ b/aya/src/programs/lirc_mode2.rs
@@ -1,8 +1,11 @@
 //! Lirc programs.
 use std::os::fd::{AsFd, AsRawFd as _, RawFd};
 
+use aya_obj::generated::{
+    bpf_attach_type::BPF_LIRC_MODE2, bpf_prog_type::BPF_PROG_TYPE_LIRC_MODE2,
+};
+
 use crate::{
-    generated::{bpf_attach_type::BPF_LIRC_MODE2, bpf_prog_type::BPF_PROG_TYPE_LIRC_MODE2},
     programs::{
         id_as_key, load_program, query, CgroupAttachMode, Link, ProgramData, ProgramError,
         ProgramFd, ProgramInfo,

--- a/aya/src/programs/lsm.rs
+++ b/aya/src/programs/lsm.rs
@@ -1,12 +1,13 @@
 //! LSM probes.
 
-use crate::{
+use aya_obj::{
+    btf::{Btf, BtfKind},
     generated::{bpf_attach_type::BPF_LSM_MAC, bpf_prog_type::BPF_PROG_TYPE_LSM},
-    obj::btf::{Btf, BtfKind},
-    programs::{
-        define_link_wrapper, load_program, utils::attach_raw_tracepoint, FdLink, FdLinkId,
-        ProgramData, ProgramError,
-    },
+};
+
+use crate::programs::{
+    define_link_wrapper, load_program, utils::attach_raw_tracepoint, FdLink, FdLinkId, ProgramData,
+    ProgramError,
 };
 
 /// A program that attaches to Linux LSM hooks. Used to implement security policy and

--- a/aya/src/programs/mod.rs
+++ b/aya/src/programs/mod.rs
@@ -78,6 +78,11 @@ use std::{
     sync::Arc,
 };
 
+use aya_obj::{
+    btf::BtfError,
+    generated::{bpf_attach_type, bpf_link_info, bpf_prog_info, bpf_prog_type},
+    VerifierLog,
+};
 use info::impl_info;
 pub use info::{loaded_programs, ProgramInfo, ProgramType};
 use libc::ENOSPC;
@@ -115,9 +120,7 @@ pub use crate::programs::{
     xdp::{Xdp, XdpError, XdpFlags},
 };
 use crate::{
-    generated::{bpf_attach_type, bpf_link_info, bpf_prog_info, bpf_prog_type},
     maps::MapError,
-    obj::{self, btf::BtfError, VerifierLog},
     pin::PinError,
     programs::{links::*, perf_attach::*},
     sys::{
@@ -490,7 +493,7 @@ impl Program {
 #[derive(Debug)]
 pub(crate) struct ProgramData<T: Link> {
     pub(crate) name: Option<String>,
-    pub(crate) obj: Option<(obj::Program, obj::Function)>,
+    pub(crate) obj: Option<(aya_obj::Program, aya_obj::Function)>,
     pub(crate) fd: Option<ProgramFd>,
     pub(crate) links: Links<T>,
     pub(crate) expected_attach_type: Option<bpf_attach_type>,
@@ -506,7 +509,7 @@ pub(crate) struct ProgramData<T: Link> {
 impl<T: Link> ProgramData<T> {
     pub(crate) fn new(
         name: Option<String>,
-        obj: (obj::Program, obj::Function),
+        obj: (aya_obj::Program, aya_obj::Function),
         btf_fd: Option<Arc<crate::MockableFd>>,
         verifier_log_level: VerifierLogLevel,
     ) -> Self {
@@ -641,12 +644,12 @@ fn load_program<T: Link>(
     }
     let obj = obj.as_ref().unwrap();
     let (
-        obj::Program {
+        aya_obj::Program {
             license,
             kernel_version,
             ..
         },
-        obj::Function {
+        aya_obj::Function {
             instructions,
             func_info,
             line_info,

--- a/aya/src/programs/perf_attach.rs
+++ b/aya/src/programs/perf_attach.rs
@@ -1,8 +1,9 @@
 //! Perf attach links.
 use std::os::fd::{AsFd as _, AsRawFd as _, BorrowedFd, RawFd};
 
+use aya_obj::generated::bpf_attach_type::BPF_PERF_EVENT;
+
 use crate::{
-    generated::bpf_attach_type::BPF_PERF_EVENT,
     programs::{
         id_as_key,
         probe::{detach_debug_fs, ProbeEvent},

--- a/aya/src/programs/perf_event.rs
+++ b/aya/src/programs/perf_event.rs
@@ -2,18 +2,19 @@
 
 use std::os::fd::AsFd as _;
 
-pub use crate::generated::{
+use aya_obj::generated::{
+    bpf_link_type,
+    bpf_prog_type::BPF_PROG_TYPE_PERF_EVENT,
+    perf_type_id::{
+        PERF_TYPE_BREAKPOINT, PERF_TYPE_HARDWARE, PERF_TYPE_HW_CACHE, PERF_TYPE_RAW,
+        PERF_TYPE_SOFTWARE, PERF_TYPE_TRACEPOINT,
+    },
+};
+pub use aya_obj::generated::{
     perf_hw_cache_id, perf_hw_cache_op_id, perf_hw_cache_op_result_id, perf_hw_id, perf_sw_ids,
 };
+
 use crate::{
-    generated::{
-        bpf_link_type,
-        bpf_prog_type::BPF_PROG_TYPE_PERF_EVENT,
-        perf_type_id::{
-            PERF_TYPE_BREAKPOINT, PERF_TYPE_HARDWARE, PERF_TYPE_HW_CACHE, PERF_TYPE_RAW,
-            PERF_TYPE_SOFTWARE, PERF_TYPE_TRACEPOINT,
-        },
-    },
     programs::{
         links::define_link_wrapper,
         load_program, perf_attach,

--- a/aya/src/programs/raw_trace_point.rs
+++ b/aya/src/programs/raw_trace_point.rs
@@ -1,12 +1,11 @@
 //! Raw tracepoints.
 use std::ffi::CString;
 
-use crate::{
-    generated::bpf_prog_type::BPF_PROG_TYPE_RAW_TRACEPOINT,
-    programs::{
-        define_link_wrapper, load_program, utils::attach_raw_tracepoint, FdLink, FdLinkId,
-        ProgramData, ProgramError,
-    },
+use aya_obj::generated::bpf_prog_type::BPF_PROG_TYPE_RAW_TRACEPOINT;
+
+use crate::programs::{
+    define_link_wrapper, load_program, utils::attach_raw_tracepoint, FdLink, FdLinkId, ProgramData,
+    ProgramError,
 };
 
 /// A program that can be attached at a pre-defined kernel trace point.

--- a/aya/src/programs/sk_lookup.rs
+++ b/aya/src/programs/sk_lookup.rs
@@ -1,9 +1,10 @@
 //! Programmable socket lookup.
 use std::os::fd::AsFd;
 
+use aya_obj::generated::{bpf_attach_type::BPF_SK_LOOKUP, bpf_prog_type::BPF_PROG_TYPE_SK_LOOKUP};
+
 use super::links::FdLink;
 use crate::{
-    generated::{bpf_attach_type::BPF_SK_LOOKUP, bpf_prog_type::BPF_PROG_TYPE_SK_LOOKUP},
     programs::{define_link_wrapper, load_program, FdLinkId, ProgramData, ProgramError},
     sys::{bpf_link_create, LinkTarget, SyscallError},
 };

--- a/aya/src/programs/sk_msg.rs
+++ b/aya/src/programs/sk_msg.rs
@@ -2,8 +2,11 @@
 
 use std::os::fd::AsFd as _;
 
+use aya_obj::generated::{
+    bpf_attach_type::BPF_SK_MSG_VERDICT, bpf_prog_type::BPF_PROG_TYPE_SK_MSG,
+};
+
 use crate::{
-    generated::{bpf_attach_type::BPF_SK_MSG_VERDICT, bpf_prog_type::BPF_PROG_TYPE_SK_MSG},
     maps::sock::SockMapFd,
     programs::{
         define_link_wrapper, load_program, CgroupAttachMode, ProgAttachLink, ProgAttachLinkId,

--- a/aya/src/programs/sk_skb.rs
+++ b/aya/src/programs/sk_skb.rs
@@ -2,11 +2,12 @@
 
 use std::{os::fd::AsFd as _, path::Path};
 
+use aya_obj::generated::{
+    bpf_attach_type::{BPF_SK_SKB_STREAM_PARSER, BPF_SK_SKB_STREAM_VERDICT},
+    bpf_prog_type::BPF_PROG_TYPE_SK_SKB,
+};
+
 use crate::{
-    generated::{
-        bpf_attach_type::{BPF_SK_SKB_STREAM_PARSER, BPF_SK_SKB_STREAM_VERDICT},
-        bpf_prog_type::BPF_PROG_TYPE_SK_SKB,
-    },
     maps::sock::SockMapFd,
     programs::{
         define_link_wrapper, load_program, CgroupAttachMode, ProgAttachLink, ProgAttachLinkId,

--- a/aya/src/programs/sock_ops.rs
+++ b/aya/src/programs/sock_ops.rs
@@ -1,8 +1,11 @@
 //! Socket option programs.
 use std::os::fd::AsFd;
 
+use aya_obj::generated::{
+    bpf_attach_type::BPF_CGROUP_SOCK_OPS, bpf_prog_type::BPF_PROG_TYPE_SOCK_OPS,
+};
+
 use crate::{
-    generated::{bpf_attach_type::BPF_CGROUP_SOCK_OPS, bpf_prog_type::BPF_PROG_TYPE_SOCK_OPS},
     programs::{
         define_link_wrapper, id_as_key, load_program, CgroupAttachMode, FdLink, Link,
         ProgAttachLink, ProgramData, ProgramError,

--- a/aya/src/programs/socket_filter.rs
+++ b/aya/src/programs/socket_filter.rs
@@ -4,13 +4,13 @@ use std::{
     os::fd::{AsFd, AsRawFd, RawFd},
 };
 
+use aya_obj::generated::{
+    bpf_prog_type::BPF_PROG_TYPE_SOCKET_FILTER, SO_ATTACH_BPF, SO_DETACH_BPF,
+};
 use libc::{setsockopt, SOL_SOCKET};
 use thiserror::Error;
 
-use crate::{
-    generated::{bpf_prog_type::BPF_PROG_TYPE_SOCKET_FILTER, SO_ATTACH_BPF, SO_DETACH_BPF},
-    programs::{id_as_key, load_program, Link, ProgramData, ProgramError},
-};
+use crate::programs::{id_as_key, load_program, Link, ProgramData, ProgramError};
 
 /// The type returned when attaching a [`SocketFilter`] fails.
 #[derive(Debug, Error)]

--- a/aya/src/programs/tc.rs
+++ b/aya/src/programs/tc.rs
@@ -6,16 +6,16 @@ use std::{
     path::Path,
 };
 
+use aya_obj::generated::{
+    bpf_attach_type::{self, BPF_TCX_EGRESS, BPF_TCX_INGRESS},
+    bpf_link_type,
+    bpf_prog_type::BPF_PROG_TYPE_SCHED_CLS,
+    TC_H_CLSACT, TC_H_MIN_EGRESS, TC_H_MIN_INGRESS,
+};
 use thiserror::Error;
 
 use super::{FdLink, ProgramInfo};
 use crate::{
-    generated::{
-        bpf_attach_type::{self, BPF_TCX_EGRESS, BPF_TCX_INGRESS},
-        bpf_link_type,
-        bpf_prog_type::BPF_PROG_TYPE_SCHED_CLS,
-        TC_H_CLSACT, TC_H_MIN_EGRESS, TC_H_MIN_INGRESS,
-    },
     programs::{
         define_link_wrapper, id_as_key, load_program, query, Link, LinkError, LinkOrder,
         ProgramData, ProgramError,

--- a/aya/src/programs/tp_btf.rs
+++ b/aya/src/programs/tp_btf.rs
@@ -1,12 +1,13 @@
 //! BTF-enabled raw tracepoints.
 
-use crate::{
+use aya_obj::{
+    btf::{Btf, BtfKind},
     generated::{bpf_attach_type::BPF_TRACE_RAW_TP, bpf_prog_type::BPF_PROG_TYPE_TRACING},
-    obj::btf::{Btf, BtfKind},
-    programs::{
-        define_link_wrapper, load_program, utils::attach_raw_tracepoint, FdLink, FdLinkId,
-        ProgramData, ProgramError,
-    },
+};
+
+use crate::programs::{
+    define_link_wrapper, load_program, utils::attach_raw_tracepoint, FdLink, FdLinkId, ProgramData,
+    ProgramError,
 };
 
 /// Marks a function as a [BTF-enabled raw tracepoint][1] eBPF program that can be attached at

--- a/aya/src/programs/trace_point.rs
+++ b/aya/src/programs/trace_point.rs
@@ -1,10 +1,10 @@
 //! Tracepoint programs.
 use std::{fs, io, os::fd::AsFd as _, path::Path};
 
+use aya_obj::generated::{bpf_link_type, bpf_prog_type::BPF_PROG_TYPE_TRACEPOINT};
 use thiserror::Error;
 
 use crate::{
-    generated::{bpf_link_type, bpf_prog_type::BPF_PROG_TYPE_TRACEPOINT},
     programs::{
         define_link_wrapper, load_program,
         perf_attach::{perf_attach, PerfLinkIdInner, PerfLinkInner},

--- a/aya/src/programs/uprobe.rs
+++ b/aya/src/programs/uprobe.rs
@@ -11,12 +11,12 @@ use std::{
     sync::LazyLock,
 };
 
+use aya_obj::generated::{bpf_link_type, bpf_prog_type::BPF_PROG_TYPE_KPROBE};
 use libc::pid_t;
 use object::{Object, ObjectSection, ObjectSymbol, Symbol};
 use thiserror::Error;
 
 use crate::{
-    generated::{bpf_link_type, bpf_prog_type::BPF_PROG_TYPE_KPROBE},
     programs::{
         define_link_wrapper, load_program,
         perf_attach::{PerfLinkIdInner, PerfLinkInner},

--- a/aya/src/programs/xdp.rs
+++ b/aya/src/programs/xdp.rs
@@ -7,15 +7,17 @@ use std::{
     path::Path,
 };
 
-use libc::if_nametoindex;
-use thiserror::Error;
-
-use crate::{
+use aya_obj::{
     generated::{
         bpf_link_type, bpf_prog_type, XDP_FLAGS_DRV_MODE, XDP_FLAGS_HW_MODE, XDP_FLAGS_REPLACE,
         XDP_FLAGS_SKB_MODE, XDP_FLAGS_UPDATE_IF_NOEXIST,
     },
-    obj::programs::XdpAttachType,
+    programs::XdpAttachType,
+};
+use libc::if_nametoindex;
+use thiserror::Error;
+
+use crate::{
     programs::{
         define_link_wrapper, id_as_key, load_program, FdLink, Link, LinkError, ProgramData,
         ProgramError,

--- a/aya/src/sys/mod.rs
+++ b/aya/src/sys/mod.rs
@@ -13,6 +13,7 @@ use std::{
     os::fd::{AsRawFd as _, BorrowedFd, OwnedFd},
 };
 
+use aya_obj::generated::{bpf_attr, bpf_cmd, perf_event_attr};
 pub(crate) use bpf::*;
 #[cfg(test)]
 pub(crate) use fake::*;
@@ -22,8 +23,6 @@ pub use netlink::netlink_set_link_up;
 pub(crate) use netlink::*;
 pub(crate) use perf_event::*;
 use thiserror::Error;
-
-use crate::generated::{bpf_attr, bpf_cmd, perf_event_attr};
 
 pub(crate) type SysResult<T> = Result<T, (c_long, io::Error)>;
 
@@ -147,9 +146,9 @@ pub enum Stats {
     RunTime,
 }
 
-impl From<Stats> for crate::generated::bpf_stats_type {
+impl From<Stats> for aya_obj::generated::bpf_stats_type {
     fn from(value: Stats) -> Self {
-        use crate::generated::bpf_stats_type::*;
+        use aya_obj::generated::bpf_stats_type::*;
 
         match value {
             Stats::RunTime => BPF_STATS_RUN_TIME,

--- a/aya/src/sys/netlink.rs
+++ b/aya/src/sys/netlink.rs
@@ -6,6 +6,12 @@ use std::{
     ptr, slice,
 };
 
+use aya_obj::generated::{
+    ifinfomsg, nlmsgerr_attrs::NLMSGERR_ATTR_MSG, tcmsg, IFLA_XDP_EXPECTED_FD, IFLA_XDP_FD,
+    IFLA_XDP_FLAGS, NLMSG_ALIGNTO, TCA_BPF_FD, TCA_BPF_FLAGS, TCA_BPF_FLAG_ACT_DIRECT,
+    TCA_BPF_NAME, TCA_KIND, TCA_OPTIONS, TC_H_CLSACT, TC_H_INGRESS, TC_H_MAJ_MASK, TC_H_UNSPEC,
+    XDP_FLAGS_REPLACE,
+};
 use libc::{
     getsockname, nlattr, nlmsgerr, nlmsghdr, recv, send, setsockopt, sockaddr_nl, socket,
     AF_NETLINK, AF_UNSPEC, ETH_P_ALL, IFF_UP, IFLA_XDP, NETLINK_CAP_ACK, NETLINK_EXT_ACK,
@@ -15,16 +21,7 @@ use libc::{
 };
 use thiserror::Error;
 
-use crate::{
-    generated::{
-        ifinfomsg, nlmsgerr_attrs::NLMSGERR_ATTR_MSG, tcmsg, IFLA_XDP_EXPECTED_FD, IFLA_XDP_FD,
-        IFLA_XDP_FLAGS, NLMSG_ALIGNTO, TCA_BPF_FD, TCA_BPF_FLAGS, TCA_BPF_FLAG_ACT_DIRECT,
-        TCA_BPF_NAME, TCA_KIND, TCA_OPTIONS, TC_H_CLSACT, TC_H_INGRESS, TC_H_MAJ_MASK, TC_H_UNSPEC,
-        XDP_FLAGS_REPLACE,
-    },
-    programs::TcAttachType,
-    util::tc_handler_make,
-};
+use crate::{programs::TcAttachType, util::tc_handler_make};
 
 const NLA_HDR_LEN: usize = align_to(mem::size_of::<nlattr>(), NLA_ALIGNTO as usize);
 

--- a/aya/src/sys/perf_event.rs
+++ b/aya/src/sys/perf_event.rs
@@ -4,16 +4,16 @@ use std::{
     os::fd::{BorrowedFd, FromRawFd as _},
 };
 
-use libc::pid_t;
-
-use super::{syscall, SysResult, Syscall};
-use crate::generated::{
+use aya_obj::generated::{
     perf_event_attr,
     perf_event_sample_format::PERF_SAMPLE_RAW,
     perf_sw_ids::PERF_COUNT_SW_BPF_OUTPUT,
     perf_type_id::{PERF_TYPE_SOFTWARE, PERF_TYPE_TRACEPOINT},
     PERF_FLAG_FD_CLOEXEC,
 };
+use libc::pid_t;
+
+use super::{syscall, SysResult, Syscall};
 
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn perf_event_open(

--- a/aya/src/util.rs
+++ b/aya/src/util.rs
@@ -12,12 +12,10 @@ use std::{
     str::{FromStr, Utf8Error},
 };
 
+use aya_obj::generated::{TC_H_MAJ_MASK, TC_H_MIN_MASK};
 use libc::{if_nametoindex, sysconf, uname, utsname, _SC_PAGESIZE};
 
-use crate::{
-    generated::{TC_H_MAJ_MASK, TC_H_MIN_MASK},
-    Pod,
-};
+use crate::Pod;
 
 /// Represents a kernel version, in major.minor.release version.
 // Adapted from https://docs.rs/procfs/latest/procfs/sys/kernel/struct.Version.html.


### PR DESCRIPTION
When `aya::obj` was migrated to be its own crate `aya-obj`, the `obj` alias was created to preserve existing imports that relied on `crate::obj`.

This resulted in 3 ways to import `aya-obj` objects:
- `use aya_obj::*`
- `use obj::*`
- `use crate::obj::*`

The `obj` alias is now removed to avoid confusion, and all `obj` imports are funneled through `aya_obj`.