### PR TITLE
aya: remove panics on indeterminate kernel version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,7 +162,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
 
       - name: bpf-linker
-        run: cargo install bpf-linker --git https://github.com/aya-rs/bpf-linker.git
+        run: cargo install --git https://github.com/aya-rs/bpf-linker.git
 
       - uses: taiki-e/install-action@cargo-hack
       - name: Build
@@ -283,7 +283,7 @@ jobs:
         # --force so that bpf-linker gets always relinked against the latest LLVM downloaded above.
         #
         # Do this on all system (not just macOS) to avoid relying on rustc-provided libLLVM.so.
-        run: cargo install --force bpf-linker --git https://github.com/aya-rs/bpf-linker.git --no-default-features
+        run: cargo install --git https://github.com/aya-rs/bpf-linker.git --no-default-features --force
 
       - name: Cache test cache
         uses: actions/cache@v4

--- a/aya/src/maps/mod.rs
+++ b/aya/src/maps/mod.rs
@@ -579,12 +579,8 @@ impl MapData {
             }
         };
 
-        #[cfg(not(test))]
-        let kernel_version = KernelVersion::current().unwrap();
-        #[cfg(test)]
-        let kernel_version = KernelVersion::new(0xff, 0xff, 0xff);
-        let fd = bpf_create_map(&c_name, &obj, btf_fd, kernel_version).map_err(|io_error| {
-            if kernel_version < KernelVersion::new(5, 11, 0) {
+        let fd = bpf_create_map(&c_name, &obj, btf_fd).map_err(|io_error| {
+            if !KernelVersion::at_least(5, 11, 0) {
                 maybe_warn_rlimit();
             }
 

--- a/aya/src/programs/cgroup_device.rs
+++ b/aya/src/programs/cgroup_device.rs
@@ -73,7 +73,7 @@ impl CgroupDevice {
         let prog_fd = prog_fd.as_fd();
         let cgroup_fd = cgroup.as_fd();
 
-        if KernelVersion::current().unwrap() >= KernelVersion::new(5, 7, 0) {
+        if KernelVersion::at_least(5, 7, 0) {
             let link_fd = bpf_link_create(
                 prog_fd,
                 LinkTarget::Fd(cgroup_fd),

--- a/aya/src/programs/cgroup_skb.rs
+++ b/aya/src/programs/cgroup_skb.rs
@@ -99,7 +99,7 @@ impl CgroupSkb {
             CgroupSkbAttachType::Ingress => BPF_CGROUP_INET_INGRESS,
             CgroupSkbAttachType::Egress => BPF_CGROUP_INET_EGRESS,
         };
-        if KernelVersion::current().unwrap() >= KernelVersion::new(5, 7, 0) {
+        if KernelVersion::at_least(5, 7, 0) {
             let link_fd = bpf_link_create(
                 prog_fd,
                 LinkTarget::Fd(cgroup_fd),

--- a/aya/src/programs/cgroup_sock.rs
+++ b/aya/src/programs/cgroup_sock.rs
@@ -76,7 +76,7 @@ impl CgroupSock {
         let prog_fd = prog_fd.as_fd();
         let cgroup_fd = cgroup.as_fd();
         let attach_type = self.data.expected_attach_type.unwrap();
-        if KernelVersion::current().unwrap() >= KernelVersion::new(5, 7, 0) {
+        if KernelVersion::at_least(5, 7, 0) {
             let link_fd = bpf_link_create(
                 prog_fd,
                 LinkTarget::Fd(cgroup_fd),

--- a/aya/src/programs/cgroup_sock_addr.rs
+++ b/aya/src/programs/cgroup_sock_addr.rs
@@ -77,7 +77,7 @@ impl CgroupSockAddr {
         let prog_fd = prog_fd.as_fd();
         let cgroup_fd = cgroup.as_fd();
         let attach_type = self.data.expected_attach_type.unwrap();
-        if KernelVersion::current().unwrap() >= KernelVersion::new(5, 7, 0) {
+        if KernelVersion::at_least(5, 7, 0) {
             let link_fd = bpf_link_create(
                 prog_fd,
                 LinkTarget::Fd(cgroup_fd),

--- a/aya/src/programs/cgroup_sockopt.rs
+++ b/aya/src/programs/cgroup_sockopt.rs
@@ -74,7 +74,7 @@ impl CgroupSockopt {
         let prog_fd = prog_fd.as_fd();
         let cgroup_fd = cgroup.as_fd();
         let attach_type = self.data.expected_attach_type.unwrap();
-        if KernelVersion::current().unwrap() >= KernelVersion::new(5, 7, 0) {
+        if KernelVersion::at_least(5, 7, 0) {
             let link_fd = bpf_link_create(
                 prog_fd,
                 LinkTarget::Fd(cgroup_fd),

--- a/aya/src/programs/cgroup_sysctl.rs
+++ b/aya/src/programs/cgroup_sysctl.rs
@@ -72,7 +72,7 @@ impl CgroupSysctl {
         let prog_fd = prog_fd.as_fd();
         let cgroup_fd = cgroup.as_fd();
 
-        if KernelVersion::current().unwrap() >= KernelVersion::new(5, 7, 0) {
+        if KernelVersion::at_least(5, 7, 0) {
             let link_fd = bpf_link_create(
                 prog_fd,
                 LinkTarget::Fd(cgroup_fd),

--- a/aya/src/programs/mod.rs
+++ b/aya/src/programs/mod.rs
@@ -659,8 +659,11 @@ fn load_program<T: Link>(
         },
     ) = obj;
 
-    let target_kernel_version =
-        kernel_version.unwrap_or_else(|| KernelVersion::current().unwrap().code());
+    let target_kernel_version = kernel_version.unwrap_or_else(|| {
+        KernelVersion::current()
+            .map(KernelVersion::code)
+            .unwrap_or(0)
+    });
 
     let prog_name = if let Some(name) = name.as_deref() {
         let prog_name = CString::new(name).map_err(|err @ std::ffi::NulError { .. }| {

--- a/aya/src/programs/probe.rs
+++ b/aya/src/programs/probe.rs
@@ -118,7 +118,7 @@ pub(crate) fn attach<T: Link + From<PerfLinkInner>>(
     // Use debugfs to create probe
     let prog_fd = program_data.fd()?;
     let prog_fd = prog_fd.as_fd();
-    let link = if KernelVersion::current().unwrap() < KernelVersion::new(4, 17, 0) {
+    let link = if !KernelVersion::at_least(4, 17, 0) {
         if cookie.is_some() {
             return Err(ProgramError::AttachCookieNotSupported);
         }

--- a/aya/src/programs/sock_ops.rs
+++ b/aya/src/programs/sock_ops.rs
@@ -71,7 +71,7 @@ impl SockOps {
         let prog_fd = prog_fd.as_fd();
         let cgroup_fd = cgroup.as_fd();
         let attach_type = BPF_CGROUP_SOCK_OPS;
-        if KernelVersion::current().unwrap() >= KernelVersion::new(5, 7, 0) {
+        if KernelVersion::at_least(5, 7, 0) {
             let link_fd = bpf_link_create(
                 prog_fd,
                 LinkTarget::Fd(cgroup_fd),

--- a/aya/src/programs/tc.rs
+++ b/aya/src/programs/tc.rs
@@ -181,9 +181,7 @@ impl SchedClassifier {
         interface: &str,
         attach_type: TcAttachType,
     ) -> Result<SchedClassifierLinkId, ProgramError> {
-        if !matches!(attach_type, TcAttachType::Custom(_))
-            && KernelVersion::current().unwrap() >= KernelVersion::new(6, 6, 0)
-        {
+        if !matches!(attach_type, TcAttachType::Custom(_)) && KernelVersion::at_least(6, 6, 0) {
             self.attach_with_options(
                 interface,
                 attach_type,

--- a/aya/src/programs/xdp.rs
+++ b/aya/src/programs/xdp.rs
@@ -133,7 +133,7 @@ impl Xdp {
         let prog_fd = self.fd()?;
         let prog_fd = prog_fd.as_fd();
 
-        if KernelVersion::current().unwrap() >= KernelVersion::new(5, 9, 0) {
+        if KernelVersion::at_least(5, 9, 0) {
             // Unwrap safety: the function starts with `self.fd()?` that will succeed if and only
             // if the program has been loaded, i.e. there is an fd. We get one by:
             // - Using `Xdp::from_pin` that sets `expected_attach_type`
@@ -255,7 +255,7 @@ impl Link for NlLink {
     }
 
     fn detach(self) -> Result<(), ProgramError> {
-        let flags = if KernelVersion::current().unwrap() >= KernelVersion::new(5, 7, 0) {
+        let flags = if KernelVersion::at_least(5, 7, 0) {
             self.flags.bits() | XDP_FLAGS_REPLACE
         } else {
             self.flags.bits()

--- a/aya/src/sys/bpf.rs
+++ b/aya/src/sys/bpf.rs
@@ -151,7 +151,7 @@ pub(crate) fn bpf_load_program(
 
     if let Some(name) = &aya_attr.name {
         let name_bytes = name.to_bytes();
-        let len = cmp::min(name_bytes.len(), u.prog_name.len());
+        let len = cmp::min(name_bytes.len(), u.prog_name.len() - 1); // Ensure NULL termination.
         u.prog_name[..len]
             .copy_from_slice(unsafe { mem::transmute::<&[u8], &[c_char]>(&name_bytes[..len]) });
     }
@@ -712,7 +712,7 @@ pub(crate) fn is_prog_name_supported() -> bool {
         let u = unsafe { &mut attr.__bindgen_anon_3 };
         let name = c"aya_name_check";
         let name_bytes = name.to_bytes();
-        let len = cmp::min(name_bytes.len(), u.prog_name.len());
+        let len = cmp::min(name_bytes.len(), u.prog_name.len() - 1); // Ensure NULL termination.
         u.prog_name[..len]
             .copy_from_slice(unsafe { mem::transmute::<&[u8], &[c_char]>(&name_bytes[..len]) });
         bpf_prog_load(attr).is_ok()

--- a/aya/src/sys/bpf.rs
+++ b/aya/src/sys/bpf.rs
@@ -46,7 +46,6 @@ pub(crate) fn bpf_create_map(
     name: &CStr,
     def: &aya_obj::Map,
     btf_fd: Option<BorrowedFd<'_>>,
-    kernel_version: KernelVersion,
 ) -> io::Result<crate::MockableFd> {
     let mut attr = unsafe { mem::zeroed::<bpf_attr>() };
 
@@ -93,7 +92,7 @@ pub(crate) fn bpf_create_map(
     // https://github.com/torvalds/linux/commit/ad5b177bd73f5107d97c36f56395c4281fb6f089
     // The map name was added as a parameter in kernel 4.15+ so we skip adding it on
     // older kernels for compatibility
-    if kernel_version >= KernelVersion::new(4, 15, 0) {
+    if KernelVersion::at_least(4, 15, 0) {
         // u.map_name is 16 bytes max and must be NULL terminated
         let name_bytes = name.to_bytes_with_nul();
         let len = cmp::min(name_bytes.len(), u.map_name.len());


### PR DESCRIPTION
Cache the current kernel version in a thread-local while I'm here.

Closes https://github.com/aya-rs/aya/issues/1024.
Closes https://github.com/aya-rs/aya/pull/1042.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aya-rs/aya/1196)
<!-- Reviewable:end -->
