### PR TITLE
aya-log-ebpf: allow macros in expr position

### DIFF
--- a/test/integration-ebpf/src/log.rs
+++ b/test/integration-ebpf/src/log.rs
@@ -83,7 +83,8 @@ pub fn test_log(ctx: ProbeContext) {
 
         let no_copy = NoCopy {};
 
-        debug!(&ctx, "{:x}", no_copy.consume());
+        // Check usage in expression position.
+        let () = debug!(&ctx, "{:x}", no_copy.consume());
     }
 }
 


### PR DESCRIPTION
This is load-bearing in aya-template.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aya-rs/aya/1339)
<!-- Reviewable:end -->
