### PR TITLE
Add licese for aya-obj

### DIFF
--- a/aya-obj/LICENSE-APACHE
+++ b/aya-obj/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../LICENSE-APACHE

--- a/aya-obj/LICENSE-MIT
+++ b/aya-obj/LICENSE-MIT
@@ -1,0 +1,1 @@
+../LICENSE-MIT


### PR DESCRIPTION
This commit adds a link for the needed licenses in aya-obj for fedora
packaging.

Signed-off-by: Daniel Mellado <dmellado@fedoraproject.org>

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aya-rs/aya/1407)
<!-- Reviewable:end -->
