### PR TITLE
aya-build: allow setting features to be enabled in ebpf by aya-build

### DIFF
--- a/test/integration-test/build.rs
+++ b/test/integration-test/build.rs
@@ -219,6 +219,7 @@ fn main() -> Result<()> {
                 .parent()
                 .ok_or_else(|| anyhow!("no parent for {manifest_path}"))?
                 .as_str(),
+            ..Default::default()
         };
         aya_build::build_ebpf([integration_ebpf_package], aya_build::Toolchain::default())?;
     } else {

--- a/xtask/public-api/aya-build.txt
+++ b/xtask/public-api/aya-build.txt
@@ -27,8 +27,12 @@ pub fn aya_build::Toolchain<'a>::borrow_mut(&mut self) -> &mut T
 impl<T> core::convert::From<T> for aya_build::Toolchain<'a>
 pub fn aya_build::Toolchain<'a>::from(t: T) -> T
 pub struct aya_build::Package<'a>
+pub aya_build::Package::features: &'a [&'a str]
 pub aya_build::Package::name: &'a str
+pub aya_build::Package::no_default_features: bool
 pub aya_build::Package::root_dir: &'a str
+impl<'a> core::default::Default for aya_build::Package<'a>
+pub fn aya_build::Package<'a>::default() -> aya_build::Package<'a>
 impl<'a> core::marker::Freeze for aya_build::Package<'a>
 impl<'a> core::marker::Send for aya_build::Package<'a>
 impl<'a> core::marker::Sync for aya_build::Package<'a>


### PR DESCRIPTION
Right now when building an ebpf program using aya-build, you can't enable or disable any features. To change this, I introduced another Package attribute which takes a Vec of features to enable.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aya-rs/aya/1381)
<!-- Reviewable:end -->
