### PR TITLE
integration-test: add missing `test_log` decorator

### DIFF
--- a/test/integration-test/src/tests/bpf_probe_read.rs
+++ b/test/integration-test/src/tests/bpf_probe_read.rs
@@ -1,14 +1,13 @@
 use aya::{Ebpf, maps::Array, programs::UProbe};
 use integration_common::bpf_probe_read::{RESULT_BUF_LEN, TestResult};
-use test_log::test;
 
-#[test]
+#[test_log::test]
 fn bpf_probe_read_user_str_bytes() {
     let bpf = set_user_buffer(b"foo\0", RESULT_BUF_LEN);
     assert_eq!(result_bytes(&bpf), b"foo");
 }
 
-#[test]
+#[test_log::test]
 fn bpf_probe_read_user_str_bytes_truncate() {
     let s = vec![b'a'; RESULT_BUF_LEN];
     let bpf = set_user_buffer(&s, RESULT_BUF_LEN);
@@ -16,25 +15,25 @@ fn bpf_probe_read_user_str_bytes_truncate() {
     assert_eq!(result_bytes(&bpf), &s[..RESULT_BUF_LEN - 1]);
 }
 
-#[test]
+#[test_log::test]
 fn bpf_probe_read_user_str_bytes_empty_string() {
     let bpf = set_user_buffer(b"\0", RESULT_BUF_LEN);
     assert_eq!(result_bytes(&bpf), b"");
 }
 
-#[test]
+#[test_log::test]
 fn bpf_probe_read_user_str_bytes_empty_dest() {
     let bpf = set_user_buffer(b"foo\0", 0);
     assert_eq!(result_bytes(&bpf), b"");
 }
 
-#[test]
+#[test_log::test]
 fn bpf_probe_read_kernel_str_bytes() {
     let bpf = set_kernel_buffer(b"foo\0", RESULT_BUF_LEN);
     assert_eq!(result_bytes(&bpf), b"foo");
 }
 
-#[test]
+#[test_log::test]
 fn bpf_probe_read_kernel_str_bytes_truncate() {
     let s = vec![b'a'; RESULT_BUF_LEN];
     let bpf = set_kernel_buffer(&s, RESULT_BUF_LEN);
@@ -42,13 +41,13 @@ fn bpf_probe_read_kernel_str_bytes_truncate() {
     assert_eq!(result_bytes(&bpf), &s[..RESULT_BUF_LEN - 1]);
 }
 
-#[test]
+#[test_log::test]
 fn bpf_probe_read_kernel_str_bytes_empty_string() {
     let bpf = set_kernel_buffer(b"\0", RESULT_BUF_LEN);
     assert_eq!(result_bytes(&bpf), b"");
 }
 
-#[test]
+#[test_log::test]
 fn bpf_probe_read_kernel_str_bytes_empty_dest() {
     let bpf = set_kernel_buffer(b"foo\0", 0);
     assert_eq!(result_bytes(&bpf), b"");

--- a/test/integration-test/src/tests/btf_relocations.rs
+++ b/test/integration-test/src/tests/btf_relocations.rs
@@ -43,6 +43,7 @@ use test_case::test_case;
     None,
     2
 )]
+#[test_log::test]
 fn relocation_tests(
     bpf: &[u8],
     btf: Option<&[u8]>,

--- a/test/integration-test/src/tests/elf.rs
+++ b/test/integration-test/src/tests/elf.rs
@@ -1,7 +1,6 @@
 use object::{Object as _, ObjectSymbol as _};
-use test_log::test;
 
-#[test]
+#[test_log::test]
 fn test_maps() {
     let obj_file = object::File::parse(crate::MAP_TEST).unwrap();
     assert!(obj_file.section_by_name("maps").is_some());

--- a/test/integration-test/src/tests/feature_probe.rs
+++ b/test/integration-test/src/tests/feature_probe.rs
@@ -11,7 +11,7 @@ use procfs::kernel_config;
 
 use crate::utils::kernel_assert;
 
-#[test]
+#[test_log::test]
 fn probe_supported_programs() {
     let kernel_config = kernel_config().unwrap_or_default();
     macro_rules! is_supported {
@@ -136,7 +136,7 @@ fn probe_supported_programs() {
     kernel_assert!(is_supported!(ProgramType::Netfilter), kern_version);
 }
 
-#[test]
+#[test_log::test]
 fn probe_supported_maps() {
     macro_rules! is_supported {
         ($map_type:expr) => {

--- a/test/integration-test/src/tests/info.rs
+++ b/test/integration-test/src/tests/info.rs
@@ -19,7 +19,7 @@ use libc::EINVAL;
 
 use crate::utils::{kernel_assert, kernel_assert_eq};
 
-#[test]
+#[test_log::test]
 fn test_loaded_programs() {
     if !is_program_supported(ProgramType::SocketFilter).unwrap() {
         eprintln!("skipping test - socket_filter program not supported");
@@ -72,7 +72,7 @@ fn test_loaded_programs() {
     p.detach(res).unwrap();
 }
 
-#[test]
+#[test_log::test]
 fn test_program_info() {
     if !is_program_supported(ProgramType::SocketFilter).unwrap() {
         eprintln!("skipping test - socket_filter program not supported");
@@ -135,7 +135,7 @@ fn test_program_info() {
     test_prog.fd().unwrap();
 }
 
-#[test]
+#[test_log::test]
 fn test_loaded_at() {
     if !is_program_supported(ProgramType::SocketFilter).unwrap() {
         eprintln!("skipping test - socket_filter program not supported");
@@ -184,7 +184,7 @@ fn test_loaded_at() {
     }
 }
 
-#[test]
+#[test_log::test]
 fn test_prog_stats() {
     if !is_program_supported(ProgramType::TracePoint).unwrap() {
         eprintln!("skipping test - tracepoint program not supported");
@@ -210,7 +210,7 @@ fn test_prog_stats() {
     kernel_assert!(test_prog.run_count() > 0, KernelVersion::new(5, 1, 0));
 }
 
-#[test]
+#[test_log::test]
 fn list_loaded_maps() {
     if !is_program_supported(ProgramType::SocketFilter).unwrap() {
         eprintln!("skipping test - socket_filter program not supported");
@@ -269,7 +269,7 @@ fn list_loaded_maps() {
     );
 }
 
-#[test]
+#[test_log::test]
 fn test_map_info() {
     if !is_program_supported(ProgramType::SocketFilter).unwrap() {
         eprintln!("skipping test - socket_filter program not supported");

--- a/test/integration-test/src/tests/iter.rs
+++ b/test/integration-test/src/tests/iter.rs
@@ -1,9 +1,8 @@
 use std::io::BufRead as _;
 
 use aya::{Btf, Ebpf, programs::Iter};
-use test_log::test;
 
-#[test]
+#[test_log::test]
 fn iter_task() {
     let mut ebpf = Ebpf::load(crate::ITER_TASK).unwrap();
     let btf = Btf::from_sys_fs().unwrap();

--- a/test/integration-test/src/tests/load.rs
+++ b/test/integration-test/src/tests/load.rs
@@ -11,12 +11,11 @@ use aya::{
     util::KernelVersion,
 };
 use aya_obj::programs::XdpAttachType;
-use test_log::test;
 
 const MAX_RETRIES: usize = 100;
 pub(crate) const RETRY_DURATION: Duration = Duration::from_millis(10);
 
-#[test]
+#[test_log::test]
 fn long_name() {
     let mut bpf = Ebpf::load(crate::NAME_TEST).unwrap();
     let name_prog: &mut Xdp = bpf
@@ -32,7 +31,7 @@ fn long_name() {
     // Therefore, as long as we were able to load the program, this is good enough.
 }
 
-#[test]
+#[test_log::test]
 fn multiple_btf_maps() {
     let mut bpf = Ebpf::load(crate::MULTIMAP_BTF).unwrap();
 
@@ -62,7 +61,7 @@ fn multiple_btf_maps() {
     remove_file(map_pin).unwrap();
 }
 
-#[test]
+#[test_log::test]
 fn pin_lifecycle_multiple_btf_maps() {
     let mut bpf = Ebpf::load(crate::MULTIMAP_BTF).unwrap();
 
@@ -191,7 +190,7 @@ fn assert_unloaded(name: &str) {
     )
 }
 
-#[test]
+#[test_log::test]
 fn unload_xdp() {
     let mut bpf = Ebpf::load(crate::TEST).unwrap();
     let prog: &mut Xdp = bpf.program_mut("pass").unwrap().try_into().unwrap();
@@ -216,7 +215,7 @@ fn unload_xdp() {
     assert_unloaded("pass");
 }
 
-#[test]
+#[test_log::test]
 fn unload_kprobe() {
     let mut bpf = Ebpf::load(crate::TEST).unwrap();
     let prog: &mut KProbe = bpf.program_mut("test_kprobe").unwrap().try_into().unwrap();
@@ -241,7 +240,7 @@ fn unload_kprobe() {
     assert_unloaded("test_kprobe");
 }
 
-#[test]
+#[test_log::test]
 fn memmove() {
     let mut bpf = Ebpf::load(crate::MEMMOVE_TEST).unwrap();
     let prog: &mut Xdp = bpf.program_mut("do_dnat").unwrap().try_into().unwrap();
@@ -250,7 +249,7 @@ fn memmove() {
     assert_loaded("do_dnat");
 }
 
-#[test]
+#[test_log::test]
 fn basic_tracepoint() {
     let mut bpf = Ebpf::load(crate::TEST).unwrap();
     let prog: &mut TracePoint = bpf
@@ -281,7 +280,7 @@ fn basic_tracepoint() {
     assert_unloaded("test_tracepoint");
 }
 
-#[test]
+#[test_log::test]
 fn basic_uprobe() {
     let mut bpf = Ebpf::load(crate::TEST).unwrap();
     let prog: &mut UProbe = bpf.program_mut("test_uprobe").unwrap().try_into().unwrap();
@@ -311,7 +310,7 @@ fn basic_uprobe() {
     assert_unloaded("test_uprobe");
 }
 
-#[test]
+#[test_log::test]
 fn basic_flow_dissector() {
     let mut bpf = Ebpf::load(crate::TEST).unwrap();
     let prog: &mut FlowDissector = bpf.program_mut("test_flow").unwrap().try_into().unwrap();
@@ -339,7 +338,7 @@ fn basic_flow_dissector() {
     assert_unloaded("test_flow");
 }
 
-#[test]
+#[test_log::test]
 fn pin_link() {
     let kernel_version = KernelVersion::current().unwrap();
     if kernel_version < KernelVersion::new(5, 9, 0) {
@@ -370,7 +369,7 @@ fn pin_link() {
     assert_unloaded("pass");
 }
 
-#[test]
+#[test_log::test]
 fn pin_lifecycle() {
     let kernel_version = KernelVersion::current().unwrap();
     if kernel_version < KernelVersion::new(5, 18, 0) {
@@ -433,7 +432,7 @@ fn pin_lifecycle() {
     assert_unloaded("pass");
 }
 
-#[test]
+#[test_log::test]
 fn pin_lifecycle_tracepoint() {
     // 1. Load Program and Pin
     {
@@ -487,7 +486,7 @@ fn pin_lifecycle_tracepoint() {
     assert_unloaded("test_tracepoint");
 }
 
-#[test]
+#[test_log::test]
 fn pin_lifecycle_kprobe() {
     // 1. Load Program and Pin
     {
@@ -551,7 +550,7 @@ extern "C" fn uprobe_function() {
     core::hint::black_box(uprobe_function);
 }
 
-#[test]
+#[test_log::test]
 fn pin_lifecycle_uprobe() {
     const FIRST_PIN_PATH: &str = "/sys/fs/bpf/aya-uprobe-test-prog-1";
     const SECOND_PIN_PATH: &str = "/sys/fs/bpf/aya-uprobe-test-prog-2";

--- a/test/integration-test/src/tests/log.rs
+++ b/test/integration-test/src/tests/log.rs
@@ -3,7 +3,6 @@ use std::{borrow::Cow, sync::Mutex};
 use aya::{Ebpf, programs::UProbe};
 use aya_log::EbpfLogger;
 use log::{Level, Log, Record};
-use test_log::test;
 
 #[unsafe(no_mangle)]
 #[inline(never)]
@@ -36,7 +35,7 @@ struct CapturedLog<'a> {
     pub target: Cow<'a, str>,
 }
 
-#[test]
+#[test_log::test]
 fn log() {
     let mut bpf = Ebpf::load(crate::LOG).unwrap();
 

--- a/test/integration-test/src/tests/raw_tracepoint.rs
+++ b/test/integration-test/src/tests/raw_tracepoint.rs
@@ -6,7 +6,7 @@ fn get_event(bpf: &mut Ebpf) -> SysEnterEvent {
     map.get(&0, 0).unwrap()
 }
 
-#[test]
+#[test_log::test]
 fn raw_tracepoint() {
     let mut bpf = Ebpf::load(crate::RAW_TRACEPOINT).unwrap();
 

--- a/test/integration-test/src/tests/rbpf.rs
+++ b/test/integration-test/src/tests/rbpf.rs
@@ -3,9 +3,8 @@ use std::collections::HashMap;
 
 use assert_matches::assert_matches;
 use aya_obj::{Object, ProgramSection, generated::bpf_insn, programs::XdpAttachType};
-use test_log::test;
 
-#[test]
+#[test_log::test]
 fn run_with_rbpf() {
     let object = Object::parse(crate::PASS).unwrap();
 
@@ -37,7 +36,7 @@ fn run_with_rbpf() {
 
 static mut MULTIMAP_MAPS: [*mut Vec<u64>; 3] = [null_mut(); 3];
 
-#[test]
+#[test_log::test]
 fn use_map_with_rbpf() {
     let mut object = Object::parse(crate::MULTIMAP_BTF).unwrap();
 

--- a/test/integration-test/src/tests/relocations.rs
+++ b/test/integration-test/src/tests/relocations.rs
@@ -3,9 +3,8 @@ use aya::{
     programs::{UProbe, Xdp},
     util::KernelVersion,
 };
-use test_log::test;
 
-#[test]
+#[test_log::test]
 fn relocations() {
     let bpf = load_and_attach("test_64_32_call_relocs", crate::RELOCATIONS);
 
@@ -17,7 +16,7 @@ fn relocations() {
     assert_eq!(m.get(&2, 0).unwrap(), 3);
 }
 
-#[test]
+#[test_log::test]
 fn text_64_64_reloc() {
     let kernel_version = KernelVersion::current().unwrap();
     if kernel_version < KernelVersion::new(5, 13, 0) {
@@ -39,7 +38,7 @@ fn text_64_64_reloc() {
     assert_eq!(m.get(&1, 0).unwrap(), 3);
 }
 
-#[test]
+#[test_log::test]
 fn variables_reloc() {
     let mut bpf = Ebpf::load(crate::VARIABLES_RELOC).unwrap();
     let prog: &mut Xdp = bpf

--- a/test/integration-test/src/tests/ring_buf.rs
+++ b/test/integration-test/src/tests/ring_buf.rs
@@ -19,7 +19,6 @@ use aya::{
 use aya_obj::generated::BPF_RINGBUF_HDR_SZ;
 use integration_common::ring_buf::Registers;
 use rand::Rng as _;
-use test_log::test;
 use tokio::io::{Interest, unix::AsyncFd};
 
 struct RingBufTest {
@@ -149,7 +148,8 @@ pub extern "C" fn ring_buf_trigger_ebpf_program(arg: u64) {
 // to fill the ring_buf. We just ensure that the number of events we see is sane given
 // what the producer sees, and that the logic does not hang. This exercises interleaving
 // discards, successful commits, and drops due to the ring_buf being full.
-#[test(tokio::test(flavor = "multi_thread"))]
+#[tokio::test(flavor = "multi_thread")]
+#[test_log::test]
 async fn ring_buf_async_with_drops() {
     let WithData(
         RingBufTest {
@@ -249,7 +249,8 @@ async fn ring_buf_async_with_drops() {
     );
 }
 
-#[test(tokio::test(flavor = "multi_thread"))]
+#[tokio::test(flavor = "multi_thread")]
+#[test_log::test]
 async fn ring_buf_async_no_drop() {
     let WithData(
         RingBufTest {
@@ -317,7 +318,7 @@ async fn ring_buf_async_no_drop() {
 // This test reproduces a bug where the ring buffer would not be notified of new entries if the
 // state was not properly synchronized between the producer and consumer. This would result in the
 // consumer never being woken up and the test hanging.
-#[test]
+#[test_log::test]
 fn ring_buf_epoll_wakeup() {
     let RingBufTest {
         mut ring_buf,
@@ -351,7 +352,8 @@ fn ring_buf_epoll_wakeup() {
 }
 
 // This test is like the above test but uses tokio and AsyncFd instead of raw epoll.
-#[test(tokio::test)]
+#[tokio::test]
+#[test_log::test]
 async fn ring_buf_asyncfd_events() {
     let RingBufTest {
         ring_buf,

--- a/test/integration-test/src/tests/smoke.rs
+++ b/test/integration-test/src/tests/smoke.rs
@@ -3,11 +3,10 @@ use aya::{
     programs::{Extension, TracePoint, Xdp, XdpFlags, tc},
     util::KernelVersion,
 };
-use test_log::test;
 
 use crate::utils::NetNsGuard;
 
-#[test]
+#[test_log::test]
 fn modprobe() {
     // This very simple looking test is actually quite complex.
     // The call to tc::qdisc_add_clsact() causes the linux kernel to call into
@@ -20,7 +19,7 @@ fn modprobe() {
     tc::qdisc_add_clsact("lo").unwrap();
 }
 
-#[test]
+#[test_log::test]
 fn xdp() {
     let kernel_version = KernelVersion::current().unwrap();
     if kernel_version < KernelVersion::new(5, 18, 0) {
@@ -38,7 +37,7 @@ fn xdp() {
     dispatcher.attach("lo", XdpFlags::default()).unwrap();
 }
 
-#[test]
+#[test_log::test]
 fn two_progs() {
     let mut bpf = Ebpf::load(crate::TWO_PROGS).unwrap();
 
@@ -60,7 +59,7 @@ fn two_progs() {
     prog_two.attach("sched", "sched_switch").unwrap();
 }
 
-#[test]
+#[test_log::test]
 fn extension() {
     let kernel_version = KernelVersion::current().unwrap();
     if kernel_version < KernelVersion::new(5, 9, 0) {

--- a/test/integration-test/src/tests/strncmp.rs
+++ b/test/integration-test/src/tests/strncmp.rs
@@ -10,7 +10,7 @@ use aya::{
 };
 use integration_common::strncmp::TestResult;
 
-#[test]
+#[test_log::test]
 fn bpf_strncmp() {
     let mut bpf = Ebpf::load(crate::STRNCMP).unwrap();
 

--- a/test/integration-test/src/tests/tcx.rs
+++ b/test/integration-test/src/tests/tcx.rs
@@ -3,11 +3,10 @@ use aya::{
     programs::{LinkOrder, ProgramId, SchedClassifier, TcAttachType, tc::TcAttachOptions},
     util::KernelVersion,
 };
-use test_log::test;
 
 use crate::utils::NetNsGuard;
 
-#[test]
+#[test_log::test]
 fn tcx() {
     let kernel_version = KernelVersion::current().unwrap();
     if kernel_version < KernelVersion::new(6, 6, 0) {

--- a/test/integration-test/src/tests/uprobe_cookie.rs
+++ b/test/integration-test/src/tests/uprobe_cookie.rs
@@ -1,7 +1,6 @@
 use aya::{EbpfLoader, maps::ring_buf::RingBuf, programs::UProbe};
-use test_log::test;
 
-#[test]
+#[test_log::test]
 fn test_uprobe_cookie() {
     const RING_BUF_BYTE_SIZE: u32 = 512; // arbitrary, but big enough
 

--- a/test/integration-test/src/tests/xdp.rs
+++ b/test/integration-test/src/tests/xdp.rs
@@ -6,12 +6,11 @@ use aya::{
     programs::{Xdp, XdpFlags},
 };
 use object::{Object as _, ObjectSection as _, ObjectSymbol as _, SymbolSection};
-use test_log::test;
 use xdpilone::{BufIdx, IfInfo, Socket, SocketConfig, Umem, UmemConfig};
 
 use crate::utils::NetNsGuard;
 
-#[test]
+#[test_log::test]
 fn af_xdp() {
     let _netns = NetNsGuard::new();
 
@@ -98,7 +97,7 @@ fn af_xdp() {
     assert_eq!(rx.available(), 2);
 }
 
-#[test]
+#[test_log::test]
 fn prog_sections() {
     let obj_file = object::File::parse(crate::XDP_SEC).unwrap();
 
@@ -132,7 +131,7 @@ fn ensure_symbol(obj_file: &object::File, sec_name: &str, sym_name: &str) {
     );
 }
 
-#[test]
+#[test_log::test]
 fn map_load() {
     let bpf = Ebpf::load(crate::XDP_SEC).unwrap();
 
@@ -144,7 +143,7 @@ fn map_load() {
     bpf.program("xdp_frags_devmap").unwrap();
 }
 
-#[test]
+#[test_log::test]
 fn cpumap_chain() {
     let _netns = NetNsGuard::new();
 


### PR DESCRIPTION
Use the fully qualified macro name which composes better with
`test_case` and makes it easier to spot cases where it is missing.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aya-rs/aya/1290)
<!-- Reviewable:end -->
