### PR TITLE
aya: Set attach mode flag to 0 in bpf_link_create

### DIFF
--- a/aya/src/programs/cgroup_skb.rs
+++ b/aya/src/programs/cgroup_skb.rs
@@ -6,6 +6,7 @@ use aya_obj::generated::{
     bpf_attach_type::{BPF_CGROUP_INET_EGRESS, BPF_CGROUP_INET_INGRESS},
     bpf_prog_type::BPF_PROG_TYPE_CGROUP_SKB,
 };
+use log::warn;
 
 use crate::{
     VerifierLogLevel,
@@ -86,6 +87,11 @@ impl CgroupSkb {
     /// Attaches the program to the given cgroup.
     ///
     /// The returned value can be used to detach, see [CgroupSkb::detach].
+    ///
+    /// # Warning
+    ///
+    /// On kernels 5.7.0 and later, attach modes other than `CgroupAttachMode::default()` are not passed to `bpf_link_create`.
+    /// On older kernels (using `bpf_prog_attach`), the attach mode is honored.
     pub fn attach<T: AsFd>(
         &mut self,
         cgroup: T,
@@ -101,17 +107,17 @@ impl CgroupSkb {
             CgroupSkbAttachType::Egress => BPF_CGROUP_INET_EGRESS,
         };
         if KernelVersion::at_least(5, 7, 0) {
-            let link_fd = bpf_link_create(
-                prog_fd,
-                LinkTarget::Fd(cgroup_fd),
-                attach_type,
-                mode.into(),
-                None,
-            )
-            .map_err(|io_error| SyscallError {
-                call: "bpf_link_create",
-                io_error,
-            })?;
+            if mode != CgroupAttachMode::default() {
+                warn!(
+                    "CgroupAttachMode {:?} will not be passed on to bpf_link_create",
+                    mode
+                );
+            }
+            let link_fd = bpf_link_create(prog_fd, LinkTarget::Fd(cgroup_fd), attach_type, 0, None)
+                .map_err(|io_error| SyscallError {
+                    call: "bpf_link_create",
+                    io_error,
+                })?;
             self.data
                 .links
                 .insert(CgroupSkbLink::new(CgroupSkbLinkInner::Fd(FdLink::new(

--- a/aya/src/programs/cgroup_sock.rs
+++ b/aya/src/programs/cgroup_sock.rs
@@ -4,6 +4,7 @@ use std::{hash::Hash, os::fd::AsFd, path::Path};
 
 use aya_obj::generated::bpf_prog_type::BPF_PROG_TYPE_CGROUP_SOCK;
 pub use aya_obj::programs::CgroupSockAttachType;
+use log::warn;
 
 use crate::{
     VerifierLogLevel,
@@ -70,6 +71,11 @@ impl CgroupSock {
     /// Attaches the program to the given cgroup.
     ///
     /// The returned value can be used to detach, see [CgroupSock::detach].
+    ///
+    /// # Warning
+    ///
+    /// On kernels 5.7.0 and later, attach modes other than `CgroupAttachMode::default()` are not passed to `bpf_link_create`.
+    /// On older kernels (using `bpf_prog_attach`), the attach mode is honored.
     pub fn attach<T: AsFd>(
         &mut self,
         cgroup: T,
@@ -80,17 +86,17 @@ impl CgroupSock {
         let cgroup_fd = cgroup.as_fd();
         let attach_type = self.data.expected_attach_type.unwrap();
         if KernelVersion::at_least(5, 7, 0) {
-            let link_fd = bpf_link_create(
-                prog_fd,
-                LinkTarget::Fd(cgroup_fd),
-                attach_type,
-                mode.into(),
-                None,
-            )
-            .map_err(|io_error| SyscallError {
-                call: "bpf_link_create",
-                io_error,
-            })?;
+            if mode != CgroupAttachMode::default() {
+                warn!(
+                    "CgroupAttachMode {:?} will not be passed on to bpf_link_create",
+                    mode
+                );
+            }
+            let link_fd = bpf_link_create(prog_fd, LinkTarget::Fd(cgroup_fd), attach_type, 0, None)
+                .map_err(|io_error| SyscallError {
+                    call: "bpf_link_create",
+                    io_error,
+                })?;
             self.data
                 .links
                 .insert(CgroupSockLink::new(CgroupSockLinkInner::Fd(FdLink::new(

--- a/aya/src/programs/cgroup_sock_addr.rs
+++ b/aya/src/programs/cgroup_sock_addr.rs
@@ -4,6 +4,7 @@ use std::{hash::Hash, os::fd::AsFd, path::Path};
 
 use aya_obj::generated::bpf_prog_type::BPF_PROG_TYPE_CGROUP_SOCK_ADDR;
 pub use aya_obj::programs::CgroupSockAddrAttachType;
+use log::warn;
 
 use crate::{
     VerifierLogLevel,
@@ -71,6 +72,11 @@ impl CgroupSockAddr {
     /// Attaches the program to the given cgroup.
     ///
     /// The returned value can be used to detach, see [CgroupSockAddr::detach].
+    ///
+    /// # Warning
+    ///
+    /// On kernels 5.7.0 and later, attach modes other than `CgroupAttachMode::default()` are not passed to `bpf_link_create`.
+    /// On older kernels (using `bpf_prog_attach`), the attach mode is honored.
     pub fn attach<T: AsFd>(
         &mut self,
         cgroup: T,
@@ -81,17 +87,17 @@ impl CgroupSockAddr {
         let cgroup_fd = cgroup.as_fd();
         let attach_type = self.data.expected_attach_type.unwrap();
         if KernelVersion::at_least(5, 7, 0) {
-            let link_fd = bpf_link_create(
-                prog_fd,
-                LinkTarget::Fd(cgroup_fd),
-                attach_type,
-                mode.into(),
-                None,
-            )
-            .map_err(|io_error| SyscallError {
-                call: "bpf_link_create",
-                io_error,
-            })?;
+            if mode != CgroupAttachMode::default() {
+                warn!(
+                    "CgroupAttachMode {:?} will not be passed on to bpf_link_create",
+                    mode
+                );
+            }
+            let link_fd = bpf_link_create(prog_fd, LinkTarget::Fd(cgroup_fd), attach_type, 0, None)
+                .map_err(|io_error| SyscallError {
+                    call: "bpf_link_create",
+                    io_error,
+                })?;
             self.data
                 .links
                 .insert(CgroupSockAddrLink::new(CgroupSockAddrLinkInner::Fd(

--- a/aya/src/programs/cgroup_sockopt.rs
+++ b/aya/src/programs/cgroup_sockopt.rs
@@ -4,6 +4,7 @@ use std::{hash::Hash, os::fd::AsFd, path::Path};
 
 use aya_obj::generated::bpf_prog_type::BPF_PROG_TYPE_CGROUP_SOCKOPT;
 pub use aya_obj::programs::CgroupSockoptAttachType;
+use log::warn;
 
 use crate::{
     VerifierLogLevel,
@@ -68,6 +69,11 @@ impl CgroupSockopt {
     /// Attaches the program to the given cgroup.
     ///
     /// The returned value can be used to detach, see [CgroupSockopt::detach].
+    ///
+    /// # Warning
+    ///
+    /// On kernels 5.7.0 and later, attach modes other than `CgroupAttachMode::default()` are not passed to `bpf_link_create`.
+    /// On older kernels (using `bpf_prog_attach`), the attach mode is honored.
     pub fn attach<T: AsFd>(
         &mut self,
         cgroup: T,
@@ -78,17 +84,17 @@ impl CgroupSockopt {
         let cgroup_fd = cgroup.as_fd();
         let attach_type = self.data.expected_attach_type.unwrap();
         if KernelVersion::at_least(5, 7, 0) {
-            let link_fd = bpf_link_create(
-                prog_fd,
-                LinkTarget::Fd(cgroup_fd),
-                attach_type,
-                mode.into(),
-                None,
-            )
-            .map_err(|io_error| SyscallError {
-                call: "bpf_link_create",
-                io_error,
-            })?;
+            if mode != CgroupAttachMode::default() {
+                warn!(
+                    "CgroupAttachMode {:?} will not be passed on to bpf_link_create",
+                    mode
+                );
+            }
+            let link_fd = bpf_link_create(prog_fd, LinkTarget::Fd(cgroup_fd), attach_type, 0, None)
+                .map_err(|io_error| SyscallError {
+                    call: "bpf_link_create",
+                    io_error,
+                })?;
             self.data
                 .links
                 .insert(CgroupSockoptLink::new(CgroupSockoptLinkInner::Fd(

--- a/aya/src/programs/cgroup_sysctl.rs
+++ b/aya/src/programs/cgroup_sysctl.rs
@@ -5,6 +5,7 @@ use std::{hash::Hash, os::fd::AsFd};
 use aya_obj::generated::{
     bpf_attach_type::BPF_CGROUP_SYSCTL, bpf_prog_type::BPF_PROG_TYPE_CGROUP_SYSCTL,
 };
+use log::warn;
 
 use crate::{
     programs::{
@@ -66,6 +67,11 @@ impl CgroupSysctl {
     /// Attaches the program to the given cgroup.
     ///
     /// The returned value can be used to detach, see [CgroupSysctl::detach].
+    ///
+    /// # Warning
+    ///
+    /// On kernels 5.7.0 and later, attach modes other than `CgroupAttachMode::default()` are not passed to `bpf_link_create`.
+    /// On older kernels (using `bpf_prog_attach`), the attach mode is honored.
     pub fn attach<T: AsFd>(
         &mut self,
         cgroup: T,
@@ -76,11 +82,17 @@ impl CgroupSysctl {
         let cgroup_fd = cgroup.as_fd();
 
         if KernelVersion::at_least(5, 7, 0) {
+            if mode != CgroupAttachMode::default() {
+                warn!(
+                    "CgroupAttachMode {:?} will not be passed on to bpf_link_create",
+                    mode
+                );
+            }
             let link_fd = bpf_link_create(
                 prog_fd,
                 LinkTarget::Fd(cgroup_fd),
                 BPF_CGROUP_SYSCTL,
-                mode.into(),
+                0,
                 None,
             )
             .map_err(|io_error| SyscallError {

--- a/aya/src/programs/links.rs
+++ b/aya/src/programs/links.rs
@@ -38,7 +38,7 @@ pub trait Link: std::fmt::Debug + Eq + std::hash::Hash + 'static {
 }
 
 /// Program attachment mode.
-#[derive(Clone, Copy, Debug, Default)]
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
 pub enum CgroupAttachMode {
     /// Allows only one BPF program in the cgroup subtree.
     #[default]

--- a/xtask/public-api/aya.txt
+++ b/xtask/public-api/aya.txt
@@ -4240,6 +4240,8 @@ pub aya::programs::links::CgroupAttachMode::AllowOverride
 pub aya::programs::links::CgroupAttachMode::Single
 impl core::clone::Clone for aya::programs::links::CgroupAttachMode
 pub fn aya::programs::links::CgroupAttachMode::clone(&self) -> aya::programs::links::CgroupAttachMode
+impl core::cmp::PartialEq for aya::programs::links::CgroupAttachMode
+pub fn aya::programs::links::CgroupAttachMode::eq(&self, other: &aya::programs::links::CgroupAttachMode) -> bool
 impl core::convert::From<aya::programs::links::CgroupAttachMode> for u32
 pub fn u32::from(mode: aya::programs::links::CgroupAttachMode) -> Self
 impl core::default::Default for aya::programs::links::CgroupAttachMode
@@ -4247,6 +4249,7 @@ pub fn aya::programs::links::CgroupAttachMode::default() -> aya::programs::links
 impl core::fmt::Debug for aya::programs::links::CgroupAttachMode
 pub fn aya::programs::links::CgroupAttachMode::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Copy for aya::programs::links::CgroupAttachMode
+impl core::marker::StructuralPartialEq for aya::programs::links::CgroupAttachMode
 impl core::marker::Freeze for aya::programs::links::CgroupAttachMode
 impl core::marker::Send for aya::programs::links::CgroupAttachMode
 impl core::marker::Sync for aya::programs::links::CgroupAttachMode
@@ -7834,6 +7837,8 @@ pub aya::programs::CgroupAttachMode::AllowOverride
 pub aya::programs::CgroupAttachMode::Single
 impl core::clone::Clone for aya::programs::links::CgroupAttachMode
 pub fn aya::programs::links::CgroupAttachMode::clone(&self) -> aya::programs::links::CgroupAttachMode
+impl core::cmp::PartialEq for aya::programs::links::CgroupAttachMode
+pub fn aya::programs::links::CgroupAttachMode::eq(&self, other: &aya::programs::links::CgroupAttachMode) -> bool
 impl core::convert::From<aya::programs::links::CgroupAttachMode> for u32
 pub fn u32::from(mode: aya::programs::links::CgroupAttachMode) -> Self
 impl core::default::Default for aya::programs::links::CgroupAttachMode
@@ -7841,6 +7846,7 @@ pub fn aya::programs::links::CgroupAttachMode::default() -> aya::programs::links
 impl core::fmt::Debug for aya::programs::links::CgroupAttachMode
 pub fn aya::programs::links::CgroupAttachMode::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Copy for aya::programs::links::CgroupAttachMode
+impl core::marker::StructuralPartialEq for aya::programs::links::CgroupAttachMode
 impl core::marker::Freeze for aya::programs::links::CgroupAttachMode
 impl core::marker::Send for aya::programs::links::CgroupAttachMode
 impl core::marker::Sync for aya::programs::links::CgroupAttachMode


### PR DESCRIPTION
Fixes #1078 
> On newer kernels that support `bpf_link_create`, the call to `bpf_link_create` will return `EINVAL` if you pass in any mode other than `CgroupAttachMode::Single`, because `bpf_link_create` when used on a cgroup doesn't seem to support flags (see [this kernel code](https://github.com/torvalds/linux/blob/b6d993310a65b994f37e3347419d9ed398ee37a3/kernel/bpf/cgroup.c#L1470)). In practice, the kernel defaults to `BPF_F_ALLOW_MULTI`.

This change sets the flag to 0 in `bpf_link_create` (used in kernels 5.7+) and adds warning logs if any other attach mode is passed in.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aya-rs/aya/1408)
<!-- Reviewable:end -->
