### PR TITLE
ci: test against 6.12 rather than 6.10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -301,12 +301,12 @@ jobs:
       - name: Download debian kernels
         if: runner.arch == 'ARM64'
         # TODO: enable tests on kernels before 6.0.
-        run: .github/scripts/download_kernel_images.sh test/.tmp/debian-kernels/arm64 arm64 6.1 6.10
+        run: .github/scripts/download_kernel_images.sh test/.tmp/debian-kernels/arm64 arm64 6.1 6.12
 
       - name: Download debian kernels
         if: runner.arch == 'X64'
         # TODO: enable tests on kernels before 6.0.
-        run: .github/scripts/download_kernel_images.sh test/.tmp/debian-kernels/amd64 amd64 6.1 6.10
+        run: .github/scripts/download_kernel_images.sh test/.tmp/debian-kernels/amd64 amd64 6.1 6.12
 
       - name: Cleanup stale kernels and modules
         run: |


### PR DESCRIPTION
6.12 is an LTS kernel, while 6.10 is not. The latter has reached EOL and
no longer lives on debian mirrors.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aya-rs/aya/1249)
<!-- Reviewable:end -->
