### PR TITLE
tracepoint: use read_kernel() for read_at()

### DIFF
--- a/ebpf/aya-ebpf/src/programs/tracepoint.rs
+++ b/ebpf/aya-ebpf/src/programs/tracepoint.rs
@@ -1,6 +1,6 @@
 use core::ffi::c_void;
 
-use crate::{EbpfContext, helpers::bpf_probe_read};
+use crate::{EbpfContext, helpers::bpf_probe_read_kernel};
 
 pub struct TracePointContext {
     ctx: *mut c_void,
@@ -16,7 +16,7 @@ impl TracePointContext {
         reason = "safety requirements come from the underlying helper"
     )]
     pub unsafe fn read_at<T>(&self, offset: usize) -> Result<T, i64> {
-        unsafe { bpf_probe_read(self.ctx.add(offset).cast()) }
+        unsafe { bpf_probe_read_kernel(self.ctx.add(offset).cast()) }
     }
 }
 


### PR DESCRIPTION
For most architectures just bpf_probe_read() works, but for those that have overlapping memory address spaces, like UML, we must use the specific helper.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aya-rs/aya/1473)
<!-- Reviewable:end -->
