### PR TITLE
aya-tool: remove redundant let binding in generate function

### DIFF
--- a/aya-tool/src/generate.rs
+++ b/aya-tool/src/generate.rs
@@ -64,7 +64,7 @@ pub fn generate<T: AsRef<str>>(
     let dir = tempdir().unwrap();
     let file_path = dir.path().join(name);
     let mut file = File::create(&file_path).unwrap();
-    let () = file.write_all(c_header.as_bytes()).unwrap();
+    file.write_all(c_header.as_bytes()).unwrap();
 
     let flags = combine_flags(&bindgen.command_line_flags(), &additional_flags);
 


### PR DESCRIPTION
Removed the unnecessary `let () = ` pattern when calling write_all in the generate function. The pattern matching was redundant since write_all returns () and we're already using unwrap() to handle errors.

This simplifies the code while maintaining the same functionality.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aya-rs/aya/1308)
<!-- Reviewable:end -->
