### PR TITLE
Do not make the static mut to prevent verification failure

### DIFF
--- a/ebpf/aya-log-ebpf/src/lib.rs
+++ b/ebpf/aya-log-ebpf/src/lib.rs
@@ -39,12 +39,11 @@ pub mod macro_support {
     ///
     /// Userspace may patch this symbol before load via `EbpfLoader::set_global`.
     #[unsafe(no_mangle)]
-    pub static mut AYA_LOG_LEVEL: u8 = 0xff;
+    pub static AYA_LOG_LEVEL: u8 = 0xff;
 
     /// Returns `true` if the provided level is enabled according to [`AYA_LOG_LEVEL`].
     #[inline(always)]
     pub fn level_enabled(level: Level) -> bool {
-        #[expect(static_mut_refs)]
         let current_level = unsafe { core::ptr::read_volatile(&AYA_LOG_LEVEL) };
         level as u8 <= current_level
     }

--- a/test/integration-ebpf/src/log.rs
+++ b/test/integration-ebpf/src/log.rs
@@ -1,7 +1,10 @@
 #![no_std]
 #![no_main]
 
-use core::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+use core::{
+    hint::black_box,
+    net::{IpAddr, Ipv4Addr, Ipv6Addr},
+};
 
 use aya_ebpf::{macros::uprobe, programs::ProbeContext};
 use aya_log_ebpf::{debug, error, info, trace, warn};
@@ -82,4 +85,13 @@ pub fn test_log(ctx: ProbeContext) {
 
         debug!(&ctx, "{:x}", no_copy.consume());
     }
+}
+
+#[uprobe]
+pub fn test_log_omission(ctx: ProbeContext) {
+    debug!(
+        &ctx,
+        "This is the last u32: {}",
+        black_box(0u32..).last().unwrap_or(u32::MAX)
+    );
 }

--- a/test/integration-test/src/tests/log.rs
+++ b/test/integration-test/src/tests/log.rs
@@ -224,3 +224,40 @@ fn log_level_only_error_warn() {
 
     assert_eq!(records.next(), None);
 }
+
+#[test_log::test]
+fn log_level_prevents_verif_fail() {
+    let level = aya_log::Level::Warn as u8;
+    let mut bpf = EbpfLoader::new()
+        .set_global(aya_log::LEVEL, &level, true /* must_exist */)
+        .load(crate::LOG)
+        .unwrap();
+
+    let mut captured_logs = Vec::new();
+    let logger = TestingLogger {
+        log: Mutex::new(|record: &Record| {
+            captured_logs.push(CapturedLog {
+                body: format!("{}", record.args()).into(),
+                level: record.level(),
+                target: record.target().to_string().into(),
+            });
+        }),
+    };
+    let mut logger = EbpfLogger::init_with_logger(&mut bpf, &logger).unwrap();
+
+    let prog: &mut UProbe = bpf
+        .program_mut("test_log_omission")
+        .unwrap()
+        .try_into()
+        .unwrap();
+    prog.load().unwrap();
+    prog.attach("trigger_ebpf_program", "/proc/self/exe", None, None)
+        .unwrap();
+
+    trigger_ebpf_program();
+    logger.flush();
+
+    let mut records = captured_logs.iter();
+
+    assert_eq!(records.next(), None);
+}


### PR DESCRIPTION
#1335 was incomplete as the static variable was declared mut, putting it into a section that the verifier considers mutable and thus breaking the check. This change simply unmarks it `mut` and adds a corresponding test which should fail if the verifier does not recognise that the loop is not executed.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aya-rs/aya/1337)
<!-- Reviewable:end -->
