### PR TITLE
chore(aya): Fix clippy unused cfg_attr

### DIFF
--- a/aya/src/maps/mod.rs
+++ b/aya/src/maps/mod.rs
@@ -438,28 +438,30 @@ macro_rules! impl_try_from_map {
     // rather than the repeated idents used later because the macro language does not allow one
     // repetition to be pasted inside another.
     ($ty_param:tt {
-        $($ty:ident $(from $($variant:ident)|+)?),+ $(,)?
+        $($(#[$meta:meta])* $ty:ident $(from $($variant:ident)|+)?),+ $(,)?
     }) => {
-        $(impl_try_from_map!(<$ty_param> $ty $(from $($variant)|+)?);)+
+        $(impl_try_from_map!($(#[$meta])* <$ty_param> $ty $(from $($variant)|+)?);)+
     };
     // Add the "from $variant" using $ty as the default if it is missing.
-    (<$ty_param:tt> $ty:ident) => {
-        impl_try_from_map!(<$ty_param> $ty from $ty);
+    ($(#[$meta:meta])* <$ty_param:tt> $ty:ident) => {
+        impl_try_from_map!($(#[$meta])* <$ty_param> $ty from $ty);
     };
     // Dispatch for each of the lifetimes.
     (
-        <($($ty_param:ident),*)> $ty:ident from $($variant:ident)|+
+        $(#[$meta:meta])* <($($ty_param:ident),*)> $ty:ident from $($variant:ident)|+
     ) => {
-        impl_try_from_map!(<'a> ($($ty_param),*) $ty from $($variant)|+);
-        impl_try_from_map!(<'a mut> ($($ty_param),*) $ty from $($variant)|+);
-        impl_try_from_map!(<> ($($ty_param),*) $ty from $($variant)|+);
+        impl_try_from_map!($(#[$meta])* <'a> ($($ty_param),*) $ty from $($variant)|+);
+        impl_try_from_map!($(#[$meta])* <'a mut> ($($ty_param),*) $ty from $($variant)|+);
+        impl_try_from_map!($(#[$meta])* <> ($($ty_param),*) $ty from $($variant)|+);
     };
     // An individual impl.
     (
+        $(#[$meta:meta])*
         <$($l:lifetime $($m:ident)?)?>
         ($($ty_param:ident),*)
         $ty:ident from $($variant:ident)|+
     ) => {
+        $(#[$meta])*
         impl<$($l,)? $($ty_param: Pod),*> TryFrom<$(&$l $($m)?)? Map>
             for $ty<$(&$l $($m)?)? MapData, $($ty_param),*>
         {
@@ -487,11 +489,8 @@ impl_try_from_map!(() {
     SockMap,
     StackTraceMap,
     XskMap,
-});
-
-#[cfg(any(feature = "async_tokio", feature = "async_std"))]
-#[cfg_attr(docsrs, doc(cfg(any(feature = "async_tokio", feature = "async_std"))))]
-impl_try_from_map!(() {
+    #[cfg(any(feature = "async_tokio", feature = "async_std"))]
+    #[cfg_attr(docsrs, doc(cfg(any(feature = "async_tokio", feature = "async_std"))))] // FIXME: This doesn't get expanded
     AsyncPerfEventArray from PerfEventArray,
 });
 


### PR DESCRIPTION
clippy complains that cfg_attr is applied to the macro invocation and therefore will not be expanded. Attempted to fix this (and clean up macro usage) by adding a meta matcher to these macros.

However, evaluating the expanded output shows that cfg_attr gets ignored?

```rust
 #[cfg(any(feature = "async_tokio", feature = "async_std"))]
    impl<'a> TryFrom<&'a mut Map> for AsyncPerfEventArray<&'a mut MapData> {
        type Error = MapError;
        fn try_from(map: &'a mut Map) -> Result<Self, Self::Error> {
            match map {
                Map::PerfEventArray(map_data) => Self::new(map_data),
                map =>
                    Err(MapError::InvalidMapType { map_type: map.map_type() }),
            }
        }
    }
```

This suppresses the clippy error for now, and the cfg_attr is only for docs so it's not a big issue, but it would be nice to get this fixed someday.