### PR TITLE
aya-ebpf: Add BPF_F_ADJ_ROOM_ENCAP_L2 "macro"

### DIFF
--- a/ebpf/aya-ebpf/src/lib.rs
+++ b/ebpf/aya-ebpf/src/lib.rs
@@ -128,6 +128,19 @@ mod intrinsics {
     }
 }
 
+/// Builds a flag for [`SkBuffContext::adjust_room`](programs::SkBuffContext::adjust_room)
+/// that defines L2 encapsulation, using `len` as the inner MAC header length.
+///
+/// Equivalent to the [`BPF_F_ADJ_ROOM_ENCAP_L2`][uapi-bpf-adj-room-encap-l2] macro
+/// in the Linux user-space API.
+///
+/// [uapi-bpf-adj-room-encap-l2]: https://github.com/torvalds/linux/blob/v6.17/include/uapi/linux/bpf.h#L6181
+#[doc(alias = "BPF_F_ADJ_ROOM_ENCAP_L2")]
+#[inline(always)]
+pub const fn bpf_f_adj_room_encap_l2(len: u64) -> u64 {
+    (len & bindings::BPF_ADJ_ROOM_ENCAP_L2_MASK as u64) << bindings::BPF_ADJ_ROOM_ENCAP_L2_SHIFT
+}
+
 /// Check if a value is within a range, using conditional forms compatible with
 /// the verifier.
 #[inline(always)]

--- a/xtask/public-api/aya-ebpf.txt
+++ b/xtask/public-api/aya-ebpf.txt
@@ -3460,4 +3460,5 @@ pub fn aya_ebpf::programs::xdp::XdpContext::gid(&self) -> u32
 pub fn aya_ebpf::programs::xdp::XdpContext::pid(&self) -> u32
 pub fn aya_ebpf::programs::xdp::XdpContext::tgid(&self) -> u32
 pub fn aya_ebpf::programs::xdp::XdpContext::uid(&self) -> u32
+pub const fn aya_ebpf::bpf_f_adj_room_encap_l2(len: u64) -> u64
 pub fn aya_ebpf::check_bounds_signed(value: i64, lower: i64, upper: i64) -> bool


### PR DESCRIPTION
This function is needed to properly add a L2 header when using `bpf_skb_adjust_room` [1]. As it is originally a C macro, it isn't automatically generated in the `bindings` crate

[1]: https://docs.ebpf.io/linux/helper-function/bpf_skb_adjust_room/

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aya-rs/aya/1344)
<!-- Reviewable:end -->
