### PR TITLE
aya: load ringbuffers with value_size 0

### DIFF
--- a/aya/src/bpf.rs
+++ b/aya/src/bpf.rs
@@ -534,14 +534,8 @@ impl<'a> EbpfLoader<'a> {
             )? {
                 obj.set_max_entries(max_entries)
             }
-            match obj.map_type().try_into() {
-                Ok(BPF_MAP_TYPE_CPUMAP) => {
-                    obj.set_value_size(if FEATURES.cpumap_prog_id() { 8 } else { 4 })
-                }
-                Ok(BPF_MAP_TYPE_DEVMAP | BPF_MAP_TYPE_DEVMAP_HASH) => {
-                    obj.set_value_size(if FEATURES.devmap_prog_id() { 8 } else { 4 })
-                }
-                _ => (),
+            if let Some(value_size) = value_size_override(map_type) {
+                obj.set_value_size(value_size)
             }
             let btf_fd = btf_fd.as_deref().map(|fd| fd.as_fd());
             let mut map = if let Some(pin_path) = map_pin_path_by_name.get(name.as_str()) {
@@ -830,6 +824,19 @@ fn max_entries_override(
             .or(user_override),
         _ => user_override,
     })
+}
+
+/// Computes the value which should be used to override the value_size value of the map
+/// based on the rules for that map type.
+fn value_size_override(map_type: bpf_map_type) -> Option<u32> {
+    match map_type {
+        BPF_MAP_TYPE_CPUMAP => Some(if FEATURES.cpumap_prog_id() { 8 } else { 4 }),
+        BPF_MAP_TYPE_DEVMAP | BPF_MAP_TYPE_DEVMAP_HASH => {
+            Some(if FEATURES.devmap_prog_id() { 8 } else { 4 })
+        }
+        BPF_MAP_TYPE_RINGBUF => Some(0),
+        _ => None,
+    }
 }
 
 // Adjusts the byte size of a RingBuf map to match a power-of-two multiple of the page size.

--- a/test/integration-test/bpf/ringbuf-btf.bpf.c
+++ b/test/integration-test/bpf/ringbuf-btf.bpf.c
@@ -1,0 +1,27 @@
+// clang-format off
+#include <vmlinux.h>
+#include <bpf/bpf_helpers.h>
+// clang-format on
+
+struct {
+  __uint(type, BPF_MAP_TYPE_RINGBUF);
+  __uint(max_entries, 1 << 24);
+  __type(value, __u32);
+} map SEC(".maps");
+
+SEC("uprobe")
+int bpf_prog(void *ctx) {
+  __u32 val = 0xdeadbeef;
+
+  __u32 *buf = bpf_ringbuf_reserve(&map, sizeof(val), 0);
+  if (!buf) {
+    return 0;
+  }
+
+  *buf = val;
+  bpf_ringbuf_submit(buf, 0);
+
+  return 0;
+}
+
+char _license[] SEC("license") = "Dual MIT/GPL";

--- a/test/integration-test/build.rs
+++ b/test/integration-test/build.rs
@@ -71,6 +71,7 @@ fn main() -> Result<()> {
         ("iter.bpf.c", true),
         ("main.bpf.c", false),
         ("multimap-btf.bpf.c", false),
+        ("ringbuf-btf.bpf.c", true),
         ("enum_signed_32_checked_variants_reloc.bpf.c", true),
         ("enum_signed_32_reloc.bpf.c", true),
         ("enum_signed_64_checked_variants_reloc.bpf.c", true),

--- a/test/integration-test/src/lib.rs
+++ b/test/integration-test/src/lib.rs
@@ -11,6 +11,7 @@ bpf_file!(
     ITER_TASK => "iter.bpf.o",
     MAIN => "main.bpf.o",
     MULTIMAP_BTF => "multimap-btf.bpf.o",
+    RINGBUF_BTF => "ringbuf-btf.bpf.o",
 
     ENUM_SIGNED_32_RELOC_BPF => "enum_signed_32_reloc.bpf.o",
     ENUM_SIGNED_32_RELOC_BTF => "enum_signed_32_reloc.bpf.target.o",


### PR DESCRIPTION
In addiiton to #1441 we want to load programs that may not have been built with aya by setting `value_size` for **RingBuf** maps to 0.

This is the same approach cilium/ebpf takes when [loading RingBuffers](https://github.com/cilium/ebpf/blob/main/elf_reader.go#L1064-L1069).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aya-rs/aya/1443)
<!-- Reviewable:end -->
