### PR TITLE
aya-log: suppress dead_code warnings for wrapper structs

### DIFF
--- a/aya-log/src/lib.rs
+++ b/aya-log/src/lib.rs
@@ -76,9 +76,11 @@ use aya_log_common::{Argument, DisplayHint, LOG_FIELDS, Level, LogValueLength, R
 use log::{Log, Record, error};
 use thiserror::Error;
 
+#[expect(dead_code)]
 #[derive(Copy, Clone)]
 #[repr(transparent)]
 struct RecordFieldWrapper(RecordField);
+#[expect(dead_code)]
 #[derive(Copy, Clone)]
 #[repr(transparent)]
 struct ArgumentWrapper(Argument);


### PR DESCRIPTION
Fixes compiler warnings about RecordFieldWrapper and ArgumentWrapper never being constructed by adding #[expect(dead_code)] attributes.


Solve the error message as follows:

```shell
# cargo build
warning: struct `RecordFieldWrapper` is never constructed
  --> aya-log/src/lib.rs:81:8
   |
81 | struct RecordFieldWrapper(RecordField);
   |        ^^^^^^^^^^^^^^^^^^
   |
   = note: `#[warn(dead_code)]` on by default

warning: struct `ArgumentWrapper` is never constructed
  --> aya-log/src/lib.rs:84:8
   |
84 | struct ArgumentWrapper(Argument);
   |        ^^^^^^^^^^^^^^^
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aya-rs/aya/1298)
<!-- Reviewable:end -->
