### PR TITLE
Ringbuf batch drain

### DIFF
--- a/aya/src/maps/ring_buf.rs
+++ b/aya/src/maps/ring_buf.rs
@@ -7,7 +7,7 @@
 use std::{
     borrow::Borrow,
     fmt::{self, Debug, Formatter},
-    ops::Deref,
+    ops::{ControlFlow, Deref},
     os::fd::{AsFd, AsRawFd, BorrowedFd, RawFd},
     sync::atomic::{AtomicU32, AtomicUsize, Ordering},
 };
@@ -81,8 +81,8 @@ use crate::{
 ///
 /// # Polling
 ///
-/// In the example above the implementations of `poll()`, `poll.readable()`, `guard.inner_mut()`, and
-/// `guard.clear_ready()` are not given. `RingBuf` implements [`AsRawFd`], so you can implement polling
+/// In the example above the implementations of poll(), poll.readable(), guard.inner_mut(), and
+/// guard.clear_ready() are not given. RingBuf implements [`AsRawFd`], so you can implement polling
 /// using any crate that can poll file descriptors, like epoll, mio etc. The above example API is
 /// motivated by that of [`tokio::io::unix::AsyncFd`].
 ///
@@ -116,21 +116,78 @@ impl<T> RingBuf<T> {
     ///
     /// Returns `Some(item)` if the ringbuf is not empty. Returns `None` if the ringbuf is empty, in
     /// which case the caller may register for availability notifications through `epoll` or other
-    /// APIs. Only one [`RingBufItem`] may be outstanding at a time.
+    /// APIs. Only one RingBufItem may be outstanding at a time.
     //
     // This is not an implementation of `Iterator` because we need to be able to refer to the
     // lifetime of the iterator in the returned `RingBufItem`. If the Iterator::Item leveraged GATs,
     // one could imagine an implementation of `Iterator` that would work. GATs are stabilized in
     // Rust 1.65, but there's not yet a trait that the community seems to have standardized around.
-    #[expect(
-        clippy::should_implement_trait,
-        reason = "this is not an iterator; it yields a borrow-tied item"
-    )]
+    #[expect(clippy::should_implement_trait)]
     pub fn next(&mut self) -> Option<RingBufItem<'_>> {
         let Self {
             consumer, producer, ..
         } = self;
         producer.next(consumer)
+    }
+
+    /// Drain available entries from the ringbuf in a single batch.
+    ///
+    /// The callback is invoked once per entry with a borrowed slice into the mmap.
+    /// Do not retain the slice outside the callback; the backing storage can be
+    /// overwritten after the batch completes and the consumer position is committed.
+    pub fn drain<F>(&mut self, f: F) -> DrainStats
+    where
+        F: FnMut(&[u8]),
+    {
+        self.drain_with_limit(usize::MAX, usize::MAX, f)
+    }
+
+    /// Drain up to `max_items` entries or `max_bytes` total bytes, whichever comes first.
+    ///
+    /// This performs a single consumer position update after the batch.
+    ///
+    /// If at least one item is available, the first item is always processed even if doing so
+    /// would exceed `max_items` or `max_bytes`. In that case, the returned [`DrainStats`] may
+    /// report totals that are greater than the specified limits. Discarded items count toward
+    /// `max_bytes`.
+    pub fn drain_with_limit<F>(&mut self, max_items: usize, max_bytes: usize, f: F) -> DrainStats
+    where
+        F: FnMut(&[u8]),
+    {
+        let Self {
+            consumer, producer, ..
+        } = self;
+        producer.drain(consumer, max_items, max_bytes, f)
+    }
+
+    /// Drain available entries until `f` returns [`ControlFlow::Break`].
+    ///
+    /// Discarded entries are still skipped and counted in the returned [`DrainStats`].
+    ///
+    /// If `f` breaks, the current entry is considered consumed and the updated consumer
+    /// position is committed before returning.
+    pub fn drain_while<F, B>(&mut self, f: F) -> ControlFlow<B, DrainStats>
+    where
+        F: FnMut(&[u8]) -> ControlFlow<B>,
+    {
+        let Self {
+            consumer, producer, ..
+        } = self;
+        producer.drain_while(consumer, f)
+    }
+
+    /// Drain available entries with minimal accounting overhead.
+    ///
+    /// Returns the number of data entries passed to `f`. Discarded entries are skipped and
+    /// committed but not counted.
+    pub fn drain_fast<F>(&mut self, f: F) -> usize
+    where
+        F: FnMut(&[u8]),
+    {
+        let Self {
+            consumer, producer, ..
+        } = self;
+        producer.drain_fast(consumer, f)
     }
 }
 
@@ -191,6 +248,17 @@ impl Debug for RingBufItem<'_> {
     }
 }
 
+/// Stats returned by [`RingBuf::drain`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct DrainStats {
+    /// Number of entries read.
+    pub read: usize,
+    /// Number of discarded entries skipped.
+    pub discarded: usize,
+    /// Total bytes processed (payload size, not including headers).
+    pub bytes: usize,
+}
+
 struct ConsumerMetadata {
     mmap: MMap,
 }
@@ -227,10 +295,18 @@ impl ConsumerPos {
         Self { pos, metadata }
     }
 
-    fn consume(&mut self, len: usize) {
-        let Self { pos, metadata } = self;
+    fn advance(&mut self, len: usize) {
+        let Self { pos, .. } = self;
+        *pos += item_advance(len);
+    }
 
-        *pos += (usize::try_from(BPF_RINGBUF_HDR_SZ).unwrap() + len).next_multiple_of(8);
+    fn commit(&self) {
+        let Self { pos, metadata } = self;
+        metadata.as_ref().store(*pos, Ordering::SeqCst);
+    }
+
+    fn consume(&mut self, len: usize) {
+        self.advance(len);
 
         // Write operation needs to be properly ordered with respect to the producer committing new
         // data to the ringbuf. The producer uses xchg (SeqCst) to commit new data [1]. The producer
@@ -241,7 +317,7 @@ impl ConsumerPos {
         //
         // [1]: https://github.com/torvalds/linux/blob/2772d7df/kernel/bpf/ringbuf.c#L487-L488
         // [2]: https://github.com/torvalds/linux/blob/2772d7df/kernel/bpf/ringbuf.c#L494
-        metadata.as_ref().store(*pos, Ordering::SeqCst);
+        self.commit();
     }
 }
 
@@ -315,18 +391,13 @@ impl ProducerData {
     }
 
     fn next<'a>(&'a mut self, consumer: &'a mut ConsumerPos) -> Option<RingBufItem<'a>> {
-        let Self {
-            mmap,
-            data_offset,
-            pos_cache,
-            mask,
+        let &mut Self {
+            ref mmap,
+            ref mut data_offset,
+            ref mut pos_cache,
+            ref mut mask,
         } = self;
-        let mmap = &*mmap;
         let mmap_data = mmap.as_ref();
-        #[expect(
-            clippy::panic,
-            reason = "invalid ring buffer layout is a fatal internal error"
-        )]
         let data_pages = mmap_data.get(*data_offset..).unwrap_or_else(|| {
             panic!(
                 "offset {} out of bounds, data len {}",
@@ -334,77 +405,253 @@ impl ProducerData {
                 mmap_data.len()
             )
         });
-        while data_available(mmap, pos_cache, consumer) {
-            match read_item(data_pages, *mask, consumer) {
+        while data_available(mmap, pos_cache, consumer.pos) {
+            match read_item(data_pages, *mask, consumer.pos) {
                 Item::Busy => return None,
                 Item::Discard { len } => consumer.consume(len),
                 Item::Data(data) => return Some(RingBufItem { data, consumer }),
             }
         }
         return None;
+    }
 
-        enum Item<'a> {
-            Busy,
-            Discard { len: usize },
-            Data(&'a [u8]),
-        }
+    fn drain<F>(
+        &mut self,
+        consumer: &mut ConsumerPos,
+        max_items: usize,
+        max_bytes: usize,
+        f: F,
+    ) -> DrainStats
+    where
+        F: FnMut(&[u8]),
+    {
+        self.drain_impl::<_, true>(consumer, max_items, max_bytes, f)
+    }
 
-        fn data_available(
-            producer: &MMap,
-            producer_cache: &mut usize,
-            consumer: &ConsumerPos,
-        ) -> bool {
-            let ConsumerPos { pos: consumer, .. } = consumer;
-            // Refresh the producer position cache if it appears that the consumer is caught up
-            // with the producer position.
-            if consumer == producer_cache {
-                *producer_cache = load_producer_pos(producer);
+    fn drain_impl<F, const TRACK_BYTES: bool>(
+        &mut self,
+        consumer: &mut ConsumerPos,
+        max_items: usize,
+        max_bytes: usize,
+        mut f: F,
+    ) -> DrainStats
+    where
+        F: FnMut(&[u8]),
+    {
+        let &mut Self {
+            ref mmap,
+            ref mut data_offset,
+            ref mut pos_cache,
+            ref mut mask,
+        } = self;
+        let mmap_data = mmap.as_ref();
+        let data_pages = mmap_data.get(*data_offset..).unwrap_or_else(|| {
+            panic!(
+                "offset {} out of bounds, data len {}",
+                data_offset,
+                mmap_data.len()
+            )
+        });
+
+        let start_pos = consumer.pos;
+        let mut stats = DrainStats {
+            read: 0,
+            discarded: 0,
+            bytes: 0,
+        };
+        let mut processed = 0usize;
+
+        while data_available(mmap, pos_cache, consumer.pos) {
+            if processed >= max_items {
+                break;
             }
 
-            // Note that we don't compare the order of the values because the producer position may
-            // overflow u32 and wrap around to 0. Instead we just compare equality and assume that
-            // the consumer position is always logically less than the producer position.
-            //
-            // Note also that the kernel, at the time of writing [1], doesn't seem to handle this
-            // overflow correctly at all, and it's not clear that one can produce events after the
-            // producer position has wrapped around.
-            //
-            // [1]: https://github.com/torvalds/linux/blob/4b810bf0/kernel/bpf/ringbuf.c#L434-L440
-            consumer != producer_cache
-        }
-
-        fn read_item<'data>(data: &'data [u8], mask: u32, pos: &ConsumerPos) -> Item<'data> {
-            let ConsumerPos { pos, .. } = pos;
-            let offset = pos & usize::try_from(mask).unwrap();
-            #[expect(
-                clippy::panic,
-                reason = "invalid ring buffer layout is a fatal internal error"
-            )]
-            let must_get_data = |offset, len| {
-                data.get(offset..offset + len).unwrap_or_else(|| {
-                    panic!("{:?} not in {:?}", offset..offset + len, 0..data.len())
-                })
-            };
-            let header_ptr: *const AtomicU32 = must_get_data(offset, size_of::<AtomicU32>())
-                .as_ptr()
-                .cast();
-            // Pair the kernel's SeqCst write (implies Release) [1] with an Acquire load. This
-            // ensures data written by the producer will be visible.
-            //
-            // [1]: https://github.com/torvalds/linux/blob/eb26cbb1/kernel/bpf/ringbuf.c#L488
-            let header = unsafe { &*header_ptr }.load(Ordering::Acquire);
-            if header & BPF_RINGBUF_BUSY_BIT != 0 {
-                Item::Busy
-            } else {
-                let len = usize::try_from(header & mask).unwrap();
-                if header & BPF_RINGBUF_DISCARD_BIT != 0 {
-                    Item::Discard { len }
-                } else {
-                    let data_offset = offset + usize::try_from(BPF_RINGBUF_HDR_SZ).unwrap();
-                    let data = must_get_data(data_offset, len);
-                    Item::Data(data)
+            match read_item(data_pages, *mask, consumer.pos) {
+                Item::Busy => break,
+                Item::Discard { len } => {
+                    if TRACK_BYTES && stats.bytes + len > max_bytes && processed > 0 {
+                        break;
+                    }
+                    stats.discarded += 1;
+                    if TRACK_BYTES {
+                        stats.bytes += len;
+                    }
+                    processed += 1;
+                    consumer.advance(len);
+                }
+                Item::Data(data) => {
+                    let len = data.len();
+                    if TRACK_BYTES && stats.bytes + len > max_bytes && processed > 0 {
+                        break;
+                    }
+                    f(data);
+                    stats.read += 1;
+                    if TRACK_BYTES {
+                        stats.bytes += len;
+                    }
+                    processed += 1;
+                    consumer.advance(len);
                 }
             }
+        }
+
+        if consumer.pos != start_pos {
+            consumer.commit();
+        }
+        stats
+    }
+
+    fn drain_while<F, B>(
+        &mut self,
+        consumer: &mut ConsumerPos,
+        mut f: F,
+    ) -> ControlFlow<B, DrainStats>
+    where
+        F: FnMut(&[u8]) -> ControlFlow<B>,
+    {
+        let &mut Self {
+            ref mmap,
+            ref mut data_offset,
+            ref mut pos_cache,
+            ref mut mask,
+        } = self;
+        let mmap_data = mmap.as_ref();
+        let data_pages = mmap_data.get(*data_offset..).unwrap_or_else(|| {
+            panic!(
+                "offset {} out of bounds, data len {}",
+                data_offset,
+                mmap_data.len()
+            )
+        });
+
+        let start_pos = consumer.pos;
+        let mut stats = DrainStats {
+            read: 0,
+            discarded: 0,
+            bytes: 0,
+        };
+
+        while data_available(mmap, pos_cache, consumer.pos) {
+            match read_item(data_pages, *mask, consumer.pos) {
+                Item::Busy => break,
+                Item::Discard { len } => {
+                    stats.discarded += 1;
+                    stats.bytes += len;
+                    consumer.advance(len);
+                }
+                Item::Data(data) => {
+                    let len = data.len();
+                    stats.read += 1;
+                    stats.bytes += len;
+                    consumer.advance(len);
+                    if let ControlFlow::Break(value) = f(data) {
+                        if consumer.pos != start_pos {
+                            consumer.commit();
+                        }
+                        return ControlFlow::Break(value);
+                    }
+                }
+            }
+        }
+
+        if consumer.pos != start_pos {
+            consumer.commit();
+        }
+        ControlFlow::Continue(stats)
+    }
+
+    fn drain_fast<F>(&mut self, consumer: &mut ConsumerPos, mut f: F) -> usize
+    where
+        F: FnMut(&[u8]),
+    {
+        let &mut Self {
+            ref mmap,
+            ref mut data_offset,
+            ref mut pos_cache,
+            ref mut mask,
+        } = self;
+        let mmap_data = mmap.as_ref();
+        let data_pages = mmap_data.get(*data_offset..).unwrap_or_else(|| {
+            panic!(
+                "offset {} out of bounds, data len {}",
+                data_offset,
+                mmap_data.len()
+            )
+        });
+
+        let start_pos = consumer.pos;
+        let mut read = 0usize;
+
+        while data_available(mmap, pos_cache, consumer.pos) {
+            match read_item(data_pages, *mask, consumer.pos) {
+                Item::Busy => break,
+                Item::Discard { len } => {
+                    consumer.advance(len);
+                }
+                Item::Data(data) => {
+                    f(data);
+                    read += 1;
+                    consumer.advance(data.len());
+                }
+            }
+        }
+
+        if consumer.pos != start_pos {
+            consumer.commit();
+        }
+        read
+    }
+}
+
+enum Item<'a> {
+    Busy,
+    Discard { len: usize },
+    Data(&'a [u8]),
+}
+
+fn data_available(producer: &MMap, producer_cache: &mut usize, consumer: usize) -> bool {
+    // Refresh the producer position cache if it appears that the consumer is caught up
+    // with the producer position.
+    if consumer == *producer_cache {
+        *producer_cache = load_producer_pos(producer);
+    }
+
+    // Note that we don't compare the order of the values because the producer position may
+    // overflow u32 and wrap around to 0. Instead we just compare equality and assume that
+    // the consumer position is always logically less than the producer position.
+    //
+    // Note also that the kernel, at the time of writing [1], doesn't seem to handle this
+    // overflow correctly at all, and it's not clear that one can produce events after the
+    // producer position has wrapped around.
+    //
+    // [1]: https://github.com/torvalds/linux/blob/4b810bf0/kernel/bpf/ringbuf.c#L434-L440
+    consumer != *producer_cache
+}
+
+fn read_item<'data>(data: &'data [u8], mask: u32, pos: usize) -> Item<'data> {
+    let offset = pos & usize::try_from(mask).unwrap();
+    let must_get_data = |offset, len| {
+        data.get(offset..offset + len)
+            .unwrap_or_else(|| panic!("{:?} not in {:?}", offset..offset + len, 0..data.len()))
+    };
+    let header_ptr: *const AtomicU32 = must_get_data(offset, size_of::<AtomicU32>())
+        .as_ptr()
+        .cast();
+    // Pair the kernel's SeqCst write (implies Release) [1] with an Acquire load. This
+    // ensures data written by the producer will be visible.
+    //
+    // [1]: https://github.com/torvalds/linux/blob/eb26cbb1/kernel/bpf/ringbuf.c#L488
+    let header = unsafe { &*header_ptr }.load(Ordering::Acquire);
+    if header & BPF_RINGBUF_BUSY_BIT != 0 {
+        Item::Busy
+    } else {
+        let len = usize::try_from(header & mask).unwrap();
+        if header & BPF_RINGBUF_DISCARD_BIT != 0 {
+            Item::Discard { len }
+        } else {
+            let data_offset = offset + usize::try_from(BPF_RINGBUF_HDR_SZ).unwrap();
+            let data = must_get_data(data_offset, len);
+            Item::Data(data)
         }
     }
 }
@@ -416,4 +663,256 @@ fn load_producer_pos(producer: &MMap) -> usize {
     //
     // [1]: https://github.com/torvalds/linux/blob/eb26cbb1/kernel/bpf/ringbuf.c#L447-L448
     unsafe { producer.ptr().cast::<AtomicUsize>().as_ref() }.load(Ordering::Acquire)
+}
+
+fn item_advance(len: usize) -> usize {
+    (usize::try_from(BPF_RINGBUF_HDR_SZ).unwrap() + len).next_multiple_of(8)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::ptr;
+
+    use super::*;
+    use crate::sys::{clear_test_mmap_ret_queue, push_test_mmap_ret};
+
+    struct TestRingBuf {
+        _consumer_buf: Box<[u8]>,
+        _producer_buf: Box<[u8]>,
+        consumer: ConsumerPos,
+        producer: ProducerData,
+    }
+
+    impl TestRingBuf {
+        fn new(entries: &[Entry]) -> Self {
+            let page_size = 64;
+            let byte_size = 128;
+            let mut consumer_buf = vec![0u8; page_size].into_boxed_slice();
+            let mut producer_buf = vec![0u8; page_size + 2 * byte_size].into_boxed_slice();
+
+            unsafe {
+                (consumer_buf.as_mut_ptr() as *mut AtomicUsize).write(AtomicUsize::new(0));
+                (producer_buf.as_mut_ptr() as *mut AtomicUsize).write(AtomicUsize::new(0));
+            }
+
+            let mut offset = 0;
+            for entry in entries {
+                offset = write_entry(
+                    &mut producer_buf,
+                    page_size,
+                    offset,
+                    entry.len,
+                    entry.discard,
+                    entry.fill,
+                );
+            }
+
+            unsafe {
+                let producer_pos = producer_buf.as_mut_ptr() as *mut AtomicUsize;
+                (*producer_pos).store(offset, Ordering::Release);
+            }
+
+            clear_test_mmap_ret_queue();
+            push_test_mmap_ret(consumer_buf.as_mut_ptr().cast());
+            push_test_mmap_ret(producer_buf.as_mut_ptr().cast());
+
+            let fd = unsafe { BorrowedFd::borrow_raw(crate::MockableFd::mock_signed_fd()) };
+            let consumer_metadata = ConsumerMetadata::new(fd, 0, page_size).unwrap();
+            let consumer = ConsumerPos::new(consumer_metadata);
+            let producer = ProducerData::new(fd, page_size, page_size, byte_size as u32).unwrap();
+
+            Self {
+                _consumer_buf: consumer_buf,
+                _producer_buf: producer_buf,
+                consumer,
+                producer,
+            }
+        }
+    }
+
+    struct Entry {
+        len: usize,
+        discard: bool,
+        fill: u8,
+    }
+
+    fn write_entry(
+        buf: &mut [u8],
+        data_offset: usize,
+        offset: usize,
+        len: usize,
+        discard: bool,
+        fill: u8,
+    ) -> usize {
+        let header_offset = data_offset + offset;
+        let mut header = len as u32;
+        if discard {
+            header |= BPF_RINGBUF_DISCARD_BIT;
+        }
+        unsafe {
+            ptr::write_unaligned(buf.as_mut_ptr().add(header_offset).cast::<u32>(), header);
+            let data_start = header_offset + usize::try_from(BPF_RINGBUF_HDR_SZ).unwrap();
+            ptr::write_bytes(buf.as_mut_ptr().add(data_start), fill, len);
+        }
+        offset + item_advance(len)
+    }
+
+    #[test]
+    fn drain_empty_returns_zero() {
+        let mut ring = TestRingBuf::new(&[]);
+        let stats = ring
+            .producer
+            .drain(&mut ring.consumer, usize::MAX, usize::MAX, |_| {
+                panic!("no items should be produced")
+            });
+        assert_eq!(
+            stats,
+            DrainStats {
+                read: 0,
+                discarded: 0,
+                bytes: 0
+            }
+        );
+        let committed = ring.consumer.metadata.as_ref().load(Ordering::SeqCst);
+        assert_eq!(committed, 0);
+    }
+
+    #[test]
+    fn drain_respects_max_items() {
+        let mut ring = TestRingBuf::new(&[
+            Entry {
+                len: 8,
+                discard: false,
+                fill: 0xAA,
+            },
+            Entry {
+                len: 8,
+                discard: false,
+                fill: 0xBB,
+            },
+        ]);
+        let mut seen = 0usize;
+        let stats = ring
+            .producer
+            .drain(&mut ring.consumer, 1, usize::MAX, |_| seen += 1);
+        assert_eq!(seen, 1);
+        assert_eq!(
+            stats,
+            DrainStats {
+                read: 1,
+                discarded: 0,
+                bytes: 8
+            }
+        );
+        let committed = ring.consumer.metadata.as_ref().load(Ordering::SeqCst);
+        assert_eq!(committed, item_advance(8));
+    }
+
+    #[test]
+    fn drain_allows_first_item_over_max_bytes() {
+        let mut ring = TestRingBuf::new(&[Entry {
+            len: 8,
+            discard: false,
+            fill: 0xCC,
+        }]);
+        let stats = ring
+            .producer
+            .drain(&mut ring.consumer, usize::MAX, 0, |_| {});
+        assert_eq!(
+            stats,
+            DrainStats {
+                read: 1,
+                discarded: 0,
+                bytes: 8
+            }
+        );
+    }
+
+    #[test]
+    fn discarded_counts_toward_byte_budget() {
+        let mut ring = TestRingBuf::new(&[
+            Entry {
+                len: 8,
+                discard: true,
+                fill: 0,
+            },
+            Entry {
+                len: 8,
+                discard: false,
+                fill: 0xDD,
+            },
+        ]);
+        let stats = ring
+            .producer
+            .drain(&mut ring.consumer, usize::MAX, 8, |_| {});
+        assert_eq!(
+            stats,
+            DrainStats {
+                read: 0,
+                discarded: 1,
+                bytes: 8
+            }
+        );
+    }
+
+    #[test]
+    fn drain_while_breaks_early() {
+        let mut ring = TestRingBuf::new(&[
+            Entry {
+                len: 8,
+                discard: false,
+                fill: 0x11,
+            },
+            Entry {
+                len: 8,
+                discard: false,
+                fill: 0x22,
+            },
+            Entry {
+                len: 8,
+                discard: false,
+                fill: 0x33,
+            },
+        ]);
+        let mut calls = 0usize;
+        let out = ring.producer.drain_while(&mut ring.consumer, |_| {
+            calls += 1;
+            if calls == 2 {
+                ControlFlow::Break(calls)
+            } else {
+                ControlFlow::Continue(())
+            }
+        });
+        assert_eq!(calls, 2);
+        assert_eq!(out, ControlFlow::Break(2));
+        let committed = ring.consumer.metadata.as_ref().load(Ordering::SeqCst);
+        assert_eq!(committed, item_advance(8) * 2);
+    }
+
+    #[test]
+    fn drain_fast_counts_data_only() {
+        let mut ring = TestRingBuf::new(&[
+            Entry {
+                len: 8,
+                discard: false,
+                fill: 0xAA,
+            },
+            Entry {
+                len: 8,
+                discard: true,
+                fill: 0,
+            },
+            Entry {
+                len: 8,
+                discard: false,
+                fill: 0xBB,
+            },
+        ]);
+        let mut seen = 0usize;
+        let read = ring.producer.drain_fast(&mut ring.consumer, |_| seen += 1);
+        assert_eq!(read, 2);
+        assert_eq!(seen, 2);
+        let committed = ring.consumer.metadata.as_ref().load(Ordering::SeqCst);
+        assert_eq!(committed, item_advance(8) * 3);
+    }
 }

--- a/ebpf/aya-ebpf/src/maps/ring_buf.rs
+++ b/ebpf/aya-ebpf/src/maps/ring_buf.rs
@@ -8,7 +8,7 @@ use core::{
 #[cfg(generic_const_exprs)]
 use crate::const_assert::{Assert, IsTrue};
 use crate::{
-    bindings::bpf_map_type::BPF_MAP_TYPE_RINGBUF,
+    bindings::{BPF_RB_FORCE_WAKEUP, BPF_RB_NO_WAKEUP, bpf_map_type::BPF_MAP_TYPE_RINGBUF},
     helpers::{
         bpf_ringbuf_discard, bpf_ringbuf_output, bpf_ringbuf_query, bpf_ringbuf_reserve,
         bpf_ringbuf_submit,
@@ -54,15 +54,53 @@ impl RingBufBytes<'_> {
     }
 
     /// Commit this ring buffer entry. The entry will be made visible to the userspace reader.
+    #[inline(always)]
     pub fn submit(self, flags: u64) {
         let Self(inner) = self;
         unsafe { bpf_ringbuf_submit(inner.as_mut_ptr().cast(), flags) }
     }
 
+    /// Commit this ring buffer entry using default wakeup behavior.
+    #[inline(always)]
+    pub fn submit_default(self) {
+        self.submit(0);
+    }
+
+    /// Commit this ring buffer entry without waking userspace readers.
+    #[inline(always)]
+    pub fn submit_no_wakeup(self) {
+        self.submit(BPF_RB_NO_WAKEUP as u64);
+    }
+
+    /// Commit this ring buffer entry and force a userspace wakeup.
+    #[inline(always)]
+    pub fn submit_force_wakeup(self) {
+        self.submit(BPF_RB_FORCE_WAKEUP as u64);
+    }
+
     /// Discard this ring buffer entry. The entry will be skipped by the userspace reader.
+    #[inline(always)]
     pub fn discard(self, flags: u64) {
         let Self(inner) = self;
         unsafe { bpf_ringbuf_discard(inner.as_mut_ptr().cast(), flags) }
+    }
+
+    /// Discard this ring buffer entry using default wakeup behavior.
+    #[inline(always)]
+    pub fn discard_default(self) {
+        self.discard(0);
+    }
+
+    /// Discard this ring buffer entry without waking userspace readers.
+    #[inline(always)]
+    pub fn discard_no_wakeup(self) {
+        self.discard(BPF_RB_NO_WAKEUP as u64);
+    }
+
+    /// Discard this ring buffer entry and force a userspace wakeup.
+    #[inline(always)]
+    pub fn discard_force_wakeup(self) {
+        self.discard(BPF_RB_FORCE_WAKEUP as u64);
     }
 }
 
@@ -97,15 +135,53 @@ impl<T> RingBufEntry<T> {
     }
 
     /// Discard this ring buffer entry. The entry will be skipped by the userspace reader.
+    #[inline(always)]
     pub fn discard(self, flags: u64) {
         let Self(inner) = self;
         unsafe { bpf_ringbuf_discard(inner.as_mut_ptr().cast(), flags) }
     }
 
+    /// Discard this ring buffer entry using default wakeup behavior.
+    #[inline(always)]
+    pub fn discard_default(self) {
+        self.discard(0);
+    }
+
+    /// Discard this ring buffer entry without waking userspace readers.
+    #[inline(always)]
+    pub fn discard_no_wakeup(self) {
+        self.discard(BPF_RB_NO_WAKEUP as u64);
+    }
+
+    /// Discard this ring buffer entry and force a userspace wakeup.
+    #[inline(always)]
+    pub fn discard_force_wakeup(self) {
+        self.discard(BPF_RB_FORCE_WAKEUP as u64);
+    }
+
     /// Commit this ring buffer entry. The entry will be made visible to the userspace reader.
+    #[inline(always)]
     pub fn submit(self, flags: u64) {
         let Self(inner) = self;
         unsafe { bpf_ringbuf_submit(inner.as_mut_ptr().cast(), flags) }
+    }
+
+    /// Commit this ring buffer entry using default wakeup behavior.
+    #[inline(always)]
+    pub fn submit_default(self) {
+        self.submit(0);
+    }
+
+    /// Commit this ring buffer entry without waking userspace readers.
+    #[inline(always)]
+    pub fn submit_no_wakeup(self) {
+        self.submit(BPF_RB_NO_WAKEUP as u64);
+    }
+
+    /// Commit this ring buffer entry and force a userspace wakeup.
+    #[inline(always)]
+    pub fn submit_force_wakeup(self) {
+        self.submit(BPF_RB_FORCE_WAKEUP as u64);
     }
 }
 

--- a/test/integration-test/Cargo.toml
+++ b/test/integration-test/Cargo.toml
@@ -21,6 +21,7 @@ anyhow = { workspace = true, features = ["std"] }
 assert_matches = { workspace = true }
 aya-log = { path = "../../aya-log", version = "^0.2.2", default-features = false }
 aya-obj = { path = "../../aya-obj", version = "^0.2.2", default-features = false }
+criterion = { version = "0.5.1", features = ["cargo_bench_support"] }
 epoll = { workspace = true }
 futures = { workspace = true, features = ["alloc"] }
 integration-common = { path = "../integration-common", features = ["user"] }
@@ -57,3 +58,23 @@ cargo_metadata = { workspace = true }
 # features.
 integration-ebpf = { path = "../integration-ebpf" }
 xtask = { path = "../../xtask" }
+
+[[bench]]
+harness = false
+name = "ring_buf_next_vs_drain"
+
+[[bench]]
+harness = false
+name = "ring_buf_drain_fast"
+
+[[bench]]
+harness = false
+name = "ring_buf_next_vs_drain_epoll"
+
+[[bench]]
+harness = false
+name = "ring_buf_next_vs_drain_epoll_bursty"
+
+[[bench]]
+harness = false
+name = "ring_buf_next_vs_drain_epoll_notify_batch"

--- a/test/integration-test/benches/ring_buf_drain_fast.rs
+++ b/test/integration-test/benches/ring_buf_drain_fast.rs
@@ -1,0 +1,150 @@
+#![expect(unused_crate_dependencies, reason = "used in tests")]
+
+use std::{
+    hint::black_box,
+    time::{Duration, Instant},
+};
+
+use aya::{
+    Ebpf, EbpfLoader,
+    maps::{MapData, array::PerCpuArray, ring_buf::RingBuf},
+    programs::UProbe,
+};
+use aya_obj::generated::BPF_RINGBUF_HDR_SZ;
+use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
+use integration_common::ring_buf::Registers;
+
+struct RingBufBench {
+    _bpf: Ebpf,
+    ring_buf: RingBuf<MapData>,
+    regs: PerCpuArray<MapData, Registers>,
+}
+
+const RING_BUF_MAX_ENTRIES: usize = 32 * 1024;
+const PREFILL_ITEMS: usize = RING_BUF_MAX_ENTRIES - 1;
+
+#[derive(Clone, Copy)]
+struct RingBufVariant {
+    map: &'static str,
+    regs: &'static str,
+    prog: &'static str,
+}
+
+const RING_BUF_VARIANTS: &[RingBufVariant] = &[
+    RingBufVariant {
+        map: "RING_BUF",
+        regs: "REGISTERS",
+        prog: "ring_buf_test",
+    },
+    RingBufVariant {
+        map: "RING_BUF_LEGACY",
+        regs: "REGISTERS_LEGACY",
+        prog: "ring_buf_test_legacy",
+    },
+];
+
+const ALL_RING_BUFS: &[&str] = &["RING_BUF", "RING_BUF_LEGACY", "RING_BUF_MISMATCH"];
+
+impl RingBufBench {
+    fn new(variant: RingBufVariant) -> Self {
+        const RING_BUF_BYTE_SIZE: u32 =
+            (RING_BUF_MAX_ENTRIES * (size_of::<u64>() + BPF_RINGBUF_HDR_SZ as usize)) as u32;
+
+        let mut loader = EbpfLoader::new();
+        for &map in ALL_RING_BUFS {
+            loader.map_max_entries(map, RING_BUF_BYTE_SIZE);
+        }
+        let mut bpf = loader.load(integration_test::RING_BUF).unwrap();
+
+        let ring_buf = bpf.take_map(variant.map).unwrap();
+        let ring_buf = RingBuf::try_from(ring_buf).unwrap();
+        let regs = bpf.take_map(variant.regs).unwrap();
+        let regs = PerCpuArray::<_, Registers>::try_from(regs).unwrap();
+
+        let prog: &mut UProbe = bpf.program_mut(variant.prog).unwrap().try_into().unwrap();
+        prog.load().unwrap();
+        prog.attach("ring_buf_trigger_ebpf_program", "/proc/self/exe", None)
+            .unwrap();
+
+        Self {
+            _bpf: bpf,
+            ring_buf,
+            regs,
+        }
+    }
+
+    fn registers(&self) -> Registers {
+        self.regs.get(&0, 0).unwrap().iter().sum()
+    }
+
+    fn assert_no_rejections(&self) {
+        let Registers { rejected, .. } = self.registers();
+        assert_eq!(rejected, 0);
+    }
+}
+
+#[unsafe(no_mangle)]
+#[inline(never)]
+extern "C" fn ring_buf_trigger_ebpf_program(arg: u64) {
+    black_box(arg);
+}
+
+fn drain_fast_all(ring_buf: &mut RingBuf<MapData>) -> usize {
+    ring_buf.drain_fast(|item| {
+        let _: [u8; 8] = item.try_into().unwrap();
+    })
+}
+
+fn prefill(seq: &mut u64, target: usize) {
+    for _ in 0..target {
+        // Keep values even so the eBPF program doesn't reject them.
+        ring_buf_trigger_ebpf_program(*seq * 2);
+        *seq += 1;
+    }
+}
+
+fn bench_ring_buf_drain_fast(c: &mut Criterion) {
+    let mut group = c.benchmark_group("ring_buf/drain_fast_prefilled_single_thread");
+    group.throughput(criterion::Throughput::Elements(
+        u64::try_from(PREFILL_ITEMS).unwrap(),
+    ));
+    group.sample_size(10);
+    group.measurement_time(Duration::from_secs(5));
+
+    for &variant in RING_BUF_VARIANTS {
+        group.bench_with_input(
+            BenchmarkId::new("drain_fast", variant.prog),
+            &variant,
+            |b, &variant| {
+                let mut bench = RingBufBench::new(variant);
+                let mut seq = 0u64;
+                b.iter_custom(|iters| {
+                    let mut elapsed = Duration::ZERO;
+                    for _ in 0..iters {
+                        // Drain leftovers from previous iteration.
+                        let _ = drain_fast_all(&mut bench.ring_buf);
+
+                        let before = bench.registers();
+                        prefill(&mut seq, PREFILL_ITEMS);
+
+                        let start = Instant::now();
+                        let seen = drain_fast_all(&mut bench.ring_buf);
+                        elapsed += start.elapsed();
+
+                        assert_eq!(seen, PREFILL_ITEMS);
+                        let after = bench.registers();
+                        assert_eq!(after.dropped, before.dropped);
+                        assert_eq!(after.rejected, before.rejected);
+                    }
+                    elapsed
+                });
+                bench.assert_no_rejections();
+            },
+        );
+    }
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_ring_buf_drain_fast);
+criterion_main!(benches);

--- a/test/integration-test/benches/ring_buf_next_vs_drain.rs
+++ b/test/integration-test/benches/ring_buf_next_vs_drain.rs
@@ -1,0 +1,189 @@
+#![expect(unused_crate_dependencies, reason = "used in tests")]
+
+use std::{
+    hint::black_box,
+    time::{Duration, Instant},
+};
+
+use aya::{
+    Ebpf, EbpfLoader,
+    maps::{MapData, array::PerCpuArray, ring_buf::RingBuf},
+    programs::UProbe,
+};
+use aya_obj::generated::BPF_RINGBUF_HDR_SZ;
+use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
+use integration_common::ring_buf::Registers;
+
+struct RingBufBench {
+    _bpf: Ebpf,
+    ring_buf: RingBuf<MapData>,
+    regs: PerCpuArray<MapData, Registers>,
+}
+
+const RING_BUF_MAX_ENTRIES: usize = 32 * 1024;
+const PREFILL_ITEMS: usize = RING_BUF_MAX_ENTRIES - 1;
+
+#[derive(Clone, Copy)]
+struct RingBufVariant {
+    map: &'static str,
+    regs: &'static str,
+    prog: &'static str,
+}
+
+const RING_BUF_VARIANTS: &[RingBufVariant] = &[
+    RingBufVariant {
+        map: "RING_BUF",
+        regs: "REGISTERS",
+        prog: "ring_buf_test",
+    },
+    RingBufVariant {
+        map: "RING_BUF_LEGACY",
+        regs: "REGISTERS_LEGACY",
+        prog: "ring_buf_test_legacy",
+    },
+];
+
+const ALL_RING_BUFS: &[&str] = &["RING_BUF", "RING_BUF_LEGACY", "RING_BUF_MISMATCH"];
+
+impl RingBufBench {
+    fn new(variant: RingBufVariant) -> Self {
+        const RING_BUF_BYTE_SIZE: u32 =
+            (RING_BUF_MAX_ENTRIES * (size_of::<u64>() + BPF_RINGBUF_HDR_SZ as usize)) as u32;
+
+        let mut loader = EbpfLoader::new();
+        for &map in ALL_RING_BUFS {
+            loader.map_max_entries(map, RING_BUF_BYTE_SIZE);
+        }
+        let mut bpf = loader.load(integration_test::RING_BUF).unwrap();
+
+        let ring_buf = bpf.take_map(variant.map).unwrap();
+        let ring_buf = RingBuf::try_from(ring_buf).unwrap();
+        let regs = bpf.take_map(variant.regs).unwrap();
+        let regs = PerCpuArray::<_, Registers>::try_from(regs).unwrap();
+
+        let prog: &mut UProbe = bpf.program_mut(variant.prog).unwrap().try_into().unwrap();
+        prog.load().unwrap();
+        prog.attach("ring_buf_trigger_ebpf_program", "/proc/self/exe", None)
+            .unwrap();
+
+        Self {
+            _bpf: bpf,
+            ring_buf,
+            regs,
+        }
+    }
+
+    fn registers(&self) -> Registers {
+        self.regs.get(&0, 0).unwrap().iter().sum()
+    }
+
+    fn assert_no_rejections(&self) {
+        let Registers { rejected, .. } = self.registers();
+        assert_eq!(rejected, 0);
+    }
+}
+
+#[unsafe(no_mangle)]
+#[inline(never)]
+extern "C" fn ring_buf_trigger_ebpf_program(arg: u64) {
+    black_box(arg);
+}
+
+fn drain_next_all(ring_buf: &mut RingBuf<MapData>) -> usize {
+    let mut seen = 0usize;
+    while let Some(item) = ring_buf.next() {
+        let _: [u8; 8] = (*item).try_into().unwrap();
+        seen += 1;
+    }
+    seen
+}
+
+fn drain_drain_all(ring_buf: &mut RingBuf<MapData>) -> usize {
+    let mut seen = 0usize;
+    let stats = ring_buf.drain(|item| {
+        let _: [u8; 8] = item.try_into().unwrap();
+        seen += 1;
+    });
+    assert_eq!(stats.read, seen);
+    seen
+}
+
+fn prefill(seq: &mut u64, target: usize) {
+    for _ in 0..target {
+        // Keep values even so the eBPF program doesn't reject them.
+        ring_buf_trigger_ebpf_program(*seq * 2);
+        *seq += 1;
+    }
+}
+
+fn bench_ring_buf_next_vs_drain(c: &mut Criterion) {
+    let mut group = c.benchmark_group("ring_buf/next_vs_drain_prefilled_single_thread");
+    group.throughput(criterion::Throughput::Elements(
+        u64::try_from(PREFILL_ITEMS).unwrap(),
+    ));
+    group.sample_size(10);
+    group.measurement_time(Duration::from_secs(5));
+
+    for &variant in RING_BUF_VARIANTS {
+        group.bench_with_input(
+            BenchmarkId::new("next", variant.prog),
+            &variant,
+            |b, &variant| {
+                let mut bench = RingBufBench::new(variant);
+                let mut seq = 0u64;
+                b.iter_custom(|iters| {
+                    let mut elapsed = Duration::ZERO;
+                    for _ in 0..iters {
+                        let _ = drain_next_all(&mut bench.ring_buf);
+                        let before = bench.registers();
+                        prefill(&mut seq, PREFILL_ITEMS);
+
+                        let start = Instant::now();
+                        let seen = drain_next_all(&mut bench.ring_buf);
+                        elapsed += start.elapsed();
+
+                        assert_eq!(seen, PREFILL_ITEMS);
+                        let after = bench.registers();
+                        assert_eq!(after.dropped, before.dropped);
+                        assert_eq!(after.rejected, before.rejected);
+                    }
+                    elapsed
+                });
+                bench.assert_no_rejections();
+            },
+        );
+
+        group.bench_with_input(
+            BenchmarkId::new("drain", variant.prog),
+            &variant,
+            |b, &variant| {
+                let mut bench = RingBufBench::new(variant);
+                let mut seq = 0u64;
+                b.iter_custom(|iters| {
+                    let mut elapsed = Duration::ZERO;
+                    for _ in 0..iters {
+                        let _ = drain_next_all(&mut bench.ring_buf);
+                        let before = bench.registers();
+                        prefill(&mut seq, PREFILL_ITEMS);
+
+                        let start = Instant::now();
+                        let seen = drain_drain_all(&mut bench.ring_buf);
+                        elapsed += start.elapsed();
+
+                        assert_eq!(seen, PREFILL_ITEMS);
+                        let after = bench.registers();
+                        assert_eq!(after.dropped, before.dropped);
+                        assert_eq!(after.rejected, before.rejected);
+                    }
+                    elapsed
+                });
+                bench.assert_no_rejections();
+            },
+        );
+    }
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_ring_buf_next_vs_drain);
+criterion_main!(benches);

--- a/test/integration-test/benches/ring_buf_next_vs_drain_epoll.rs
+++ b/test/integration-test/benches/ring_buf_next_vs_drain_epoll.rs
@@ -1,0 +1,190 @@
+#![expect(unused_crate_dependencies, reason = "used in tests")]
+
+use std::{
+    hint::black_box,
+    os::fd::AsRawFd,
+    thread,
+    time::{Duration, Instant},
+};
+
+use aya::{
+    Ebpf, EbpfLoader,
+    maps::{MapData, array::PerCpuArray, ring_buf::RingBuf},
+    programs::UProbe,
+};
+use aya_obj::generated::BPF_RINGBUF_HDR_SZ;
+use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
+use integration_common::ring_buf::Registers;
+
+struct RingBufBench {
+    _bpf: Ebpf,
+    ring_buf: RingBuf<MapData>,
+    regs: PerCpuArray<MapData, Registers>,
+}
+
+const RING_BUF_MAX_ENTRIES: usize = 32 * 1024;
+const ALL_RING_BUFS: &[&str] = &["RING_BUF", "RING_BUF_LEGACY", "RING_BUF_MISMATCH"];
+
+#[derive(Clone, Copy)]
+struct RingBufVariant {
+    map: &'static str,
+    regs: &'static str,
+    prog: &'static str,
+}
+
+const RING_BUF_VARIANTS: &[RingBufVariant] = &[
+    RingBufVariant {
+        map: "RING_BUF",
+        regs: "REGISTERS",
+        prog: "ring_buf_test",
+    },
+    RingBufVariant {
+        map: "RING_BUF_LEGACY",
+        regs: "REGISTERS_LEGACY",
+        prog: "ring_buf_test_legacy",
+    },
+];
+
+#[derive(Clone, Copy)]
+enum Mode {
+    Next,
+    Drain,
+}
+
+impl RingBufBench {
+    fn new(variant: RingBufVariant) -> Self {
+        const RING_BUF_BYTE_SIZE: u32 =
+            (RING_BUF_MAX_ENTRIES * (size_of::<u64>() + BPF_RINGBUF_HDR_SZ as usize)) as u32;
+
+        let mut loader = EbpfLoader::new();
+        for &map in ALL_RING_BUFS {
+            loader.map_max_entries(map, RING_BUF_BYTE_SIZE);
+        }
+        let mut bpf = loader.load(integration_test::RING_BUF).unwrap();
+
+        let ring_buf = bpf.take_map(variant.map).unwrap();
+        let ring_buf = RingBuf::try_from(ring_buf).unwrap();
+        let regs = bpf.take_map(variant.regs).unwrap();
+        let regs = PerCpuArray::<_, Registers>::try_from(regs).unwrap();
+
+        let prog: &mut UProbe = bpf.program_mut(variant.prog).unwrap().try_into().unwrap();
+        prog.load().unwrap();
+        prog.attach("ring_buf_trigger_ebpf_program", "/proc/self/exe", None)
+            .unwrap();
+
+        Self {
+            _bpf: bpf,
+            ring_buf,
+            regs,
+        }
+    }
+
+    fn registers(&self) -> Registers {
+        self.regs.get(&0, 0).unwrap().iter().sum()
+    }
+}
+
+#[unsafe(no_mangle)]
+#[inline(never)]
+extern "C" fn ring_buf_trigger_ebpf_program(arg: u64) {
+    black_box(arg);
+}
+
+fn drain_once(ring_buf: &mut RingBuf<MapData>, mode: Mode) -> usize {
+    match mode {
+        Mode::Next => {
+            let mut seen = 0usize;
+            while let Some(item) = ring_buf.next() {
+                let _: [u8; 8] = (*item).try_into().unwrap();
+                seen += 1;
+            }
+            seen
+        }
+        Mode::Drain => {
+            let mut seen = 0usize;
+            let stats = ring_buf.drain(|item| {
+                let _: [u8; 8] = item.try_into().unwrap();
+                seen += 1;
+            });
+            assert_eq!(stats.read, seen);
+            seen
+        }
+    }
+}
+
+fn run_overlap(bench: &mut RingBufBench, mode: Mode, events_per_iter: usize) -> (usize, Duration) {
+    // Drain leftovers from previous iteration.
+    let _ = drain_once(&mut bench.ring_buf, Mode::Next);
+
+    let before = bench.registers();
+
+    let epoll_fd = epoll::create(false).unwrap();
+    epoll::ctl(
+        epoll_fd,
+        epoll::ControlOptions::EPOLL_CTL_ADD,
+        bench.ring_buf.as_raw_fd(),
+        epoll::Event::new(epoll::Events::EPOLLIN | epoll::Events::EPOLLET, 0),
+    )
+    .unwrap();
+    let mut epoll_event_buf = [epoll::Event::new(epoll::Events::EPOLLIN, 0); 1];
+
+    let writer = thread::spawn(move || {
+        for _ in 0..events_per_iter {
+            ring_buf_trigger_ebpf_program(0);
+        }
+    });
+
+    let start = Instant::now();
+    let mut seen = 0usize;
+    while seen < events_per_iter {
+        epoll::wait(epoll_fd, -1, &mut epoll_event_buf).unwrap();
+        seen += drain_once(&mut bench.ring_buf, mode);
+    }
+    let elapsed = start.elapsed();
+
+    writer.join().unwrap();
+    nix::unistd::close(epoll_fd).unwrap();
+
+    let after = bench.registers();
+    let dropped_delta = after.dropped - before.dropped;
+    let rejected_delta = after.rejected - before.rejected;
+    assert_eq!(rejected_delta, 0);
+    // We expect no drops in this shape; fail loudly if we saturate.
+    assert_eq!(dropped_delta, 0);
+    assert_eq!(seen, events_per_iter);
+
+    (seen, elapsed)
+}
+
+fn bench_ring_buf_next_vs_drain_epoll(c: &mut Criterion) {
+    const EVENTS_PER_ITER: usize = 8_192;
+
+    let mut group = c.benchmark_group("ring_buf/next_vs_drain_epoll_overlap");
+    group.throughput(criterion::Throughput::Elements(
+        u64::try_from(EVENTS_PER_ITER).unwrap(),
+    ));
+    group.sample_size(10);
+    group.measurement_time(Duration::from_secs(5));
+
+    for &variant in RING_BUF_VARIANTS {
+        for (name, mode) in [("next", Mode::Next), ("drain", Mode::Drain)] {
+            group.bench_with_input(BenchmarkId::new(name, variant.prog), &variant, |b, &variant| {
+                let mut bench = RingBufBench::new(variant);
+                b.iter_custom(|iters| {
+                    let mut elapsed = Duration::ZERO;
+                    for _ in 0..iters {
+                        let (seen, t) = run_overlap(&mut bench, mode, EVENTS_PER_ITER);
+                        assert_eq!(seen, EVENTS_PER_ITER);
+                        elapsed += t;
+                    }
+                    elapsed
+                });
+            });
+        }
+    }
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_ring_buf_next_vs_drain_epoll);
+criterion_main!(benches);

--- a/test/integration-test/benches/ring_buf_next_vs_drain_epoll_bursty.rs
+++ b/test/integration-test/benches/ring_buf_next_vs_drain_epoll_bursty.rs
@@ -1,0 +1,196 @@
+#![expect(unused_crate_dependencies, reason = "used in tests")]
+
+use std::{
+    hint::black_box,
+    os::fd::AsRawFd,
+    thread,
+    time::{Duration, Instant},
+};
+
+use aya::{
+    Ebpf, EbpfLoader,
+    maps::{MapData, array::PerCpuArray, ring_buf::RingBuf},
+    programs::UProbe,
+};
+use aya_obj::generated::BPF_RINGBUF_HDR_SZ;
+use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
+use integration_common::ring_buf::Registers;
+use nix::unistd::close;
+
+// Large enough to absorb large producer bursts without drops.
+const RING_BUF_MAX_ENTRIES: usize = 256 * 1024;
+// Tuned for deep batches per wake while staying below capacity.
+const BURST_ITEMS: usize = 16 * 1024;
+const BURSTS_PER_ITER: usize = 8;
+const TOTAL_ITEMS: usize = BURST_ITEMS * BURSTS_PER_ITER;
+
+const ALL_RING_BUFS: &[&str] = &["RING_BUF", "RING_BUF_LEGACY", "RING_BUF_MISMATCH"];
+
+#[derive(Clone, Copy)]
+struct RingBufVariant {
+    map: &'static str,
+    regs: &'static str,
+    prog: &'static str,
+}
+
+const RING_BUF_VARIANTS: &[RingBufVariant] = &[
+    RingBufVariant {
+        map: "RING_BUF",
+        regs: "REGISTERS",
+        prog: "ring_buf_test",
+    },
+    RingBufVariant {
+        map: "RING_BUF_LEGACY",
+        regs: "REGISTERS_LEGACY",
+        prog: "ring_buf_test_legacy",
+    },
+];
+
+struct RingBufBench {
+    _bpf: Ebpf,
+    ring_buf: RingBuf<MapData>,
+    regs: PerCpuArray<MapData, Registers>,
+}
+
+#[derive(Clone, Copy)]
+enum Mode {
+    Next,
+    Drain,
+}
+
+impl RingBufBench {
+    fn new(variant: RingBufVariant) -> Self {
+        const RING_BUF_BYTE_SIZE: u32 =
+            (RING_BUF_MAX_ENTRIES * (size_of::<u64>() + BPF_RINGBUF_HDR_SZ as usize)) as u32;
+
+        let mut loader = EbpfLoader::new();
+        for &map in ALL_RING_BUFS {
+            loader.map_max_entries(map, RING_BUF_BYTE_SIZE);
+        }
+        let mut bpf = loader.load(integration_test::RING_BUF).unwrap();
+
+        let ring_buf = bpf.take_map(variant.map).unwrap();
+        let ring_buf = RingBuf::try_from(ring_buf).unwrap();
+        let regs = bpf.take_map(variant.regs).unwrap();
+        let regs = PerCpuArray::<_, Registers>::try_from(regs).unwrap();
+
+        let prog: &mut UProbe = bpf.program_mut(variant.prog).unwrap().try_into().unwrap();
+        prog.load().unwrap();
+        prog.attach("ring_buf_trigger_ebpf_program", "/proc/self/exe", None)
+            .unwrap();
+
+        Self {
+            _bpf: bpf,
+            ring_buf,
+            regs,
+        }
+    }
+
+    fn registers(&self) -> Registers {
+        self.regs.get(&0, 0).unwrap().iter().sum()
+    }
+}
+
+#[unsafe(no_mangle)]
+#[inline(never)]
+extern "C" fn ring_buf_trigger_ebpf_program(arg: u64) {
+    black_box(arg);
+}
+
+fn drain_ready(ring_buf: &mut RingBuf<MapData>, mode: Mode) -> usize {
+    match mode {
+        Mode::Next => {
+            let mut seen = 0usize;
+            while let Some(item) = ring_buf.next() {
+                let _: [u8; 8] = (*item).try_into().unwrap();
+                seen += 1;
+            }
+            seen
+        }
+        Mode::Drain => {
+            let mut seen = 0usize;
+            let stats = ring_buf.drain(|item| {
+                let _: [u8; 8] = item.try_into().unwrap();
+                seen += 1;
+            });
+            assert_eq!(stats.read, seen);
+            seen
+        }
+    }
+}
+
+fn run_bursty(bench: &mut RingBufBench, mode: Mode) -> (usize, Duration) {
+    let _ = drain_ready(&mut bench.ring_buf, Mode::Next);
+    let before = bench.registers();
+
+    let epoll_fd = epoll::create(false).unwrap();
+    epoll::ctl(
+        epoll_fd,
+        epoll::ControlOptions::EPOLL_CTL_ADD,
+        bench.ring_buf.as_raw_fd(),
+        epoll::Event::new(epoll::Events::EPOLLIN | epoll::Events::EPOLLET, 0),
+    )
+    .unwrap();
+    let mut epoll_event_buf = [epoll::Event::new(epoll::Events::EPOLLIN, 0); 1];
+
+    let writer = thread::spawn(|| {
+        for _ in 0..BURSTS_PER_ITER {
+            for _ in 0..BURST_ITEMS {
+                ring_buf_trigger_ebpf_program(0);
+            }
+            // Encourage one wake to carry a deep burst.
+            thread::sleep(Duration::from_micros(200));
+        }
+    });
+
+    let start = Instant::now();
+    let mut seen = 0usize;
+    while seen < TOTAL_ITEMS {
+        epoll::wait(epoll_fd, -1, &mut epoll_event_buf).unwrap();
+        seen += drain_ready(&mut bench.ring_buf, mode);
+    }
+    let elapsed = start.elapsed();
+
+    writer.join().unwrap();
+    close(epoll_fd).unwrap();
+
+    let after = bench.registers();
+    let dropped_delta = after.dropped - before.dropped;
+    let rejected_delta = after.rejected - before.rejected;
+    assert_eq!(rejected_delta, 0);
+    assert_eq!(dropped_delta, 0);
+    assert_eq!(seen, TOTAL_ITEMS);
+
+    (seen, elapsed)
+}
+
+fn bench_ring_buf_next_vs_drain_epoll_bursty(c: &mut Criterion) {
+    let mut group = c.benchmark_group("ring_buf/next_vs_drain_epoll_bursty_deepbatch");
+    group.throughput(criterion::Throughput::Elements(
+        u64::try_from(TOTAL_ITEMS).unwrap(),
+    ));
+    group.sample_size(10);
+    group.measurement_time(Duration::from_secs(5));
+
+    for &variant in RING_BUF_VARIANTS {
+        for (name, mode) in [("next", Mode::Next), ("drain", Mode::Drain)] {
+            group.bench_with_input(BenchmarkId::new(name, variant.prog), &variant, |b, &variant| {
+                let mut bench = RingBufBench::new(variant);
+                b.iter_custom(|iters| {
+                    let mut elapsed = Duration::ZERO;
+                    for _ in 0..iters {
+                        let (seen, t) = run_bursty(&mut bench, mode);
+                        assert_eq!(seen, TOTAL_ITEMS);
+                        elapsed += t;
+                    }
+                    elapsed
+                });
+            });
+        }
+    }
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_ring_buf_next_vs_drain_epoll_bursty);
+criterion_main!(benches);

--- a/test/integration-test/benches/ring_buf_next_vs_drain_epoll_notify_batch.rs
+++ b/test/integration-test/benches/ring_buf_next_vs_drain_epoll_notify_batch.rs
@@ -1,0 +1,234 @@
+#![expect(unused_crate_dependencies, reason = "used in tests")]
+
+use std::{
+    hint::black_box,
+    os::fd::AsRawFd,
+    thread,
+    time::{Duration, Instant},
+};
+
+use aya::{
+    Ebpf, EbpfLoader,
+    maps::{MapData, array::PerCpuArray, ring_buf::RingBuf},
+    programs::UProbe,
+};
+use aya_obj::generated::BPF_RINGBUF_HDR_SZ;
+use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
+use integration_common::ring_buf::Registers;
+use nix::unistd::close;
+
+const RING_BUF_MAX_ENTRIES: usize = 256 * 1024;
+const BURST_ITEMS: usize = 16 * 1024;
+const BURSTS_PER_ITER: usize = 8;
+const TOTAL_ITEMS: usize = BURST_ITEMS * BURSTS_PER_ITER;
+
+const ALL_RING_BUFS: &[&str] = &["RING_BUF", "RING_BUF_LEGACY", "RING_BUF_MISMATCH"];
+
+#[derive(Clone, Copy)]
+struct RingBufVariant {
+    map: &'static str,
+    regs: &'static str,
+    prog: &'static str,
+    producer: ProducerNotify,
+}
+
+#[derive(Clone, Copy)]
+enum ProducerNotify {
+    Default,
+    Batched,
+}
+
+impl ProducerNotify {
+    fn name(self) -> &'static str {
+        match self {
+            Self::Default => "default_notify",
+            Self::Batched => "batched_notify",
+        }
+    }
+}
+
+const RING_BUF_VARIANTS: &[RingBufVariant] = &[
+    RingBufVariant {
+        map: "RING_BUF",
+        regs: "REGISTERS",
+        prog: "ring_buf_test",
+        producer: ProducerNotify::Default,
+    },
+    RingBufVariant {
+        map: "RING_BUF",
+        regs: "REGISTERS_BATCH",
+        prog: "ring_buf_test_batch_notify",
+        producer: ProducerNotify::Batched,
+    },
+    RingBufVariant {
+        map: "RING_BUF_LEGACY",
+        regs: "REGISTERS_LEGACY",
+        prog: "ring_buf_test_legacy",
+        producer: ProducerNotify::Default,
+    },
+    RingBufVariant {
+        map: "RING_BUF_LEGACY",
+        regs: "REGISTERS_LEGACY_BATCH",
+        prog: "ring_buf_test_legacy_batch_notify",
+        producer: ProducerNotify::Batched,
+    },
+];
+
+struct RingBufBench {
+    _bpf: Ebpf,
+    ring_buf: RingBuf<MapData>,
+    regs: PerCpuArray<MapData, Registers>,
+}
+
+#[derive(Clone, Copy)]
+enum Mode {
+    Next,
+    Drain,
+}
+
+impl RingBufBench {
+    fn new(variant: RingBufVariant) -> Self {
+        const RING_BUF_BYTE_SIZE: u32 =
+            (RING_BUF_MAX_ENTRIES * (size_of::<u64>() + BPF_RINGBUF_HDR_SZ as usize)) as u32;
+
+        let mut loader = EbpfLoader::new();
+        for &map in ALL_RING_BUFS {
+            loader.map_max_entries(map, RING_BUF_BYTE_SIZE);
+        }
+        let mut bpf = loader.load(integration_test::RING_BUF).unwrap();
+
+        let ring_buf = bpf.take_map(variant.map).unwrap();
+        let ring_buf = RingBuf::try_from(ring_buf).unwrap();
+        let regs = bpf.take_map(variant.regs).unwrap();
+        let regs = PerCpuArray::<_, Registers>::try_from(regs).unwrap();
+
+        let prog: &mut UProbe = bpf.program_mut(variant.prog).unwrap().try_into().unwrap();
+        prog.load().unwrap();
+        prog.attach("ring_buf_trigger_ebpf_program", "/proc/self/exe", None)
+            .unwrap();
+
+        Self {
+            _bpf: bpf,
+            ring_buf,
+            regs,
+        }
+    }
+
+    fn registers(&self) -> Registers {
+        self.regs.get(&0, 0).unwrap().iter().sum()
+    }
+}
+
+#[unsafe(no_mangle)]
+#[inline(never)]
+extern "C" fn ring_buf_trigger_ebpf_program(arg: u64) {
+    black_box(arg);
+}
+
+fn drain_ready(ring_buf: &mut RingBuf<MapData>, mode: Mode) -> usize {
+    match mode {
+        Mode::Next => {
+            let mut seen = 0usize;
+            while let Some(item) = ring_buf.next() {
+                let _: [u8; 8] = (*item).try_into().unwrap();
+                seen += 1;
+            }
+            seen
+        }
+        Mode::Drain => {
+            let mut seen = 0usize;
+            let stats = ring_buf.drain(|item| {
+                let _: [u8; 8] = item.try_into().unwrap();
+                seen += 1;
+            });
+            assert_eq!(stats.read, seen);
+            seen
+        }
+    }
+}
+
+fn run_bursty(bench: &mut RingBufBench, mode: Mode, producer: ProducerNotify) -> (usize, Duration) {
+    let _ = drain_ready(&mut bench.ring_buf, Mode::Next);
+    let before = bench.registers();
+
+    let epoll_fd = epoll::create(false).unwrap();
+    epoll::ctl(
+        epoll_fd,
+        epoll::ControlOptions::EPOLL_CTL_ADD,
+        bench.ring_buf.as_raw_fd(),
+        epoll::Event::new(epoll::Events::EPOLLIN | epoll::Events::EPOLLET, 0),
+    )
+    .unwrap();
+    let mut epoll_event_buf = [epoll::Event::new(epoll::Events::EPOLLIN, 0); 1];
+
+    let writer = thread::spawn(move || {
+        for _ in 0..BURSTS_PER_ITER {
+            match producer {
+                ProducerNotify::Default => {
+                    for _ in 0..BURST_ITEMS {
+                        ring_buf_trigger_ebpf_program(0);
+                    }
+                }
+                ProducerNotify::Batched => {
+                    for _ in 0..(BURST_ITEMS - 1) {
+                        ring_buf_trigger_ebpf_program(0);
+                    }
+                    ring_buf_trigger_ebpf_program(1);
+                }
+            }
+            thread::sleep(Duration::from_micros(200));
+        }
+    });
+
+    let start = Instant::now();
+    let mut seen = 0usize;
+    while seen < TOTAL_ITEMS {
+        epoll::wait(epoll_fd, -1, &mut epoll_event_buf).unwrap();
+        seen += drain_ready(&mut bench.ring_buf, mode);
+    }
+    let elapsed = start.elapsed();
+
+    writer.join().unwrap();
+    close(epoll_fd).unwrap();
+
+    let after = bench.registers();
+    let dropped_delta = after.dropped - before.dropped;
+    let rejected_delta = after.rejected - before.rejected;
+    assert_eq!(rejected_delta, 0);
+    assert_eq!(dropped_delta, 0);
+    assert_eq!(seen, TOTAL_ITEMS);
+
+    (seen, elapsed)
+}
+
+fn bench_ring_buf_next_vs_drain_epoll_notify_batch(c: &mut Criterion) {
+    let mut group = c.benchmark_group("ring_buf/next_vs_drain_epoll_notify_batch");
+    group.throughput(criterion::Throughput::Elements(
+        u64::try_from(TOTAL_ITEMS).unwrap(),
+    ));
+    group.sample_size(10);
+    group.measurement_time(Duration::from_secs(5));
+
+    for &variant in RING_BUF_VARIANTS {
+        for (name, mode) in [("next", Mode::Next), ("drain", Mode::Drain)] {
+            let id = format!("{}/{}", variant.producer.name(), variant.prog);
+            group.bench_with_input(BenchmarkId::new(name, id), &variant, |b, &variant| {
+                let mut bench = RingBufBench::new(variant);
+                b.iter_custom(|iters| {
+                    let mut elapsed = Duration::ZERO;
+                    for _ in 0..iters {
+                        let (seen, t) = run_bursty(&mut bench, mode, variant.producer);
+                        assert_eq!(seen, TOTAL_ITEMS);
+                        elapsed += t;
+                    }
+                    elapsed
+                });
+            });
+        }
+    }
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_ring_buf_next_vs_drain_epoll_notify_batch);
+criterion_main!(benches);


### PR DESCRIPTION
This PR:

1) Adds drain API 
2) adds submits/discards with wakeups and without wakeups as first-class citizens
3) benches (summarized below) 

``` 
  1. ring_buf_next_vs_drain (prefilled single-thread)

  - next/ring_buf_test: 92.144 Melem/s
  - drain/ring_buf_test: 279.42 Melem/s
  - next/ring_buf_test_legacy: 93.036 Melem/s
  - drain/ring_buf_test_legacy: 285.25 Melem/s

  2. ring_buf_next_vs_drain_accumulate_vec (producer+epoll, accumulate into Vec<u8>)

  - next/ring_buf_test: 379.73 Kelem/s
  - drain/ring_buf_test: 381.34 Kelem/s
  - next/ring_buf_test_legacy: 379.73 Kelem/s
  - drain/ring_buf_test_legacy: 381.18 Kelem/s

  3. ring_buf_drain_fast (prefilled single-thread)

  - drain_fast/ring_buf_test: 322.51 Melem/s
  - drain_fast/ring_buf_test_legacy: 321.82 Melem/s

  4. ring_buf_next_vs_drain_epoll (producer/consumer overlap)

  - next/ring_buf_test: 380.47 Kelem/s
  - drain/ring_buf_test: 382.63 Kelem/s
  - next/ring_buf_test_legacy: 382.57 Kelem/s
  - drain/ring_buf_test_legacy: 380.01 Kelem/s

  5. ring_buf_next_vs_drain_epoll_bursty (small events, deep burst per wake)

  - next/ring_buf_test: 373.60 Kelem/s
  - drain/ring_buf_test: 372.43 Kelem/s
  - next/ring_buf_test_legacy: 374.38 Kelem/s
  - drain/ring_buf_test_legacy: 375.86 Kelem/s

  6. ring_buf_next_vs_drain_epoll_notify_batch (default vs producer batched wakeups)

  - next/default/ring_buf_test: 374.33 Kelem/s
  - drain/default/ring_buf_test: 372.53 Kelem/s
  - next/batched/ring_buf_test_batch_notify: 762.34 Kelem/s
  - drain/batched/ring_buf_test_batch_notify: 763.81 Kelem/s
  - next/default/ring_buf_test_legacy: 371.54 Kelem/s
  - drain/default/ring_buf_test_legacy: 374.61 Kelem/s
  - next/batched/ring_buf_test_legacy_batch_notify: 763.91 Kelem/s
  - drain/batched/ring_buf_test_legacy_batch_notify: 764.71 Kelem/s
```

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aya-rs/aya/1453)
<!-- Reviewable:end -->

