### PR TITLE
Add a check to skip .ksyms/.kconfig from BTF section fixups

### DIFF
--- a/aya-obj/src/btf/types.rs
+++ b/aya-obj/src/btf/types.rs
@@ -276,6 +276,10 @@ impl Func {
     pub(crate) fn set_linkage(&mut self, linkage: FuncLinkage) {
         self.info = (self.info & 0xFFFF0000) | (linkage as u32) & 0xFFFF;
     }
+
+    pub(crate) fn info(&self) -> u32 {
+        self.info
+    }
 }
 
 #[repr(C)]

--- a/aya-obj/src/obj.rs
+++ b/aya-obj/src/obj.rs
@@ -441,6 +441,7 @@ impl FromStr for ProgramSection {
 impl Object {
     /// Parses the binary data as an object file into an [Object]
     pub fn parse(data: &[u8]) -> Result<Self, ParseError> {
+        log::debug!("Object::parse called with {} bytes", data.len());
         let obj = object::read::File::parse(data).map_err(ParseError::ElfError)?;
         let endianness = obj.endianness();
 
@@ -492,10 +493,14 @@ impl Object {
         // as they're required to prepare function and line information
         // when parsing program sections
         if let Some(s) = obj.section_by_name(".BTF") {
+            log::debug!("Found .BTF section in object file");
             bpf_obj.parse_section(Section::try_from(&s)?)?;
             if let Some(s) = obj.section_by_name(".BTF.ext") {
+                log::debug!("Found .BTF.ext section in object file");
                 bpf_obj.parse_section(Section::try_from(&s)?)?;
             }
+        } else {
+            log::debug!("No .BTF section found in object file");
         }
 
         for s in obj.sections() {


### PR DESCRIPTION
When I was trying to use a [custom kfunc](https://eunomia.dev/tutorials/43-kfuncs/) I was met with the following error when trying to load my bpf object:

```
Error: BTF error: Unable to determine the size of section `.ksyms`

Caused by:
    Unable to determine the size of section `.ksyms`

```

libbpf (and [cilium/ebpf](https://github.com/cilium/ebpf/blob/32e841a02106c2faa9f5c65ea25836c6d58d3965/btf/btf.go#L257)) ignore .ksyms and .kconfig when patching missing info in Datasecs. This is because these two sections are external, and won't have any information to gather in ELF sections. Aya should do the same.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aya-rs/aya/1422)
<!-- Reviewable:end -->
