### PR TITLE
integration-test: appease clippy

### DIFF
--- a/test/integration-test/src/tests/ring_buf.rs
+++ b/test/integration-test/src/tests/ring_buf.rs
@@ -231,18 +231,14 @@ async fn ring_buf_async_with_drops() {
     // Make sure that there is nothing else in the ring_buf.
     assert_matches!(async_fd.into_inner().next(), None);
 
-    let max_dropped: u64 = u64::try_from(
-        data.len()
-            .checked_sub(RING_BUF_MAX_ENTRIES - 1)
-            .unwrap_or_default(),
-    )
-    .unwrap();
+    let max_dropped: u64 =
+        u64::try_from(data.len().saturating_sub(RING_BUF_MAX_ENTRIES - 1)).unwrap();
     let max_seen = u64::try_from(data.iter().filter(|v| *v % 2 == 0).count()).unwrap();
     let max_rejected = u64::try_from(data.len()).unwrap() - max_seen;
     let Registers { dropped, rejected } = regs.get(&0, 0).unwrap().iter().sum();
     let total = u64::try_from(data.len()).unwrap();
-    let min_seen = max_seen.checked_sub(max_dropped).unwrap_or_default();
-    let min_rejected = max_rejected.checked_sub(dropped).unwrap_or_default();
+    let min_seen = max_seen.saturating_sub(max_dropped);
+    let min_rejected = max_rejected.saturating_sub(dropped);
     let facts = format!(
         "seen={seen}, rejected={rejected}, dropped={dropped}, total={total}, max_seen={max_seen}, \
         max_rejected={max_rejected}, max_dropped={max_dropped}",


### PR DESCRIPTION
Before this change:
```
warning: manual saturating arithmetic
   --> test/integration-test/src/tests/ring_buf.rs:235:9
    |
235 | /         data.len()
236 | |             .checked_sub(RING_BUF_MAX_ENTRIES - 1)
237 | |             .unwrap_or_default(),
    | |________________________________^ help: consider using `saturating_sub`: `data.len().saturating_sub(RING_BUF_MAX_ENTRIES - 1)`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#manual_saturating_arithmetic
    = note: `-W clippy::manual-saturating-arithmetic` implied by `-W clippy::all`
    = help: to override `-W clippy::all` add `#[allow(clippy::manual_saturating_arithmetic)]`

warning: manual saturating arithmetic
   --> test/integration-test/src/tests/ring_buf.rs:244:20
    |
244 |     let min_seen = max_seen.checked_sub(max_dropped).unwrap_or_default();
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using `saturating_sub`: `max_seen.saturating_sub(max_dropped)`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#manual_saturating_arithmetic

warning: manual saturating arithmetic
   --> test/integration-test/src/tests/ring_buf.rs:245:24
    |
245 |     let min_rejected = max_rejected.checked_sub(dropped).unwrap_or_default();
    |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using `saturating_sub`: `max_rejected.saturating_sub(dropped)`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#manual_saturating_arithmetic

warning: `integration-test` (lib test) generated 3 warnings (run `cargo clippy --fix --lib -p integration-test --tests` to apply 3 suggestions)
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aya-rs/aya/1418)
<!-- Reviewable:end -->
