### PR TITLE
aya: Support loading programs with ksyms

### DIFF
--- a/aya-obj/src/btf/btf.rs
+++ b/aya-obj/src/btf/btf.rs
@@ -18,6 +18,7 @@ use crate::{
         info::{FuncSecInfo, LineSecInfo},
         relocation::Relocation,
     },
+    extern_types::ExternCollection,
     generated::{btf_ext_header, btf_header},
     util::{HashMap, bytes_of},
 };
@@ -277,6 +278,8 @@ pub struct Btf {
     strings: Vec<u8>,
     types: BtfTypes,
     _endianness: Endianness,
+    /// Extern symbols parsed from the `.ksyms` section.
+    pub(crate) externs: ExternCollection,
 }
 
 fn add_type(header: &mut btf_header, types: &mut BtfTypes, btf_type: BtfType) -> u32 {
@@ -305,6 +308,7 @@ impl Btf {
             strings: vec![0],
             types: BtfTypes::default(),
             _endianness: Endianness::default(),
+            externs: ExternCollection::new(),
         }
     }
 
@@ -375,6 +379,7 @@ impl Btf {
             strings,
             types,
             _endianness: endianness,
+            externs: ExternCollection::new(),
         })
     }
 
@@ -511,6 +516,13 @@ impl Btf {
         symbol_offsets: &HashMap<String, u64>,
         features: &BtfFeatures,
     ) -> Result<(), BtfError> {
+        if !self.externs.is_empty() {
+            let datasec_id = self
+                .externs
+                .datasec_id
+                .expect("non-empty externs must have datasec_id");
+            self.fixup_ksyms_datasec(datasec_id, self.externs.ksym_func_placeholder_id)?;
+        }
         let enum64_placeholder_id = OnceCell::new();
         let filler_var_id = OnceCell::new();
         let mut types = mem::take(&mut self.types);
@@ -811,6 +823,135 @@ impl Btf {
             }
         }
         self.types = types;
+        Ok(())
+    }
+
+    /// Fixes up BTF for `.ksyms` datasec entries containing extern kernel symbols and
+    /// makes it acceptable by the kernel:
+    ///
+    /// * Changes linkage of extern functions to `GLOBAL`, fixes parameter names, injects
+    ///   a placeholder variable representing them in datasec.
+    /// * Changes linkage of extern variables to `GLOBAL`, replaces their type
+    ///   with `int`.
+    pub(crate) fn fixup_ksyms_datasec(
+        &mut self,
+        datasec_id: u32,
+        ksym_func_placeholder_id: Option<u32>,
+    ) -> Result<(), BtfError> {
+        // Use the placeholder var's name/type when present; otherwise fall back to a plain
+        // 4-byte int for `.ksyms` datasec fixup.
+        let (placeholder_name_offset, int_btf_id) =
+            if let Some(placeholder_id) = ksym_func_placeholder_id {
+                let placeholder_type = &self.types.types[placeholder_id as usize];
+                if let BtfType::Var(v) = placeholder_type {
+                    (Some(v.name_offset), v.btf_type)
+                } else {
+                    return Err(BtfError::InvalidDatasec);
+                }
+            } else {
+                let int_id = self
+                    .types
+                    .types
+                    .iter()
+                    .enumerate()
+                    .find_map(|(idx, t)| {
+                        if let BtfType::Int(int_type) = t {
+                            (int_type.size == 4).then_some(idx as u32)
+                        } else {
+                            None
+                        }
+                    })
+                    .unwrap_or_else(|| {
+                        let name_offset = self.add_string("int");
+                        self.add_type(BtfType::Int(Int::new(
+                            name_offset,
+                            4,
+                            IntEncoding::Signed,
+                            0,
+                        )))
+                    });
+
+                (None, int_id)
+            };
+
+        let datasec_name = {
+            let datasec = &self.types.types[datasec_id as usize];
+            let BtfType::DataSec(d) = datasec else {
+                return Err(BtfError::InvalidDatasec);
+            };
+            self.string_at(d.name_offset)?.into_owned()
+        };
+
+        debug!("DATASEC {datasec_name}: fixing up extern ksyms");
+
+        let entry_type_ids: Vec<u32> = {
+            let BtfType::DataSec(d) = &self.types.types[datasec_id as usize] else {
+                return Err(BtfError::InvalidDatasec);
+            };
+            d.entries.iter().map(|e| e.btf_type).collect()
+        };
+
+        let mut offset = 0u32;
+        let size = size_of::<i32>() as u32;
+
+        for (i, &type_id) in entry_type_ids.iter().enumerate() {
+            match &self.types.types[type_id as usize] {
+                BtfType::Func(f) => {
+                    let (func_name, proto_id) =
+                        { (self.string_at(f.name_offset)?.into_owned(), f.btf_type) };
+
+                    if let BtfType::Func(f) = &mut self.types.types[type_id as usize] {
+                        f.set_linkage(FuncLinkage::Global);
+                    }
+
+                    if let Some(placeholder_name_offset) = placeholder_name_offset {
+                        if let BtfType::FuncProto(func_proto) =
+                            &mut self.types.types[proto_id as usize]
+                        {
+                            for param in &mut func_proto.params {
+                                if param.btf_type != 0 && param.name_offset == 0 {
+                                    param.name_offset = placeholder_name_offset;
+                                }
+                            }
+                        }
+                    }
+
+                    if let (Some(placeholder_id), BtfType::DataSec(d)) = (
+                        ksym_func_placeholder_id,
+                        &mut self.types.types[datasec_id as usize],
+                    ) {
+                        d.entries[i].btf_type = placeholder_id;
+                    }
+
+                    debug!("DATASEC {datasec_name}: FUNC {func_name}: fixup offset {offset}");
+                }
+                BtfType::Var(v) => {
+                    let var_name = { self.string_at(v.name_offset)?.into_owned() };
+
+                    if let BtfType::Var(v) = &mut self.types.types[type_id as usize] {
+                        v.linkage = VarLinkage::Global;
+                        v.btf_type = int_btf_id;
+                    }
+
+                    debug!("DATASEC {datasec_name}: VAR {var_name}: fixup offset {offset}");
+                }
+                _ => return Err(BtfError::InvalidDatasec),
+            }
+
+            let BtfType::DataSec(d) = &mut self.types.types[datasec_id as usize] else {
+                return Err(BtfError::InvalidDatasec);
+            };
+            d.entries[i].offset = offset;
+            d.entries[i].size = size;
+
+            offset += size;
+        }
+
+        if let BtfType::DataSec(d) = &mut self.types.types[datasec_id as usize] {
+            d.size = offset;
+            debug!("DATASEC {datasec_name}: fixup size to {offset}");
+        }
+
         Ok(())
     }
 }
@@ -1579,6 +1720,61 @@ mod tests {
         // Ensure we can convert to bytes and back again
         let raw = btf.to_bytes();
         Btf::parse(&raw, Endianness::default()).unwrap();
+    }
+
+    #[test]
+    fn test_fixup_ksyms_datasec_creates_int_type_for_var_only_datasec() {
+        let mut btf = Btf::new();
+
+        let var_name_offset = btf.add_string("init_task");
+        let var_type_id = btf.add_type(BtfType::Var(Var::new(
+            var_name_offset,
+            0,
+            VarLinkage::Extern,
+        )));
+
+        let datasec_name_offset = btf.add_string(".ksyms");
+        let variables = vec![DataSecEntry {
+            btf_type: var_type_id,
+            offset: 0,
+            size: 0,
+        }];
+        let datasec_type_id = btf.add_type(BtfType::DataSec(DataSec::new(
+            datasec_name_offset,
+            variables,
+            0,
+        )));
+
+        btf.fixup_ksyms_datasec(datasec_type_id, None).unwrap();
+
+        let int_type_id = match btf.type_by_id(var_type_id).unwrap() {
+            BtfType::Var(fixed) => {
+                assert_eq!(fixed.linkage, VarLinkage::Global);
+                fixed.btf_type
+            }
+            other => panic!("expected var, got {other:?}"),
+        };
+
+        assert_matches!(btf.type_by_id(int_type_id).unwrap(), BtfType::Int(int) => {
+            assert_eq!(btf.string_at(int.name_offset).unwrap(), "int");
+            assert_eq!(int.size, 4);
+            assert_eq!(int.encoding(), IntEncoding::Signed);
+        });
+
+        assert_matches!(btf.type_by_id(datasec_type_id).unwrap(), BtfType::DataSec(fixed) => {
+            assert_eq!(fixed.size, 4);
+            assert_matches!(*fixed.entries, [
+                DataSecEntry {
+                    btf_type,
+                    offset,
+                    size,
+                },
+            ] => {
+                assert_eq!(btf_type, var_type_id);
+                assert_eq!(offset, 0);
+                assert_eq!(size, 4);
+            });
+        });
     }
 
     #[test]

--- a/aya-obj/src/btf/extern_types.rs
+++ b/aya-obj/src/btf/extern_types.rs
@@ -105,7 +105,7 @@ impl Btf {
 
         // Resolve through modifiers (const, volatile, typedef, etc.)
         // Type ID 0 represents void in BTF
-        let resolved_type_id = self.resolve_type(var_btf_type).unwrap_or(var_btf_type);
+        let resolved_type_id = self.resolve_type(var_btf_type)?;
 
         // Typeless ksyms are declared as `extern const void symbol __ksym`
         // They resolve to void (type_id 0) and are resolved via /proc/kallsyms

--- a/aya-obj/src/btf/extern_types.rs
+++ b/aya-obj/src/btf/extern_types.rs
@@ -1,0 +1,164 @@
+use log::debug;
+
+use crate::{
+    Object,
+    btf::{Btf, BtfError, BtfType, DataSec, DataSecEntry},
+    extern_types::{ExternDesc, ExternType},
+    relocation::Symbol,
+    util::HashMap,
+};
+
+impl Btf {
+    /// Creates a placeholder global variable for `.ksyms` function entries.
+    ///
+    /// Kernel BTF datasec entries are variable-oriented, so function entries in `.ksyms`
+    /// need a placeholder variable type during datasec fixup.
+    pub(crate) fn create_ksym_func_placeholder(&mut self) -> u32 {
+        let maybe_int_type_id = self.types().enumerate().find_map(|(idx, t)| match t {
+            BtfType::Int(int) if int.size == 4 => Some(idx as u32),
+            _ => None,
+        });
+
+        let int_type_id = maybe_int_type_id
+            .inspect(|id| debug!("found 4-byte int type_id: {id}"))
+            .unwrap_or_else(|| {
+                let name_offset = self.add_string("int");
+                let int_type_id = self.add_type(BtfType::Int(crate::btf::Int::new(
+                    name_offset,
+                    4,
+                    crate::btf::IntEncoding::Signed,
+                    0,
+                )));
+                debug!("created 4-byte int type_id: {int_type_id}");
+                int_type_id
+            });
+
+        let name_offset = self.add_string("ksym_func_placeholder");
+        let placeholder_id = self.add_type(BtfType::Var(crate::btf::Var::new(
+            name_offset,
+            int_type_id,
+            crate::btf::VarLinkage::Global,
+        )));
+
+        debug!("created ksym function placeholder type_id: {placeholder_id}");
+        placeholder_id
+    }
+
+    /// Searches for the `.ksyms` datasec in BTF, returns it if found.
+    fn find_ksyms_datasec(&self) -> Result<Option<(u32, DataSec)>, BtfError> {
+        for (idx, btf_type) in self.types().enumerate() {
+            if let BtfType::DataSec(datasec) = btf_type {
+                let name = self.type_name(btf_type)?;
+                if name == ".ksyms" {
+                    return Ok(Some((idx as u32, datasec.clone())));
+                }
+            }
+        }
+
+        Ok(None)
+    }
+
+    /// Checks if datasec contains any functions.
+    pub(crate) fn datasec_has_functions(&self, datasec: &DataSec) -> Result<bool, BtfError> {
+        for entry in &datasec.entries {
+            let t = self.type_by_id(entry.btf_type)?;
+            if matches!(t, BtfType::Func(_)) {
+                return Ok(true);
+            }
+        }
+        Ok(false)
+    }
+
+    /// Returns an iterator over extern descriptors from datasec entries.
+    pub(crate) fn extern_entries<'a>(
+        &'a self,
+        datasec: &'a DataSec,
+        symbol_table: &'a HashMap<usize, Symbol>,
+    ) -> impl Iterator<Item = Result<ExternDesc, BtfError>> + 'a {
+        datasec
+            .entries
+            .iter()
+            .map(move |entry| self.process_datasec_entry(entry, symbol_table))
+    }
+
+    /// Processes a single datasec entry into an [`ExternDesc`].
+    fn process_datasec_entry(
+        &self,
+        entry: &DataSecEntry,
+        symbol_table: &HashMap<usize, Symbol>,
+    ) -> Result<ExternDesc, BtfError> {
+        let btf_type = self.type_by_id(entry.btf_type)?;
+
+        let (name, is_func, var_btf_type) = match btf_type {
+            BtfType::Func(func) => {
+                let name = self.string_at(func.name_offset)?.into_owned();
+                (name, true, func.btf_type)
+            }
+            BtfType::Var(var) => {
+                let name = self.string_at(var.name_offset)?.into_owned();
+                (name, false, var.btf_type)
+            }
+            _ => return Err(BtfError::InvalidDatasec),
+        };
+
+        let symbol = find_symbol_by_name(symbol_table, &name).ok_or(BtfError::InvalidSymbolName)?;
+
+        // Resolve through modifiers (const, volatile, typedef, etc.)
+        // Type ID 0 represents void in BTF
+        let resolved_type_id = self.resolve_type(var_btf_type).unwrap_or(var_btf_type);
+
+        // Typeless ksyms are declared as `extern const void symbol __ksym`
+        // They resolve to void (type_id 0) and are resolved via /proc/kallsyms
+        let is_typeless = !is_func && resolved_type_id == 0;
+
+        let mut extern_desc =
+            ExternDesc::new(name, ExternType::Ksym, entry.btf_type, symbol.is_weak);
+
+        // For typeless ksyms, don't set type_id so they skip kernel BTF resolution
+        if !is_typeless {
+            extern_desc.type_id = Some(resolved_type_id);
+        }
+
+        Ok(extern_desc)
+    }
+}
+
+fn find_symbol_by_name<'a>(
+    symbol_table: &'a HashMap<usize, Symbol>,
+    name: &str,
+) -> Option<&'a Symbol> {
+    symbol_table
+        .values()
+        .find(|sym| sym.name.as_deref() == Some(name))
+}
+
+impl Object {
+    /// Collects extern kernel symbols from BTF datasec entries.
+    pub(crate) fn collect_ksyms_from_btf(&mut self) -> Result<(), BtfError> {
+        let Some(btf) = self.btf.as_mut() else {
+            return Ok(());
+        };
+        let Some((datasec_id, datasec)) = btf.find_ksyms_datasec()? else {
+            return Ok(());
+        };
+
+        if btf.datasec_has_functions(&datasec)? {
+            let placeholder_id = btf.create_ksym_func_placeholder();
+            btf.externs.set_ksym_func_placeholder_id(placeholder_id);
+        }
+
+        let collected: Vec<ExternDesc> = btf
+            .extern_entries(&datasec, &self.symbol_table)
+            .collect::<Result<Vec<_>, _>>()?;
+
+        for extern_desc in collected {
+            btf.externs.insert(extern_desc.name.clone(), extern_desc);
+        }
+
+        if !btf.externs.is_empty() {
+            btf.externs.datasec_id = Some(datasec_id);
+        }
+
+        Ok(())
+    }
+}

--- a/aya-obj/src/btf/mod.rs
+++ b/aya-obj/src/btf/mod.rs
@@ -2,6 +2,7 @@
 
 #[expect(clippy::module_inception, reason = "TODO")]
 mod btf;
+mod extern_types;
 mod info;
 mod relocation;
 mod types;

--- a/aya-obj/src/extern_types.rs
+++ b/aya-obj/src/extern_types.rs
@@ -273,6 +273,9 @@ impl Object {
             crate::btf::types_are_compatible(obj_btf, local_type_id, kernel_btf, kernel_type_id)?;
 
         if !compatible {
+            if extern_desc.is_weak {
+                return Ok(None);
+            }
             return Err(KsymsError::IncompatibleVariableType {
                 name: name.to_string(),
             });

--- a/aya-obj/src/extern_types.rs
+++ b/aya-obj/src/extern_types.rs
@@ -386,41 +386,12 @@ pub(crate) struct ExternDesc {
     pub(crate) essential_name: Option<String>,
 }
 
-/// Given `some_struct_name___with_flavor` return the length of a name prefix
-/// before last triple underscore. Struct name part after last triple
-/// underscore is ignored by BPF CO-RE relocation during relocation matching.
-fn essential_name_len(name: &str) -> usize {
-    let n = name.len();
-    if n < 5 {
-        return n;
-    }
-
-    for i in (0..=n - 5).rev() {
-        if is_flavor_sep(name, i) {
-            return i + 1;
-        }
-    }
-
-    n
-}
-
-fn is_flavor_sep(s: &str, pos: usize) -> bool {
-    let bytes = s.as_bytes();
-    if pos + 4 >= bytes.len() {
-        return false;
-    }
-    bytes[pos] != b'_'
-        && bytes[pos + 1] == b'_'
-        && bytes[pos + 2] == b'_'
-        && bytes[pos + 3] == b'_'
-        && bytes[pos + 4] != b'_'
-}
-
 impl ExternDesc {
     pub(crate) fn new(name: String, extern_type: ExternType, btf_id: u32, is_weak: bool) -> Self {
-        let essential_len = essential_name_len(&name);
-        let essential_name =
-            (essential_len != name.len()).then(|| name[..essential_len].to_string());
+        // Extract essential name by stripping the BPF CO-RE flavor suffix.
+        // Given `some_struct_name___with_flavor`, the triple-underscore and
+        // everything after it is ignored during relocation matching.
+        let essential_name = name.split_once("___").map(|(name, _)| name.to_string());
 
         Self {
             name,

--- a/aya-obj/src/extern_types.rs
+++ b/aya-obj/src/extern_types.rs
@@ -90,7 +90,7 @@ impl Object {
             self.resolve_kallsyms_from_reader(reader, &unresolved)?;
         }
 
-        // Default unresolved weak ksyms to address 0 so pointer checks evaluate to false.
+        // Set unresolved weak ksyms to address 0 so they appear as null pointers.
         if let Some(obj_btf) = self.btf.as_mut() {
             for ext in obj_btf.externs.externs.values_mut() {
                 if ext.extern_type == ExternType::Ksym && !ext.is_resolved && ext.is_weak {

--- a/aya-obj/src/extern_types.rs
+++ b/aya-obj/src/extern_types.rs
@@ -332,9 +332,9 @@ pub enum KsymsError {
         second_addr: u64,
     },
 
-    /// Could not read kallsyms entries.
-    #[error("failed to read /proc/kallsyms: {0}")]
-    KallsymsReadError(#[from] std::io::Error),
+    /// Could not access kallsyms entries.
+    #[error("failed to access /proc/kallsyms: {0}")]
+    KallsymsAccessError(#[from] std::io::Error),
 
     /// Failed to parse kallsyms data.
     #[error("failed to parse kallsyms: {0}")]

--- a/aya-obj/src/extern_types.rs
+++ b/aya-obj/src/extern_types.rs
@@ -1,0 +1,807 @@
+//! Extern type resolution and relocation.
+use crate::{
+    Object,
+    btf::{Btf, BtfError, BtfKind, BtfType},
+    util::{HashMap, HashSet},
+};
+
+impl Object {
+    /// Resolves extern kernel symbols through kernel `BTF` and `kallsyms`.
+    pub fn resolve_externs(&mut self, kernel_btf: Option<&Btf>) -> Result<(), KsymsError> {
+        if self.btf.is_none() {
+            return Ok(());
+        }
+
+        if let Some(kernel_btf) = kernel_btf {
+            self.resolve_typed_externs(kernel_btf)?;
+        } else if self.has_strong_typed_ksyms() {
+            return Err(KsymsError::TypedKsymRequiresKernelBtf);
+        }
+
+        self.resolve_typeless_externs()?;
+
+        Ok(())
+    }
+
+    /// Returns whether the object contains strong typed ksyms that require kernel `BTF`.
+    pub(crate) fn has_strong_typed_ksyms(&self) -> bool {
+        self.btf.as_ref().is_some_and(|btf| {
+            btf.externs.iter().any(|(_, ext)| {
+                ext.extern_type == ExternType::Ksym && ext.type_id.is_some() && !ext.is_weak
+            })
+        })
+    }
+
+    /// Resolves typed externs through kernel `BTF`.
+    pub(crate) fn resolve_typed_externs(&mut self, kernel_btf: &Btf) -> Result<(), KsymsError> {
+        let mut resolutions = Vec::new();
+        {
+            let obj_btf = self
+                .btf
+                .as_ref()
+                .expect("resolve_typed_externs called without local BTF");
+
+            for (name, extern_desc) in obj_btf
+                .externs
+                .iter()
+                .filter(|(_, extern_desc)| extern_desc.type_id.is_some())
+            {
+                let btf_type = obj_btf.type_by_id(extern_desc.btf_id)?;
+                let kernel_btf_id = match btf_type {
+                    BtfType::Func(_) => {
+                        self.resolve_extern_function(name, extern_desc, kernel_btf)?
+                    }
+                    BtfType::Var(_) => {
+                        self.resolve_extern_variable(name, extern_desc, kernel_btf)?
+                    }
+                    _ => {
+                        return Err(KsymsError::InvalidExternType { name: name.clone() });
+                    }
+                };
+
+                if let Some(btf_id) = kernel_btf_id {
+                    resolutions.push((name.clone(), btf_id));
+                }
+            }
+        }
+
+        let obj_mut = self
+            .btf
+            .as_mut()
+            .expect("resolve_typed_externs called without local BTF");
+
+        for (name, kernel_btf_id) in resolutions {
+            if let Some(ext) = obj_mut.externs.get_mut(&name) {
+                ext.kernel_btf_id = Some(kernel_btf_id);
+                ext.is_resolved = true;
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Resolves typeless extern vars found in `.ksyms` section through `kallsyms`.
+    pub(crate) fn resolve_typeless_externs(&mut self) -> Result<(), KsymsError> {
+        let unresolved: Vec<String> = self.unresolved_typeless_ksym_vars();
+
+        if !unresolved.is_empty() {
+            let file = std::fs::File::open("/proc/kallsyms")?;
+            let reader = std::io::BufReader::new(file);
+            self.resolve_kallsyms_from_reader(reader, &unresolved)?;
+        }
+
+        // Default unresolved weak ksyms to address 0 so pointer checks evaluate to false.
+        if let Some(obj_btf) = self.btf.as_mut() {
+            for ext in obj_btf.externs.externs.values_mut() {
+                if ext.extern_type == ExternType::Ksym && !ext.is_resolved && ext.is_weak {
+                    ext.ksym_addr = Some(0);
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Resolves typeless ksym addresses by matching symbol names against parsed kallsyms lines.
+    fn resolve_kallsyms_from_reader<R, S>(
+        &mut self,
+        reader: R,
+        unresolved: &[S],
+    ) -> Result<(), KsymsError>
+    where
+        R: std::io::BufRead,
+        S: AsRef<str>,
+    {
+        let obj_btf = self
+            .btf
+            .as_mut()
+            .expect("resolve_kallsyms_from_reader called without local BTF");
+
+        let unresolved: HashSet<_> = unresolved.iter().map(AsRef::as_ref).collect();
+
+        for line in reader.lines() {
+            let line = line?;
+            let mut parts = line.split_whitespace();
+            let (Some(addr_str), Some(_sym_type), Some(sym_name)) =
+                (parts.next(), parts.next(), parts.next())
+            else {
+                continue;
+            };
+
+            if !unresolved.contains(sym_name) {
+                continue;
+            }
+
+            let addr = u64::from_str_radix(addr_str, 16).map_err(|_err| {
+                KsymsError::KallsymsParseError(format!("invalid address: {addr_str}"))
+            })?;
+            if addr == 0 {
+                continue;
+            }
+
+            if let Some(ext) = obj_btf.externs.get_mut(sym_name) {
+                if ext.is_resolved {
+                    if let Some(existing_addr) = ext.ksym_addr {
+                        if existing_addr != addr {
+                            return Err(KsymsError::AmbiguousResolution {
+                                name: sym_name.to_string(),
+                                first_addr: existing_addr,
+                                second_addr: addr,
+                            });
+                        }
+                    }
+                    continue;
+                }
+
+                ext.ksym_addr = Some(addr);
+                ext.is_resolved = true;
+            }
+        }
+
+        // Reject unresolved strong typeless ksyms after the kallsyms pass.
+        // Typed ksyms fail earlier during BTF resolution.
+        for (name, ext) in obj_btf.externs.iter() {
+            if ext.extern_type == ExternType::Ksym && !ext.is_resolved && !ext.is_weak {
+                return Err(KsymsError::VariableNotFound { name: name.clone() });
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Returns unresolved typeless ksym variables from [`ExternCollection`].
+    fn unresolved_typeless_ksym_vars(&self) -> Vec<String> {
+        let Some(obj_btf) = self.btf.as_ref() else {
+            return Vec::new();
+        };
+
+        obj_btf
+            .externs
+            .externs
+            .iter()
+            .filter(|(_, ext)| {
+                ext.extern_type == ExternType::Ksym && !ext.is_resolved && ext.type_id.is_none()
+            })
+            .map(|(name, _)| name.clone())
+            .collect()
+    }
+
+    /// Resolves a single extern function. Returns BTF ID if found, otherwise
+    /// returns `None`.
+    fn resolve_extern_function(
+        &self,
+        name: &str,
+        extern_desc: &ExternDesc,
+        kernel_btf: &Btf,
+    ) -> Result<Option<u32>, KsymsError> {
+        let lookup_name = extern_desc.essential_name.as_deref().unwrap_or(name);
+        let Ok(kernel_func_id) = kernel_btf.id_by_type_name_kind(lookup_name, BtfKind::Func) else {
+            if extern_desc.is_weak {
+                return Ok(None);
+            }
+
+            return Err(KsymsError::FunctionNotFound {
+                name: lookup_name.to_string(),
+            });
+        };
+
+        let kernel_func_type = kernel_btf.type_by_id(kernel_func_id)?;
+        let kernel_proto_id = match kernel_func_type {
+            BtfType::Func(func) => func.btf_type,
+            _ => {
+                return Err(KsymsError::BtfError(BtfError::UnexpectedBtfType {
+                    type_id: kernel_func_id,
+                }));
+            }
+        };
+
+        let local_proto_id = extern_desc.type_id.expect("typed extern must have type_id");
+
+        let obj_btf = self
+            .btf
+            .as_ref()
+            .expect("resolve_extern_function called without local BTF");
+        let compatible =
+            crate::btf::types_are_compatible(obj_btf, local_proto_id, kernel_btf, kernel_proto_id)?;
+
+        if !compatible {
+            if extern_desc.is_weak {
+                return Ok(None);
+            }
+            return Err(KsymsError::IncompatibleFunctionSignature {
+                name: lookup_name.to_string(),
+            });
+        }
+
+        Ok(Some(kernel_func_id))
+    }
+
+    /// Resolves a single extern variable. Returns BTF ID if found, otherwise
+    /// returns `None`.
+    fn resolve_extern_variable(
+        &self,
+        name: &str,
+        extern_desc: &ExternDesc,
+        kernel_btf: &Btf,
+    ) -> Result<Option<u32>, KsymsError> {
+        let Ok(kernel_var_id) = kernel_btf.id_by_type_name_kind(name, BtfKind::Var) else {
+            if extern_desc.is_weak {
+                return Ok(None);
+            }
+            return Err(KsymsError::VariableNotFound {
+                name: name.to_string(),
+            });
+        };
+
+        let kernel_var_type = kernel_btf.type_by_id(kernel_var_id)?;
+        let kernel_type_id = match kernel_var_type {
+            BtfType::Var(var) => var.btf_type,
+            _ => {
+                return Err(KsymsError::BtfError(BtfError::UnexpectedBtfType {
+                    type_id: kernel_var_id,
+                }));
+            }
+        };
+
+        let local_type_id = extern_desc.type_id.expect("typed extern must have type_id");
+
+        let obj_btf = self
+            .btf
+            .as_ref()
+            .expect("resolve_extern_variable called without local BTF");
+        let compatible =
+            crate::btf::types_are_compatible(obj_btf, local_type_id, kernel_btf, kernel_type_id)?;
+
+        if !compatible {
+            return Err(KsymsError::IncompatibleVariableType {
+                name: name.to_string(),
+            });
+        }
+
+        Ok(Some(kernel_var_id))
+    }
+}
+
+/// Errors that can occur during ksyms operations.
+#[derive(Debug, thiserror::Error)]
+pub enum KsymsError {
+    /// A typed ksym was encountered but kernel BTF is unavailable.
+    #[error("typed ksyms require kernel BTF for resolution")]
+    TypedKsymRequiresKernelBtf,
+
+    /// A non-weak extern variable was not found in kernel BTF or kallsyms.
+    #[error("kernel variable '{name}' not found")]
+    VariableNotFound {
+        /// The name of the variable that was not found.
+        name: String,
+    },
+
+    /// The extern function's signature is incompatible with the kernel function.
+    #[error("kernel function '{name}' has incompatible signature")]
+    IncompatibleFunctionSignature {
+        /// The name of the function with incompatible signature.
+        name: String,
+    },
+
+    /// The extern variable's type is incompatible with the kernel variable.
+    #[error("kernel variable '{name}' has incompatible type")]
+    IncompatibleVariableType {
+        /// The name of the variable with incompatible type.
+        name: String,
+    },
+
+    /// The extern symbol has an invalid BTF type (neither `Func` nor `Var`).
+    #[error("extern '{name}' has invalid BTF type (neither Func nor Var)")]
+    InvalidExternType {
+        /// The name of the extern with invalid type.
+        name: String,
+    },
+
+    /// An error occurred while working with BTF data.
+    #[error("BTF error: {0}")]
+    BtfError(#[from] BtfError),
+
+    /// Resolved extern's kallsyms address does not match against the loaded kallsyms.
+    #[error("extern (ksym) '{name}': resolution is ambiguous: {first_addr:#x} or {second_addr:#x}")]
+    AmbiguousResolution {
+        /// The name of the symbol with ambiguous resolution.
+        name: String,
+        /// The first address found.
+        first_addr: u64,
+        /// The second (conflicting) address found.
+        second_addr: u64,
+    },
+
+    /// Could not read kallsyms entries.
+    #[error("failed to read /proc/kallsyms: {0}")]
+    KallsymsReadError(#[from] std::io::Error),
+
+    /// Failed to parse kallsyms data.
+    #[error("failed to parse kallsyms: {0}")]
+    KallsymsParseError(String),
+
+    /// A non-weak typed extern function was not found in kernel BTF.
+    #[error("kernel function '{name}' not found in kernel BTF")]
+    FunctionNotFound {
+        /// The function name.
+        name: String,
+    },
+}
+
+/// Type of extern symbol.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ExternType {
+    /// Kernel symbol - variable or function (`.ksyms` section).
+    Ksym,
+}
+
+/// Descriptor for an extern symbol.
+#[derive(Debug, Clone)]
+pub(crate) struct ExternDesc {
+    /// Symbol name.
+    pub(crate) name: String,
+
+    /// Type of extern.
+    pub(crate) extern_type: ExternType,
+
+    /// BTF type ID in local (program) BTF.
+    pub(crate) btf_id: u32,
+
+    /// Whether this is a weak symbol.
+    pub(crate) is_weak: bool,
+
+    /// Whether extern has been resolved.
+    pub(crate) is_resolved: bool,
+
+    /// For ksym: kernel BTF ID (after resolution).
+    pub(crate) kernel_btf_id: Option<u32>,
+
+    /// For ksym variables: resolved kernel address.
+    pub(crate) ksym_addr: Option<u64>,
+
+    /// For ksym: resolved type ID (after skipping modifiers/typedefs).
+    pub(crate) type_id: Option<u32>,
+
+    /// For names with flavors: stripped essential name.
+    pub(crate) essential_name: Option<String>,
+}
+
+/// Given `some_struct_name___with_flavor` return the length of a name prefix
+/// before last triple underscore. Struct name part after last triple
+/// underscore is ignored by BPF CO-RE relocation during relocation matching.
+fn essential_name_len(name: &str) -> usize {
+    let n = name.len();
+    if n < 5 {
+        return n;
+    }
+
+    for i in (0..=n - 5).rev() {
+        if is_flavor_sep(name, i) {
+            return i + 1;
+        }
+    }
+
+    n
+}
+
+fn is_flavor_sep(s: &str, pos: usize) -> bool {
+    let bytes = s.as_bytes();
+    if pos + 4 >= bytes.len() {
+        return false;
+    }
+    bytes[pos] != b'_'
+        && bytes[pos + 1] == b'_'
+        && bytes[pos + 2] == b'_'
+        && bytes[pos + 3] == b'_'
+        && bytes[pos + 4] != b'_'
+}
+
+impl ExternDesc {
+    pub(crate) fn new(name: String, extern_type: ExternType, btf_id: u32, is_weak: bool) -> Self {
+        let essential_len = essential_name_len(&name);
+        let essential_name =
+            (essential_len != name.len()).then(|| name[..essential_len].to_string());
+
+        Self {
+            name,
+            extern_type,
+            btf_id,
+            is_weak,
+            is_resolved: false,
+            kernel_btf_id: None,
+            ksym_addr: None,
+            type_id: None,
+            essential_name,
+        }
+    }
+}
+
+/// Collection of extern symbols.
+#[derive(Debug, Default, Clone)]
+pub(crate) struct ExternCollection {
+    /// Map of extern descriptors by name.
+    pub(crate) externs: HashMap<String, ExternDesc>,
+
+    /// BTF ID of the placeholder var used for `.ksyms` function entries (if created).
+    pub(crate) ksym_func_placeholder_id: Option<u32>,
+
+    /// Index ID of `.ksyms` datasec entry in BTF types.
+    pub(crate) datasec_id: Option<u32>,
+}
+
+impl ExternCollection {
+    pub(crate) fn new() -> Self {
+        Self::default()
+    }
+
+    pub(crate) fn insert(&mut self, name: String, desc: ExternDesc) {
+        self.externs.insert(name, desc);
+    }
+
+    pub(crate) fn get_mut(&mut self, name: &str) -> Option<&mut ExternDesc> {
+        self.externs.get_mut(name)
+    }
+
+    pub(crate) fn iter(&self) -> impl Iterator<Item = (&String, &ExternDesc)> {
+        self.externs.iter()
+    }
+
+    pub(crate) const fn set_ksym_func_placeholder_id(&mut self, id: u32) {
+        self.ksym_func_placeholder_id = Some(id);
+    }
+
+    pub(crate) fn is_empty(&self) -> bool {
+        self.externs.is_empty()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{collections::BTreeMap, ffi::CString};
+
+    use object::Endianness;
+
+    use super::{ExternCollection, ExternDesc, ExternType, KsymsError};
+    use crate::{
+        Object,
+        btf::{
+            Btf, BtfParam, BtfType, Func, FuncLinkage, FuncProto, Int, IntEncoding, Ptr, Var,
+            VarLinkage,
+        },
+    };
+
+    fn object_with_externs(externs: ExternCollection) -> Object {
+        let mut btf = Btf::new();
+        btf.externs = externs;
+
+        Object {
+            endianness: Endianness::default(),
+            license: CString::new("GPL").unwrap(),
+            kernel_version: None,
+            btf: Some(btf),
+            btf_ext: None,
+            maps: Default::default(),
+            programs: Default::default(),
+            functions: BTreeMap::new(),
+            relocations: Default::default(),
+            symbol_table: Default::default(),
+            symbols_by_section: Default::default(),
+            section_infos: Default::default(),
+            symbol_offset_by_name: Default::default(),
+        }
+    }
+
+    fn object_with_btf_and_externs(mut btf: Btf, externs: ExternCollection) -> Object {
+        btf.externs = externs;
+
+        Object {
+            endianness: Endianness::default(),
+            license: CString::new("GPL").unwrap(),
+            kernel_version: None,
+            btf: Some(btf),
+            btf_ext: None,
+            maps: Default::default(),
+            programs: Default::default(),
+            functions: BTreeMap::new(),
+            relocations: Default::default(),
+            symbol_table: Default::default(),
+            symbols_by_section: Default::default(),
+            section_infos: Default::default(),
+            symbol_offset_by_name: Default::default(),
+        }
+    }
+
+    fn add_int(btf: &mut Btf, name: &str) -> u32 {
+        let name_offset = btf.add_string(name);
+        btf.add_type(BtfType::Int(Int::new(
+            name_offset,
+            4,
+            IntEncoding::Signed,
+            0,
+        )))
+    }
+
+    fn add_var(btf: &mut Btf, name: &str, type_id: u32) -> u32 {
+        let name_offset = btf.add_string(name);
+        btf.add_type(BtfType::Var(Var::new(
+            name_offset,
+            type_id,
+            VarLinkage::Global,
+        )))
+    }
+
+    fn add_func_proto(btf: &mut Btf, return_type: u32, params: Vec<BtfParam>) -> u32 {
+        btf.add_type(BtfType::FuncProto(FuncProto::new(params, return_type)))
+    }
+
+    fn add_func(btf: &mut Btf, name: &str, proto_id: u32) -> u32 {
+        let name_offset = btf.add_string(name);
+        btf.add_type(BtfType::Func(Func::new(
+            name_offset,
+            proto_id,
+            FuncLinkage::Global,
+        )))
+    }
+
+    #[test]
+    fn resolve_externs_requires_kernel_btf_for_typed_ksyms() {
+        let mut externs = ExternCollection::new();
+
+        let mut typed = ExternDesc::new("typed".into(), ExternType::Ksym, 1, false);
+        typed.type_id = Some(42);
+        externs.insert(typed.name.clone(), typed);
+
+        let mut object = object_with_externs(externs);
+
+        let err = object.resolve_externs(None).unwrap_err();
+        assert!(matches!(err, KsymsError::TypedKsymRequiresKernelBtf));
+    }
+
+    #[test]
+    fn resolve_externs_allows_weak_typed_ksyms_without_kernel_btf() {
+        let mut externs = ExternCollection::new();
+
+        let mut typed = ExternDesc::new("typed".into(), ExternType::Ksym, 1, true);
+        typed.type_id = Some(42);
+        externs.insert(typed.name.clone(), typed);
+
+        let mut object = object_with_externs(externs);
+
+        object.resolve_externs(None).unwrap();
+
+        let ext = &object.btf.as_ref().unwrap().externs.externs["typed"];
+        assert!(!ext.is_resolved);
+        assert_eq!(ext.ksym_addr, Some(0));
+    }
+
+    #[test]
+    fn resolve_typed_externs_rejects_invalid_extern_type() {
+        let mut btf = Btf::new();
+        let int_id = add_int(&mut btf, "int");
+
+        let mut externs = ExternCollection::new();
+        let mut ext = ExternDesc::new("bad".into(), ExternType::Ksym, int_id, false);
+        ext.type_id = Some(int_id);
+        externs.insert(ext.name.clone(), ext);
+
+        let mut object = object_with_btf_and_externs(btf, externs);
+        let kernel_btf = Btf::new();
+
+        let err = object.resolve_typed_externs(&kernel_btf).unwrap_err();
+        assert!(matches!(err, KsymsError::InvalidExternType { name } if name == "bad"));
+    }
+
+    #[test]
+    fn resolve_extern_variable_incompatible_type() {
+        let mut local_btf = Btf::new();
+        let local_int_id = add_int(&mut local_btf, "int");
+        let local_var_id = add_var(&mut local_btf, "foo", local_int_id);
+
+        let mut externs = ExternCollection::new();
+        let mut ext = ExternDesc::new("foo".into(), ExternType::Ksym, local_var_id, false);
+        ext.type_id = Some(local_int_id);
+        externs.insert(ext.name.clone(), ext);
+
+        let mut object = object_with_btf_and_externs(local_btf, externs);
+
+        let mut kernel_btf = Btf::new();
+        let kernel_int_id = add_int(&mut kernel_btf, "int");
+        let ptr_name_offset = kernel_btf.add_string("int_ptr");
+        let kernel_ptr_id =
+            kernel_btf.add_type(BtfType::Ptr(Ptr::new(ptr_name_offset, kernel_int_id)));
+        add_var(&mut kernel_btf, "foo", kernel_ptr_id);
+
+        let err = object.resolve_typed_externs(&kernel_btf).unwrap_err();
+        assert!(matches!(err, KsymsError::IncompatibleVariableType { name } if name == "foo"));
+    }
+
+    #[test]
+    fn resolve_extern_function_incompatible_signature() {
+        let mut local_btf = Btf::new();
+        let local_int_id = add_int(&mut local_btf, "int");
+        let local_proto_id = add_func_proto(&mut local_btf, local_int_id, vec![]);
+        let local_func_id = add_func(&mut local_btf, "bar", local_proto_id);
+
+        let mut externs = ExternCollection::new();
+        let mut ext = ExternDesc::new("bar".into(), ExternType::Ksym, local_func_id, false);
+        ext.type_id = Some(local_proto_id);
+        externs.insert(ext.name.clone(), ext);
+
+        let mut object = object_with_btf_and_externs(local_btf, externs);
+
+        let mut kernel_btf = Btf::new();
+        let kernel_int_id = add_int(&mut kernel_btf, "int");
+        let kernel_param = BtfParam {
+            name_offset: kernel_btf.add_string("x"),
+            btf_type: kernel_int_id,
+        };
+        let kernel_proto_id = add_func_proto(&mut kernel_btf, kernel_int_id, vec![kernel_param]);
+        add_func(&mut kernel_btf, "bar", kernel_proto_id);
+
+        let err = object.resolve_typed_externs(&kernel_btf).unwrap_err();
+        assert!(matches!(err, KsymsError::IncompatibleFunctionSignature { name } if name == "bar"));
+    }
+
+    mod kallsyms_tests {
+        use super::*;
+
+        impl Object {
+            /// Resolves typeless ksym addresses by matching symbol names against parsed kallsyms lines.
+            fn resolve_kallsyms_from_lines<I, S, U>(
+                &mut self,
+                lines: I,
+                unresolved: &[U],
+            ) -> Result<(), KsymsError>
+            where
+                I: IntoIterator<Item = S>,
+                S: AsRef<str>,
+                U: AsRef<str>,
+            {
+                let text = lines
+                    .into_iter()
+                    .map(|line| String::from(line.as_ref()))
+                    .collect::<Vec<_>>()
+                    .join("\n");
+                self.resolve_kallsyms_from_reader(std::io::Cursor::new(text), unresolved)
+            }
+
+            fn finalize_weak_typeless_ksyms_for_test(&mut self) {
+                if let Some(obj_btf) = self.btf.as_mut() {
+                    for ext in obj_btf.externs.externs.values_mut() {
+                        if ext.extern_type == ExternType::Ksym && !ext.is_resolved && ext.is_weak {
+                            ext.ksym_addr = Some(0);
+                        }
+                    }
+                }
+            }
+        }
+
+        #[test]
+        fn unresolved_typeless_ksym_vars_excludes_typed_vars() {
+            let mut externs = ExternCollection::new();
+
+            let mut typed = ExternDesc::new("typed".into(), ExternType::Ksym, 1, true);
+            typed.type_id = Some(42);
+            externs.insert(typed.name.clone(), typed);
+
+            let typeless = ExternDesc::new("typeless".into(), ExternType::Ksym, 2, true);
+            externs.insert(typeless.name.clone(), typeless);
+
+            let object = object_with_externs(externs);
+
+            assert_eq!(
+                object.unresolved_typeless_ksym_vars(),
+                vec![String::from("typeless")]
+            );
+        }
+
+        #[test]
+        fn resolve_kallsyms_from_lines_ambiguous_address() {
+            let mut externs = ExternCollection::new();
+            let ext = ExternDesc::new("init_task".into(), ExternType::Ksym, 1, false);
+            externs.insert(ext.name.clone(), ext);
+
+            let mut object = object_with_externs(externs);
+            let lines = vec![
+                String::from("1000 D init_task"),
+                String::from("3000 D other"),
+                String::from("2000 D init_task"),
+            ];
+            let unresolved = vec![String::from("init_task")];
+
+            let err = object
+                .resolve_kallsyms_from_lines(&lines, &unresolved)
+                .unwrap_err();
+
+            match err {
+                KsymsError::AmbiguousResolution {
+                    name,
+                    first_addr,
+                    second_addr,
+                } => {
+                    assert_eq!(name, "init_task");
+                    assert_eq!(first_addr, 0x1000);
+                    assert_eq!(second_addr, 0x2000);
+                }
+                other => panic!("expected AmbiguousResolution, got {other:?}"),
+            }
+        }
+
+        #[test]
+        fn resolve_kallsyms_from_lines_bad_address() {
+            let mut externs = ExternCollection::new();
+            let ext = ExternDesc::new("init_task".into(), ExternType::Ksym, 1, false);
+            externs.insert(ext.name.clone(), ext);
+
+            let mut object = object_with_externs(externs);
+            let lines = vec![String::from("not_hex D init_task")];
+            let unresolved = vec![String::from("init_task")];
+
+            let err = object
+                .resolve_kallsyms_from_lines(&lines, &unresolved)
+                .unwrap_err();
+
+            match err {
+                KsymsError::KallsymsParseError(msg) => {
+                    assert!(msg.contains("invalid address"), "unexpected error: {msg}");
+                }
+                other => panic!("expected KallsymsParseError, got {other:?}"),
+            }
+        }
+
+        #[test]
+        fn resolve_kallsyms_from_lines_rejects_masked_strong_address() {
+            let mut externs = ExternCollection::new();
+            let ext = ExternDesc::new("init_task".into(), ExternType::Ksym, 1, false);
+            externs.insert(ext.name.clone(), ext);
+
+            let mut object = object_with_externs(externs);
+            let lines = vec![String::from("0000000000000000 D init_task")];
+            let unresolved = vec![String::from("init_task")];
+
+            let err = object
+                .resolve_kallsyms_from_lines(&lines, &unresolved)
+                .unwrap_err();
+
+            assert!(matches!(
+                err,
+                KsymsError::VariableNotFound { name } if name == "init_task"
+            ));
+        }
+
+        #[test]
+        fn resolve_typeless_externs_sets_weak_ksym_addr_to_zero() {
+            let mut externs = ExternCollection::new();
+            let ext = ExternDesc::new("missing".into(), ExternType::Ksym, 1, true);
+            externs.insert(ext.name.clone(), ext);
+
+            let mut object = object_with_externs(externs);
+
+            object.finalize_weak_typeless_ksyms_for_test();
+
+            let ext = &object.btf.as_ref().unwrap().externs.externs["missing"];
+            assert_eq!(ext.ksym_addr, Some(0));
+            assert!(!ext.is_resolved);
+        }
+    }
+}

--- a/aya-obj/src/lib.rs
+++ b/aya-obj/src/lib.rs
@@ -65,6 +65,7 @@
 #![cfg_attr(test, expect(unused_crate_dependencies, reason = "used in doctests"))]
 
 pub mod btf;
+mod extern_types;
 #[expect(
     clippy::all,
     clippy::as_pointer_underscore,
@@ -96,6 +97,7 @@ pub mod programs;
 pub mod relocation;
 mod util;
 
+pub use extern_types::KsymsError;
 pub use maps::Map;
 pub use obj::*;
 

--- a/aya-obj/src/obj.rs
+++ b/aya-obj/src/obj.rs
@@ -498,6 +498,7 @@ impl Object {
                     size: symbol.size(),
                     is_definition: symbol.is_definition(),
                     kind: symbol.kind(),
+                    is_weak: symbol.is_weak(),
                 };
                 bpf_obj.symbol_table.insert(symbol.index().0, sym);
                 if let Some(section_idx) = symbol.section().index() {
@@ -521,6 +522,8 @@ impl Object {
             if let Some(s) = obj.section_by_name(".BTF.ext") {
                 bpf_obj.parse_section(Section::try_from(&s)?)?;
             }
+
+            bpf_obj.collect_ksyms_from_btf()?;
         }
 
         for s in obj.sections() {
@@ -1577,6 +1580,7 @@ mod tests {
                 size,
                 is_definition: false,
                 kind: SymbolKind::Text,
+                is_weak: false,
             },
         );
         obj.symbols_by_section
@@ -2820,6 +2824,7 @@ mod tests {
                 size: 3,
                 is_definition: true,
                 kind: SymbolKind::Data,
+                is_weak: false,
             },
         );
 

--- a/aya-obj/src/relocation.rs
+++ b/aya-obj/src/relocation.rs
@@ -283,7 +283,10 @@ fn patch_extern_relocations<'a, I: Iterator<Item = &'a Relocation>>(
         // `insn_is_call()` is for internal pseudo-calls.
         let is_call = ins.code == (BPF_JMP | BPF_CALL) as u8;
 
-        if is_call {
+        // We can't borrow two instructions mutably at once. Start from
+        // modifying the first one, and carry the override of `imm` for the
+        // next instruction if necessary.
+        let ins_next_imm = if is_call {
             ins.set_src_reg(BPF_PSEUDO_KFUNC_CALL as u8);
             if extern_desc.is_resolved {
                 let kernel_btf_id = extern_desc
@@ -299,25 +302,26 @@ fn patch_extern_relocations<'a, I: Iterator<Item = &'a Relocation>>(
                     name: extern_name.clone(),
                 });
             }
+            None
         } else {
-            match (extern_desc.kernel_btf_id, extern_desc.ksym_addr) {
+            Some(match (extern_desc.kernel_btf_id, extern_desc.ksym_addr) {
                 // symbol found in kernel BTF
                 (Some(btf_id), _) => {
                     ins.set_src_reg(BPF_PSEUDO_BTF_ID as u8);
                     ins.imm = btf_id as i32;
-                    instructions[ins_index + 1].imm = 0; // vmlinux
+                    0 // vmlinux
                 }
                 // fallback to kallsyms (BTF missing but address found)
                 (None, Some(addr)) => {
                     ins.set_src_reg(0); // Standard 64-bit absolute load
                     ins.imm = (addr & 0xFFFFFFFF) as i32;
-                    instructions[ins_index + 1].imm = (addr >> 32) as i32;
+                    (addr >> 32) as i32
                 }
                 // weak symbol not found, null-patch
                 (None, None) if extern_desc.is_weak => {
                     ins.set_src_reg(0);
                     ins.imm = 0;
-                    instructions[ins_index + 1].imm = 0;
+                    0
                 }
                 // strong symbol not found anywhere
                 _ => {
@@ -325,7 +329,18 @@ fn patch_extern_relocations<'a, I: Iterator<Item = &'a Relocation>>(
                         name: extern_name.clone(),
                     });
                 }
-            }
+            })
+        };
+        if let Some(ins_next_imm) = ins_next_imm {
+            // Non-call extern relocations should always target an ld_imm64 (LDDW),
+            // which occupies two instructions. Guard against malformed relocations.
+            let ins_next = instructions.get_mut(ins_index + 1).ok_or(
+                RelocationError::InvalidRelocationOffset {
+                    offset: rel.offset,
+                    relocation_number: rel_n,
+                },
+            )?;
+            ins_next.imm = ins_next_imm;
         }
     }
 
@@ -1041,5 +1056,47 @@ mod test {
         assert_eq!(fun.instructions[0].src_reg(), 0);
         assert_eq!(fun.instructions[0].imm, 0);
         assert_eq!(fun.instructions[1].imm, 0);
+    }
+
+    #[test]
+    fn test_extern_ldimm_relocation_requires_second_instruction() {
+        let mut fun = fake_func(
+            "test",
+            vec![ins(&[0x18, 0x01, 0x00, 0x00, 0xaa, 0xbb, 0xcc, 0xdd])],
+        );
+
+        let relocations = [Relocation {
+            offset: 0,
+            symbol_index: 1,
+            size: 64,
+        }];
+
+        let externs = HashMap::from([(
+            "missing_var".to_string(),
+            ExternDesc {
+                name: "missing_var".to_string(),
+                extern_type: ExternType::Ksym,
+                btf_id: 1,
+                is_weak: true,
+                is_resolved: false,
+                kernel_btf_id: None,
+                ksym_addr: None,
+                type_id: None,
+                essential_name: None,
+            },
+        )]);
+
+        let symbol_table = HashMap::from([(1, fake_extern_sym(1, "missing_var", true))]);
+
+        let err = patch_extern_relocations(&mut fun, relocations.iter(), &externs, &symbol_table)
+            .unwrap_err();
+
+        assert!(matches!(
+            err,
+            RelocationError::InvalidRelocationOffset {
+                offset: 0,
+                relocation_number: 0,
+            }
+        ));
     }
 }

--- a/aya-obj/src/relocation.rs
+++ b/aya-obj/src/relocation.rs
@@ -9,8 +9,8 @@ use crate::{
     EbpfSectionKind,
     extern_types::ExternDesc,
     generated::{
-        BPF_CALL, BPF_JMP, BPF_K, BPF_PSEUDO_BTF_ID, BPF_PSEUDO_CALL, BPF_PSEUDO_FUNC,
-        BPF_PSEUDO_KFUNC_CALL, BPF_PSEUDO_MAP_FD, BPF_PSEUDO_MAP_VALUE, bpf_insn,
+        BPF_CALL, BPF_DW, BPF_IMM, BPF_JMP, BPF_K, BPF_LD, BPF_PSEUDO_BTF_ID, BPF_PSEUDO_CALL,
+        BPF_PSEUDO_FUNC, BPF_PSEUDO_KFUNC_CALL, BPF_PSEUDO_MAP_FD, BPF_PSEUDO_MAP_VALUE, bpf_insn,
     },
     maps::Map,
     obj::{Function, Object},
@@ -304,6 +304,13 @@ fn patch_extern_relocations<'a, I: Iterator<Item = &'a Relocation>>(
             }
             None
         } else {
+            if ins.code != (BPF_LD | BPF_DW | BPF_IMM) as u8 {
+                return Err(RelocationError::InvalidRelocationOffset {
+                    offset: rel.offset,
+                    relocation_number: rel_n,
+                });
+            }
+
             Some(match (extern_desc.kernel_btf_id, extern_desc.ksym_addr) {
                 // symbol found in kernel BTF
                 (Some(btf_id), _) => {
@@ -1063,6 +1070,51 @@ mod test {
         let mut fun = fake_func(
             "test",
             vec![ins(&[0x18, 0x01, 0x00, 0x00, 0xaa, 0xbb, 0xcc, 0xdd])],
+        );
+
+        let relocations = [Relocation {
+            offset: 0,
+            symbol_index: 1,
+            size: 64,
+        }];
+
+        let externs = HashMap::from([(
+            "missing_var".to_string(),
+            ExternDesc {
+                name: "missing_var".to_string(),
+                extern_type: ExternType::Ksym,
+                btf_id: 1,
+                is_weak: true,
+                is_resolved: false,
+                kernel_btf_id: None,
+                ksym_addr: None,
+                type_id: None,
+                essential_name: None,
+            },
+        )]);
+
+        let symbol_table = HashMap::from([(1, fake_extern_sym(1, "missing_var", true))]);
+
+        let err = patch_extern_relocations(&mut fun, relocations.iter(), &externs, &symbol_table)
+            .unwrap_err();
+
+        assert!(matches!(
+            err,
+            RelocationError::InvalidRelocationOffset {
+                offset: 0,
+                relocation_number: 0,
+            }
+        ));
+    }
+
+    #[test]
+    fn test_extern_variable_relocation_requires_ldimm64() {
+        let mut fun = fake_func(
+            "test",
+            vec![
+                ins(&[0xb7, 0x00, 0x00, 0x00, 0xaa, 0xbb, 0xcc, 0xdd]),
+                ins(&[0x95, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]),
+            ],
         );
 
         let relocations = [Relocation {

--- a/aya-obj/src/relocation.rs
+++ b/aya-obj/src/relocation.rs
@@ -7,9 +7,10 @@ use object::{SectionIndex, SymbolKind};
 
 use crate::{
     EbpfSectionKind,
+    extern_types::ExternDesc,
     generated::{
-        BPF_CALL, BPF_JMP, BPF_K, BPF_PSEUDO_CALL, BPF_PSEUDO_FUNC, BPF_PSEUDO_MAP_FD,
-        BPF_PSEUDO_MAP_VALUE, bpf_insn,
+        BPF_CALL, BPF_JMP, BPF_K, BPF_PSEUDO_BTF_ID, BPF_PSEUDO_CALL, BPF_PSEUDO_FUNC,
+        BPF_PSEUDO_KFUNC_CALL, BPF_PSEUDO_MAP_FD, BPF_PSEUDO_MAP_VALUE, bpf_insn,
     },
     maps::Map,
     obj::{Function, Object},
@@ -81,6 +82,20 @@ pub enum RelocationError {
         /// The relocation number
         relocation_number: usize,
     },
+
+    /// Extern not found.
+    #[error("extern `{name}` not found")]
+    ExternNotFound {
+        /// Name of the extern symbol.
+        name: String,
+    },
+
+    /// Strong symbol not found anywhere (neither BTF nor kallsyms).
+    #[error("strong extern `{name}` not resolvable (not in kernel BTF or kallsyms)")]
+    UnresolvableSymbol {
+        /// Name of the extern symbol
+        name: String,
+    },
 }
 
 #[derive(Debug, Copy, Clone)]
@@ -101,6 +116,17 @@ pub(crate) struct Symbol {
     pub(crate) size: u64,
     pub(crate) is_definition: bool,
     pub(crate) kind: SymbolKind,
+    pub(crate) is_weak: bool,
+}
+
+impl Symbol {
+    /// Returns true if this symbol is an extern (undefined) symbol
+    pub(crate) fn is_extern(&self) -> bool {
+        self.section_index.is_none()
+            && self.name.is_some()
+            && !self.is_definition
+            && self.kind == SymbolKind::Unknown
+    }
 }
 
 impl Object {
@@ -128,6 +154,37 @@ impl Object {
                     &maps_by_symbol,
                     &self.symbol_table,
                     text_sections,
+                )
+                .map_err(|error| EbpfRelocationError {
+                    function: function.name.clone(),
+                    error,
+                })?;
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Relocates extern kernel symbol references after they have been resolved.
+    pub fn relocate_externs(&mut self) -> Result<(), EbpfRelocationError> {
+        let Some(obj_btf) = self.btf.as_mut() else {
+            return Ok(());
+        };
+
+        for (name, extern_desc) in obj_btf.externs.iter() {
+            debug!(
+                "extern '{}': resolved={}, btf_id={:?}",
+                name, extern_desc.is_resolved, extern_desc.kernel_btf_id
+            );
+        }
+
+        for function in self.functions.values_mut() {
+            if let Some(relocations) = self.relocations.get(&function.section_index) {
+                patch_extern_relocations(
+                    function,
+                    relocations.values(),
+                    &obj_btf.externs.externs,
+                    &self.symbol_table,
                 )
                 .map_err(|error| EbpfRelocationError {
                     function: function.name.clone(),
@@ -175,6 +232,114 @@ impl Object {
 
         Ok(())
     }
+}
+
+fn patch_extern_relocations<'a, I: Iterator<Item = &'a Relocation>>(
+    fun: &mut Function,
+    relocations: I,
+    externs: &HashMap<String, ExternDesc>,
+    symbol_table: &HashMap<usize, Symbol>,
+) -> Result<(), RelocationError> {
+    let section_offset = fun.section_offset;
+    let instructions = &mut fun.instructions;
+    let function_size = instructions.len() * INS_SIZE;
+
+    for (rel_n, rel) in relocations.enumerate() {
+        let rel_offset = rel.offset as usize;
+        if rel_offset < section_offset || rel_offset >= section_offset + function_size {
+            continue;
+        }
+
+        let ins_offset = rel_offset - section_offset;
+        if !ins_offset.is_multiple_of(INS_SIZE) {
+            return Err(RelocationError::InvalidRelocationOffset {
+                offset: rel.offset,
+                relocation_number: rel_n,
+            });
+        }
+        let ins_index = ins_offset / INS_SIZE;
+
+        let sym = symbol_table
+            .get(&rel.symbol_index)
+            .ok_or(RelocationError::UnknownSymbol {
+                index: rel.symbol_index,
+            })?;
+
+        // Only process extern symbols
+        if !sym.is_extern() {
+            continue;
+        }
+
+        let extern_name = sym.name.as_ref().expect("extern symbol must have a name");
+        let extern_desc =
+            externs
+                .get(extern_name)
+                .ok_or_else(|| RelocationError::ExternNotFound {
+                    name: extern_name.clone(),
+                })?;
+
+        let ins = &mut instructions[ins_index];
+        // Extern relocations use CALL opcode to identify kfunc-call sites.
+        // `insn_is_call()` is for internal pseudo-calls.
+        let is_call = ins.code == (BPF_JMP | BPF_CALL) as u8;
+
+        if is_call {
+            ins.set_src_reg(BPF_PSEUDO_KFUNC_CALL as u8);
+            if extern_desc.is_resolved {
+                let kernel_btf_id = extern_desc
+                    .kernel_btf_id
+                    .expect("resolved extern must have kernel_btf_id");
+                ins.imm = kernel_btf_id as i32;
+                ins.off = 0; // btf_fd_idx, typically 0 for vmlinux
+            } else if extern_desc.is_weak {
+                // Unresolved weak kfunc call
+                poison_kfunc_call(ins, rel.symbol_index);
+            } else {
+                return Err(RelocationError::UnresolvableSymbol {
+                    name: extern_name.clone(),
+                });
+            }
+        } else {
+            match (extern_desc.kernel_btf_id, extern_desc.ksym_addr) {
+                // symbol found in kernel BTF
+                (Some(btf_id), _) => {
+                    ins.set_src_reg(BPF_PSEUDO_BTF_ID as u8);
+                    ins.imm = btf_id as i32;
+                    instructions[ins_index + 1].imm = 0; // vmlinux
+                }
+                // fallback to kallsyms (BTF missing but address found)
+                (None, Some(addr)) => {
+                    ins.set_src_reg(0); // Standard 64-bit absolute load
+                    ins.imm = (addr & 0xFFFFFFFF) as i32;
+                    instructions[ins_index + 1].imm = (addr >> 32) as i32;
+                }
+                // weak symbol not found, null-patch
+                (None, None) if extern_desc.is_weak => {
+                    ins.set_src_reg(0);
+                    ins.imm = 0;
+                    instructions[ins_index + 1].imm = 0;
+                }
+                // strong symbol not found anywhere
+                _ => {
+                    return Err(RelocationError::UnresolvableSymbol {
+                        name: extern_name.clone(),
+                    });
+                }
+            }
+        }
+    }
+
+    Ok(())
+}
+
+const POISON_CALL_KFUNC_BASE: i32 = 2002000000;
+
+fn poison_kfunc_call(ins: &mut bpf_insn, ext_idx: usize) {
+    ins.code = (BPF_JMP | BPF_CALL) as u8;
+    ins.set_dst_reg(0);
+    ins.set_src_reg(0);
+    ins.off = 0;
+    ins.imm = POISON_CALL_KFUNC_BASE.wrapping_add(ext_idx as i32);
 }
 
 fn relocate_maps<'a, I: Iterator<Item = &'a Relocation>>(
@@ -365,8 +530,9 @@ impl<'a> FunctionLinker<'a> {
                         .map(|sym| (rel, sym))
                 })
                 .filter(|(_rel, sym)| {
-                    // only consider text relocations, data relocations are
-                    // relocated in relocate_maps()
+                    if sym.is_extern() {
+                        return false;
+                    }
                     sym.kind == SymbolKind::Text
                         || sym.section_index.is_some_and(|section_index| {
                             self.text_sections.contains(&section_index)
@@ -495,7 +661,10 @@ mod test {
     use std::string::ToString as _;
 
     use super::*;
-    use crate::maps::{BtfMap, LegacyMap};
+    use crate::{
+        extern_types::ExternType,
+        maps::{BtfMap, LegacyMap},
+    };
 
     fn fake_sym(index: usize, section_index: usize, address: u64, name: &str, size: u64) -> Symbol {
         Symbol {
@@ -506,6 +675,20 @@ mod test {
             size,
             is_definition: false,
             kind: SymbolKind::Data,
+            is_weak: false,
+        }
+    }
+
+    fn fake_extern_sym(index: usize, name: &str, is_weak: bool) -> Symbol {
+        Symbol {
+            index,
+            section_index: None,
+            name: Some(name.to_string()),
+            address: 0,
+            size: 0,
+            is_definition: false,
+            kind: SymbolKind::Unknown,
+            is_weak,
         }
     }
 
@@ -736,5 +919,127 @@ mod test {
 
         assert_eq!(fun.instructions[1].src_reg(), BPF_PSEUDO_MAP_FD as u8);
         assert_eq!(fun.instructions[1].imm, 2);
+    }
+
+    #[test]
+    fn test_unresolved_weak_kfunc_call_is_poisoned() {
+        let mut fun = fake_func(
+            "test",
+            vec![ins(&[0x85, 0x10, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00])],
+        );
+
+        let relocations = [Relocation {
+            offset: 0,
+            symbol_index: 1,
+            size: 32,
+        }];
+
+        let externs = HashMap::from([(
+            "missing_kfunc".to_string(),
+            ExternDesc {
+                name: "missing_kfunc".to_string(),
+                extern_type: ExternType::Ksym,
+                btf_id: 1,
+                is_weak: true,
+                is_resolved: false,
+                kernel_btf_id: None,
+                ksym_addr: None,
+                type_id: Some(1),
+                essential_name: None,
+            },
+        )]);
+
+        let symbol_table = HashMap::from([(1, fake_extern_sym(1, "missing_kfunc", true))]);
+
+        patch_extern_relocations(&mut fun, relocations.iter(), &externs, &symbol_table).unwrap();
+
+        let ins = fun.instructions[0];
+        assert_eq!(ins.code, (BPF_JMP | BPF_CALL) as u8);
+        assert_eq!(ins.src_reg(), 0);
+        assert_eq!(ins.dst_reg(), 0);
+        assert_eq!(ins.off, 0);
+        assert_eq!(ins.imm, POISON_CALL_KFUNC_BASE + 1);
+    }
+
+    #[test]
+    fn test_unresolved_strong_kfunc_call_is_rejected() {
+        let mut fun = fake_func(
+            "test",
+            vec![ins(&[0x85, 0x10, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00])],
+        );
+
+        let relocations = [Relocation {
+            offset: 0,
+            symbol_index: 1,
+            size: 32,
+        }];
+
+        let externs = HashMap::from([(
+            "missing_kfunc".to_string(),
+            ExternDesc {
+                name: "missing_kfunc".to_string(),
+                extern_type: ExternType::Ksym,
+                btf_id: 1,
+                is_weak: false,
+                is_resolved: false,
+                kernel_btf_id: None,
+                ksym_addr: None,
+                type_id: Some(1),
+                essential_name: None,
+            },
+        )]);
+
+        let symbol_table = HashMap::from([(1, fake_extern_sym(1, "missing_kfunc", false))]);
+
+        let err = patch_extern_relocations(&mut fun, relocations.iter(), &externs, &symbol_table)
+            .unwrap_err();
+
+        assert!(matches!(
+            err,
+            RelocationError::UnresolvableSymbol { name } if name == "missing_kfunc"
+        ));
+    }
+
+    #[test]
+    fn test_unresolved_weak_var_reference_is_null_patched() {
+        let mut fun = fake_func(
+            "test",
+            vec![
+                ins(&[
+                    0x18, 0x01, 0x00, 0x00, 0xaa, 0xbb, 0xcc, 0xdd, 0x00, 0x00, 0x00, 0x00, 0x11,
+                    0x22, 0x33, 0x44,
+                ]),
+                ins(&[0; 8]),
+            ],
+        );
+
+        let relocations = [Relocation {
+            offset: 0,
+            symbol_index: 1,
+            size: 64,
+        }];
+
+        let externs = HashMap::from([(
+            "missing_var".to_string(),
+            ExternDesc {
+                name: "missing_var".to_string(),
+                extern_type: ExternType::Ksym,
+                btf_id: 1,
+                is_weak: true,
+                is_resolved: false,
+                kernel_btf_id: None,
+                ksym_addr: None,
+                type_id: None,
+                essential_name: None,
+            },
+        )]);
+
+        let symbol_table = HashMap::from([(1, fake_extern_sym(1, "missing_var", true))]);
+
+        patch_extern_relocations(&mut fun, relocations.iter(), &externs, &symbol_table).unwrap();
+
+        assert_eq!(fun.instructions[0].src_reg(), 0);
+        assert_eq!(fun.instructions[0].imm, 0);
+        assert_eq!(fun.instructions[1].imm, 0);
     }
 }

--- a/aya/src/bpf.rs
+++ b/aya/src/bpf.rs
@@ -8,7 +8,7 @@ use std::{
 };
 
 use aya_obj::{
-    EbpfSectionKind, Features, Object, ParseError, ProgramSection,
+    EbpfSectionKind, Features, KsymsError, Object, ParseError, ProgramSection,
     btf::{Btf, BtfError, BtfFeatures, BtfRelocationError},
     generated::{BPF_F_SLEEPABLE, BPF_F_XDP_HAS_FRAGS, bpf_map_type},
     relocation::EbpfRelocationError,
@@ -496,6 +496,8 @@ impl<'a> EbpfLoader<'a> {
             obj.relocate_btf(btf)?;
         }
 
+        obj.resolve_externs(self.btf.as_deref())?;
+
         const fn is_map_of_maps(map_type: bpf_map_type) -> bool {
             matches!(
                 map_type,
@@ -604,6 +606,9 @@ impl<'a> EbpfLoader<'a> {
                 .map(|(s, data)| (s.as_str(), data.fd().as_fd().as_raw_fd(), data.obj())),
             &text_sections,
         )?;
+
+        obj.relocate_externs()?;
+
         obj.relocate_calls(&text_sections)?;
         obj.sanitize_functions(&FEATURES);
 
@@ -1246,6 +1251,10 @@ pub enum EbpfError {
     /// Error performing relocations
     #[error("error relocating section")]
     BtfRelocationError(#[from] BtfRelocationError),
+
+    /// Error resolving extern kernel symbols.
+    #[error("kernel symbol error: {0}")]
+    KsymsError(#[from] KsymsError),
 
     /// No BTF parsed for object
     #[error("no BTF parsed for object")]

--- a/aya/src/bpf.rs
+++ b/aya/src/bpf.rs
@@ -496,7 +496,7 @@ impl<'a> EbpfLoader<'a> {
             obj.relocate_btf(btf)?;
         }
 
-        obj.resolve_externs(self.btf.as_deref())?;
+        obj.resolve_externs(btf.as_deref())?;
 
         const fn is_map_of_maps(map_type: bpf_map_type) -> bool {
             matches!(

--- a/test/integration-test/BUILD.bazel
+++ b/test/integration-test/BUILD.bazel
@@ -25,6 +25,11 @@ C_BPF_OBJECTS = [
     ("bpf/struct_flavors_reloc.bpf.c", True),
     ("bpf/text_64_64_reloc.c", False),
     ("bpf/variables_reloc.bpf.c", False),
+    ("bpf/ksyms.bpf.c", True),
+    ("bpf/ksyms_strong.bpf.c", True),
+    ("bpf/ksyms_typed_missing_kfunc.bpf.c", True),
+    ("bpf/ksyms_typed_missing_var.bpf.c", True),
+    ("bpf/ksyms_typeless_missing.bpf.c", True),
 ]
 
 aya_c_bpf_objects(

--- a/test/integration-test/bpf/ksyms.bpf.c
+++ b/test/integration-test/bpf/ksyms.bpf.c
@@ -1,0 +1,101 @@
+// clang-format off
+// SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
+#include <vmlinux.h>
+#include <bpf/bpf_core_read.h>
+#include <bpf/bpf_helpers.h>
+#include <bpf/bpf_tracing.h>
+// clang-format on
+
+#ifndef __ksym
+#define __ksym __attribute__((section(".ksyms")))
+#endif
+
+#ifndef __weak
+#define __weak __attribute__((weak))
+#endif
+
+char _license[] SEC("license") = "GPL";
+
+struct {
+  __uint(type, BPF_MAP_TYPE_ARRAY);
+  __uint(max_entries, 16);
+  __type(key, __u32);
+  __type(value, __u64);
+} output SEC(".maps");
+
+// Weak typed ksym for missing-symbol behavior.
+extern const int nonexistent_typed_ksym __ksym __weak;
+
+// Typeless ksyms exercise kallsyms-based resolution.
+extern const void init_task __ksym __weak;
+extern const void nonexistent_typeless_ksym __ksym __weak;
+
+// Weak kfuncs exercise typed function resolution and unresolved-call handling.
+extern void bpf_rcu_read_lock(void) __ksym __weak;
+extern void bpf_rcu_read_unlock(void) __ksym __weak;
+extern void bpf_rcu_read_lock_trace(void) __ksym __weak;
+extern void bpf_rcu_read_unlock_trace(void) __ksym __weak;
+
+SEC("tp_btf/sys_enter")
+int BPF_PROG(ksyms_typed_weak, struct pt_regs *regs, long id) {
+  __u32 key;
+  __u64 val;
+
+  key = 2;
+  val = (&nonexistent_typed_ksym) ? 1 : 0;
+  bpf_map_update_elem(&output, &key, &val, BPF_ANY);
+
+  key = 3;
+  val = (__u64)(unsigned long)bpf_rcu_read_lock;
+  bpf_map_update_elem(&output, &key, &val, BPF_ANY);
+
+  key = 4;
+  if (bpf_rcu_read_lock) {
+    bpf_rcu_read_lock();
+    val = 1;
+    bpf_rcu_read_unlock();
+  } else {
+    val = 0;
+  }
+  bpf_map_update_elem(&output, &key, &val, BPF_ANY);
+
+  key = 5;
+  val = 0xDEADBEEF;
+  bpf_map_update_elem(&output, &key, &val, BPF_ANY);
+
+  key = 6;
+  val = (__u64)(unsigned long)bpf_rcu_read_lock_trace;
+  bpf_map_update_elem(&output, &key, &val, BPF_ANY);
+
+  key = 7;
+  if (bpf_rcu_read_lock_trace) {
+    bpf_rcu_read_lock_trace();
+    val = 1;
+    bpf_rcu_read_unlock_trace();
+  } else {
+    val = 0;
+  }
+  bpf_map_update_elem(&output, &key, &val, BPF_ANY);
+
+  return 0;
+}
+
+SEC("tp_btf/sys_enter")
+int BPF_PROG(ksyms_typeless, struct pt_regs *regs, long id) {
+  __u32 key;
+  __u64 val;
+
+  key = 8;
+  val = (__u64)(unsigned long)&init_task;
+  bpf_map_update_elem(&output, &key, &val, BPF_ANY);
+
+  key = 9;
+  val = (__u64)(unsigned long)&nonexistent_typeless_ksym;
+  bpf_map_update_elem(&output, &key, &val, BPF_ANY);
+
+  key = 10;
+  val = 0xCAFEBABE;
+  bpf_map_update_elem(&output, &key, &val, BPF_ANY);
+
+  return 0;
+}

--- a/test/integration-test/bpf/ksyms_strong.bpf.c
+++ b/test/integration-test/bpf/ksyms_strong.bpf.c
@@ -1,0 +1,54 @@
+// clang-format off
+// SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
+#include <vmlinux.h>
+#include <bpf/bpf_core_read.h>
+#include <bpf/bpf_helpers.h>
+#include <bpf/bpf_tracing.h>
+// clang-format on
+
+#ifndef __ksym
+#define __ksym __attribute__((section(".ksyms")))
+#endif
+
+char _license[] SEC("license") = "GPL";
+
+struct {
+  __uint(type, BPF_MAP_TYPE_ARRAY);
+  __uint(max_entries, 8);
+  __type(key, __u32);
+  __type(value, __u64);
+} strong_output SEC(".maps");
+
+// Strong typed ksym used to exercise typed variable resolution and per-cpu
+// helpers.
+extern const int bpf_prog_active __ksym;
+
+SEC("tp_btf/sys_enter")
+int BPF_PROG(ksyms_typed_strong, struct pt_regs *regs, long id) {
+  __u32 key;
+  __u64 val;
+
+  key = 0;
+  int *p = bpf_this_cpu_ptr(&bpf_prog_active);
+  val = (__u64)(unsigned long)p;
+  bpf_map_update_elem(&strong_output, &key, &val, BPF_ANY);
+
+  key = 1;
+  val = p ? (__u64)*p : 0;
+  bpf_map_update_elem(&strong_output, &key, &val, BPF_ANY);
+
+  key = 2;
+  int *p0 = bpf_per_cpu_ptr(&bpf_prog_active, 0);
+  val = (__u64)(unsigned long)p0;
+  bpf_map_update_elem(&strong_output, &key, &val, BPF_ANY);
+
+  key = 3;
+  val = p0 ? (__u64)*p0 : 0xFFFFFFFF;
+  bpf_map_update_elem(&strong_output, &key, &val, BPF_ANY);
+
+  key = 4;
+  val = 0xBEEFCAFE;
+  bpf_map_update_elem(&strong_output, &key, &val, BPF_ANY);
+
+  return 0;
+}

--- a/test/integration-test/bpf/ksyms_typed_missing_kfunc.bpf.c
+++ b/test/integration-test/bpf/ksyms_typed_missing_kfunc.bpf.c
@@ -1,0 +1,20 @@
+// clang-format off
+// SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
+#include <vmlinux.h>
+#include <bpf/bpf_helpers.h>
+#include <bpf/bpf_tracing.h>
+// clang-format on
+
+#ifndef __ksym
+#define __ksym __attribute__((section(".ksyms")))
+#endif
+
+char _license[] SEC("license") = "GPL";
+
+extern void nonexistent_kfunc(void) __ksym;
+
+SEC("tp_btf/sys_enter")
+int BPF_PROG(ksyms_typed_missing_kfunc, struct pt_regs *regs, long id) {
+  nonexistent_kfunc();
+  return 0;
+}

--- a/test/integration-test/bpf/ksyms_typed_missing_var.bpf.c
+++ b/test/integration-test/bpf/ksyms_typed_missing_var.bpf.c
@@ -1,0 +1,19 @@
+// clang-format off
+// SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
+#include <vmlinux.h>
+#include <bpf/bpf_helpers.h>
+#include <bpf/bpf_tracing.h>
+// clang-format on
+
+#ifndef __ksym
+#define __ksym __attribute__((section(".ksyms")))
+#endif
+
+char _license[] SEC("license") = "GPL";
+
+extern const int totally_bogus_symbol __ksym;
+
+SEC("tp_btf/sys_enter")
+int BPF_PROG(ksyms_typed_missing_var, struct pt_regs *regs, long id) {
+  return (int)(unsigned long)&totally_bogus_symbol;
+}

--- a/test/integration-test/bpf/ksyms_typeless_missing.bpf.c
+++ b/test/integration-test/bpf/ksyms_typeless_missing.bpf.c
@@ -1,0 +1,19 @@
+// clang-format off
+// SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
+#include <vmlinux.h>
+#include <bpf/bpf_helpers.h>
+#include <bpf/bpf_tracing.h>
+// clang-format on
+
+#ifndef __ksym
+#define __ksym __attribute__((section(".ksyms")))
+#endif
+
+char _license[] SEC("license") = "GPL";
+
+extern const void totally_bogus_typeless_symbol __ksym;
+
+SEC("tp_btf/sys_enter")
+int BPF_PROG(ksyms_typeless_missing, struct pt_regs *regs, long id) {
+  return (int)(unsigned long)&totally_bogus_typeless_symbol;
+}

--- a/test/integration-test/build.rs
+++ b/test/integration-test/build.rs
@@ -95,6 +95,11 @@ fn main() -> Result<()> {
         ("struct_flavors_reloc.bpf.c", true),
         ("text_64_64_reloc.c", false),
         ("variables_reloc.bpf.c", false),
+        ("ksyms.bpf.c", true),
+        ("ksyms_strong.bpf.c", true),
+        ("ksyms_typed_missing_var.bpf.c", true),
+        ("ksyms_typed_missing_kfunc.bpf.c", true),
+        ("ksyms_typeless_missing.bpf.c", true),
     ];
     const C_BPF_HEADERS: &[&str] = &["reloc.h", "struct_with_scalars.h"];
 

--- a/test/integration-test/src/lib.rs
+++ b/test/integration-test/src/lib.rs
@@ -12,6 +12,11 @@ bpf_file!(
     MAIN => "main.bpf.o",
     MULTIMAP_BTF => "multimap-btf.bpf.o",
     RINGBUF_BTF => "ringbuf-btf.bpf.o",
+    KSYMS => "ksyms.bpf.o",
+    KSYMS_STRONG => "ksyms_strong.bpf.o",
+    KSYMS_TYPED_MISSING_VAR => "ksyms_typed_missing_var.bpf.o",
+    KSYMS_TYPED_MISSING_KFUNC => "ksyms_typed_missing_kfunc.bpf.o",
+    KSYMS_TYPELESS_MISSING => "ksyms_typeless_missing.bpf.o",
 
     ENUM_SIGNED_32_RELOC_BPF => "enum_signed_32_reloc.bpf.o",
     ENUM_SIGNED_32_RELOC_BTF => "enum_signed_32_reloc.bpf.target.o",

--- a/test/integration-test/src/tests.rs
+++ b/test/integration-test/src/tests.rs
@@ -39,6 +39,7 @@ mod info;
 mod inode_storage;
 mod iter;
 mod kprobe;
+mod ksyms;
 mod linear_data_structures;
 mod load;
 mod log;

--- a/test/integration-test/src/tests/ksyms.rs
+++ b/test/integration-test/src/tests/ksyms.rs
@@ -1,0 +1,335 @@
+//! Integration tests for kernel symbol (ksym) resolution.
+
+use std::{
+    fs::File,
+    io::{BufRead as _, BufReader},
+};
+
+use aya::{Btf, Ebpf, EbpfError, maps::Array, programs::BtfTracePoint, util::KernelVersion};
+use aya_obj::KsymsError;
+use test_log::test;
+
+const PROC_KALLSYMS: &str = "/proc/kallsyms";
+const SYS_ENTER: &str = "sys_enter";
+
+fn kallsyms_available() -> bool {
+    let file = File::open(PROC_KALLSYMS)
+        .unwrap_or_else(|e| panic!("failed to open {PROC_KALLSYMS}: {e:?}"));
+    for line in BufReader::new(file).lines() {
+        let line =
+            line.unwrap_or_else(|e| panic!("failed to read the line from {PROC_KALLSYMS}: {e:?}"));
+        if let Some(addr) = line.split_whitespace().next() {
+            let addr = u64::from_str_radix(addr, 16)
+                .unwrap_or_else(|e| panic!("failed to parse the address: {addr}: {e:?}"));
+            if addr != 0 {
+                return true;
+            }
+        }
+    }
+    false
+}
+
+fn kallsyms_find(symbol_name: &str) -> Option<u64> {
+    let file = File::open(PROC_KALLSYMS)
+        .unwrap_or_else(|e| panic!("failed to open {PROC_KALLSYMS}: {e:?}"));
+    for line in BufReader::new(file).lines() {
+        let line =
+            line.unwrap_or_else(|e| panic!("failed to read the line from {PROC_KALLSYMS}: {e:?}"));
+        let parts: Vec<&str> = line.split_whitespace().collect();
+        if let [addr, _type, name, ..] = parts.as_slice()
+            && *name == symbol_name
+        {
+            let addr = u64::from_str_radix(addr, 16)
+                .unwrap_or_else(|e| panic!("failed to parse the address: {addr}: {e:?}"));
+            return Some(addr);
+        }
+    }
+    None
+}
+
+/// Check if PERCPU DATASEC exists in kernel BTF.
+/// Required for `bpf_this_cpu_ptr`/`bpf_per_cpu_ptr` to work.
+fn btf_has_percpu_datasec(btf: &Btf) -> bool {
+    use aya_obj::btf::BtfKind;
+    btf.id_by_type_name_kind(".data..percpu", BtfKind::DataSec)
+        .is_ok()
+}
+
+mod output_keys {
+    pub(super) const WEAK_TYPED: u32 = 2;
+    pub(super) const KFUNC_ADDR: u32 = 3;
+    pub(super) const KFUNC_CALLED: u32 = 4;
+    pub(super) const TYPED_MARKER: u32 = 5;
+    pub(super) const KFUNC2_ADDR: u32 = 6;
+    pub(super) const KFUNC2_CALLED: u32 = 7;
+    pub(super) const TYPELESS_ADDR: u32 = 8;
+    pub(super) const WEAK_TYPELESS: u32 = 9;
+    pub(super) const TYPELESS_MARKER: u32 = 10;
+}
+
+mod output_keys_strong {
+    pub(super) const TYPED_ADDR: u32 = 0;
+    pub(super) const TYPED_VALUE: u32 = 1;
+    pub(super) const PER_CPU_PTR_ADDR: u32 = 2;
+    pub(super) const PER_CPU_PTR_VALUE: u32 = 3;
+    pub(super) const MARKER: u32 = 4;
+}
+
+/// Test STRONG typed ksym resolution with per-cpu helpers.
+/// Tests: strong ksym (`bpf_prog_active`), `bpf_this_cpu_ptr`, `bpf_per_cpu_ptr`.
+#[test]
+fn ksyms_typed_strong() {
+    let kernel_version = KernelVersion::current().unwrap();
+    if kernel_version < KernelVersion::new(5, 10, 0) {
+        eprintln!("skipping test on kernel {kernel_version:?}, typed ksyms require kernel >= 5.10");
+        return;
+    }
+
+    let btf = Btf::from_sys_fs().unwrap();
+
+    if !btf_has_percpu_datasec(&btf) {
+        eprintln!("skipping test, no PERCPU DATASEC in kernel BTF");
+        return;
+    }
+
+    // Strong typed ksyms require the symbol to be in kallsyms.
+    // With CONFIG_KALLSYMS_ALL=n, only function symbols are exported,
+    // not variables like bpf_prog_active. The verifier uses
+    // bpf_kallsyms_lookup_name() internally and will reject the program
+    // if the symbol address cannot be resolved.
+    if !kallsyms_available() {
+        eprintln!("skipping test, kallsyms not available");
+        return;
+    }
+    if kallsyms_find("bpf_prog_active").is_none() {
+        eprintln!(
+            "skipping test, bpf_prog_active kallsyms not available \
+            (usually due to CONFIG_KALLSYMS_ALL kernel configuration disabled)"
+        );
+        return;
+    }
+
+    let mut bpf = Ebpf::load(crate::KSYMS_STRONG).unwrap();
+
+    let prog: &mut BtfTracePoint = bpf
+        .program_mut("ksyms_typed_strong")
+        .unwrap()
+        .try_into()
+        .unwrap();
+
+    if let Err(e) = prog.load(SYS_ENTER, &btf) {
+        panic!("failed to load program {SYS_ENTER}: {e:?}");
+    }
+    prog.attach().unwrap();
+
+    // Trigger the tracepoint
+    drop(std::fs::metadata("/"));
+
+    let output: Array<_, u64> = Array::try_from(bpf.map("strong_output").unwrap()).unwrap();
+
+    // Verify BPF program executed
+    let marker = output.get(&output_keys_strong::MARKER, 0).unwrap();
+    assert_eq!(marker, 0xBEEFCAFE, "BPF program did not execute");
+
+    // bpf_this_cpu_ptr: address should be non-zero
+    let typed_addr = output.get(&output_keys_strong::TYPED_ADDR, 0).unwrap();
+    assert!(typed_addr != 0, "strong ksym address should be non-zero");
+
+    // bpf_this_cpu_ptr: value should be >= 0 (like libbpf)
+    let typed_value = output.get(&output_keys_strong::TYPED_VALUE, 0).unwrap();
+    let signed_value = typed_value as i32;
+    assert!(
+        signed_value >= 0,
+        "bpf_prog_active should be >= 0, got {signed_value}"
+    );
+
+    // bpf_per_cpu_ptr: address should be non-zero
+    let per_cpu_addr = output
+        .get(&output_keys_strong::PER_CPU_PTR_ADDR, 0)
+        .unwrap();
+    assert!(
+        per_cpu_addr != 0,
+        "bpf_per_cpu_ptr address should be non-zero"
+    );
+
+    // bpf_per_cpu_ptr: value should be >= 0
+    let per_cpu_value = output
+        .get(&output_keys_strong::PER_CPU_PTR_VALUE, 0)
+        .unwrap();
+    let signed_per_cpu = per_cpu_value as i32;
+    assert!(
+        signed_per_cpu >= 0,
+        "bpf_per_cpu_ptr value should be >= 0, got {signed_per_cpu}"
+    );
+}
+
+/// Test WEAK typed ksym resolution and kfunc calls.
+/// Tests: weak nonexistent typed ksym = 0, kfunc resolution.
+#[test]
+fn ksyms_typed_weak() {
+    let kernel_version = KernelVersion::current().unwrap();
+    if kernel_version < KernelVersion::new(5, 10, 0) {
+        eprintln!("skipping test on kernel {kernel_version:?}, typed ksyms require kernel >= 5.10");
+        return;
+    }
+
+    let mut bpf = Ebpf::load(crate::KSYMS).unwrap();
+    let prog: &mut BtfTracePoint = bpf
+        .program_mut("ksyms_typed_weak")
+        .unwrap()
+        .try_into()
+        .unwrap();
+
+    let btf = Btf::from_sys_fs().unwrap();
+    if let Err(e) = prog.load(SYS_ENTER, &btf) {
+        panic!("failed to load program {SYS_ENTER}: {e:?}");
+    }
+    prog.attach().unwrap();
+
+    // Trigger the tracepoint
+    drop(std::fs::metadata("/"));
+
+    let output: Array<_, u64> = Array::try_from(bpf.map("output").unwrap()).unwrap();
+
+    // Verify BPF program executed
+    let marker = output.get(&output_keys::TYPED_MARKER, 0).unwrap();
+    assert_eq!(marker, 0xDEADBEEF, "BPF program did not execute");
+
+    // Weak typed ksym (nonexistent) should resolve to 0
+    let weak_typed = output.get(&output_keys::WEAK_TYPED, 0).unwrap();
+    assert_eq!(
+        weak_typed, 0,
+        "weak nonexistent typed ksym should be 0, got {weak_typed}"
+    );
+
+    // Kfunc resolution - availability depends on kernel config, not just version
+    let kfunc_addr = output.get(&output_keys::KFUNC_ADDR, 0).unwrap();
+    let kfunc_called = output.get(&output_keys::KFUNC_CALLED, 0).unwrap();
+    let kfunc2_addr = output.get(&output_keys::KFUNC2_ADDR, 0).unwrap();
+    let kfunc2_called = output.get(&output_keys::KFUNC2_CALLED, 0).unwrap();
+
+    // Consistency: if resolved, must be callable
+    if kfunc_addr != 0 {
+        assert_eq!(kfunc_called, 1, "kfunc resolved but not called");
+    }
+    if kfunc2_addr != 0 {
+        assert_eq!(kfunc2_called, 1, "kfunc2 resolved but not called");
+    }
+}
+
+/// Test typeless ksym resolution (kallsyms-based).
+/// Tests: `init_task` address + kallsyms cross-check, weak nonexistent = 0.
+#[test]
+fn ksyms_typeless() {
+    let kernel_version = KernelVersion::current().unwrap();
+    if kernel_version < KernelVersion::new(5, 10, 0) {
+        eprintln!(
+            "skipping test on kernel {kernel_version:?}, typeless ksyms require kernel >= 5.10"
+        );
+        return;
+    }
+
+    let kallsyms_ok = kallsyms_available();
+    let expected_addr = if kallsyms_ok {
+        kallsyms_find("init_task")
+    } else {
+        None
+    };
+
+    let mut bpf = Ebpf::load(crate::KSYMS).unwrap();
+    let prog: &mut BtfTracePoint = bpf
+        .program_mut("ksyms_typeless")
+        .unwrap()
+        .try_into()
+        .unwrap();
+
+    let btf = Btf::from_sys_fs().unwrap();
+    if let Err(e) = prog.load(SYS_ENTER, &btf) {
+        panic!("failed to load program {SYS_ENTER}: {e:?}");
+    }
+    prog.attach().unwrap();
+
+    // Trigger the tracepoint
+    drop(std::fs::metadata("/"));
+
+    let output: Array<_, u64> = Array::try_from(bpf.map("output").unwrap()).unwrap();
+
+    // Verify BPF program executed
+    let marker = output.get(&output_keys::TYPELESS_MARKER, 0).unwrap();
+    assert_eq!(marker, 0xCAFEBABE, "BPF program did not execute");
+
+    // Typeless ksym: init_task - cross-verify with kallsyms when available
+    let typeless_addr = output.get(&output_keys::TYPELESS_ADDR, 0).unwrap();
+    if typeless_addr != 0 {
+        if let Some(kallsyms_addr) = expected_addr {
+            assert_eq!(
+                typeless_addr, kallsyms_addr,
+                "BPF-resolved init_task ({typeless_addr:#x}) != kallsyms ({kallsyms_addr:#x})"
+            );
+        }
+    }
+
+    // Weak typeless ksym (nonexistent) should be 0
+    let weak_typeless = output.get(&output_keys::WEAK_TYPELESS, 0).unwrap();
+    assert_eq!(
+        weak_typeless, 0,
+        "weak nonexistent typeless ksym should be 0, got {weak_typeless:#x}"
+    );
+}
+
+#[test]
+fn ksyms_typed_missing_var_fails_at_load() {
+    let kernel_version = KernelVersion::current().unwrap();
+    if kernel_version < KernelVersion::new(5, 10, 0) {
+        eprintln!("skipping test on kernel {kernel_version:?}, typed ksyms require kernel >= 5.10");
+        return;
+    }
+
+    let err = Ebpf::load(crate::KSYMS_TYPED_MISSING_VAR).unwrap_err();
+    match err {
+        EbpfError::KsymsError(KsymsError::VariableNotFound { name }) => {
+            assert_eq!(name, "totally_bogus_symbol");
+        }
+        other => panic!("expected VariableNotFound KsymsError, got {other:?}"),
+    }
+}
+
+#[test]
+fn ksyms_typed_missing_kfunc_fails_at_load() {
+    let kernel_version = KernelVersion::current().unwrap();
+    if kernel_version < KernelVersion::new(5, 10, 0) {
+        eprintln!("skipping test on kernel {kernel_version:?}, typed ksyms require kernel >= 5.10");
+        return;
+    }
+
+    let err = Ebpf::load(crate::KSYMS_TYPED_MISSING_KFUNC).unwrap_err();
+    match err {
+        EbpfError::KsymsError(KsymsError::FunctionNotFound { name }) => {
+            assert_eq!(name, "nonexistent_kfunc");
+        }
+        other => panic!("expected FunctionNotFound KsymsError, got {other:?}"),
+    }
+}
+
+#[test]
+fn ksyms_typeless_missing_fails_at_load() {
+    let kernel_version = KernelVersion::current().unwrap();
+    if kernel_version < KernelVersion::new(5, 10, 0) {
+        eprintln!(
+            "skipping test on kernel {kernel_version:?}, typeless ksyms require kernel >= 5.10"
+        );
+        return;
+    }
+    if !kallsyms_available() {
+        eprintln!("skipping test, kallsyms not available");
+        return;
+    }
+
+    let err = Ebpf::load(crate::KSYMS_TYPELESS_MISSING).unwrap_err();
+    match err {
+        EbpfError::KsymsError(KsymsError::VariableNotFound { name }) => {
+            assert_eq!(name, "totally_bogus_typeless_symbol");
+        }
+        other => panic!("expected VariableNotFound KsymsError, got {other:?}"),
+    }
+}

--- a/xtask/public-api/aya-obj.txt
+++ b/xtask/public-api/aya-obj.txt
@@ -44,6 +44,8 @@ pub aya_obj::btf::BtfError::UnknownBtfTypeName
 pub aya_obj::btf::BtfError::UnknownBtfTypeName::type_name: alloc::string::String
 pub aya_obj::btf::BtfError::UnknownSectionSize
 pub aya_obj::btf::BtfError::UnknownSectionSize::section_name: alloc::string::String
+impl core::convert::From<aya_obj::btf::BtfError> for aya_obj::KsymsError
+pub fn aya_obj::KsymsError::from(aya_obj::btf::BtfError) -> Self
 impl core::convert::From<aya_obj::btf::BtfError> for aya_obj::ParseError
 pub fn aya_obj::ParseError::from(aya_obj::btf::BtfError) -> Self
 impl core::error::Error for aya_obj::btf::BtfError
@@ -4853,7 +4855,10 @@ impl aya_obj::Object
 pub fn aya_obj::Object::relocate_btf(&mut self, &aya_obj::btf::Btf) -> core::result::Result<(), aya_obj::btf::BtfRelocationError>
 impl aya_obj::Object
 pub fn aya_obj::Object::relocate_calls(&mut self, &std::collections::hash::set::HashSet<usize>) -> core::result::Result<(), aya_obj::relocation::EbpfRelocationError>
+pub fn aya_obj::Object::relocate_externs(&mut self) -> core::result::Result<(), aya_obj::relocation::EbpfRelocationError>
 pub fn aya_obj::Object::relocate_maps<'a, I: core::iter::traits::iterator::Iterator<Item = (&'a str, std::os::fd::raw::RawFd, &'a aya_obj::maps::Map)>>(&mut self, I, &std::collections::hash::set::HashSet<usize>) -> core::result::Result<(), aya_obj::relocation::EbpfRelocationError>
+impl aya_obj::Object
+pub fn aya_obj::Object::resolve_externs(&mut self, core::option::Option<&aya_obj::btf::Btf>) -> core::result::Result<(), aya_obj::KsymsError>
 impl core::clone::Clone for aya_obj::Object
 pub fn aya_obj::Object::clone(&self) -> aya_obj::Object
 impl core::fmt::Debug for aya_obj::Object
@@ -5164,6 +5169,8 @@ impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::programs::xdp::XdpAtta
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::programs::xdp::XdpAttachType
 pub mod aya_obj::relocation
 pub enum aya_obj::relocation::RelocationError
+pub aya_obj::relocation::RelocationError::ExternNotFound
+pub aya_obj::relocation::RelocationError::ExternNotFound::name: alloc::string::String
 pub aya_obj::relocation::RelocationError::InvalidRelocationOffset
 pub aya_obj::relocation::RelocationError::InvalidRelocationOffset::offset: u64
 pub aya_obj::relocation::RelocationError::InvalidRelocationOffset::relocation_number: usize
@@ -5179,6 +5186,8 @@ pub aya_obj::relocation::RelocationError::UnknownProgram::address: u64
 pub aya_obj::relocation::RelocationError::UnknownProgram::section_index: usize
 pub aya_obj::relocation::RelocationError::UnknownSymbol
 pub aya_obj::relocation::RelocationError::UnknownSymbol::index: usize
+pub aya_obj::relocation::RelocationError::UnresolvableSymbol
+pub aya_obj::relocation::RelocationError::UnresolvableSymbol::name: alloc::string::String
 impl core::error::Error for aya_obj::relocation::RelocationError
 impl core::fmt::Debug for aya_obj::relocation::RelocationError
 pub fn aya_obj::relocation::RelocationError::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
@@ -5234,6 +5243,42 @@ impl core::marker::Unpin for aya_obj::EbpfSectionKind
 impl core::marker::UnsafeUnpin for aya_obj::EbpfSectionKind
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::EbpfSectionKind
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::EbpfSectionKind
+pub enum aya_obj::KsymsError
+pub aya_obj::KsymsError::AmbiguousResolution
+pub aya_obj::KsymsError::AmbiguousResolution::first_addr: u64
+pub aya_obj::KsymsError::AmbiguousResolution::name: alloc::string::String
+pub aya_obj::KsymsError::AmbiguousResolution::second_addr: u64
+pub aya_obj::KsymsError::BtfError(aya_obj::btf::BtfError)
+pub aya_obj::KsymsError::FunctionNotFound
+pub aya_obj::KsymsError::FunctionNotFound::name: alloc::string::String
+pub aya_obj::KsymsError::IncompatibleFunctionSignature
+pub aya_obj::KsymsError::IncompatibleFunctionSignature::name: alloc::string::String
+pub aya_obj::KsymsError::IncompatibleVariableType
+pub aya_obj::KsymsError::IncompatibleVariableType::name: alloc::string::String
+pub aya_obj::KsymsError::InvalidExternType
+pub aya_obj::KsymsError::InvalidExternType::name: alloc::string::String
+pub aya_obj::KsymsError::KallsymsParseError(alloc::string::String)
+pub aya_obj::KsymsError::KallsymsReadError(core::io::error::Error)
+pub aya_obj::KsymsError::TypedKsymRequiresKernelBtf
+pub aya_obj::KsymsError::VariableNotFound
+pub aya_obj::KsymsError::VariableNotFound::name: alloc::string::String
+impl core::convert::From<aya_obj::btf::BtfError> for aya_obj::KsymsError
+pub fn aya_obj::KsymsError::from(aya_obj::btf::BtfError) -> Self
+impl core::convert::From<core::io::error::Error> for aya_obj::KsymsError
+pub fn aya_obj::KsymsError::from(core::io::error::Error) -> Self
+impl core::error::Error for aya_obj::KsymsError
+pub fn aya_obj::KsymsError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+impl core::fmt::Debug for aya_obj::KsymsError
+pub fn aya_obj::KsymsError::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::fmt::Display for aya_obj::KsymsError
+pub fn aya_obj::KsymsError::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for aya_obj::KsymsError
+impl core::marker::Send for aya_obj::KsymsError
+impl core::marker::Sync for aya_obj::KsymsError
+impl core::marker::Unpin for aya_obj::KsymsError
+impl core::marker::UnsafeUnpin for aya_obj::KsymsError
+impl !core::panic::unwind_safe::RefUnwindSafe for aya_obj::KsymsError
+impl !core::panic::unwind_safe::UnwindSafe for aya_obj::KsymsError
 pub enum aya_obj::Map
 pub aya_obj::Map::Btf(aya_obj::maps::BtfMap)
 pub aya_obj::Map::Legacy(aya_obj::maps::LegacyMap)
@@ -5450,7 +5495,10 @@ impl aya_obj::Object
 pub fn aya_obj::Object::relocate_btf(&mut self, &aya_obj::btf::Btf) -> core::result::Result<(), aya_obj::btf::BtfRelocationError>
 impl aya_obj::Object
 pub fn aya_obj::Object::relocate_calls(&mut self, &std::collections::hash::set::HashSet<usize>) -> core::result::Result<(), aya_obj::relocation::EbpfRelocationError>
+pub fn aya_obj::Object::relocate_externs(&mut self) -> core::result::Result<(), aya_obj::relocation::EbpfRelocationError>
 pub fn aya_obj::Object::relocate_maps<'a, I: core::iter::traits::iterator::Iterator<Item = (&'a str, std::os::fd::raw::RawFd, &'a aya_obj::maps::Map)>>(&mut self, I, &std::collections::hash::set::HashSet<usize>) -> core::result::Result<(), aya_obj::relocation::EbpfRelocationError>
+impl aya_obj::Object
+pub fn aya_obj::Object::resolve_externs(&mut self, core::option::Option<&aya_obj::btf::Btf>) -> core::result::Result<(), aya_obj::KsymsError>
 impl core::clone::Clone for aya_obj::Object
 pub fn aya_obj::Object::clone(&self) -> aya_obj::Object
 impl core::fmt::Debug for aya_obj::Object

--- a/xtask/public-api/aya-obj.txt
+++ b/xtask/public-api/aya-obj.txt
@@ -5257,8 +5257,8 @@ pub aya_obj::KsymsError::IncompatibleVariableType
 pub aya_obj::KsymsError::IncompatibleVariableType::name: alloc::string::String
 pub aya_obj::KsymsError::InvalidExternType
 pub aya_obj::KsymsError::InvalidExternType::name: alloc::string::String
+pub aya_obj::KsymsError::KallsymsAccessError(core::io::error::Error)
 pub aya_obj::KsymsError::KallsymsParseError(alloc::string::String)
-pub aya_obj::KsymsError::KallsymsReadError(core::io::error::Error)
 pub aya_obj::KsymsError::TypedKsymRequiresKernelBtf
 pub aya_obj::KsymsError::VariableNotFound
 pub aya_obj::KsymsError::VariableNotFound::name: alloc::string::String

--- a/xtask/public-api/aya.txt
+++ b/xtask/public-api/aya.txt
@@ -7843,6 +7843,7 @@ pub aya::EbpfError::BtfRelocationError(aya_obj::btf::relocation::BtfRelocationEr
 pub aya::EbpfError::FileError
 pub aya::EbpfError::FileError::error: core::io::error::Error
 pub aya::EbpfError::FileError::path: std::path::PathBuf
+pub aya::EbpfError::KsymsError(aya_obj::extern_types::KsymsError)
 pub aya::EbpfError::MapError(aya::maps::MapError)
 pub aya::EbpfError::NoBTF
 pub aya::EbpfError::ParseError(aya_obj::obj::ParseError)
@@ -7858,6 +7859,8 @@ impl core::convert::From<aya_obj::btf::btf::BtfError> for aya::EbpfError
 pub fn aya::EbpfError::from(aya_obj::btf::btf::BtfError) -> Self
 impl core::convert::From<aya_obj::btf::relocation::BtfRelocationError> for aya::EbpfError
 pub fn aya::EbpfError::from(aya_obj::btf::relocation::BtfRelocationError) -> Self
+impl core::convert::From<aya_obj::extern_types::KsymsError> for aya::EbpfError
+pub fn aya::EbpfError::from(aya_obj::extern_types::KsymsError) -> Self
 impl core::convert::From<aya_obj::obj::ParseError> for aya::EbpfError
 pub fn aya::EbpfError::from(aya_obj::obj::ParseError) -> Self
 impl core::convert::From<aya_obj::relocation::EbpfRelocationError> for aya::EbpfError


### PR DESCRIPTION
Collect extern symbols from object BTF and fix up the .ksyms datasec so the resulting BTF is acceptable to the kernel.

Resolve typed extern vars and kfuncs through kernel BTF. Fall back to `/proc/kallsyms` for typeless vars, then apply the corresponding extern relocations before program load.

Expose the object-level ksym APIs in aya-obj via `Object::resolve_externs()`, `Object::relocate_externs()`, and `KsymsError`.

Weak extern handling follows libbpf-style behavior. Unresolved weak var references are null-patched, unresolved weak kfunc calls are poisoned, and unresolved strong extern relocations are rejected.

Add integration coverage for typed ksyms, typed kfuncs, kallsyms-backed ksyms, and missing strong-symbol failures.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aya-rs/aya/1372)
<!-- Reviewable:end -->
