### PR TITLE
aya-obj: fix variable length array index check

### DIFF
--- a/aya-obj/src/btf/relocation.rs
+++ b/aya-obj/src/btf/relocation.rs
@@ -809,7 +809,7 @@ impl<'a> AccessSpec<'a> {
                                 let parent = accessors.last().unwrap();
                                 let parent_ty = btf.type_by_id(parent.type_id)?;
                                 match parent_ty {
-                                    BtfType::Struct(s) => index == s.members.len() - 1,
+                                    BtfType::Struct(s) => parent.index == s.members.len() - 1,
                                     _ => false,
                                 }
                             };


### PR DESCRIPTION
The variable length array access check in `aya_obj::btf::relocation::AccessSpec::new` is wrong: `index` is the array index, not the field index.  A similar but correct check can be found in `match_candidate`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aya-rs/aya/1343)
<!-- Reviewable:end -->
