### PR TITLE
chore: Disable mergify on dependabot PRs

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,11 +1,4 @@
 pull_request_rules:
-  - name: automatic merge for Dependabot pull request that pass CI
-    conditions:
-      - author=dependabot[bot]
-    actions:
-      comment:
-        message: "@dependabot merge"
-
   # REVIEW MANAGEMENT
 
   - name: ask alessandrod to review public API changes


### PR DESCRIPTION
Merging via comment isn't possible. We could merge this automatically on green, however we'd prefer to use @dependabot merge or merge manually.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aya-rs/aya/1210)
<!-- Reviewable:end -->
