### PR TITLE
aya: add multi-uprobe attach support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -215,6 +215,7 @@ dependencies = [
  "log",
  "object",
  "rbpf",
+ "rstest",
  "thiserror",
 ]
 

--- a/aya-obj/Cargo.toml
+++ b/aya-obj/Cargo.toml
@@ -25,3 +25,4 @@ thiserror = { workspace = true, features = ["std"] }
 [dev-dependencies]
 assert_matches = { workspace = true }
 rbpf = { workspace = true }
+rstest = { workspace = true }

--- a/aya-obj/src/obj.rs
+++ b/aya-obj/src/obj.rs
@@ -232,9 +232,11 @@ pub enum ProgramSection {
     KProbe,
     UProbe {
         sleepable: bool,
+        multi: bool,
     },
     URetProbe {
         sleepable: bool,
+        multi: bool,
     },
     TracePoint,
     SocketFilter,
@@ -306,10 +308,38 @@ impl FromStr for ProgramSection {
         Ok(match kind {
             "kprobe" => Self::KProbe,
             "kretprobe" => Self::KRetProbe,
-            "uprobe" => Self::UProbe { sleepable: false },
-            "uprobe.s" => Self::UProbe { sleepable: true },
-            "uretprobe" => Self::URetProbe { sleepable: false },
-            "uretprobe.s" => Self::URetProbe { sleepable: true },
+            "uprobe" => Self::UProbe {
+                sleepable: false,
+                multi: false,
+            },
+            "uprobe.s" => Self::UProbe {
+                sleepable: true,
+                multi: false,
+            },
+            "uprobe.multi" => Self::UProbe {
+                sleepable: false,
+                multi: true,
+            },
+            "uprobe.multi.s" => Self::UProbe {
+                sleepable: true,
+                multi: true,
+            },
+            "uretprobe" => Self::URetProbe {
+                sleepable: false,
+                multi: false,
+            },
+            "uretprobe.s" => Self::URetProbe {
+                sleepable: true,
+                multi: false,
+            },
+            "uretprobe.multi" => Self::URetProbe {
+                sleepable: false,
+                multi: true,
+            },
+            "uretprobe.multi.s" => Self::URetProbe {
+                sleepable: true,
+                multi: true,
+            },
             "xdp" | "xdp.frags" => Self::Xdp {
                 frags: kind == "xdp.frags",
                 attach_type: match pieces.next() {
@@ -1534,6 +1564,7 @@ fn get_func_and_line_info(
 #[cfg(test)]
 mod tests {
     use assert_matches::assert_matches;
+    use rstest::rstest;
 
     use super::*;
     use crate::generated::{bpf_map_type::BPF_MAP_TYPE_BLOOM_FILTER, btf_ext_header};
@@ -2050,102 +2081,75 @@ mod tests {
         );
     }
 
-    #[test]
-    fn test_parse_section_uprobe() {
+    #[rstest]
+    #[case::uprobe_plain(
+        "uprobe/foo",
+        ProgramSection::UProbe { sleepable: false, multi: false }
+    )]
+    #[case::uprobe_sleepable(
+        "uprobe.s/foo",
+        ProgramSection::UProbe { sleepable: true, multi: false }
+    )]
+    #[case::uprobe_multi(
+        "uprobe.multi/foo",
+        ProgramSection::UProbe { sleepable: false, multi: true }
+    )]
+    #[case::uprobe_multi_sleepable(
+        "uprobe.multi.s/foo",
+        ProgramSection::UProbe { sleepable: true, multi: true }
+    )]
+    #[case::uretprobe_plain(
+        "uretprobe/foo",
+        ProgramSection::URetProbe { sleepable: false, multi: false }
+    )]
+    #[case::uretprobe_sleepable(
+        "uretprobe.s/foo",
+        ProgramSection::URetProbe { sleepable: true, multi: false }
+    )]
+    #[case::uretprobe_multi(
+        "uretprobe.multi/foo",
+        ProgramSection::URetProbe { sleepable: false, multi: true }
+    )]
+    #[case::uretprobe_multi_sleepable(
+        "uretprobe.multi.s/foo",
+        ProgramSection::URetProbe { sleepable: true, multi: true }
+    )]
+    fn test_parse_section_user_probe(
+        #[case] section: &str,
+        #[case] expected_section: ProgramSection,
+    ) {
         let mut obj = fake_obj();
         fake_sym(&mut obj, 0, 0, "foo", FAKE_INS_LEN);
 
         assert_matches!(
             obj.parse_section(fake_section(
                 EbpfSectionKind::Program,
-                "uprobe/foo",
+                section,
                 bytes_of(&fake_ins()),
                 None
             )),
             Ok(())
         );
-        assert_matches!(
-            obj.programs.get("foo"),
-            Some(Program {
-                section: ProgramSection::UProbe { .. },
-                ..
-            })
-        );
-    }
-
-    #[test]
-    fn test_parse_section_uprobe_sleepable() {
-        let mut obj = fake_obj();
-        fake_sym(&mut obj, 0, 0, "foo", FAKE_INS_LEN);
-
-        assert_matches!(
-            obj.parse_section(fake_section(
-                EbpfSectionKind::Program,
-                "uprobe.s/foo",
-                bytes_of(&fake_ins()),
-                None
-            )),
-            Ok(())
-        );
-        assert_matches!(
-            obj.programs.get("foo"),
-            Some(Program {
-                section: ProgramSection::UProbe {
-                    sleepable: true,
-                    ..
+        let program = obj.programs.remove("foo").unwrap();
+        match (program.section, expected_section) {
+            (
+                ProgramSection::UProbe {
+                    sleepable: actual_sleepable,
+                    multi: actual_multi,
                 },
-                ..
-            })
-        );
-    }
-
-    #[test]
-    fn test_parse_section_uretprobe() {
-        let mut obj = fake_obj();
-        fake_sym(&mut obj, 0, 0, "foo", FAKE_INS_LEN);
-
-        assert_matches!(
-            obj.parse_section(fake_section(
-                EbpfSectionKind::Program,
-                "uretprobe/foo",
-                bytes_of(&fake_ins()),
-                None
-            )),
-            Ok(())
-        );
-        assert_matches!(
-            obj.programs.get("foo"),
-            Some(Program {
-                section: ProgramSection::URetProbe { .. },
-                ..
-            })
-        );
-    }
-
-    #[test]
-    fn test_parse_section_uretprobe_sleepable() {
-        let mut obj = fake_obj();
-        fake_sym(&mut obj, 0, 0, "foo", FAKE_INS_LEN);
-
-        assert_matches!(
-            obj.parse_section(fake_section(
-                EbpfSectionKind::Program,
-                "uretprobe.s/foo",
-                bytes_of(&fake_ins()),
-                None
-            )),
-            Ok(())
-        );
-        assert_matches!(
-            obj.programs.get("foo"),
-            Some(Program {
-                section: ProgramSection::URetProbe {
-                    sleepable: true,
-                    ..
+                ProgramSection::UProbe { sleepable, multi },
+            )
+            | (
+                ProgramSection::URetProbe {
+                    sleepable: actual_sleepable,
+                    multi: actual_multi,
                 },
-                ..
-            })
-        );
+                ProgramSection::URetProbe { sleepable, multi },
+            ) => assert_eq!((actual_sleepable, actual_multi), (sleepable, multi)),
+            (section, expected_section) => {
+                panic!("unexpected section: {section:?}, expected: {expected_section:?}")
+            }
+        }
     }
 
     #[test]

--- a/aya/src/bpf.rs
+++ b/aya/src/bpf.rs
@@ -23,7 +23,7 @@ use crate::{
         CgroupSysctl, Extension, FEntry, FExit, FlowDissector, Iter, KProbe, LircMode2, Lsm,
         LsmCgroup, PerfEvent, ProbeKind, Program, ProgramData, ProgramError, RawTracePoint,
         SchedClassifier, SkLookup, SkMsg, SkReuseport, SkSkb, SockOps, SocketFilter, TracePoint,
-        UProbe, Xdp,
+        UProbe, Xdp, uprobe::AttachMode,
     },
     sys::{
         bpf_load_btf, is_bpf_cookie_supported, is_bpf_global_data_supported,
@@ -520,8 +520,14 @@ impl<'a> EbpfLoader<'a> {
                                 }
                                 ProgramSection::KRetProbe
                                 | ProgramSection::KProbe
-                                | ProgramSection::UProbe { sleepable: _ }
-                                | ProgramSection::URetProbe { sleepable: _ }
+                                | ProgramSection::UProbe {
+                                    sleepable: _,
+                                    multi: _,
+                                }
+                                | ProgramSection::URetProbe {
+                                    sleepable: _,
+                                    multi: _,
+                                }
                                 | ProgramSection::TracePoint
                                 | ProgramSection::SocketFilter
                                 | ProgramSection::Xdp {
@@ -744,7 +750,7 @@ impl<'a> EbpfLoader<'a> {
                             data: ProgramData::new(prog_name, obj, btf_fd, *verifier_log_level),
                             kind: ProbeKind::Return,
                         }),
-                        ProgramSection::UProbe { sleepable } => {
+                        ProgramSection::UProbe { sleepable, multi } => {
                             let mut data =
                                 ProgramData::new(prog_name, obj, btf_fd, *verifier_log_level);
                             if *sleepable {
@@ -753,9 +759,14 @@ impl<'a> EbpfLoader<'a> {
                             Program::UProbe(UProbe {
                                 data,
                                 kind: ProbeKind::Entry,
+                                attach_mode: if *multi {
+                                    AttachMode::Multi
+                                } else {
+                                    AttachMode::Single
+                                },
                             })
                         }
-                        ProgramSection::URetProbe { sleepable } => {
+                        ProgramSection::URetProbe { sleepable, multi } => {
                             let mut data =
                                 ProgramData::new(prog_name, obj, btf_fd, *verifier_log_level);
                             if *sleepable {
@@ -764,6 +775,11 @@ impl<'a> EbpfLoader<'a> {
                             Program::UProbe(UProbe {
                                 data,
                                 kind: ProbeKind::Return,
+                                attach_mode: if *multi {
+                                    AttachMode::Multi
+                                } else {
+                                    AttachMode::Single
+                                },
                             })
                         }
                         ProgramSection::TracePoint => Program::TracePoint(TracePoint {
@@ -1292,7 +1308,7 @@ impl Ebpf {
     ///
     /// let program: &mut UProbe = bpf.program_mut("SSL_read").unwrap().try_into()?;
     /// program.load()?;
-    /// program.attach("SSL_read", "libssl", UProbeScope::AllProcesses)?;
+    /// program.attach(["SSL_read"], "libssl", UProbeScope::AllProcesses)?;
     /// # Ok::<(), aya::EbpfError>(())
     /// ```
     pub fn program_mut(&mut self, name: &str) -> Option<&mut Program> {

--- a/aya/src/programs/mod.rs
+++ b/aya/src/programs/mod.rs
@@ -1322,11 +1322,17 @@ impl_from_pin!(
 
 macro_rules! impl_from_prog_info {
     (
-        $(#[$doc:meta])*
+        @docs
+            [$($doc:meta)*]
+        @safety_docs
+            [$($safety_doc:meta)*]
         @safety
             [$($safety:tt)?]
         @rest
-            $struct_name:ident $($var:ident : $var_ty:ty)?
+            $struct_name:ident
+            $($var:ident : $var_ty:ty,)?
+        @extra_fields
+            [$($extra_field:ident : $extra_value:expr),* $(,)?]
     ) => {
         impl $struct_name {
             /// Constructs an instance of a [`Self`] from a [`ProgramInfo`].
@@ -1334,12 +1340,14 @@ macro_rules! impl_from_prog_info {
             /// This allows the caller to get a handle to an already loaded
             /// program from the kernel without having to load it again.
             ///
+            $(#[$doc])*
+            ///
             /// # Errors
             ///
             /// - If the program type reported by the kernel does not match
             ///   [`Self::PROGRAM_TYPE`].
             /// - If the file descriptor of the program cannot be cloned.
-            $(#[$doc])*
+            $(#[$safety_doc])*
             pub $($safety)?
             fn from_program_info(
                 info: ProgramInfo,
@@ -1362,6 +1370,7 @@ macro_rules! impl_from_prog_info {
                         VerifierLogLevel::default(),
                     )?,
                     $($var,)?
+                    $($extra_field: $extra_value,)*
                 })
             }
         }
@@ -1369,30 +1378,45 @@ macro_rules! impl_from_prog_info {
 
     // Handle unsafe cases and pass a safety doc section
     (
-        unsafe $struct_name:ident $($var:ident : $var_ty:ty)? $(, $($rest:tt)*)?
+        $(#[$doc:meta])*
+        unsafe $struct_name:ident
+        $($var:ident : $var_ty:ty)?
+        $(=> { $($extra_field:ident : $extra_value:expr),+ $(,)? })?
+        $(, $($rest:tt)*)?
     ) => {
         impl_from_prog_info! {
-            ///
-            /// # Safety
-            ///
-            /// The runtime type of this program, as used by the kernel, is
-            /// overloaded. We assert the program type matches the runtime type
-            /// but we're unable to perform further checks. Therefore, the caller
-            /// must ensure that the program type is correct or the behavior is
-            /// undefined.
+            @docs [$($doc)*]
+            @safety_docs [
+                doc = ""
+                doc = "# Safety"
+                doc = ""
+                doc = "The runtime type of this program, as used by the kernel, is"
+                doc = "overloaded. We assert the program type matches the runtime type"
+                doc = "but we're unable to perform further checks. Therefore, the caller"
+                doc = "must ensure that the program type is correct or the behavior is"
+                doc = "undefined."
+            ]
             @safety [unsafe]
-            @rest $struct_name $($var : $var_ty)?
+            @rest $struct_name $($var : $var_ty,)?
+            @extra_fields [$($($extra_field : $extra_value),+)?]
         }
         $( impl_from_prog_info!($($rest)*); )?
     };
 
     // Handle non-unsafe cases and omit safety doc section
     (
-        $struct_name:ident $($var:ident : $var_ty:ty)? $(, $($rest:tt)*)?
+        $(#[$doc:meta])*
+        $struct_name:ident
+        $($var:ident : $var_ty:ty)?
+        $(=> { $($extra_field:ident : $extra_value:expr),+ $(,)? })?
+        $(, $($rest:tt)*)?
     ) => {
         impl_from_prog_info! {
+            @docs [$($doc)*]
+            @safety_docs []
             @safety []
-            @rest $struct_name $($var : $var_ty)?
+            @rest $struct_name $($var : $var_ty,)?
+            @extra_fields [$($($extra_field : $extra_value),+)?]
         }
         $( impl_from_prog_info!($($rest)*); )?
     };
@@ -1405,7 +1429,11 @@ macro_rules! impl_from_prog_info {
 
 impl_from_prog_info!(
     unsafe KProbe kind : ProbeKind,
-    unsafe UProbe kind : ProbeKind,
+    /// As with [`Self::from_pin`], this constructor starts in unknown mode
+    /// because it does not know whether the original program came from an
+    /// `uprobe` or `uprobe.multi` section. As a result, [`Self::attach`]
+    /// performs runtime mode selection.
+    unsafe UProbe kind : ProbeKind => { attach_mode: uprobe::AttachMode::Unknown },
     TracePoint,
     SocketFilter,
     ReusePortSocketFilter,

--- a/aya/src/programs/perf_attach.rs
+++ b/aya/src/programs/perf_attach.rs
@@ -68,6 +68,8 @@ impl Link for PerfLink {
     }
 
     fn detach(self) -> Result<(), ProgramError> {
+        // ProbeLinkInner::Many relies on this method being infallible. If errors are surfaced here,
+        // update it to attempt every detach and aggregate all failures.
         let Self { perf_fd, event } = self;
         let _unused: io::Result<()> =
             perf_event_ioctl(perf_fd.as_fd(), PerfEventIoctlRequest::Disable);

--- a/aya/src/programs/probe.rs
+++ b/aya/src/programs/probe.rs
@@ -3,7 +3,7 @@ use std::{
     fmt::{self, Write},
     fs::{self, OpenOptions},
     io::{self, Write as _},
-    os::fd::AsFd as _,
+    os::fd::{AsFd as _, BorrowedFd},
     path::{Path, PathBuf},
     process,
     sync::atomic::{AtomicUsize, Ordering},
@@ -11,8 +11,9 @@ use std::{
 
 use crate::{
     programs::{
-        Link, ProgramData, ProgramError, perf_attach, perf_attach::PerfLinkInner,
-        perf_attach_debugfs, trace_point::read_sys_fs_trace_point_id, utils::find_tracefs_path,
+        FdLink, Link, PerfLinkIdInner, PerfLinkInner, ProgramData, ProgramError, id_as_key,
+        perf_attach, perf_attach_debugfs, trace_point::read_sys_fs_trace_point_id,
+        utils::find_tracefs_path,
     },
     sys::{SyscallError, perf_event_open_probe, perf_event_open_trace_point},
     util::KernelVersion,
@@ -28,6 +29,96 @@ pub enum ProbeKind {
     /// Probe the return of the function
     Return,
 }
+
+#[derive(Debug, Hash, Eq, PartialEq)]
+pub(crate) enum ProbeLinkIdInner {
+    // This includes native multi-probe links: the kernel represents many
+    // attachment points with one BPF link.
+    One(PerfLinkIdInner),
+    // Legacy multi-point fallback creates one perf link per attachment point.
+    Many(Vec<PerfLinkIdInner>),
+}
+
+/// Internal representation shared by probe programs whose logical attachment
+/// may be backed by one native link or several legacy perf links.
+#[derive(Debug)]
+pub(crate) enum ProbeLinkInner {
+    // This includes native multi-probe links: the kernel represents many
+    // attachment points with one BPF link.
+    One(PerfLinkInner),
+    // Legacy multi-point fallback creates one perf link per attachment point.
+    Many(Vec<PerfLinkInner>),
+}
+
+impl ProbeLinkInner {
+    pub(crate) fn into_fd_links(self) -> Result<Vec<FdLink>, Self> {
+        match self {
+            Self::One(PerfLinkInner::Fd(link)) => Ok(vec![link]),
+            Self::One(link @ PerfLinkInner::PerfLink(_)) => Err(Self::One(link)),
+            Self::Many(links) => {
+                let mut fd_links = Vec::with_capacity(links.len());
+                let mut pending = links.into_iter();
+
+                while let Some(link) = pending.next() {
+                    match link {
+                        PerfLinkInner::Fd(link) => fd_links.push(link),
+                        link @ PerfLinkInner::PerfLink(_) => {
+                            let mut links = fd_links
+                                .into_iter()
+                                .map(PerfLinkInner::Fd)
+                                .collect::<Vec<_>>();
+                            links.push(link);
+                            links.extend(pending);
+                            return Err(Self::Many(links));
+                        }
+                    }
+                }
+
+                Ok(fd_links)
+            }
+        }
+    }
+}
+
+impl From<PerfLinkInner> for ProbeLinkInner {
+    fn from(link: PerfLinkInner) -> Self {
+        Self::One(link)
+    }
+}
+
+impl From<FdLink> for ProbeLinkInner {
+    fn from(link: FdLink) -> Self {
+        Self::One(PerfLinkInner::Fd(link))
+    }
+}
+
+impl Link for ProbeLinkInner {
+    type Id = ProbeLinkIdInner;
+
+    fn id(&self) -> Self::Id {
+        match self {
+            Self::One(link) => ProbeLinkIdInner::One(link.id()),
+            Self::Many(links) => ProbeLinkIdInner::Many(links.iter().map(Link::id).collect()),
+        }
+    }
+
+    fn detach(self) -> Result<(), ProgramError> {
+        match self {
+            Self::One(link) => link.detach(),
+            Self::Many(links) => {
+                // FdLink and PerfLink currently always return Ok from detach; Result is only
+                // required by Link's interface. If PerfLink starts returning detach errors, replace
+                // this with best-effort aggregation so every error can be reported.
+                for link in links {
+                    link.detach()?;
+                }
+                Ok(())
+            }
+        }
+    }
+}
+
+id_as_key!(ProbeLinkInner, ProbeLinkIdInner);
 
 pub(crate) trait Probe {
     const PMU: &'static str;
@@ -152,7 +243,19 @@ pub(crate) fn attach<P: Probe, T: Link + From<PerfLinkInner>>(
     // Use debugfs to create probe
     let prog_fd = program_data.fd()?;
     let prog_fd = prog_fd.as_fd();
-    let link = if KernelVersion::at_least(4, 17, 0) {
+    let link = attach_perf_link::<P>(prog_fd, kind, fn_name, offset, pid, cookie)?;
+    program_data.links.insert(T::from(link))
+}
+
+pub(crate) fn attach_perf_link<P: Probe>(
+    prog_fd: BorrowedFd<'_>,
+    kind: ProbeKind,
+    fn_name: &OsStr,
+    offset: u64,
+    pid: Option<u32>,
+    cookie: Option<u64>,
+) -> Result<PerfLinkInner, ProgramError> {
+    if KernelVersion::at_least(4, 17, 0) {
         let perf_fd = create_as_probe::<P>(kind, fn_name, offset, pid)?;
         perf_attach(prog_fd, perf_fd, cookie)
     } else {
@@ -161,8 +264,7 @@ pub(crate) fn attach<P: Probe, T: Link + From<PerfLinkInner>>(
         }
         let (perf_fd, event) = create_as_trace_point::<P>(kind, fn_name, offset, pid)?;
         perf_attach_debugfs(prog_fd, perf_fd, event)
-    }?;
-    program_data.links.insert(T::from(link))
+    }
 }
 
 fn detach_debug_fs<P: Probe>(event_alias: &OsStr) -> Result<(), ProgramError> {

--- a/aya/src/programs/uprobe.rs
+++ b/aya/src/programs/uprobe.rs
@@ -1,30 +1,39 @@
 //! User space probes.
 use std::{
     borrow::Cow,
+    collections::HashMap,
     error::Error,
-    ffi::{CStr, OsStr, OsString},
+    ffi::{CStr, CString, OsStr, OsString},
     fmt::{self, Write},
     fs,
     io::{self, BufRead as _, Cursor, Read as _},
+    iter::once,
     num::NonZeroU32,
-    os::unix::ffi::{OsStrExt as _, OsStringExt as _},
+    os::{
+        fd::{AsFd as _, BorrowedFd},
+        unix::ffi::{OsStrExt as _, OsStringExt as _},
+    },
     path::{Path, PathBuf},
+    slice::from_ref,
     sync::LazyLock,
 };
 
-use aya_obj::generated::{bpf_link_type, bpf_prog_type::BPF_PROG_TYPE_KPROBE};
+use aya_obj::generated::{
+    bpf_attach_type::BPF_TRACE_UPROBE_MULTI, bpf_link_type, bpf_prog_type::BPF_PROG_TYPE_KPROBE,
+};
+use libc::{EINVAL, ENOTSUP, EOPNOTSUPP};
 use object::{Object as _, ObjectSection as _, ObjectSymbol as _, Symbol};
 use thiserror::Error;
 
 use crate::{
     VerifierLogLevel,
     programs::{
-        ProgramData, ProgramError, ProgramType, define_link_wrapper, impl_try_from_fdlink,
-        impl_try_into_fdlink, load_program_without_attach_type,
-        perf_attach::{PerfLinkIdInner, PerfLinkInner},
-        probe::{OsStringExt as _, Probe, ProbeKind, attach},
+        FdLink, Link as _, LinkError, PerfLinkInner, ProgramData, ProgramError, ProgramType,
+        define_link_wrapper, load_program_with_attach_type, load_program_without_attach_type,
+        probe::{self, OsStringExt as _, Probe, ProbeKind, ProbeLinkIdInner, ProbeLinkInner},
     },
-    util::MMap,
+    sys::{SyscallError, bpf_link_create_uprobe_multi},
+    util::{KernelVersion, MMap},
 };
 
 const LD_SO_CACHE_FILE: &str = "/etc/ld.so.cache";
@@ -46,11 +55,19 @@ const LD_SO_CACHE_HEADER_NEW: &str = "glibc-ld.so.cache1.1";
 pub struct UProbe {
     pub(crate) data: ProgramData<UProbeLink>,
     pub(crate) kind: ProbeKind,
+    pub(crate) attach_mode: AttachMode,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) enum AttachMode {
+    Single,
+    Multi,
+    Unknown,
 }
 
 /// The location in the target object file to which the uprobe is to be
 /// attached.
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 pub enum UProbeAttachLocation<'a> {
     /// The location of the target function in the target object file.
     Symbol(&'a str),
@@ -63,6 +80,12 @@ pub enum UProbeAttachLocation<'a> {
 
 impl<'a> From<&'a str> for UProbeAttachLocation<'a> {
     fn from(s: &'a str) -> Self {
+        Self::Symbol(s)
+    }
+}
+
+impl<'a> From<&&'a str> for UProbeAttachLocation<'a> {
+    fn from(s: &&'a str) -> Self {
         Self::Symbol(s)
     }
 }
@@ -160,7 +183,14 @@ impl UProbeAttachLocation<'static> {
     }
 }
 
+impl From<&u64> for UProbeAttachLocation<'static> {
+    fn from(offset: &u64) -> Self {
+        Self::AbsoluteOffset(*offset)
+    }
+}
+
 /// Describes a single attachment point along with its optional cookie.
+#[derive(Debug, Clone, Copy)]
 pub struct UProbeAttachPoint<'a> {
     /// The actual target location.
     pub location: UProbeAttachLocation<'a>,
@@ -177,6 +207,12 @@ impl<'a, L: Into<UProbeAttachLocation<'a>>> From<L> for UProbeAttachPoint<'a> {
     }
 }
 
+impl From<&Self> for UProbeAttachPoint<'_> {
+    fn from(point: &Self) -> Self {
+        *point
+    }
+}
+
 /// Specifies which processes a uprobe should fire for.
 #[derive(Debug, Clone, Copy)]
 pub enum UProbeScope {
@@ -188,14 +224,137 @@ pub enum UProbeScope {
     OneProcess(NonZeroU32),
 }
 
+enum ResolvedPoints {
+    One {
+        offset: u64,
+        cookie: Option<u64>,
+    },
+    // Keep these as separate arrays to match the uprobe_multi kernel ABI,
+    // which takes offsets and cookies separately. This is private internal
+    // state, so keeping the arrays aligned is controlled here and avoids
+    // splitting a point-oriented representation before link_create.
+    Many {
+        offsets: Vec<u64>,
+        cookies: Option<Vec<u64>>,
+    },
+}
+
+enum PendingOffset<'a> {
+    Absolute(u64),
+    Symbol { symbol: &'a str, additional: u64 },
+}
+
+impl ResolvedPoints {
+    fn offsets(&self) -> &[u64] {
+        match self {
+            Self::One { offset, .. } => from_ref(offset),
+            Self::Many { offsets, .. } => offsets,
+        }
+    }
+
+    fn cookies(&self) -> Option<&[u64]> {
+        match self {
+            Self::One {
+                cookie: Some(cookie),
+                ..
+            } => Some(from_ref(cookie)),
+            Self::One { cookie: None, .. } => None,
+            Self::Many { cookies, .. } => cookies.as_deref(),
+        }
+    }
+}
+
+fn resolve_points<'a, I>(
+    path: &Path,
+    first: I::Item,
+    rest: I,
+) -> Result<ResolvedPoints, UProbeError>
+where
+    I: IntoIterator,
+    I::Item: Into<UProbeAttachPoint<'a>>,
+{
+    let first = first.into();
+    let mut rest = rest.into_iter();
+    let Some(second) = rest.next() else {
+        let UProbeAttachPoint { location, cookie } = first;
+        let (symbol, additional) = match location {
+            UProbeAttachLocation::Symbol(symbol) => (Some(symbol), 0),
+            UProbeAttachLocation::SymbolOffset(symbol, additional) => (Some(symbol), additional),
+            UProbeAttachLocation::AbsoluteOffset(offset) => (None, offset),
+        };
+        let offset = match symbol {
+            Some(symbol) => {
+                let offset =
+                    resolve_symbol(path, symbol).map_err(|error| UProbeError::SymbolError {
+                        symbol: symbol.to_string(),
+                        error: Box::new(error),
+                    })?;
+                offset + additional
+            }
+            None => additional,
+        };
+        return Ok(ResolvedPoints::One { offset, cookie });
+    };
+
+    let points = once(first)
+        .chain(once(second.into()))
+        .chain(rest.map(Into::into));
+    let (lower, _) = points.size_hint();
+    let mut pending_offsets = Vec::with_capacity(lower);
+    // `bpf_link_create()` expects either no cookie array at all or a full `u64`
+    // array aligned with the requested attach points (`cnt == offsets.len()`).
+    // Once any point has a cookie, fill in `0` for points that do not.
+    let mut cookies: Option<Vec<u64>> = None;
+    for UProbeAttachPoint { location, cookie } in points {
+        let index = pending_offsets.len();
+        let offset = match location {
+            UProbeAttachLocation::Symbol(symbol) => PendingOffset::Symbol {
+                symbol,
+                additional: 0,
+            },
+            UProbeAttachLocation::SymbolOffset(symbol, additional) => {
+                PendingOffset::Symbol { symbol, additional }
+            }
+            UProbeAttachLocation::AbsoluteOffset(offset) => PendingOffset::Absolute(offset),
+        };
+
+        pending_offsets.push(offset);
+        match (&mut cookies, cookie) {
+            (Some(values), Some(cookie)) => values.push(cookie),
+            (Some(values), None) => values.push(0),
+            (slot @ None, Some(cookie)) => {
+                let mut values = vec![0; index];
+                values.push(cookie);
+                *slot = Some(values);
+            }
+            (None, None) => {}
+        }
+    }
+
+    let offsets = resolve_pending_offsets(path, pending_offsets)?;
+
+    Ok(ResolvedPoints::Many { offsets, cookies })
+}
+
 impl UProbe {
     /// The type of the program according to the kernel.
     pub const PROGRAM_TYPE: ProgramType = ProgramType::KProbe;
 
     /// Loads the program inside the kernel.
     pub fn load(&mut self) -> Result<(), ProgramError> {
-        let Self { data, kind: _ } = self;
-        load_program_without_attach_type(BPF_PROG_TYPE_KPROBE, data)
+        let Self {
+            data,
+            kind: _,
+            attach_mode,
+        } = self;
+        match attach_mode {
+            AttachMode::Multi => {
+                load_program_with_attach_type(BPF_PROG_TYPE_KPROBE, BPF_TRACE_UPROBE_MULTI, data)
+            }
+            AttachMode::Single | AttachMode::Unknown => {
+                load_program_without_attach_type(BPF_PROG_TYPE_KPROBE, data)
+            }
+        }
     }
 
     /// Returns [`ProbeKind::Entry`] if the program is a `uprobe`, or
@@ -204,47 +363,79 @@ impl UProbe {
         self.kind
     }
 
-    /// Attaches the program.
+    /// Attaches the program to one or more locations.
     ///
-    /// Attaches the uprobe to `point` in the `target`. If the attach point is a
-    /// symbol offset, the offset is added to the address of the target function.
+    /// `points` accepts any `IntoIterator` of attachment points. For a single
+    /// point, pass a one-element array such as `["malloc"]`, `[0x10]`, or
+    /// `[UProbeAttachPoint { .. }]`. Each point can carry an optional cookie
+    /// exposed to eBPF through `bpf_get_attach_cookie()`. Empty input is
+    /// rejected with [`UProbeError::EmptyPoints`].
+    ///
+    /// Symbol offsets are added to the address of the target function.
     /// Absolute offsets must already be target object file offsets; use
     /// [`UProbeAttachLocation::from_virtual_address()`] to construct one from an
-    /// ELF virtual address. `scope` specifies which processes should trigger
-    /// the uprobe.
+    /// ELF virtual address.
     ///
-    /// The `target` argument can be an absolute or relative path to a binary or
-    /// shared library, or a library name (eg: `"libc"`).
+    /// On the multi-attach path, if any point has a cookie, Aya passes a full
+    /// cookie array to the kernel; points without cookies are filled with `0`.
+    /// `0` is also what `bpf_get_attach_cookie()` returns when the kernel has
+    /// no cookie for a point.
     ///
-    /// If the program is an `uprobe`, it is attached to the *start* address of
-    /// the target function.  Instead if the program is a `uretprobe`, it is
-    /// attached to the return address of the target function.
+    /// `target` can be an absolute or relative path to a binary or library, or
+    /// a library name (for example `"libc"`). `scope` specifies which processes
+    /// should trigger the uprobe.
+    ///
+    /// For handles created via `Ebpf::load*`, `attach_mode` is initialized
+    /// from the ELF section kind (`uprobe` or `uprobe.multi`). Handles created
+    /// via `from_pin` or `from_program_info` start in unknown mode, so this
+    /// method first attempts the multi path and falls back to the per-point
+    /// path on mode-related failures.
     ///
     /// The returned value can be used to detach, see [`UProbe::detach`].
     ///
     /// The cookie is supported since kernel 5.15, and it is made available to
-    /// the eBPF program via the `bpf_get_attach_cookie()` helper. The `point`
-    /// argument may be just a location (no cookie) or a [`UProbeAttachPoint`],
-    /// only the latter sets the cookie explicitly.
-    pub fn attach<'a, T: AsRef<Path>, Point: Into<UProbeAttachPoint<'a>>>(
+    /// the eBPF program via the `bpf_get_attach_cookie()` helper.
+    ///
+    /// On the legacy per-point attach path, each point is attached separately and
+    /// one logical link id manages all of them.
+    pub fn attach<'a, T, I>(
         &mut self,
-        point: Point,
+        points: I,
         target: T,
         scope: UProbeScope,
-    ) -> Result<UProbeLinkId, ProgramError> {
-        let UProbeAttachPoint { location, cookie } = point.into();
+    ) -> Result<UProbeLinkId, ProgramError>
+    where
+        T: AsRef<Path>,
+        I: IntoIterator,
+        I::Item: Into<UProbeAttachPoint<'a>>,
+    {
         let target = target.as_ref();
-        let (proc_map_pid, perf_event_pid) = match scope {
-            UProbeScope::AllProcesses => (None, None),
-            // /proc/0/maps does not exist, so use the real pid for ProcMap
-            // resolution while keeping the kernel's pid=0 sentinel for attach.
-            UProbeScope::CallingProcess => (Some(std::process::id()), Some(0)),
-            UProbeScope::OneProcess(pid) => {
-                let pid = pid.get();
-                (Some(pid), Some(pid))
+        let mut points = points.into_iter();
+        let Some(first) = points.next() else {
+            return Err(UProbeError::EmptyPoints {
+                target: target.to_path_buf(),
             }
+            .into());
         };
 
+        let (proc_map_pid, perf_event_pid, multi_link_pid) = match scope {
+            // For BPF_TRACE_UPROBE_MULTI link_create, pid=0 means no PID filter
+            // (all processes), so pass 0 for the multi-attach path.
+            UProbeScope::AllProcesses => (None, None, 0),
+            UProbeScope::CallingProcess => {
+                let pid = std::process::id();
+                // /proc/0/maps does not exist, so use the real pid for ProcMap
+                // resolution. Preserve pid=0 only for the legacy single-attach
+                // perf_event_open path, where it means calling process/thread.
+                // For uprobe_multi links, pid=0 means all processes; pass the
+                // real pid to scope the link to this process.
+                (Some(pid), Some(0), pid)
+            }
+            UProbeScope::OneProcess(pid) => {
+                let pid = pid.get();
+                (Some(pid), Some(pid), pid)
+            }
+        };
         // Keep ProcMap in this scope so resolve_attach_target_basename can return
         // a path borrowed from the maps buffer without cloning the matched path.
         // This keeps the borrow alive until attach uses it.
@@ -252,43 +443,142 @@ impl UProbe {
         // /proc/<pid>/maps entries are matched by basename, so only bare-basename
         // targets can benefit from the lookup; paths with a directory separator
         // are passed through unchanged.
-        let path = if is_basename_only(target) {
+        let resolved_path = if is_basename_only(target) {
             proc_map = proc_map_pid.map(ProcMap::new).transpose()?;
             resolve_attach_target_basename(target, proc_map.as_ref())?
         } else {
             target
         };
-
-        let (symbol, offset) = match location {
-            UProbeAttachLocation::Symbol(s) => (Some(s), 0),
-            UProbeAttachLocation::SymbolOffset(s, offset) => (Some(s), offset),
-            UProbeAttachLocation::AbsoluteOffset(offset) => (None, offset),
-        };
-        let offset = if let Some(symbol) = symbol {
-            let symbol_offset =
-                resolve_symbol(path, symbol).map_err(|error| UProbeError::SymbolError {
-                    symbol: symbol.to_string(),
-                    error: Box::new(error),
-                })?;
-            symbol_offset + offset
-        } else {
-            offset
-        };
-
-        let Self { data, kind } = self;
-        let path = path.as_os_str();
-        attach::<Self, _>(data, *kind, path, offset, perf_event_pid, cookie)
+        let resolved = resolve_points(resolved_path, first, points)?;
+        self.attach_impl(resolved_path, &resolved, perf_event_pid, multi_link_pid)
     }
 
-    /// Creates a program from a pinned entry on a bpffs.
+    /// Creates a program handle from a pinned entry on bpffs.
     ///
-    /// Existing links will not be populated. To work with existing links you should use [`crate::programs::links::PinnedLink`].
+    /// Existing links are not populated. To work with existing links, use
+    /// [`crate::programs::links::PinnedLink`].
+    ///
+    /// This constructor starts in unknown mode because it does not know
+    /// whether the original program came from an `uprobe` or `uprobe.multi`
+    /// section. As a result, [`Self::attach`] performs runtime mode selection.
     ///
     /// On drop, any managed links are detached and the program is unloaded. This will not result in
     /// the program being unloaded from the kernel if it is still pinned.
     pub fn from_pin<P: AsRef<Path>>(path: P, kind: ProbeKind) -> Result<Self, ProgramError> {
         let data = ProgramData::from_pinned_path(path, VerifierLogLevel::default())?;
-        Ok(Self { data, kind })
+        Ok(Self {
+            data,
+            kind,
+            attach_mode: AttachMode::Unknown,
+        })
+    }
+
+    fn attach_impl(
+        &mut self,
+        path: &Path,
+        resolved: &ResolvedPoints,
+        perf_event_pid: Option<u32>,
+        multi_link_pid: u32,
+    ) -> Result<UProbeLinkId, ProgramError> {
+        match self.attach_mode {
+            AttachMode::Single => self.attach_single_impl(path, resolved, perf_event_pid),
+            AttachMode::Multi => self.attach_multi_impl(path, resolved, multi_link_pid),
+            AttachMode::Unknown => {
+                let multi_result = self.attach_multi_impl(path, resolved, multi_link_pid);
+                match multi_result {
+                    Ok(link_id) => {
+                        self.attach_mode = AttachMode::Multi;
+                        Ok(link_id)
+                    }
+                    Err(multi_error) if should_fallback_to_single(&multi_error) => {
+                        match self.attach_single_impl(path, resolved, perf_event_pid) {
+                            Ok(link_id) => {
+                                self.attach_mode = AttachMode::Single;
+                                Ok(link_id)
+                            }
+                            Err(single_error) => Err(UProbeError::AttachModeSelectionFailed {
+                                multi_error: Box::new(multi_error),
+                                single_error: Box::new(single_error),
+                            }
+                            .into()),
+                        }
+                    }
+                    Err(error) => Err(error),
+                }
+            }
+        }
+    }
+
+    fn attach_single_impl(
+        &mut self,
+        path: &Path,
+        resolved: &ResolvedPoints,
+        pid: Option<u32>,
+    ) -> Result<UProbeLinkId, ProgramError> {
+        let Self { data, kind, .. } = self;
+        let path = path.as_os_str();
+        match resolved {
+            ResolvedPoints::One { offset, cookie } => {
+                let link = attach_single_point::<Self>(data, *kind, path, *offset, pid, *cookie)?;
+                data.links
+                    .insert(UProbeLink::from(ProbeLinkInner::from(link)))
+            }
+            ResolvedPoints::Many { offsets, cookies } => {
+                let mut links = Vec::with_capacity(offsets.len());
+
+                for (index, offset) in offsets.iter().copied().enumerate() {
+                    let cookie = cookies
+                        .as_ref()
+                        .and_then(|cookies| cookies.get(index).copied());
+                    let link = attach_single_point::<Self>(data, *kind, path, offset, pid, cookie);
+                    match link {
+                        Ok(link) => links.push(link),
+                        Err(error) => {
+                            // FdLink and PerfLink currently detach infallibly; this Result exists
+                            // only because Link::detach requires it. If either starts surfacing
+                            // errors, update this rollback path to report all cleanup errors
+                            // alongside the attach error.
+                            let _unused: Result<(), ProgramError> =
+                                ProbeLinkInner::Many(links).detach();
+                            return Err(UProbeError::LegacyPerfAttachPointError {
+                                index,
+                                resolved_offset: offset,
+                                attach_error: Box::new(error),
+                            }
+                            .into());
+                        }
+                    }
+                }
+
+                data.links
+                    .insert(UProbeLink::from(ProbeLinkInner::Many(links)))
+            }
+        }
+    }
+
+    fn attach_multi_impl(
+        &mut self,
+        path: &Path,
+        resolved: &ResolvedPoints,
+        pid: u32,
+    ) -> Result<UProbeLinkId, ProgramError> {
+        let Self { data, kind, .. } = self;
+        let prog_fd = data.fd()?;
+        let prog_fd = prog_fd.as_fd();
+        let path_cstr = CString::new(path.as_os_str().as_bytes()).map_err(|error| {
+            ProgramError::IOError(io::Error::new(io::ErrorKind::InvalidInput, error))
+        })?;
+
+        let link = try_attach_uprobe_multi_link(
+            prog_fd,
+            &path_cstr,
+            resolved.offsets(),
+            pid,
+            *kind,
+            resolved.cookies(),
+        )?;
+        data.links
+            .insert(UProbeLink::from(ProbeLinkInner::from(link)))
     }
 }
 
@@ -349,21 +639,297 @@ where
 define_link_wrapper!(
     UProbeLink,
     UProbeLinkId,
-    PerfLinkInner,
-    PerfLinkIdInner,
+    ProbeLinkInner,
+    ProbeLinkIdInner,
     UProbe,
 );
 
-impl_try_into_fdlink!(UProbeLink, PerfLinkInner);
-impl_try_from_fdlink!(
-    UProbeLink,
-    PerfLinkInner,
-    bpf_link_type::BPF_LINK_TYPE_PERF_EVENT
-);
+impl TryFrom<UProbeLink> for FdLink {
+    type Error = LinkError;
+
+    fn try_from(value: UProbeLink) -> Result<Self, Self::Error> {
+        match value.into_inner() {
+            ProbeLinkInner::One(PerfLinkInner::Fd(link)) => Ok(link),
+            ProbeLinkInner::One(PerfLinkInner::PerfLink(_)) | ProbeLinkInner::Many(_) => {
+                Err(LinkError::InvalidLink)
+            }
+        }
+    }
+}
+
+impl TryFrom<FdLink> for UProbeLink {
+    type Error = LinkError;
+
+    fn try_from(fd_link: FdLink) -> Result<Self, Self::Error> {
+        let info = crate::sys::bpf_link_get_info_by_fd(fd_link.fd.as_fd())?;
+        if info.type_ == bpf_link_type::BPF_LINK_TYPE_PERF_EVENT as u32
+            || info.type_ == bpf_link_type::BPF_LINK_TYPE_UPROBE_MULTI as u32
+        {
+            return Ok(Self::new(ProbeLinkInner::from(fd_link)));
+        }
+        Err(LinkError::InvalidLink)
+    }
+}
+
+impl UProbeLink {
+    /// Returns the underlying fd-backed links when available.
+    ///
+    /// A single [`UProbeLink`] may correspond to multiple [`FdLink`] values
+    /// when [`UProbe::attach`] falls back to the legacy single-point attach
+    /// path for multiple attachment points.
+    ///
+    /// If the underlying link representation is not fd-backed, the original
+    /// [`UProbeLink`] is returned.
+    pub fn into_fd_links(self) -> Result<Vec<FdLink>, Self> {
+        self.into_inner().into_fd_links().map_err(Self::from)
+    }
+}
+
+fn attach_single_point<P: Probe>(
+    data: &ProgramData<UProbeLink>,
+    kind: ProbeKind,
+    path: &OsStr,
+    offset: u64,
+    pid: Option<u32>,
+    cookie: Option<u64>,
+) -> Result<PerfLinkInner, ProgramError> {
+    let prog_fd = data.fd()?;
+    let prog_fd = prog_fd.as_fd();
+    probe::attach_perf_link::<P>(prog_fd, kind, path, offset, pid, cookie)
+}
+
+fn find_symbol_in_object<'a>(obj: &'a object::File<'a>, symbol: &str) -> Option<Symbol<'a, 'a>> {
+    obj.dynamic_symbols()
+        .chain(obj.symbols())
+        .find(|sym| sym.name().is_ok_and(|name| name == symbol))
+}
+
+fn resolve_symbol(path: &Path, symbol: &str) -> Result<u64, ResolveSymbolError> {
+    let data = MMap::map_copy_read_only(path)?;
+    let obj = object::read::File::parse(data.as_ref())?;
+
+    if let Some(sym) = find_symbol_in_object(&obj, symbol) {
+        symbol_translated_address(&obj, sym, symbol)
+    } else {
+        let debug_path = find_debug_path_in_object(&obj, path, symbol)?;
+        let debug_data = MMap::map_copy_read_only(&debug_path).map_err(|error| {
+            ResolveSymbolError::DebuglinkAccessError(debug_path.into_owned(), error)
+        })?;
+        let debug_obj = object::read::File::parse(debug_data.as_ref())?;
+
+        verify_build_ids(&obj, &debug_obj, symbol)?;
+
+        let sym = find_symbol_in_object(&debug_obj, symbol)
+            .ok_or_else(|| ResolveSymbolError::Unknown(symbol.to_string()))?;
+        symbol_translated_address(&debug_obj, sym, symbol)
+    }
+}
+
+fn resolve_pending_offsets(
+    path: &Path,
+    pending_offsets: Vec<PendingOffset<'_>>,
+) -> Result<Vec<u64>, UProbeError> {
+    // Resolve each requested symbol once. Duplicate attach points share the
+    // resolved base offset before their per-point additional offsets are
+    // applied below.
+    let mut resolved_symbols = pending_offsets
+        .iter()
+        .filter_map(|offset| match offset {
+            PendingOffset::Absolute(_) => None,
+            PendingOffset::Symbol { symbol, .. } => Some((*symbol, None)),
+        })
+        .collect::<HashMap<_, _>>();
+
+    if let Some(first_symbol) = pending_offsets.iter().find_map(|offset| match offset {
+        PendingOffset::Absolute(_) => None,
+        PendingOffset::Symbol { symbol, .. } => Some(*symbol),
+    }) {
+        let symbol_error = |fallback_symbol: &str, error: ResolveSymbolError| {
+            let symbol = match &error {
+                ResolveSymbolError::Unknown(symbol)
+                | ResolveSymbolError::NotInSection(symbol)
+                | ResolveSymbolError::SectionFileRangeNone(symbol, _)
+                | ResolveSymbolError::BuildIdMismatch(symbol) => symbol.as_str(),
+                _ => fallback_symbol,
+            }
+            .to_owned();
+            UProbeError::SymbolError {
+                symbol,
+                error: Box::new(error),
+            }
+        };
+
+        let data = MMap::map_copy_read_only(path)
+            .map_err(|error| symbol_error(first_symbol, ResolveSymbolError::Io(error)))?;
+        let obj = object::read::File::parse(data.as_ref())
+            .map_err(|error| symbol_error(first_symbol, ResolveSymbolError::Object(error)))?;
+        resolve_symbols_in_object(&obj, &mut resolved_symbols)
+            .map_err(|error| symbol_error(first_symbol, error))?;
+
+        let unresolved_first_symbol = pending_offsets.iter().find_map(|offset| match offset {
+            PendingOffset::Absolute(_) => None,
+            PendingOffset::Symbol { symbol, .. }
+                if resolved_symbols.get(symbol).is_some_and(Option::is_none) =>
+            {
+                Some(*symbol)
+            }
+            PendingOffset::Symbol { .. } => None,
+        });
+
+        if let Some(unresolved_first_symbol) = unresolved_first_symbol {
+            let debug_path = find_debug_path_in_object(&obj, path, unresolved_first_symbol)
+                .map_err(|error| symbol_error(unresolved_first_symbol, error))?;
+            let data = MMap::map_copy_read_only(&debug_path).map_err(|e| {
+                symbol_error(
+                    unresolved_first_symbol,
+                    ResolveSymbolError::DebuglinkAccessError(debug_path.clone().into_owned(), e),
+                )
+            })?;
+            let debug_obj = object::read::File::parse(data.as_ref()).map_err(|error| {
+                symbol_error(unresolved_first_symbol, ResolveSymbolError::Object(error))
+            })?;
+            verify_build_ids(&obj, &debug_obj, unresolved_first_symbol)
+                .map_err(|error| symbol_error(unresolved_first_symbol, error))?;
+            resolve_symbols_in_object(&debug_obj, &mut resolved_symbols)
+                .map_err(|error| symbol_error(unresolved_first_symbol, error))?;
+        }
+    }
+
+    pending_offsets
+        .into_iter()
+        .map(|offset| match offset {
+            PendingOffset::Absolute(offset) => Ok(offset),
+            PendingOffset::Symbol { symbol, additional } => {
+                let offset = resolved_symbols
+                    .get(symbol)
+                    .copied()
+                    .flatten()
+                    .ok_or_else(|| UProbeError::SymbolError {
+                        symbol: symbol.to_string(),
+                        error: Box::new(ResolveSymbolError::Unknown(symbol.to_string())),
+                    })?;
+                Ok(offset + additional)
+            }
+        })
+        .collect()
+}
+
+fn resolve_symbols_in_object(
+    obj: &object::File<'_>,
+    symbols: &mut HashMap<&str, Option<u64>>,
+) -> Result<(), ResolveSymbolError> {
+    if symbols.is_empty() {
+        return Ok(());
+    }
+
+    let mut remaining = symbols.values().filter(|offset| offset.is_none()).count();
+
+    for sym in obj.dynamic_symbols().chain(obj.symbols()) {
+        let Ok(symbol_name) = sym.name() else {
+            continue;
+        };
+
+        let Some(offset) = symbols.get_mut(symbol_name) else {
+            continue;
+        };
+        if offset.is_some() {
+            continue;
+        }
+
+        *offset = Some(symbol_translated_address(obj, sym, symbol_name)?);
+        remaining -= 1;
+        if remaining == 0 {
+            return Ok(());
+        }
+    }
+
+    Ok(())
+}
+
+fn try_attach_uprobe_multi_link(
+    prog_fd: BorrowedFd<'_>,
+    path: &CStr,
+    offsets: &[u64],
+    pid: u32,
+    kind: ProbeKind,
+    cookies: Option<&[u64]>,
+) -> Result<PerfLinkInner, ProgramError> {
+    let link_fd = bpf_link_create_uprobe_multi(
+        prog_fd,
+        path,
+        offsets,
+        None,
+        cookies,
+        pid,
+        matches!(kind, ProbeKind::Return),
+    )
+    .map_err(|io_error| {
+        let errno = io_error.raw_os_error();
+        let is_unsupported = match errno {
+            Some(code) if code == ENOTSUP || code == EOPNOTSUPP => true,
+            // Multi-uprobe landed in Linux 6.6, older kernels may return EINVAL
+            // for the unknown attach type (see BPF_TRACE_UPROBE_MULTI in
+            // https://elixir.bootlin.com/linux/v6.6/source/include/uapi/linux/bpf.h#L1042).
+            Some(code) if code == EINVAL => {
+                KernelVersion::current().is_ok_and(|kv| kv < KernelVersion::new(6, 6, 0))
+            }
+            _ => false,
+        };
+
+        if is_unsupported {
+            ProgramError::UProbeError(UProbeError::MultiLinkNotSupported)
+        } else {
+            ProgramError::SyscallError(SyscallError {
+                call: "bpf_link_create",
+                io_error,
+            })
+        }
+    })?;
+    Ok(PerfLinkInner::Fd(FdLink::new(link_fd)))
+}
+
+// In AttachMode::Unknown we probe whether the loaded program should attach via
+// BPF_TRACE_UPROBE_MULTI or the legacy single-point perf path.
+//
+// Fallback is appropriate in two cases:
+// - MultiLinkNotSupported: try_attach_uprobe_multi_link() uses this for
+//   kernels that do not implement multi-uprobe links, including older kernels
+//   (< 6.6) that may report the unknown attach type as EINVAL.
+// - bpf_link_create(...)=EINVAL: on kernels that do support multi-uprobe links,
+//   a handle loaded from pin/program info can still hit EINVAL when the loaded
+//   program expects the legacy per-point attach path rather than the multi
+//   attach type. In that case we intentionally retry via the per-point path
+//   instead of surfacing the mode-probing error.
+//
+// Other errors indicate a real multi-attach failure and are propagated.
+fn should_fallback_to_single(error: &ProgramError) -> bool {
+    match error {
+        ProgramError::UProbeError(UProbeError::MultiLinkNotSupported) => true,
+        ProgramError::SyscallError(SyscallError {
+            call: "bpf_link_create",
+            io_error,
+        }) => io_error.raw_os_error() == Some(EINVAL),
+        _ => false,
+    }
+}
 
 /// The type returned when attaching an [`UProbe`] fails.
 #[derive(Debug, Error)]
 pub enum UProbeError {
+    /// Automatic attach-mode selection failed in both multi and legacy perf paths.
+    #[error(
+        "automatic uprobe attach-mode selection failed: multi={multi_error}; \
+         legacy perf={single_error}"
+    )]
+    // Box the nested ProgramError values to avoid the recursive
+    // `ProgramError -> UProbeError -> ProgramError` type.
+    AttachModeSelectionFailed {
+        /// Error returned by the multi-uprobe path.
+        multi_error: Box<ProgramError>,
+        /// Error returned by the legacy perf path.
+        single_error: Box<ProgramError>,
+    },
+
     /// There was an error parsing `/etc/ld.so.cache`.
     #[error("error reading `{}` file", LD_SO_CACHE_FILE)]
     InvalidLdSoCache {
@@ -399,7 +965,7 @@ pub enum UProbeError {
         io_error: io::Error,
     },
 
-    /// There was en error fetching the memory map for `pid`.
+    /// There was an error fetching the memory map for `pid`.
     #[error("error fetching libs for {pid}")]
     ProcMap {
         /// The pid.
@@ -407,6 +973,34 @@ pub enum UProbeError {
         /// The [`ProcMapError`] that caused the error.
         #[source]
         source: ProcMapError,
+    },
+
+    /// The kernel does not support native multi-uprobe links.
+    #[error("native multi-uprobe links are not supported by the running kernel")]
+    MultiLinkNotSupported,
+
+    /// No attach points were provided.
+    #[error("no uprobe attach points provided for target `{target}`")]
+    EmptyPoints {
+        /// Target provided by the caller.
+        target: PathBuf,
+    },
+
+    /// The legacy perf attach path failed for a specific point.
+    #[error(
+        "legacy perf attach failed at point #{index}, resolved offset \
+         {resolved_offset:#x}: {attach_error}"
+    )]
+    // Box the nested ProgramError values to avoid the recursive
+    // `ProgramError -> UProbeError -> ProgramError` type.
+    LegacyPerfAttachPointError {
+        /// Index of the attach point within the caller input slice.
+        index: usize,
+        /// Resolved file offset used by the failing perf attach operation.
+        resolved_offset: u64,
+        /// Original error returned by the attach syscall path.
+        #[source]
+        attach_error: Box<ProgramError>,
     },
 }
 
@@ -425,7 +1019,7 @@ pub enum ProcMapError {
     },
 }
 
-/// A entry that has been parsed from /proc/`pid`/maps.
+/// An entry parsed from /proc/`pid`/maps.
 ///
 /// This contains information about a mapped portion of memory
 /// for the process, ranging from address to `address_end`.
@@ -806,34 +1400,6 @@ fn find_debug_path_in_object<'a>(
     }
 }
 
-fn find_symbol_in_object<'a>(obj: &'a object::File<'a>, symbol: &str) -> Option<Symbol<'a, 'a>> {
-    obj.dynamic_symbols()
-        .chain(obj.symbols())
-        .find(|sym| sym.name().is_ok_and(|name| name == symbol))
-}
-
-fn resolve_symbol(path: &Path, symbol: &str) -> Result<u64, ResolveSymbolError> {
-    let data = MMap::map_copy_read_only(path)?;
-    let obj = object::read::File::parse(data.as_ref())?;
-
-    if let Some(sym) = find_symbol_in_object(&obj, symbol) {
-        symbol_translated_address(&obj, sym, symbol)
-    } else {
-        // Only search in the debug object if the symbol was not found in the main object
-        let debug_path = find_debug_path_in_object(&obj, path, symbol)?;
-        let debug_data = MMap::map_copy_read_only(&debug_path)
-            .map_err(|e| ResolveSymbolError::DebuglinkAccessError(debug_path.into_owned(), e))?;
-        let debug_obj = object::read::File::parse(debug_data.as_ref())?;
-
-        verify_build_ids(&obj, &debug_obj, symbol)?;
-
-        let sym = find_symbol_in_object(&debug_obj, symbol)
-            .ok_or_else(|| ResolveSymbolError::Unknown(symbol.to_string()))?;
-
-        symbol_translated_address(&debug_obj, sym, symbol)
-    }
-}
-
 fn symbol_translated_address(
     obj: &object::File<'_>,
     sym: Symbol<'_, '_>,
@@ -862,11 +1428,161 @@ fn symbol_translated_address(
 
 #[cfg(test)]
 mod tests {
+    use std::os::fd::FromRawFd as _;
+
     use assert_matches::assert_matches;
-    use object::{Architecture, BinaryFormat, Endianness, write::SectionKind};
+    use object::{
+        Architecture, BinaryFormat, Endianness, SymbolKind, SymbolScope,
+        write::{SectionKind, StandardSection, Symbol, SymbolFlags, SymbolSection},
+    };
     use rstest::rstest;
+    use tempfile::tempdir;
 
     use super::*;
+    use crate::programs::FdLinkId;
+
+    fn mock_fd_link(raw_fd: i32) -> FdLink {
+        let fd = unsafe { crate::MockableFd::from_raw_fd(raw_fd) };
+        FdLink::new(fd)
+    }
+
+    #[test]
+    fn test_resolve_points_one_preserves_cookie() {
+        let mut points = once(UProbeAttachPoint {
+            location: UProbeAttachLocation::AbsoluteOffset(0x42),
+            cookie: Some(0x42),
+        });
+        match resolve_points(Path::new("/proc/self/exe"), points.next().unwrap(), points).unwrap() {
+            ResolvedPoints::One {
+                offset: 0x42,
+                cookie: Some(0x42),
+            } => {}
+            ResolvedPoints::One { .. } => panic!("unexpected points"),
+            ResolvedPoints::Many { .. } => panic!("unexpected points"),
+        }
+    }
+
+    #[test]
+    fn test_resolve_points_many_fills_missing_cookies_with_zero() {
+        let mut points = [
+            UProbeAttachPoint {
+                location: UProbeAttachLocation::AbsoluteOffset(0x11),
+                cookie: Some(0x22),
+            },
+            UProbeAttachPoint {
+                location: UProbeAttachLocation::AbsoluteOffset(0x33),
+                cookie: None,
+            },
+        ]
+        .into_iter();
+        match resolve_points(Path::new("/proc/self/exe"), points.next().unwrap(), points).unwrap() {
+            ResolvedPoints::Many { offsets, cookies } => {
+                assert_eq!(offsets, vec![0x11, 0x33]);
+                assert_eq!(cookies, Some(vec![0x22, 0]));
+            }
+            ResolvedPoints::One { .. } => panic!("unexpected points"),
+        }
+    }
+
+    fn create_elf_with_text_symbols(
+        symbols: &[(&[u8], u64)],
+    ) -> Result<Vec<u8>, object::write::Error> {
+        let mut obj =
+            object::write::Object::new(BinaryFormat::Elf, Architecture::X86_64, Endianness::Little);
+        let text_section = obj.section_id(StandardSection::Text);
+        obj.append_section_data(text_section, &[0; 0x40], 1);
+
+        for &(name, value) in symbols {
+            obj.add_symbol(Symbol {
+                name: name.to_vec(),
+                value,
+                size: 1,
+                kind: SymbolKind::Text,
+                scope: SymbolScope::Linkage,
+                weak: false,
+                section: SymbolSection::Section(text_section),
+                flags: SymbolFlags::None,
+            });
+        }
+
+        obj.write()
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore = "`mkdir` not available when isolation is enabled")]
+    fn test_resolve_points_many_resolves_mixed_offsets_in_order() {
+        let mut bytes =
+            create_elf_with_text_symbols(&[(b"first", 0x10), (b"second", 0x24)]).unwrap();
+        crate::sys::TEST_MMAP_RET.with(|ret| *ret.borrow_mut() = bytes.as_mut_ptr().cast());
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("symbols.elf");
+        fs::write(&path, &bytes).unwrap();
+        // Mix duplicate symbols, per-point additional offsets, and an absolute
+        // offset to verify that batch resolution preserves the original point
+        // order.
+        let mut points = [
+            UProbeAttachLocation::SymbolOffset("first", 0x4),
+            UProbeAttachLocation::AbsoluteOffset(0x88),
+            UProbeAttachLocation::Symbol("second"),
+            UProbeAttachLocation::SymbolOffset("first", 0x8),
+        ]
+        .into_iter();
+
+        match resolve_points(&path, points.next().unwrap(), points).unwrap() {
+            ResolvedPoints::Many { offsets, cookies } => {
+                assert_eq!(offsets, vec![0x14, 0x88, 0x24, 0x18]);
+                assert_eq!(cookies, None);
+            }
+            ResolvedPoints::One { .. } => panic!("unexpected points"),
+        }
+    }
+
+    #[test]
+    fn test_resolve_symbols_in_object_preserves_resolved_symbols() {
+        let mut bytes =
+            create_elf_with_text_symbols(&[(b"first", 0x10), (b"second", 0x24)]).unwrap();
+        let align_bytes = aligned_slice(&mut bytes);
+        let obj = object::File::parse(&*align_bytes).unwrap();
+        let mut symbols = HashMap::from([("first", Some(0x42)), ("second", None)]);
+
+        resolve_symbols_in_object(&obj, &mut symbols).unwrap();
+        assert_eq!(symbols["first"], Some(0x42));
+        assert_eq!(symbols["second"], Some(0x24));
+    }
+
+    #[test]
+    fn test_uprobe_link_into_fd_links_single() {
+        let fd = crate::MockableFd::mock_signed_fd();
+        let link = UProbeLink::from(ProbeLinkInner::from(mock_fd_link(fd)));
+
+        let fd_links = link.into_fd_links().unwrap();
+        assert_eq!(
+            fd_links
+                .into_iter()
+                .map(|link| link.id())
+                .collect::<Vec<_>>(),
+            vec![FdLinkId(fd)]
+        );
+    }
+
+    #[test]
+    fn test_uprobe_link_into_fd_links_many() {
+        let first_fd = crate::MockableFd::mock_signed_fd();
+        let second_fd = first_fd + 1;
+        let link = UProbeLink::from(ProbeLinkInner::Many(vec![
+            PerfLinkInner::Fd(mock_fd_link(first_fd)),
+            PerfLinkInner::Fd(mock_fd_link(second_fd)),
+        ]));
+
+        let fd_links = link.into_fd_links().unwrap();
+        assert_eq!(
+            fd_links
+                .into_iter()
+                .map(|link| link.id())
+                .collect::<Vec<_>>(),
+            vec![FdLinkId(first_fd), FdLinkId(second_fd)]
+        );
+    }
 
     // Only run this test on with libc dynamically linked so that it can
     // exercise resolving the path to libc via the current process's memory map.

--- a/aya/src/sys/bpf.rs
+++ b/aya/src/sys/bpf.rs
@@ -16,10 +16,11 @@ use aya_obj::{
         VarLinkage,
     },
     generated::{
-        BPF_ALU64, BPF_DW, BPF_EXIT, BPF_F_REPLACE, BPF_F_TEST_RUN_ON_CPU, BPF_IMM, BPF_JMP, BPF_K,
-        BPF_LD, BPF_MEM, BPF_MOV, BPF_PSEUDO_MAP_VALUE, BPF_ST, bpf_attach_type, bpf_attr,
-        bpf_attr__bindgen_ty_7, bpf_btf_info, bpf_cmd, bpf_insn, bpf_link_info, bpf_map_info,
-        bpf_map_type, bpf_prog_info, bpf_prog_type, bpf_stats_type,
+        BPF_ALU64, BPF_DW, BPF_EXIT, BPF_F_REPLACE, BPF_F_TEST_RUN_ON_CPU,
+        BPF_F_UPROBE_MULTI_RETURN, BPF_IMM, BPF_JMP, BPF_K, BPF_LD, BPF_MEM, BPF_MOV,
+        BPF_PSEUDO_MAP_VALUE, BPF_ST, bpf_attach_type, bpf_attr, bpf_attr__bindgen_ty_7,
+        bpf_btf_info, bpf_cmd, bpf_insn, bpf_link_info, bpf_map_info, bpf_map_type, bpf_prog_info,
+        bpf_prog_type, bpf_stats_type,
     },
     maps::{LegacyMap, bpf_map_def},
 };
@@ -421,15 +422,26 @@ pub(crate) enum LinkTarget<'f> {
     Fd(BorrowedFd<'f>),
     IfIndex(u32),
     Iter,
+    None,
 }
 
 // Models https://github.com/torvalds/linux/blob/2144da25/include/uapi/linux/bpf.h#L1724-L1782.
 pub(crate) enum BpfLinkCreateArgs<'a> {
     TargetBtfId(u32),
     // since kernel 5.15
-    PerfEvent { bpf_cookie: u64 },
+    PerfEvent {
+        bpf_cookie: u64,
+    },
     // since kernel 6.6
     Tcx(&'a LinkRef),
+    UProbeMulti {
+        path: &'a CStr,
+        offsets: &'a [u64],
+        ref_ctr_offsets: Option<&'a [u64]>,
+        cookies: Option<&'a [u64]>,
+        pid: u32,
+        flags: u32,
+    },
 }
 
 // since kernel 5.7
@@ -455,7 +467,7 @@ pub(crate) fn bpf_link_create(
         // fact, the kernel explicitly rejects non-zero target FDs for
         // iterators:
         // https://github.com/torvalds/linux/blob/v6.12/kernel/bpf/bpf_iter.c#L517-L518
-        LinkTarget::Iter => {}
+        LinkTarget::Iter | LinkTarget::None => {}
     }
     attr.link_create.attach_type = attach_type.into() as u32;
     attr.link_create.flags = flags;
@@ -487,6 +499,27 @@ pub(crate) fn bpf_link_create(
                     );
                 },
             },
+            BpfLinkCreateArgs::UProbeMulti {
+                path,
+                offsets,
+                ref_ctr_offsets,
+                cookies,
+                pid,
+                flags,
+            } => {
+                let multi = unsafe { &mut attr.link_create.__bindgen_anon_3.uprobe_multi };
+                multi.path = path.as_ptr() as u64;
+                multi.offsets = offsets.as_ptr() as u64;
+                multi.cnt = offsets.len() as u32;
+                multi.flags = flags;
+                multi.pid = pid;
+                multi.ref_ctr_offsets = ref_ctr_offsets
+                    .map(|slice| slice.as_ptr() as u64)
+                    .unwrap_or_default();
+                multi.cookies = cookies
+                    .map(|slice| slice.as_ptr() as u64)
+                    .unwrap_or_default();
+            }
         }
     }
 
@@ -497,6 +530,36 @@ pub(crate) fn bpf_link_create(
     with_raised_rlimit_retry(
         || unsafe { fd_sys_bpf(bpf_cmd::BPF_LINK_CREATE, &mut attr) },
         &[EPERM, ENOMEM],
+    )
+}
+
+pub(crate) fn bpf_link_create_uprobe_multi(
+    prog_fd: BorrowedFd<'_>,
+    path: &CStr,
+    offsets: &[u64],
+    ref_ctr_offsets: Option<&[u64]>,
+    cookies: Option<&[u64]>,
+    pid: u32,
+    retprobe: bool,
+) -> io::Result<crate::MockableFd> {
+    let args = BpfLinkCreateArgs::UProbeMulti {
+        path,
+        offsets,
+        ref_ctr_offsets,
+        cookies,
+        pid,
+        flags: if retprobe {
+            BPF_F_UPROBE_MULTI_RETURN
+        } else {
+            0
+        },
+    };
+    bpf_link_create(
+        prog_fd,
+        LinkTarget::None,
+        bpf_attach_type::BPF_TRACE_UPROBE_MULTI,
+        0,
+        Some(args),
     )
 }
 

--- a/test/integration-ebpf/Cargo.toml
+++ b/test/integration-ebpf/Cargo.toml
@@ -165,6 +165,10 @@ name = "uprobe_cookie"
 path = "src/uprobe_cookie.rs"
 
 [[bin]]
+name = "uprobe_multi"
+path = "src/uprobe_multi.rs"
+
+[[bin]]
 name = "perf_event_bp"
 path = "src/perf_event_bp.rs"
 

--- a/test/integration-ebpf/src/uprobe_multi.rs
+++ b/test/integration-ebpf/src/uprobe_multi.rs
@@ -1,0 +1,32 @@
+#![no_std]
+#![no_main]
+#![expect(unused_crate_dependencies, reason = "used in other bins")]
+
+use aya_ebpf::{
+    EbpfContext as _, helpers,
+    macros::{map, uprobe},
+    maps::RingBuf,
+    programs::ProbeContext,
+};
+#[cfg(not(test))]
+extern crate ebpf_panic;
+
+#[map]
+static RING_BUF: RingBuf = RingBuf::with_byte_size(0, 0);
+
+#[inline(always)]
+fn output_cookie(ctx: &ProbeContext) {
+    let cookie = unsafe { helpers::bpf_get_attach_cookie(ctx.as_ptr()) };
+    let cookie_bytes = cookie.to_ne_bytes();
+    let _res = RING_BUF.output::<[u8]>(cookie_bytes, 0);
+}
+
+#[uprobe(multi)]
+fn uprobe_multi(ctx: ProbeContext) {
+    output_cookie(&ctx);
+}
+
+#[uprobe]
+fn uprobe_single(ctx: ProbeContext) {
+    output_cookie(&ctx);
+}

--- a/test/integration-test/src/lib.rs
+++ b/test/integration-test/src/lib.rs
@@ -90,6 +90,7 @@ bpf_file!(
     XSK_MAP => "xsk_map",
     INODE_STORAGE => "inode_storage",
     CGRP_STORAGE => "cgrp_storage",
+    UPROBE_MULTI => "uprobe_multi",
 );
 
 #[cfg(test)]

--- a/test/integration-test/src/tests.rs
+++ b/test/integration-test/src/tests.rs
@@ -68,4 +68,5 @@ mod strncmp;
 mod tc_netlink;
 mod tcx;
 mod uprobe_cookie;
+mod uprobe_multi;
 mod xdp;

--- a/test/integration-test/src/tests/array.rs
+++ b/test/integration-test/src/tests/array.rs
@@ -64,7 +64,7 @@ fn test_array(
             .unwrap_or_else(|err| panic!("program {prog_name} is not a uprobe: {err}"));
         prog.load()
             .unwrap_or_else(|err| panic!("load {prog_name}: {err}"));
-        prog.attach(symbol, "/proc/self/exe", UProbeScope::AllProcesses)
+        prog.attach([symbol], "/proc/self/exe", UProbeScope::AllProcesses)
             .unwrap_or_else(|err| panic!("attach {prog_name}: {err}"));
     }
 

--- a/test/integration-test/src/tests/bloom_filter.rs
+++ b/test/integration-test/src/tests/bloom_filter.rs
@@ -63,7 +63,7 @@ fn bloom_filter_basic(
             .unwrap_or_else(|err| panic!("program {prog_name} is not a uprobe: {err}"));
         prog.load()
             .unwrap_or_else(|err| panic!("load {prog_name}: {err}"));
-        prog.attach(symbol, "/proc/self/exe", UProbeScope::AllProcesses)
+        prog.attach([symbol], "/proc/self/exe", UProbeScope::AllProcesses)
             .unwrap_or_else(|err| panic!("attach {prog_name}: {err}"));
     }
 

--- a/test/integration-test/src/tests/bpf_probe_read.rs
+++ b/test/integration-test/src/tests/bpf_probe_read.rs
@@ -103,7 +103,7 @@ fn load_and_attach_uprobe(prog_name: &str, func_name: &str, bytes: &[u8]) -> Ebp
     let prog: &mut UProbe = bpf.program_mut(prog_name).unwrap().try_into().unwrap();
     prog.load().unwrap();
 
-    prog.attach(func_name, "/proc/self/exe", UProbeScope::AllProcesses)
+    prog.attach([func_name], "/proc/self/exe", UProbeScope::AllProcesses)
         .unwrap();
 
     bpf

--- a/test/integration-test/src/tests/btf_map_of_maps.rs
+++ b/test/integration-test/src/tests/btf_map_of_maps.rs
@@ -53,8 +53,9 @@ fn load_and_attach(ebpf: &mut Ebpf, name: &str) {
         .try_into()
         .unwrap();
     prog.load().unwrap();
+    let symbol = format!("trigger_{name}");
     prog.attach(
-        format!("trigger_{name}").as_str(),
+        [symbol.as_str()],
         "/proc/self/exe",
         UProbeScope::AllProcesses,
     )

--- a/test/integration-test/src/tests/btf_relocations.rs
+++ b/test/integration-test/src/tests/btf_relocations.rs
@@ -103,7 +103,7 @@ fn assert_relocation(mut bpf: Ebpf, expected: u64) {
     program.load().unwrap();
     program
         .attach(
-            "trigger_btf_relocations_program",
+            ["trigger_btf_relocations_program"],
             "/proc/self/exe",
             UProbeScope::AllProcesses,
         )

--- a/test/integration-test/src/tests/cgroup_array.rs
+++ b/test/integration-test/src/tests/cgroup_array.rs
@@ -56,7 +56,7 @@ fn current_task_under_cgroup(
             .unwrap_or_else(|err| panic!("load {prog}: {err}"));
         program
             .attach(
-                "trigger_current_task_under_cgroup",
+                ["trigger_current_task_under_cgroup"],
                 "/proc/self/exe",
                 UProbeScope::AllProcesses,
             )

--- a/test/integration-test/src/tests/hash_map.rs
+++ b/test/integration-test/src/tests/hash_map.rs
@@ -91,7 +91,7 @@ fn hash_basic(
     let prog: &mut UProbe = bpf.program_mut(prog_name).unwrap().try_into().unwrap();
     prog.load().unwrap();
     prog.attach(
-        "trigger_hash_lookup",
+        ["trigger_hash_lookup"],
         "/proc/self/exe",
         UProbeScope::AllProcesses,
     )

--- a/test/integration-test/src/tests/info.rs
+++ b/test/integration-test/src/tests/info.rs
@@ -69,7 +69,7 @@ fn test_loaded_programs() {
     // Ensure we can perform basic operations on the re-created program.
     let res = p
         .attach(
-            "uprobe_function",
+            ["uprobe_function"],
             "/proc/self/exe",
             UProbeScope::AllProcesses,
         )

--- a/test/integration-test/src/tests/linear_data_structures.rs
+++ b/test/integration-test/src/tests/linear_data_structures.rs
@@ -58,7 +58,7 @@ macro_rules! define_linear_ds_host_test {
             ] {
                 let prog: &mut UProbe = bpf.program_mut(prog_name).unwrap().try_into().unwrap();
                 prog.load().unwrap();
-                prog.attach(symbol, "/proc/self/exe", UProbeScope::AllProcesses)
+                prog.attach([symbol], "/proc/self/exe", UProbeScope::AllProcesses)
                     .unwrap();
             }
             let array = Array::<_, u64>::try_from(bpf.map($result_map).unwrap()).unwrap();

--- a/test/integration-test/src/tests/load.rs
+++ b/test/integration-test/src/tests/load.rs
@@ -59,7 +59,7 @@ fn ringbuffer_btf_map() {
     let prog: &mut UProbe = bpf.program_mut("bpf_prog").unwrap().try_into().unwrap();
     prog.load().unwrap();
     prog.attach(
-        "trigger_bpf_program",
+        ["trigger_bpf_program"],
         "/proc/self/exe",
         UProbeScope::AllProcesses,
     )
@@ -85,7 +85,7 @@ fn multiple_btf_maps() {
     let prog: &mut UProbe = bpf.program_mut("bpf_prog").unwrap().try_into().unwrap();
     prog.load().unwrap();
     prog.attach(
-        "trigger_bpf_program",
+        ["trigger_bpf_program"],
         "/proc/self/exe",
         UProbeScope::AllProcesses,
     )
@@ -139,7 +139,7 @@ fn pin_lifecycle_multiple_btf_maps() {
     let prog: &mut UProbe = bpf.program_mut("bpf_prog").unwrap().try_into().unwrap();
     prog.load().unwrap();
     prog.attach(
-        "trigger_bpf_program",
+        ["trigger_bpf_program"],
         "/proc/self/exe",
         UProbeScope::AllProcesses,
     )
@@ -378,7 +378,7 @@ fn basic_uprobe_scopes(#[case] scope: UProbeScope) {
 
     let program_name = "test_uprobe";
     let attach = |prog: &mut P| {
-        prog.attach("uprobe_function", "/proc/self/exe", scope)
+        prog.attach(["uprobe_function"], "/proc/self/exe", scope)
             .unwrap()
     };
 
@@ -682,7 +682,7 @@ fn pin_lifecycle_uprobe() {
     let program_name = "test_uprobe";
     let attach = |prog: &mut P| {
         prog.attach(
-            "uprobe_function",
+            ["uprobe_function"],
             "/proc/self/exe",
             UProbeScope::AllProcesses,
         )

--- a/test/integration-test/src/tests/log.rs
+++ b/test/integration-test/src/tests/log.rs
@@ -74,7 +74,7 @@ fn log() {
     let prog: &mut UProbe = bpf.program_mut("test_log").unwrap().try_into().unwrap();
     prog.load().unwrap();
     prog.attach(
-        "trigger_ebpf_program",
+        ["trigger_ebpf_program"],
         "/proc/self/exe",
         UProbeScope::AllProcesses,
     )
@@ -257,7 +257,7 @@ fn log_level_only_error_warn() {
     let prog: &mut UProbe = bpf.program_mut("test_log").unwrap().try_into().unwrap();
     prog.load().unwrap();
     prog.attach(
-        "trigger_ebpf_program",
+        ["trigger_ebpf_program"],
         "/proc/self/exe",
         UProbeScope::AllProcesses,
     )
@@ -316,7 +316,7 @@ fn log_level_prevents_verif_fail() {
         .unwrap();
     prog.load().unwrap();
     prog.attach(
-        "trigger_ebpf_program",
+        ["trigger_ebpf_program"],
         "/proc/self/exe",
         UProbeScope::AllProcesses,
     )

--- a/test/integration-test/src/tests/lpm_trie.rs
+++ b/test/integration-test/src/tests/lpm_trie.rs
@@ -38,7 +38,7 @@ fn lpm_trie_basic(#[case] prog_name: &str, #[case] routes_map: &str, #[case] res
     prog.load()
         .unwrap_or_else(|err| panic!("load {prog_name}: {err}"));
     prog.attach(
-        "trigger_lpm_trie",
+        ["trigger_lpm_trie"],
         "/proc/self/exe",
         UProbeScope::AllProcesses,
     )

--- a/test/integration-test/src/tests/maps_disjoint.rs
+++ b/test/integration-test/src/tests/maps_disjoint.rs
@@ -21,7 +21,7 @@ fn test_maps_disjoint() {
 
     prog.load().unwrap();
     prog.attach(
-        "trigger_ebpf_program_maps_disjoint",
+        ["trigger_ebpf_program_maps_disjoint"],
         "/proc/self/exe",
         UProbeScope::AllProcesses,
     )

--- a/test/integration-test/src/tests/per_cpu_array.rs
+++ b/test/integration-test/src/tests/per_cpu_array.rs
@@ -73,7 +73,7 @@ fn per_cpu_array_basic(
             .unwrap_or_else(|err| panic!("program {prog_name} is not a uprobe: {err}"));
         prog.load()
             .unwrap_or_else(|err| panic!("load {prog_name}: {err}"));
-        prog.attach(symbol, "/proc/self/exe", UProbeScope::AllProcesses)
+        prog.attach([symbol], "/proc/self/exe", UProbeScope::AllProcesses)
             .unwrap_or_else(|err| panic!("attach {prog_name}: {err}"));
     }
 

--- a/test/integration-test/src/tests/perf_event_array.rs
+++ b/test/integration-test/src/tests/perf_event_array.rs
@@ -40,7 +40,7 @@ fn emit_event(#[case] bpf_obj: &[u8], #[case] events_map: &str, #[case] prog: &s
         .unwrap_or_else(|err| panic!("load {prog}: {err}"));
     uprobe
         .attach(
-            "trigger_emit_event",
+            ["trigger_emit_event"],
             "/proc/self/exe",
             UProbeScope::AllProcesses,
         )

--- a/test/integration-test/src/tests/printk.rs
+++ b/test/integration-test/src/tests/printk.rs
@@ -82,7 +82,7 @@ async fn bpf_printk<const N: usize>(
         .unwrap();
     prog.load().unwrap();
     prog.attach(
-        "trigger_bpf_printk",
+        ["trigger_bpf_printk"],
         "/proc/self/exe",
         UProbeScope::AllProcesses,
     )

--- a/test/integration-test/src/tests/prog_array.rs
+++ b/test/integration-test/src/tests/prog_array.rs
@@ -43,7 +43,7 @@ fn tail_call_empty(#[case] result_map: &str, #[case] entry_prog: &str) {
     prog.load()
         .unwrap_or_else(|err| panic!("load {entry_prog}: {err}"));
     prog.attach(
-        "trigger_tail_call_empty",
+        ["trigger_tail_call_empty"],
         "/proc/self/exe",
         UProbeScope::AllProcesses,
     )
@@ -106,7 +106,7 @@ fn tail_call_success(
             .unwrap_or_else(|err| panic!("load {entry_prog}: {err}"));
         entry
             .attach(
-                "trigger_tail_call_success",
+                ["trigger_tail_call_success"],
                 "/proc/self/exe",
                 UProbeScope::AllProcesses,
             )

--- a/test/integration-test/src/tests/relocations.rs
+++ b/test/integration-test/src/tests/relocations.rs
@@ -56,7 +56,7 @@ fn load_and_attach(name: &str, bytes: &[u8]) -> Ebpf {
     prog.load().unwrap();
 
     prog.attach(
-        "trigger_relocations_program",
+        ["trigger_relocations_program"],
         "/proc/self/exe",
         UProbeScope::AllProcesses,
     )

--- a/test/integration-test/src/tests/ring_buf.rs
+++ b/test/integration-test/src/tests/ring_buf.rs
@@ -92,7 +92,7 @@ impl RingBufTest {
         let prog: &mut UProbe = bpf.program_mut(variant.prog).unwrap().try_into().unwrap();
         prog.load().unwrap();
         prog.attach(
-            "ring_buf_trigger_ebpf_program",
+            ["ring_buf_trigger_ebpf_program"],
             "/proc/self/exe",
             UProbeScope::AllProcesses,
         )
@@ -205,8 +205,12 @@ fn ring_buf_mismatch_size<T>(
     let mut ring_buf = RingBuf::try_from(ring_buf).unwrap();
     let prog: &mut UProbe = bpf.program_mut(prog).unwrap().try_into().unwrap();
     prog.load().unwrap();
-    prog.attach(trigger_symbol, "/proc/self/exe", UProbeScope::AllProcesses)
-        .unwrap();
+    prog.attach(
+        [trigger_symbol],
+        "/proc/self/exe",
+        UProbeScope::AllProcesses,
+    )
+    .unwrap();
 
     trigger(value.into());
     {

--- a/test/integration-test/src/tests/stack_trace.rs
+++ b/test/integration-test/src/tests/stack_trace.rs
@@ -37,7 +37,7 @@ fn record_stackid(#[case] stacks_map: &str, #[case] result_map: &str, #[case] pr
         .unwrap_or_else(|err| panic!("load {prog}: {err}"));
     uprobe
         .attach(
-            "trigger_record_stackid",
+            ["trigger_record_stackid"],
             "/proc/self/exe",
             UProbeScope::AllProcesses,
         )

--- a/test/integration-test/src/tests/strncmp.rs
+++ b/test/integration-test/src/tests/strncmp.rs
@@ -30,7 +30,7 @@ fn bpf_strncmp() {
         prog.load().unwrap();
 
         prog.attach(
-            "trigger_bpf_strncmp",
+            ["trigger_bpf_strncmp"],
             "/proc/self/exe",
             UProbeScope::AllProcesses,
         )

--- a/test/integration-test/src/tests/uprobe_cookie.rs
+++ b/test/integration-test/src/tests/uprobe_cookie.rs
@@ -17,8 +17,11 @@ fn test_uprobe_cookie() {
         );
         return;
     }
-    const RING_BUF_BYTE_SIZE: u32 = 512; // arbitrary, but big enough
-
+    // Ring buffer sizes are rounded up to a page-sized power-of-two multiple when
+    // the object is loaded. Using 512 here therefore yields a one-page ring
+    // buffer on supported test systems, which is ample for the handful of `u64`
+    // cookie records emitted by this test.
+    const RING_BUF_BYTE_SIZE: u32 = 512;
     let mut bpf = EbpfLoader::new()
         .map_max_entries("RING_BUF", RING_BUF_BYTE_SIZE)
         .load(crate::UPROBE_COOKIE)
@@ -35,10 +38,10 @@ fn test_uprobe_cookie() {
     const PROG_B: &str = "uprobe_cookie_trigger_ebpf_program_b";
     let attach = |prog: &mut UProbe, fn_name: &str, cookie| {
         prog.attach(
-            UProbeAttachPoint {
+            [UProbeAttachPoint {
                 location: fn_name.into(),
                 cookie: Some(cookie),
-            },
+            }],
             "/proc/self/exe",
             UProbeScope::AllProcesses,
         )

--- a/test/integration-test/src/tests/uprobe_multi.rs
+++ b/test/integration-test/src/tests/uprobe_multi.rs
@@ -1,0 +1,341 @@
+use std::{
+    path::Path,
+    process::{Command, Stdio},
+};
+
+use aya::{
+    EbpfLoader,
+    maps::ring_buf::RingBuf,
+    programs::{
+        ProbeKind, ProgramError, UProbe,
+        uprobe::{UProbeAttachLocation, UProbeAttachPoint, UProbeError, UProbeScope},
+    },
+    util::KernelVersion,
+};
+
+const PROG_A: &str = "uprobe_multi_trigger_program_a";
+const PROG_B: &str = "uprobe_multi_trigger_program_b";
+const PROG_NO_COOKIE: &str = "uprobe_multi_trigger_program_no_cookie";
+const PROG_SYMBOL_INVALID: &str = "uprobe_multi_missing_symbol";
+const UPROBE_MULTI: &str = "uprobe_multi";
+const UPROBE_SINGLE: &str = "uprobe_single";
+const UPROBE_SCOPE_CHILD: &str = "AYA_INTEGRATION_TEST_UPROBE_SCOPE_CHILD";
+// Ring buffer sizes are rounded up to a page-sized power-of-two multiple when
+// the object is loaded. Using 512 here therefore yields a one-page ring
+// buffer on supported test systems, which is ample for the handful of `u64`
+// cookie records emitted by these tests.
+const RING_BUF_BYTE_SIZE: u32 = 512;
+
+fn run_scope_child() {
+    let status = Command::new(std::env::current_exe().unwrap())
+        .arg("tests::uprobe_multi::uprobe_multi_scope_child")
+        .arg("--exact")
+        .env(UPROBE_SCOPE_CHILD, "1")
+        .stdout(Stdio::null())
+        .status()
+        .unwrap();
+    assert!(status.success(), "scope test child failed: {status}");
+}
+
+#[test]
+fn uprobe_multi_scope_child() {
+    if std::env::var_os(UPROBE_SCOPE_CHILD).is_none() {
+        return;
+    }
+
+    uprobe_multi_trigger_program_a();
+    uprobe_multi_trigger_program_b();
+}
+
+#[test_log::test]
+fn test_uprobe_attach_multi() {
+    if !aya::features().bpf_cookie() {
+        eprintln!(
+            "skipping test: bpf_get_attach_cookie is unsupported so the test program cannot load"
+        );
+        return;
+    }
+    let mut bpf = EbpfLoader::new()
+        .map_max_entries("RING_BUF", RING_BUF_BYTE_SIZE)
+        .load(crate::UPROBE_MULTI)
+        .unwrap();
+    let ring_buf = bpf.take_map("RING_BUF").unwrap();
+    let mut ring_buf = RingBuf::try_from(ring_buf).unwrap();
+    let prog: &mut UProbe = bpf.program_mut(UPROBE_MULTI).unwrap().try_into().unwrap();
+    prog.load().unwrap();
+
+    const COOKIE_A: u64 = 0x11;
+    const COOKIE_B: u64 = 0x22;
+
+    let points = [
+        UProbeAttachPoint {
+            location: UProbeAttachLocation::Symbol(PROG_A),
+            cookie: Some(COOKIE_A),
+        },
+        UProbeAttachPoint {
+            location: UProbeAttachLocation::Symbol(PROG_B),
+            cookie: Some(COOKIE_B),
+        },
+        UProbeAttachPoint {
+            location: UProbeAttachLocation::Symbol(PROG_NO_COOKIE),
+            cookie: None,
+        },
+    ];
+    let attach_res = prog.attach(
+        &points,
+        Path::new("/proc/self/exe"),
+        UProbeScope::CallingProcess,
+    );
+    let link_id = match attach_res {
+        Ok(link) => link,
+        Err(ProgramError::UProbeError(UProbeError::MultiLinkNotSupported)) => {
+            let kernel_version = KernelVersion::current().unwrap();
+            let multi_min = KernelVersion::new(6, 6, 0);
+            assert!(
+                kernel_version < multi_min,
+                "kernel {kernel_version:?} is >= 6.6 but returned MultiLinkNotSupported"
+            );
+            return;
+        }
+        Err(err) => panic!("attach failed: {err:?}"),
+    };
+
+    // Drain any stale events emitted by other tests before we generate fresh ones.
+    while ring_buf.next().is_some() {}
+
+    // CallingProcess must ignore events from another process.
+    run_scope_child();
+    uprobe_multi_trigger_program_a();
+    uprobe_multi_trigger_program_b();
+    uprobe_multi_trigger_program_no_cookie();
+    uprobe_multi_trigger_program_a();
+
+    prog.detach(link_id).unwrap();
+    // Call again, expect no events because detach removed all active links.
+    uprobe_multi_trigger_program_a();
+
+    const EXP: &[u64] = &[COOKIE_A, COOKIE_B, 0, COOKIE_A];
+    let mut seen = Vec::new();
+    while let Some(record) = ring_buf.next() {
+        let data = record.as_ref();
+        match data.try_into() {
+            Ok(bytes) => seen.push(u64::from_ne_bytes(bytes)),
+            Err(std::array::TryFromSliceError { .. }) => {
+                panic!("invalid ring buffer data: {data:x?}")
+            }
+        }
+    }
+    assert_eq!(seen, EXP);
+}
+
+#[test_log::test]
+fn test_uprobe_unknown_program_falls_back_to_multiple_single_points() {
+    if !aya::features().bpf_cookie() {
+        eprintln!(
+            "skipping test: bpf_get_attach_cookie is unsupported so the test program cannot load"
+        );
+        return;
+    }
+    let mut bpf = EbpfLoader::new()
+        .map_max_entries("RING_BUF", RING_BUF_BYTE_SIZE)
+        .load(crate::UPROBE_MULTI)
+        .unwrap();
+    let ring_buf = bpf.take_map("RING_BUF").unwrap();
+    let mut ring_buf = RingBuf::try_from(ring_buf).unwrap();
+    let info = {
+        let prog: &mut UProbe = bpf.program_mut(UPROBE_SINGLE).unwrap().try_into().unwrap();
+        prog.load().unwrap();
+        prog.info().unwrap()
+    };
+    // Handles reconstructed from program info do not know whether the original
+    // section was `uprobe` or `uprobe.multi`, so attach must probe and fall back.
+    let mut prog =
+        unsafe { UProbe::from_program_info(info, UPROBE_SINGLE.into(), ProbeKind::Entry) }.unwrap();
+
+    const COOKIE_A: u64 = 0x33;
+    const COOKIE_B: u64 = 0x44;
+    let points = [
+        UProbeAttachPoint {
+            location: UProbeAttachLocation::Symbol(PROG_A),
+            cookie: Some(COOKIE_A),
+        },
+        UProbeAttachPoint {
+            location: UProbeAttachLocation::Symbol(PROG_B),
+            cookie: Some(COOKIE_B),
+        },
+    ];
+    let link_id = prog
+        .attach(
+            &points,
+            Path::new("/proc/self/exe"),
+            UProbeScope::CallingProcess,
+        )
+        .expect("unknown-mode multi-point attach should fall back to single attach");
+
+    // Drain any stale events emitted by other tests before we generate fresh ones.
+    while ring_buf.next().is_some() {}
+
+    // CallingProcess must be preserved when unknown mode falls back to the
+    // legacy per-point attach path.
+    run_scope_child();
+    uprobe_multi_trigger_program_a();
+    uprobe_multi_trigger_program_b();
+
+    prog.detach(link_id).unwrap();
+    // Call again, expect no events because detach removed all underlying links.
+    uprobe_multi_trigger_program_a();
+    uprobe_multi_trigger_program_b();
+
+    // Attach the same unknown-mode handle again. The first attach should have
+    // selected the legacy per-point mode for this ordinary `uprobe` program; a
+    // second attach verifies the handle remains usable after fallback and detach.
+    let link_id = prog
+        .attach(
+            &points,
+            Path::new("/proc/self/exe"),
+            UProbeScope::CallingProcess,
+        )
+        .expect("unknown-mode fallback should allow attaching again");
+
+    uprobe_multi_trigger_program_a();
+    uprobe_multi_trigger_program_b();
+
+    prog.detach(link_id).unwrap();
+
+    let mut seen = Vec::new();
+    while let Some(record) = ring_buf.next() {
+        let data = record.as_ref();
+        match data.try_into() {
+            Ok(bytes) => seen.push(u64::from_ne_bytes(bytes)),
+            Err(std::array::TryFromSliceError { .. }) => {
+                panic!("invalid ring buffer data: {data:x?}")
+            }
+        }
+    }
+    assert_eq!(seen, vec![COOKIE_A, COOKIE_B, COOKIE_A, COOKIE_B]);
+}
+
+#[test_log::test]
+fn test_uprobe_single_program_composite_link_drop_detaches_all_points() {
+    if !aya::features().bpf_cookie() {
+        eprintln!(
+            "skipping test: bpf_get_attach_cookie is unsupported so the test program cannot load"
+        );
+        return;
+    }
+    let mut bpf = EbpfLoader::new()
+        .map_max_entries("RING_BUF", RING_BUF_BYTE_SIZE)
+        .load(crate::UPROBE_MULTI)
+        .unwrap();
+    let ring_buf = bpf.take_map("RING_BUF").unwrap();
+    let mut ring_buf = RingBuf::try_from(ring_buf).unwrap();
+    let prog: &mut UProbe = bpf.program_mut(UPROBE_SINGLE).unwrap().try_into().unwrap();
+    prog.load().unwrap();
+
+    const COOKIE_A: u64 = 0x55;
+    const COOKIE_B: u64 = 0x66;
+    let points = [
+        UProbeAttachPoint {
+            location: UProbeAttachLocation::Symbol(PROG_A),
+            cookie: Some(COOKIE_A),
+        },
+        UProbeAttachPoint {
+            location: UProbeAttachLocation::Symbol(PROG_B),
+            cookie: Some(COOKIE_B),
+        },
+    ];
+    let link_id = prog
+        .attach(
+            &points,
+            Path::new("/proc/self/exe"),
+            UProbeScope::AllProcesses,
+        )
+        .expect("legacy single-mode multi-point attach should succeed");
+
+    // Drain any stale events emitted by other tests before we generate fresh ones.
+    while ring_buf.next().is_some() {}
+
+    uprobe_multi_trigger_program_a();
+    uprobe_multi_trigger_program_b();
+
+    let link = prog.take_link(link_id).unwrap();
+    drop(link);
+
+    // Call again, expect no events because dropping the managed composite link
+    // must detach all underlying single-point links.
+    uprobe_multi_trigger_program_a();
+    uprobe_multi_trigger_program_b();
+
+    let mut seen = Vec::new();
+    while let Some(record) = ring_buf.next() {
+        let data = record.as_ref();
+        match data.try_into() {
+            Ok(bytes) => seen.push(u64::from_ne_bytes(bytes)),
+            Err(std::array::TryFromSliceError { .. }) => {
+                panic!("invalid ring buffer data: {data:x?}")
+            }
+        }
+    }
+    assert_eq!(seen, vec![COOKIE_A, COOKIE_B]);
+}
+
+#[test_log::test]
+fn test_uprobe_attach_multi_invalid_symbol() {
+    if !aya::features().bpf_cookie() {
+        eprintln!(
+            "skipping test: bpf_get_attach_cookie is unsupported so the test program cannot load"
+        );
+        return;
+    }
+    let mut bpf = EbpfLoader::new()
+        .map_max_entries("RING_BUF", RING_BUF_BYTE_SIZE)
+        .load(crate::UPROBE_MULTI)
+        .unwrap();
+    let prog: &mut UProbe = bpf.program_mut(UPROBE_MULTI).unwrap().try_into().unwrap();
+    prog.load().unwrap();
+
+    let points = [PROG_A, PROG_SYMBOL_INVALID];
+
+    let attach_res = prog.attach(
+        &points,
+        Path::new("/proc/self/exe"),
+        UProbeScope::AllProcesses,
+    );
+    match attach_res {
+        Err(ProgramError::UProbeError(UProbeError::SymbolError { symbol, .. })) => {
+            assert_eq!(symbol, PROG_SYMBOL_INVALID);
+        }
+        Err(ProgramError::UProbeError(UProbeError::MultiLinkNotSupported)) => {
+            let kernel_version = KernelVersion::current().unwrap();
+            // Multi-uprobe landed in Linux 6.6 (see BPF_TRACE_UPROBE_MULTI in
+            // https://elixir.bootlin.com/linux/v6.6/source/include/uapi/linux/bpf.h#L1042).
+            let multi_min = KernelVersion::new(6, 6, 0);
+            assert!(
+                kernel_version < multi_min,
+                "kernel {kernel_version:?} is >= 6.6 but returned MultiLinkNotSupported"
+            );
+        }
+        Err(err) => panic!("unexpected error for invalid symbol: {err:?}"),
+        Ok(link) => panic!("attach succeeded for invalid symbol: {link:?}"),
+    }
+}
+
+// Keep these bodies distinct so link-time ICF does not fold the symbols onto
+// the same address; the exact values are otherwise irrelevant to the tests.
+#[unsafe(no_mangle)]
+#[inline(never)]
+extern "C" fn uprobe_multi_trigger_program_a() {
+    std::hint::black_box(0u64);
+}
+
+#[unsafe(no_mangle)]
+#[inline(never)]
+extern "C" fn uprobe_multi_trigger_program_b() {
+    std::hint::black_box(1u64);
+}
+
+#[unsafe(no_mangle)]
+#[inline(never)]
+extern "C" fn uprobe_multi_trigger_program_no_cookie() {
+    std::hint::black_box(2u64);
+}

--- a/xtask/public-api/aya-obj.txt
+++ b/xtask/public-api/aya-obj.txt
@@ -4764,8 +4764,10 @@ pub aya_obj::obj::ProgramSection::SockOps
 pub aya_obj::obj::ProgramSection::SocketFilter
 pub aya_obj::obj::ProgramSection::TracePoint
 pub aya_obj::obj::ProgramSection::UProbe
+pub aya_obj::obj::ProgramSection::UProbe::multi: bool
 pub aya_obj::obj::ProgramSection::UProbe::sleepable: bool
 pub aya_obj::obj::ProgramSection::URetProbe
+pub aya_obj::obj::ProgramSection::URetProbe::multi: bool
 pub aya_obj::obj::ProgramSection::URetProbe::sleepable: bool
 pub aya_obj::obj::ProgramSection::Xdp
 pub aya_obj::obj::ProgramSection::Xdp::attach_type: aya_obj::programs::xdp::XdpAttachType
@@ -5406,8 +5408,10 @@ pub aya_obj::ProgramSection::SockOps
 pub aya_obj::ProgramSection::SocketFilter
 pub aya_obj::ProgramSection::TracePoint
 pub aya_obj::ProgramSection::UProbe
+pub aya_obj::ProgramSection::UProbe::multi: bool
 pub aya_obj::ProgramSection::UProbe::sleepable: bool
 pub aya_obj::ProgramSection::URetProbe
+pub aya_obj::ProgramSection::URetProbe::multi: bool
 pub aya_obj::ProgramSection::URetProbe::sleepable: bool
 pub aya_obj::ProgramSection::Xdp
 pub aya_obj::ProgramSection::Xdp::attach_type: aya_obj::programs::xdp::XdpAttachType

--- a/xtask/public-api/aya.txt
+++ b/xtask/public-api/aya.txt
@@ -5287,12 +5287,19 @@ pub aya::programs::uprobe::UProbeAttachLocation::Symbol(&'a str)
 pub aya::programs::uprobe::UProbeAttachLocation::SymbolOffset(&'a str, u64)
 impl aya::programs::uprobe::UProbeAttachLocation<'static>
 pub fn aya::programs::uprobe::UProbeAttachLocation<'static>::from_virtual_address(u64, u64, u64) -> core::result::Result<Self, aya::programs::uprobe::UProbeAttachLocationError>
+impl core::convert::From<&u64> for aya::programs::uprobe::UProbeAttachLocation<'static>
+pub fn aya::programs::uprobe::UProbeAttachLocation<'static>::from(&u64) -> Self
 impl core::convert::From<u64> for aya::programs::uprobe::UProbeAttachLocation<'static>
 pub fn aya::programs::uprobe::UProbeAttachLocation<'static>::from(u64) -> Self
+impl<'a> core::clone::Clone for aya::programs::uprobe::UProbeAttachLocation<'a>
+pub fn aya::programs::uprobe::UProbeAttachLocation<'a>::clone(&self) -> aya::programs::uprobe::UProbeAttachLocation<'a>
+impl<'a> core::convert::From<&&'a str> for aya::programs::uprobe::UProbeAttachLocation<'a>
+pub fn aya::programs::uprobe::UProbeAttachLocation<'a>::from(&&'a str) -> Self
 impl<'a> core::convert::From<&'a str> for aya::programs::uprobe::UProbeAttachLocation<'a>
 pub fn aya::programs::uprobe::UProbeAttachLocation<'a>::from(&'a str) -> Self
 impl<'a> core::fmt::Debug for aya::programs::uprobe::UProbeAttachLocation<'a>
 pub fn aya::programs::uprobe::UProbeAttachLocation<'a>::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl<'a> core::marker::Copy for aya::programs::uprobe::UProbeAttachLocation<'a>
 impl<'a> core::marker::Freeze for aya::programs::uprobe::UProbeAttachLocation<'a>
 impl<'a> core::marker::Send for aya::programs::uprobe::UProbeAttachLocation<'a>
 impl<'a> core::marker::Sync for aya::programs::uprobe::UProbeAttachLocation<'a>
@@ -5321,6 +5328,11 @@ impl core::marker::UnsafeUnpin for aya::programs::uprobe::UProbeAttachLocationEr
 impl core::panic::unwind_safe::RefUnwindSafe for aya::programs::uprobe::UProbeAttachLocationError
 impl core::panic::unwind_safe::UnwindSafe for aya::programs::uprobe::UProbeAttachLocationError
 pub enum aya::programs::uprobe::UProbeError
+pub aya::programs::uprobe::UProbeError::AttachModeSelectionFailed
+pub aya::programs::uprobe::UProbeError::AttachModeSelectionFailed::multi_error: alloc::boxed::Box<aya::programs::ProgramError>
+pub aya::programs::uprobe::UProbeError::AttachModeSelectionFailed::single_error: alloc::boxed::Box<aya::programs::ProgramError>
+pub aya::programs::uprobe::UProbeError::EmptyPoints
+pub aya::programs::uprobe::UProbeError::EmptyPoints::target: std::path::PathBuf
 pub aya::programs::uprobe::UProbeError::FileError
 pub aya::programs::uprobe::UProbeError::FileError::filename: std::path::PathBuf
 pub aya::programs::uprobe::UProbeError::FileError::io_error: core::io::error::Error
@@ -5328,6 +5340,11 @@ pub aya::programs::uprobe::UProbeError::InvalidLdSoCache
 pub aya::programs::uprobe::UProbeError::InvalidLdSoCache::io_error: &'static core::io::error::Error
 pub aya::programs::uprobe::UProbeError::InvalidTarget
 pub aya::programs::uprobe::UProbeError::InvalidTarget::path: std::path::PathBuf
+pub aya::programs::uprobe::UProbeError::LegacyPerfAttachPointError
+pub aya::programs::uprobe::UProbeError::LegacyPerfAttachPointError::attach_error: alloc::boxed::Box<aya::programs::ProgramError>
+pub aya::programs::uprobe::UProbeError::LegacyPerfAttachPointError::index: usize
+pub aya::programs::uprobe::UProbeError::LegacyPerfAttachPointError::resolved_offset: u64
+pub aya::programs::uprobe::UProbeError::MultiLinkNotSupported
 pub aya::programs::uprobe::UProbeError::ProcMap
 pub aya::programs::uprobe::UProbeError::ProcMap::pid: u32
 pub aya::programs::uprobe::UProbeError::ProcMap::source: aya::programs::uprobe::ProcMapError
@@ -5368,7 +5385,7 @@ impl core::panic::unwind_safe::UnwindSafe for aya::programs::uprobe::UProbeScope
 pub struct aya::programs::uprobe::UProbe
 impl aya::programs::uprobe::UProbe
 pub const aya::programs::uprobe::UProbe::PROGRAM_TYPE: aya::programs::ProgramType
-pub fn aya::programs::uprobe::UProbe::attach<'a, T: core::convert::AsRef<std::path::Path>, Point: core::convert::Into<aya::programs::uprobe::UProbeAttachPoint<'a>>>(&mut self, Point, T, aya::programs::uprobe::UProbeScope) -> core::result::Result<aya::programs::uprobe::UProbeLinkId, aya::programs::ProgramError>
+pub fn aya::programs::uprobe::UProbe::attach<'a, T, I>(&mut self, I, T, aya::programs::uprobe::UProbeScope) -> core::result::Result<aya::programs::uprobe::UProbeLinkId, aya::programs::ProgramError> where T: core::convert::AsRef<std::path::Path>, I: core::iter::traits::collect::IntoIterator, <I as core::iter::traits::collect::IntoIterator>::Item: core::convert::Into<aya::programs::uprobe::UProbeAttachPoint<'a>>
 pub fn aya::programs::uprobe::UProbe::from_pin<P: core::convert::AsRef<std::path::Path>>(P, aya::programs::ProbeKind) -> core::result::Result<Self, aya::programs::ProgramError>
 pub const fn aya::programs::uprobe::UProbe::kind(&self) -> aya::programs::ProbeKind
 pub fn aya::programs::uprobe::UProbe::load(&mut self) -> core::result::Result<(), aya::programs::ProgramError>
@@ -5406,8 +5423,15 @@ impl core::panic::unwind_safe::UnwindSafe for aya::programs::uprobe::UProbe
 pub struct aya::programs::uprobe::UProbeAttachPoint<'a>
 pub aya::programs::uprobe::UProbeAttachPoint::cookie: core::option::Option<u64>
 pub aya::programs::uprobe::UProbeAttachPoint::location: aya::programs::uprobe::UProbeAttachLocation<'a>
+impl core::convert::From<&aya::programs::uprobe::UProbeAttachPoint<'_>> for aya::programs::uprobe::UProbeAttachPoint<'_>
+pub fn aya::programs::uprobe::UProbeAttachPoint<'_>::from(&Self) -> Self
 impl<'a, L: core::convert::Into<aya::programs::uprobe::UProbeAttachLocation<'a>>> core::convert::From<L> for aya::programs::uprobe::UProbeAttachPoint<'a>
 pub fn aya::programs::uprobe::UProbeAttachPoint<'a>::from(L) -> Self
+impl<'a> core::clone::Clone for aya::programs::uprobe::UProbeAttachPoint<'a>
+pub fn aya::programs::uprobe::UProbeAttachPoint<'a>::clone(&self) -> aya::programs::uprobe::UProbeAttachPoint<'a>
+impl<'a> core::fmt::Debug for aya::programs::uprobe::UProbeAttachPoint<'a>
+pub fn aya::programs::uprobe::UProbeAttachPoint<'a>::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl<'a> core::marker::Copy for aya::programs::uprobe::UProbeAttachPoint<'a>
 impl<'a> core::marker::Freeze for aya::programs::uprobe::UProbeAttachPoint<'a>
 impl<'a> core::marker::Send for aya::programs::uprobe::UProbeAttachPoint<'a>
 impl<'a> core::marker::Sync for aya::programs::uprobe::UProbeAttachPoint<'a>
@@ -5416,6 +5440,8 @@ impl<'a> core::marker::UnsafeUnpin for aya::programs::uprobe::UProbeAttachPoint<
 impl<'a> core::panic::unwind_safe::RefUnwindSafe for aya::programs::uprobe::UProbeAttachPoint<'a>
 impl<'a> core::panic::unwind_safe::UnwindSafe for aya::programs::uprobe::UProbeAttachPoint<'a>
 pub struct aya::programs::uprobe::UProbeLink(_)
+impl aya::programs::uprobe::UProbeLink
+pub fn aya::programs::uprobe::UProbeLink::into_fd_links(self) -> core::result::Result<alloc::vec::Vec<aya::programs::links::FdLink>, Self>
 impl aya::programs::links::Link for aya::programs::uprobe::UProbeLink
 pub type aya::programs::uprobe::UProbeLink::Id = aya::programs::uprobe::UProbeLinkId
 pub fn aya::programs::uprobe::UProbeLink::detach(self) -> core::result::Result<(), aya::programs::ProgramError>
@@ -6132,6 +6158,11 @@ impl core::marker::UnsafeUnpin for aya::programs::trace_point::TracePointError
 impl !core::panic::unwind_safe::RefUnwindSafe for aya::programs::trace_point::TracePointError
 impl !core::panic::unwind_safe::UnwindSafe for aya::programs::trace_point::TracePointError
 pub enum aya::programs::UProbeError
+pub aya::programs::UProbeError::AttachModeSelectionFailed
+pub aya::programs::UProbeError::AttachModeSelectionFailed::multi_error: alloc::boxed::Box<aya::programs::ProgramError>
+pub aya::programs::UProbeError::AttachModeSelectionFailed::single_error: alloc::boxed::Box<aya::programs::ProgramError>
+pub aya::programs::UProbeError::EmptyPoints
+pub aya::programs::UProbeError::EmptyPoints::target: std::path::PathBuf
 pub aya::programs::UProbeError::FileError
 pub aya::programs::UProbeError::FileError::filename: std::path::PathBuf
 pub aya::programs::UProbeError::FileError::io_error: core::io::error::Error
@@ -6139,6 +6170,11 @@ pub aya::programs::UProbeError::InvalidLdSoCache
 pub aya::programs::UProbeError::InvalidLdSoCache::io_error: &'static core::io::error::Error
 pub aya::programs::UProbeError::InvalidTarget
 pub aya::programs::UProbeError::InvalidTarget::path: std::path::PathBuf
+pub aya::programs::UProbeError::LegacyPerfAttachPointError
+pub aya::programs::UProbeError::LegacyPerfAttachPointError::attach_error: alloc::boxed::Box<aya::programs::ProgramError>
+pub aya::programs::UProbeError::LegacyPerfAttachPointError::index: usize
+pub aya::programs::UProbeError::LegacyPerfAttachPointError::resolved_offset: u64
+pub aya::programs::UProbeError::MultiLinkNotSupported
 pub aya::programs::UProbeError::ProcMap
 pub aya::programs::UProbeError::ProcMap::pid: u32
 pub aya::programs::UProbeError::ProcMap::source: aya::programs::uprobe::ProcMapError
@@ -7422,7 +7458,7 @@ impl core::panic::unwind_safe::UnwindSafe for aya::programs::trace_point::TraceP
 pub struct aya::programs::UProbe
 impl aya::programs::uprobe::UProbe
 pub const aya::programs::uprobe::UProbe::PROGRAM_TYPE: aya::programs::ProgramType
-pub fn aya::programs::uprobe::UProbe::attach<'a, T: core::convert::AsRef<std::path::Path>, Point: core::convert::Into<aya::programs::uprobe::UProbeAttachPoint<'a>>>(&mut self, Point, T, aya::programs::uprobe::UProbeScope) -> core::result::Result<aya::programs::uprobe::UProbeLinkId, aya::programs::ProgramError>
+pub fn aya::programs::uprobe::UProbe::attach<'a, T, I>(&mut self, I, T, aya::programs::uprobe::UProbeScope) -> core::result::Result<aya::programs::uprobe::UProbeLinkId, aya::programs::ProgramError> where T: core::convert::AsRef<std::path::Path>, I: core::iter::traits::collect::IntoIterator, <I as core::iter::traits::collect::IntoIterator>::Item: core::convert::Into<aya::programs::uprobe::UProbeAttachPoint<'a>>
 pub fn aya::programs::uprobe::UProbe::from_pin<P: core::convert::AsRef<std::path::Path>>(P, aya::programs::ProbeKind) -> core::result::Result<Self, aya::programs::ProgramError>
 pub const fn aya::programs::uprobe::UProbe::kind(&self) -> aya::programs::ProbeKind
 pub fn aya::programs::uprobe::UProbe::load(&mut self) -> core::result::Result<(), aya::programs::ProgramError>


### PR DESCRIPTION
This PR tackles #992 and focuses on multi-attach uprobes.

Main talking points:

1. Refactors symbol resolution to batch lookups over a single object::File mmap, since repeated mmap/parse per location was too expensive for multi-attach workloads. I haven’t split out a dedicated symbol resolver yet because that felt heavier, but I’m open to doing this.

2. Introduces `#[uprobe(multi)]` expectations, add attach-type checks, and emit friendly `ProgramNotMulti`/`UProbeMultiNotSupported` errors. To keep `compiled_for_multi` in sync, `UProbe` can no longer rely on the shared  `impl_from_prog_info!` macro, so it now hand-rolls `from_program_info` (open to suggestions for a more reusable pattern).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aya-rs/aya/1417)
<!-- Reviewable:end -->
