### PR TITLE
aya: implement TryFrom<[Program Type]> for FdLink for various program types

### DIFF
--- a/aya/src/programs/cgroup_skb.rs
+++ b/aya/src/programs/cgroup_skb.rs
@@ -11,7 +11,7 @@ use crate::{
     VerifierLogLevel,
     programs::{
         CgroupAttachMode, FdLink, Link, ProgAttachLink, ProgramData, ProgramError, ProgramType,
-        define_link_wrapper, id_as_key, load_program,
+        define_link_wrapper, id_as_key, impl_try_into_fdlink, load_program,
     },
     sys::{LinkTarget, SyscallError, bpf_link_create},
     util::KernelVersion,
@@ -185,6 +185,8 @@ define_link_wrapper!(
     CgroupSkbLinkIdInner,
     CgroupSkb,
 );
+
+impl_try_into_fdlink!(CgroupSkbLink, CgroupSkbLinkInner);
 
 /// Defines where to attach a [`CgroupSkb`] program.
 #[derive(Copy, Clone, Debug)]

--- a/aya/src/programs/cgroup_sock.rs
+++ b/aya/src/programs/cgroup_sock.rs
@@ -9,7 +9,7 @@ use crate::{
     VerifierLogLevel,
     programs::{
         CgroupAttachMode, FdLink, Link, ProgAttachLink, ProgramData, ProgramError, ProgramType,
-        define_link_wrapper, id_as_key, load_program,
+        define_link_wrapper, id_as_key, impl_try_into_fdlink, load_program,
     },
     sys::{LinkTarget, SyscallError, bpf_link_create},
     util::KernelVersion,
@@ -161,3 +161,5 @@ define_link_wrapper!(
     CgroupSockLinkIdInner,
     CgroupSock,
 );
+
+impl_try_into_fdlink!(CgroupSockLink, CgroupSockLinkInner);

--- a/aya/src/programs/cgroup_sock_addr.rs
+++ b/aya/src/programs/cgroup_sock_addr.rs
@@ -9,7 +9,7 @@ use crate::{
     VerifierLogLevel,
     programs::{
         CgroupAttachMode, FdLink, Link, ProgAttachLink, ProgramData, ProgramError, ProgramType,
-        define_link_wrapper, id_as_key, load_program,
+        define_link_wrapper, id_as_key, impl_try_into_fdlink, load_program,
     },
     sys::{LinkTarget, SyscallError, bpf_link_create},
     util::KernelVersion,
@@ -162,3 +162,5 @@ define_link_wrapper!(
     CgroupSockAddrLinkIdInner,
     CgroupSockAddr,
 );
+
+impl_try_into_fdlink!(CgroupSockAddrLink, CgroupSockAddrLinkInner);

--- a/aya/src/programs/links.rs
+++ b/aya/src/programs/links.rs
@@ -556,6 +556,24 @@ macro_rules! define_link_wrapper {
 
 pub(crate) use define_link_wrapper;
 
+macro_rules! impl_try_into_fdlink {
+    ($wrapper:ident, $inner:ident) => {
+        impl TryFrom<$wrapper> for $crate::programs::FdLink {
+            type Error = $crate::programs::LinkError;
+
+            fn try_from(value: $wrapper) -> Result<Self, Self::Error> {
+                if let $inner::Fd(fd) = value.into_inner() {
+                    Ok(fd)
+                } else {
+                    Err($crate::programs::LinkError::InvalidLink)
+                }
+            }
+        }
+    };
+}
+
+pub(crate) use impl_try_into_fdlink;
+
 #[derive(Error, Debug)]
 /// Errors from operations on links.
 pub enum LinkError {

--- a/aya/src/programs/perf_attach.rs
+++ b/aya/src/programs/perf_attach.rs
@@ -26,7 +26,7 @@ pub(crate) enum PerfLinkIdInner {
 
 #[derive(Debug)]
 pub(crate) enum PerfLinkInner {
-    FdLink(FdLink),
+    Fd(FdLink),
     PerfLink(PerfLink),
 }
 
@@ -35,14 +35,14 @@ impl Link for PerfLinkInner {
 
     fn id(&self) -> Self::Id {
         match self {
-            Self::FdLink(link) => PerfLinkIdInner::FdLinkId(link.id()),
+            Self::Fd(link) => PerfLinkIdInner::FdLinkId(link.id()),
             Self::PerfLink(link) => PerfLinkIdInner::PerfLinkId(link.id()),
         }
     }
 
     fn detach(self) -> Result<(), ProgramError> {
         match self {
-            Self::FdLink(link) => link.detach(),
+            Self::Fd(link) => link.detach(),
             Self::PerfLink(link) => link.detach(),
         }
     }
@@ -101,7 +101,7 @@ pub(crate) fn perf_attach(
             call: "bpf_link_create",
             io_error,
         })?;
-        Ok(PerfLinkInner::FdLink(FdLink::new(link_fd)))
+        Ok(PerfLinkInner::Fd(FdLink::new(link_fd)))
     } else {
         perf_attach_either(prog_fd, fd, None)
     }

--- a/aya/src/programs/perf_event.rs
+++ b/aya/src/programs/perf_event.rs
@@ -16,7 +16,7 @@ pub use aya_obj::generated::{
 
 use crate::{
     programs::{
-        FdLink, LinkError, ProgramData, ProgramError, ProgramType,
+        FdLink, LinkError, ProgramData, ProgramError, ProgramType, impl_try_into_fdlink,
         links::define_link_wrapper,
         load_program, perf_attach,
         perf_attach::{PerfLinkIdInner, PerfLinkInner},
@@ -188,17 +188,7 @@ impl PerfEvent {
     }
 }
 
-impl TryFrom<PerfEventLink> for FdLink {
-    type Error = LinkError;
-
-    fn try_from(value: PerfEventLink) -> Result<Self, Self::Error> {
-        if let PerfLinkInner::FdLink(fd) = value.into_inner() {
-            Ok(fd)
-        } else {
-            Err(LinkError::InvalidLink)
-        }
-    }
-}
+impl_try_into_fdlink!(PerfEventLink, PerfLinkInner);
 
 impl TryFrom<FdLink> for PerfEventLink {
     type Error = LinkError;
@@ -206,7 +196,7 @@ impl TryFrom<FdLink> for PerfEventLink {
     fn try_from(fd_link: FdLink) -> Result<Self, Self::Error> {
         let info = bpf_link_get_info_by_fd(fd_link.fd.as_fd())?;
         if info.type_ == (bpf_link_type::BPF_LINK_TYPE_PERF_EVENT as u32) {
-            return Ok(Self::new(PerfLinkInner::FdLink(fd_link)));
+            return Ok(Self::new(PerfLinkInner::Fd(fd_link)));
         }
         Err(LinkError::InvalidLink)
     }

--- a/aya/src/programs/sock_ops.rs
+++ b/aya/src/programs/sock_ops.rs
@@ -8,7 +8,7 @@ use aya_obj::generated::{
 use crate::{
     programs::{
         CgroupAttachMode, FdLink, Link, ProgAttachLink, ProgramData, ProgramError, ProgramType,
-        define_link_wrapper, id_as_key, load_program,
+        define_link_wrapper, id_as_key, impl_try_into_fdlink, load_program,
     },
     sys::{LinkTarget, SyscallError, bpf_link_create},
     util::KernelVersion,
@@ -140,3 +140,5 @@ define_link_wrapper!(
     SockOpsLinkIdInner,
     SockOps,
 );
+
+impl_try_into_fdlink!(SockOpsLink, SockOpsLinkInner);

--- a/aya/src/programs/trace_point.rs
+++ b/aya/src/programs/trace_point.rs
@@ -11,7 +11,7 @@ use thiserror::Error;
 use crate::{
     programs::{
         FdLink, LinkError, ProgramData, ProgramError, ProgramType, define_link_wrapper,
-        load_program,
+        impl_try_into_fdlink, load_program,
         perf_attach::{PerfLinkIdInner, PerfLinkInner, perf_attach},
         utils::find_tracefs_path,
     },
@@ -99,17 +99,7 @@ define_link_wrapper!(
     TracePoint,
 );
 
-impl TryFrom<TracePointLink> for FdLink {
-    type Error = LinkError;
-
-    fn try_from(value: TracePointLink) -> Result<Self, Self::Error> {
-        if let PerfLinkInner::FdLink(fd) = value.into_inner() {
-            Ok(fd)
-        } else {
-            Err(LinkError::InvalidLink)
-        }
-    }
-}
+impl_try_into_fdlink!(TracePointLink, PerfLinkInner);
 
 impl TryFrom<FdLink> for TracePointLink {
     type Error = LinkError;
@@ -117,7 +107,7 @@ impl TryFrom<FdLink> for TracePointLink {
     fn try_from(fd_link: FdLink) -> Result<Self, Self::Error> {
         let info = bpf_link_get_info_by_fd(fd_link.fd.as_fd())?;
         if info.type_ == (bpf_link_type::BPF_LINK_TYPE_TRACING as u32) {
-            return Ok(Self::new(PerfLinkInner::FdLink(fd_link)));
+            return Ok(Self::new(PerfLinkInner::Fd(fd_link)));
         }
         Err(LinkError::InvalidLink)
     }

--- a/aya/src/programs/uprobe.rs
+++ b/aya/src/programs/uprobe.rs
@@ -19,7 +19,7 @@ use crate::{
     VerifierLogLevel,
     programs::{
         FdLink, LinkError, ProgramData, ProgramError, ProgramType, define_link_wrapper,
-        load_program,
+        impl_try_into_fdlink, load_program,
         perf_attach::{PerfLinkIdInner, PerfLinkInner},
         probe::{OsStringExt as _, ProbeKind, attach},
     },
@@ -220,17 +220,7 @@ define_link_wrapper!(
     UProbe,
 );
 
-impl TryFrom<UProbeLink> for FdLink {
-    type Error = LinkError;
-
-    fn try_from(value: UProbeLink) -> Result<Self, Self::Error> {
-        if let PerfLinkInner::FdLink(fd) = value.into_inner() {
-            Ok(fd)
-        } else {
-            Err(LinkError::InvalidLink)
-        }
-    }
-}
+impl_try_into_fdlink!(UProbeLink, PerfLinkInner);
 
 impl TryFrom<FdLink> for UProbeLink {
     type Error = LinkError;
@@ -238,7 +228,7 @@ impl TryFrom<FdLink> for UProbeLink {
     fn try_from(fd_link: FdLink) -> Result<Self, Self::Error> {
         let info = bpf_link_get_info_by_fd(fd_link.fd.as_fd())?;
         if info.type_ == (bpf_link_type::BPF_LINK_TYPE_TRACING as u32) {
-            return Ok(Self::new(PerfLinkInner::FdLink(fd_link)));
+            return Ok(Self::new(PerfLinkInner::Fd(fd_link)));
         }
         Err(LinkError::InvalidLink)
     }

--- a/aya/src/programs/xdp.rs
+++ b/aya/src/programs/xdp.rs
@@ -21,7 +21,7 @@ use crate::{
     VerifierLogLevel,
     programs::{
         FdLink, Link, LinkError, ProgramData, ProgramError, ProgramType, define_link_wrapper,
-        id_as_key, load_program,
+        id_as_key, impl_try_into_fdlink, load_program,
     },
     sys::{
         LinkTarget, NetlinkError, SyscallError, bpf_link_create, bpf_link_get_info_by_fd,
@@ -158,7 +158,7 @@ impl Xdp {
             })?;
             self.data
                 .links
-                .insert(XdpLink::new(XdpLinkInner::FdLink(FdLink::new(link_fd))))
+                .insert(XdpLink::new(XdpLinkInner::Fd(FdLink::new(link_fd))))
         } else {
             let if_index = if_index as i32;
             unsafe { netlink_set_xdp_fd(if_index, Some(prog_fd), None, flags.bits()) }
@@ -197,7 +197,7 @@ impl Xdp {
         let prog_fd = self.fd()?;
         let prog_fd = prog_fd.as_fd();
         match link.into_inner() {
-            XdpLinkInner::FdLink(fd_link) => {
+            XdpLinkInner::Fd(fd_link) => {
                 let link_fd = fd_link.fd;
                 bpf_link_update(link_fd.as_fd(), prog_fd, None, 0).map_err(|io_error| {
                     SyscallError {
@@ -208,7 +208,7 @@ impl Xdp {
 
                 self.data
                     .links
-                    .insert(XdpLink::new(XdpLinkInner::FdLink(FdLink::new(link_fd))))
+                    .insert(XdpLink::new(XdpLinkInner::Fd(FdLink::new(link_fd))))
             }
             XdpLinkInner::NlLink(nl_link) => {
                 let if_index = nl_link.if_index;
@@ -280,7 +280,7 @@ pub(crate) enum XdpLinkIdInner {
 
 #[derive(Debug)]
 pub(crate) enum XdpLinkInner {
-    FdLink(FdLink),
+    Fd(FdLink),
     NlLink(NlLink),
 }
 
@@ -289,14 +289,14 @@ impl Link for XdpLinkInner {
 
     fn id(&self) -> Self::Id {
         match self {
-            Self::FdLink(link) => XdpLinkIdInner::FdLinkId(link.id()),
+            Self::Fd(link) => XdpLinkIdInner::FdLinkId(link.id()),
             Self::NlLink(link) => XdpLinkIdInner::NlLinkId(link.id()),
         }
     }
 
     fn detach(self) -> Result<(), ProgramError> {
         match self {
-            Self::FdLink(link) => link.detach(),
+            Self::Fd(link) => link.detach(),
             Self::NlLink(link) => link.detach(),
         }
     }
@@ -304,17 +304,7 @@ impl Link for XdpLinkInner {
 
 id_as_key!(XdpLinkInner, XdpLinkIdInner);
 
-impl TryFrom<XdpLink> for FdLink {
-    type Error = LinkError;
-
-    fn try_from(value: XdpLink) -> Result<Self, Self::Error> {
-        if let XdpLinkInner::FdLink(fd) = value.into_inner() {
-            Ok(fd)
-        } else {
-            Err(LinkError::InvalidLink)
-        }
-    }
-}
+impl_try_into_fdlink!(XdpLink, XdpLinkInner);
 
 impl TryFrom<FdLink> for XdpLink {
     type Error = LinkError;
@@ -323,7 +313,7 @@ impl TryFrom<FdLink> for XdpLink {
         // unwrap of fd_link.fd will not panic since it's only None when being dropped.
         let info = bpf_link_get_info_by_fd(fd_link.fd.as_fd())?;
         if info.type_ == (bpf_link_type::BPF_LINK_TYPE_XDP as u32) {
-            return Ok(Self::new(XdpLinkInner::FdLink(fd_link)));
+            return Ok(Self::new(XdpLinkInner::Fd(fd_link)));
         }
         Err(LinkError::InvalidLink)
     }

--- a/xtask/public-api/aya.txt
+++ b/xtask/public-api/aya.txt
@@ -2753,6 +2753,9 @@ pub fn aya::programs::cgroup_skb::CgroupSkbLink::id(&self) -> Self::Id
 impl core::cmp::Eq for aya::programs::cgroup_skb::CgroupSkbLink
 impl core::cmp::PartialEq for aya::programs::cgroup_skb::CgroupSkbLink
 pub fn aya::programs::cgroup_skb::CgroupSkbLink::eq(&self, other: &Self) -> bool
+impl core::convert::TryFrom<aya::programs::cgroup_skb::CgroupSkbLink> for aya::programs::links::FdLink
+pub type aya::programs::links::FdLink::Error = aya::programs::links::LinkError
+pub fn aya::programs::links::FdLink::try_from(value: aya::programs::cgroup_skb::CgroupSkbLink) -> core::result::Result<Self, Self::Error>
 impl core::fmt::Debug for aya::programs::cgroup_skb::CgroupSkbLink
 pub fn aya::programs::cgroup_skb::CgroupSkbLink::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::hash::Hash for aya::programs::cgroup_skb::CgroupSkbLink
@@ -2880,6 +2883,9 @@ pub fn aya::programs::cgroup_sock::CgroupSockLink::id(&self) -> Self::Id
 impl core::cmp::Eq for aya::programs::cgroup_sock::CgroupSockLink
 impl core::cmp::PartialEq for aya::programs::cgroup_sock::CgroupSockLink
 pub fn aya::programs::cgroup_sock::CgroupSockLink::eq(&self, other: &Self) -> bool
+impl core::convert::TryFrom<aya::programs::cgroup_sock::CgroupSockLink> for aya::programs::links::FdLink
+pub type aya::programs::links::FdLink::Error = aya::programs::links::LinkError
+pub fn aya::programs::links::FdLink::try_from(value: aya::programs::cgroup_sock::CgroupSockLink) -> core::result::Result<Self, Self::Error>
 impl core::fmt::Debug for aya::programs::cgroup_sock::CgroupSockLink
 pub fn aya::programs::cgroup_sock::CgroupSockLink::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::hash::Hash for aya::programs::cgroup_sock::CgroupSockLink
@@ -3007,6 +3013,9 @@ pub fn aya::programs::cgroup_sock_addr::CgroupSockAddrLink::id(&self) -> Self::I
 impl core::cmp::Eq for aya::programs::cgroup_sock_addr::CgroupSockAddrLink
 impl core::cmp::PartialEq for aya::programs::cgroup_sock_addr::CgroupSockAddrLink
 pub fn aya::programs::cgroup_sock_addr::CgroupSockAddrLink::eq(&self, other: &Self) -> bool
+impl core::convert::TryFrom<aya::programs::cgroup_sock_addr::CgroupSockAddrLink> for aya::programs::links::FdLink
+pub type aya::programs::links::FdLink::Error = aya::programs::links::LinkError
+pub fn aya::programs::links::FdLink::try_from(value: aya::programs::cgroup_sock_addr::CgroupSockAddrLink) -> core::result::Result<Self, Self::Error>
 impl core::fmt::Debug for aya::programs::cgroup_sock_addr::CgroupSockAddrLink
 pub fn aya::programs::cgroup_sock_addr::CgroupSockAddrLink::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::hash::Hash for aya::programs::cgroup_sock_addr::CgroupSockAddrLink
@@ -4400,6 +4409,15 @@ impl core::convert::From<aya::programs::sk_lookup::SkLookupLink> for aya::progra
 pub fn aya::programs::links::FdLink::from(w: aya::programs::sk_lookup::SkLookupLink) -> aya::programs::links::FdLink
 impl core::convert::From<aya::programs::tp_btf::BtfTracePointLink> for aya::programs::links::FdLink
 pub fn aya::programs::links::FdLink::from(w: aya::programs::tp_btf::BtfTracePointLink) -> aya::programs::links::FdLink
+impl core::convert::TryFrom<aya::programs::cgroup_skb::CgroupSkbLink> for aya::programs::links::FdLink
+pub type aya::programs::links::FdLink::Error = aya::programs::links::LinkError
+pub fn aya::programs::links::FdLink::try_from(value: aya::programs::cgroup_skb::CgroupSkbLink) -> core::result::Result<Self, Self::Error>
+impl core::convert::TryFrom<aya::programs::cgroup_sock::CgroupSockLink> for aya::programs::links::FdLink
+pub type aya::programs::links::FdLink::Error = aya::programs::links::LinkError
+pub fn aya::programs::links::FdLink::try_from(value: aya::programs::cgroup_sock::CgroupSockLink) -> core::result::Result<Self, Self::Error>
+impl core::convert::TryFrom<aya::programs::cgroup_sock_addr::CgroupSockAddrLink> for aya::programs::links::FdLink
+pub type aya::programs::links::FdLink::Error = aya::programs::links::LinkError
+pub fn aya::programs::links::FdLink::try_from(value: aya::programs::cgroup_sock_addr::CgroupSockAddrLink) -> core::result::Result<Self, Self::Error>
 impl core::convert::TryFrom<aya::programs::iter::IterLink> for aya::programs::links::FdLink
 pub type aya::programs::links::FdLink::Error = aya::programs::links::LinkError
 pub fn aya::programs::links::FdLink::try_from(value: aya::programs::iter::IterLink) -> core::result::Result<Self, Self::Error>
@@ -4430,6 +4448,9 @@ pub fn aya::programs::xdp::XdpLink::try_from(fd_link: aya::programs::links::FdLi
 impl core::convert::TryFrom<aya::programs::perf_event::PerfEventLink> for aya::programs::links::FdLink
 pub type aya::programs::links::FdLink::Error = aya::programs::links::LinkError
 pub fn aya::programs::links::FdLink::try_from(value: aya::programs::perf_event::PerfEventLink) -> core::result::Result<Self, Self::Error>
+impl core::convert::TryFrom<aya::programs::sock_ops::SockOpsLink> for aya::programs::links::FdLink
+pub type aya::programs::links::FdLink::Error = aya::programs::links::LinkError
+pub fn aya::programs::links::FdLink::try_from(value: aya::programs::sock_ops::SockOpsLink) -> core::result::Result<Self, Self::Error>
 impl core::convert::TryFrom<aya::programs::tc::SchedClassifierLink> for aya::programs::links::FdLink
 pub type aya::programs::links::FdLink::Error = aya::programs::links::LinkError
 pub fn aya::programs::links::FdLink::try_from(value: aya::programs::tc::SchedClassifierLink) -> core::result::Result<Self, Self::Error>
@@ -6026,6 +6047,9 @@ pub fn aya::programs::sock_ops::SockOpsLink::id(&self) -> Self::Id
 impl core::cmp::Eq for aya::programs::sock_ops::SockOpsLink
 impl core::cmp::PartialEq for aya::programs::sock_ops::SockOpsLink
 pub fn aya::programs::sock_ops::SockOpsLink::eq(&self, other: &Self) -> bool
+impl core::convert::TryFrom<aya::programs::sock_ops::SockOpsLink> for aya::programs::links::FdLink
+pub type aya::programs::links::FdLink::Error = aya::programs::links::LinkError
+pub fn aya::programs::links::FdLink::try_from(value: aya::programs::sock_ops::SockOpsLink) -> core::result::Result<Self, Self::Error>
 impl core::fmt::Debug for aya::programs::sock_ops::SockOpsLink
 pub fn aya::programs::sock_ops::SockOpsLink::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::hash::Hash for aya::programs::sock_ops::SockOpsLink


### PR DESCRIPTION
Implements TryFrom for FdLink for CgroupSkb, CgroupSock, CgroupSockAddr and SockOps program types. This allows support for link pinning for these program types, aligning with the [documentation for FdLink.](https://github.com/aya-rs/aya/blob/main/aya/src/programs/links.rs#L110)

Fixes: #739

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aya-rs/aya/1264)
<!-- Reviewable:end -->
