### PR TITLE
aya-build: try to build when rustup is not found

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,6 +95,7 @@ public-api = { version = "0.50.0", default-features = false }
 quote = { version = "1", default-features = false }
 rand = { version = "0.9", default-features = false }
 rbpf = { version = "0.4.0", default-features = false }
+rustc_version = { version = "0.4.1", default-features = false }
 rustdoc-json = { version = "0.9.0", default-features = false }
 rustup-toolchain = { version = "0.1.5", default-features = false }
 rustversion = { version = "1.0.0", default-features = false }

--- a/aya-build/Cargo.toml
+++ b/aya-build/Cargo.toml
@@ -16,3 +16,5 @@ workspace = true
 [dependencies]
 anyhow = { workspace = true, default-features = true }
 cargo_metadata = { workspace = true }
+rustc_version = { workspace = true }
+which = { workspace = true, features = ["real-sys"] }


### PR DESCRIPTION
In some environments, rustup is not availible but cargo and its targets are. This changes aya-build to try to continue building if rustup is not found, even with stable Rust. If the Rust channel differs from the selected toolchain, the user will be warned but a build will still be attempted.

Fixes: #1329

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aya-rs/aya/1439)
<!-- Reviewable:end -->
