### PR TITLE
ci: Cancel stale PR runs automatically

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,10 @@ on:
 env:
   CARGO_TERM_COLOR: always
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions: {}
 
 jobs:


### PR DESCRIPTION
Add a workflow-level concurrency group so PR workflows share a `<workflow>-pr-<number>` group and GitHub cancels any in-progress run when a new push arrives. Non-PR events fall back to the ref name, which keeps push/cron runs isolated while still preventing multiple runs per ref from piling up.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aya-rs/aya/1465)
<!-- Reviewable:end -->
