### PR TITLE
chore(*): set clippy unused_trait_names = warn

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -107,6 +107,9 @@ which = { version = "7.0.0", default-features = false }
 xdpilone = { version = "1.0.5", default-features = false }
 xz2 = { version = "0.1.7", default-features = false }
 
+[workspace.lints.clippy]
+unused_trait_names = "warn"
+
 [workspace.lints.rust]
 unused-extern-crates = "warn"
 

--- a/aya-log/src/lib.rs
+++ b/aya-log/src/lib.rs
@@ -736,7 +736,7 @@ fn try_read<T: Pod>(mut buf: &[u8]) -> Result<(T, &[u8], &[u8]), ()> {
 mod test {
     use std::net::IpAddr;
 
-    use aya_log_common::{WriteToBuf, write_record_header};
+    use aya_log_common::{WriteToBuf as _, write_record_header};
     use log::{Level, logger};
 
     use super::*;

--- a/aya-obj/src/btf/btf.rs
+++ b/aya-obj/src/btf/btf.rs
@@ -7,7 +7,7 @@ use alloc::{
 };
 use core::{ffi::CStr, mem, ptr};
 
-use bytes::BufMut;
+use bytes::BufMut as _;
 use log::debug;
 use object::{Endianness, SectionIndex};
 
@@ -308,7 +308,7 @@ impl Btf {
         path: P,
         endianness: Endianness,
     ) -> Result<Btf, BtfError> {
-        use std::{borrow::ToOwned, fs};
+        use std::{borrow::ToOwned as _, fs};
         let path = path.as_ref();
         Btf::parse(
             &fs::read(path).map_err(|error| BtfError::FileError {

--- a/aya-obj/src/btf/info.rs
+++ b/aya-obj/src/btf/info.rs
@@ -1,6 +1,6 @@
 use alloc::{string::String, vec, vec::Vec};
 
-use bytes::BufMut;
+use bytes::BufMut as _;
 use object::Endianness;
 
 use crate::{

--- a/aya-obj/src/btf/relocation.rs
+++ b/aya-obj/src/btf/relocation.rs
@@ -2,7 +2,7 @@ use alloc::{
     borrow::{Cow, ToOwned as _},
     collections::BTreeMap,
     format,
-    string::{String, ToString},
+    string::{String, ToString as _},
     vec,
     vec::Vec,
 };

--- a/aya-obj/src/btf/types.rs
+++ b/aya-obj/src/btf/types.rs
@@ -1,6 +1,6 @@
 #![expect(missing_docs)]
 
-use alloc::{string::ToString, vec, vec::Vec};
+use alloc::{string::ToString as _, vec, vec::Vec};
 use core::{fmt::Display, mem, ptr};
 
 use object::Endianness;

--- a/aya-obj/src/obj.rs
+++ b/aya-obj/src/obj.rs
@@ -1,10 +1,10 @@
 //! Object file loading, parsing, and relocation.
 
 use alloc::{
-    borrow::ToOwned,
+    borrow::ToOwned as _,
     collections::BTreeMap,
     ffi::CString,
-    string::{String, ToString},
+    string::{String, ToString as _},
     vec,
     vec::Vec,
 };
@@ -12,9 +12,9 @@ use core::{ffi::CStr, mem, ptr, slice::from_raw_parts_mut, str::FromStr};
 
 use log::debug;
 use object::{
-    Endianness, ObjectSymbol, ObjectSymbolTable, RelocationTarget, SectionIndex, SectionKind,
-    SymbolKind,
-    read::{Object as ElfObject, ObjectSection, Section as ObjSection},
+    Endianness, ObjectSymbol as _, ObjectSymbolTable as _, RelocationTarget, SectionIndex,
+    SectionKind, SymbolKind,
+    read::{Object as _, ObjectSection as _, Section as ObjSection},
 };
 
 use crate::{

--- a/aya-obj/src/relocation.rs
+++ b/aya-obj/src/relocation.rs
@@ -1,6 +1,6 @@
 //! Program relocation handling.
 
-use alloc::{borrow::ToOwned, collections::BTreeMap, string::String};
+use alloc::{borrow::ToOwned as _, collections::BTreeMap, string::String};
 use core::mem;
 
 use log::debug;
@@ -502,7 +502,7 @@ fn insn_is_call(ins: &bpf_insn) -> bool {
 
 #[cfg(test)]
 mod test {
-    use alloc::{string::ToString, vec, vec::Vec};
+    use alloc::{string::ToString as _, vec, vec::Vec};
 
     use super::*;
     use crate::maps::{BtfMap, LegacyMap};

--- a/aya-tool/src/generate.rs
+++ b/aya-tool/src/generate.rs
@@ -1,6 +1,6 @@
 use std::{
     fs::{self, File},
-    io::{self, Write},
+    io::{self, Write as _},
     path::{Path, PathBuf},
     process::Command,
     str,

--- a/aya/src/maps/perf/perf_event_array.rs
+++ b/aya/src/maps/perf/perf_event_array.rs
@@ -3,7 +3,7 @@
 //! [`perf`]: https://perf.wiki.kernel.org/index.php/Main_Page.
 use std::{
     borrow::{Borrow, BorrowMut},
-    ops::Deref,
+    ops::Deref as _,
     os::fd::{AsFd, AsRawFd, BorrowedFd, RawFd},
     path::Path,
     sync::Arc,

--- a/aya/src/maps/xdp/cpu_map.rs
+++ b/aya/src/maps/xdp/cpu_map.rs
@@ -3,7 +3,7 @@
 use std::{
     borrow::{Borrow, BorrowMut},
     num::NonZeroU32,
-    os::fd::{AsFd, AsRawFd},
+    os::fd::{AsFd as _, AsRawFd as _},
 };
 
 use aya_obj::generated::bpf_cpumap_val;

--- a/aya/src/maps/xdp/dev_map.rs
+++ b/aya/src/maps/xdp/dev_map.rs
@@ -3,7 +3,7 @@
 use std::{
     borrow::{Borrow, BorrowMut},
     num::NonZeroU32,
-    os::fd::{AsFd, AsRawFd},
+    os::fd::{AsFd as _, AsRawFd as _},
 };
 
 use aya_obj::generated::bpf_devmap_val;

--- a/aya/src/maps/xdp/dev_map_hash.rs
+++ b/aya/src/maps/xdp/dev_map_hash.rs
@@ -3,7 +3,7 @@
 use std::{
     borrow::{Borrow, BorrowMut},
     num::NonZeroU32,
-    os::fd::{AsFd, AsRawFd},
+    os::fd::{AsFd as _, AsRawFd as _},
 };
 
 use aya_obj::generated::bpf_devmap_val;

--- a/aya/src/maps/xdp/xsk_map.rs
+++ b/aya/src/maps/xdp/xsk_map.rs
@@ -2,7 +2,7 @@
 
 use std::{
     borrow::{Borrow, BorrowMut},
-    os::fd::{AsFd, AsRawFd, BorrowedFd, RawFd},
+    os::fd::{AsFd as _, AsRawFd, BorrowedFd, RawFd},
 };
 
 use crate::{

--- a/aya/src/programs/probe.rs
+++ b/aya/src/programs/probe.rs
@@ -2,7 +2,7 @@ use std::{
     ffi::{OsStr, OsString},
     fmt::Write as _,
     fs::{self, OpenOptions},
-    io::{self, Write},
+    io::{self, Write as _},
     os::fd::AsFd as _,
     path::{Path, PathBuf},
     process,

--- a/aya/src/programs/socket_filter.rs
+++ b/aya/src/programs/socket_filter.rs
@@ -1,7 +1,7 @@
 //! Socket filter programs.
 use std::{
     io, mem,
-    os::fd::{AsFd, AsRawFd, RawFd},
+    os::fd::{AsFd, AsRawFd as _, RawFd},
 };
 
 use aya_obj::generated::{

--- a/aya/src/programs/uprobe.rs
+++ b/aya/src/programs/uprobe.rs
@@ -12,7 +12,7 @@ use std::{
 
 use aya_obj::generated::{bpf_link_type, bpf_prog_type::BPF_PROG_TYPE_KPROBE};
 use libc::pid_t;
-use object::{Object, ObjectSection, ObjectSymbol, Symbol};
+use object::{Object as _, ObjectSection as _, ObjectSymbol as _, Symbol};
 use thiserror::Error;
 
 use crate::{

--- a/aya/src/programs/utils.rs
+++ b/aya/src/programs/utils.rs
@@ -2,7 +2,7 @@
 use std::{
     ffi::CStr,
     fs::File,
-    io::{self, BufRead, BufReader},
+    io::{self, BufRead as _, BufReader},
     os::fd::{AsFd as _, AsRawFd as _, BorrowedFd},
     path::Path,
     sync::LazyLock,

--- a/ebpf/aya-ebpf/src/maps/sock_hash.rs
+++ b/ebpf/aya-ebpf/src/maps/sock_hash.rs
@@ -3,7 +3,7 @@ use core::{borrow::Borrow, cell::UnsafeCell, marker::PhantomData, mem};
 use aya_ebpf_cty::c_void;
 
 use crate::{
-    EbpfContext,
+    EbpfContext as _,
     bindings::{bpf_map_def, bpf_map_type::BPF_MAP_TYPE_SOCKHASH, bpf_sock_ops},
     helpers::{
         bpf_msg_redirect_hash, bpf_sk_assign, bpf_sk_redirect_hash, bpf_sk_release,

--- a/ebpf/aya-ebpf/src/maps/sock_map.rs
+++ b/ebpf/aya-ebpf/src/maps/sock_map.rs
@@ -1,7 +1,7 @@
 use core::{cell::UnsafeCell, mem};
 
 use crate::{
-    EbpfContext,
+    EbpfContext as _,
     bindings::{bpf_map_def, bpf_map_type::BPF_MAP_TYPE_SOCKMAP, bpf_sock_ops},
     helpers::{
         bpf_msg_redirect_map, bpf_sk_assign, bpf_sk_redirect_map, bpf_sk_release,

--- a/test/integration-ebpf/src/uprobe_cookie.rs
+++ b/test/integration-ebpf/src/uprobe_cookie.rs
@@ -2,7 +2,7 @@
 #![no_main]
 
 use aya_ebpf::{
-    EbpfContext, helpers,
+    EbpfContext as _, helpers,
     macros::{map, uprobe},
     maps::RingBuf,
     programs::ProbeContext,

--- a/test/integration-test/src/tests/elf.rs
+++ b/test/integration-test/src/tests/elf.rs
@@ -1,4 +1,4 @@
-use object::{Object, ObjectSymbol};
+use object::{Object as _, ObjectSymbol as _};
 use test_log::test;
 
 #[test]

--- a/test/integration-test/src/tests/iter.rs
+++ b/test/integration-test/src/tests/iter.rs
@@ -1,4 +1,4 @@
-use std::io::BufRead;
+use std::io::BufRead as _;
 
 use aya::{Btf, Ebpf, programs::Iter};
 use test_log::test;

--- a/test/integration-test/src/tests/xdp.rs
+++ b/test/integration-test/src/tests/xdp.rs
@@ -5,7 +5,7 @@ use aya::{
     maps::{Array, CpuMap, XskMap},
     programs::{Xdp, XdpFlags},
 };
-use object::{Object, ObjectSection, ObjectSymbol, SymbolSection};
+use object::{Object as _, ObjectSection as _, ObjectSymbol as _, SymbolSection};
 use test_log::test;
 use xdpilone::{BufIdx, IfInfo, Socket, SocketConfig, Umem, UmemConfig};
 

--- a/xtask/src/codegen/aya_ebpf_bindings.rs
+++ b/xtask/src/codegen/aya_ebpf_bindings.rs
@@ -8,7 +8,7 @@ use std::{
 use anyhow::{Context as _, Result};
 use aya_tool::bindgen;
 use proc_macro2::TokenStream;
-use quote::ToTokens;
+use quote::ToTokens as _;
 use syn::{Item, parse_str};
 
 use crate::{

--- a/xtask/src/codegen/helpers.rs
+++ b/xtask/src/codegen/helpers.rs
@@ -1,5 +1,5 @@
 use proc_macro2::TokenStream;
-use quote::{TokenStreamExt, quote};
+use quote::{TokenStreamExt as _, quote};
 use syn::{
     AngleBracketedGenericArguments, BareFnArg, ForeignItem, ForeignItemStatic, GenericArgument,
     Ident, Item, Path, PathArguments, ReturnType, Token, Type, TypeBareFn, TypePath,


### PR DESCRIPTION
We have previously tried to import traits anonymously where possible but enforcing this manually was hard.

Since Rust 1.83 clippy can now enforce this for us.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aya-rs/aya/1224)
<!-- Reviewable:end -->
