### PR TITLE
feat: Added bounds check for `SkBuff::load_bytes` and relevant integration test.

### DIFF
--- a/ebpf/aya-ebpf/src/programs/sk_buff.rs
+++ b/ebpf/aya-ebpf/src/programs/sk_buff.rs
@@ -10,7 +10,7 @@ use aya_ebpf_bindings::helpers::{
 };
 use aya_ebpf_cty::c_long;
 
-use crate::{EbpfContext, bindings::__sk_buff};
+use crate::{bindings::__sk_buff, check_bounds_signed, EbpfContext};
 
 pub struct SkBuff {
     pub skb: *mut __sk_buff,
@@ -90,6 +90,9 @@ impl SkBuff {
         let len = usize::try_from(self.len()).map_err(|core::num::TryFromIntError { .. }| -1)?;
         let len = len.checked_sub(offset).ok_or(-1)?;
         let len = len.min(dst.len());
+        if !check_bounds_signed(len as c_long, 1, dst.len() as c_long) {
+            return Err(-1);
+        }
         let len_u32 = u32::try_from(len).map_err(|core::num::TryFromIntError { .. }| -1)?;
         let ret = unsafe {
             bpf_skb_load_bytes(

--- a/test/integration-ebpf/Cargo.toml
+++ b/test/integration-ebpf/Cargo.toml
@@ -89,3 +89,7 @@ path = "src/xdp_sec.rs"
 [[bin]]
 name = "uprobe_cookie"
 path = "src/uprobe_cookie.rs"
+
+[[bin]]
+name = "socket_filter"
+path = "src/socket_filter.rs"

--- a/test/integration-ebpf/src/socket_filter.rs
+++ b/test/integration-ebpf/src/socket_filter.rs
@@ -7,7 +7,7 @@ use aya_ebpf::{macros::socket_filter, programs::SkBuffContext};
 #[socket_filter]
 pub fn read_one(ctx: SkBuffContext) -> i64 {
     // Read 1 byte
-    let mut dst = [0; 1];
+    let mut dst = [0; 2];
     let _ = ctx.load_bytes(0, &mut dst);
 
     0

--- a/test/integration-ebpf/src/socket_filter.rs
+++ b/test/integration-ebpf/src/socket_filter.rs
@@ -1,0 +1,20 @@
+#![no_std]
+#![no_main]
+
+use aya_ebpf::{macros::socket_filter, programs::SkBuffContext};
+
+
+#[socket_filter]
+pub fn read_one(ctx: SkBuffContext) -> i64 {
+    // Read 1 byte
+    let mut dst = [0; 1];
+    let _ = ctx.load_bytes(0, &mut dst);
+
+    0
+}
+
+#[cfg(not(test))]
+#[panic_handler]
+fn panic(_info: &core::panic::PanicInfo) -> ! {
+    loop {}
+}

--- a/test/integration-test/src/lib.rs
+++ b/test/integration-test/src/lib.rs
@@ -32,6 +32,7 @@ pub const TEST: &[u8] = include_bytes_aligned!(concat!(env!("OUT_DIR"), "/test")
 pub const TWO_PROGS: &[u8] = include_bytes_aligned!(concat!(env!("OUT_DIR"), "/two_progs"));
 pub const XDP_SEC: &[u8] = include_bytes_aligned!(concat!(env!("OUT_DIR"), "/xdp_sec"));
 pub const UPROBE_COOKIE: &[u8] = include_bytes_aligned!(concat!(env!("OUT_DIR"), "/uprobe_cookie"));
+pub const SOCKET_FILTER: &[u8] = include_bytes_aligned!(concat!(env!("OUT_DIR"), "/socket_filter"));
 
 #[cfg(test)]
 mod tests;

--- a/test/integration-test/src/tests.rs
+++ b/test/integration-test/src/tests.rs
@@ -14,3 +14,4 @@ mod strncmp;
 mod tcx;
 mod uprobe_cookie;
 mod xdp;
+mod socket_filter;

--- a/test/integration-test/src/tests/socket_filter.rs
+++ b/test/integration-test/src/tests/socket_filter.rs
@@ -1,0 +1,13 @@
+use aya::{programs::SocketFilter, Ebpf};
+
+#[test]
+fn socket_filter_load() {
+    let mut bpf = Ebpf::load(crate::SOCKET_FILTER).unwrap();
+    let prog: &mut SocketFilter = bpf
+        .program_mut("read_one")
+        .unwrap()
+        .try_into()
+        .unwrap();
+    prog.load().unwrap();
+
+}


### PR DESCRIPTION
Alternative to https://github.com/aya-rs/aya/pull/1187, attempting to resolve the `invalid zero-sized read` error found on discord and in my personal projects. 

This PR contains: 

The correct inclusive bounds check.

An integration test which fails before the update and succeeds after.