### PR TITLE
test: integration: add bloom filter tests

### DIFF
--- a/test/integration-ebpf/Cargo.toml
+++ b/test/integration-ebpf/Cargo.toml
@@ -29,6 +29,10 @@ name = "array"
 path = "src/array.rs"
 
 [[bin]]
+name = "bloom_filter"
+path = "src/bloom_filter.rs"
+
+[[bin]]
 name = "bpf_probe_read"
 path = "src/bpf_probe_read.rs"
 

--- a/test/integration-ebpf/src/bloom_filter.rs
+++ b/test/integration-ebpf/src/bloom_filter.rs
@@ -1,0 +1,51 @@
+#![no_std]
+#![no_main]
+#![expect(unused_crate_dependencies, reason = "used in other bins")]
+
+#[cfg(not(test))]
+extern crate ebpf_panic;
+
+use aya_ebpf::{
+    cty::c_long,
+    macros::{map, uprobe},
+    maps::{Array, bloom_filter::BloomFilter},
+    programs::ProbeContext,
+};
+
+#[map]
+static mut BLOOMFILTER: BloomFilter<u32> = BloomFilter::with_max_entries(4, 0);
+
+#[map]
+static RESULT: Array<i64> = Array::with_max_entries(1, 0);
+
+#[uprobe]
+fn test_contains(ctx: ProbeContext) -> Result<(), c_long> {
+    let value = ctx.arg(0).ok_or(-1)?;
+
+    // Reset result
+    RESULT.set(0, 0, 0)?;
+
+    #[allow(static_mut_refs)]
+    match unsafe { BLOOMFILTER.contains(&value) } {
+        Ok(_) => RESULT.set(0, 1, 0)?,
+        Err(err) => RESULT.set(0, err, 0)?,
+    }
+
+    Ok(())
+}
+
+#[uprobe]
+fn test_insert(ctx: ProbeContext) -> Result<(), c_long> {
+    let value = ctx.arg(0).ok_or(-1)?;
+
+    // Reset result
+    RESULT.set(0, 0, 0)?;
+
+    #[allow(static_mut_refs)]
+    match unsafe { BLOOMFILTER.insert(&value, 0) } {
+        Ok(_) => RESULT.set(0, 1, 0)?,
+        Err(err) => RESULT.set(0, err, 0)?,
+    }
+
+    Ok(())
+}

--- a/test/integration-test/src/lib.rs
+++ b/test/integration-test/src/lib.rs
@@ -40,6 +40,7 @@ bpf_file!(
     VARIABLES_RELOC => "variables_reloc.bpf.o",
 
     ARRAY => "array",
+    BLOOM_FILTER => "bloom_filter",
     BPF_PROBE_READ => "bpf_probe_read",
     BTF_MAPS_PLAIN => "btf_maps_plain",
     LINEAR_DATA_STRUCTURES => "linear_data_structures",

--- a/test/integration-test/src/tests.rs
+++ b/test/integration-test/src/tests.rs
@@ -9,6 +9,7 @@
 )]
 
 mod array;
+mod bloom_filter;
 mod bpf_probe_read;
 mod btf_maps;
 mod btf_relocations;

--- a/test/integration-test/src/tests/bloom_filter.rs
+++ b/test/integration-test/src/tests/bloom_filter.rs
@@ -1,0 +1,151 @@
+use aya::{
+    EbpfLoader,
+    maps::{Array, bloom_filter::BloomFilter},
+    programs::UProbe,
+};
+use libc::ENOENT;
+
+const BF_USER_VALUE: u32 = 1;
+const BF_KERNEL_VALUE: u32 = 2;
+
+#[unsafe(no_mangle)]
+#[inline(never)]
+extern "C" fn test_contains(index: u32) {
+    std::hint::black_box(index);
+}
+
+#[unsafe(no_mangle)]
+#[inline(never)]
+extern "C" fn test_insert(value: u32) {
+    std::hint::black_box(value);
+}
+
+#[test_log::test]
+fn test_bloom_filter_contains_returns_error_item_not_found() {
+    let mut ebpf = EbpfLoader::new().load(crate::BLOOM_FILTER).unwrap();
+    let contains_prog: &mut UProbe = ebpf
+        .program_mut("test_contains")
+        .unwrap()
+        .try_into()
+        .unwrap();
+    contains_prog.load().unwrap();
+    contains_prog
+        .attach("test_contains", "/proc/self/exe", None)
+        .unwrap();
+
+    let bloom_filter = {
+        let bloom_map = ebpf.map_mut("BLOOMFILTER").unwrap();
+        BloomFilter::try_from(bloom_map).unwrap()
+    };
+
+    // Test contains from user space
+    assert!(bloom_filter.contains(&BF_USER_VALUE, 0).is_err());
+
+    // Test contains from kernel space
+    {
+        test_contains(BF_KERNEL_VALUE);
+        let result = {
+            let array_map = ebpf.map("RESULT").unwrap();
+            Array::<_, i64>::try_from(array_map).unwrap()
+        };
+        assert_eq!(result.get(&0, 0).unwrap(), (-ENOENT).into());
+    }
+}
+
+#[test_log::test]
+fn test_bloom_filter_insert_returns_sucessfully() {
+    let mut ebpf = EbpfLoader::new().load(crate::BLOOM_FILTER).unwrap();
+    let insert_prog: &mut UProbe = ebpf.program_mut("test_insert").unwrap().try_into().unwrap();
+    insert_prog.load().unwrap();
+    insert_prog
+        .attach("test_insert", "/proc/self/exe", None)
+        .unwrap();
+
+    let mut bloom_filter = {
+        let bloom_map = ebpf.map_mut("BLOOMFILTER").unwrap();
+        BloomFilter::try_from(bloom_map).unwrap()
+    };
+
+    // Test insert from user space
+    assert!(bloom_filter.insert(BF_USER_VALUE, 0).is_ok());
+
+    // Test insert from kernel space
+    test_insert(BF_KERNEL_VALUE);
+    let result = {
+        let array_map = ebpf.map("RESULT").unwrap();
+        Array::<_, i64>::try_from(array_map).unwrap()
+    };
+    assert_eq!(result.get(&0, 0).unwrap(), 1);
+}
+
+#[test_log::test]
+fn test_bloom_filter_contains_user_space() {
+    let mut ebpf = EbpfLoader::new().load(crate::BLOOM_FILTER).unwrap();
+    let insert_prog: &mut UProbe = ebpf.program_mut("test_insert").unwrap().try_into().unwrap();
+    insert_prog.load().unwrap();
+    insert_prog
+        .attach("test_insert", "/proc/self/exe", None)
+        .unwrap();
+
+    // Test insert from kernel space
+    let mut bloom_filter = {
+        let bloom_map = ebpf.map_mut("BLOOMFILTER").unwrap();
+        BloomFilter::try_from(bloom_map).unwrap()
+    };
+    assert!(bloom_filter.contains(&BF_KERNEL_VALUE, 0).is_err());
+    assert!(bloom_filter.contains(&BF_USER_VALUE, 0).is_err());
+
+    assert!(bloom_filter.insert(BF_USER_VALUE, 0).is_ok());
+    test_insert(BF_KERNEL_VALUE);
+
+    assert!(bloom_filter.contains(&BF_KERNEL_VALUE, 0).is_ok());
+    assert!(bloom_filter.contains(&BF_USER_VALUE, 0).is_ok());
+}
+
+#[test_log::test]
+fn test_bloom_filter_contains_kernel_space() {
+    let mut ebpf = EbpfLoader::new().load(crate::BLOOM_FILTER).unwrap();
+    let contains_prog: &mut UProbe = ebpf
+        .program_mut("test_contains")
+        .unwrap()
+        .try_into()
+        .unwrap();
+    contains_prog.load().unwrap();
+    contains_prog
+        .attach("test_contains", "/proc/self/exe", None)
+        .unwrap();
+    let insert_prog: &mut UProbe = ebpf.program_mut("test_insert").unwrap().try_into().unwrap();
+    insert_prog.load().unwrap();
+    insert_prog
+        .attach("test_insert", "/proc/self/exe", None)
+        .unwrap();
+
+    // Test that bloom filter does not contain values before insertion
+    for val in [BF_KERNEL_VALUE, BF_USER_VALUE] {
+        test_contains(val);
+        let result = {
+            let array_map = ebpf.map("RESULT").unwrap();
+            Array::<_, i64>::try_from(array_map).unwrap()
+        };
+        assert_eq!(result.get(&0, 0).unwrap(), (-ENOENT).into());
+    }
+
+    // Insert elements
+    let mut bloom_filter = {
+        let bloom_map = ebpf.map_mut("BLOOMFILTER").unwrap();
+        BloomFilter::try_from(bloom_map).unwrap()
+    };
+
+    // Test that elemts are inserted
+    assert!(bloom_filter.insert(BF_USER_VALUE, 0).is_ok());
+    test_insert(BF_KERNEL_VALUE);
+
+    for val in [BF_KERNEL_VALUE, BF_USER_VALUE] {
+        test_contains(val);
+        let result = {
+            let array_map = ebpf.map("RESULT").unwrap();
+            Array::<_, i64>::try_from(array_map).unwrap()
+        };
+        assert_eq!(result.get(&0, 0).unwrap(), 1);
+    }
+}


### PR DESCRIPTION
This commit proves the problem in the bloom filter implementation in issue #953.
Calling contains from user space will always fail and does not work properly.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aya-rs/aya/1470)
<!-- Reviewable:end -->
