### PR TITLE
feat(test): BPF_PROG_TEST_RUN for unittest. 

### DIFF
--- a/aya/src/lib.rs
+++ b/aya/src/lib.rs
@@ -52,6 +52,10 @@ use std::os::fd::{AsFd, AsRawFd, BorrowedFd, FromRawFd, OwnedFd, RawFd};
 pub use aya_obj::btf::{Btf, BtfError};
 pub use bpf::*;
 pub use object::Endianness;
+pub use programs::{
+    RawTracePointRunOptions, RawTracePointTestRunResult, TestRun, TestRunAttrs, TestRunOptions,
+    TestRunResult,
+};
 #[doc(hidden)]
 pub use sys::netlink_set_link_up;
 

--- a/aya/src/programs/mod.rs
+++ b/aya/src/programs/mod.rs
@@ -85,10 +85,7 @@ use std::{
 use aya_obj::{
     VerifierLog,
     btf::BtfError,
-    generated::{
-        BPF_F_TEST_RUN_ON_CPU, BPF_F_TEST_XDP_LIVE_FRAMES, bpf_attach_type, bpf_prog_info,
-        bpf_prog_type,
-    },
+    generated::{BPF_F_TEST_XDP_LIVE_FRAMES, bpf_attach_type, bpf_prog_info, bpf_prog_type},
     programs::XdpAttachType,
 };
 use info::impl_info;
@@ -920,7 +917,6 @@ impl_fd!(
 /// the associated flag bits), as opposed to *what* data is passed.
 #[derive(Debug)]
 pub struct TestRunAttrs {
-    pub(crate) cpu: u32,
     pub(crate) batch_size: u32,
     pub(crate) flags: u32,
 }
@@ -929,21 +925,9 @@ impl TestRunAttrs {
     /// Creates a new `TestRunAttrs` with default values.
     pub const fn new() -> Self {
         Self {
-            cpu: 0,
             batch_size: 0,
             flags: 0,
         }
-    }
-
-    /// Sets the CPU to run the test on.
-    ///
-    /// This automatically sets the `BPF_F_TEST_RUN_ON_CPU` flag.
-    /// This option only works with `RawTracePoint` programs.
-    #[must_use]
-    pub const fn run_on_cpu(mut self, cpu: u32) -> Self {
-        self.cpu = cpu;
-        self.flags |= BPF_F_TEST_RUN_ON_CPU;
-        self
     }
 
     /// Sets the batch size for XDP live frames testing.
@@ -1097,11 +1081,10 @@ pub trait TestRun {
     ///
     /// # Returns
     ///
-    /// Returns a [`crate::TestRunResult`] containing:
-    /// - `return_value`: The value returned by the program
-    /// - `duration`: Execution time in nanoseconds
-    /// - `data_size_out`: Size of data written to output buffer
-    /// - `ctx_size_out`: Size of context written to output buffer
+    /// Returns a [`Self::Result`] containing the program-specific test output.
+    ///
+    /// For most program types this is [`crate::TestRunResult`]. For
+    /// [`RawTracePoint`] it is [`RawTracePointTestRunResult`].
     ///
     /// # Errors
     ///

--- a/aya/src/programs/mod.rs
+++ b/aya/src/programs/mod.rs
@@ -85,7 +85,10 @@ use std::{
 use aya_obj::{
     VerifierLog,
     btf::BtfError,
-    generated::{bpf_attach_type, bpf_prog_info, bpf_prog_type},
+    generated::{
+        BPF_F_TEST_RUN_ON_CPU, BPF_F_TEST_XDP_LIVE_FRAMES, bpf_attach_type, bpf_prog_info,
+        bpf_prog_type,
+    },
     programs::XdpAttachType,
 };
 use info::impl_info;
@@ -619,6 +622,22 @@ impl<T: Link> ProgramData<T> {
     }
 }
 
+fn test_run<T: Link>(
+    data: &ProgramData<T>,
+    opts: TestRunOptions<'_>,
+) -> Result<TestRunResult, ProgramError> {
+    let fd = data.fd()?.as_fd();
+    crate::sys::bpf_prog_test_run(fd, opts).map_err(Into::into)
+}
+
+fn test_run_raw_tp<T: Link>(
+    data: &ProgramData<T>,
+    opts: RawTracePointRunOptions,
+) -> Result<RawTracePointTestRunResult, ProgramError> {
+    let fd = data.fd()?.as_fd();
+    crate::sys::bpf_prog_test_run_raw_tp(fd, opts).map_err(Into::into)
+}
+
 fn unload_program<T: Link>(data: &mut ProgramData<T>) -> Result<(), ProgramError> {
     data.links.remove_all()?;
     data.fd
@@ -894,6 +913,246 @@ impl_fd!(
     CgroupDevice,
     Iter,
 );
+
+/// Kernel-side execution attributes for [`TestRunOptions`].
+///
+/// Controls *how* the kernel runs the test (CPU pinning, XDP batch size, and
+/// the associated flag bits), as opposed to *what* data is passed.
+#[derive(Debug)]
+pub struct TestRunAttrs {
+    pub(crate) cpu: u32,
+    pub(crate) batch_size: u32,
+    pub(crate) flags: u32,
+}
+
+impl TestRunAttrs {
+    /// Creates a new `TestRunAttrs` with default values.
+    pub const fn new() -> Self {
+        Self {
+            cpu: 0,
+            batch_size: 0,
+            flags: 0,
+        }
+    }
+
+    /// Sets the CPU to run the test on.
+    ///
+    /// This automatically sets the `BPF_F_TEST_RUN_ON_CPU` flag.
+    /// This option only works with `RawTracePoint` programs.
+    #[must_use]
+    pub const fn run_on_cpu(mut self, cpu: u32) -> Self {
+        self.cpu = cpu;
+        self.flags |= BPF_F_TEST_RUN_ON_CPU;
+        self
+    }
+
+    /// Sets the batch size for XDP live frames testing.
+    ///
+    /// This automatically sets the `BPF_F_TEST_XDP_LIVE_FRAMES` flag.
+    /// This option only works with `XDP` programs.
+    #[must_use]
+    pub const fn xdp_live_frames(mut self, batch_size: u32) -> Self {
+        self.batch_size = batch_size;
+        self.flags |= BPF_F_TEST_XDP_LIVE_FRAMES;
+        self
+    }
+}
+
+impl Default for TestRunAttrs {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Options for running a BPF program test.
+///
+/// see [kernel doc](https://docs.kernel.org/bpf/bpf_prog_run.html)
+/// and [ebpf.io](https://docs.ebpf.io/linux/syscall/BPF_PROG_TEST_RUN/) for detailed usages.
+#[derive(Debug)]
+pub struct TestRunOptions<'a> {
+    /// Input packet data to pass to the program.
+    pub data_in: Option<&'a [u8]>,
+    /// Output buffer for packet data modified by the program.
+    pub data_out: Option<&'a mut [u8]>,
+    /// Input context to pass to the program.
+    pub ctx_in: Option<&'a [u8]>,
+    /// Output buffer for context written back by the program.
+    pub ctx_out: Option<&'a mut [u8]>,
+    /// Number of times to repeat the test. Defaults to `1`.
+    pub repeat: u32,
+    /// Kernel execution attributes (CPU pinning, XDP batch size).
+    pub attrs: TestRunAttrs,
+}
+
+impl Default for TestRunOptions<'_> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl TestRunOptions<'_> {
+    /// Creates a new `TestRunOptions` with default values.
+    pub const fn new() -> Self {
+        Self {
+            data_in: None,
+            data_out: None,
+            ctx_in: None,
+            ctx_out: None,
+            repeat: 1,
+            attrs: TestRunAttrs::new(),
+        }
+    }
+}
+
+/// Options for running a [`RawTracePoint`] program test via `BPF_PROG_TEST_RUN`.
+///
+/// The kernel's `bpf_prog_test_run_raw_tp` handler (v5.10, commit `b84e6faeed1`)
+/// is far more restrictive than the skb/XDP path:
+///
+/// - `data_in`, `data_out`, `ctx_out`, `repeat`, `batch_size` must all be zero/NULL;
+///   passing any of them returns `EINVAL`.
+/// - `ctx_in` is the only data path: a packed array of `u64` values that the
+///   kernel presents to the program as raw tracepoint arguments (registers r1–r5).
+/// - CPU pinning via `BPF_F_TEST_RUN_ON_CPU` is supported and is the primary
+///   reason to use `BPF_PROG_TEST_RUN` with raw tracepoints.
+///
+/// This struct deliberately omits the forbidden fields so misuse is a
+/// compile-time error rather than a runtime `EINVAL`.
+#[derive(Debug, Default)]
+pub struct RawTracePointRunOptions {
+    /// Fake tracepoint arguments, up to 12 `u64` values.
+    ///
+    /// Each element corresponds to one tracepoint argument in order. The kernel
+    /// copies the entire array into `ctx_in` before calling the program, which
+    /// reads them via `ctx.arg(n)`. Unused slots default to zero.
+    ///
+    /// The array size of 12 matches the kernel's maximum: the longest tracepoint
+    /// in the kernel takes 12 arguments. See
+    /// [`net/bpf/test_run.c`](https://github.com/torvalds/linux/blob/d91a46d680/net/bpf/test_run.c#L762).
+    pub args: [u64; 12],
+    /// If `Some(cpu)`, pin execution to that CPU via `BPF_F_TEST_RUN_ON_CPU`.
+    ///
+    /// The only flag the kernel accepts for raw tracepoints; `batch_size` and
+    /// all other [`TestRunAttrs`] knobs return `EINVAL`.
+    pub cpu: Option<u32>,
+}
+
+impl RawTracePointRunOptions {
+    /// Creates a new `RawTracePointRunOptions` with all arguments zeroed.
+    pub const fn new() -> Self {
+        Self {
+            args: [0; 12],
+            cpu: None,
+        }
+    }
+}
+
+/// Result of running a BPF program test.
+#[derive(Debug)]
+pub struct TestRunResult {
+    /// Return value from the program.
+    pub return_value: u32,
+    /// Duration of the test run.
+    pub duration: std::time::Duration,
+    /// Size of data written to `data_out`.
+    pub data_size_out: u32,
+    /// Size of context written to `ctx_out`.
+    pub ctx_size_out: u32,
+}
+
+/// Result of running a BPF program test for [`RawTracePoint`]
+/// program type
+///
+/// the duration field omitted since it's always [`std::time::Duration::ZERO`]
+#[derive(Debug)]
+pub struct RawTracePointTestRunResult {
+    /// Return value from the program.
+    pub return_value: u32,
+    /// Size of data written to `data_out`.
+    pub data_size_out: u32,
+    /// Size of context written to `ctx_out`.
+    pub ctx_size_out: u32,
+}
+
+/// Trait for BPF programs that support test execution via `BPF_PROG_TEST_RUN`.
+pub trait TestRun {
+    /// The options type used to configure a single test invocation.
+    ///
+    /// Different program types require different options: skb/XDP programs use
+    /// [`TestRunOptions`], while [`RawTracePoint`] programs use
+    /// [`RawTracePointRunOptions`].
+    type Opts<'a>;
+
+    /// The Result type for a single test invocation.
+    type Result;
+
+    /// Runs the program with test input data and returns the result.
+    ///
+    /// This function uses the kernel's `BPF_PROG_TEST_RUN` command to execute
+    /// the program in a test environment with provided input data.
+    ///
+    /// # Arguments
+    ///
+    /// * `opts` - Test run options including input/output data and context
+    ///
+    /// # Returns
+    ///
+    /// Returns a [`crate::TestRunResult`] containing:
+    /// - `return_value`: The value returned by the program
+    /// - `duration`: Execution time in nanoseconds
+    /// - `data_size_out`: Size of data written to output buffer
+    /// - `ctx_size_out`: Size of context written to output buffer
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ProgramError::SyscallError`] if the underlying syscall fails.
+    /// Common errors include `-ENOSPC` if output buffers are too small.
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// let input_data = [0u8; 64];
+    /// let mut output_data = [0u8; 64];
+    ///
+    /// let opts = TestRunOptions {
+    ///     data_in: Some(&input_data),
+    ///     data_out: Some(&mut output_data),
+    ///     repeat: 1,
+    ///     ..Default::default()
+    /// };
+    ///
+    /// let result = program.test_run(opts)?;
+    /// println!("Program returned: {}, took {} ns", result.return_value, result.duration.as_nanos());
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// ```
+    fn test_run(&self, opts: Self::Opts<'_>) -> Result<Self::Result, ProgramError>;
+}
+
+macro_rules! impl_program_test_run {
+    ($($struct_name:ident), + $(,)?) => {
+        $(
+            impl TestRun for $struct_name {
+                type Opts<'a> = TestRunOptions<'a>;
+                type Result = TestRunResult;
+
+                fn test_run(&self, opts: Self::Opts<'_>) -> Result<Self::Result, ProgramError> {
+                    test_run(&self.data, opts)
+                }
+            }
+        )+
+    }
+}
+
+impl_program_test_run!(SocketFilter, SchedClassifier, Xdp, CgroupSkb, FlowDissector);
+
+impl TestRun for RawTracePoint {
+    type Opts<'a> = RawTracePointRunOptions;
+    type Result = RawTracePointTestRunResult;
+
+    fn test_run(&self, opts: Self::Opts<'_>) -> Result<Self::Result, ProgramError> {
+        test_run_raw_tp(&self.data, opts)
+    }
+}
 
 /// Trait implemented by the [`Program`] types which support the kernel's
 /// [generic multi-prog API](https://github.com/torvalds/linux/commit/053c8e1f235dc3f69d13375b32f4209228e1cb96).

--- a/aya/src/programs/mod.rs
+++ b/aya/src/programs/mod.rs
@@ -950,8 +950,8 @@ impl Default for TestRunAttrs {
 
 /// Options for running a BPF program test.
 ///
-/// see [kernel doc](https://docs.kernel.org/bpf/bpf_prog_run.html)
-/// and [ebpf.io](https://docs.ebpf.io/linux/syscall/BPF_PROG_TEST_RUN/) for detailed usages.
+/// See [kernel doc](https://docs.kernel.org/bpf/bpf_prog_run.html)
+/// and [ebpf.io](https://docs.ebpf.io/linux/syscall/BPF_PROG_TEST_RUN/) for detailed usage.
 #[derive(Debug)]
 pub struct TestRunOptions<'a> {
     /// Input packet data to pass to the program.

--- a/aya/src/programs/mod.rs
+++ b/aya/src/programs/mod.rs
@@ -995,8 +995,7 @@ impl TestRunOptions<'_> {
 ///
 /// - `data_in`, `data_out`, `ctx_out`, `repeat`, `batch_size` must all be zero/NULL;
 ///   passing any of them returns `EINVAL`.
-/// - `ctx_in` is the only data path: a packed array of `u64` values that the
-///   kernel presents to the program as raw tracepoint arguments (registers r1–r5).
+/// - `ctx_in` is the only data path: a packed array of `u64` tracepoint arguments.
 /// - CPU pinning via `BPF_F_TEST_RUN_ON_CPU` is supported and is the primary
 ///   reason to use `BPF_PROG_TEST_RUN` with raw tracepoints.
 ///
@@ -1044,18 +1043,14 @@ pub struct TestRunResult {
     pub ctx_size_out: u32,
 }
 
-/// Result of running a BPF program test for [`RawTracePoint`]
-/// program type
+/// Result of running a [`RawTracePoint`] program test via `BPF_PROG_TEST_RUN`.
 ///
-/// the duration field omitted since it's always [`std::time::Duration::ZERO`]
+/// Only `return_value` is returned by the kernel; `duration`, `data_size_out`,
+/// and `ctx_size_out` are omitted.
 #[derive(Debug)]
 pub struct RawTracePointTestRunResult {
     /// Return value from the program.
     pub return_value: u32,
-    /// Size of data written to `data_out`.
-    pub data_size_out: u32,
-    /// Size of context written to `ctx_out`.
-    pub ctx_size_out: u32,
 }
 
 /// Trait for BPF programs that support test execution via `BPF_PROG_TEST_RUN`.

--- a/aya/src/programs/mod.rs
+++ b/aya/src/programs/mod.rs
@@ -913,7 +913,7 @@ impl_fd!(
 
 /// Kernel-side execution attributes for [`TestRunOptions`].
 ///
-/// Controls *how* the kernel runs the test (CPU pinning, XDP batch size, and
+/// Controls *how* the kernel runs the test (XDP batch size, and
 /// the associated flag bits), as opposed to *what* data is passed.
 #[derive(Debug)]
 pub struct TestRunAttrs {
@@ -964,7 +964,7 @@ pub struct TestRunOptions<'a> {
     pub ctx_out: Option<&'a mut [u8]>,
     /// Number of times to repeat the test. Defaults to `1`.
     pub repeat: u32,
-    /// Kernel execution attributes (CPU pinning, XDP batch size).
+    /// Kernel execution attributes (XDP batch size).
     pub attrs: TestRunAttrs,
 }
 

--- a/aya/src/sys/bpf.rs
+++ b/aya/src/sys/bpf.rs
@@ -613,7 +613,6 @@ pub(crate) fn bpf_prog_test_run(
         ctx_out,
         repeat,
         attrs: TestRunAttrs {
-            cpu,
             batch_size,
             flags,
         },
@@ -625,7 +624,7 @@ pub(crate) fn bpf_prog_test_run(
     test.prog_fd = prog_fd.as_raw_fd() as u32;
     test.repeat = repeat;
     test.flags = flags;
-    test.cpu = cpu;
+    test.cpu = 0;
     test.batch_size = batch_size;
 
     if let Some(data_in) = data_in {

--- a/aya/src/sys/bpf.rs
+++ b/aya/src/sys/bpf.rs
@@ -612,10 +612,7 @@ pub(crate) fn bpf_prog_test_run(
         ctx_in,
         ctx_out,
         repeat,
-        attrs: TestRunAttrs {
-            batch_size,
-            flags,
-        },
+        attrs: TestRunAttrs { batch_size, flags },
     } = opts;
 
     let mut attr = unsafe { mem::zeroed::<bpf_attr>() };

--- a/aya/src/sys/bpf.rs
+++ b/aya/src/sys/bpf.rs
@@ -16,10 +16,10 @@ use aya_obj::{
         VarLinkage,
     },
     generated::{
-        BPF_ADD, BPF_ALU64, BPF_CALL, BPF_DW, BPF_EXIT, BPF_F_REPLACE, BPF_IMM, BPF_JMP, BPF_K,
-        BPF_LD, BPF_MEM, BPF_MOV, BPF_PSEUDO_MAP_VALUE, BPF_ST, BPF_X, bpf_attach_type, bpf_attr,
-        bpf_btf_info, bpf_cmd, bpf_func_id, bpf_insn, bpf_link_info, bpf_map_info, bpf_map_type,
-        bpf_prog_info, bpf_prog_type, bpf_stats_type,
+        BPF_ADD, BPF_ALU64, BPF_CALL, BPF_DW, BPF_EXIT, BPF_F_REPLACE, BPF_F_TEST_RUN_ON_CPU,
+        BPF_IMM, BPF_JMP, BPF_K, BPF_LD, BPF_MEM, BPF_MOV, BPF_PSEUDO_MAP_VALUE, BPF_ST, BPF_X,
+        bpf_attach_type, bpf_attr, bpf_btf_info, bpf_cmd, bpf_func_id, bpf_insn, bpf_link_info,
+        bpf_map_info, bpf_map_type, bpf_prog_info, bpf_prog_type, bpf_stats_type,
     },
     maps::{LegacyMap, bpf_map_def},
 };
@@ -30,9 +30,12 @@ use libc::{
 use log::warn;
 
 use crate::{
-    Btf, Pod, VerifierLogLevel,
+    Btf, Pod, TestRunAttrs, VerifierLogLevel,
     maps::{MapData, PerCpuValues},
-    programs::{LsmAttachType, ProgramType, links::LinkRef},
+    programs::{
+        LsmAttachType, ProgramType, RawTracePointRunOptions, RawTracePointTestRunResult,
+        TestRunOptions, TestRunResult, links::LinkRef,
+    },
     sys::{Syscall, SyscallError, syscall},
     util::KernelVersion,
 };
@@ -593,6 +596,112 @@ pub(crate) fn bpf_prog_get_fd_by_id(prog_id: u32) -> Result<crate::MockableFd, S
             call: "bpf_prog_get_fd_by_id",
             io_error,
         }
+    })
+}
+
+/// Run a loaded BPF program with test data.
+///
+/// Introduced in kernel v4.12.
+pub(crate) fn bpf_prog_test_run(
+    prog_fd: BorrowedFd<'_>,
+    opts: TestRunOptions<'_>,
+) -> Result<TestRunResult, SyscallError> {
+    let TestRunOptions {
+        data_in,
+        data_out,
+        ctx_in,
+        ctx_out,
+        repeat,
+        attrs: TestRunAttrs {
+            cpu,
+            batch_size,
+            flags,
+        },
+    } = opts;
+
+    let mut attr = unsafe { mem::zeroed::<bpf_attr>() };
+
+    let test = unsafe { &mut attr.test };
+    test.prog_fd = prog_fd.as_raw_fd() as u32;
+    test.repeat = repeat;
+    test.flags = flags;
+    test.cpu = cpu;
+    test.batch_size = batch_size;
+
+    if let Some(data_in) = data_in {
+        test.data_in = data_in.as_ptr() as u64;
+        test.data_size_in = data_in.len() as u32;
+    }
+
+    if let Some(data_out) = data_out {
+        test.data_out = data_out.as_mut_ptr() as u64;
+        test.data_size_out = data_out.len() as u32;
+    }
+
+    if let Some(ctx_in) = ctx_in {
+        test.ctx_in = ctx_in.as_ptr() as u64;
+        test.ctx_size_in = ctx_in.len() as u32;
+    }
+
+    if let Some(ctx_out) = ctx_out {
+        test.ctx_out = ctx_out.as_mut_ptr() as u64;
+        test.ctx_size_out = ctx_out.len() as u32;
+    }
+
+    unit_sys_bpf(bpf_cmd::BPF_PROG_TEST_RUN, &mut attr).map_err(|io_error| SyscallError {
+        call: "bpf_prog_test_run",
+        io_error,
+    })?;
+
+    let test = unsafe { &attr.test };
+
+    Ok(TestRunResult {
+        return_value: test.retval,
+        duration: std::time::Duration::from_nanos(u64::from(test.duration)),
+        data_size_out: test.data_size_out,
+        ctx_size_out: test.ctx_size_out,
+    })
+}
+
+/// Run a loaded [`RawTracePoint`](crate::programs::RawTracePoint) program with
+/// fake tracepoint arguments.
+///
+/// Introduced in kernel v5.10
+///
+/// The kernel handler (`bpf_prog_test_run_raw_tp`) enforces that `data_in`,
+/// `data_out`, `ctx_out`, `repeat`, and `batch_size` are all zero/NULL,
+/// returning `EINVAL` otherwise. This function only sets the fields the kernel
+/// actually accepts: `ctx_in` (fake tracepoint args) and, optionally,
+/// `cpu`/`BPF_F_TEST_RUN_ON_CPU`.
+pub(crate) fn bpf_prog_test_run_raw_tp(
+    prog_fd: BorrowedFd<'_>,
+    opts: RawTracePointRunOptions,
+) -> Result<RawTracePointTestRunResult, SyscallError> {
+    let RawTracePointRunOptions { args, cpu } = opts;
+
+    let mut attr = unsafe { mem::zeroed::<bpf_attr>() };
+    // repeat, data_in, data_out, ctx_out, batch_size intentionally left as 0/NULL.
+    let test = unsafe { &mut attr.test };
+    test.prog_fd = prog_fd.as_raw_fd() as u32;
+
+    test.ctx_in = args.as_ptr() as u64;
+    test.ctx_size_in = size_of_val(&args) as u32;
+
+    if let Some(cpu) = cpu {
+        test.cpu = cpu;
+        test.flags |= BPF_F_TEST_RUN_ON_CPU;
+    }
+
+    unit_sys_bpf(bpf_cmd::BPF_PROG_TEST_RUN, &mut attr).map_err(|io_error| SyscallError {
+        call: "bpf_prog_test_run",
+        io_error,
+    })?;
+
+    let test = unsafe { &attr.test };
+    Ok(RawTracePointTestRunResult {
+        return_value: test.retval,
+        data_size_out: 0,
+        ctx_size_out: 0,
     })
 }
 

--- a/aya/src/sys/bpf.rs
+++ b/aya/src/sys/bpf.rs
@@ -18,8 +18,9 @@ use aya_obj::{
     generated::{
         BPF_ADD, BPF_ALU64, BPF_CALL, BPF_DW, BPF_EXIT, BPF_F_REPLACE, BPF_F_TEST_RUN_ON_CPU,
         BPF_IMM, BPF_JMP, BPF_K, BPF_LD, BPF_MEM, BPF_MOV, BPF_PSEUDO_MAP_VALUE, BPF_ST, BPF_X,
-        bpf_attach_type, bpf_attr, bpf_btf_info, bpf_cmd, bpf_func_id, bpf_insn, bpf_link_info,
-        bpf_map_info, bpf_map_type, bpf_prog_info, bpf_prog_type, bpf_stats_type,
+        bpf_attach_type, bpf_attr, bpf_attr__bindgen_ty_7, bpf_btf_info, bpf_cmd, bpf_func_id,
+        bpf_insn, bpf_link_info, bpf_map_info, bpf_map_type, bpf_prog_info, bpf_prog_type,
+        bpf_stats_type,
     },
     maps::{LegacyMap, bpf_map_def},
 };
@@ -599,6 +600,14 @@ pub(crate) fn bpf_prog_get_fd_by_id(prog_id: u32) -> Result<crate::MockableFd, S
     })
 }
 
+fn invoke_prog_test_run(attr: &mut bpf_attr) -> Result<&bpf_attr__bindgen_ty_7, SyscallError> {
+    unit_sys_bpf(bpf_cmd::BPF_PROG_TEST_RUN, attr).map_err(|io_error| SyscallError {
+        call: "bpf_prog_test_run",
+        io_error,
+    })?;
+    Ok(unsafe { &attr.test })
+}
+
 /// Run a loaded BPF program with test data.
 ///
 /// Introduced in kernel v4.12.
@@ -621,7 +630,6 @@ pub(crate) fn bpf_prog_test_run(
     test.prog_fd = prog_fd.as_raw_fd() as u32;
     test.repeat = repeat;
     test.flags = flags;
-    test.cpu = 0;
     test.batch_size = batch_size;
 
     if let Some(data_in) = data_in {
@@ -644,12 +652,7 @@ pub(crate) fn bpf_prog_test_run(
         test.ctx_size_out = ctx_out.len() as u32;
     }
 
-    unit_sys_bpf(bpf_cmd::BPF_PROG_TEST_RUN, &mut attr).map_err(|io_error| SyscallError {
-        call: "bpf_prog_test_run",
-        io_error,
-    })?;
-
-    let test = unsafe { &attr.test };
+    let test = invoke_prog_test_run(&mut attr)?;
 
     Ok(TestRunResult {
         return_value: test.retval,
@@ -662,7 +665,7 @@ pub(crate) fn bpf_prog_test_run(
 /// Run a loaded [`RawTracePoint`](crate::programs::RawTracePoint) program with
 /// fake tracepoint arguments.
 ///
-/// Introduced in kernel v5.10
+/// Introduced in kernel v5.10.
 ///
 /// The kernel handler (`bpf_prog_test_run_raw_tp`) enforces that `data_in`,
 /// `data_out`, `ctx_out`, `repeat`, and `batch_size` are all zero/NULL,
@@ -688,16 +691,9 @@ pub(crate) fn bpf_prog_test_run_raw_tp(
         test.flags |= BPF_F_TEST_RUN_ON_CPU;
     }
 
-    unit_sys_bpf(bpf_cmd::BPF_PROG_TEST_RUN, &mut attr).map_err(|io_error| SyscallError {
-        call: "bpf_prog_test_run",
-        io_error,
-    })?;
-
-    let test = unsafe { &attr.test };
+    let test = invoke_prog_test_run(&mut attr)?;
     Ok(RawTracePointTestRunResult {
         return_value: test.retval,
-        data_size_out: 0,
-        ctx_size_out: 0,
     })
 }
 

--- a/test/integration-common/src/lib.rs
+++ b/test/integration-common/src/lib.rs
@@ -181,3 +181,9 @@ pub mod stack_trace {
     #[cfg(feature = "user")]
     unsafe impl aya::Pod for TestResult {}
 }
+
+pub mod test_run {
+    pub const XDP_MODIFY_VAL: u8 = 0xAA;
+    pub const IF_INDEX: u32 = 1;
+    pub const XDP_MODIFY_LEN: usize = 16;
+}

--- a/test/integration-ebpf/Cargo.toml
+++ b/test/integration-ebpf/Cargo.toml
@@ -117,6 +117,10 @@ name = "test"
 path = "src/test.rs"
 
 [[bin]]
+name = "test_run"
+path = "src/test_run.rs"
+
+[[bin]]
 name = "two_progs"
 path = "src/two_progs.rs"
 

--- a/test/integration-ebpf/src/test_run.rs
+++ b/test/integration-ebpf/src/test_run.rs
@@ -1,0 +1,90 @@
+#![no_std]
+#![no_main]
+#![expect(unused_crate_dependencies, reason = "used in other bins")]
+
+use aya_ebpf::{
+    bindings::{sk_action::SK_PASS, xdp_action},
+    macros::{classifier, map, raw_tracepoint, socket_filter, xdp},
+    maps::Array,
+    programs::{RawTracePointContext, SkBuffContext, TcContext, XdpContext},
+};
+use integration_common::test_run::{IF_INDEX, XDP_MODIFY_LEN, XDP_MODIFY_VAL};
+#[cfg(not(test))]
+extern crate ebpf_panic;
+
+#[map]
+static EXEC_COUNT: Array<u64> = Array::with_max_entries(1, 0);
+
+/// Stores the value of arg0 passed via `BPF_PROG_TEST_RUN` `ctx_in`.
+#[map]
+static LAST_ARG: Array<u64> = Array::with_max_entries(1, 0);
+
+#[xdp]
+const fn test_xdp(_ctx: XdpContext) -> u32 {
+    xdp_action::XDP_PASS
+}
+
+#[socket_filter]
+fn test_sock_filter(ctx: SkBuffContext) -> i64 {
+    ctx.len().into()
+}
+
+#[classifier]
+const fn test_classifier(_ctx: TcContext) -> i32 {
+    SK_PASS as i32
+}
+
+#[classifier]
+fn test_count_exec(_ctx: TcContext) -> i32 {
+    if let Some(count) = EXEC_COUNT.get_ptr_mut(0) {
+        unsafe {
+            *count += 1;
+        }
+    }
+    SK_PASS as i32
+}
+
+#[xdp]
+fn test_xdp_modify(ctx: XdpContext) -> u32 {
+    let data = ctx.data();
+    let data_end = ctx.data_end();
+
+    if data + XDP_MODIFY_LEN > data_end {
+        return xdp_action::XDP_PASS;
+    }
+
+    let packet = data as *mut u8;
+    unsafe {
+        packet.write_bytes(XDP_MODIFY_VAL, XDP_MODIFY_LEN);
+    }
+
+    xdp_action::XDP_PASS
+}
+
+#[xdp]
+fn test_xdp_context(ctx: XdpContext) -> u32 {
+    let md = ctx.ctx;
+    let ingress_ifindex = unsafe { (*md).ingress_ifindex };
+
+    if ingress_ifindex == IF_INDEX {
+        xdp_action::XDP_PASS
+    } else {
+        xdp_action::XDP_DROP
+    }
+}
+
+/// Reads arg0 from the raw tracepoint context and stores it in `LAST_ARG`.
+///
+/// When invoked via `BPF_PROG_TEST_RUN`, the kernel populates the
+/// `bpf_raw_tracepoint_args` register file from the `ctx_in` byte slice passed
+/// by the caller. arg(0) therefore holds the first u64 from `ctx_in`.
+#[raw_tracepoint]
+fn test_raw_tp(ctx: RawTracePointContext) -> i32 {
+    let arg0: u64 = ctx.arg(0);
+    if let Some(slot) = LAST_ARG.get_ptr_mut(0) {
+        unsafe {
+            *slot = arg0;
+        }
+    }
+    0
+}

--- a/test/integration-test/src/lib.rs
+++ b/test/integration-test/src/lib.rs
@@ -63,6 +63,7 @@ bpf_file!(
     STRNCMP => "strncmp",
     TCX => "tcx",
     TEST => "test",
+    TEST_RUN => "test_run",
     TWO_PROGS => "two_progs",
     XDP_SEC => "xdp_sec",
     UPROBE_COOKIE => "uprobe_cookie",

--- a/test/integration-test/src/tests.rs
+++ b/test/integration-test/src/tests.rs
@@ -29,6 +29,7 @@ mod per_cpu_array;
 mod perf_event_bp;
 mod printk;
 mod prog_array;
+mod prog_test_run;
 mod raw_tracepoint;
 mod rbpf;
 mod relocations;

--- a/test/integration-test/src/tests/prog_test_run.rs
+++ b/test/integration-test/src/tests/prog_test_run.rs
@@ -270,7 +270,7 @@ fn test_raw_tracepoint_test_run() {
     const SENTINEL: u64 = 0xdead_beef_cafe_babe;
 
     let mut opts = RawTracePointRunOptions::default();
-    opts[0] = SENTINEL;
+    opts.args[0] = SENTINEL;
 
     let RawTracePointTestRunResult {
         return_value,

--- a/test/integration-test/src/tests/prog_test_run.rs
+++ b/test/integration-test/src/tests/prog_test_run.rs
@@ -1,0 +1,360 @@
+use aya::{
+    Ebpf, RawTracePointRunOptions, TestRunOptions, TestRunResult,
+    maps::Array,
+    programs::{
+        RawTracePoint, RawTracePointTestRunResult, SchedClassifier, SocketFilter, TestRun as _, Xdp,
+    },
+};
+use integration_common::test_run::{IF_INDEX, XDP_MODIFY_LEN, XDP_MODIFY_VAL};
+
+// https://github.com/torvalds/linux/blob/8fdb05de/tools/testing/selftests/bpf/prog_tests/xdp_context_test_run.c#L48
+// `sizeof(pkt_v4)` = Size(Ethernet) + Size(IPv4) + Size(TCP) = 14 + 20 + 20
+const PKT_ETH_HDR_SIZE: usize = 14;
+const PKT_IP4_HDR_SIZE: usize = 20;
+const PKT_TCP_HDR_SIZE: usize = 20;
+const PKT_V4_SIZE: usize = PKT_ETH_HDR_SIZE + PKT_IP4_HDR_SIZE + PKT_TCP_HDR_SIZE;
+
+fn bytes_of<T: Sized>(val: &T) -> &[u8] {
+    let size = size_of::<T>();
+    unsafe { core::slice::from_raw_parts(core::ptr::from_ref::<T>(val).cast::<u8>(), size) }
+}
+
+#[test_log::test]
+fn test_classifier_test_run() {
+    let kernel_version = aya::util::KernelVersion::current().unwrap();
+    // BPF_PROG_TEST_RUN was introduced in v4.12 (1cf1cae963c2, "bpf: introduce
+    // BPF_PROG_TEST_RUN command") with support for sched_cls (used here) and
+    // sched_act program types. On kernels before v4.12 the syscall command does
+    // not exist and the bpf(2) call returns EINVAL.
+    if kernel_version < aya::util::KernelVersion::new(4, 12, 0) {
+        return;
+    }
+
+    let mut bpf = Ebpf::load(crate::TEST_RUN).unwrap();
+    let prog: &mut SchedClassifier = bpf
+        .program_mut("test_classifier")
+        .unwrap()
+        .try_into()
+        .unwrap();
+    prog.load().unwrap();
+
+    let data_in = vec![0u8; PKT_V4_SIZE];
+    let mut data_out = vec![0u8; PKT_V4_SIZE];
+
+    let opts = TestRunOptions {
+        data_in: Some(&data_in),
+        data_out: Some(&mut data_out),
+        ..TestRunOptions::default()
+    };
+
+    let TestRunResult {
+        return_value,
+        duration,
+        data_size_out,
+        ctx_size_out,
+    } = prog.test_run(opts).unwrap();
+
+    assert_eq!(return_value, 1, "Expected SK_PASS(1)");
+    assert!(!duration.is_zero());
+    assert_eq!(data_size_out as usize, PKT_V4_SIZE);
+    assert_eq!(ctx_size_out, 0);
+}
+
+#[test_log::test]
+fn test_run_repeat() {
+    let kernel_version = aya::util::KernelVersion::current().unwrap();
+    // BPF_PROG_TEST_RUN was introduced in v4.12 (1cf1cae963c2, "bpf: introduce
+    // BPF_PROG_TEST_RUN command") with support for sched_cls (used here) and
+    // sched_act program types.
+    // The `repeat` field in the BPF_PROG_TEST_RUN attribute struct was present from v4.12
+    if kernel_version < aya::util::KernelVersion::new(4, 12, 0) {
+        return;
+    }
+
+    let mut bpf = Ebpf::load(crate::TEST_RUN).unwrap();
+
+    let mut exec_count: Array<_, u64> = bpf.take_map("EXEC_COUNT").unwrap().try_into().unwrap();
+
+    exec_count.set(0, 0, 0).unwrap();
+
+    let prog: &mut SchedClassifier = bpf
+        .program_mut("test_count_exec")
+        .unwrap()
+        .try_into()
+        .unwrap();
+    prog.load().unwrap();
+
+    let data_in = vec![0u8; PKT_V4_SIZE];
+    let mut data_out = vec![0u8; PKT_V4_SIZE];
+
+    let opts = TestRunOptions {
+        data_in: Some(&data_in),
+        data_out: Some(&mut data_out),
+        repeat: 50,
+        ..TestRunOptions::default()
+    };
+    let TestRunResult {
+        return_value,
+        duration,
+        data_size_out,
+        ctx_size_out,
+    } = prog.test_run(opts).unwrap();
+
+    let final_count: u64 = exec_count.get(&0, 0).unwrap();
+    assert_eq!(return_value, 1, "Expected SK_PASS(1)");
+    assert_eq!(final_count, 50);
+    assert!(!duration.is_zero());
+    assert_eq!(data_size_out as usize, PKT_V4_SIZE);
+    assert_eq!(ctx_size_out, 0);
+}
+
+#[test_log::test]
+fn test_xdp_modify_packet() {
+    let kernel_version = aya::util::KernelVersion::current().unwrap();
+    // The test_xdp_modify eBPF program uses a bounded for-loop to overwrite packet
+    // bytes. Before v5.3, the BPF verifier rejected all back-edges unconditionally,
+    // treating even provably-terminating loops as potential infinite loops. The v5.3
+    // merge (94079b64255f, "bpf: bounded loops") taught the verifier to track loop
+    // bounds and accept loops with a statically-known iteration count. Without this,
+    // prog.load() fails with a verifier error ("back-edge from insn N to M").
+    // We require v5.6 rather than v5.3 as a conservative bound validated in CI.
+    if kernel_version < aya::util::KernelVersion::new(5, 6, 0) {
+        return;
+    }
+
+    let mut bpf = Ebpf::load(crate::TEST_RUN).unwrap();
+    let prog: &mut Xdp = bpf
+        .program_mut("test_xdp_modify")
+        .unwrap()
+        .try_into()
+        .unwrap();
+    prog.load().unwrap();
+
+    let data_in = vec![0u8; PKT_V4_SIZE];
+    let mut data_out = vec![0u8; PKT_V4_SIZE];
+
+    let opts = TestRunOptions {
+        data_in: Some(&data_in),
+        data_out: Some(&mut data_out),
+        ..TestRunOptions::default()
+    };
+
+    let TestRunResult {
+        return_value,
+        duration,
+        data_size_out,
+        ctx_size_out,
+    } = prog.test_run(opts).unwrap();
+
+    assert_eq!(return_value, 2, "Expected XDP_PASS(2)");
+    assert!(!duration.is_zero());
+    assert_eq!(data_size_out as usize, PKT_V4_SIZE);
+    assert_eq!(ctx_size_out, 0);
+
+    let expected_pattern: Vec<u8> = vec![XDP_MODIFY_VAL; XDP_MODIFY_LEN];
+    assert_eq!(&data_out[..XDP_MODIFY_LEN], &*expected_pattern);
+    assert_eq!(&data_out[XDP_MODIFY_LEN..], &data_in[XDP_MODIFY_LEN..]);
+}
+
+#[test_log::test]
+fn test_socket_filter_test_run() {
+    let kernel_version = aya::util::KernelVersion::current().unwrap();
+    // BPF_PROG_TEST_RUN was introduced in v4.12 but initially only supported
+    // sched_cls and sched_act program types. Support for BPF_PROG_TYPE_SOCKET_FILTER
+    // was added in v4.16 (61f3c964dfd2, "bpf: allow socket_filter programs to use
+    // bpf_prog_test_run"). On earlier kernels, calling BPF_PROG_TEST_RUN on a socket
+    // filter program returns EINVAL.
+    if kernel_version < aya::util::KernelVersion::new(4, 16, 0) {
+        return;
+    }
+
+    let mut bpf = Ebpf::load(crate::TEST_RUN).unwrap();
+    let prog: &mut SocketFilter = bpf
+        .program_mut("test_sock_filter")
+        .unwrap()
+        .try_into()
+        .unwrap();
+    prog.load().unwrap();
+
+    let data_in = vec![0u8; PKT_V4_SIZE];
+    let mut data_out = vec![0u8; PKT_V4_SIZE];
+
+    let opts = TestRunOptions {
+        data_in: Some(&data_in),
+        data_out: Some(&mut data_out),
+        ..TestRunOptions::default()
+    };
+
+    let TestRunResult {
+        return_value,
+        duration,
+        data_size_out,
+        ctx_size_out,
+    } = prog.test_run(opts).unwrap();
+
+    assert_eq!(return_value as usize, PKT_V4_SIZE - PKT_ETH_HDR_SIZE);
+    assert!(!duration.is_zero());
+    assert_eq!(data_size_out as usize, PKT_V4_SIZE);
+    assert_eq!(ctx_size_out, 0);
+}
+
+#[test_log::test]
+fn test_xdp_test_run() {
+    let kernel_version = aya::util::KernelVersion::current().unwrap();
+    // XDP test-run with a writable data_out buffer requires the kernel to properly
+    // initialize xdp_buff.frame_sz during test execution. Before v5.8
+    // (bc56c919fce7, "bpf: Add xdp.frame_sz in bpf_prog_test_run_xdp"), frame_sz
+    // was left as zero. The kernel uses frame_sz to compute available headroom and
+    // tailroom; with frame_sz=0 those bounds are wrong and bpf_prog_test_run may
+    // return an error or silently produce incorrect data_out contents.
+    if kernel_version < aya::util::KernelVersion::new(5, 8, 0) {
+        return;
+    }
+
+    let mut bpf = Ebpf::load(crate::TEST_RUN).unwrap();
+    let prog: &mut Xdp = bpf.program_mut("test_xdp").unwrap().try_into().unwrap();
+    prog.load().unwrap();
+
+    let data_in = vec![0u8; PKT_V4_SIZE];
+    let mut data_out = vec![0u8; PKT_V4_SIZE];
+
+    let opts = TestRunOptions {
+        data_in: Some(&data_in),
+        data_out: Some(&mut data_out),
+        ..TestRunOptions::default()
+    };
+
+    let TestRunResult {
+        return_value,
+        duration,
+        data_size_out,
+        ctx_size_out,
+    } = prog.test_run(opts).unwrap();
+
+    assert_eq!(return_value, 2, "Expected XDP_PASS(2)");
+    assert!(!duration.is_zero());
+    assert_eq!(data_size_out as usize, PKT_V4_SIZE);
+    assert_eq!(ctx_size_out, 0);
+}
+
+#[test_log::test]
+fn test_raw_tracepoint_test_run() {
+    let kernel_version = aya::util::KernelVersion::current().unwrap();
+    // BPF_PROG_TEST_RUN support for BPF_PROG_TYPE_RAW_TRACEPOINT was added in
+    // v5.10 (b84e6faeed1, "bpf: Implement bpf_prog_test_run for raw_tp").
+    // Before v5.10, calling BPF_PROG_TEST_RUN on a raw tracepoint program
+    // returns EINVAL because the kernel has no test_run handler for that
+    // program type.
+    //
+    // The handler interprets ctx_in as a packed array of u64 values loaded
+    // into the BPF register file (r1-r5) before calling the program, so the
+    // program can read tracepoint arguments without the tracepoint firing for
+    // real. This makes it possible to unit-test argument parsing logic in
+    // isolation.
+    if kernel_version < aya::util::KernelVersion::new(5, 10, 0) {
+        return;
+    }
+
+    let mut bpf = Ebpf::load(crate::TEST_RUN).unwrap();
+
+    let mut last_arg: Array<_, u64> = bpf.take_map("LAST_ARG").unwrap().try_into().unwrap();
+    last_arg.set(0, 0, 0).unwrap();
+
+    let prog: &mut RawTracePoint = bpf.program_mut("test_raw_tp").unwrap().try_into().unwrap();
+    prog.load().unwrap();
+
+    // Pass a sentinel as arg0 via ctx_in. The kernel requires ctx_size_in to
+    // be at least max_ctx_offset bytes; since the program reads arg(0), the
+    // verifier sets max_ctx_offset = 8 (one u64), so we must supply at least
+    // one element.
+    const SENTINEL: u64 = 0xdead_beef_cafe_babe;
+
+    let mut opts = RawTracePointRunOptions::default();
+    opts[0] = SENTINEL;
+
+    let RawTracePointTestRunResult {
+        return_value,
+        data_size_out,
+        ctx_size_out,
+    } = prog.test_run(opts).unwrap();
+
+    let stored: u64 = last_arg.get(&0, 0).unwrap();
+    assert_eq!(stored, SENTINEL);
+    assert_eq!(return_value, 0);
+    assert_eq!(data_size_out, 0);
+    assert_eq!(ctx_size_out, 0);
+}
+
+#[test_log::test]
+fn test_xdp_context() {
+    let kernel_version = aya::util::KernelVersion::current().unwrap();
+    // BPF_PROG_TEST_RUN gained ctx_in/ctx_out support for XDP programs in v5.15.
+    // Two commits together enabled this: 47316f4a3053 ("bpf: Support input xdp_md
+    // context in BPF_PROG_TEST_RUN") wired up the ctx_in/ctx_out fields so the
+    // test runner populates the XDP metadata (including ingress_ifindex) from the
+    // caller-supplied context, and ec94670fcb3b added ingress_ifindex propagation
+    // into the live xdp_buff. Before v5.15, passing ctx_in for an XDP program
+    // returns EINVAL because the kernel does not recognise or forward the context.
+    if kernel_version < aya::util::KernelVersion::new(5, 15, 0) {
+        return;
+    }
+
+    let mut bpf = Ebpf::load(crate::TEST_RUN).unwrap();
+    let prog: &mut Xdp = bpf
+        .program_mut("test_xdp_context")
+        .unwrap()
+        .try_into()
+        .unwrap();
+    prog.load().unwrap();
+
+    let data_in = vec![0u8; PKT_V4_SIZE];
+    let mut data_out = vec![0u8; PKT_V4_SIZE];
+
+    #[repr(C)]
+    #[derive(Clone, Copy)]
+    struct XdpMd {
+        data: u32,
+        data_end: u32,
+        data_meta: u32,
+        ingress_ifindex: u32,
+        rx_queue_index: u32,
+        egress_ifindex: u32,
+    }
+
+    // see: https://github.com/torvalds/linux/blob/63804fed/tools/testing/selftests/bpf/prog_tests/xdp_context_test_run.c#L92
+    // for more details.
+    let ctx = XdpMd {
+        data: 0,
+        data_end: data_in.len() as u32,
+        data_meta: 0,
+        ingress_ifindex: IF_INDEX,
+        // RX queue cannot be specified without specifying an ingress
+        rx_queue_index: 0,
+        // egress cannot be specified
+        egress_ifindex: 0,
+    };
+
+    let size = size_of::<XdpMd>();
+    let ctx_bytes = bytes_of(&ctx);
+    let mut ctx_out = vec![0u8; size];
+
+    let opts = TestRunOptions {
+        data_in: Some(&data_in),
+        data_out: Some(&mut data_out),
+        ctx_in: Some(ctx_bytes),
+        ctx_out: Some(&mut ctx_out),
+        ..TestRunOptions::default()
+    };
+
+    let TestRunResult {
+        return_value,
+        duration,
+        data_size_out,
+        ctx_size_out,
+    } = prog.test_run(opts).unwrap();
+
+    assert_eq!(return_value, 2, "Expected XDP_PASS(2)");
+    assert!(!duration.is_zero());
+    assert_eq!(data_size_out as usize, PKT_V4_SIZE);
+    assert_eq!(ctx_size_out as usize, size_of::<XdpMd>());
+}

--- a/test/integration-test/src/tests/prog_test_run.rs
+++ b/test/integration-test/src/tests/prog_test_run.rs
@@ -278,17 +278,11 @@ fn test_raw_tracepoint_test_run() {
     let mut opts = RawTracePointRunOptions::default();
     opts.args[0] = SENTINEL;
 
-    let RawTracePointTestRunResult {
-        return_value,
-        data_size_out,
-        ctx_size_out,
-    } = prog.test_run(opts).unwrap();
+    let RawTracePointTestRunResult { return_value } = prog.test_run(opts).unwrap();
 
     let stored: u64 = last_arg.get(&0, 0).unwrap();
     assert_eq!(stored, SENTINEL);
     assert_eq!(return_value, 0);
-    assert_eq!(data_size_out, 0);
-    assert_eq!(ctx_size_out, 0);
 }
 
 #[test_log::test]

--- a/test/integration-test/src/tests/prog_test_run.rs
+++ b/test/integration-test/src/tests/prog_test_run.rs
@@ -117,8 +117,10 @@ fn test_xdp_modify_packet() {
     // merge (94079b64255f, "bpf: bounded loops") taught the verifier to track loop
     // bounds and accept loops with a statically-known iteration count. Without this,
     // prog.load() fails with a verifier error ("back-edge from insn N to M").
-    // We require v5.6 rather than v5.3 as a conservative bound validated in CI.
-    if kernel_version < aya::util::KernelVersion::new(5, 6, 0) {
+    // Kernels 5.6–5.7 are still affected by the pre-v5.8 xdp_buff.frame_sz test-run bug,
+    // so this test can fail/flap there
+    // so we guard it with 5.8
+    if kernel_version < aya::util::KernelVersion::new(5, 8, 0) {
         return;
     }
 

--- a/test/integration-test/src/tests/prog_test_run.rs
+++ b/test/integration-test/src/tests/prog_test_run.rs
@@ -111,15 +111,19 @@ fn test_run_repeat() {
 #[test_log::test]
 fn test_xdp_modify_packet() {
     let kernel_version = aya::util::KernelVersion::current().unwrap();
-    // The test_xdp_modify eBPF program uses a bounded for-loop to overwrite packet
-    // bytes. Before v5.3, the BPF verifier rejected all back-edges unconditionally,
-    // treating even provably-terminating loops as potential infinite loops. The v5.3
-    // merge (94079b64255f, "bpf: bounded loops") taught the verifier to track loop
-    // bounds and accept loops with a statically-known iteration count. Without this,
-    // prog.load() fails with a verifier error ("back-edge from insn N to M").
-    // Kernels 5.6–5.7 are still affected by the pre-v5.8 xdp_buff.frame_sz test-run bug,
-    // so this test can fail/flap there
-    // so we guard it with 5.8
+    // Two separate kernel requirements combine to set this guard at v5.8:
+    //
+    // 1. The test_xdp_modify eBPF program uses a bounded for-loop to overwrite
+    //    packet bytes. Before v5.3 (94079b64255f, "bpf: bounded loops"), the BPF
+    //    verifier rejected all back-edges unconditionally, so prog.load() would
+    //    fail with a verifier error ("back-edge from insn N to M").
+    //
+    // 2. XDP test-run with a writable data_out buffer requires the kernel to properly
+    //    initialize xdp_buff.frame_sz. Before v5.8 (bc56c919fce7, "bpf: Add
+    //    xdp.frame_sz in bpf_prog_test_run_xdp"), frame_sz was left as zero, causing
+    //    bpf_prog_test_run to return an error or produce incorrect data_out contents.
+    //
+    // v5.8 is the stricter of the two requirements, so we guard at v5.8.
     if kernel_version < aya::util::KernelVersion::new(5, 8, 0) {
         return;
     }

--- a/xtask/public-api/aya.txt
+++ b/xtask/public-api/aya.txt
@@ -1841,6 +1841,10 @@ pub fn aya::programs::cgroup_skb::CgroupSkb::pin<P: core::convert::AsRef<std::pa
 pub fn aya::programs::cgroup_skb::CgroupSkb::unpin(&mut self) -> core::result::Result<(), std::io::error::Error>
 impl aya::programs::cgroup_skb::CgroupSkb
 pub fn aya::programs::cgroup_skb::CgroupSkb::unload(&mut self) -> core::result::Result<(), aya::programs::ProgramError>
+impl aya::programs::TestRun for aya::programs::cgroup_skb::CgroupSkb
+pub type aya::programs::cgroup_skb::CgroupSkb::Opts<'a> = aya::programs::TestRunOptions<'a>
+pub type aya::programs::cgroup_skb::CgroupSkb::Result = aya::programs::TestRunResult
+pub fn aya::programs::cgroup_skb::CgroupSkb::test_run(&self, opts: Self::Opts) -> core::result::Result<Self::Result, aya::programs::ProgramError>
 impl core::fmt::Debug for aya::programs::cgroup_skb::CgroupSkb
 pub fn aya::programs::cgroup_skb::CgroupSkb::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::ops::drop::Drop for aya::programs::cgroup_skb::CgroupSkb
@@ -2513,6 +2517,10 @@ pub fn aya::programs::flow_dissector::FlowDissector::pin<P: core::convert::AsRef
 pub fn aya::programs::flow_dissector::FlowDissector::unpin(&mut self) -> core::result::Result<(), std::io::error::Error>
 impl aya::programs::flow_dissector::FlowDissector
 pub fn aya::programs::flow_dissector::FlowDissector::unload(&mut self) -> core::result::Result<(), aya::programs::ProgramError>
+impl aya::programs::TestRun for aya::programs::flow_dissector::FlowDissector
+pub type aya::programs::flow_dissector::FlowDissector::Opts<'a> = aya::programs::TestRunOptions<'a>
+pub type aya::programs::flow_dissector::FlowDissector::Result = aya::programs::TestRunResult
+pub fn aya::programs::flow_dissector::FlowDissector::test_run(&self, opts: Self::Opts) -> core::result::Result<Self::Result, aya::programs::ProgramError>
 impl core::fmt::Debug for aya::programs::flow_dissector::FlowDissector
 pub fn aya::programs::flow_dissector::FlowDissector::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::ops::drop::Drop for aya::programs::flow_dissector::FlowDissector
@@ -3785,6 +3793,10 @@ pub fn aya::programs::raw_trace_point::RawTracePoint::pin<P: core::convert::AsRe
 pub fn aya::programs::raw_trace_point::RawTracePoint::unpin(&mut self) -> core::result::Result<(), std::io::error::Error>
 impl aya::programs::raw_trace_point::RawTracePoint
 pub fn aya::programs::raw_trace_point::RawTracePoint::unload(&mut self) -> core::result::Result<(), aya::programs::ProgramError>
+impl aya::programs::TestRun for aya::programs::raw_trace_point::RawTracePoint
+pub type aya::programs::raw_trace_point::RawTracePoint::Opts<'a> = aya::programs::RawTracePointRunOptions
+pub type aya::programs::raw_trace_point::RawTracePoint::Result = aya::programs::RawTracePointTestRunResult
+pub fn aya::programs::raw_trace_point::RawTracePoint::test_run(&self, opts: Self::Opts) -> core::result::Result<Self::Result, aya::programs::ProgramError>
 impl core::fmt::Debug for aya::programs::raw_trace_point::RawTracePoint
 pub fn aya::programs::raw_trace_point::RawTracePoint::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::ops::drop::Drop for aya::programs::raw_trace_point::RawTracePoint
@@ -4275,6 +4287,10 @@ pub fn aya::programs::socket_filter::SocketFilter::pin<P: core::convert::AsRef<s
 pub fn aya::programs::socket_filter::SocketFilter::unpin(&mut self) -> core::result::Result<(), std::io::error::Error>
 impl aya::programs::socket_filter::SocketFilter
 pub fn aya::programs::socket_filter::SocketFilter::unload(&mut self) -> core::result::Result<(), aya::programs::ProgramError>
+impl aya::programs::TestRun for aya::programs::socket_filter::SocketFilter
+pub type aya::programs::socket_filter::SocketFilter::Opts<'a> = aya::programs::TestRunOptions<'a>
+pub type aya::programs::socket_filter::SocketFilter::Result = aya::programs::TestRunResult
+pub fn aya::programs::socket_filter::SocketFilter::test_run(&self, opts: Self::Opts) -> core::result::Result<Self::Result, aya::programs::ProgramError>
 impl core::fmt::Debug for aya::programs::socket_filter::SocketFilter
 pub fn aya::programs::socket_filter::SocketFilter::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::ops::drop::Drop for aya::programs::socket_filter::SocketFilter
@@ -4437,6 +4453,10 @@ impl aya::programs::tc::SchedClassifier
 pub fn aya::programs::tc::SchedClassifier::unload(&mut self) -> core::result::Result<(), aya::programs::ProgramError>
 impl aya::programs::MultiProgram for aya::programs::tc::SchedClassifier
 pub fn aya::programs::tc::SchedClassifier::fd(&self) -> core::result::Result<std::os::fd::owned::BorrowedFd<'_>, aya::programs::ProgramError>
+impl aya::programs::TestRun for aya::programs::tc::SchedClassifier
+pub type aya::programs::tc::SchedClassifier::Opts<'a> = aya::programs::TestRunOptions<'a>
+pub type aya::programs::tc::SchedClassifier::Result = aya::programs::TestRunResult
+pub fn aya::programs::tc::SchedClassifier::test_run(&self, opts: Self::Opts) -> core::result::Result<Self::Result, aya::programs::ProgramError>
 impl core::fmt::Debug for aya::programs::tc::SchedClassifier
 pub fn aya::programs::tc::SchedClassifier::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::ops::drop::Drop for aya::programs::tc::SchedClassifier
@@ -4919,6 +4939,10 @@ pub fn aya::programs::xdp::Xdp::pin<P: core::convert::AsRef<std::path::Path>>(&m
 pub fn aya::programs::xdp::Xdp::unpin(&mut self) -> core::result::Result<(), std::io::error::Error>
 impl aya::programs::xdp::Xdp
 pub fn aya::programs::xdp::Xdp::unload(&mut self) -> core::result::Result<(), aya::programs::ProgramError>
+impl aya::programs::TestRun for aya::programs::xdp::Xdp
+pub type aya::programs::xdp::Xdp::Opts<'a> = aya::programs::TestRunOptions<'a>
+pub type aya::programs::xdp::Xdp::Result = aya::programs::TestRunResult
+pub fn aya::programs::xdp::Xdp::test_run(&self, opts: Self::Opts) -> core::result::Result<Self::Result, aya::programs::ProgramError>
 impl core::fmt::Debug for aya::programs::xdp::Xdp
 pub fn aya::programs::xdp::Xdp::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::ops::drop::Drop for aya::programs::xdp::Xdp
@@ -5741,6 +5765,10 @@ pub fn aya::programs::cgroup_skb::CgroupSkb::pin<P: core::convert::AsRef<std::pa
 pub fn aya::programs::cgroup_skb::CgroupSkb::unpin(&mut self) -> core::result::Result<(), std::io::error::Error>
 impl aya::programs::cgroup_skb::CgroupSkb
 pub fn aya::programs::cgroup_skb::CgroupSkb::unload(&mut self) -> core::result::Result<(), aya::programs::ProgramError>
+impl aya::programs::TestRun for aya::programs::cgroup_skb::CgroupSkb
+pub type aya::programs::cgroup_skb::CgroupSkb::Opts<'a> = aya::programs::TestRunOptions<'a>
+pub type aya::programs::cgroup_skb::CgroupSkb::Result = aya::programs::TestRunResult
+pub fn aya::programs::cgroup_skb::CgroupSkb::test_run(&self, opts: Self::Opts) -> core::result::Result<Self::Result, aya::programs::ProgramError>
 impl core::fmt::Debug for aya::programs::cgroup_skb::CgroupSkb
 pub fn aya::programs::cgroup_skb::CgroupSkb::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::ops::drop::Drop for aya::programs::cgroup_skb::CgroupSkb
@@ -6037,6 +6065,10 @@ pub fn aya::programs::flow_dissector::FlowDissector::pin<P: core::convert::AsRef
 pub fn aya::programs::flow_dissector::FlowDissector::unpin(&mut self) -> core::result::Result<(), std::io::error::Error>
 impl aya::programs::flow_dissector::FlowDissector
 pub fn aya::programs::flow_dissector::FlowDissector::unload(&mut self) -> core::result::Result<(), aya::programs::ProgramError>
+impl aya::programs::TestRun for aya::programs::flow_dissector::FlowDissector
+pub type aya::programs::flow_dissector::FlowDissector::Opts<'a> = aya::programs::TestRunOptions<'a>
+pub type aya::programs::flow_dissector::FlowDissector::Result = aya::programs::TestRunResult
+pub fn aya::programs::flow_dissector::FlowDissector::test_run(&self, opts: Self::Opts) -> core::result::Result<Self::Result, aya::programs::ProgramError>
 impl core::fmt::Debug for aya::programs::flow_dissector::FlowDissector
 pub fn aya::programs::flow_dissector::FlowDissector::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::ops::drop::Drop for aya::programs::flow_dissector::FlowDissector
@@ -6373,6 +6405,10 @@ pub fn aya::programs::raw_trace_point::RawTracePoint::pin<P: core::convert::AsRe
 pub fn aya::programs::raw_trace_point::RawTracePoint::unpin(&mut self) -> core::result::Result<(), std::io::error::Error>
 impl aya::programs::raw_trace_point::RawTracePoint
 pub fn aya::programs::raw_trace_point::RawTracePoint::unload(&mut self) -> core::result::Result<(), aya::programs::ProgramError>
+impl aya::programs::TestRun for aya::programs::raw_trace_point::RawTracePoint
+pub type aya::programs::raw_trace_point::RawTracePoint::Opts<'a> = aya::programs::RawTracePointRunOptions
+pub type aya::programs::raw_trace_point::RawTracePoint::Result = aya::programs::RawTracePointTestRunResult
+pub fn aya::programs::raw_trace_point::RawTracePoint::test_run(&self, opts: Self::Opts) -> core::result::Result<Self::Result, aya::programs::ProgramError>
 impl core::fmt::Debug for aya::programs::raw_trace_point::RawTracePoint
 pub fn aya::programs::raw_trace_point::RawTracePoint::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::ops::drop::Drop for aya::programs::raw_trace_point::RawTracePoint
@@ -6390,6 +6426,35 @@ impl core::marker::Unpin for aya::programs::raw_trace_point::RawTracePoint
 impl core::marker::UnsafeUnpin for aya::programs::raw_trace_point::RawTracePoint
 impl core::panic::unwind_safe::RefUnwindSafe for aya::programs::raw_trace_point::RawTracePoint
 impl core::panic::unwind_safe::UnwindSafe for aya::programs::raw_trace_point::RawTracePoint
+pub struct aya::programs::RawTracePointRunOptions
+pub aya::programs::RawTracePointRunOptions::args: [u64; 12]
+pub aya::programs::RawTracePointRunOptions::cpu: core::option::Option<u32>
+impl aya::programs::RawTracePointRunOptions
+pub const fn aya::programs::RawTracePointRunOptions::new() -> Self
+impl core::default::Default for aya::programs::RawTracePointRunOptions
+pub fn aya::programs::RawTracePointRunOptions::default() -> aya::programs::RawTracePointRunOptions
+impl core::fmt::Debug for aya::programs::RawTracePointRunOptions
+pub fn aya::programs::RawTracePointRunOptions::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for aya::programs::RawTracePointRunOptions
+impl core::marker::Send for aya::programs::RawTracePointRunOptions
+impl core::marker::Sync for aya::programs::RawTracePointRunOptions
+impl core::marker::Unpin for aya::programs::RawTracePointRunOptions
+impl core::marker::UnsafeUnpin for aya::programs::RawTracePointRunOptions
+impl core::panic::unwind_safe::RefUnwindSafe for aya::programs::RawTracePointRunOptions
+impl core::panic::unwind_safe::UnwindSafe for aya::programs::RawTracePointRunOptions
+pub struct aya::programs::RawTracePointTestRunResult
+pub aya::programs::RawTracePointTestRunResult::ctx_size_out: u32
+pub aya::programs::RawTracePointTestRunResult::data_size_out: u32
+pub aya::programs::RawTracePointTestRunResult::return_value: u32
+impl core::fmt::Debug for aya::programs::RawTracePointTestRunResult
+pub fn aya::programs::RawTracePointTestRunResult::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for aya::programs::RawTracePointTestRunResult
+impl core::marker::Send for aya::programs::RawTracePointTestRunResult
+impl core::marker::Sync for aya::programs::RawTracePointTestRunResult
+impl core::marker::Unpin for aya::programs::RawTracePointTestRunResult
+impl core::marker::UnsafeUnpin for aya::programs::RawTracePointTestRunResult
+impl core::panic::unwind_safe::RefUnwindSafe for aya::programs::RawTracePointTestRunResult
+impl core::panic::unwind_safe::UnwindSafe for aya::programs::RawTracePointTestRunResult
 pub struct aya::programs::SchedClassifier
 impl aya::programs::tc::SchedClassifier
 pub const aya::programs::tc::SchedClassifier::PROGRAM_TYPE: aya::programs::ProgramType
@@ -6415,6 +6480,10 @@ impl aya::programs::tc::SchedClassifier
 pub fn aya::programs::tc::SchedClassifier::unload(&mut self) -> core::result::Result<(), aya::programs::ProgramError>
 impl aya::programs::MultiProgram for aya::programs::tc::SchedClassifier
 pub fn aya::programs::tc::SchedClassifier::fd(&self) -> core::result::Result<std::os::fd::owned::BorrowedFd<'_>, aya::programs::ProgramError>
+impl aya::programs::TestRun for aya::programs::tc::SchedClassifier
+pub type aya::programs::tc::SchedClassifier::Opts<'a> = aya::programs::TestRunOptions<'a>
+pub type aya::programs::tc::SchedClassifier::Result = aya::programs::TestRunResult
+pub fn aya::programs::tc::SchedClassifier::test_run(&self, opts: Self::Opts) -> core::result::Result<Self::Result, aya::programs::ProgramError>
 impl core::fmt::Debug for aya::programs::tc::SchedClassifier
 pub fn aya::programs::tc::SchedClassifier::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::ops::drop::Drop for aya::programs::tc::SchedClassifier
@@ -6636,6 +6705,10 @@ pub fn aya::programs::socket_filter::SocketFilter::pin<P: core::convert::AsRef<s
 pub fn aya::programs::socket_filter::SocketFilter::unpin(&mut self) -> core::result::Result<(), std::io::error::Error>
 impl aya::programs::socket_filter::SocketFilter
 pub fn aya::programs::socket_filter::SocketFilter::unload(&mut self) -> core::result::Result<(), aya::programs::ProgramError>
+impl aya::programs::TestRun for aya::programs::socket_filter::SocketFilter
+pub type aya::programs::socket_filter::SocketFilter::Opts<'a> = aya::programs::TestRunOptions<'a>
+pub type aya::programs::socket_filter::SocketFilter::Result = aya::programs::TestRunResult
+pub fn aya::programs::socket_filter::SocketFilter::test_run(&self, opts: Self::Opts) -> core::result::Result<Self::Result, aya::programs::ProgramError>
 impl core::fmt::Debug for aya::programs::socket_filter::SocketFilter
 pub fn aya::programs::socket_filter::SocketFilter::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::ops::drop::Drop for aya::programs::socket_filter::SocketFilter
@@ -6653,6 +6726,56 @@ impl core::marker::Unpin for aya::programs::socket_filter::SocketFilter
 impl core::marker::UnsafeUnpin for aya::programs::socket_filter::SocketFilter
 impl core::panic::unwind_safe::RefUnwindSafe for aya::programs::socket_filter::SocketFilter
 impl core::panic::unwind_safe::UnwindSafe for aya::programs::socket_filter::SocketFilter
+pub struct aya::programs::TestRunAttrs
+impl aya::programs::TestRunAttrs
+pub const fn aya::programs::TestRunAttrs::new() -> Self
+pub const fn aya::programs::TestRunAttrs::run_on_cpu(self, cpu: u32) -> Self
+pub const fn aya::programs::TestRunAttrs::xdp_live_frames(self, batch_size: u32) -> Self
+impl core::default::Default for aya::programs::TestRunAttrs
+pub fn aya::programs::TestRunAttrs::default() -> Self
+impl core::fmt::Debug for aya::programs::TestRunAttrs
+pub fn aya::programs::TestRunAttrs::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for aya::programs::TestRunAttrs
+impl core::marker::Send for aya::programs::TestRunAttrs
+impl core::marker::Sync for aya::programs::TestRunAttrs
+impl core::marker::Unpin for aya::programs::TestRunAttrs
+impl core::marker::UnsafeUnpin for aya::programs::TestRunAttrs
+impl core::panic::unwind_safe::RefUnwindSafe for aya::programs::TestRunAttrs
+impl core::panic::unwind_safe::UnwindSafe for aya::programs::TestRunAttrs
+pub struct aya::programs::TestRunOptions<'a>
+pub aya::programs::TestRunOptions::attrs: aya::programs::TestRunAttrs
+pub aya::programs::TestRunOptions::ctx_in: core::option::Option<&'a [u8]>
+pub aya::programs::TestRunOptions::ctx_out: core::option::Option<&'a mut [u8]>
+pub aya::programs::TestRunOptions::data_in: core::option::Option<&'a [u8]>
+pub aya::programs::TestRunOptions::data_out: core::option::Option<&'a mut [u8]>
+pub aya::programs::TestRunOptions::repeat: u32
+impl aya::programs::TestRunOptions<'_>
+pub const fn aya::programs::TestRunOptions<'_>::new() -> Self
+impl core::default::Default for aya::programs::TestRunOptions<'_>
+pub fn aya::programs::TestRunOptions<'_>::default() -> Self
+impl<'a> core::fmt::Debug for aya::programs::TestRunOptions<'a>
+pub fn aya::programs::TestRunOptions<'a>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl<'a> core::marker::Freeze for aya::programs::TestRunOptions<'a>
+impl<'a> core::marker::Send for aya::programs::TestRunOptions<'a>
+impl<'a> core::marker::Sync for aya::programs::TestRunOptions<'a>
+impl<'a> core::marker::Unpin for aya::programs::TestRunOptions<'a>
+impl<'a> core::marker::UnsafeUnpin for aya::programs::TestRunOptions<'a>
+impl<'a> core::panic::unwind_safe::RefUnwindSafe for aya::programs::TestRunOptions<'a>
+impl<'a> !core::panic::unwind_safe::UnwindSafe for aya::programs::TestRunOptions<'a>
+pub struct aya::programs::TestRunResult
+pub aya::programs::TestRunResult::ctx_size_out: u32
+pub aya::programs::TestRunResult::data_size_out: u32
+pub aya::programs::TestRunResult::duration: core::time::Duration
+pub aya::programs::TestRunResult::return_value: u32
+impl core::fmt::Debug for aya::programs::TestRunResult
+pub fn aya::programs::TestRunResult::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for aya::programs::TestRunResult
+impl core::marker::Send for aya::programs::TestRunResult
+impl core::marker::Sync for aya::programs::TestRunResult
+impl core::marker::Unpin for aya::programs::TestRunResult
+impl core::marker::UnsafeUnpin for aya::programs::TestRunResult
+impl core::panic::unwind_safe::RefUnwindSafe for aya::programs::TestRunResult
+impl core::panic::unwind_safe::UnwindSafe for aya::programs::TestRunResult
 pub struct aya::programs::TracePoint
 impl aya::programs::trace_point::TracePoint
 pub const aya::programs::trace_point::TracePoint::PROGRAM_TYPE: aya::programs::ProgramType
@@ -6751,6 +6874,10 @@ pub fn aya::programs::xdp::Xdp::pin<P: core::convert::AsRef<std::path::Path>>(&m
 pub fn aya::programs::xdp::Xdp::unpin(&mut self) -> core::result::Result<(), std::io::error::Error>
 impl aya::programs::xdp::Xdp
 pub fn aya::programs::xdp::Xdp::unload(&mut self) -> core::result::Result<(), aya::programs::ProgramError>
+impl aya::programs::TestRun for aya::programs::xdp::Xdp
+pub type aya::programs::xdp::Xdp::Opts<'a> = aya::programs::TestRunOptions<'a>
+pub type aya::programs::xdp::Xdp::Result = aya::programs::TestRunResult
+pub fn aya::programs::xdp::Xdp::test_run(&self, opts: Self::Opts) -> core::result::Result<Self::Result, aya::programs::ProgramError>
 impl core::fmt::Debug for aya::programs::xdp::Xdp
 pub fn aya::programs::xdp::Xdp::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::ops::drop::Drop for aya::programs::xdp::Xdp
@@ -6988,6 +7115,34 @@ pub trait aya::programs::MultiProgram
 pub fn aya::programs::MultiProgram::fd(&self) -> core::result::Result<std::os::fd::owned::BorrowedFd<'_>, aya::programs::ProgramError>
 impl aya::programs::MultiProgram for aya::programs::tc::SchedClassifier
 pub fn aya::programs::tc::SchedClassifier::fd(&self) -> core::result::Result<std::os::fd::owned::BorrowedFd<'_>, aya::programs::ProgramError>
+pub trait aya::programs::TestRun
+pub type aya::programs::TestRun::Opts<'a>
+pub type aya::programs::TestRun::Result
+pub fn aya::programs::TestRun::test_run(&self, opts: Self::Opts) -> core::result::Result<Self::Result, aya::programs::ProgramError>
+impl aya::programs::TestRun for aya::programs::cgroup_skb::CgroupSkb
+pub type aya::programs::cgroup_skb::CgroupSkb::Opts<'a> = aya::programs::TestRunOptions<'a>
+pub type aya::programs::cgroup_skb::CgroupSkb::Result = aya::programs::TestRunResult
+pub fn aya::programs::cgroup_skb::CgroupSkb::test_run(&self, opts: Self::Opts) -> core::result::Result<Self::Result, aya::programs::ProgramError>
+impl aya::programs::TestRun for aya::programs::flow_dissector::FlowDissector
+pub type aya::programs::flow_dissector::FlowDissector::Opts<'a> = aya::programs::TestRunOptions<'a>
+pub type aya::programs::flow_dissector::FlowDissector::Result = aya::programs::TestRunResult
+pub fn aya::programs::flow_dissector::FlowDissector::test_run(&self, opts: Self::Opts) -> core::result::Result<Self::Result, aya::programs::ProgramError>
+impl aya::programs::TestRun for aya::programs::raw_trace_point::RawTracePoint
+pub type aya::programs::raw_trace_point::RawTracePoint::Opts<'a> = aya::programs::RawTracePointRunOptions
+pub type aya::programs::raw_trace_point::RawTracePoint::Result = aya::programs::RawTracePointTestRunResult
+pub fn aya::programs::raw_trace_point::RawTracePoint::test_run(&self, opts: Self::Opts) -> core::result::Result<Self::Result, aya::programs::ProgramError>
+impl aya::programs::TestRun for aya::programs::socket_filter::SocketFilter
+pub type aya::programs::socket_filter::SocketFilter::Opts<'a> = aya::programs::TestRunOptions<'a>
+pub type aya::programs::socket_filter::SocketFilter::Result = aya::programs::TestRunResult
+pub fn aya::programs::socket_filter::SocketFilter::test_run(&self, opts: Self::Opts) -> core::result::Result<Self::Result, aya::programs::ProgramError>
+impl aya::programs::TestRun for aya::programs::tc::SchedClassifier
+pub type aya::programs::tc::SchedClassifier::Opts<'a> = aya::programs::TestRunOptions<'a>
+pub type aya::programs::tc::SchedClassifier::Result = aya::programs::TestRunResult
+pub fn aya::programs::tc::SchedClassifier::test_run(&self, opts: Self::Opts) -> core::result::Result<Self::Result, aya::programs::ProgramError>
+impl aya::programs::TestRun for aya::programs::xdp::Xdp
+pub type aya::programs::xdp::Xdp::Opts<'a> = aya::programs::TestRunOptions<'a>
+pub type aya::programs::xdp::Xdp::Result = aya::programs::TestRunResult
+pub fn aya::programs::xdp::Xdp::test_run(&self, opts: Self::Opts) -> core::result::Result<Self::Result, aya::programs::ProgramError>
 pub fn aya::programs::loaded_links() -> impl core::iter::traits::iterator::Iterator<Item = core::result::Result<aya::programs::links::LinkInfo, aya::programs::links::LinkError>>
 pub fn aya::programs::loaded_programs() -> impl core::iter::traits::iterator::Iterator<Item = core::result::Result<aya::programs::ProgramInfo, aya::programs::ProgramError>>
 pub mod aya::sys
@@ -7164,6 +7319,85 @@ impl<'a> core::marker::Unpin for aya::GlobalData<'a>
 impl<'a> core::marker::UnsafeUnpin for aya::GlobalData<'a>
 impl<'a> core::panic::unwind_safe::RefUnwindSafe for aya::GlobalData<'a>
 impl<'a> core::panic::unwind_safe::UnwindSafe for aya::GlobalData<'a>
+pub struct aya::RawTracePointRunOptions
+pub aya::RawTracePointRunOptions::args: [u64; 12]
+pub aya::RawTracePointRunOptions::cpu: core::option::Option<u32>
+impl aya::programs::RawTracePointRunOptions
+pub const fn aya::programs::RawTracePointRunOptions::new() -> Self
+impl core::default::Default for aya::programs::RawTracePointRunOptions
+pub fn aya::programs::RawTracePointRunOptions::default() -> aya::programs::RawTracePointRunOptions
+impl core::fmt::Debug for aya::programs::RawTracePointRunOptions
+pub fn aya::programs::RawTracePointRunOptions::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for aya::programs::RawTracePointRunOptions
+impl core::marker::Send for aya::programs::RawTracePointRunOptions
+impl core::marker::Sync for aya::programs::RawTracePointRunOptions
+impl core::marker::Unpin for aya::programs::RawTracePointRunOptions
+impl core::marker::UnsafeUnpin for aya::programs::RawTracePointRunOptions
+impl core::panic::unwind_safe::RefUnwindSafe for aya::programs::RawTracePointRunOptions
+impl core::panic::unwind_safe::UnwindSafe for aya::programs::RawTracePointRunOptions
+pub struct aya::RawTracePointTestRunResult
+pub aya::RawTracePointTestRunResult::ctx_size_out: u32
+pub aya::RawTracePointTestRunResult::data_size_out: u32
+pub aya::RawTracePointTestRunResult::return_value: u32
+impl core::fmt::Debug for aya::programs::RawTracePointTestRunResult
+pub fn aya::programs::RawTracePointTestRunResult::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for aya::programs::RawTracePointTestRunResult
+impl core::marker::Send for aya::programs::RawTracePointTestRunResult
+impl core::marker::Sync for aya::programs::RawTracePointTestRunResult
+impl core::marker::Unpin for aya::programs::RawTracePointTestRunResult
+impl core::marker::UnsafeUnpin for aya::programs::RawTracePointTestRunResult
+impl core::panic::unwind_safe::RefUnwindSafe for aya::programs::RawTracePointTestRunResult
+impl core::panic::unwind_safe::UnwindSafe for aya::programs::RawTracePointTestRunResult
+pub struct aya::TestRunAttrs
+impl aya::programs::TestRunAttrs
+pub const fn aya::programs::TestRunAttrs::new() -> Self
+pub const fn aya::programs::TestRunAttrs::run_on_cpu(self, cpu: u32) -> Self
+pub const fn aya::programs::TestRunAttrs::xdp_live_frames(self, batch_size: u32) -> Self
+impl core::default::Default for aya::programs::TestRunAttrs
+pub fn aya::programs::TestRunAttrs::default() -> Self
+impl core::fmt::Debug for aya::programs::TestRunAttrs
+pub fn aya::programs::TestRunAttrs::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for aya::programs::TestRunAttrs
+impl core::marker::Send for aya::programs::TestRunAttrs
+impl core::marker::Sync for aya::programs::TestRunAttrs
+impl core::marker::Unpin for aya::programs::TestRunAttrs
+impl core::marker::UnsafeUnpin for aya::programs::TestRunAttrs
+impl core::panic::unwind_safe::RefUnwindSafe for aya::programs::TestRunAttrs
+impl core::panic::unwind_safe::UnwindSafe for aya::programs::TestRunAttrs
+pub struct aya::TestRunOptions<'a>
+pub aya::TestRunOptions::attrs: aya::programs::TestRunAttrs
+pub aya::TestRunOptions::ctx_in: core::option::Option<&'a [u8]>
+pub aya::TestRunOptions::ctx_out: core::option::Option<&'a mut [u8]>
+pub aya::TestRunOptions::data_in: core::option::Option<&'a [u8]>
+pub aya::TestRunOptions::data_out: core::option::Option<&'a mut [u8]>
+pub aya::TestRunOptions::repeat: u32
+impl aya::programs::TestRunOptions<'_>
+pub const fn aya::programs::TestRunOptions<'_>::new() -> Self
+impl core::default::Default for aya::programs::TestRunOptions<'_>
+pub fn aya::programs::TestRunOptions<'_>::default() -> Self
+impl<'a> core::fmt::Debug for aya::programs::TestRunOptions<'a>
+pub fn aya::programs::TestRunOptions<'a>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl<'a> core::marker::Freeze for aya::programs::TestRunOptions<'a>
+impl<'a> core::marker::Send for aya::programs::TestRunOptions<'a>
+impl<'a> core::marker::Sync for aya::programs::TestRunOptions<'a>
+impl<'a> core::marker::Unpin for aya::programs::TestRunOptions<'a>
+impl<'a> core::marker::UnsafeUnpin for aya::programs::TestRunOptions<'a>
+impl<'a> core::panic::unwind_safe::RefUnwindSafe for aya::programs::TestRunOptions<'a>
+impl<'a> !core::panic::unwind_safe::UnwindSafe for aya::programs::TestRunOptions<'a>
+pub struct aya::TestRunResult
+pub aya::TestRunResult::ctx_size_out: u32
+pub aya::TestRunResult::data_size_out: u32
+pub aya::TestRunResult::duration: core::time::Duration
+pub aya::TestRunResult::return_value: u32
+impl core::fmt::Debug for aya::programs::TestRunResult
+pub fn aya::programs::TestRunResult::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for aya::programs::TestRunResult
+impl core::marker::Send for aya::programs::TestRunResult
+impl core::marker::Sync for aya::programs::TestRunResult
+impl core::marker::Unpin for aya::programs::TestRunResult
+impl core::marker::UnsafeUnpin for aya::programs::TestRunResult
+impl core::panic::unwind_safe::RefUnwindSafe for aya::programs::TestRunResult
+impl core::panic::unwind_safe::UnwindSafe for aya::programs::TestRunResult
 pub struct aya::VerifierLogLevel(_)
 impl aya::VerifierLogLevel
 pub const aya::VerifierLogLevel::DEBUG: Self
@@ -7271,6 +7505,34 @@ impl aya::Pod for u64
 impl aya::Pod for u8
 impl<K: aya::Pod> aya::Pod for aya::maps::lpm_trie::Key<K>
 impl<T: aya::Pod, const N: usize> aya::Pod for [T; N]
+pub trait aya::TestRun
+pub type aya::TestRun::Opts<'a>
+pub type aya::TestRun::Result
+pub fn aya::TestRun::test_run(&self, opts: Self::Opts) -> core::result::Result<Self::Result, aya::programs::ProgramError>
+impl aya::programs::TestRun for aya::programs::cgroup_skb::CgroupSkb
+pub type aya::programs::cgroup_skb::CgroupSkb::Opts<'a> = aya::programs::TestRunOptions<'a>
+pub type aya::programs::cgroup_skb::CgroupSkb::Result = aya::programs::TestRunResult
+pub fn aya::programs::cgroup_skb::CgroupSkb::test_run(&self, opts: Self::Opts) -> core::result::Result<Self::Result, aya::programs::ProgramError>
+impl aya::programs::TestRun for aya::programs::flow_dissector::FlowDissector
+pub type aya::programs::flow_dissector::FlowDissector::Opts<'a> = aya::programs::TestRunOptions<'a>
+pub type aya::programs::flow_dissector::FlowDissector::Result = aya::programs::TestRunResult
+pub fn aya::programs::flow_dissector::FlowDissector::test_run(&self, opts: Self::Opts) -> core::result::Result<Self::Result, aya::programs::ProgramError>
+impl aya::programs::TestRun for aya::programs::raw_trace_point::RawTracePoint
+pub type aya::programs::raw_trace_point::RawTracePoint::Opts<'a> = aya::programs::RawTracePointRunOptions
+pub type aya::programs::raw_trace_point::RawTracePoint::Result = aya::programs::RawTracePointTestRunResult
+pub fn aya::programs::raw_trace_point::RawTracePoint::test_run(&self, opts: Self::Opts) -> core::result::Result<Self::Result, aya::programs::ProgramError>
+impl aya::programs::TestRun for aya::programs::socket_filter::SocketFilter
+pub type aya::programs::socket_filter::SocketFilter::Opts<'a> = aya::programs::TestRunOptions<'a>
+pub type aya::programs::socket_filter::SocketFilter::Result = aya::programs::TestRunResult
+pub fn aya::programs::socket_filter::SocketFilter::test_run(&self, opts: Self::Opts) -> core::result::Result<Self::Result, aya::programs::ProgramError>
+impl aya::programs::TestRun for aya::programs::tc::SchedClassifier
+pub type aya::programs::tc::SchedClassifier::Opts<'a> = aya::programs::TestRunOptions<'a>
+pub type aya::programs::tc::SchedClassifier::Result = aya::programs::TestRunResult
+pub fn aya::programs::tc::SchedClassifier::test_run(&self, opts: Self::Opts) -> core::result::Result<Self::Result, aya::programs::ProgramError>
+impl aya::programs::TestRun for aya::programs::xdp::Xdp
+pub type aya::programs::xdp::Xdp::Opts<'a> = aya::programs::TestRunOptions<'a>
+pub type aya::programs::xdp::Xdp::Result = aya::programs::TestRunResult
+pub fn aya::programs::xdp::Xdp::test_run(&self, opts: Self::Opts) -> core::result::Result<Self::Result, aya::programs::ProgramError>
 pub fn aya::features() -> &'static aya_obj::obj::Features
 pub type aya::Bpf = aya::Ebpf
 pub type aya::BpfError = aya::EbpfError

--- a/xtask/public-api/aya.txt
+++ b/xtask/public-api/aya.txt
@@ -6729,7 +6729,6 @@ impl core::panic::unwind_safe::UnwindSafe for aya::programs::socket_filter::Sock
 pub struct aya::programs::TestRunAttrs
 impl aya::programs::TestRunAttrs
 pub const fn aya::programs::TestRunAttrs::new() -> Self
-pub const fn aya::programs::TestRunAttrs::run_on_cpu(self, cpu: u32) -> Self
 pub const fn aya::programs::TestRunAttrs::xdp_live_frames(self, batch_size: u32) -> Self
 impl core::default::Default for aya::programs::TestRunAttrs
 pub fn aya::programs::TestRunAttrs::default() -> Self
@@ -7351,7 +7350,6 @@ impl core::panic::unwind_safe::UnwindSafe for aya::programs::RawTracePointTestRu
 pub struct aya::TestRunAttrs
 impl aya::programs::TestRunAttrs
 pub const fn aya::programs::TestRunAttrs::new() -> Self
-pub const fn aya::programs::TestRunAttrs::run_on_cpu(self, cpu: u32) -> Self
 pub const fn aya::programs::TestRunAttrs::xdp_live_frames(self, batch_size: u32) -> Self
 impl core::default::Default for aya::programs::TestRunAttrs
 pub fn aya::programs::TestRunAttrs::default() -> Self

--- a/xtask/public-api/aya.txt
+++ b/xtask/public-api/aya.txt
@@ -6443,8 +6443,6 @@ impl core::marker::UnsafeUnpin for aya::programs::RawTracePointRunOptions
 impl core::panic::unwind_safe::RefUnwindSafe for aya::programs::RawTracePointRunOptions
 impl core::panic::unwind_safe::UnwindSafe for aya::programs::RawTracePointRunOptions
 pub struct aya::programs::RawTracePointTestRunResult
-pub aya::programs::RawTracePointTestRunResult::ctx_size_out: u32
-pub aya::programs::RawTracePointTestRunResult::data_size_out: u32
 pub aya::programs::RawTracePointTestRunResult::return_value: u32
 impl core::fmt::Debug for aya::programs::RawTracePointTestRunResult
 pub fn aya::programs::RawTracePointTestRunResult::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
@@ -7335,8 +7333,6 @@ impl core::marker::UnsafeUnpin for aya::programs::RawTracePointRunOptions
 impl core::panic::unwind_safe::RefUnwindSafe for aya::programs::RawTracePointRunOptions
 impl core::panic::unwind_safe::UnwindSafe for aya::programs::RawTracePointRunOptions
 pub struct aya::RawTracePointTestRunResult
-pub aya::RawTracePointTestRunResult::ctx_size_out: u32
-pub aya::RawTracePointTestRunResult::data_size_out: u32
 pub aya::RawTracePointTestRunResult::return_value: u32
 impl core::fmt::Debug for aya::programs::RawTracePointTestRunResult
 pub fn aya::programs::RawTracePointTestRunResult::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result


### PR DESCRIPTION
## background 

`BPF_PROG_TEST_RUN`(hereafter referred as `TEST_RUN`) was introduced in 4.12 and is very convenient for testing. https://github.com/aya-rs/aya/issues/36 mentioned but it's not yet implemented.
It's quite useful especially if you wish to handle complex logics. [Cilium](https://github.com/cilium/cilium/pull/20017) had also brought this testing framework to their project.
 
This PR aims at bring `TEST_RUN` to aya to improve the testing experience. 

## implementation

Basically, it's a wrap around `sys_bpf` syscall with option `TEST_RUN`.

### Supported programs 

the following program are supported as mentioned [here](https://docs.ebpf.io/linux/syscall/BPF_PROG_TEST_RUN/#usage), some type does not have a public api in Aya, so I did not implemented `TEST_RUN` for them either.

| Program type (doc) | Aya program struct | test_run in Aya? |
|---|---:|---:|
| BPF_PROG_TYPE_SOCKET_FILTER | `SocketFilter` | ✔ | 
| BPF_PROG_TYPE_SCHED_CLS | `SchedClassifier` | ✔ | 
| BPF_PROG_TYPE_SCHED_ACT | (none) | No | 
| BPF_PROG_TYPE_SK_LOOKUP | `SkLookup` | No |
| BPF_PROG_TYPE_CGROUP_SKB | `CgroupSkb` | ✔ | 
| BPF_PROG_TYPE_LWT_IN | (none) | No |
| BPF_PROG_TYPE_LWT_OUT | (none) | No | 
| BPF_PROG_TYPE_LWT_XMIT | (none) | No | 
| BPF_PROG_TYPE_FLOW_DISSECTOR | `FlowDissector` | ✔ | 
| BPF_PROG_TYPE_STRUCT_OPS | (none) | No | 
| BPF_PROG_TYPE_RAW_TRACEPOINT | `RawTracePoint` | ✔ | 
| BPF_PROG_TYPE_SYSCALL | (none) | No | 
| BPF_PROG_TYPE_TRACING (note) | `TracePoint` | No | 
| XDP (extra) | `Xdp` | ✔ | 

### example

```rust
use aya::{Ebpf, programs::Xdp, sys::TestRunOptions};

// Load your eBPF program
let mut bpf = Ebpf::load_file("my_program.o")?;

// Get and load the XDP program
let prog: &mut Xdp = bpf.program_mut("my_xdp").unwrap().try_into()?;
prog.load()?;

// Create test input
let input_packet = vec![
    // Ethernet header
    0xff, 0xff, 0xff, 0xff, 0xff, 0xff, // dest MAC
    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // src MAC
    0x08, 0x00, // EtherType (IPv4)
    // ... rest of packet ...
];

// Prepare output buffer
let mut output_packet = vec![0u8; input_packet.len()];

// Configure test run options
let mut opts = TestRunOptions {
    data_in: Some(&input_packet),
    data_out: Some(&mut output_packet),
    repeat: 1,
    ..Default::default()
};

// Run the test
let result = prog.test_run(&mut opts)?;

// Check results
println!("Return value: {}", result.return_value);
println!("Duration: {} ns", result.duration);
println!("Output size: {}", result.data_size_out);
```

## testing

I add some tests that covers the options for `BPF_PROG_TEST_RUN` in integration tests, which also including some explanations on how to config some context for test purpose. 

## references

- https://docs.ebpf.io/linux/syscall/BPF_PROG_TEST_RUN/
- https://github.com/cilium/cilium/pull/20017/

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aya-rs/aya/1461)
<!-- Reviewable:end -->
