### PR TITLE
aya: rename `set_` methods on `EbpfLoader`

### DIFF
--- a/aya-log/README.md
+++ b/aya-log/README.md
@@ -82,7 +82,7 @@ By default all bits are set (all logging enabled). To disable all logging:
 
 ```rust
 let mut bpf = aya::EbpfLoader::new()
-    .set_global(aya_log::LEVEL, &0, false /* must_exist */)
+    .override_global(aya_log::LEVEL, &0, false /* must_exist */)
     .load_file("prog.bpf.o")?;
 # Ok::<(), aya::EbpfError>(())
 ```
@@ -92,7 +92,7 @@ Enable only Error and Warn:
 ```rust
 let level = aya_log::Level::Warn as u8;
 let mut bpf = EbpfLoader::new()
-    .set_global(aya_log::LEVEL, &level, false /* must_exist */)
+    .override_global(aya_log::LEVEL, &level, false /* must_exist */)
     .load_file("prog.bpf.o")?;
 ```
 

--- a/aya/CHANGELOG.md
+++ b/aya/CHANGELOG.md
@@ -13,7 +13,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
    avoid maintaining support for multiple async runtimes. Use `PerfEventArrayBuffer`, which
    implements `As{,Raw}Fd` for integration with async executors.
  - Rename `EbpfLoader::map_pin_path` to `EbpfLoader::default_map_pin_directory`.
+ - Rename `EbpfLoader::set_global` to `EbpfLoader::override_global`.
+ - Rename `EbpfLoader::set_max_entries` to `EbpfLoader::map_max_entries`.
 
+### Other
+
+ - Provide deprecated aliases to ease migration, these will be removed in a future release;
+    - `EbpfLoader::set_global` calls `EbpfLoader::override_global`, and
+    - `EbpfLoader::set_max_entries` calls `EbpfLoader::map_max_entries`.
+ 
 ## 0.13.1 (2024-11-01)
 
 ### Chore

--- a/aya/src/bpf.rs
+++ b/aya/src/bpf.rs
@@ -242,7 +242,7 @@ impl<'a> EbpfLoader<'a> {
         self
     }
 
-    /// Sets the value of a global variable.
+    /// Override the value of a global variable.
     ///
     /// If the `must_exist` argument is `true`, [`EbpfLoader::load`] will fail with [`ParseError::SymbolNotFound`] if the loaded object code does not contain the variable.
     ///
@@ -275,13 +275,13 @@ impl<'a> EbpfLoader<'a> {
     /// use aya::EbpfLoader;
     ///
     /// let bpf = EbpfLoader::new()
-    ///     .set_global("VERSION", &2, true)
-    ///     .set_global("PIDS", &[1234u16, 5678], true)
+    ///     .override_global("VERSION", &2, true)
+    ///     .override_global("PIDS", &[1234u16, 5678], true)
     ///     .load_file("file.o")?;
     /// # Ok::<(), aya::EbpfError>(())
     /// ```
     ///
-    pub fn set_global<T: Into<GlobalData<'a>>>(
+    pub fn override_global<T: Into<GlobalData<'a>>>(
         &mut self,
         name: &'a str,
         value: T,
@@ -289,6 +289,12 @@ impl<'a> EbpfLoader<'a> {
     ) -> &mut Self {
         self.globals.insert(name, (value.into().bytes, must_exist));
         self
+    }
+
+    /// Override the value of a global variable.
+    #[deprecated(since = "0.13.2", note = "please use `override_global` instead")]
+    pub fn set_global<T: Into<GlobalData<'a>>>(&mut self, name: &'a str, value: T) -> &mut Self {
+        self.override_global(name, value, false)
     }
 
     /// Set the max_entries for specified map.
@@ -302,14 +308,20 @@ impl<'a> EbpfLoader<'a> {
     /// use aya::EbpfLoader;
     ///
     /// let bpf = EbpfLoader::new()
-    ///     .set_max_entries("map", 64)
+    ///     .map_max_entries("map", 64)
     ///     .load_file("file.o")?;
     /// # Ok::<(), aya::EbpfError>(())
     /// ```
     ///
-    pub fn set_max_entries(&mut self, name: &'a str, size: u32) -> &mut Self {
+    pub fn map_max_entries(&mut self, name: &'a str, size: u32) -> &mut Self {
         self.max_entries.insert(name, size);
         self
+    }
+
+    /// Set the max_entries for specified map.
+    #[deprecated(since = "0.13.2", note = "please use `map_max_entries` instead")]
+    pub fn set_max_entries(&mut self, name: &'a str, size: u32) -> &mut Self {
+        self.map_max_entries(name, size)
     }
 
     /// Set the pin path for the map that matches the provided name.
@@ -1189,7 +1201,7 @@ fn load_btf(
 /// Global data that can be exported to eBPF programs before they are loaded.
 ///
 /// Valid global data includes `Pod` types and slices of `Pod` types. See also
-/// [EbpfLoader::set_global].
+/// [EbpfLoader::override_global].
 pub struct GlobalData<'a> {
     bytes: &'a [u8],
 }

--- a/aya/src/maps/xdp/cpu_map.rs
+++ b/aya/src/maps/xdp/cpu_map.rs
@@ -33,7 +33,7 @@ use crate::{
 ///
 /// let nr_cpus = nr_cpus().unwrap() as u32;
 /// let mut bpf = aya::EbpfLoader::new()
-///     .set_max_entries("CPUS", nr_cpus)
+///     .map_max_entries("CPUS", nr_cpus)
 ///     .load(elf_bytes)
 ///     .unwrap();
 /// let mut cpumap = CpuMap::try_from(bpf.map_mut("CPUS").unwrap())?;

--- a/ebpf/aya-log-ebpf/src/lib.rs
+++ b/ebpf/aya-log-ebpf/src/lib.rs
@@ -32,7 +32,7 @@ pub mod macro_support {
 
     /// Global log level controlling which log statements are active.
     ///
-    /// Userspace may patch this symbol before load via `EbpfLoader::set_global`.
+    /// Userspace may patch this symbol before load via `EbpfLoader::override_global`.
     #[unsafe(no_mangle)]
     pub static AYA_LOG_LEVEL: u8 = 0xff;
 

--- a/test/integration-test/src/tests/log.rs
+++ b/test/integration-test/src/tests/log.rs
@@ -230,7 +230,7 @@ fn log() {
 fn log_level_only_error_warn() {
     let level = aya_log::Level::Warn as u8;
     let mut bpf = EbpfLoader::new()
-        .set_global(aya_log::LEVEL, &level, true /* must_exist */)
+        .override_global(aya_log::LEVEL, &level, true /* must_exist */)
         .load(crate::LOG)
         .unwrap();
 
@@ -281,7 +281,7 @@ fn log_level_only_error_warn() {
 fn log_level_prevents_verif_fail() {
     let level = aya_log::Level::Warn as u8;
     let mut bpf = EbpfLoader::new()
-        .set_global(aya_log::LEVEL, &level, true /* must_exist */)
+        .override_global(aya_log::LEVEL, &level, true /* must_exist */)
         .load(crate::LOG)
         .unwrap();
 

--- a/test/integration-test/src/tests/ring_buf.rs
+++ b/test/integration-test/src/tests/ring_buf.rs
@@ -52,7 +52,7 @@ impl RingBufTest {
 
         // Use the loader API to control the size of the ring_buf.
         let mut loader = EbpfLoader::new();
-        loader.set_max_entries("RING_BUF", RING_BUF_BYTE_SIZE);
+        loader.map_max_entries("RING_BUF", RING_BUF_BYTE_SIZE);
         loader_fn(&mut loader);
         let mut bpf = loader.load(crate::RING_BUF).unwrap();
         bpf_fn(&mut bpf);

--- a/test/integration-test/src/tests/uprobe_cookie.rs
+++ b/test/integration-test/src/tests/uprobe_cookie.rs
@@ -12,7 +12,7 @@ fn test_uprobe_cookie() {
     const RING_BUF_BYTE_SIZE: u32 = 512; // arbitrary, but big enough
 
     let mut bpf = EbpfLoader::new()
-        .set_max_entries("RING_BUF", RING_BUF_BYTE_SIZE)
+        .map_max_entries("RING_BUF", RING_BUF_BYTE_SIZE)
         .load(crate::UPROBE_COOKIE)
         .unwrap();
     let ring_buf = bpf.take_map("RING_BUF").unwrap();

--- a/xtask/public-api/aya.txt
+++ b/xtask/public-api/aya.txt
@@ -10746,9 +10746,11 @@ pub fn aya::EbpfLoader<'a>::default_map_pin_directory<P: core::convert::AsRef<st
 pub fn aya::EbpfLoader<'a>::extension(&mut self, name: &'a str) -> &mut Self
 pub fn aya::EbpfLoader<'a>::load(&mut self, data: &[u8]) -> core::result::Result<aya::Ebpf, aya::EbpfError>
 pub fn aya::EbpfLoader<'a>::load_file<P: core::convert::AsRef<std::path::Path>>(&mut self, path: P) -> core::result::Result<aya::Ebpf, aya::EbpfError>
+pub fn aya::EbpfLoader<'a>::map_max_entries(&mut self, name: &'a str, size: u32) -> &mut Self
 pub fn aya::EbpfLoader<'a>::map_pin_path<P: core::convert::Into<alloc::borrow::Cow<'a, std::path::Path>>>(&mut self, name: &'a str, path: P) -> &mut Self
 pub fn aya::EbpfLoader<'a>::new() -> Self
-pub fn aya::EbpfLoader<'a>::set_global<T: core::convert::Into<aya::GlobalData<'a>>>(&mut self, name: &'a str, value: T, must_exist: bool) -> &mut Self
+pub fn aya::EbpfLoader<'a>::override_global<T: core::convert::Into<aya::GlobalData<'a>>>(&mut self, name: &'a str, value: T, must_exist: bool) -> &mut Self
+pub fn aya::EbpfLoader<'a>::set_global<T: core::convert::Into<aya::GlobalData<'a>>>(&mut self, name: &'a str, value: T) -> &mut Self
 pub fn aya::EbpfLoader<'a>::set_max_entries(&mut self, name: &'a str, size: u32) -> &mut Self
 pub fn aya::EbpfLoader<'a>::verifier_log_level(&mut self, level: aya::VerifierLogLevel) -> &mut Self
 impl core::default::Default for aya::EbpfLoader<'_>


### PR DESCRIPTION
This loader is more of a builder, so these `set_` methods didn't
quite fit. See [this discussion][1] for the motivation.

[1]: https://reviewable.io/reviews/aya-rs/aya/1318#gh-2384180366

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aya-rs/aya/1371)
<!-- Reviewable:end -->
