### PR TITLE
aya-build: Avoid OUT_DIR collisions

### DIFF
--- a/aya-build/src/lib.rs
+++ b/aya-build/src/lib.rs
@@ -125,7 +125,11 @@ pub fn build_ebpf<'a>(
         }
 
         // Workaround for https://github.com/rust-lang/cargo/issues/6412 where cargo flocks itself.
-        let target_dir = out_dir.join(name);
+        //
+        // Keep the cargo `--target-dir` separate from `OUT_DIR`'s output artifacts. Otherwise, if
+        // the package name matches a bin target name, `target_dir` would collide with the file we
+        // later copy to `OUT_DIR/<bin-name>`, causing `fs::copy` to fail with EISDIR.
+        let target_dir = out_dir.join("aya-build").join("target").join(name);
         cmd.arg("--target-dir").arg(&target_dir);
 
         let mut child = cmd


### PR DESCRIPTION
When the eBPF package name matches a bin target name, aya-build used
OUT_DIR/<package-name> as Cargo's --target-dir and then tried to copy
the built binary to OUT_DIR/<bin-name>. This makes the destination a
directory and fails with EISDIR.

Put the cargo --target-dir under a dedicated subdirectory inside OUT_DIR
to keep build artifacts separate from copied outputs.

Fixes https://github.com/aya-rs/aya/issues/1432.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aya-rs/aya/1433)
<!-- Reviewable:end -->
