### PR TITLE
aya-ebpf: Make use of `Borrow` and `BorrowMut` in map methods

### DIFF
--- a/ebpf/aya-ebpf/src/btf_maps/array.rs
+++ b/ebpf/aya-ebpf/src/btf_maps/array.rs
@@ -1,4 +1,4 @@
-use core::{cell::UnsafeCell, ptr::NonNull};
+use core::{borrow::Borrow, cell::UnsafeCell, ptr::NonNull};
 
 use crate::{bindings::bpf_map_type::BPF_MAP_TYPE_ARRAY, btf_map_def, cty::c_long, insert, lookup};
 
@@ -51,7 +51,7 @@ impl<T, const M: usize, const F: usize> Array<T, M, F> {
 
     /// Sets the value of the element at the given index.
     #[inline(always)]
-    pub fn set(&self, index: u32, value: &T, flags: u64) -> Result<(), c_long> {
-        insert(self.0.get().cast(), &index, value, flags)
+    pub fn set(&self, index: u32, value: impl Borrow<T>, flags: u64) -> Result<(), c_long> {
+        insert(self.0.get().cast(), &index, value.borrow(), flags)
     }
 }

--- a/ebpf/aya-ebpf/src/maps/array.rs
+++ b/ebpf/aya-ebpf/src/maps/array.rs
@@ -1,4 +1,4 @@
-use core::{cell::UnsafeCell, marker::PhantomData, mem, ptr::NonNull};
+use core::{borrow::Borrow, cell::UnsafeCell, marker::PhantomData, mem, ptr::NonNull};
 
 use aya_ebpf_cty::c_long;
 
@@ -69,7 +69,7 @@ impl<T> Array<T> {
 
     /// Sets the value of the element at the given index.
     #[inline(always)]
-    pub fn set(&self, index: u32, value: &T, flags: u64) -> Result<(), c_long> {
-        insert(self.def.get().cast(), &index, value, flags)
+    pub fn set(&self, index: u32, value: impl Borrow<T>, flags: u64) -> Result<(), c_long> {
+        insert(self.def.get().cast(), &index, value.borrow(), flags)
     }
 }

--- a/ebpf/aya-ebpf/src/maps/bloom_filter.rs
+++ b/ebpf/aya-ebpf/src/maps/bloom_filter.rs
@@ -1,4 +1,4 @@
-use core::{marker::PhantomData, mem, ptr};
+use core::{borrow::Borrow, marker::PhantomData, mem, ptr};
 
 use crate::{
     bindings::{bpf_map_def, bpf_map_type::BPF_MAP_TYPE_BLOOM_FILTER},
@@ -38,22 +38,22 @@ impl<T> BloomFilter<T> {
     }
 
     #[inline]
-    pub fn contains(&mut self, value: &T) -> Result<(), i64> {
+    pub fn contains(&mut self, value: impl Borrow<T>) -> Result<(), i64> {
         let ret = unsafe {
             bpf_map_peek_elem(
                 ptr::from_ref(&self.def).cast_mut().cast(),
-                ptr::from_ref(value).cast_mut().cast(),
+                ptr::from_ref(value.borrow()).cast_mut().cast(),
             )
         };
         (ret == 0).then_some(()).ok_or(ret)
     }
 
     #[inline]
-    pub fn insert(&mut self, value: &T, flags: u64) -> Result<(), i64> {
+    pub fn insert(&mut self, value: impl Borrow<T>, flags: u64) -> Result<(), i64> {
         let ret = unsafe {
             bpf_map_push_elem(
                 ptr::from_ref(&self.def).cast_mut().cast(),
-                ptr::from_ref(value).cast(),
+                ptr::from_ref(value.borrow()).cast(),
                 flags,
             )
         };

--- a/ebpf/aya-ebpf/src/maps/hash_map.rs
+++ b/ebpf/aya-ebpf/src/maps/hash_map.rs
@@ -1,4 +1,4 @@
-use core::{cell::UnsafeCell, marker::PhantomData, mem};
+use core::{borrow::Borrow, cell::UnsafeCell, marker::PhantomData, mem};
 
 use aya_ebpf_bindings::bindings::bpf_map_type::{
     BPF_MAP_TYPE_LRU_HASH, BPF_MAP_TYPE_LRU_PERCPU_HASH, BPF_MAP_TYPE_PERCPU_HASH,
@@ -56,16 +56,16 @@ impl<K, V> HashMap<K, V> {
     /// of `insert` or `remove`, and any element removed from the map might get aliased by another
     /// element in the map, causing garbage to be read, or corruption in case of writes.
     #[inline]
-    pub unsafe fn get(&self, key: &K) -> Option<&V> {
-        unsafe { get(self.def.get(), key) }
+    pub unsafe fn get(&self, key: impl Borrow<K>) -> Option<&V> {
+        unsafe { get(self.def.get(), key.borrow()) }
     }
 
     /// Retrieve the value associate with `key` from the map.
     /// The same caveat as `get` applies, but this returns a raw pointer and it's up to the caller
     /// to decide whether it's safe to dereference the pointer or not.
     #[inline]
-    pub fn get_ptr(&self, key: &K) -> Option<*const V> {
-        get_ptr(self.def.get(), key)
+    pub fn get_ptr(&self, key: impl Borrow<K>) -> Option<*const V> {
+        get_ptr(self.def.get(), key.borrow())
     }
 
     /// Retrieve the value associate with `key` from the map.
@@ -73,18 +73,23 @@ impl<K, V> HashMap<K, V> {
     /// concurrent writes, but it's up to the caller to decide whether it's safe to dereference the
     /// pointer or not.
     #[inline]
-    pub fn get_ptr_mut(&self, key: &K) -> Option<*mut V> {
-        get_ptr_mut(self.def.get(), key)
+    pub fn get_ptr_mut(&self, key: impl Borrow<K>) -> Option<*mut V> {
+        get_ptr_mut(self.def.get(), key.borrow())
     }
 
     #[inline]
-    pub fn insert(&self, key: &K, value: &V, flags: u64) -> Result<(), c_long> {
-        insert(self.def.get().cast(), key, value, flags)
+    pub fn insert(
+        &self,
+        key: impl Borrow<K>,
+        value: impl Borrow<V>,
+        flags: u64,
+    ) -> Result<(), c_long> {
+        insert(self.def.get().cast(), key.borrow(), value.borrow(), flags)
     }
 
     #[inline]
-    pub fn remove(&self, key: &K) -> Result<(), c_long> {
-        remove(self.def.get().cast(), key)
+    pub fn remove(&self, key: impl Borrow<K>) -> Result<(), c_long> {
+        remove(self.def.get().cast(), key.borrow())
     }
 }
 
@@ -132,16 +137,16 @@ impl<K, V> LruHashMap<K, V> {
     /// of `insert` or `remove`, and any element removed from the map might get aliased by another
     /// element in the map, causing garbage to be read, or corruption in case of writes.
     #[inline]
-    pub unsafe fn get(&self, key: &K) -> Option<&V> {
-        unsafe { get(self.def.get(), key) }
+    pub unsafe fn get(&self, key: impl Borrow<K>) -> Option<&V> {
+        unsafe { get(self.def.get(), key.borrow()) }
     }
 
     /// Retrieve the value associate with `key` from the map.
     /// The same caveat as `get` applies, but this returns a raw pointer and it's up to the caller
     /// to decide whether it's safe to dereference the pointer or not.
     #[inline]
-    pub fn get_ptr(&self, key: &K) -> Option<*const V> {
-        get_ptr(self.def.get(), key)
+    pub fn get_ptr(&self, key: impl Borrow<K>) -> Option<*const V> {
+        get_ptr(self.def.get(), key.borrow())
     }
 
     /// Retrieve the value associate with `key` from the map.
@@ -149,18 +154,23 @@ impl<K, V> LruHashMap<K, V> {
     /// concurrent writes, but it's up to the caller to decide whether it's safe to dereference the
     /// pointer or not.
     #[inline]
-    pub fn get_ptr_mut(&self, key: &K) -> Option<*mut V> {
-        get_ptr_mut(self.def.get(), key)
+    pub fn get_ptr_mut(&self, key: impl Borrow<K>) -> Option<*mut V> {
+        get_ptr_mut(self.def.get(), key.borrow())
     }
 
     #[inline]
-    pub fn insert(&self, key: &K, value: &V, flags: u64) -> Result<(), c_long> {
-        insert(self.def.get().cast(), key, value, flags)
+    pub fn insert(
+        &self,
+        key: impl Borrow<K>,
+        value: impl Borrow<V>,
+        flags: u64,
+    ) -> Result<(), c_long> {
+        insert(self.def.get().cast(), key.borrow(), value.borrow(), flags)
     }
 
     #[inline]
-    pub fn remove(&self, key: &K) -> Result<(), c_long> {
-        remove(self.def.get().cast(), key)
+    pub fn remove(&self, key: impl Borrow<K>) -> Result<(), c_long> {
+        remove(self.def.get().cast(), key.borrow())
     }
 }
 
@@ -208,16 +218,16 @@ impl<K, V> PerCpuHashMap<K, V> {
     /// of `insert` or `remove`, and any element removed from the map might get aliased by another
     /// element in the map, causing garbage to be read, or corruption in case of writes.
     #[inline]
-    pub unsafe fn get(&self, key: &K) -> Option<&V> {
-        unsafe { get(self.def.get(), key) }
+    pub unsafe fn get(&self, key: impl Borrow<K>) -> Option<&V> {
+        unsafe { get(self.def.get(), key.borrow()) }
     }
 
     /// Retrieve the value associate with `key` from the map.
     /// The same caveat as `get` applies, but this returns a raw pointer and it's up to the caller
     /// to decide whether it's safe to dereference the pointer or not.
     #[inline]
-    pub fn get_ptr(&self, key: &K) -> Option<*const V> {
-        get_ptr(self.def.get(), key)
+    pub fn get_ptr(&self, key: impl Borrow<K>) -> Option<*const V> {
+        get_ptr(self.def.get(), key.borrow())
     }
 
     /// Retrieve the value associate with `key` from the map.
@@ -225,18 +235,23 @@ impl<K, V> PerCpuHashMap<K, V> {
     /// concurrent writes, but it's up to the caller to decide whether it's safe to dereference the
     /// pointer or not.
     #[inline]
-    pub fn get_ptr_mut(&self, key: &K) -> Option<*mut V> {
-        get_ptr_mut(self.def.get(), key)
+    pub fn get_ptr_mut(&self, key: impl Borrow<K>) -> Option<*mut V> {
+        get_ptr_mut(self.def.get(), key.borrow())
     }
 
     #[inline]
-    pub fn insert(&self, key: &K, value: &V, flags: u64) -> Result<(), c_long> {
-        insert(self.def.get().cast(), key, value, flags)
+    pub fn insert(
+        &self,
+        key: impl Borrow<K>,
+        value: impl Borrow<V>,
+        flags: u64,
+    ) -> Result<(), c_long> {
+        insert(self.def.get().cast(), key.borrow(), value.borrow(), flags)
     }
 
     #[inline]
-    pub fn remove(&self, key: &K) -> Result<(), c_long> {
-        remove(self.def.get().cast(), key)
+    pub fn remove(&self, key: impl Borrow<K>) -> Result<(), c_long> {
+        remove(self.def.get().cast(), key.borrow())
     }
 }
 
@@ -284,16 +299,16 @@ impl<K, V> LruPerCpuHashMap<K, V> {
     /// of `insert` or `remove`, and any element removed from the map might get aliased by another
     /// element in the map, causing garbage to be read, or corruption in case of writes.
     #[inline]
-    pub unsafe fn get(&self, key: &K) -> Option<&V> {
-        unsafe { get(self.def.get(), key) }
+    pub unsafe fn get(&self, key: impl Borrow<K>) -> Option<&V> {
+        unsafe { get(self.def.get(), key.borrow()) }
     }
 
     /// Retrieve the value associate with `key` from the map.
     /// The same caveat as `get` applies, but this returns a raw pointer and it's up to the caller
     /// to decide whether it's safe to dereference the pointer or not.
     #[inline]
-    pub fn get_ptr(&self, key: &K) -> Option<*const V> {
-        get_ptr(self.def.get(), key)
+    pub fn get_ptr(&self, key: impl Borrow<K>) -> Option<*const V> {
+        get_ptr(self.def.get(), key.borrow())
     }
 
     /// Retrieve the value associate with `key` from the map.
@@ -301,18 +316,23 @@ impl<K, V> LruPerCpuHashMap<K, V> {
     /// concurrent writes, but it's up to the caller to decide whether it's safe to dereference the
     /// pointer or not.
     #[inline]
-    pub fn get_ptr_mut(&self, key: &K) -> Option<*mut V> {
-        get_ptr_mut(self.def.get(), key)
+    pub fn get_ptr_mut(&self, key: impl Borrow<K>) -> Option<*mut V> {
+        get_ptr_mut(self.def.get(), key.borrow())
     }
 
     #[inline]
-    pub fn insert(&self, key: &K, value: &V, flags: u64) -> Result<(), c_long> {
-        insert(self.def.get().cast(), key, value, flags)
+    pub fn insert(
+        &self,
+        key: impl Borrow<K>,
+        value: impl Borrow<V>,
+        flags: u64,
+    ) -> Result<(), c_long> {
+        insert(self.def.get().cast(), key.borrow(), value.borrow(), flags)
     }
 
     #[inline]
-    pub fn remove(&self, key: &K) -> Result<(), c_long> {
-        remove(self.def.get().cast(), key)
+    pub fn remove(&self, key: impl Borrow<K>) -> Result<(), c_long> {
+        remove(self.def.get().cast(), key.borrow())
     }
 }
 

--- a/ebpf/aya-ebpf/src/maps/lpm_trie.rs
+++ b/ebpf/aya-ebpf/src/maps/lpm_trie.rs
@@ -1,4 +1,4 @@
-use core::{cell::UnsafeCell, marker::PhantomData, mem};
+use core::{borrow::Borrow, cell::UnsafeCell, marker::PhantomData, mem};
 
 use aya_ebpf_bindings::bindings::BPF_F_NO_PREALLOC;
 use aya_ebpf_cty::c_long;
@@ -63,18 +63,23 @@ impl<K, V> LpmTrie<K, V> {
     }
 
     #[inline]
-    pub fn get(&self, key: &Key<K>) -> Option<&V> {
-        lookup(self.def.get().cast(), key).map(|p| unsafe { p.as_ref() })
+    pub fn get(&self, key: impl Borrow<Key<K>>) -> Option<&V> {
+        lookup(self.def.get().cast(), key.borrow()).map(|p| unsafe { p.as_ref() })
     }
 
     #[inline]
-    pub fn insert(&self, key: &Key<K>, value: &V, flags: u64) -> Result<(), c_long> {
-        insert(self.def.get().cast(), key, value, flags)
+    pub fn insert(
+        &self,
+        key: impl Borrow<Key<K>>,
+        value: impl Borrow<V>,
+        flags: u64,
+    ) -> Result<(), c_long> {
+        insert(self.def.get().cast(), key.borrow(), value.borrow(), flags)
     }
 
     #[inline]
-    pub fn remove(&self, key: &Key<K>) -> Result<(), c_long> {
-        remove(self.def.get().cast(), key)
+    pub fn remove(&self, key: impl Borrow<Key<K>>) -> Result<(), c_long> {
+        remove(self.def.get().cast(), key.borrow())
     }
 }
 

--- a/ebpf/aya-ebpf/src/maps/ring_buf.rs
+++ b/ebpf/aya-ebpf/src/maps/ring_buf.rs
@@ -1,4 +1,5 @@
 use core::{
+    borrow::Borrow,
     cell::UnsafeCell,
     mem,
     mem::MaybeUninit,
@@ -205,7 +206,8 @@ impl RingBuf {
     ///
     /// [`reserve`]: RingBuf::reserve
     /// [`submit`]: RingBufEntry::submit
-    pub fn output<T: ?Sized>(&self, data: &T, flags: u64) -> Result<(), i64> {
+    pub fn output<T: ?Sized>(&self, data: impl Borrow<T>, flags: u64) -> Result<(), i64> {
+        let data = data.borrow();
         assert_eq!(8 % mem::align_of_val(data), 0);
         let ret = unsafe {
             bpf_ringbuf_output(

--- a/ebpf/aya-ebpf/src/maps/stack.rs
+++ b/ebpf/aya-ebpf/src/maps/stack.rs
@@ -1,4 +1,4 @@
-use core::{marker::PhantomData, mem, ptr};
+use core::{borrow::Borrow, marker::PhantomData, mem, ptr};
 
 use crate::{
     bindings::{bpf_map_def, bpf_map_type::BPF_MAP_TYPE_STACK},
@@ -43,11 +43,11 @@ impl<T> Stack<T> {
         }
     }
 
-    pub fn push(&self, value: &T, flags: u64) -> Result<(), i64> {
+    pub fn push(&self, value: impl Borrow<T>, flags: u64) -> Result<(), i64> {
         let ret = unsafe {
             bpf_map_push_elem(
                 ptr::from_ref(&self.def).cast_mut().cast(),
-                ptr::from_ref(value).cast(),
+                ptr::from_ref(value.borrow()).cast(),
                 flags,
             )
         };

--- a/ebpf/aya-ebpf/src/maps/stack_trace.rs
+++ b/ebpf/aya-ebpf/src/maps/stack_trace.rs
@@ -1,4 +1,4 @@
-use core::{cell::UnsafeCell, mem};
+use core::{borrow::Borrow, cell::UnsafeCell, mem};
 
 use crate::{
     EbpfContext,
@@ -46,8 +46,12 @@ impl StackTrace {
     }
 
     #[expect(clippy::missing_safety_doc)]
-    pub unsafe fn get_stackid<C: EbpfContext>(&self, ctx: &C, flags: u64) -> Result<i64, i64> {
-        let ret = unsafe { bpf_get_stackid(ctx.as_ptr(), self.def.get().cast(), flags) };
+    pub unsafe fn get_stackid<C: EbpfContext>(
+        &self,
+        ctx: impl Borrow<C>,
+        flags: u64,
+    ) -> Result<i64, i64> {
+        let ret = unsafe { bpf_get_stackid(ctx.borrow().as_ptr(), self.def.get().cast(), flags) };
         if ret < 0 { Err(ret) } else { Ok(ret) }
     }
 }

--- a/test/integration-ebpf/src/map_test.rs
+++ b/test/integration-ebpf/src/map_test.rs
@@ -31,7 +31,7 @@ fn simple_prog(_ctx: SkBuffContext) -> i64 {
     // If we use the literal value `0` instead of the local variable `i`, then an additional
     // `.rodata` map will be associated with the program.
     let i = 0;
-    BAZ.get_ptr(&i);
+    BAZ.get_ptr(i);
 
     0
 }

--- a/test/integration-ebpf/src/memmove_test.rs
+++ b/test/integration-ebpf/src/memmove_test.rs
@@ -44,7 +44,7 @@ fn do_dnat(ctx: XdpContext) -> u32 {
 
 fn try_do_dnat(ctx: XdpContext) -> Result<u32, ()> {
     let index = 0;
-    if let Some(nat) = unsafe { RULES.get(&index) } {
+    if let Some(nat) = unsafe { RULES.get(index) } {
         let hproto: *const EtherType = ptr_at(&ctx, mem::offset_of!(EthHdr, ether_type))?;
         match unsafe { *hproto } {
             EtherType::Ipv6 => {

--- a/test/integration-ebpf/src/uprobe_cookie.rs
+++ b/test/integration-ebpf/src/uprobe_cookie.rs
@@ -18,5 +18,5 @@ static RING_BUF: RingBuf = RingBuf::with_byte_size(0, 0);
 fn uprobe_cookie(ctx: ProbeContext) {
     let cookie = unsafe { helpers::bpf_get_attach_cookie(ctx.as_ptr()) };
     let cookie_bytes = cookie.to_le_bytes();
-    let _res = RING_BUF.output(&cookie_bytes, 0);
+    let _res = RING_BUF.output::<[u8; 8]>(&cookie_bytes, 0);
 }

--- a/xtask/public-api/aya-ebpf.txt
+++ b/xtask/public-api/aya-ebpf.txt
@@ -10,7 +10,7 @@ pub fn aya_ebpf::btf_maps::array::Array<T, M, F>::get(&self, index: u32) -> core
 pub fn aya_ebpf::btf_maps::array::Array<T, M, F>::get_ptr(&self, index: u32) -> core::option::Option<*const T>
 pub fn aya_ebpf::btf_maps::array::Array<T, M, F>::get_ptr_mut(&self, index: u32) -> core::option::Option<*mut T>
 pub const fn aya_ebpf::btf_maps::array::Array<T, M, F>::new() -> Self
-pub fn aya_ebpf::btf_maps::array::Array<T, M, F>::set(&self, index: u32, value: &T, flags: u64) -> core::result::Result<(), aya_ebpf_cty::od::c_long>
+pub fn aya_ebpf::btf_maps::array::Array<T, M, F>::set(&self, index: u32, value: impl core::borrow::Borrow<T>, flags: u64) -> core::result::Result<(), aya_ebpf_cty::od::c_long>
 impl<T: core::marker::Sync, const M: usize, const F: usize> core::marker::Sync for aya_ebpf::btf_maps::array::Array<T, M, F>
 impl<T, const M: usize, const F: usize> !core::marker::Freeze for aya_ebpf::btf_maps::array::Array<T, M, F>
 impl<T, const M: usize, const F: usize> !core::marker::Send for aya_ebpf::btf_maps::array::Array<T, M, F>
@@ -118,7 +118,7 @@ pub fn aya_ebpf::btf_maps::array::Array<T, M, F>::get(&self, index: u32) -> core
 pub fn aya_ebpf::btf_maps::array::Array<T, M, F>::get_ptr(&self, index: u32) -> core::option::Option<*const T>
 pub fn aya_ebpf::btf_maps::array::Array<T, M, F>::get_ptr_mut(&self, index: u32) -> core::option::Option<*mut T>
 pub const fn aya_ebpf::btf_maps::array::Array<T, M, F>::new() -> Self
-pub fn aya_ebpf::btf_maps::array::Array<T, M, F>::set(&self, index: u32, value: &T, flags: u64) -> core::result::Result<(), aya_ebpf_cty::od::c_long>
+pub fn aya_ebpf::btf_maps::array::Array<T, M, F>::set(&self, index: u32, value: impl core::borrow::Borrow<T>, flags: u64) -> core::result::Result<(), aya_ebpf_cty::od::c_long>
 impl<T: core::marker::Sync, const M: usize, const F: usize> core::marker::Sync for aya_ebpf::btf_maps::array::Array<T, M, F>
 impl<T, const M: usize, const F: usize> !core::marker::Freeze for aya_ebpf::btf_maps::array::Array<T, M, F>
 impl<T, const M: usize, const F: usize> !core::marker::Send for aya_ebpf::btf_maps::array::Array<T, M, F>
@@ -252,7 +252,7 @@ pub fn aya_ebpf::maps::array::Array<T>::get(&self, index: u32) -> core::option::
 pub fn aya_ebpf::maps::array::Array<T>::get_ptr(&self, index: u32) -> core::option::Option<*const T>
 pub fn aya_ebpf::maps::array::Array<T>::get_ptr_mut(&self, index: u32) -> core::option::Option<*mut T>
 pub const fn aya_ebpf::maps::array::Array<T>::pinned(max_entries: u32, flags: u32) -> Self
-pub fn aya_ebpf::maps::array::Array<T>::set(&self, index: u32, value: &T, flags: u64) -> core::result::Result<(), aya_ebpf_cty::od::c_long>
+pub fn aya_ebpf::maps::array::Array<T>::set(&self, index: u32, value: impl core::borrow::Borrow<T>, flags: u64) -> core::result::Result<(), aya_ebpf_cty::od::c_long>
 pub const fn aya_ebpf::maps::array::Array<T>::with_max_entries(max_entries: u32, flags: u32) -> Self
 impl<T: core::marker::Sync> core::marker::Sync for aya_ebpf::maps::array::Array<T>
 impl<T> !core::marker::Freeze for aya_ebpf::maps::array::Array<T>
@@ -279,8 +279,8 @@ pub fn aya_ebpf::maps::array::Array<T>::from(t: T) -> T
 pub mod aya_ebpf::maps::bloom_filter
 #[repr(transparent)] pub struct aya_ebpf::maps::bloom_filter::BloomFilter<T>
 impl<T> aya_ebpf::maps::bloom_filter::BloomFilter<T>
-pub fn aya_ebpf::maps::bloom_filter::BloomFilter<T>::contains(&mut self, value: &T) -> core::result::Result<(), i64>
-pub fn aya_ebpf::maps::bloom_filter::BloomFilter<T>::insert(&mut self, value: &T, flags: u64) -> core::result::Result<(), i64>
+pub fn aya_ebpf::maps::bloom_filter::BloomFilter<T>::contains(&mut self, value: impl core::borrow::Borrow<T>) -> core::result::Result<(), i64>
+pub fn aya_ebpf::maps::bloom_filter::BloomFilter<T>::insert(&mut self, value: impl core::borrow::Borrow<T>, flags: u64) -> core::result::Result<(), i64>
 pub const fn aya_ebpf::maps::bloom_filter::BloomFilter<T>::pinned(max_entries: u32, flags: u32) -> Self
 pub const fn aya_ebpf::maps::bloom_filter::BloomFilter<T>::with_max_entries(max_entries: u32, flags: u32) -> Self
 impl<T> core::marker::Freeze for aya_ebpf::maps::bloom_filter::BloomFilter<T>
@@ -308,12 +308,12 @@ pub fn aya_ebpf::maps::bloom_filter::BloomFilter<T>::from(t: T) -> T
 pub mod aya_ebpf::maps::hash_map
 #[repr(transparent)] pub struct aya_ebpf::maps::hash_map::HashMap<K, V>
 impl<K, V> aya_ebpf::maps::hash_map::HashMap<K, V>
-pub unsafe fn aya_ebpf::maps::hash_map::HashMap<K, V>::get(&self, key: &K) -> core::option::Option<&V>
-pub fn aya_ebpf::maps::hash_map::HashMap<K, V>::get_ptr(&self, key: &K) -> core::option::Option<*const V>
-pub fn aya_ebpf::maps::hash_map::HashMap<K, V>::get_ptr_mut(&self, key: &K) -> core::option::Option<*mut V>
-pub fn aya_ebpf::maps::hash_map::HashMap<K, V>::insert(&self, key: &K, value: &V, flags: u64) -> core::result::Result<(), aya_ebpf_cty::od::c_long>
+pub unsafe fn aya_ebpf::maps::hash_map::HashMap<K, V>::get(&self, key: impl core::borrow::Borrow<K>) -> core::option::Option<&V>
+pub fn aya_ebpf::maps::hash_map::HashMap<K, V>::get_ptr(&self, key: impl core::borrow::Borrow<K>) -> core::option::Option<*const V>
+pub fn aya_ebpf::maps::hash_map::HashMap<K, V>::get_ptr_mut(&self, key: impl core::borrow::Borrow<K>) -> core::option::Option<*mut V>
+pub fn aya_ebpf::maps::hash_map::HashMap<K, V>::insert(&self, key: impl core::borrow::Borrow<K>, value: impl core::borrow::Borrow<V>, flags: u64) -> core::result::Result<(), aya_ebpf_cty::od::c_long>
 pub const fn aya_ebpf::maps::hash_map::HashMap<K, V>::pinned(max_entries: u32, flags: u32) -> Self
-pub fn aya_ebpf::maps::hash_map::HashMap<K, V>::remove(&self, key: &K) -> core::result::Result<(), aya_ebpf_cty::od::c_long>
+pub fn aya_ebpf::maps::hash_map::HashMap<K, V>::remove(&self, key: impl core::borrow::Borrow<K>) -> core::result::Result<(), aya_ebpf_cty::od::c_long>
 pub const fn aya_ebpf::maps::hash_map::HashMap<K, V>::with_max_entries(max_entries: u32, flags: u32) -> Self
 impl<K: core::marker::Sync, V: core::marker::Sync> core::marker::Sync for aya_ebpf::maps::hash_map::HashMap<K, V>
 impl<K, V> !core::marker::Freeze for aya_ebpf::maps::hash_map::HashMap<K, V>
@@ -339,12 +339,12 @@ impl<T> core::convert::From<T> for aya_ebpf::maps::hash_map::HashMap<K, V>
 pub fn aya_ebpf::maps::hash_map::HashMap<K, V>::from(t: T) -> T
 #[repr(transparent)] pub struct aya_ebpf::maps::hash_map::LruHashMap<K, V>
 impl<K, V> aya_ebpf::maps::hash_map::LruHashMap<K, V>
-pub unsafe fn aya_ebpf::maps::hash_map::LruHashMap<K, V>::get(&self, key: &K) -> core::option::Option<&V>
-pub fn aya_ebpf::maps::hash_map::LruHashMap<K, V>::get_ptr(&self, key: &K) -> core::option::Option<*const V>
-pub fn aya_ebpf::maps::hash_map::LruHashMap<K, V>::get_ptr_mut(&self, key: &K) -> core::option::Option<*mut V>
-pub fn aya_ebpf::maps::hash_map::LruHashMap<K, V>::insert(&self, key: &K, value: &V, flags: u64) -> core::result::Result<(), aya_ebpf_cty::od::c_long>
+pub unsafe fn aya_ebpf::maps::hash_map::LruHashMap<K, V>::get(&self, key: impl core::borrow::Borrow<K>) -> core::option::Option<&V>
+pub fn aya_ebpf::maps::hash_map::LruHashMap<K, V>::get_ptr(&self, key: impl core::borrow::Borrow<K>) -> core::option::Option<*const V>
+pub fn aya_ebpf::maps::hash_map::LruHashMap<K, V>::get_ptr_mut(&self, key: impl core::borrow::Borrow<K>) -> core::option::Option<*mut V>
+pub fn aya_ebpf::maps::hash_map::LruHashMap<K, V>::insert(&self, key: impl core::borrow::Borrow<K>, value: impl core::borrow::Borrow<V>, flags: u64) -> core::result::Result<(), aya_ebpf_cty::od::c_long>
 pub const fn aya_ebpf::maps::hash_map::LruHashMap<K, V>::pinned(max_entries: u32, flags: u32) -> Self
-pub fn aya_ebpf::maps::hash_map::LruHashMap<K, V>::remove(&self, key: &K) -> core::result::Result<(), aya_ebpf_cty::od::c_long>
+pub fn aya_ebpf::maps::hash_map::LruHashMap<K, V>::remove(&self, key: impl core::borrow::Borrow<K>) -> core::result::Result<(), aya_ebpf_cty::od::c_long>
 pub const fn aya_ebpf::maps::hash_map::LruHashMap<K, V>::with_max_entries(max_entries: u32, flags: u32) -> Self
 impl<K: core::marker::Sync, V: core::marker::Sync> core::marker::Sync for aya_ebpf::maps::hash_map::LruHashMap<K, V>
 impl<K, V> !core::marker::Freeze for aya_ebpf::maps::hash_map::LruHashMap<K, V>
@@ -370,12 +370,12 @@ impl<T> core::convert::From<T> for aya_ebpf::maps::hash_map::LruHashMap<K, V>
 pub fn aya_ebpf::maps::hash_map::LruHashMap<K, V>::from(t: T) -> T
 #[repr(transparent)] pub struct aya_ebpf::maps::hash_map::LruPerCpuHashMap<K, V>
 impl<K, V> aya_ebpf::maps::hash_map::LruPerCpuHashMap<K, V>
-pub unsafe fn aya_ebpf::maps::hash_map::LruPerCpuHashMap<K, V>::get(&self, key: &K) -> core::option::Option<&V>
-pub fn aya_ebpf::maps::hash_map::LruPerCpuHashMap<K, V>::get_ptr(&self, key: &K) -> core::option::Option<*const V>
-pub fn aya_ebpf::maps::hash_map::LruPerCpuHashMap<K, V>::get_ptr_mut(&self, key: &K) -> core::option::Option<*mut V>
-pub fn aya_ebpf::maps::hash_map::LruPerCpuHashMap<K, V>::insert(&self, key: &K, value: &V, flags: u64) -> core::result::Result<(), aya_ebpf_cty::od::c_long>
+pub unsafe fn aya_ebpf::maps::hash_map::LruPerCpuHashMap<K, V>::get(&self, key: impl core::borrow::Borrow<K>) -> core::option::Option<&V>
+pub fn aya_ebpf::maps::hash_map::LruPerCpuHashMap<K, V>::get_ptr(&self, key: impl core::borrow::Borrow<K>) -> core::option::Option<*const V>
+pub fn aya_ebpf::maps::hash_map::LruPerCpuHashMap<K, V>::get_ptr_mut(&self, key: impl core::borrow::Borrow<K>) -> core::option::Option<*mut V>
+pub fn aya_ebpf::maps::hash_map::LruPerCpuHashMap<K, V>::insert(&self, key: impl core::borrow::Borrow<K>, value: impl core::borrow::Borrow<V>, flags: u64) -> core::result::Result<(), aya_ebpf_cty::od::c_long>
 pub const fn aya_ebpf::maps::hash_map::LruPerCpuHashMap<K, V>::pinned(max_entries: u32, flags: u32) -> Self
-pub fn aya_ebpf::maps::hash_map::LruPerCpuHashMap<K, V>::remove(&self, key: &K) -> core::result::Result<(), aya_ebpf_cty::od::c_long>
+pub fn aya_ebpf::maps::hash_map::LruPerCpuHashMap<K, V>::remove(&self, key: impl core::borrow::Borrow<K>) -> core::result::Result<(), aya_ebpf_cty::od::c_long>
 pub const fn aya_ebpf::maps::hash_map::LruPerCpuHashMap<K, V>::with_max_entries(max_entries: u32, flags: u32) -> Self
 impl<K, V> core::marker::Sync for aya_ebpf::maps::hash_map::LruPerCpuHashMap<K, V>
 impl<K, V> !core::marker::Freeze for aya_ebpf::maps::hash_map::LruPerCpuHashMap<K, V>
@@ -401,12 +401,12 @@ impl<T> core::convert::From<T> for aya_ebpf::maps::hash_map::LruPerCpuHashMap<K,
 pub fn aya_ebpf::maps::hash_map::LruPerCpuHashMap<K, V>::from(t: T) -> T
 #[repr(transparent)] pub struct aya_ebpf::maps::hash_map::PerCpuHashMap<K, V>
 impl<K, V> aya_ebpf::maps::hash_map::PerCpuHashMap<K, V>
-pub unsafe fn aya_ebpf::maps::hash_map::PerCpuHashMap<K, V>::get(&self, key: &K) -> core::option::Option<&V>
-pub fn aya_ebpf::maps::hash_map::PerCpuHashMap<K, V>::get_ptr(&self, key: &K) -> core::option::Option<*const V>
-pub fn aya_ebpf::maps::hash_map::PerCpuHashMap<K, V>::get_ptr_mut(&self, key: &K) -> core::option::Option<*mut V>
-pub fn aya_ebpf::maps::hash_map::PerCpuHashMap<K, V>::insert(&self, key: &K, value: &V, flags: u64) -> core::result::Result<(), aya_ebpf_cty::od::c_long>
+pub unsafe fn aya_ebpf::maps::hash_map::PerCpuHashMap<K, V>::get(&self, key: impl core::borrow::Borrow<K>) -> core::option::Option<&V>
+pub fn aya_ebpf::maps::hash_map::PerCpuHashMap<K, V>::get_ptr(&self, key: impl core::borrow::Borrow<K>) -> core::option::Option<*const V>
+pub fn aya_ebpf::maps::hash_map::PerCpuHashMap<K, V>::get_ptr_mut(&self, key: impl core::borrow::Borrow<K>) -> core::option::Option<*mut V>
+pub fn aya_ebpf::maps::hash_map::PerCpuHashMap<K, V>::insert(&self, key: impl core::borrow::Borrow<K>, value: impl core::borrow::Borrow<V>, flags: u64) -> core::result::Result<(), aya_ebpf_cty::od::c_long>
 pub const fn aya_ebpf::maps::hash_map::PerCpuHashMap<K, V>::pinned(max_entries: u32, flags: u32) -> Self
-pub fn aya_ebpf::maps::hash_map::PerCpuHashMap<K, V>::remove(&self, key: &K) -> core::result::Result<(), aya_ebpf_cty::od::c_long>
+pub fn aya_ebpf::maps::hash_map::PerCpuHashMap<K, V>::remove(&self, key: impl core::borrow::Borrow<K>) -> core::result::Result<(), aya_ebpf_cty::od::c_long>
 pub const fn aya_ebpf::maps::hash_map::PerCpuHashMap<K, V>::with_max_entries(max_entries: u32, flags: u32) -> Self
 impl<K, V> core::marker::Sync for aya_ebpf::maps::hash_map::PerCpuHashMap<K, V>
 impl<K, V> !core::marker::Freeze for aya_ebpf::maps::hash_map::PerCpuHashMap<K, V>
@@ -460,10 +460,10 @@ impl<T> core::convert::From<T> for aya_ebpf::maps::lpm_trie::Key<K>
 pub fn aya_ebpf::maps::lpm_trie::Key<K>::from(t: T) -> T
 #[repr(transparent)] pub struct aya_ebpf::maps::lpm_trie::LpmTrie<K, V>
 impl<K, V> aya_ebpf::maps::lpm_trie::LpmTrie<K, V>
-pub fn aya_ebpf::maps::lpm_trie::LpmTrie<K, V>::get(&self, key: &aya_ebpf::maps::lpm_trie::Key<K>) -> core::option::Option<&V>
-pub fn aya_ebpf::maps::lpm_trie::LpmTrie<K, V>::insert(&self, key: &aya_ebpf::maps::lpm_trie::Key<K>, value: &V, flags: u64) -> core::result::Result<(), aya_ebpf_cty::od::c_long>
+pub fn aya_ebpf::maps::lpm_trie::LpmTrie<K, V>::get(&self, key: impl core::borrow::Borrow<aya_ebpf::maps::lpm_trie::Key<K>>) -> core::option::Option<&V>
+pub fn aya_ebpf::maps::lpm_trie::LpmTrie<K, V>::insert(&self, key: impl core::borrow::Borrow<aya_ebpf::maps::lpm_trie::Key<K>>, value: impl core::borrow::Borrow<V>, flags: u64) -> core::result::Result<(), aya_ebpf_cty::od::c_long>
 pub const fn aya_ebpf::maps::lpm_trie::LpmTrie<K, V>::pinned(max_entries: u32, flags: u32) -> Self
-pub fn aya_ebpf::maps::lpm_trie::LpmTrie<K, V>::remove(&self, key: &aya_ebpf::maps::lpm_trie::Key<K>) -> core::result::Result<(), aya_ebpf_cty::od::c_long>
+pub fn aya_ebpf::maps::lpm_trie::LpmTrie<K, V>::remove(&self, key: impl core::borrow::Borrow<aya_ebpf::maps::lpm_trie::Key<K>>) -> core::result::Result<(), aya_ebpf_cty::od::c_long>
 pub const fn aya_ebpf::maps::lpm_trie::LpmTrie<K, V>::with_max_entries(max_entries: u32, flags: u32) -> Self
 impl<K: core::marker::Sync, V: core::marker::Sync> core::marker::Sync for aya_ebpf::maps::lpm_trie::LpmTrie<K, V>
 impl<K, V> !core::marker::Freeze for aya_ebpf::maps::lpm_trie::LpmTrie<K, V>
@@ -521,8 +521,8 @@ pub mod aya_ebpf::maps::perf
 #[repr(transparent)] pub struct aya_ebpf::maps::perf::PerfEventArray<T>
 impl<T> aya_ebpf::maps::PerfEventArray<T>
 pub const fn aya_ebpf::maps::PerfEventArray<T>::new(flags: u32) -> Self
-pub fn aya_ebpf::maps::PerfEventArray<T>::output<C: aya_ebpf::EbpfContext>(&self, ctx: &C, data: &T, flags: u32)
-pub fn aya_ebpf::maps::PerfEventArray<T>::output_at_index<C: aya_ebpf::EbpfContext>(&self, ctx: &C, index: u32, data: &T, flags: u32)
+pub fn aya_ebpf::maps::PerfEventArray<T>::output<C: aya_ebpf::EbpfContext>(&self, ctx: &C, data: impl core::borrow::Borrow<T>, flags: u32)
+pub fn aya_ebpf::maps::PerfEventArray<T>::output_at_index<C: aya_ebpf::EbpfContext>(&self, ctx: &C, index: u32, data: impl core::borrow::Borrow<T>, flags: u32)
 pub const fn aya_ebpf::maps::PerfEventArray<T>::pinned(flags: u32) -> Self
 impl<T: core::marker::Sync> core::marker::Sync for aya_ebpf::maps::PerfEventArray<T>
 impl<T> !core::marker::Freeze for aya_ebpf::maps::PerfEventArray<T>
@@ -608,7 +608,7 @@ impl<T> aya_ebpf::maps::queue::Queue<T>
 pub fn aya_ebpf::maps::queue::Queue<T>::peek(&self) -> core::option::Option<T>
 pub const fn aya_ebpf::maps::queue::Queue<T>::pinned(max_entries: u32, flags: u32) -> Self
 pub fn aya_ebpf::maps::queue::Queue<T>::pop(&self) -> core::option::Option<T>
-pub fn aya_ebpf::maps::queue::Queue<T>::push(&self, value: &T, flags: u64) -> core::result::Result<(), i64>
+pub fn aya_ebpf::maps::queue::Queue<T>::push(&self, value: impl core::borrow::Borrow<T>, flags: u64) -> core::result::Result<(), i64>
 pub const fn aya_ebpf::maps::queue::Queue<T>::with_max_entries(max_entries: u32, flags: u32) -> Self
 impl<T: core::marker::Sync> core::marker::Sync for aya_ebpf::maps::queue::Queue<T>
 impl<T> !core::marker::Freeze for aya_ebpf::maps::queue::Queue<T>
@@ -635,7 +635,7 @@ pub fn aya_ebpf::maps::queue::Queue<T>::from(t: T) -> T
 pub mod aya_ebpf::maps::ring_buf
 #[repr(transparent)] pub struct aya_ebpf::maps::ring_buf::RingBuf
 impl aya_ebpf::maps::ring_buf::RingBuf
-pub fn aya_ebpf::maps::ring_buf::RingBuf::output<T: ?core::marker::Sized>(&self, data: &T, flags: u64) -> core::result::Result<(), i64>
+pub fn aya_ebpf::maps::ring_buf::RingBuf::output<T: ?core::marker::Sized>(&self, data: impl core::borrow::Borrow<T>, flags: u64) -> core::result::Result<(), i64>
 pub const fn aya_ebpf::maps::ring_buf::RingBuf::pinned(byte_size: u32, flags: u32) -> Self
 pub fn aya_ebpf::maps::ring_buf::RingBuf::query(&self, flags: u64) -> u64
 pub fn aya_ebpf::maps::ring_buf::RingBuf::reserve<T: 'static>(&self, flags: u64) -> core::option::Option<aya_ebpf::maps::ring_buf::RingBufEntry<T>>
@@ -733,10 +733,10 @@ pub mod aya_ebpf::maps::sock_hash
 #[repr(transparent)] pub struct aya_ebpf::maps::sock_hash::SockHash<K>
 impl<K> aya_ebpf::maps::sock_hash::SockHash<K>
 pub const fn aya_ebpf::maps::sock_hash::SockHash<K>::pinned(max_entries: u32, flags: u32) -> Self
-pub fn aya_ebpf::maps::sock_hash::SockHash<K>::redirect_msg(&self, ctx: &aya_ebpf::programs::sk_msg::SkMsgContext, key: &mut K, flags: u64) -> i64
-pub fn aya_ebpf::maps::sock_hash::SockHash<K>::redirect_sk_lookup(&mut self, ctx: &aya_ebpf::programs::sk_lookup::SkLookupContext, key: impl core::borrow::Borrow<K>, flags: u64) -> core::result::Result<(), u32>
-pub fn aya_ebpf::maps::sock_hash::SockHash<K>::redirect_skb(&self, ctx: &aya_ebpf::programs::sk_buff::SkBuffContext, key: &mut K, flags: u64) -> i64
-pub fn aya_ebpf::maps::sock_hash::SockHash<K>::update(&self, key: &mut K, sk_ops: &mut aya_ebpf_bindings::x86_64::bindings::bpf_sock_ops, flags: u64) -> core::result::Result<(), i64>
+pub fn aya_ebpf::maps::sock_hash::SockHash<K>::redirect_msg(&self, ctx: impl core::borrow::Borrow<aya_ebpf::programs::sk_msg::SkMsgContext>, key: impl core::borrow::BorrowMut<K>, flags: u64) -> i64
+pub fn aya_ebpf::maps::sock_hash::SockHash<K>::redirect_sk_lookup(&mut self, ctx: impl core::borrow::Borrow<aya_ebpf::programs::sk_lookup::SkLookupContext>, key: impl core::borrow::Borrow<K>, flags: u64) -> core::result::Result<(), u32>
+pub fn aya_ebpf::maps::sock_hash::SockHash<K>::redirect_skb(&self, ctx: impl core::borrow::Borrow<aya_ebpf::programs::sk_buff::SkBuffContext>, key: impl core::borrow::BorrowMut<K>, flags: u64) -> i64
+pub fn aya_ebpf::maps::sock_hash::SockHash<K>::update(&self, key: impl core::borrow::BorrowMut<K>, sk_ops: impl core::borrow::BorrowMut<aya_ebpf_bindings::x86_64::bindings::bpf_sock_ops>, flags: u64) -> core::result::Result<(), i64>
 pub const fn aya_ebpf::maps::sock_hash::SockHash<K>::with_max_entries(max_entries: u32, flags: u32) -> Self
 impl<K: core::marker::Sync> core::marker::Sync for aya_ebpf::maps::sock_hash::SockHash<K>
 impl<K> !core::marker::Freeze for aya_ebpf::maps::sock_hash::SockHash<K>
@@ -797,7 +797,7 @@ impl<T> aya_ebpf::maps::stack::Stack<T>
 pub fn aya_ebpf::maps::stack::Stack<T>::peek(&self) -> core::option::Option<T>
 pub const fn aya_ebpf::maps::stack::Stack<T>::pinned(max_entries: u32, flags: u32) -> Self
 pub fn aya_ebpf::maps::stack::Stack<T>::pop(&self) -> core::option::Option<T>
-pub fn aya_ebpf::maps::stack::Stack<T>::push(&self, value: &T, flags: u64) -> core::result::Result<(), i64>
+pub fn aya_ebpf::maps::stack::Stack<T>::push(&self, value: impl core::borrow::Borrow<T>, flags: u64) -> core::result::Result<(), i64>
 pub const fn aya_ebpf::maps::stack::Stack<T>::with_max_entries(max_entries: u32, flags: u32) -> Self
 impl<T> core::marker::Freeze for aya_ebpf::maps::stack::Stack<T>
 impl<T> core::marker::Send for aya_ebpf::maps::stack::Stack<T> where T: core::marker::Send
@@ -824,7 +824,7 @@ pub fn aya_ebpf::maps::stack::Stack<T>::from(t: T) -> T
 pub mod aya_ebpf::maps::stack_trace
 #[repr(transparent)] pub struct aya_ebpf::maps::stack_trace::StackTrace
 impl aya_ebpf::maps::stack_trace::StackTrace
-pub unsafe fn aya_ebpf::maps::stack_trace::StackTrace::get_stackid<C: aya_ebpf::EbpfContext>(&self, ctx: &C, flags: u64) -> core::result::Result<i64, i64>
+pub unsafe fn aya_ebpf::maps::stack_trace::StackTrace::get_stackid<C: aya_ebpf::EbpfContext>(&self, ctx: impl core::borrow::Borrow<C>, flags: u64) -> core::result::Result<i64, i64>
 pub const fn aya_ebpf::maps::stack_trace::StackTrace::pinned(max_entries: u32, flags: u32) -> Self
 pub const fn aya_ebpf::maps::stack_trace::StackTrace::with_max_entries(max_entries: u32, flags: u32) -> Self
 impl core::marker::Sync for aya_ebpf::maps::stack_trace::StackTrace
@@ -967,7 +967,7 @@ pub fn aya_ebpf::maps::array::Array<T>::get(&self, index: u32) -> core::option::
 pub fn aya_ebpf::maps::array::Array<T>::get_ptr(&self, index: u32) -> core::option::Option<*const T>
 pub fn aya_ebpf::maps::array::Array<T>::get_ptr_mut(&self, index: u32) -> core::option::Option<*mut T>
 pub const fn aya_ebpf::maps::array::Array<T>::pinned(max_entries: u32, flags: u32) -> Self
-pub fn aya_ebpf::maps::array::Array<T>::set(&self, index: u32, value: &T, flags: u64) -> core::result::Result<(), aya_ebpf_cty::od::c_long>
+pub fn aya_ebpf::maps::array::Array<T>::set(&self, index: u32, value: impl core::borrow::Borrow<T>, flags: u64) -> core::result::Result<(), aya_ebpf_cty::od::c_long>
 pub const fn aya_ebpf::maps::array::Array<T>::with_max_entries(max_entries: u32, flags: u32) -> Self
 impl<T: core::marker::Sync> core::marker::Sync for aya_ebpf::maps::array::Array<T>
 impl<T> !core::marker::Freeze for aya_ebpf::maps::array::Array<T>
@@ -993,8 +993,8 @@ impl<T> core::convert::From<T> for aya_ebpf::maps::array::Array<T>
 pub fn aya_ebpf::maps::array::Array<T>::from(t: T) -> T
 #[repr(transparent)] pub struct aya_ebpf::maps::BloomFilter<T>
 impl<T> aya_ebpf::maps::bloom_filter::BloomFilter<T>
-pub fn aya_ebpf::maps::bloom_filter::BloomFilter<T>::contains(&mut self, value: &T) -> core::result::Result<(), i64>
-pub fn aya_ebpf::maps::bloom_filter::BloomFilter<T>::insert(&mut self, value: &T, flags: u64) -> core::result::Result<(), i64>
+pub fn aya_ebpf::maps::bloom_filter::BloomFilter<T>::contains(&mut self, value: impl core::borrow::Borrow<T>) -> core::result::Result<(), i64>
+pub fn aya_ebpf::maps::bloom_filter::BloomFilter<T>::insert(&mut self, value: impl core::borrow::Borrow<T>, flags: u64) -> core::result::Result<(), i64>
 pub const fn aya_ebpf::maps::bloom_filter::BloomFilter<T>::pinned(max_entries: u32, flags: u32) -> Self
 pub const fn aya_ebpf::maps::bloom_filter::BloomFilter<T>::with_max_entries(max_entries: u32, flags: u32) -> Self
 impl<T> core::marker::Freeze for aya_ebpf::maps::bloom_filter::BloomFilter<T>
@@ -1104,12 +1104,12 @@ impl<T> core::convert::From<T> for aya_ebpf::maps::DevMapHash
 pub fn aya_ebpf::maps::DevMapHash::from(t: T) -> T
 #[repr(transparent)] pub struct aya_ebpf::maps::HashMap<K, V>
 impl<K, V> aya_ebpf::maps::hash_map::HashMap<K, V>
-pub unsafe fn aya_ebpf::maps::hash_map::HashMap<K, V>::get(&self, key: &K) -> core::option::Option<&V>
-pub fn aya_ebpf::maps::hash_map::HashMap<K, V>::get_ptr(&self, key: &K) -> core::option::Option<*const V>
-pub fn aya_ebpf::maps::hash_map::HashMap<K, V>::get_ptr_mut(&self, key: &K) -> core::option::Option<*mut V>
-pub fn aya_ebpf::maps::hash_map::HashMap<K, V>::insert(&self, key: &K, value: &V, flags: u64) -> core::result::Result<(), aya_ebpf_cty::od::c_long>
+pub unsafe fn aya_ebpf::maps::hash_map::HashMap<K, V>::get(&self, key: impl core::borrow::Borrow<K>) -> core::option::Option<&V>
+pub fn aya_ebpf::maps::hash_map::HashMap<K, V>::get_ptr(&self, key: impl core::borrow::Borrow<K>) -> core::option::Option<*const V>
+pub fn aya_ebpf::maps::hash_map::HashMap<K, V>::get_ptr_mut(&self, key: impl core::borrow::Borrow<K>) -> core::option::Option<*mut V>
+pub fn aya_ebpf::maps::hash_map::HashMap<K, V>::insert(&self, key: impl core::borrow::Borrow<K>, value: impl core::borrow::Borrow<V>, flags: u64) -> core::result::Result<(), aya_ebpf_cty::od::c_long>
 pub const fn aya_ebpf::maps::hash_map::HashMap<K, V>::pinned(max_entries: u32, flags: u32) -> Self
-pub fn aya_ebpf::maps::hash_map::HashMap<K, V>::remove(&self, key: &K) -> core::result::Result<(), aya_ebpf_cty::od::c_long>
+pub fn aya_ebpf::maps::hash_map::HashMap<K, V>::remove(&self, key: impl core::borrow::Borrow<K>) -> core::result::Result<(), aya_ebpf_cty::od::c_long>
 pub const fn aya_ebpf::maps::hash_map::HashMap<K, V>::with_max_entries(max_entries: u32, flags: u32) -> Self
 impl<K: core::marker::Sync, V: core::marker::Sync> core::marker::Sync for aya_ebpf::maps::hash_map::HashMap<K, V>
 impl<K, V> !core::marker::Freeze for aya_ebpf::maps::hash_map::HashMap<K, V>
@@ -1135,10 +1135,10 @@ impl<T> core::convert::From<T> for aya_ebpf::maps::hash_map::HashMap<K, V>
 pub fn aya_ebpf::maps::hash_map::HashMap<K, V>::from(t: T) -> T
 #[repr(transparent)] pub struct aya_ebpf::maps::LpmTrie<K, V>
 impl<K, V> aya_ebpf::maps::lpm_trie::LpmTrie<K, V>
-pub fn aya_ebpf::maps::lpm_trie::LpmTrie<K, V>::get(&self, key: &aya_ebpf::maps::lpm_trie::Key<K>) -> core::option::Option<&V>
-pub fn aya_ebpf::maps::lpm_trie::LpmTrie<K, V>::insert(&self, key: &aya_ebpf::maps::lpm_trie::Key<K>, value: &V, flags: u64) -> core::result::Result<(), aya_ebpf_cty::od::c_long>
+pub fn aya_ebpf::maps::lpm_trie::LpmTrie<K, V>::get(&self, key: impl core::borrow::Borrow<aya_ebpf::maps::lpm_trie::Key<K>>) -> core::option::Option<&V>
+pub fn aya_ebpf::maps::lpm_trie::LpmTrie<K, V>::insert(&self, key: impl core::borrow::Borrow<aya_ebpf::maps::lpm_trie::Key<K>>, value: impl core::borrow::Borrow<V>, flags: u64) -> core::result::Result<(), aya_ebpf_cty::od::c_long>
 pub const fn aya_ebpf::maps::lpm_trie::LpmTrie<K, V>::pinned(max_entries: u32, flags: u32) -> Self
-pub fn aya_ebpf::maps::lpm_trie::LpmTrie<K, V>::remove(&self, key: &aya_ebpf::maps::lpm_trie::Key<K>) -> core::result::Result<(), aya_ebpf_cty::od::c_long>
+pub fn aya_ebpf::maps::lpm_trie::LpmTrie<K, V>::remove(&self, key: impl core::borrow::Borrow<aya_ebpf::maps::lpm_trie::Key<K>>) -> core::result::Result<(), aya_ebpf_cty::od::c_long>
 pub const fn aya_ebpf::maps::lpm_trie::LpmTrie<K, V>::with_max_entries(max_entries: u32, flags: u32) -> Self
 impl<K: core::marker::Sync, V: core::marker::Sync> core::marker::Sync for aya_ebpf::maps::lpm_trie::LpmTrie<K, V>
 impl<K, V> !core::marker::Freeze for aya_ebpf::maps::lpm_trie::LpmTrie<K, V>
@@ -1164,12 +1164,12 @@ impl<T> core::convert::From<T> for aya_ebpf::maps::lpm_trie::LpmTrie<K, V>
 pub fn aya_ebpf::maps::lpm_trie::LpmTrie<K, V>::from(t: T) -> T
 #[repr(transparent)] pub struct aya_ebpf::maps::LruHashMap<K, V>
 impl<K, V> aya_ebpf::maps::hash_map::LruHashMap<K, V>
-pub unsafe fn aya_ebpf::maps::hash_map::LruHashMap<K, V>::get(&self, key: &K) -> core::option::Option<&V>
-pub fn aya_ebpf::maps::hash_map::LruHashMap<K, V>::get_ptr(&self, key: &K) -> core::option::Option<*const V>
-pub fn aya_ebpf::maps::hash_map::LruHashMap<K, V>::get_ptr_mut(&self, key: &K) -> core::option::Option<*mut V>
-pub fn aya_ebpf::maps::hash_map::LruHashMap<K, V>::insert(&self, key: &K, value: &V, flags: u64) -> core::result::Result<(), aya_ebpf_cty::od::c_long>
+pub unsafe fn aya_ebpf::maps::hash_map::LruHashMap<K, V>::get(&self, key: impl core::borrow::Borrow<K>) -> core::option::Option<&V>
+pub fn aya_ebpf::maps::hash_map::LruHashMap<K, V>::get_ptr(&self, key: impl core::borrow::Borrow<K>) -> core::option::Option<*const V>
+pub fn aya_ebpf::maps::hash_map::LruHashMap<K, V>::get_ptr_mut(&self, key: impl core::borrow::Borrow<K>) -> core::option::Option<*mut V>
+pub fn aya_ebpf::maps::hash_map::LruHashMap<K, V>::insert(&self, key: impl core::borrow::Borrow<K>, value: impl core::borrow::Borrow<V>, flags: u64) -> core::result::Result<(), aya_ebpf_cty::od::c_long>
 pub const fn aya_ebpf::maps::hash_map::LruHashMap<K, V>::pinned(max_entries: u32, flags: u32) -> Self
-pub fn aya_ebpf::maps::hash_map::LruHashMap<K, V>::remove(&self, key: &K) -> core::result::Result<(), aya_ebpf_cty::od::c_long>
+pub fn aya_ebpf::maps::hash_map::LruHashMap<K, V>::remove(&self, key: impl core::borrow::Borrow<K>) -> core::result::Result<(), aya_ebpf_cty::od::c_long>
 pub const fn aya_ebpf::maps::hash_map::LruHashMap<K, V>::with_max_entries(max_entries: u32, flags: u32) -> Self
 impl<K: core::marker::Sync, V: core::marker::Sync> core::marker::Sync for aya_ebpf::maps::hash_map::LruHashMap<K, V>
 impl<K, V> !core::marker::Freeze for aya_ebpf::maps::hash_map::LruHashMap<K, V>
@@ -1195,12 +1195,12 @@ impl<T> core::convert::From<T> for aya_ebpf::maps::hash_map::LruHashMap<K, V>
 pub fn aya_ebpf::maps::hash_map::LruHashMap<K, V>::from(t: T) -> T
 #[repr(transparent)] pub struct aya_ebpf::maps::LruPerCpuHashMap<K, V>
 impl<K, V> aya_ebpf::maps::hash_map::LruPerCpuHashMap<K, V>
-pub unsafe fn aya_ebpf::maps::hash_map::LruPerCpuHashMap<K, V>::get(&self, key: &K) -> core::option::Option<&V>
-pub fn aya_ebpf::maps::hash_map::LruPerCpuHashMap<K, V>::get_ptr(&self, key: &K) -> core::option::Option<*const V>
-pub fn aya_ebpf::maps::hash_map::LruPerCpuHashMap<K, V>::get_ptr_mut(&self, key: &K) -> core::option::Option<*mut V>
-pub fn aya_ebpf::maps::hash_map::LruPerCpuHashMap<K, V>::insert(&self, key: &K, value: &V, flags: u64) -> core::result::Result<(), aya_ebpf_cty::od::c_long>
+pub unsafe fn aya_ebpf::maps::hash_map::LruPerCpuHashMap<K, V>::get(&self, key: impl core::borrow::Borrow<K>) -> core::option::Option<&V>
+pub fn aya_ebpf::maps::hash_map::LruPerCpuHashMap<K, V>::get_ptr(&self, key: impl core::borrow::Borrow<K>) -> core::option::Option<*const V>
+pub fn aya_ebpf::maps::hash_map::LruPerCpuHashMap<K, V>::get_ptr_mut(&self, key: impl core::borrow::Borrow<K>) -> core::option::Option<*mut V>
+pub fn aya_ebpf::maps::hash_map::LruPerCpuHashMap<K, V>::insert(&self, key: impl core::borrow::Borrow<K>, value: impl core::borrow::Borrow<V>, flags: u64) -> core::result::Result<(), aya_ebpf_cty::od::c_long>
 pub const fn aya_ebpf::maps::hash_map::LruPerCpuHashMap<K, V>::pinned(max_entries: u32, flags: u32) -> Self
-pub fn aya_ebpf::maps::hash_map::LruPerCpuHashMap<K, V>::remove(&self, key: &K) -> core::result::Result<(), aya_ebpf_cty::od::c_long>
+pub fn aya_ebpf::maps::hash_map::LruPerCpuHashMap<K, V>::remove(&self, key: impl core::borrow::Borrow<K>) -> core::result::Result<(), aya_ebpf_cty::od::c_long>
 pub const fn aya_ebpf::maps::hash_map::LruPerCpuHashMap<K, V>::with_max_entries(max_entries: u32, flags: u32) -> Self
 impl<K, V> core::marker::Sync for aya_ebpf::maps::hash_map::LruPerCpuHashMap<K, V>
 impl<K, V> !core::marker::Freeze for aya_ebpf::maps::hash_map::LruPerCpuHashMap<K, V>
@@ -1255,12 +1255,12 @@ impl<T> core::convert::From<T> for aya_ebpf::maps::per_cpu_array::PerCpuArray<T>
 pub fn aya_ebpf::maps::per_cpu_array::PerCpuArray<T>::from(t: T) -> T
 #[repr(transparent)] pub struct aya_ebpf::maps::PerCpuHashMap<K, V>
 impl<K, V> aya_ebpf::maps::hash_map::PerCpuHashMap<K, V>
-pub unsafe fn aya_ebpf::maps::hash_map::PerCpuHashMap<K, V>::get(&self, key: &K) -> core::option::Option<&V>
-pub fn aya_ebpf::maps::hash_map::PerCpuHashMap<K, V>::get_ptr(&self, key: &K) -> core::option::Option<*const V>
-pub fn aya_ebpf::maps::hash_map::PerCpuHashMap<K, V>::get_ptr_mut(&self, key: &K) -> core::option::Option<*mut V>
-pub fn aya_ebpf::maps::hash_map::PerCpuHashMap<K, V>::insert(&self, key: &K, value: &V, flags: u64) -> core::result::Result<(), aya_ebpf_cty::od::c_long>
+pub unsafe fn aya_ebpf::maps::hash_map::PerCpuHashMap<K, V>::get(&self, key: impl core::borrow::Borrow<K>) -> core::option::Option<&V>
+pub fn aya_ebpf::maps::hash_map::PerCpuHashMap<K, V>::get_ptr(&self, key: impl core::borrow::Borrow<K>) -> core::option::Option<*const V>
+pub fn aya_ebpf::maps::hash_map::PerCpuHashMap<K, V>::get_ptr_mut(&self, key: impl core::borrow::Borrow<K>) -> core::option::Option<*mut V>
+pub fn aya_ebpf::maps::hash_map::PerCpuHashMap<K, V>::insert(&self, key: impl core::borrow::Borrow<K>, value: impl core::borrow::Borrow<V>, flags: u64) -> core::result::Result<(), aya_ebpf_cty::od::c_long>
 pub const fn aya_ebpf::maps::hash_map::PerCpuHashMap<K, V>::pinned(max_entries: u32, flags: u32) -> Self
-pub fn aya_ebpf::maps::hash_map::PerCpuHashMap<K, V>::remove(&self, key: &K) -> core::result::Result<(), aya_ebpf_cty::od::c_long>
+pub fn aya_ebpf::maps::hash_map::PerCpuHashMap<K, V>::remove(&self, key: impl core::borrow::Borrow<K>) -> core::result::Result<(), aya_ebpf_cty::od::c_long>
 pub const fn aya_ebpf::maps::hash_map::PerCpuHashMap<K, V>::with_max_entries(max_entries: u32, flags: u32) -> Self
 impl<K, V> core::marker::Sync for aya_ebpf::maps::hash_map::PerCpuHashMap<K, V>
 impl<K, V> !core::marker::Freeze for aya_ebpf::maps::hash_map::PerCpuHashMap<K, V>
@@ -1287,8 +1287,8 @@ pub fn aya_ebpf::maps::hash_map::PerCpuHashMap<K, V>::from(t: T) -> T
 #[repr(transparent)] pub struct aya_ebpf::maps::PerfEventArray<T>
 impl<T> aya_ebpf::maps::PerfEventArray<T>
 pub const fn aya_ebpf::maps::PerfEventArray<T>::new(flags: u32) -> Self
-pub fn aya_ebpf::maps::PerfEventArray<T>::output<C: aya_ebpf::EbpfContext>(&self, ctx: &C, data: &T, flags: u32)
-pub fn aya_ebpf::maps::PerfEventArray<T>::output_at_index<C: aya_ebpf::EbpfContext>(&self, ctx: &C, index: u32, data: &T, flags: u32)
+pub fn aya_ebpf::maps::PerfEventArray<T>::output<C: aya_ebpf::EbpfContext>(&self, ctx: &C, data: impl core::borrow::Borrow<T>, flags: u32)
+pub fn aya_ebpf::maps::PerfEventArray<T>::output_at_index<C: aya_ebpf::EbpfContext>(&self, ctx: &C, index: u32, data: impl core::borrow::Borrow<T>, flags: u32)
 pub const fn aya_ebpf::maps::PerfEventArray<T>::pinned(flags: u32) -> Self
 impl<T: core::marker::Sync> core::marker::Sync for aya_ebpf::maps::PerfEventArray<T>
 impl<T> !core::marker::Freeze for aya_ebpf::maps::PerfEventArray<T>
@@ -1372,7 +1372,7 @@ impl<T> aya_ebpf::maps::queue::Queue<T>
 pub fn aya_ebpf::maps::queue::Queue<T>::peek(&self) -> core::option::Option<T>
 pub const fn aya_ebpf::maps::queue::Queue<T>::pinned(max_entries: u32, flags: u32) -> Self
 pub fn aya_ebpf::maps::queue::Queue<T>::pop(&self) -> core::option::Option<T>
-pub fn aya_ebpf::maps::queue::Queue<T>::push(&self, value: &T, flags: u64) -> core::result::Result<(), i64>
+pub fn aya_ebpf::maps::queue::Queue<T>::push(&self, value: impl core::borrow::Borrow<T>, flags: u64) -> core::result::Result<(), i64>
 pub const fn aya_ebpf::maps::queue::Queue<T>::with_max_entries(max_entries: u32, flags: u32) -> Self
 impl<T: core::marker::Sync> core::marker::Sync for aya_ebpf::maps::queue::Queue<T>
 impl<T> !core::marker::Freeze for aya_ebpf::maps::queue::Queue<T>
@@ -1398,7 +1398,7 @@ impl<T> core::convert::From<T> for aya_ebpf::maps::queue::Queue<T>
 pub fn aya_ebpf::maps::queue::Queue<T>::from(t: T) -> T
 #[repr(transparent)] pub struct aya_ebpf::maps::RingBuf
 impl aya_ebpf::maps::ring_buf::RingBuf
-pub fn aya_ebpf::maps::ring_buf::RingBuf::output<T: ?core::marker::Sized>(&self, data: &T, flags: u64) -> core::result::Result<(), i64>
+pub fn aya_ebpf::maps::ring_buf::RingBuf::output<T: ?core::marker::Sized>(&self, data: impl core::borrow::Borrow<T>, flags: u64) -> core::result::Result<(), i64>
 pub const fn aya_ebpf::maps::ring_buf::RingBuf::pinned(byte_size: u32, flags: u32) -> Self
 pub fn aya_ebpf::maps::ring_buf::RingBuf::query(&self, flags: u64) -> u64
 pub fn aya_ebpf::maps::ring_buf::RingBuf::reserve<T: 'static>(&self, flags: u64) -> core::option::Option<aya_ebpf::maps::ring_buf::RingBufEntry<T>>
@@ -1429,10 +1429,10 @@ pub fn aya_ebpf::maps::ring_buf::RingBuf::from(t: T) -> T
 #[repr(transparent)] pub struct aya_ebpf::maps::SockHash<K>
 impl<K> aya_ebpf::maps::sock_hash::SockHash<K>
 pub const fn aya_ebpf::maps::sock_hash::SockHash<K>::pinned(max_entries: u32, flags: u32) -> Self
-pub fn aya_ebpf::maps::sock_hash::SockHash<K>::redirect_msg(&self, ctx: &aya_ebpf::programs::sk_msg::SkMsgContext, key: &mut K, flags: u64) -> i64
-pub fn aya_ebpf::maps::sock_hash::SockHash<K>::redirect_sk_lookup(&mut self, ctx: &aya_ebpf::programs::sk_lookup::SkLookupContext, key: impl core::borrow::Borrow<K>, flags: u64) -> core::result::Result<(), u32>
-pub fn aya_ebpf::maps::sock_hash::SockHash<K>::redirect_skb(&self, ctx: &aya_ebpf::programs::sk_buff::SkBuffContext, key: &mut K, flags: u64) -> i64
-pub fn aya_ebpf::maps::sock_hash::SockHash<K>::update(&self, key: &mut K, sk_ops: &mut aya_ebpf_bindings::x86_64::bindings::bpf_sock_ops, flags: u64) -> core::result::Result<(), i64>
+pub fn aya_ebpf::maps::sock_hash::SockHash<K>::redirect_msg(&self, ctx: impl core::borrow::Borrow<aya_ebpf::programs::sk_msg::SkMsgContext>, key: impl core::borrow::BorrowMut<K>, flags: u64) -> i64
+pub fn aya_ebpf::maps::sock_hash::SockHash<K>::redirect_sk_lookup(&mut self, ctx: impl core::borrow::Borrow<aya_ebpf::programs::sk_lookup::SkLookupContext>, key: impl core::borrow::Borrow<K>, flags: u64) -> core::result::Result<(), u32>
+pub fn aya_ebpf::maps::sock_hash::SockHash<K>::redirect_skb(&self, ctx: impl core::borrow::Borrow<aya_ebpf::programs::sk_buff::SkBuffContext>, key: impl core::borrow::BorrowMut<K>, flags: u64) -> i64
+pub fn aya_ebpf::maps::sock_hash::SockHash<K>::update(&self, key: impl core::borrow::BorrowMut<K>, sk_ops: impl core::borrow::BorrowMut<aya_ebpf_bindings::x86_64::bindings::bpf_sock_ops>, flags: u64) -> core::result::Result<(), i64>
 pub const fn aya_ebpf::maps::sock_hash::SockHash<K>::with_max_entries(max_entries: u32, flags: u32) -> Self
 impl<K: core::marker::Sync> core::marker::Sync for aya_ebpf::maps::sock_hash::SockHash<K>
 impl<K> !core::marker::Freeze for aya_ebpf::maps::sock_hash::SockHash<K>
@@ -1491,7 +1491,7 @@ impl<T> aya_ebpf::maps::stack::Stack<T>
 pub fn aya_ebpf::maps::stack::Stack<T>::peek(&self) -> core::option::Option<T>
 pub const fn aya_ebpf::maps::stack::Stack<T>::pinned(max_entries: u32, flags: u32) -> Self
 pub fn aya_ebpf::maps::stack::Stack<T>::pop(&self) -> core::option::Option<T>
-pub fn aya_ebpf::maps::stack::Stack<T>::push(&self, value: &T, flags: u64) -> core::result::Result<(), i64>
+pub fn aya_ebpf::maps::stack::Stack<T>::push(&self, value: impl core::borrow::Borrow<T>, flags: u64) -> core::result::Result<(), i64>
 pub const fn aya_ebpf::maps::stack::Stack<T>::with_max_entries(max_entries: u32, flags: u32) -> Self
 impl<T> core::marker::Freeze for aya_ebpf::maps::stack::Stack<T>
 impl<T> core::marker::Send for aya_ebpf::maps::stack::Stack<T> where T: core::marker::Send
@@ -1517,7 +1517,7 @@ impl<T> core::convert::From<T> for aya_ebpf::maps::stack::Stack<T>
 pub fn aya_ebpf::maps::stack::Stack<T>::from(t: T) -> T
 #[repr(transparent)] pub struct aya_ebpf::maps::StackTrace
 impl aya_ebpf::maps::stack_trace::StackTrace
-pub unsafe fn aya_ebpf::maps::stack_trace::StackTrace::get_stackid<C: aya_ebpf::EbpfContext>(&self, ctx: &C, flags: u64) -> core::result::Result<i64, i64>
+pub unsafe fn aya_ebpf::maps::stack_trace::StackTrace::get_stackid<C: aya_ebpf::EbpfContext>(&self, ctx: impl core::borrow::Borrow<C>, flags: u64) -> core::result::Result<i64, i64>
 pub const fn aya_ebpf::maps::stack_trace::StackTrace::pinned(max_entries: u32, flags: u32) -> Self
 pub const fn aya_ebpf::maps::stack_trace::StackTrace::with_max_entries(max_entries: u32, flags: u32) -> Self
 impl core::marker::Sync for aya_ebpf::maps::stack_trace::StackTrace


### PR DESCRIPTION
Let callers pass either owned objects or references. We do that already in the user-space methods.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aya-rs/aya/1362)
<!-- Reviewable:end -->
