### PR TITLE
aya: restore must_exist argument to set_global

### DIFF
--- a/aya/src/bpf.rs
+++ b/aya/src/bpf.rs
@@ -293,8 +293,13 @@ impl<'a> EbpfLoader<'a> {
 
     /// Override the value of a global variable.
     #[deprecated(since = "0.13.2", note = "please use `override_global` instead")]
-    pub fn set_global<T: Into<GlobalData<'a>>>(&mut self, name: &'a str, value: T) -> &mut Self {
-        self.override_global(name, value, false)
+    pub fn set_global<T: Into<GlobalData<'a>>>(
+        &mut self,
+        name: &'a str,
+        value: T,
+        must_exist: bool,
+    ) -> &mut Self {
+        self.override_global(name, value, must_exist)
     }
 
     /// Set the max_entries for specified map.

--- a/xtask/public-api/aya.txt
+++ b/xtask/public-api/aya.txt
@@ -10750,7 +10750,7 @@ pub fn aya::EbpfLoader<'a>::map_max_entries(&mut self, name: &'a str, size: u32)
 pub fn aya::EbpfLoader<'a>::map_pin_path<P: core::convert::Into<alloc::borrow::Cow<'a, std::path::Path>>>(&mut self, name: &'a str, path: P) -> &mut Self
 pub fn aya::EbpfLoader<'a>::new() -> Self
 pub fn aya::EbpfLoader<'a>::override_global<T: core::convert::Into<aya::GlobalData<'a>>>(&mut self, name: &'a str, value: T, must_exist: bool) -> &mut Self
-pub fn aya::EbpfLoader<'a>::set_global<T: core::convert::Into<aya::GlobalData<'a>>>(&mut self, name: &'a str, value: T) -> &mut Self
+pub fn aya::EbpfLoader<'a>::set_global<T: core::convert::Into<aya::GlobalData<'a>>>(&mut self, name: &'a str, value: T, must_exist: bool) -> &mut Self
 pub fn aya::EbpfLoader<'a>::set_max_entries(&mut self, name: &'a str, size: u32) -> &mut Self
 pub fn aya::EbpfLoader<'a>::verifier_log_level(&mut self, level: aya::VerifierLogLevel) -> &mut Self
 impl core::default::Default for aya::EbpfLoader<'_>


### PR DESCRIPTION
In
https://github.com/aya-rs/aya/commit/03e84871773e09badf08bdef8e83b4f1256850a4 we deprecated set_global but accidentally broke its API by deleting the must_exist argument.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aya-rs/aya/1379)
<!-- Reviewable:end -->
