### PR TITLE
introduce workspace lints, warn on unused crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -103,6 +103,9 @@ tokio = { version = "1.24.0", default-features = false }
 which = { version = "7.0.0", default-features = false }
 xdpilone = { version = "1.0.5", default-features = false }
 
+[workspace.lints.rust]
+unused-extern-crates = "warn"
+
 [profile.release.package.integration-ebpf]
 debug = 2
 codegen-units = 1

--- a/aya-build/Cargo.toml
+++ b/aya-build/Cargo.toml
@@ -9,6 +9,9 @@ homepage.workspace = true
 rust-version.workspace = true
 edition.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 anyhow = { workspace = true, default-features = true }
 cargo_metadata = { workspace = true }

--- a/aya-ebpf-macros/Cargo.toml
+++ b/aya-ebpf-macros/Cargo.toml
@@ -9,6 +9,9 @@ homepage.workspace = true
 rust-version.workspace = true
 edition.workspace = true
 
+[lints]
+workspace = true
+
 [lib]
 proc-macro = true
 

--- a/aya-log-common/Cargo.toml
+++ b/aya-log-common/Cargo.toml
@@ -11,6 +11,9 @@ homepage.workspace = true
 rust-version.workspace = true
 edition.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 num_enum = { workspace = true }
 

--- a/aya-log-ebpf-macros/Cargo.toml
+++ b/aya-log-ebpf-macros/Cargo.toml
@@ -9,6 +9,9 @@ homepage.workspace = true
 rust-version.workspace = true
 edition.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 aya-log-common = { path = "../aya-log-common", version = "^0.1.14", default-features = false }
 aya-log-parser = { path = "../aya-log-parser", version = "^0.1.13", default-features = false }

--- a/aya-log-parser/Cargo.toml
+++ b/aya-log-parser/Cargo.toml
@@ -9,6 +9,9 @@ homepage.workspace = true
 rust-version.workspace = true
 edition.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 aya-log-common = { path = "../aya-log-common", version = "^0.1.14", default-features = false }
 

--- a/aya-log/Cargo.toml
+++ b/aya-log/Cargo.toml
@@ -12,6 +12,9 @@ homepage.workspace = true
 rust-version.workspace = true
 edition.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 aya = { path = "../aya", version = "^0.13.1", features = ["async_tokio"] }
 aya-log-common = { path = "../aya-log-common", version = "^0.1.15", default-features = false }

--- a/aya-obj/Cargo.toml
+++ b/aya-obj/Cargo.toml
@@ -12,6 +12,9 @@ homepage.workspace = true
 rust-version.workspace = true
 edition.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 bytes = { workspace = true }
 hashbrown = { workspace = true, default-features = true }

--- a/aya-tool/Cargo.toml
+++ b/aya-tool/Cargo.toml
@@ -10,6 +10,9 @@ homepage.workspace = true
 rust-version.workspace = true
 edition.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 bindgen = { workspace = true, default-features = true }
 clap = { workspace = true, default-features = true, features = ["derive"] }

--- a/aya/Cargo.toml
+++ b/aya/Cargo.toml
@@ -12,6 +12,9 @@ homepage.workspace = true
 rust-version.workspace = true
 edition.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 assert_matches = { workspace = true }
 async-io = { workspace = true, optional = true }

--- a/ebpf/aya-ebpf-bindings/Cargo.toml
+++ b/ebpf/aya-ebpf-bindings/Cargo.toml
@@ -8,5 +8,8 @@ repository.workspace = true
 homepage.workspace = true
 edition.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 aya-ebpf-cty = { version = "^0.2.2", path = "../aya-ebpf-cty" }

--- a/ebpf/aya-ebpf-cty/Cargo.toml
+++ b/ebpf/aya-ebpf-cty/Cargo.toml
@@ -10,3 +10,6 @@ repository.workspace = true
 homepage.workspace = true
 rust-version.workspace = true
 edition.workspace = true
+
+[lints]
+workspace = true

--- a/ebpf/aya-ebpf/Cargo.toml
+++ b/ebpf/aya-ebpf/Cargo.toml
@@ -9,6 +9,9 @@ homepage.workspace = true
 rust-version.workspace = true
 edition.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 aya-ebpf-cty = { version = "^0.2.2", path = "../aya-ebpf-cty" }
 aya-ebpf-macros = { version = "^0.1.1", path = "../../aya-ebpf-macros" }

--- a/ebpf/aya-log-ebpf/Cargo.toml
+++ b/ebpf/aya-log-ebpf/Cargo.toml
@@ -9,6 +9,9 @@ homepage.workspace = true
 rust-version.workspace = true
 edition.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 aya-ebpf = { version = "^0.1.1", path = "../aya-ebpf" }
 aya-log-common = { version = "^0.1.15", path = "../../aya-log-common" }

--- a/init/Cargo.toml
+++ b/init/Cargo.toml
@@ -9,6 +9,9 @@ homepage.workspace = true
 rust-version.workspace = true
 edition.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 anyhow = { workspace = true, features = ["std"] }
 nix = { workspace = true, features = ["fs", "mount", "reboot"] }

--- a/test/integration-common/Cargo.toml
+++ b/test/integration-common/Cargo.toml
@@ -9,6 +9,9 @@ homepage.workspace = true
 rust-version.workspace = true
 edition.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 aya = { path = "../../aya", optional = true }
 

--- a/test/integration-ebpf/Cargo.toml
+++ b/test/integration-ebpf/Cargo.toml
@@ -9,6 +9,9 @@ homepage.workspace = true
 rust-version.workspace = true
 edition.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 aya-ebpf = { path = "../../ebpf/aya-ebpf" }
 aya-log-ebpf = { path = "../../ebpf/aya-log-ebpf" }

--- a/test/integration-test/Cargo.toml
+++ b/test/integration-test/Cargo.toml
@@ -9,6 +9,9 @@ homepage.workspace = true
 rust-version.workspace = true
 edition.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 anyhow = { workspace = true, features = ["std"] }
 assert_matches = { workspace = true }

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -9,6 +9,9 @@ homepage.workspace = true
 rust-version.workspace = true
 edition.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 anyhow = { workspace = true, features = ["std"] }
 aya-tool = { path = "../aya-tool", version = "0.1.0", default-features = false }


### PR DESCRIPTION
In practice this will forbid unused dependencies because we run clippy
with `--deny warnings`.

Workspace lints is a nice place to ratchet up lints through the codebase
all at once and consistently.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aya-rs/aya/1212)
<!-- Reviewable:end -->
