### PR TITLE
ci: test against 5.10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -300,13 +300,11 @@ jobs:
 
       - name: Download debian kernels
         if: runner.arch == 'ARM64'
-        # TODO: enable tests on kernels before 6.0.
-        run: .github/scripts/download_kernel_images.sh test/.tmp/debian-kernels/arm64 arm64 6.1 6.12
+        run: .github/scripts/download_kernel_images.sh test/.tmp/debian-kernels/arm64 arm64 5.10 6.1 6.12
 
       - name: Download debian kernels
         if: runner.arch == 'X64'
-        # TODO: enable tests on kernels before 6.0.
-        run: .github/scripts/download_kernel_images.sh test/.tmp/debian-kernels/amd64 amd64 6.1 6.12
+        run: .github/scripts/download_kernel_images.sh test/.tmp/debian-kernels/amd64 amd64 5.10 6.1 6.12
 
       - name: Cleanup stale kernels and modules
         run: |


### PR DESCRIPTION
This is the earliest LTS that still exists on debian mirrors.
