### PR TITLE
aya-log: simplify EbpfLogger as_raw_fd implementation

### DIFF
--- a/aya-log/src/lib.rs
+++ b/aya-log/src/lib.rs
@@ -100,11 +100,7 @@ pub struct EbpfLogger<T> {
 
 impl<T> AsRawFd for EbpfLogger<T> {
     fn as_raw_fd(&self) -> std::os::unix::prelude::RawFd {
-        let Self {
-            ring_buf,
-            logger: _,
-        } = self;
-        ring_buf.as_raw_fd()
+        self.ring_buf.as_raw_fd()
     }
 }
 


### PR DESCRIPTION
Replace struct pattern matching with direct field access in the as_raw_fd method, making the code more concise and cleaner.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aya-rs/aya/1297)
<!-- Reviewable:end -->
