### PR TITLE
Add batch_lookup_and_delete method to PerCpuHashMap

### DIFF
--- a/aya/src/sys/bpf.rs
+++ b/aya/src/sys/bpf.rs
@@ -257,6 +257,108 @@ pub(crate) fn bpf_map_lookup_elem_per_cpu<K: Pod, V: Pod>(
     }
 }
 
+/// Result of a batch lookup operation on a per-CPU map.
+pub(crate) struct PerCpuBatch<K: Pod, V: Pod> {
+    /// Vector of retrieved keys
+    pub(crate) keys: Vec<K>,
+    /// Vector of retrieved per-CPU values
+    pub(crate) values: Vec<PerCpuValues<V>>,
+    /// Optional cursor for the next batch
+    pub(crate) out_batch: Option<K>,
+}
+
+type PerCpuBatchResult<K, V> = io::Result<PerCpuBatch<K, V>>;
+
+/// Batch lookup and delete elements from a per-cpu map.
+///
+/// # Arguments
+///
+/// * `fd` - The file descriptor of the map
+/// * `in_batch` - Optional reference to the previous batch cursor (None for first call)
+/// * `batch_size` - Maximum number of elements to retrieve
+/// * `flags` - Operation flags
+///
+/// # Returns
+///
+/// Returns a tuple of (keys, values, out_batch) where:
+/// - keys: Vector of retrieved keys
+/// - values: Vector of retrieved per-CPU values
+/// - out_batch: Optional cursor for the next batch
+///
+/// # Introduced in kernel v5.6
+pub(crate) fn bpf_map_lookup_and_delete_batch_per_cpu<K: Pod, V: Pod>(
+    fd: BorrowedFd<'_>,
+    in_batch: Option<&K>,
+    batch_size: usize,
+    flags: u64,
+) -> PerCpuBatchResult<K, V> {
+    if batch_size == 0 {
+        return Ok(PerCpuBatch {
+            keys: Vec::new(),
+            values: Vec::new(),
+            out_batch: None,
+        });
+    }
+
+    let mut attr = unsafe { mem::zeroed::<bpf_attr>() };
+    let mut out_batch = MaybeUninit::<K>::uninit();
+    let mut keys = vec![unsafe { mem::zeroed() }; batch_size];
+
+    let value_size = (mem::size_of::<V>() + 7) & !7;
+    let nr_cpus = crate::util::nr_cpus().map_err(|(_, error)| error)?;
+    // value out buffer
+    let mut values_buffer = vec![0u8; batch_size * nr_cpus * value_size];
+
+    let batch_attr = unsafe { &mut attr.batch };
+    batch_attr.map_fd = fd.as_raw_fd() as u32;
+    batch_attr.keys = keys.as_mut_ptr() as u64;
+    batch_attr.values = values_buffer.as_mut_ptr() as u64;
+    batch_attr.count = batch_size as u32;
+    if let Some(batch) = in_batch {
+        batch_attr.in_batch = ptr::from_ref(batch) as u64;
+    }
+    batch_attr.out_batch = ptr::from_mut(&mut out_batch) as u64;
+    batch_attr.flags = flags;
+
+    if let Err(e) = unit_sys_bpf(bpf_cmd::BPF_MAP_LOOKUP_AND_DELETE_BATCH, &mut attr) {
+        // ENOENT is returned when the map is empty or we've reached the end of iteration.
+        // This is not an error condition - we still return the partial results via attr.batch.count.
+        if e.raw_os_error() != Some(ENOENT) {
+            return Err(e);
+        }
+    }
+
+    let actual_count = unsafe { attr.batch.count } as usize;
+    keys.truncate(actual_count);
+    let mut values = Vec::with_capacity(actual_count);
+    for i in 0..actual_count {
+        let offset = i * nr_cpus * value_size;
+        let per_cpu_values: Vec<V> = (0..nr_cpus)
+            .map(|cpu| {
+                let value_offset = offset + cpu * value_size;
+                // SAFETY:
+                // 1. `values_buffer` is allocated with size `batch_size * nr_cpus * value_size`.
+                // 2. The loop bounds ensure `i < actual_count` (<= batch_size) and `cpu < nr_cpus`.
+                // 3. Therefore, `value_offset` is always within the bounds of `values_buffer`.
+                // 4. `ptr::read_unaligned` allows reading potentially unaligned values from the byte buffer.
+                unsafe { ptr::read_unaligned(values_buffer.as_ptr().add(value_offset).cast::<V>()) }
+            })
+            .collect();
+
+        values.push(PerCpuValues::try_from(per_cpu_values).map_err(io::Error::other)?);
+    }
+    let out_batch = if actual_count > 0 {
+        Some(unsafe { out_batch.assume_init() })
+    } else {
+        None
+    };
+    Ok(PerCpuBatch {
+        keys,
+        values,
+        out_batch,
+    })
+}
+
 pub(crate) fn bpf_map_lookup_elem_ptr<K: Pod, V>(
     fd: BorrowedFd<'_>,
     key: Option<&K>,

--- a/xtask/public-api/aya.txt
+++ b/xtask/public-api/aya.txt
@@ -221,6 +221,7 @@ impl<T> core::convert::From<T> for aya::maps::hash_map::HashMap<T, K, V>
 pub fn aya::maps::hash_map::HashMap<T, K, V>::from(t: T) -> T
 pub struct aya::maps::hash_map::PerCpuHashMap<T, K: aya::Pod, V: aya::Pod>
 impl<T: core::borrow::Borrow<aya::maps::MapData>, K: aya::Pod, V: aya::Pod> aya::maps::hash_map::PerCpuHashMap<T, K, V>
+pub fn aya::maps::hash_map::PerCpuHashMap<T, K, V>::batch_lookup_and_delete(&self, batch_size: usize, in_batch: core::option::Option<&K>, flags: u64) -> core::result::Result<(alloc::vec::Vec<K>, alloc::vec::Vec<aya::maps::PerCpuValues<V>>, core::option::Option<K>), aya::maps::MapError>
 pub fn aya::maps::hash_map::PerCpuHashMap<T, K, V>::get(&self, key: &K, flags: u64) -> core::result::Result<aya::maps::PerCpuValues<V>, aya::maps::MapError>
 pub fn aya::maps::hash_map::PerCpuHashMap<T, K, V>::iter(&self) -> aya::maps::MapIter<'_, K, aya::maps::PerCpuValues<V>, Self>
 pub fn aya::maps::hash_map::PerCpuHashMap<T, K, V>::keys(&self) -> aya::maps::MapKeys<'_, K>
@@ -1964,6 +1965,7 @@ impl<T> core::convert::From<T> for aya::maps::PerCpuArray<T, V>
 pub fn aya::maps::PerCpuArray<T, V>::from(t: T) -> T
 pub struct aya::maps::PerCpuHashMap<T, K: aya::Pod, V: aya::Pod>
 impl<T: core::borrow::Borrow<aya::maps::MapData>, K: aya::Pod, V: aya::Pod> aya::maps::hash_map::PerCpuHashMap<T, K, V>
+pub fn aya::maps::hash_map::PerCpuHashMap<T, K, V>::batch_lookup_and_delete(&self, batch_size: usize, in_batch: core::option::Option<&K>, flags: u64) -> core::result::Result<(alloc::vec::Vec<K>, alloc::vec::Vec<aya::maps::PerCpuValues<V>>, core::option::Option<K>), aya::maps::MapError>
 pub fn aya::maps::hash_map::PerCpuHashMap<T, K, V>::get(&self, key: &K, flags: u64) -> core::result::Result<aya::maps::PerCpuValues<V>, aya::maps::MapError>
 pub fn aya::maps::hash_map::PerCpuHashMap<T, K, V>::iter(&self) -> aya::maps::MapIter<'_, K, aya::maps::PerCpuValues<V>, Self>
 pub fn aya::maps::hash_map::PerCpuHashMap<T, K, V>::keys(&self) -> aya::maps::MapKeys<'_, K>


### PR DESCRIPTION
 - Add batch_lookup_and_delete method to PerCpuHashMap that retrieves and removes multiple entries in a single syscall
  - Implement low-level bpf_map_lookup_and_delete_batch_per_cpu syscall wrapper in sys/bpf.rs
  - Provide efficient batch operations for per-CPU hash maps, improving performance when processing multiple entries (requires kernel 5.6+)

  What Changed

  New API (aya/src/maps/hash_map/per_cpu_hash_map.rs:141):
  - Added batch_lookup_and_delete() method that accepts batch size, optional cursor, and flags
  - Returns tuple of (keys, values, out_batch) for cursor-based iteration
  - Includes comprehensive documentation with usage examples

  System Call Implementation (aya/src/sys/bpf.rs:260):
  - Added bpf_map_lookup_and_delete_batch_per_cpu() to handle the BPF syscall
  - Properly handles per-CPU value alignment and memory layout
  - Returns ENOENT when no entries remain

  Testing:
  - Added test for empty map scenario
  - Added test with mock entries to verify correct key/value retrieval and cursor handling

  Test plan

  - Verify existing tests pass with cargo test
  - Check that the new batch API correctly handles empty maps
  - Confirm batch operations work with multiple entries across CPUs
  - Validate cursor-based iteration for large datasets
  - Test on kernel 5.6+ to ensure syscall compatibility

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aya-rs/aya/1434)
<!-- Reviewable:end -->
