### PR TITLE
ci: Fix bpf-linker installation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,7 +170,7 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
 
-      - run: cargo install --git https://github.com/aya-rs/bpf-linker.git
+      - run: cargo install --git https://github.com/aya-rs/bpf-linker.git bpf-linker
 
       - uses: taiki-e/install-action@cargo-hack
 
@@ -297,7 +297,7 @@ jobs:
       # --force so that bpf-linker gets always relinked against the latest LLVM downloaded above.
       #
       # Do this on all system (not just macOS) to avoid relying on rustc-provided libLLVM.so.
-      - run: cargo install --git https://github.com/aya-rs/bpf-linker.git --no-default-features --force
+      - run: cargo install --git https://github.com/aya-rs/bpf-linker.git bpf-linker --no-default-features --force
 
       - uses: actions/cache@v4
         with:


### PR DESCRIPTION
We've recently added an xtask to bpf-linker (aya-rs/bpf-linker#282), which resulted in multiple binary targets. Therefore, bpf-linker has to be installed with the following command:

```
cargo install --git https://github.com/aya-rs/bpf-linker.git bpf-linker
```

The last argument (`bpf-linker`) specifies the binary target.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aya-rs/aya/1295)
<!-- Reviewable:end -->
