### PR TITLE
aya-{common,ebpf}: Add spin lock support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 members = [
     "aya",
     "aya-build",
+    "aya-common",
     "aya-log",
     "aya-log-common",
     "aya-log-parser",

--- a/aya-common/Cargo.toml
+++ b/aya-common/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+description = "Library shared across eBPF and user-space"
+documentation = "https://docs.rs/aya-common"
+keywords = ["bpf", "ebpf", "common"]
+name = "aya-common"
+version = "0.1.0"
+
+authors.workspace = true
+edition.workspace = true
+homepage.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+
+[lints]
+workspace = true
+
+[dependencies]
+aya = { path = "../aya", version = "^0.13.1", optional = true }
+aya-ebpf-cty = { version = "^0.2.2", path = "../ebpf/aya-ebpf-cty" }
+
+[features]
+user = ["dep:aya"]

--- a/aya-common/src/lib.rs
+++ b/aya-common/src/lib.rs
@@ -1,0 +1,5 @@
+#![no_std]
+
+pub mod spin_lock;
+
+pub use spin_lock::SpinLock;

--- a/aya-common/src/spin_lock.rs
+++ b/aya-common/src/spin_lock.rs
@@ -1,0 +1,22 @@
+use aya_ebpf_cty::c_uint;
+
+// #[expect(non_camel_case_types, reason = "Binding to a C type.")]
+#[repr(C)]
+#[derive(Debug, Copy, Clone, Default)]
+pub struct bpf_spin_lock {
+    pub val: c_uint,
+}
+
+/// A spin lock that can be used to procect shared data in eBPF maps.
+#[repr(C)]
+#[derive(Debug, Copy, Clone, Default)]
+pub struct SpinLock(bpf_spin_lock);
+
+impl SpinLock {
+    pub fn as_ptr(&self) -> *mut bpf_spin_lock {
+        core::ptr::from_ref::<bpf_spin_lock>(&self.0).cast_mut()
+    }
+}
+
+#[cfg(feature = "user")]
+unsafe impl aya::Pod for SpinLock {}

--- a/ebpf/aya-ebpf/Cargo.toml
+++ b/ebpf/aya-ebpf/Cargo.toml
@@ -14,6 +14,7 @@ rust-version.workspace = true
 workspace = true
 
 [dependencies]
+aya-common = { version = "^0.1.0", path = "../../aya-common" }
 aya-ebpf-bindings = { version = "^0.1.1", path = "../aya-ebpf-bindings" }
 aya-ebpf-cty = { version = "^0.2.2", path = "../aya-ebpf-cty" }
 aya-ebpf-macros = { version = "^0.1.1", path = "../../aya-ebpf-macros" }

--- a/ebpf/aya-ebpf/src/lib.rs
+++ b/ebpf/aya-ebpf/src/lib.rs
@@ -27,6 +27,7 @@ pub mod btf_maps;
 pub mod helpers;
 pub mod maps;
 pub mod programs;
+pub mod spin_lock;
 
 use core::ptr::NonNull;
 

--- a/ebpf/aya-ebpf/src/spin_lock.rs
+++ b/ebpf/aya-ebpf/src/spin_lock.rs
@@ -1,0 +1,33 @@
+pub use aya_common::spin_lock::SpinLock;
+
+use crate::{bindings, helpers};
+
+/// An RAII implementation of a scope of a spin lock. When this structure is
+/// dropped (falls out of scope), the lock will be unlocked.
+pub struct SpinLockGuard<'a> {
+    spin_lock: &'a SpinLock,
+}
+
+impl Drop for SpinLockGuard<'_> {
+    fn drop(&mut self) {
+        unsafe {
+            helpers::bpf_spin_unlock(self.spin_lock.as_ptr().cast::<bindings::bpf_spin_lock>());
+        }
+    }
+}
+
+/// Extension trait allowing to acquire a [`SpinLock`] in an eBPF program.
+pub trait EbpfSpinLock {
+    /// Acquires a spin lock and returns a [`SpinLockGuard`]. The lock is
+    /// acquired as long as the guard is alive.
+    fn lock(&self) -> SpinLockGuard<'_>;
+}
+
+impl EbpfSpinLock for SpinLock {
+    fn lock(&self) -> SpinLockGuard<'_> {
+        unsafe {
+            helpers::bpf_spin_lock(self.as_ptr().cast::<bindings::bpf_spin_lock>());
+        }
+        SpinLockGuard { spin_lock: self }
+    }
+}

--- a/test/integration-common/Cargo.toml
+++ b/test/integration-common/Cargo.toml
@@ -15,6 +15,7 @@ workspace = true
 
 [dependencies]
 aya = { path = "../../aya", optional = true }
+aya-common = { path = "../../aya-common" }
 
 [features]
 user = ["aya"]

--- a/test/integration-common/src/lib.rs
+++ b/test/integration-common/src/lib.rs
@@ -76,6 +76,20 @@ pub mod ring_buf {
     unsafe impl aya::Pod for Registers {}
 }
 
+pub mod spin_lock {
+    use aya_common::SpinLock;
+
+    #[derive(Copy, Clone)]
+    #[repr(C)]
+    pub struct Counter {
+        pub count: u32,
+        pub spin_lock: SpinLock,
+    }
+
+    #[cfg(feature = "user")]
+    unsafe impl aya::Pod for Counter {}
+}
+
 pub mod strncmp {
     #[derive(Copy, Clone)]
     #[repr(C)]

--- a/test/integration-ebpf/Cargo.toml
+++ b/test/integration-ebpf/Cargo.toml
@@ -77,6 +77,10 @@ name = "simple_prog"
 path = "src/simple_prog.rs"
 
 [[bin]]
+name = "spin_lock"
+path = "src/spin_lock.rs"
+
+[[bin]]
 name = "strncmp"
 path = "src/strncmp.rs"
 

--- a/test/integration-ebpf/src/spin_lock.rs
+++ b/test/integration-ebpf/src/spin_lock.rs
@@ -1,0 +1,32 @@
+#![no_std]
+#![no_main]
+#![expect(unused_crate_dependencies, reason = "used in other bins")]
+
+#[cfg(not(test))]
+extern crate ebpf_panic;
+
+use aya_ebpf::{
+    bindings::xdp_action,
+    btf_maps::Array,
+    macros::{btf_map, xdp},
+    programs::XdpContext,
+    spin_lock::EbpfSpinLock as _,
+};
+use integration_common::spin_lock::Counter;
+
+#[btf_map]
+static COUNTER: Array<Counter, 1> = Array::new();
+
+#[xdp]
+fn packet_counter(_ctx: XdpContext) -> u32 {
+    let Some(counter) = COUNTER.get_ptr_mut(0) else {
+        return xdp_action::XDP_PASS;
+    };
+    let counter = unsafe { &mut *counter };
+    {
+        let _guard = counter.spin_lock.lock();
+        counter.count = counter.count.saturating_add(1);
+    }
+
+    xdp_action::XDP_PASS
+}

--- a/test/integration-test/src/lib.rs
+++ b/test/integration-test/src/lib.rs
@@ -51,6 +51,7 @@ bpf_file!(
     RELOCATIONS => "relocations",
     RING_BUF => "ring_buf",
     SIMPLE_PROG => "simple_prog",
+    SPIN_LOCK => "spin_lock",
     STRNCMP => "strncmp",
     TCX => "tcx",
     TEST => "test",

--- a/test/integration-test/src/tests.rs
+++ b/test/integration-test/src/tests.rs
@@ -14,6 +14,7 @@ mod rbpf;
 mod relocations;
 mod ring_buf;
 mod smoke;
+mod spin_lock;
 mod strncmp;
 mod tcx;
 mod uprobe_cookie;

--- a/test/integration-test/src/tests/spin_lock.rs
+++ b/test/integration-test/src/tests/spin_lock.rs
@@ -1,0 +1,51 @@
+use std::{net::UdpSocket, time::Duration};
+
+use aya::{
+    EbpfLoader,
+    maps::Array,
+    programs::{Xdp, XdpFlags},
+};
+use integration_common::spin_lock::Counter;
+
+use crate::utils::NetNsGuard;
+
+#[test_log::test]
+fn test_spin_lock() {
+    let _netns = NetNsGuard::new();
+
+    let mut ebpf = EbpfLoader::new().load(crate::SPIN_LOCK).unwrap();
+
+    let prog: &mut Xdp = ebpf
+        .program_mut("packet_counter")
+        .unwrap()
+        .try_into()
+        .unwrap();
+    prog.load().unwrap();
+    prog.attach("lo", XdpFlags::default()).unwrap();
+
+    const PAYLOAD: &str = "hello counter";
+
+    let sock = UdpSocket::bind("127.0.0.1:0").unwrap();
+    let addr = sock.local_addr().unwrap();
+    sock.set_read_timeout(Some(Duration::from_secs(60)))
+        .unwrap();
+
+    let num_packets = 10;
+    for _ in 0..num_packets {
+        sock.send_to(PAYLOAD.as_bytes(), addr).unwrap();
+    }
+
+    // Read back the packets to ensure it went through the entire network stack,
+    // including the XDP program.
+    let mut buf = [0u8; PAYLOAD.len() + 1];
+    for _ in 0..num_packets {
+        let n = sock.recv(&mut buf).unwrap();
+        assert_eq!(n, PAYLOAD.len());
+        assert_eq!(&buf[..n], PAYLOAD.as_bytes());
+    }
+
+    let counter_map = ebpf.map("COUNTER").unwrap();
+    let counter_map = Array::<_, Counter>::try_from(counter_map).unwrap();
+    let Counter { count, .. } = counter_map.get(&0, 0).unwrap();
+    assert_eq!(count, num_packets);
+}

--- a/xtask/public-api/aya-common.txt
+++ b/xtask/public-api/aya-common.txt
@@ -1,0 +1,117 @@
+pub mod aya_common
+pub mod aya_common::spin_lock
+#[repr(C)] pub struct aya_common::spin_lock::SpinLock(_)
+impl aya_common::spin_lock::SpinLock
+pub fn aya_common::spin_lock::SpinLock::as_ptr(&self) -> *mut aya_common::spin_lock::bpf_spin_lock
+impl aya::bpf::Pod for aya_common::spin_lock::SpinLock
+impl core::clone::Clone for aya_common::spin_lock::SpinLock
+pub fn aya_common::spin_lock::SpinLock::clone(&self) -> aya_common::spin_lock::SpinLock
+impl core::default::Default for aya_common::spin_lock::SpinLock
+pub fn aya_common::spin_lock::SpinLock::default() -> aya_common::spin_lock::SpinLock
+impl core::fmt::Debug for aya_common::spin_lock::SpinLock
+pub fn aya_common::spin_lock::SpinLock::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Copy for aya_common::spin_lock::SpinLock
+impl core::marker::Freeze for aya_common::spin_lock::SpinLock
+impl core::marker::Send for aya_common::spin_lock::SpinLock
+impl core::marker::Sync for aya_common::spin_lock::SpinLock
+impl core::marker::Unpin for aya_common::spin_lock::SpinLock
+impl core::panic::unwind_safe::RefUnwindSafe for aya_common::spin_lock::SpinLock
+impl core::panic::unwind_safe::UnwindSafe for aya_common::spin_lock::SpinLock
+impl<T, U> core::convert::Into<U> for aya_common::spin_lock::SpinLock where U: core::convert::From<T>
+pub fn aya_common::spin_lock::SpinLock::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for aya_common::spin_lock::SpinLock where U: core::convert::Into<T>
+pub type aya_common::spin_lock::SpinLock::Error = core::convert::Infallible
+pub fn aya_common::spin_lock::SpinLock::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for aya_common::spin_lock::SpinLock where U: core::convert::TryFrom<T>
+pub type aya_common::spin_lock::SpinLock::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn aya_common::spin_lock::SpinLock::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for aya_common::spin_lock::SpinLock where T: core::clone::Clone
+pub type aya_common::spin_lock::SpinLock::Owned = T
+pub fn aya_common::spin_lock::SpinLock::clone_into(&self, target: &mut T)
+pub fn aya_common::spin_lock::SpinLock::to_owned(&self) -> T
+impl<T> core::any::Any for aya_common::spin_lock::SpinLock where T: 'static + ?core::marker::Sized
+pub fn aya_common::spin_lock::SpinLock::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for aya_common::spin_lock::SpinLock where T: ?core::marker::Sized
+pub fn aya_common::spin_lock::SpinLock::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for aya_common::spin_lock::SpinLock where T: ?core::marker::Sized
+pub fn aya_common::spin_lock::SpinLock::borrow_mut(&mut self) -> &mut T
+impl<T> core::clone::CloneToUninit for aya_common::spin_lock::SpinLock where T: core::clone::Clone
+pub unsafe fn aya_common::spin_lock::SpinLock::clone_to_uninit(&self, dest: *mut u8)
+impl<T> core::convert::From<T> for aya_common::spin_lock::SpinLock
+pub fn aya_common::spin_lock::SpinLock::from(t: T) -> T
+#[repr(C)] pub struct aya_common::spin_lock::bpf_spin_lock
+pub aya_common::spin_lock::bpf_spin_lock::val: aya_ebpf_cty::ad::c_uint
+impl core::clone::Clone for aya_common::spin_lock::bpf_spin_lock
+pub fn aya_common::spin_lock::bpf_spin_lock::clone(&self) -> aya_common::spin_lock::bpf_spin_lock
+impl core::default::Default for aya_common::spin_lock::bpf_spin_lock
+pub fn aya_common::spin_lock::bpf_spin_lock::default() -> aya_common::spin_lock::bpf_spin_lock
+impl core::fmt::Debug for aya_common::spin_lock::bpf_spin_lock
+pub fn aya_common::spin_lock::bpf_spin_lock::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Copy for aya_common::spin_lock::bpf_spin_lock
+impl core::marker::Freeze for aya_common::spin_lock::bpf_spin_lock
+impl core::marker::Send for aya_common::spin_lock::bpf_spin_lock
+impl core::marker::Sync for aya_common::spin_lock::bpf_spin_lock
+impl core::marker::Unpin for aya_common::spin_lock::bpf_spin_lock
+impl core::panic::unwind_safe::RefUnwindSafe for aya_common::spin_lock::bpf_spin_lock
+impl core::panic::unwind_safe::UnwindSafe for aya_common::spin_lock::bpf_spin_lock
+impl<T, U> core::convert::Into<U> for aya_common::spin_lock::bpf_spin_lock where U: core::convert::From<T>
+pub fn aya_common::spin_lock::bpf_spin_lock::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for aya_common::spin_lock::bpf_spin_lock where U: core::convert::Into<T>
+pub type aya_common::spin_lock::bpf_spin_lock::Error = core::convert::Infallible
+pub fn aya_common::spin_lock::bpf_spin_lock::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for aya_common::spin_lock::bpf_spin_lock where U: core::convert::TryFrom<T>
+pub type aya_common::spin_lock::bpf_spin_lock::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn aya_common::spin_lock::bpf_spin_lock::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for aya_common::spin_lock::bpf_spin_lock where T: core::clone::Clone
+pub type aya_common::spin_lock::bpf_spin_lock::Owned = T
+pub fn aya_common::spin_lock::bpf_spin_lock::clone_into(&self, target: &mut T)
+pub fn aya_common::spin_lock::bpf_spin_lock::to_owned(&self) -> T
+impl<T> core::any::Any for aya_common::spin_lock::bpf_spin_lock where T: 'static + ?core::marker::Sized
+pub fn aya_common::spin_lock::bpf_spin_lock::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for aya_common::spin_lock::bpf_spin_lock where T: ?core::marker::Sized
+pub fn aya_common::spin_lock::bpf_spin_lock::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for aya_common::spin_lock::bpf_spin_lock where T: ?core::marker::Sized
+pub fn aya_common::spin_lock::bpf_spin_lock::borrow_mut(&mut self) -> &mut T
+impl<T> core::clone::CloneToUninit for aya_common::spin_lock::bpf_spin_lock where T: core::clone::Clone
+pub unsafe fn aya_common::spin_lock::bpf_spin_lock::clone_to_uninit(&self, dest: *mut u8)
+impl<T> core::convert::From<T> for aya_common::spin_lock::bpf_spin_lock
+pub fn aya_common::spin_lock::bpf_spin_lock::from(t: T) -> T
+#[repr(C)] pub struct aya_common::SpinLock(_)
+impl aya_common::spin_lock::SpinLock
+pub fn aya_common::spin_lock::SpinLock::as_ptr(&self) -> *mut aya_common::spin_lock::bpf_spin_lock
+impl aya::bpf::Pod for aya_common::spin_lock::SpinLock
+impl core::clone::Clone for aya_common::spin_lock::SpinLock
+pub fn aya_common::spin_lock::SpinLock::clone(&self) -> aya_common::spin_lock::SpinLock
+impl core::default::Default for aya_common::spin_lock::SpinLock
+pub fn aya_common::spin_lock::SpinLock::default() -> aya_common::spin_lock::SpinLock
+impl core::fmt::Debug for aya_common::spin_lock::SpinLock
+pub fn aya_common::spin_lock::SpinLock::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Copy for aya_common::spin_lock::SpinLock
+impl core::marker::Freeze for aya_common::spin_lock::SpinLock
+impl core::marker::Send for aya_common::spin_lock::SpinLock
+impl core::marker::Sync for aya_common::spin_lock::SpinLock
+impl core::marker::Unpin for aya_common::spin_lock::SpinLock
+impl core::panic::unwind_safe::RefUnwindSafe for aya_common::spin_lock::SpinLock
+impl core::panic::unwind_safe::UnwindSafe for aya_common::spin_lock::SpinLock
+impl<T, U> core::convert::Into<U> for aya_common::spin_lock::SpinLock where U: core::convert::From<T>
+pub fn aya_common::spin_lock::SpinLock::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for aya_common::spin_lock::SpinLock where U: core::convert::Into<T>
+pub type aya_common::spin_lock::SpinLock::Error = core::convert::Infallible
+pub fn aya_common::spin_lock::SpinLock::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for aya_common::spin_lock::SpinLock where U: core::convert::TryFrom<T>
+pub type aya_common::spin_lock::SpinLock::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn aya_common::spin_lock::SpinLock::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for aya_common::spin_lock::SpinLock where T: core::clone::Clone
+pub type aya_common::spin_lock::SpinLock::Owned = T
+pub fn aya_common::spin_lock::SpinLock::clone_into(&self, target: &mut T)
+pub fn aya_common::spin_lock::SpinLock::to_owned(&self) -> T
+impl<T> core::any::Any for aya_common::spin_lock::SpinLock where T: 'static + ?core::marker::Sized
+pub fn aya_common::spin_lock::SpinLock::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for aya_common::spin_lock::SpinLock where T: ?core::marker::Sized
+pub fn aya_common::spin_lock::SpinLock::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for aya_common::spin_lock::SpinLock where T: ?core::marker::Sized
+pub fn aya_common::spin_lock::SpinLock::borrow_mut(&mut self) -> &mut T
+impl<T> core::clone::CloneToUninit for aya_common::spin_lock::SpinLock where T: core::clone::Clone
+pub unsafe fn aya_common::spin_lock::SpinLock::clone_to_uninit(&self, dest: *mut u8)
+impl<T> core::convert::From<T> for aya_common::spin_lock::SpinLock
+pub fn aya_common::spin_lock::SpinLock::from(t: T) -> T

--- a/xtask/public-api/aya-ebpf.txt
+++ b/xtask/public-api/aya-ebpf.txt
@@ -2851,6 +2851,37 @@ impl<T> core::borrow::BorrowMut<T> for aya_ebpf::programs::xdp::XdpContext where
 pub fn aya_ebpf::programs::xdp::XdpContext::borrow_mut(&mut self) -> &mut T
 impl<T> core::convert::From<T> for aya_ebpf::programs::xdp::XdpContext
 pub fn aya_ebpf::programs::xdp::XdpContext::from(t: T) -> T
+pub mod aya_ebpf::spin_lock
+pub use aya_ebpf::spin_lock::SpinLock
+pub struct aya_ebpf::spin_lock::SpinLockGuard<'a>
+impl core::ops::drop::Drop for aya_ebpf::spin_lock::SpinLockGuard<'_>
+pub fn aya_ebpf::spin_lock::SpinLockGuard<'_>::drop(&mut self)
+impl<'a> core::marker::Freeze for aya_ebpf::spin_lock::SpinLockGuard<'a>
+impl<'a> core::marker::Send for aya_ebpf::spin_lock::SpinLockGuard<'a>
+impl<'a> core::marker::Sync for aya_ebpf::spin_lock::SpinLockGuard<'a>
+impl<'a> core::marker::Unpin for aya_ebpf::spin_lock::SpinLockGuard<'a>
+impl<'a> core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::spin_lock::SpinLockGuard<'a>
+impl<'a> core::panic::unwind_safe::UnwindSafe for aya_ebpf::spin_lock::SpinLockGuard<'a>
+impl<T, U> core::convert::Into<U> for aya_ebpf::spin_lock::SpinLockGuard<'a> where U: core::convert::From<T>
+pub fn aya_ebpf::spin_lock::SpinLockGuard<'a>::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for aya_ebpf::spin_lock::SpinLockGuard<'a> where U: core::convert::Into<T>
+pub type aya_ebpf::spin_lock::SpinLockGuard<'a>::Error = core::convert::Infallible
+pub fn aya_ebpf::spin_lock::SpinLockGuard<'a>::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for aya_ebpf::spin_lock::SpinLockGuard<'a> where U: core::convert::TryFrom<T>
+pub type aya_ebpf::spin_lock::SpinLockGuard<'a>::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn aya_ebpf::spin_lock::SpinLockGuard<'a>::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> core::any::Any for aya_ebpf::spin_lock::SpinLockGuard<'a> where T: 'static + ?core::marker::Sized
+pub fn aya_ebpf::spin_lock::SpinLockGuard<'a>::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for aya_ebpf::spin_lock::SpinLockGuard<'a> where T: ?core::marker::Sized
+pub fn aya_ebpf::spin_lock::SpinLockGuard<'a>::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for aya_ebpf::spin_lock::SpinLockGuard<'a> where T: ?core::marker::Sized
+pub fn aya_ebpf::spin_lock::SpinLockGuard<'a>::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for aya_ebpf::spin_lock::SpinLockGuard<'a>
+pub fn aya_ebpf::spin_lock::SpinLockGuard<'a>::from(t: T) -> T
+pub trait aya_ebpf::spin_lock::EbpfSpinLock
+pub fn aya_ebpf::spin_lock::EbpfSpinLock::lock(&self) -> aya_ebpf::spin_lock::SpinLockGuard<'_>
+impl aya_ebpf::spin_lock::EbpfSpinLock for aya_common::spin_lock::SpinLock
+pub fn aya_common::spin_lock::SpinLock::lock(&self) -> aya_ebpf::spin_lock::SpinLockGuard<'_>
 pub macro aya_ebpf::bpf_printk!
 pub macro aya_ebpf::btf_map_def!
 pub struct aya_ebpf::PtRegs


### PR DESCRIPTION
Add a new `aya-common` crate with a `SpinLock` struct, that wraps `bpf_spin_lock` and allows to use it in BPF maps.

Add an extension trait `EbpfSpinLock` that provides a `lock` method, which is a wrapper over `bpf_spin_lock` helper. It returns a `SpinLockGuard` that calls `bpf_spin_unlock` helper once dropped.

Test that functionality with a simple XDP counter program.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aya-rs/aya/1356)
<!-- Reviewable:end -->
