### PR TITLE
xtask: Use reqwest to fetch `gen_init_cpio.c`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -316,7 +316,7 @@ jobs:
         run: |
           set -euxo pipefail
           find test/.tmp -name 'vmlinuz-*' -print0 | xargs -t -0 \
-            cargo xtask integration-test vm --cache-dir test/.tmp --github-api-token ${{ secrets.GITHUB_TOKEN }}
+            cargo xtask integration-test vm --cache-dir test/.tmp
 
   # Provides a single status check for the entire build workflow.
   # This is used for merge automation, like Mergify, since GH actions

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,7 +60,6 @@ edition = "2024"
 # them to do that, but in the meantime we need to be careful.
 [workspace.dependencies]
 anyhow = { version = "1", default-features = false }
-base64 = { version = "0.22.1", default-features = false }
 assert_matches = { version = "1.5.0", default-features = false }
 async-io = { version = "2.0", default-features = false }
 bindgen = { version = "0.71", default-features = false }
@@ -82,7 +81,6 @@ netns-rs = { version = "0.1", default-features = false }
 nix = { version = "0.29.0", default-features = false }
 num_enum = { version = "0.7", default-features = false }
 object = { version = "0.36", default-features = false }
-octorust = { version = "0.9.0", default-features = false }
 once_cell = { version = "1.20.1", default-features = false }
 proc-macro2 = { version = "1", default-features = false }
 proc-macro2-diagnostics = { version = "0.10.1", default-features = false }
@@ -90,6 +88,7 @@ public-api = { version = "0.44.0", default-features = false }
 quote = { version = "1", default-features = false }
 rand = { version = "0.9", default-features = false }
 rbpf = { version = "0.3.0", default-features = false }
+reqwest = { version = "0.12", default-features = false }
 rustdoc-json = { version = "0.9.0", default-features = false }
 rustup-toolchain = { version = "0.1.5", default-features = false }
 rustversion = { version = "1.0.0", default-features = false }

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -12,16 +12,15 @@ edition.workspace = true
 [dependencies]
 anyhow = { workspace = true, features = ["std"] }
 aya-tool = { path = "../aya-tool", version = "0.1.0", default-features = false }
-base64 = { workspace = true, features = ["std"] }
 cargo_metadata = { workspace = true }
 clap = { workspace = true, features = ["derive"] }
 dialoguer = { workspace = true }
 diff = { workspace = true }
 indoc = { workspace = true }
-octorust = { workspace = true, features = ["rustls-tls"] }
 proc-macro2 = { workspace = true }
 public-api = { workspace = true }
 quote = { workspace = true }
+reqwest = { workspace = true, features = ["rustls-tls"] }
 rustdoc-json = { workspace = true }
 rustup-toolchain = { workspace = true }
 syn = { workspace = true }


### PR DESCRIPTION
Since `octorust` depends on an old version of `ring`, some newer Rust targets cannot compile with it. This patch switches to using `reqwest` to fetch `gen_init_cpio.c` to make it work on more targets.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aya-rs/aya/1208)
<!-- Reviewable:end -->
