### PR TITLE
Add macos-latest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -218,10 +218,10 @@ jobs:
       matrix:
         # We don't have a fast solution for running virtualized integration
         # tests on arm64 because:
-        # - Github broke nested virtualization on macos-15-intel (see below).
-        # - Github arm64 runners don't support nested virtualization (see
+        # - GitHub Ubuntu arm64 runners don't support nested virtualization (see
         #   https://github.com/orgs/community/discussions/148648#discussioncomment-11863547).
-        # - Unlike HVF, KVM doesn't emulate CPUs.
+        # - GitHub macOS arm64 runners don't support nested virtualization (see
+        #   https://docs.github.com/en/actions/reference/runners/github-hosted-runners#limitations-for-arm64-macos-runners).
         #
         # So we spin a runner for every arm64 kernel to avoid waiting 20 minutes
         # for CI. We use arm64 runners to avoid cross-compilation.
@@ -234,15 +234,11 @@ jobs:
         skip-local:
           - true
         include:
-          # TODO(https://github.com/actions/runner-images/issues/13277): Reenable when fixed.
-          # macos-15 is arm64[0] which doesn't support nested
-          # virtualization[1].
-          #
-          # [0] https://github.com/actions/runner-images#available-images
-          #
-          # [1] https://docs.github.com/en/actions/reference/runners/github-hosted-runners#limitations-for-arm64-macos-runners
-          #
-          # - os: macos-15-intel
+          - os: macos-latest
+            # Just one kernel to keep things fast. We just want to keep things from rotting on
+            # macOS. We use amd64 because otherwise qemu tries to use HVF and hits a hard error:
+            # qemu-system-aarch64: -accel hvf: Error: ret = HV_UNSUPPORTED (0xfae9400f, at ../target/arm/hvf/hvf.c:956)
+            download-kernel-images: amd64 5.10
 
           # We don't use ubuntu-latest because we care about the apt packages available.
           - os: ubuntu-24.04


### PR DESCRIPTION
There's no way to get hardware acceleration on arm64 at all, so let's at
least make sure our stuff keeps working on macOS.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aya-rs/aya/1394)
<!-- Reviewable:end -->
