### PR TITLE
xtask: use `-cpu host` on x86

### DIFF
--- a/xtask/src/run.rs
+++ b/xtask/src/run.rs
@@ -442,7 +442,7 @@ pub(crate) fn run(opts: Options) -> Result<()> {
 
                 let (guest_arch, machine, cpu, console) = match guest_arch {
                     "ARM64" => ("aarch64", Some("virt"), Some("max"), "ttyAMA0"),
-                    "x86" => ("x86_64", None, None, "ttyS0"),
+                    "x86" => ("x86_64", None, Some("host"), "ttyS0"),
                     guest_arch => (guest_arch, None, None, "ttyS0"),
                 };
 


### PR DESCRIPTION
We have started to see errors in CI:

  qemu-system-x86_64: warning: host doesn't support requested feature: CPUID[eax=80000001h].ECX.svm [bit 2]

The internet says this is the remedy.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aya-rs/aya/1384)
<!-- Reviewable:end -->
