### PR TITLE
chore(xtask): Add loongarch64 to codegen

### DIFF
--- a/.github/workflows/gen.yml
+++ b/.github/workflows/gen.yml
@@ -28,7 +28,7 @@ jobs:
         run: |
           set -euxo pipefail
           sudo apt -y update
-          sudo apt -y install libelf-dev libc6-dev libc6-dev-{arm64,armel,riscv64,ppc64el,s390x,mips}-cross
+          sudo apt -y install libelf-dev libc6-dev libc6-dev-{arm64,armel,loong64,riscv64,ppc64el,s390x,mips}-cross
 
       - run: cargo xtask codegen
       - run: cargo xtask public-api --bless

--- a/xtask/src/codegen/aya.rs
+++ b/xtask/src/codegen/aya.rs
@@ -43,6 +43,7 @@ fn codegen_bindings(opts: &SysrootOptions, libbpf_dir: &Path) -> Result<()> {
         powerpc64_sysroot,
         s390x_sysroot,
         mips_sysroot,
+        loongarch64_sysroot,
     } = opts;
     let dir = PathBuf::from("aya-obj");
     let generated = dir.join("src/generated");
@@ -204,6 +205,7 @@ fn codegen_bindings(opts: &SysrootOptions, libbpf_dir: &Path) -> Result<()> {
             Architecture::PowerPC64 => "powerpc64le-unknown-linux-gnu",
             Architecture::S390X => "s390x-unknown-linux-gnu",
             Architecture::Mips => "mips-unknown-linux-gnu",
+            Architecture::LoongArch64 => "loongarch64-unknown-linux-gnu",
         };
         bindgen = bindgen.clang_args(&["-target", target]);
 
@@ -217,6 +219,7 @@ fn codegen_bindings(opts: &SysrootOptions, libbpf_dir: &Path) -> Result<()> {
             Architecture::PowerPC64 => powerpc64_sysroot,
             Architecture::S390X => s390x_sysroot,
             Architecture::Mips => mips_sysroot,
+            Architecture::LoongArch64 => loongarch64_sysroot,
         };
         bindgen = bindgen.clang_args(["-I", sysroot.to_str().unwrap()]);
 

--- a/xtask/src/codegen/aya_ebpf_bindings.rs
+++ b/xtask/src/codegen/aya_ebpf_bindings.rs
@@ -28,6 +28,7 @@ pub fn codegen(opts: &SysrootOptions, libbpf_dir: &Path) -> Result<()> {
         powerpc64_sysroot,
         s390x_sysroot,
         mips_sysroot,
+        loongarch64_sysroot,
     } = opts;
 
     let tmp_dir = tempfile::tempdir().context("tempdir failed")?;
@@ -113,6 +114,7 @@ pub fn codegen(opts: &SysrootOptions, libbpf_dir: &Path) -> Result<()> {
             Architecture::PowerPC64 => "powerpc64le-unknown-linux-gnu",
             Architecture::S390X => "s390x-unknown-linux-gnu",
             Architecture::Mips => "mips-unknown-linux-gnu",
+            Architecture::LoongArch64 => "loongarch64-unknown-linux-gnu",
         };
         bindgen = bindgen.clang_args(["-target", target]);
 
@@ -126,6 +128,7 @@ pub fn codegen(opts: &SysrootOptions, libbpf_dir: &Path) -> Result<()> {
             Architecture::PowerPC64 => powerpc64_sysroot,
             Architecture::S390X => s390x_sysroot,
             Architecture::Mips => mips_sysroot,
+            Architecture::LoongArch64 => loongarch64_sysroot,
         };
         bindgen = bindgen.clang_args(["-I", sysroot.to_str().unwrap()]);
 

--- a/xtask/src/codegen/mod.rs
+++ b/xtask/src/codegen/mod.rs
@@ -15,6 +15,7 @@ const SUPPORTED_ARCHS: &[Architecture] = &[
     Architecture::RISCV64,
     Architecture::PowerPC64,
     Architecture::S390X,
+    Architecture::LoongArch64,
 ];
 
 #[derive(Debug, Copy, Clone)]
@@ -26,6 +27,7 @@ pub enum Architecture {
     PowerPC64,
     S390X,
     Mips,
+    LoongArch64,
 }
 
 impl Architecture {
@@ -46,6 +48,7 @@ impl std::str::FromStr for Architecture {
             "riscv64" => Architecture::RISCV64,
             "powerpc64" => Architecture::PowerPC64,
             "s390x" => Architecture::S390X,
+            "loongarch64" => Architecture::LoongArch64,
             _ => return Err("invalid architecture"),
         })
     }
@@ -61,6 +64,7 @@ impl std::fmt::Display for Architecture {
             Architecture::RISCV64 => "riscv64",
             Architecture::PowerPC64 => "powerpc64",
             Architecture::S390X => "s390x",
+            Architecture::LoongArch64 => "loongarch64",
         })
     }
 }
@@ -89,6 +93,9 @@ pub struct SysrootOptions {
 
     #[arg(long, default_value = "/usr/mips-linux-gnu/include", action)]
     mips_sysroot: PathBuf,
+
+    #[arg(long, default_value = "/usr/loongarch64-linux-gnu/include", action)]
+    loongarch64_sysroot: PathBuf,
 }
 
 #[derive(Parser)]


### PR DESCRIPTION
This patch adds binding generation support for the Rust Tier 2 targets `loongarch64-unknown-linux-*`. I will send subsequent patches to enable full support once the binding files are generated. Thanks.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aya-rs/aya/1197)
<!-- Reviewable:end -->
