### PR TITLE
doc(aya): document tcx link pinning for atomic program replacement

### DIFF
--- a/aya/src/programs/tc.rs
+++ b/aya/src/programs/tc.rs
@@ -205,12 +205,55 @@ impl SchedClassifier {
     ///
     /// The returned value can be used to detach, see [SchedClassifier::detach].
     ///
+    /// # Link Pinning (TCX mode, kernel >= 6.6)
+    ///
+    /// Links can be pinned to bpffs for atomic replacement across process restarts.
+    ///
+    /// ```no_run
+    /// # use std::{io, path::Path};
+    ///
+    /// # use aya::{
+    /// #     programs::{
+    /// #         LinkOrder, SchedClassifier, TcAttachType,
+    /// #         links::{FdLink, LinkError, PinnedLink},
+    /// #         tc::TcAttachOptions,
+    /// #     },
+    /// #     sys::SyscallError,
+    /// # };
+    ///
+    /// # let mut bpf = aya::Ebpf::load(&[])?;
+    /// # let prog: &mut SchedClassifier = bpf.program_mut("prog").unwrap().try_into()?;
+    /// # prog.load()?;
+    /// let pin_path = "/sys/fs/bpf/my_link";
+    ///
+    /// let link_id = match PinnedLink::from_pin(pin_path) {
+    ///     Ok(old) => {
+    ///         let link = FdLink::from(old).try_into()?;
+    ///         prog.attach_to_link(link)?
+    ///     }
+    ///     Err(LinkError::SyscallError(SyscallError { io_error, .. }))
+    ///         if io_error.kind() == io::ErrorKind::NotFound =>
+    ///     {
+    ///         prog.attach_with_options(
+    ///             "eth0",
+    ///             TcAttachType::Ingress,
+    ///             TcAttachOptions::TcxOrder(LinkOrder::default()),
+    ///         )?
+    ///     }
+    ///     Err(e) => return Err(e.into()),
+    /// };
+    ///
+    /// let link = prog.take_link(link_id)?;
+    /// let fd_link: FdLink = link.try_into()?;
+    /// fd_link.pin(pin_path)?;
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// ```
+    ///
     /// # Errors
     ///
     /// [`TcError::NetlinkError`] is returned if attaching fails. A common cause
     /// of failure is not having added the `clsact` qdisc to the given
-    /// interface, see [`qdisc_add_clsact`]
-    ///
+    /// interface, see [`qdisc_add_clsact`].
     pub fn attach_with_options(
         &mut self,
         interface: &str,


### PR DESCRIPTION
Add documentation and integration test for SchedClassifier link pinning, which enables zero-downtime program updates in production environments.

- Add link pinning example to SchedClassifier::attach_with_options() showing atomic replacement workflow for TCX mode (kernel >= 6.6).
- Add pin_tcx_link() integration test verifying link persistence across program unload and atomic replacement capability.

Closes #1395

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aya-rs/aya/1396)
<!-- Reviewable:end -->
