### PR TITLE
maps: Add BPF_MAP_TYPE_ARRAY_OF_MAPS support

### DIFF
--- a/aya-obj/src/relocation.rs
+++ b/aya-obj/src/relocation.rs
@@ -6,14 +6,14 @@ use log::debug;
 use object::{SectionIndex, SymbolKind};
 
 use crate::{
-    EbpfSectionKind,
     generated::{
-        BPF_CALL, BPF_JMP, BPF_K, BPF_PSEUDO_CALL, BPF_PSEUDO_FUNC, BPF_PSEUDO_MAP_FD,
-        BPF_PSEUDO_MAP_VALUE, bpf_insn,
+        bpf_insn, BPF_CALL, BPF_JMP, BPF_K, BPF_PSEUDO_CALL, BPF_PSEUDO_FUNC, BPF_PSEUDO_MAP_FD,
+        BPF_PSEUDO_MAP_VALUE,
     },
     maps::Map,
     obj::{Function, Object},
     util::{HashMap, HashSet},
+    EbpfSectionKind,
 };
 
 #[cfg(feature = "std")]
@@ -519,6 +519,7 @@ mod test {
     fn fake_legacy_map(symbol_index: usize) -> Map {
         Map::Legacy(LegacyMap {
             def: Default::default(),
+            inner_map_def: None,
             section_index: 0,
             section_kind: EbpfSectionKind::Undefined,
             symbol_index: Some(symbol_index),

--- a/aya/src/maps/array/array_of_maps.rs
+++ b/aya/src/maps/array/array_of_maps.rs
@@ -1,0 +1,78 @@
+//! An array of BPF maps (BPF_MAP_TYPE_ARRAY_OF_MAPS).
+
+use std::{
+    borrow::{Borrow, BorrowMut},
+    os::fd::{AsFd as _, AsRawFd as _, RawFd},
+};
+
+use crate::maps::{check_bounds, check_kv_size, hash_map, MapData, MapError, MapFd, MapKeys};
+
+/// An array of BPF maps (`BPF_MAP_TYPE_ARRAY_OF_MAPS`).
+///
+/// Each entry in the outer array holds a file descriptor to an inner BPF map.
+/// The inner maps must all share the same type, key_size, and value_size
+/// (established at outer map creation time via a template).
+///
+/// From userspace, you can insert and remove inner maps at specific indices.
+/// From eBPF programs, `bpf_map_lookup_elem` on the outer map returns a pointer
+/// to the inner map that can then be used with another `bpf_map_lookup_elem`.
+///
+/// # Minimum kernel version
+///
+/// The minimum kernel version required to use this feature is 4.12.
+///
+/// # Examples
+/// ```no_run
+/// # let mut bpf = aya::Ebpf::load(&[])?;
+/// use aya::maps::ArrayOfMaps;
+/// use aya::maps::Array;
+///
+/// let mut outer = ArrayOfMaps::try_from(bpf.take_map("OUTER_MAP").unwrap())?;
+///
+/// // Create or obtain an inner map fd, then insert it at index 0
+/// // outer.set(0, inner_map_fd, 0)?;
+/// # Ok::<(), aya::EbpfError>(())
+/// ```
+#[doc(alias = "BPF_MAP_TYPE_ARRAY_OF_MAPS")]
+pub struct ArrayOfMaps<T> {
+    pub(crate) inner: T,
+}
+
+impl<T: Borrow<MapData>> ArrayOfMaps<T> {
+    pub(crate) fn new(map: T) -> Result<Self, MapError> {
+        let data = map.borrow();
+        check_kv_size::<u32, RawFd>(data)?;
+
+        Ok(Self { inner: map })
+    }
+
+    /// An iterator over the indices of the array that have an inner map set.
+    pub fn indices(&self) -> MapKeys<'_, u32> {
+        MapKeys::new(self.inner.borrow())
+    }
+
+    /// Returns the map's file descriptor.
+    pub fn fd(&self) -> &MapFd {
+        self.inner.borrow().fd()
+    }
+}
+
+impl<T: BorrowMut<MapData>> ArrayOfMaps<T> {
+    /// Sets the inner map at `index` to the map identified by `map_fd`.
+    ///
+    /// The inner map must have the same type, key_size, and value_size as the
+    /// template used when the outer map was created. The inner map's max_entries
+    /// may differ from the template.
+    pub fn set(&mut self, index: u32, map_fd: &MapFd, flags: u64) -> Result<(), MapError> {
+        let data = self.inner.borrow_mut();
+        check_bounds(data, index)?;
+        hash_map::insert(data, &index, &map_fd.as_fd().as_raw_fd(), flags)
+    }
+
+    /// Removes the inner map at `index`.
+    pub fn clear_index(&mut self, index: &u32) -> Result<(), MapError> {
+        let data = self.inner.borrow_mut();
+        check_bounds(data, *index)?;
+        hash_map::remove(data, index)
+    }
+}

--- a/aya/src/maps/array/mod.rs
+++ b/aya/src/maps/array/mod.rs
@@ -5,9 +5,11 @@
     reason = "module name matches the exported type"
 )]
 mod array;
+mod array_of_maps;
 mod per_cpu_array;
 mod program_array;
 
 pub use array::*;
+pub use array_of_maps::ArrayOfMaps;
 pub use per_cpu_array::PerCpuArray;
 pub use program_array::ProgramArray;

--- a/aya/src/maps/info.rs
+++ b/aya/src/maps/info.rs
@@ -10,11 +10,11 @@ use aya_obj::generated::{bpf_map_info, bpf_map_type};
 
 use super::{MapError, MapFd};
 use crate::{
-    FEATURES,
     sys::{
-        SyscallError, bpf_get_object, bpf_map_get_fd_by_id, bpf_map_get_info_by_fd, iter_map_ids,
+        bpf_get_object, bpf_map_get_fd_by_id, bpf_map_get_info_by_fd, iter_map_ids, SyscallError,
     },
     util::bytes_of_bpf_name,
+    FEATURES,
 };
 
 /// Provides Provides metadata information about a loaded eBPF map.

--- a/aya/src/sys/bpf.rs
+++ b/aya/src/sys/bpf.rs
@@ -51,6 +51,7 @@ pub(crate) fn bpf_create_map(
     name: &CStr,
     def: &aya_obj::Map,
     btf_fd: Option<BorrowedFd<'_>>,
+    inner_map_fd: Option<BorrowedFd<'_>>,
 ) -> io::Result<crate::MockableFd> {
     let mut attr = unsafe { mem::zeroed::<bpf_attr>() };
 
@@ -60,6 +61,11 @@ pub(crate) fn bpf_create_map(
     u.value_size = def.value_size();
     u.max_entries = def.max_entries();
     u.map_flags = def.map_flags();
+
+    // For map-of-maps types, set the inner map fd that describes the inner map schema.
+    if let Some(fd) = inner_map_fd {
+        u.inner_map_fd = fd.as_raw_fd() as u32;
+    }
 
     if let aya_obj::Map::Btf(m) = def {
         // Mimic https://github.com/libbpf/libbpf/issues/355
@@ -945,6 +951,7 @@ pub(crate) fn is_bpf_global_data_supported() -> bool {
                 max_entries: 1,
                 ..Default::default()
             },
+            inner_map_def: None,
             section_index: 0,
             section_kind: EbpfSectionKind::Maps,
             symbol_index: None,

--- a/ebpf/aya-ebpf/src/maps/array_of_maps.rs
+++ b/ebpf/aya-ebpf/src/maps/array_of_maps.rs
@@ -1,0 +1,143 @@
+use core::ptr::NonNull;
+
+use aya_ebpf_cty::c_void;
+
+use crate::{
+    bindings::{bpf_map_def, bpf_map_type::BPF_MAP_TYPE_ARRAY_OF_MAPS},
+    helpers::bpf_map_lookup_elem,
+    maps::def::PinningType,
+};
+
+/// A BPF map of type `BPF_MAP_TYPE_ARRAY_OF_MAPS`.
+///
+/// The outer map is an array indexed by `u32`. Each entry holds a file descriptor
+/// (managed by the kernel) pointing to an inner map. The inner map's schema
+/// (type, key_size, value_size) is fixed at outer-map creation time via a template.
+///
+/// From BPF programs, `get()` returns an opaque pointer to the inner map which can
+/// be passed to [`bpf_map_lookup_elem`] to read entries from that inner map.
+///
+/// # Layout
+///
+/// The struct embeds **two** `bpf_map_def` values back-to-back:
+/// - `def`: the outer map definition (`BPF_MAP_TYPE_ARRAY_OF_MAPS`)
+/// - `inner_def`: describes the inner map template (type, key/value sizes, max_entries)
+///
+/// The aya userspace loader reads both definitions from the ELF `maps` section and
+/// uses `inner_def` to create a temporary inner map whose fd is passed as
+/// `inner_map_fd` when creating the outer map.
+///
+/// # Examples
+///
+/// ```no_run
+/// use aya_ebpf::{macros::map, maps::ArrayOfMaps};
+/// use aya_ebpf::bindings::bpf_map_type::BPF_MAP_TYPE_ARRAY;
+///
+/// #[map]
+/// static OUTER: ArrayOfMaps = ArrayOfMaps::with_max_entries(
+///     16,                // outer map: up to 16 inner maps
+///     BPF_MAP_TYPE_ARRAY,// inner map type
+///     4,                 // inner key_size (u32)
+///     12,                // inner value_size
+///     1024,              // inner max_entries (template; each actual inner map may differ)
+///     0,
+/// );
+/// ```
+#[repr(C)]
+pub struct ArrayOfMaps {
+    def: core::cell::UnsafeCell<bpf_map_def>,
+    inner_def: bpf_map_def,
+}
+
+unsafe impl Sync for ArrayOfMaps {}
+
+impl ArrayOfMaps {
+    /// Creates a new `ArrayOfMaps` with the given outer max_entries and inner map template.
+    ///
+    /// # Arguments
+    ///
+    /// * `max_entries` - Maximum number of inner maps in the outer array.
+    /// * `inner_type` - The `BPF_MAP_TYPE_*` constant for inner maps (e.g., `BPF_MAP_TYPE_ARRAY`).
+    /// * `inner_key_size` - Key size in bytes for inner maps.
+    /// * `inner_value_size` - Value size in bytes for inner maps.
+    /// * `inner_max_entries` - Template max_entries for inner maps (actual inner maps may differ).
+    /// * `flags` - Map flags for the outer map.
+    pub const fn with_max_entries(
+        max_entries: u32,
+        inner_type: u32,
+        inner_key_size: u32,
+        inner_value_size: u32,
+        inner_max_entries: u32,
+        flags: u32,
+    ) -> Self {
+        Self {
+            def: core::cell::UnsafeCell::new(bpf_map_def {
+                type_: BPF_MAP_TYPE_ARRAY_OF_MAPS,
+                key_size: size_of::<u32>() as u32,
+                value_size: size_of::<u32>() as u32, // inner map fd
+                max_entries,
+                map_flags: flags,
+                id: 0,
+                pinning: PinningType::None as u32,
+            }),
+            inner_def: bpf_map_def {
+                type_: inner_type,
+                key_size: inner_key_size,
+                value_size: inner_value_size,
+                max_entries: inner_max_entries,
+                map_flags: 0,
+                id: 0,
+                pinning: PinningType::None as u32,
+            },
+        }
+    }
+
+    /// Creates a new pinned `ArrayOfMaps`.
+    pub const fn pinned(
+        max_entries: u32,
+        inner_type: u32,
+        inner_key_size: u32,
+        inner_value_size: u32,
+        inner_max_entries: u32,
+        flags: u32,
+    ) -> Self {
+        Self {
+            def: core::cell::UnsafeCell::new(bpf_map_def {
+                type_: BPF_MAP_TYPE_ARRAY_OF_MAPS,
+                key_size: size_of::<u32>() as u32,
+                value_size: size_of::<u32>() as u32,
+                max_entries,
+                map_flags: flags,
+                id: 0,
+                pinning: PinningType::ByName as u32,
+            }),
+            inner_def: bpf_map_def {
+                type_: inner_type,
+                key_size: inner_key_size,
+                value_size: inner_value_size,
+                max_entries: inner_max_entries,
+                map_flags: 0,
+                id: 0,
+                pinning: PinningType::None as u32,
+            },
+        }
+    }
+
+    /// Look up the inner map at `index`.
+    ///
+    /// Returns an opaque pointer to the inner map. This pointer can be passed
+    /// directly to [`bpf_map_lookup_elem`] as the map argument to read values
+    /// from the inner map.
+    ///
+    /// Returns `None` if no inner map is set at `index`.
+    #[inline(always)]
+    pub fn get(&self, index: u32) -> Option<*mut c_void> {
+        unsafe {
+            let ptr = bpf_map_lookup_elem(
+                self.def.get() as *mut _,
+                &index as *const _ as *const c_void,
+            );
+            NonNull::new(ptr).map(|p| p.as_ptr())
+        }
+    }
+}

--- a/ebpf/aya-ebpf/src/maps/mod.rs
+++ b/ebpf/aya-ebpf/src/maps/mod.rs
@@ -76,6 +76,7 @@ macro_rules! map_constructors {
 }
 
 pub mod array;
+pub mod array_of_maps;
 pub mod bloom_filter;
 pub mod hash_map;
 pub mod lpm_trie;
@@ -91,6 +92,7 @@ pub mod stack_trace;
 pub mod xdp;
 
 pub use array::Array;
+pub use array_of_maps::ArrayOfMaps;
 pub use bloom_filter::BloomFilter;
 pub use hash_map::{HashMap, LruHashMap, LruPerCpuHashMap, PerCpuHashMap};
 pub use lpm_trie::LpmTrie;


### PR DESCRIPTION
Add ArrayOfMaps for both eBPF and userspace, enabling BPF programs to use arrays of inner maps with heterogeneous max_entries.

eBPF side (aya-ebpf):
- New ArrayOfMaps struct with dual bpf_map_def layout (outer + inner template)
- with_max_entries() constructor accepting inner map schema parameters
- get() method returning opaque inner map pointer for bpf_map_lookup_elem

Userspace side (aya):
- ArrayOfMaps<T> wrapper with set(), clear_index(), indices(), fd() methods
- Map::ArrayOfMaps variant in the map enum
- create_map_of_maps() in MapData: creates template inner map, passes its fd as inner_map_fd to the outer map creation syscall

ELF parsing (aya-obj):
- LegacyMap gains inner_map_def field for map-of-maps types
- parse_maps() extracts the second bpf_map_def when the symbol is large enough and map_type is ARRAY_OF_MAPS or HASH_OF_MAPS
- Loader dispatches to create_map_of_maps() for these map types

Related issues
- https://github.com/aya-rs/aya/discussions/457
- https://github.com/zz85/profile-bee/pull/69

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aya-rs/aya/1478)
<!-- Reviewable:end -->
