### PR TITLE
aya-build: Allow to opt out

### DIFF
--- a/aya-build/src/lib.rs
+++ b/aya-build/src/lib.rs
@@ -43,6 +43,18 @@ pub fn build_ebpf<'a>(
     packages: impl IntoIterator<Item = Package<'a>>,
     toolchain: Toolchain<'a>,
 ) -> Result<()> {
+    const AYA_BUILD_SKIP: &str = "AYA_BUILD_SKIP";
+    println!("cargo:rerun-if-env-changed={AYA_BUILD_SKIP}");
+    if let Some(aya_build_skip) = env::var_os(AYA_BUILD_SKIP)
+        && (aya_build_skip.eq("1") || aya_build_skip.eq_ignore_ascii_case("true"))
+    {
+        println!(
+            "cargo:warning={AYA_BUILD_SKIP}={}; skipping eBPF build",
+            aya_build_skip.display()
+        );
+        return Ok(());
+    }
+
     let out_dir = env::var_os("OUT_DIR").ok_or(anyhow!("OUT_DIR not set"))?;
     let out_dir = PathBuf::from(out_dir);
 


### PR DESCRIPTION
Allow to opt out from cargo-in-cargo by setting `AYA_BUILD_SKIP` environment variable to `1` or `true`. That makes it easier for people using custom toolchains not managed by rustup (e.g. package maintainers).

Fixes: #1329

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aya-rs/aya/1450)
<!-- Reviewable:end -->
