### PR TITLE
aya-ebpf: replace match statement with then_some for cleaner code

### DIFF
--- a/ebpf/aya-ebpf/src/maps/sock_hash.rs
+++ b/ebpf/aya-ebpf/src/maps/sock_hash.rs
@@ -96,9 +96,6 @@ impl<K> SockHash<K> {
         let sk = lookup(self.def.get(), key.borrow()).ok_or(1u32)?;
         let ret = unsafe { bpf_sk_assign(ctx.as_ptr().cast(), sk.as_ptr(), flags) };
         unsafe { bpf_sk_release(sk.as_ptr()) };
-        match ret {
-            0 => Ok(()),
-            _ret => Err(1),
-        }
+        (ret == 0).then_some(()).ok_or(1)
     }
 }


### PR DESCRIPTION
Replace verbose match statement with more idiomatic then_some().ok_or() pattern for handling boolean return values in assign method.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aya-rs/aya/1304)
<!-- Reviewable:end -->
