### PR TITLE
fix: check length in SkBuff's load_bytes function

### DIFF
--- a/ebpf/aya-ebpf/src/programs/sk_buff.rs
+++ b/ebpf/aya-ebpf/src/programs/sk_buff.rs
@@ -86,6 +86,10 @@ impl SkBuff {
         let len = usize::try_from(self.len()).map_err(|core::num::TryFromIntError { .. }| -1)?;
         let len = len.checked_sub(offset).ok_or(-1)?;
         let len = len.min(dst.len());
+        if len == 0 {
+            return Ok(0);
+        }
+
         let len_u32 = u32::try_from(len).map_err(|core::num::TryFromIntError { .. }| -1)?;
         let ret = unsafe {
             bpf_skb_load_bytes(

--- a/test/integration-test/src/tests.rs
+++ b/test/integration-test/src/tests.rs
@@ -18,6 +18,7 @@ mod info;
 mod iter;
 mod linear_data_structures;
 mod load;
+mod load_bytes;
 mod log;
 mod lsm;
 mod map_pin;

--- a/test/integration-test/src/tests/load_bytes.rs
+++ b/test/integration-test/src/tests/load_bytes.rs
@@ -6,14 +6,13 @@ use aya::{
 
 #[test_log::test]
 fn test_load_bytes() {
-    // This ProgramType and these two MapTypes are needed because the MAP_TEST sample program uses all three.
+    // Ensure SocketFilter programs are supported on this kernel before running the test.
     if !is_program_supported(ProgramType::SocketFilter).unwrap() {
         eprintln!("skipping test - socket_filter program not supported");
         return;
     }
 
-    // Load the eBPF program to create the file descriptor associated with the BAR map. This is
-    // required to read and write to the map which we test below.
+    // Load the eBPF program from in-memory bytes and prepare the SocketFilter program.
     let mut bpf: Ebpf = Ebpf::load(crate::TEST).unwrap();
     let prog: &mut SocketFilter = bpf
         .program_mut("fix_test_load_bytes")

--- a/test/integration-test/src/tests/load_bytes.rs
+++ b/test/integration-test/src/tests/load_bytes.rs
@@ -4,15 +4,15 @@ use aya::{
     sys::is_program_supported,
 };
 
+// Load the eBPF socket filter program from the embedded bytes and ensure it loads
+// successfully (i.e., passes verification) using Ebpf::load and prog.load().
 #[test_log::test]
 fn test_load_bytes() {
-    // Ensure SocketFilter programs are supported on this kernel before running the test.
     if !is_program_supported(ProgramType::SocketFilter).unwrap() {
         eprintln!("skipping test - socket_filter program not supported");
         return;
     }
 
-    // Load the eBPF program from in-memory bytes and prepare the SocketFilter program.
     let mut bpf: Ebpf = Ebpf::load(crate::TEST).unwrap();
     let prog: &mut SocketFilter = bpf
         .program_mut("fix_test_load_bytes")
@@ -20,4 +20,5 @@ fn test_load_bytes() {
         .try_into()
         .unwrap();
     prog.load().unwrap();
+    // should pass verification
 }

--- a/test/integration-test/src/tests/load_bytes.rs
+++ b/test/integration-test/src/tests/load_bytes.rs
@@ -1,0 +1,24 @@
+use aya::{
+    Ebpf,
+    programs::{ProgramType, SocketFilter},
+    sys::is_program_supported,
+};
+
+#[test_log::test]
+fn test_load_bytes() {
+    // This ProgramType and these two MapTypes are needed because the MAP_TEST sample program uses all three.
+    if !is_program_supported(ProgramType::SocketFilter).unwrap() {
+        eprintln!("skipping test - socket_filter program not supported");
+        return;
+    }
+
+    // Load the eBPF program to create the file descriptor associated with the BAR map. This is
+    // required to read and write to the map which we test below.
+    let mut bpf: Ebpf = Ebpf::load(crate::TEST).unwrap();
+    let prog: &mut SocketFilter = bpf
+        .program_mut("fix_test_load_bytes")
+        .unwrap()
+        .try_into()
+        .unwrap();
+    prog.load().unwrap();
+}


### PR DESCRIPTION
Fix: https://github.com/aya-rs/aya/issues/1207

Should i create a new file for the eBPF program? Though that seems odd in current integration-test's file structure.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aya-rs/aya/1469)
<!-- Reviewable:end -->
