### PR TITLE
xtask: Allow to run VM integration tests without dpkg

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,6 +62,7 @@ rust-version = "1.85.0"
 # them to do that, but in the meantime we need to be careful.
 [workspace.dependencies]
 anyhow = { version = "1", default-features = false }
+ar = { version = "0.9", default-features = false }
 assert_matches = { version = "1.5.0", default-features = false }
 base64 = { version = "0.22.1", default-features = false }
 bindgen = { version = "0.72", default-features = false }

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -15,6 +15,7 @@ workspace = true
 
 [dependencies]
 anyhow = { workspace = true, features = ["std"] }
+ar = { workspace = true }
 aya-tool = { path = "../aya-tool", version = "0.1.0", default-features = false }
 cargo_metadata = { workspace = true }
 clap = { workspace = true, features = ["derive"] }
@@ -30,3 +31,4 @@ syn = { workspace = true }
 tar = { workspace = true }
 tempfile = { workspace = true }
 walkdir = { workspace = true }
+xz2 = { workspace = true }


### PR DESCRIPTION
Debian packages are just nested archives, where the outer one is ar and the inner one is lzma2 tarball. Use Rust crates to unpack them.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aya-rs/aya/1373)
<!-- Reviewable:end -->
