### PR TITLE
aya-ebpf-macros: split vectors to avoid panicking

### DIFF
--- a/aya-ebpf-macros/src/args.rs
+++ b/aya-ebpf-macros/src/args.rs
@@ -9,75 +9,91 @@ pub(crate) struct NameValue {
     value: LitStr,
 }
 
-pub(crate) enum Arg {
-    String(NameValue),
-    Bool(Ident),
-}
-
 pub(crate) struct Args {
-    pub(crate) args: Vec<Arg>,
+    pub(crate) strings: Vec<NameValue>,
+    pub(crate) bools: Vec<Ident>,
 }
 
 impl Parse for Args {
     fn parse(input: ParseStream<'_>) -> Result<Self> {
-        let args = Punctuated::<Arg, Token![,]>::parse_terminated_with(input, |input| {
-            let ident = input.parse::<Ident>()?;
-            let lookahead = input.lookahead1();
-            if input.is_empty() || lookahead.peek(Token![,]) {
-                Ok(Arg::Bool(ident))
-            } else if lookahead.peek(Token![=]) {
-                let _: Token![=] = input.parse()?;
-                Ok(Arg::String(NameValue {
-                    name: ident,
-                    value: input.parse()?,
-                }))
-            } else {
-                Err(lookahead.error())
+        enum NameValueOrBool {
+            String(NameValue),
+            Bool(Ident),
+        }
+
+        let args =
+            Punctuated::<NameValueOrBool, Token![,]>::parse_terminated_with(input, |input| {
+                let ident = input.parse::<Ident>()?;
+                let lookahead = input.lookahead1();
+                if input.is_empty() || lookahead.peek(Token![,]) {
+                    Ok(NameValueOrBool::Bool(ident))
+                } else if lookahead.peek(Token![=]) {
+                    let _: Token![=] = input.parse()?;
+                    Ok(NameValueOrBool::String(NameValue {
+                        name: ident,
+                        value: input.parse()?,
+                    }))
+                } else {
+                    Err(lookahead.error())
+                }
+            })?
+            .into_pairs()
+            .map(|pair| match pair {
+                Pair::Punctuated(name_val, _) => name_val,
+                Pair::End(name_val) => name_val,
+            });
+
+        let mut strings = Vec::new();
+        let mut bools = Vec::new();
+        for arg in args {
+            match arg {
+                NameValueOrBool::String(name_val) => strings.push(name_val),
+                NameValueOrBool::Bool(ident) => bools.push(ident),
             }
-        })?
-        .into_pairs()
-        .map(|pair| match pair {
-            Pair::Punctuated(name_val, _) => name_val,
-            Pair::End(name_val) => name_val,
-        })
-        .collect();
+        }
 
-        Ok(Self { args })
+        Ok(Self { strings, bools })
     }
 }
 
-pub(crate) fn pop_string_arg(args: &mut Args, name: &str) -> Option<String> {
-    args.args
-        .iter()
-        .position(|arg| matches!(arg, Arg::String(name_val) if name_val.name == name))
-        .map(|index| match args.args.remove(index) {
-            Arg::String(v) => v.value.value(),
-            _ => panic!("impossible variant"),
-        })
-}
-
-pub(crate) fn pop_bool_arg(args: &mut Args, name: &str) -> bool {
-    args.args
-        .iter()
-        .position(|arg| matches!(arg, Arg::Bool(ident) if ident == name))
-        .map(|index| match args.args.remove(index) {
-            Arg::Bool(ident) => ident,
-            _ => panic!("impossible variant"),
-        })
-        .is_some()
-}
-
-pub(crate) fn err_on_unknown_args(args: &Args) -> Result<()> {
-    if let Some(arg) = args.args.first() {
-        let tokens = match arg {
-            Arg::String(name_val) => name_val.name.clone(),
-            Arg::Bool(ident) => ident.clone(),
-        };
-        return Err(Error::new_spanned(tokens, "invalid argument"));
+impl Args {
+    pub(crate) fn pop_string(&mut self, name: &str) -> Option<String> {
+        let Self { strings, bools: _ } = self;
+        strings
+            .iter()
+            .position(|name_val| name_val.name == name)
+            .map(|index| strings.swap_remove(index).value.value())
     }
-    Ok(())
-}
 
-pub(crate) fn name_arg(args: &mut Args) -> Option<String> {
-    pop_string_arg(args, "name")
+    pub(crate) fn pop_bool(&mut self, name: &str) -> bool {
+        let Self { strings: _, bools } = self;
+        bools
+            .iter()
+            .position(|ident| ident == name)
+            .map(|index| bools.swap_remove(index))
+            .is_some()
+    }
+
+    pub(crate) fn into_error(self) -> Result<()> {
+        let Self { strings, bools } = self;
+        match strings
+            .into_iter()
+            .map(|NameValue { name, value: _ }| Error::new_spanned(name, "invalid argument"))
+            .chain(
+                bools
+                    .into_iter()
+                    .map(|ident| Error::new_spanned(ident, "invalid argument")),
+            )
+            .reduce(|mut acc, err| {
+                acc.combine(err);
+                acc
+            }) {
+            Some(err) => Err(err),
+            None => Ok(()),
+        }
+    }
+
+    pub(crate) fn pop_name(&mut self) -> Option<String> {
+        self.pop_string("name")
+    }
 }

--- a/aya-ebpf-macros/src/btf_map.rs
+++ b/aya-ebpf-macros/src/btf_map.rs
@@ -4,7 +4,7 @@ use proc_macro2::TokenStream;
 use quote::quote;
 use syn::{ItemStatic, Result};
 
-use crate::args::name_arg;
+use crate::args::Args;
 
 pub(crate) struct BtfMap {
     item: ItemStatic,
@@ -14,8 +14,9 @@ pub(crate) struct BtfMap {
 impl BtfMap {
     pub(crate) fn parse(attrs: TokenStream, item: TokenStream) -> Result<Self> {
         let item: ItemStatic = syn::parse2(item)?;
-        let mut args = syn::parse2(attrs)?;
-        let name = name_arg(&mut args).unwrap_or_else(|| item.ident.to_string());
+        let mut args: Args = syn::parse2(attrs)?;
+        let name = args.pop_name().unwrap_or_else(|| item.ident.to_string());
+        args.into_error()?;
         Ok(Self { item, name })
     }
 

--- a/aya-ebpf-macros/src/btf_tracepoint.rs
+++ b/aya-ebpf-macros/src/btf_tracepoint.rs
@@ -4,7 +4,7 @@ use proc_macro2::TokenStream;
 use quote::quote;
 use syn::{ItemFn, Result};
 
-use crate::args::{Args, err_on_unknown_args, pop_string_arg};
+use crate::args::Args;
 
 pub(crate) struct BtfTracePoint {
     item: ItemFn,
@@ -15,8 +15,8 @@ impl BtfTracePoint {
     pub(crate) fn parse(attrs: TokenStream, item: TokenStream) -> Result<Self> {
         let item = syn::parse2(item)?;
         let mut args: Args = syn::parse2(attrs)?;
-        let function = pop_string_arg(&mut args, "function");
-        err_on_unknown_args(&args)?;
+        let function = args.pop_string("function");
+        args.into_error()?;
 
         Ok(Self { item, function })
     }

--- a/aya-ebpf-macros/src/fentry.rs
+++ b/aya-ebpf-macros/src/fentry.rs
@@ -4,7 +4,7 @@ use proc_macro2::TokenStream;
 use quote::quote;
 use syn::{ItemFn, Result};
 
-use crate::args::{err_on_unknown_args, pop_bool_arg, pop_string_arg};
+use crate::args::Args;
 
 pub(crate) struct FEntry {
     item: ItemFn,
@@ -15,10 +15,10 @@ pub(crate) struct FEntry {
 impl FEntry {
     pub(crate) fn parse(attrs: TokenStream, item: TokenStream) -> Result<Self> {
         let item = syn::parse2(item)?;
-        let mut args = syn::parse2(attrs)?;
-        let function = pop_string_arg(&mut args, "function");
-        let sleepable = pop_bool_arg(&mut args, "sleepable");
-        err_on_unknown_args(&args)?;
+        let mut args: Args = syn::parse2(attrs)?;
+        let function = args.pop_string("function");
+        let sleepable = args.pop_bool("sleepable");
+        args.into_error()?;
         Ok(Self {
             item,
             function,

--- a/aya-ebpf-macros/src/fexit.rs
+++ b/aya-ebpf-macros/src/fexit.rs
@@ -4,7 +4,7 @@ use proc_macro2::TokenStream;
 use quote::quote;
 use syn::{ItemFn, Result};
 
-use crate::args::{err_on_unknown_args, pop_bool_arg, pop_string_arg};
+use crate::args::Args;
 
 pub(crate) struct FExit {
     item: ItemFn,
@@ -15,10 +15,10 @@ pub(crate) struct FExit {
 impl FExit {
     pub(crate) fn parse(attrs: TokenStream, item: TokenStream) -> Result<Self> {
         let item = syn::parse2(item)?;
-        let mut args = syn::parse2(attrs)?;
-        let function = pop_string_arg(&mut args, "function");
-        let sleepable = pop_bool_arg(&mut args, "sleepable");
-        err_on_unknown_args(&args)?;
+        let mut args: Args = syn::parse2(attrs)?;
+        let function = args.pop_string("function");
+        let sleepable = args.pop_bool("sleepable");
+        args.into_error()?;
         Ok(Self {
             item,
             function,

--- a/aya-ebpf-macros/src/kprobe.rs
+++ b/aya-ebpf-macros/src/kprobe.rs
@@ -5,7 +5,7 @@ use proc_macro2_diagnostics::{Diagnostic, SpanDiagnosticExt as _};
 use quote::quote;
 use syn::{ItemFn, spanned::Spanned as _};
 
-use crate::args::{err_on_unknown_args, pop_string_arg};
+use crate::args::Args;
 
 #[derive(Debug, Copy, Clone)]
 pub(crate) enum KProbeKind {
@@ -37,14 +37,15 @@ impl KProbe {
     ) -> Result<Self, Diagnostic> {
         let item = syn::parse2(item)?;
         let span = attrs.span();
-        let mut args = syn::parse2(attrs)?;
-        let function = pop_string_arg(&mut args, "function");
-        let offset = pop_string_arg(&mut args, "offset")
+        let mut args: Args = syn::parse2(attrs)?;
+        let function = args.pop_string("function");
+        let offset = args
+            .pop_string("offset")
             .as_deref()
             .map(str::parse)
             .transpose()
             .map_err(|err| span.error(format!("failed to parse `offset` argument: {err}")))?;
-        err_on_unknown_args(&args)?;
+        args.into_error()?;
 
         Ok(Self {
             kind,

--- a/aya-ebpf-macros/src/lsm.rs
+++ b/aya-ebpf-macros/src/lsm.rs
@@ -4,7 +4,7 @@ use proc_macro2::TokenStream;
 use quote::quote;
 use syn::{ItemFn, Result};
 
-use crate::args::{err_on_unknown_args, pop_bool_arg, pop_string_arg};
+use crate::args::Args;
 
 pub(crate) struct Lsm {
     item: ItemFn,
@@ -15,10 +15,10 @@ pub(crate) struct Lsm {
 impl Lsm {
     pub(crate) fn parse(attrs: TokenStream, item: TokenStream) -> Result<Self> {
         let item = syn::parse2(item)?;
-        let mut args = syn::parse2(attrs)?;
-        let hook = pop_string_arg(&mut args, "hook");
-        let sleepable = pop_bool_arg(&mut args, "sleepable");
-        err_on_unknown_args(&args)?;
+        let mut args: Args = syn::parse2(attrs)?;
+        let hook = args.pop_string("hook");
+        let sleepable = args.pop_bool("sleepable");
+        args.into_error()?;
         Ok(Self {
             item,
             hook,

--- a/aya-ebpf-macros/src/lsm_cgroup.rs
+++ b/aya-ebpf-macros/src/lsm_cgroup.rs
@@ -4,7 +4,7 @@ use proc_macro2::TokenStream;
 use quote::quote;
 use syn::{ItemFn, Result};
 
-use crate::args::{err_on_unknown_args, pop_string_arg};
+use crate::args::Args;
 
 pub(crate) struct LsmCgroup {
     item: ItemFn,
@@ -14,9 +14,9 @@ pub(crate) struct LsmCgroup {
 impl LsmCgroup {
     pub(crate) fn parse(attrs: TokenStream, item: TokenStream) -> Result<Self> {
         let item = syn::parse2(item)?;
-        let mut args = syn::parse2(attrs)?;
-        let hook = pop_string_arg(&mut args, "hook");
-        err_on_unknown_args(&args)?;
+        let mut args: Args = syn::parse2(attrs)?;
+        let hook = args.pop_string("hook");
+        args.into_error()?;
 
         Ok(Self { item, hook })
     }

--- a/aya-ebpf-macros/src/map.rs
+++ b/aya-ebpf-macros/src/map.rs
@@ -4,7 +4,7 @@ use proc_macro2::TokenStream;
 use quote::quote;
 use syn::{ItemStatic, Result};
 
-use crate::args::name_arg;
+use crate::args::Args;
 pub(crate) struct Map {
     item: ItemStatic,
     name: String,
@@ -13,8 +13,9 @@ pub(crate) struct Map {
 impl Map {
     pub(crate) fn parse(attrs: TokenStream, item: TokenStream) -> Result<Self> {
         let item: ItemStatic = syn::parse2(item)?;
-        let mut args = syn::parse2(attrs)?;
-        let name = name_arg(&mut args).unwrap_or_else(|| item.ident.to_string());
+        let mut args: Args = syn::parse2(attrs)?;
+        let name = args.pop_name().unwrap_or_else(|| item.ident.to_string());
+        args.into_error()?;
         Ok(Self { item, name })
     }
 

--- a/aya-ebpf-macros/src/raw_tracepoint.rs
+++ b/aya-ebpf-macros/src/raw_tracepoint.rs
@@ -4,7 +4,7 @@ use proc_macro2::TokenStream;
 use quote::quote;
 use syn::{ItemFn, Result};
 
-use crate::args::{err_on_unknown_args, pop_string_arg};
+use crate::args::Args;
 
 pub(crate) struct RawTracePoint {
     item: ItemFn,
@@ -14,9 +14,9 @@ pub(crate) struct RawTracePoint {
 impl RawTracePoint {
     pub(crate) fn parse(attrs: TokenStream, item: TokenStream) -> Result<Self> {
         let item = syn::parse2(item)?;
-        let mut args = syn::parse2(attrs)?;
-        let tracepoint = pop_string_arg(&mut args, "tracepoint");
-        err_on_unknown_args(&args)?;
+        let mut args: Args = syn::parse2(attrs)?;
+        let tracepoint = args.pop_string("tracepoint");
+        args.into_error()?;
         Ok(Self { item, tracepoint })
     }
 

--- a/aya-ebpf-macros/src/tracepoint.rs
+++ b/aya-ebpf-macros/src/tracepoint.rs
@@ -5,7 +5,7 @@ use proc_macro2_diagnostics::{Diagnostic, SpanDiagnosticExt as _};
 use quote::quote;
 use syn::{ItemFn, spanned::Spanned as _};
 
-use crate::args::{err_on_unknown_args, pop_string_arg};
+use crate::args::Args;
 
 pub(crate) struct TracePoint {
     item: ItemFn,
@@ -16,10 +16,10 @@ impl TracePoint {
     pub(crate) fn parse(attrs: TokenStream, item: TokenStream) -> Result<Self, Diagnostic> {
         let item = syn::parse2(item)?;
         let span = attrs.span();
-        let mut args = syn::parse2(attrs)?;
-        let name = pop_string_arg(&mut args, "name");
-        let category = pop_string_arg(&mut args, "category");
-        err_on_unknown_args(&args)?;
+        let mut args: Args = syn::parse2(attrs)?;
+        let name = args.pop_string("name");
+        let category = args.pop_string("category");
+        args.into_error()?;
         match (name, category) {
             (None, None) => Ok(Self {
                 item,

--- a/aya-ebpf-macros/src/xdp.rs
+++ b/aya-ebpf-macros/src/xdp.rs
@@ -3,7 +3,7 @@ use proc_macro2_diagnostics::{Diagnostic, SpanDiagnosticExt as _};
 use quote::quote;
 use syn::{ItemFn, spanned::Spanned as _};
 
-use crate::args::{Args, err_on_unknown_args, pop_bool_arg, pop_string_arg};
+use crate::args::Args;
 
 pub(crate) struct Xdp {
     item: ItemFn,
@@ -23,8 +23,8 @@ impl Xdp {
         let span = attrs.span();
         let mut args: Args = syn::parse2(attrs)?;
 
-        let frags = pop_bool_arg(&mut args, "frags");
-        let map = match pop_string_arg(&mut args, "map").as_deref() {
+        let frags = args.pop_bool("frags");
+        let map = match args.pop_string("map").as_deref() {
             Some("cpumap") => Some(XdpMap::CpuMap),
             Some("devmap") => Some(XdpMap::DevMap),
             Some(name) => {
@@ -35,7 +35,7 @@ impl Xdp {
             None => None,
         };
 
-        err_on_unknown_args(&args)?;
+        args.into_error()?;
         Ok(Self { item, frags, map })
     }
 


### PR DESCRIPTION
Statically avoid panicking branch. While I'm here emit errors for all
unknown macro arguments, not just the first one.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aya-rs/aya/1448)
<!-- Reviewable:end -->
