### PR TITLE
aya: fix handle null bytes in paths when creating CString

### DIFF
--- a/aya/src/maps/info.rs
+++ b/aya/src/maps/info.rs
@@ -118,8 +118,8 @@ impl MapInfo {
     pub fn from_pin<P: AsRef<Path>>(path: P) -> Result<Self, MapError> {
         use std::os::unix::ffi::OsStrExt as _;
 
-        // TODO: avoid this unwrap by adding a new error variant.
-        let path_string = CString::new(path.as_ref().as_os_str().as_bytes()).unwrap();
+        let path_string =
+            CString::new(path.as_ref().as_os_str().as_bytes()).map_err(MapError::from)?;
         let fd = bpf_get_object(&path_string).map_err(|io_error| SyscallError {
             call: "BPF_OBJ_GET",
             io_error,

--- a/aya/src/maps/mod.rs
+++ b/aya/src/maps/mod.rs
@@ -174,6 +174,10 @@ pub enum MapError {
     #[error(transparent)]
     SyscallError(#[from] SyscallError),
 
+    /// An error indicating that an interior nul byte was found.
+    #[error(transparent)]
+    NulError(#[from] std::ffi::NulError),
+
     /// Could not pin map
     #[error("map `{name:?}` requested pinning. pinning failed")]
     PinError {


### PR DESCRIPTION
Add a new InvalidPath error variant to MapError enum that wraps std::ffi::NulError


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aya-rs/aya/1312)
<!-- Reviewable:end -->
