### PR TITLE
maps: add ring buffer batch API

### DIFF
--- a/aya-log/src/lib.rs
+++ b/aya-log/src/lib.rs
@@ -182,9 +182,7 @@ impl<T: Log> EbpfLogger<T> {
     /// Reads log records from eBPF and writes them to the logger.
     pub fn flush(&mut self) {
         let Self { ring_buf, logger } = self;
-        while let Some(buf) = ring_buf.next() {
-            log_buf(buf.as_ref(), logger).unwrap();
-        }
+        ring_buf.for_each(|buf| log_buf(buf, logger).unwrap());
     }
 }
 

--- a/aya/src/maps/ring_buf.rs
+++ b/aya/src/maps/ring_buf.rs
@@ -132,7 +132,9 @@ impl<T> RingBuf<T> {
     )]
     pub fn next(&mut self) -> Option<RingBufItem<'_>> {
         let Self {
-            consumer, producer, ..
+            map: _,
+            consumer,
+            producer,
         } = self;
         producer.next(consumer)
     }
@@ -165,7 +167,7 @@ impl Deref for RingBufItem<'_> {
     type Target = [u8];
 
     fn deref(&self) -> &Self::Target {
-        let Self { data, .. } = self;
+        let Self { data, consumer: _ } = self;
         data
     }
 }
@@ -351,7 +353,7 @@ impl ProducerData {
             let caught_up = *pos == *pos_cache;
 
             if !caught_up {
-                match read_item(data_pages, *mask, consumer) {
+                match consumer.read_item(data_pages, *mask) {
                     Item::Busy => {}
                     Item::Discard { len } => {
                         consumer.consume(len);
@@ -375,44 +377,45 @@ impl ProducerData {
                 *pos_cache = load_producer_pos(mmap);
             }
         }
+    }
+}
 
-        enum Item<'a> {
-            Busy,
-            Discard { len: usize },
-            Data(&'a [u8]),
-        }
+enum Item<'a> {
+    Busy,
+    Discard { len: usize },
+    Data(&'a [u8]),
+}
 
-        fn read_item<'data>(data: &'data [u8], mask: u32, pos: &ConsumerPos) -> Item<'data> {
-            let ConsumerPos { pos, .. } = pos;
-            let offset = pos & usize::try_from(mask).unwrap();
-            #[expect(
-                clippy::panic,
-                reason = "invalid ring buffer layout is a fatal internal error"
-            )]
-            let must_get_data = |offset, len| {
-                data.get(offset..offset + len).unwrap_or_else(|| {
-                    panic!("{:?} not in {:?}", offset..offset + len, 0..data.len())
-                })
-            };
-            let header_ptr: *const AtomicU32 = must_get_data(offset, size_of::<AtomicU32>())
-                .as_ptr()
-                .cast();
-            // The kernel commits the record with a fully ordered xchg [1]. Pair it with an Acquire
-            // load so data written by the producer is visible after the busy bit is cleared.
-            //
-            // [1]: https://github.com/torvalds/linux/blob/eb26cbb1/kernel/bpf/ringbuf.c#L488
-            let header = unsafe { &*header_ptr }.load(Ordering::Acquire);
-            if header & BPF_RINGBUF_BUSY_BIT != 0 {
-                Item::Busy
+impl ConsumerPos {
+    fn read_item<'data>(&self, data: &'data [u8], mask: u32) -> Item<'data> {
+        let Self { pos, metadata: _ } = self;
+        let offset = pos & usize::try_from(mask).unwrap();
+        #[expect(
+            clippy::panic,
+            reason = "invalid ring buffer layout is a fatal internal error"
+        )]
+        let must_get_data = |offset, len| {
+            data.get(offset..offset + len)
+                .unwrap_or_else(|| panic!("{:?} not in {:?}", offset..offset + len, 0..data.len()))
+        };
+        let header_ptr: *const AtomicU32 = must_get_data(offset, size_of::<AtomicU32>())
+            .as_ptr()
+            .cast();
+        // The kernel commits the record with a fully ordered xchg [1]. Pair it with an Acquire
+        // load so data written by the producer is visible after the busy bit is cleared.
+        //
+        // [1]: https://github.com/torvalds/linux/blob/eb26cbb1/kernel/bpf/ringbuf.c#L488
+        let header = unsafe { &*header_ptr }.load(Ordering::Acquire);
+        if header & BPF_RINGBUF_BUSY_BIT != 0 {
+            Item::Busy
+        } else {
+            let len = usize::try_from(header & mask).unwrap();
+            if header & BPF_RINGBUF_DISCARD_BIT != 0 {
+                Item::Discard { len }
             } else {
-                let len = usize::try_from(header & mask).unwrap();
-                if header & BPF_RINGBUF_DISCARD_BIT != 0 {
-                    Item::Discard { len }
-                } else {
-                    let data_offset = offset + usize::try_from(BPF_RINGBUF_HDR_SZ).unwrap();
-                    let data = must_get_data(data_offset, len);
-                    Item::Data(data)
-                }
+                let data_offset = offset + usize::try_from(BPF_RINGBUF_HDR_SZ).unwrap();
+                let data = must_get_data(data_offset, len);
+                Item::Data(data)
             }
         }
     }

--- a/aya/src/maps/ring_buf.rs
+++ b/aya/src/maps/ring_buf.rs
@@ -6,8 +6,9 @@
 
 use std::{
     borrow::Borrow,
+    convert::Infallible,
     fmt::{self, Debug, Formatter},
-    ops::Deref,
+    ops::{ControlFlow, Deref},
     os::fd::{AsFd, AsRawFd, BorrowedFd, RawFd},
     sync::atomic::{self, AtomicU32, AtomicUsize, Ordering},
 };
@@ -37,7 +38,9 @@ use crate::{
 ///
 /// To receive events you need to:
 /// * Construct [`RingBuf`] using [`RingBuf::try_from`].
-/// * Call [`RingBuf::next`] to poll events from the [`RingBuf`].
+/// * Call [`RingBuf::next`] to read one entry at a time, or
+///   [`RingBuf::try_fold`], [`RingBuf::fold`], or [`RingBuf::for_each`] to
+///   process available entries in bulk.
 ///
 /// To receive async notifications of data availability, you may construct an
 /// [`tokio::io::unix::AsyncFd`] from the [`RingBuf`]'s file descriptor and poll it for readiness.
@@ -71,9 +74,9 @@ use crate::{
 /// loop {
 ///     let mut guard = poll.readable();
 ///     let ring_buf = guard.inner_mut();
-///     while let Some(item) = ring_buf.next() {
+///     ring_buf.for_each(|item| {
 ///         println!("received: {:?}", item);
-///     }
+///     });
 ///     guard.clear_ready();
 /// }
 /// # Ok::<(), aya::EbpfError>(())
@@ -138,6 +141,57 @@ impl<T> RingBuf<T> {
         } = self;
         producer.next(consumer)
     }
+
+    /// Processes entries in the ring buffer with `f`.
+    ///
+    /// For each available data entry, `f` receives the accumulator and
+    /// entry:
+    /// * [`ControlFlow::Continue(next)`](ControlFlow::Continue) keeps draining with `next`.
+    /// * [`ControlFlow::Break(break_value)`](ControlFlow::Break) stops early and returns `break_value`.
+    ///
+    /// After stopping early, unread entries might not produce another readiness
+    /// notification. Drain the ring buffer before waiting for readiness again.
+    ///
+    /// If the ring buffer is fully drained, returns [`ControlFlow::Continue`]
+    /// containing the final accumulator.
+    pub fn try_fold<B, C, F>(&mut self, init: C, f: F) -> ControlFlow<B, C>
+    where
+        F: FnMut(C, &[u8]) -> ControlFlow<B, C>,
+    {
+        let Self {
+            map: _,
+            consumer,
+            producer,
+        } = self;
+        producer.try_fold(consumer, init, f)
+    }
+
+    /// Processes entries in the ring buffer with `f`.
+    ///
+    /// For each available data entry, `f` receives the accumulator and entry,
+    /// and returns the next accumulator.
+    ///
+    /// Unlike [`RingBuf::try_fold`], this function cannot short-circuit: it
+    /// always processes entries until the ring buffer is fully drained, then
+    /// returns the final accumulator.
+    pub fn fold<C, F>(&mut self, init: C, mut f: F) -> C
+    where
+        F: FnMut(C, &[u8]) -> C,
+    {
+        let ControlFlow::Continue(acc) = self
+            .try_fold::<Infallible, _, _>(init, |acc, data| ControlFlow::Continue(f(acc, data)));
+        acc
+    }
+
+    /// Processes entries in the ring buffer with `f`.
+    ///
+    /// For each available data entry, `f` receives the entry.
+    pub fn for_each<F>(&mut self, mut f: F)
+    where
+        F: FnMut(&[u8]),
+    {
+        self.fold((), |(), data| f(data))
+    }
 }
 
 impl<T: Borrow<MapData>> AsFd for RingBuf<T> {
@@ -157,7 +211,7 @@ impl<T: Borrow<MapData>> AsRawFd for RingBuf<T> {
     }
 }
 
-/// The current outstanding item read from the ringbuf.
+/// An item read from the ring buffer.
 pub struct RingBufItem<'a> {
     data: &'a [u8],
     consumer: &'a mut ConsumerPos,
@@ -174,8 +228,9 @@ impl Deref for RingBufItem<'_> {
 
 impl Drop for RingBufItem<'_> {
     fn drop(&mut self) {
-        let Self { consumer, data } = self;
-        consumer.consume(data.len())
+        let Self { data, consumer } = self;
+        consumer.consume(data.len());
+        consumer.commit();
     }
 }
 
@@ -233,11 +288,14 @@ impl ConsumerPos {
     }
 
     fn consume(&mut self, len: usize) {
-        let Self { pos, metadata } = self;
+        let Self { pos, metadata: _ } = self;
 
         let record_len = (usize::try_from(BPF_RINGBUF_HDR_SZ).unwrap() + len).next_multiple_of(8);
         *pos = pos.wrapping_add(record_len);
+    }
 
+    fn commit(&mut self) {
+        let Self { pos, metadata } = self;
         // Publish the new position after reading the record. The kernel pairs this with an Acquire
         // load before reusing the record's storage [1].
         //
@@ -322,22 +380,57 @@ impl ProducerData {
             pos_cache,
             mask,
         } = self;
-        let mmap = &*mmap;
+        let data_pages = Self::data_pages(mmap, *data_offset);
+        // The item returned by the previous call may have published a new consumer position after
+        // this function returned.
+        let mut may_have_published = true;
+        loop {
+            match Self::next_item(
+                mmap,
+                data_pages,
+                pos_cache,
+                *mask,
+                consumer,
+                &mut may_have_published,
+                |_consumer| false,
+            )? {
+                Item::Discard { len } => {
+                    consumer.consume(len);
+                    consumer.commit();
+                    may_have_published = true;
+                }
+                Item::Data(data) => return Some(RingBufItem { data, consumer }),
+            }
+        }
+    }
+
+    fn data_pages(mmap: &MMap, data_offset: usize) -> &[u8] {
         let mmap_data = mmap.as_ref();
         #[expect(
             clippy::panic,
             reason = "invalid ring buffer layout is a fatal internal error"
         )]
-        let data_pages = mmap_data.get(*data_offset..).unwrap_or_else(|| {
+        mmap_data.get(data_offset..).unwrap_or_else(|| {
             panic!(
                 "offset {} out of bounds, data len {}",
                 data_offset,
                 mmap_data.len()
             )
-        });
-        // The item returned by the previous call may have published a new consumer position after
-        // this function returned.
-        let mut may_have_published = true;
+        })
+    }
+
+    fn next_item<'a, F>(
+        mmap: &'a MMap,
+        data_pages: &'a [u8],
+        pos_cache: &mut usize,
+        mask: u32,
+        consumer: &mut ConsumerPos,
+        may_have_published: &mut bool,
+        mut flush: F,
+    ) -> Option<Item<'a>>
+    where
+        F: FnMut(&mut ConsumerPos) -> bool,
+    {
         loop {
             let ConsumerPos { pos, metadata: _ } = consumer;
             // Note that we don't compare the order of the values because the word-sized producer
@@ -353,41 +446,101 @@ impl ProducerData {
             let caught_up = *pos == *pos_cache;
 
             if !caught_up {
-                match consumer.read_item(data_pages, *mask) {
-                    Item::Busy => {}
-                    Item::Discard { len } => {
-                        consumer.consume(len);
-                        may_have_published = true;
-                        continue;
-                    }
-                    Item::Data(data) => return Some(RingBufItem { data, consumer }),
+                if let Some(item) = consumer.read_item(data_pages, mask) {
+                    return Some(item);
                 }
             }
 
-            if !may_have_published {
+            if flush(consumer) {
+                *may_have_published = true;
+            }
+            if !*may_have_published {
                 return None;
             }
 
             // Ensure either the next load sees a new record or its producer sees the updated
             // consumer position and sends a notification.
             atomic::fence(Ordering::SeqCst);
-            may_have_published = false;
+            *may_have_published = false;
 
             if caught_up {
                 *pos_cache = load_producer_pos(mmap);
             }
         }
     }
+
+    fn try_fold<B, C, F>(
+        &mut self,
+        consumer: &mut ConsumerPos,
+        init: C,
+        mut f: F,
+    ) -> ControlFlow<B, C>
+    where
+        F: FnMut(C, &[u8]) -> ControlFlow<B, C>,
+    {
+        let Self {
+            mmap,
+            data_offset,
+            pos_cache,
+            mask,
+        } = self;
+        let data_pages = Self::data_pages(mmap, *data_offset);
+        let mut acc = init;
+        let mut advanced = false;
+        let consume = |consumer: &mut ConsumerPos, advanced: &mut bool, len: usize| {
+            consumer.consume(len);
+            *advanced = true;
+        };
+        let flush = |consumer: &mut ConsumerPos, advanced: &mut bool| {
+            let was_advanced = std::mem::replace(advanced, false);
+            if was_advanced {
+                consumer.commit();
+            }
+            was_advanced
+        };
+        // This must be deferred in case `f` panics.
+        let mut guard = scopeguard::guard((consumer, &mut advanced), |(consumer, advanced)| {
+            flush(consumer, advanced);
+        });
+        // The item returned by the previous call may have published a new consumer position after
+        // this function returned.
+        let mut may_have_published = true;
+        loop {
+            let (consumer, advanced) = &mut *guard;
+            let Some(item) = Self::next_item(
+                mmap,
+                data_pages,
+                pos_cache,
+                *mask,
+                consumer,
+                &mut may_have_published,
+                |consumer| flush(consumer, advanced),
+            ) else {
+                break;
+            };
+            match item {
+                Item::Discard { len } => consume(consumer, advanced, len),
+                Item::Data(data) => {
+                    // This must be deferred in case `f` panics.
+                    scopeguard::defer! { consume(consumer, advanced, data.len()) };
+                    match f(acc, data) {
+                        ControlFlow::Continue(next) => acc = next,
+                        ControlFlow::Break(v) => return ControlFlow::Break(v),
+                    }
+                }
+            }
+        }
+        ControlFlow::Continue(acc)
+    }
 }
 
 enum Item<'a> {
-    Busy,
     Discard { len: usize },
     Data(&'a [u8]),
 }
 
 impl ConsumerPos {
-    fn read_item<'data>(&self, data: &'data [u8], mask: u32) -> Item<'data> {
+    fn read_item<'data>(&self, data: &'data [u8], mask: u32) -> Option<Item<'data>> {
         let Self { pos, metadata: _ } = self;
         let offset = pos & usize::try_from(mask).unwrap();
         #[expect(
@@ -407,15 +560,15 @@ impl ConsumerPos {
         // [1]: https://github.com/torvalds/linux/blob/eb26cbb1/kernel/bpf/ringbuf.c#L488
         let header = unsafe { &*header_ptr }.load(Ordering::Acquire);
         if header & BPF_RINGBUF_BUSY_BIT != 0 {
-            Item::Busy
+            None
         } else {
             let len = usize::try_from(header & mask).unwrap();
             if header & BPF_RINGBUF_DISCARD_BIT != 0 {
-                Item::Discard { len }
+                Some(Item::Discard { len })
             } else {
                 let data_offset = offset + usize::try_from(BPF_RINGBUF_HDR_SZ).unwrap();
                 let data = must_get_data(data_offset, len);
-                Item::Data(data)
+                Some(Item::Data(data))
             }
         }
     }

--- a/aya/src/maps/ring_buf.rs
+++ b/aya/src/maps/ring_buf.rs
@@ -243,7 +243,8 @@ impl ConsumerPos {
             needs_wakeup,
         } = self;
 
-        *pos += (usize::try_from(BPF_RINGBUF_HDR_SZ).unwrap() + len).next_multiple_of(8);
+        let record_len = (usize::try_from(BPF_RINGBUF_HDR_SZ).unwrap() + len).next_multiple_of(8);
+        *pos = pos.wrapping_add(record_len);
 
         // Publish the new position after reading the record. The kernel pairs this with an Acquire
         // load before reusing the record's storage [1].

--- a/aya/src/maps/ring_buf.rs
+++ b/aya/src/maps/ring_buf.rs
@@ -185,7 +185,6 @@ impl Debug for RingBufItem<'_> {
                 ConsumerPos {
                     pos,
                     metadata: ConsumerMetadata { mmap: _ },
-                    needs_wakeup: _,
                 },
         } = self;
         // In general Relaxed here is sufficient, for debugging, it certainly is.
@@ -222,26 +221,17 @@ impl AsRef<AtomicUsize> for ConsumerMetadata {
 struct ConsumerPos {
     pos: usize,
     metadata: ConsumerMetadata,
-    needs_wakeup: bool,
 }
 
 impl ConsumerPos {
     fn new(metadata: ConsumerMetadata) -> Self {
         // Read the starting position before producer data.
         let pos = metadata.as_ref().load(Ordering::Acquire);
-        Self {
-            pos,
-            metadata,
-            needs_wakeup: false,
-        }
+        Self { pos, metadata }
     }
 
     fn consume(&mut self, len: usize) {
-        let Self {
-            pos,
-            metadata,
-            needs_wakeup,
-        } = self;
+        let Self { pos, metadata } = self;
 
         let record_len = (usize::try_from(BPF_RINGBUF_HDR_SZ).unwrap() + len).next_multiple_of(8);
         *pos = pos.wrapping_add(record_len);
@@ -251,7 +241,6 @@ impl ConsumerPos {
         //
         // [1]: https://github.com/torvalds/linux/blob/2772d7df/kernel/bpf/ringbuf.c#L422
         metadata.as_ref().store(*pos, Ordering::Release);
-        *needs_wakeup = true;
     }
 }
 
@@ -344,51 +333,11 @@ impl ProducerData {
                 mmap_data.len()
             )
         });
-        while data_available(mmap, pos_cache, consumer) {
-            match read_item(data_pages, *mask, consumer) {
-                Item::Busy => {
-                    if !consumer.needs_wakeup {
-                        return None;
-                    }
-                    // Ensure either a retry sees the committed record or its producer sees the
-                    // updated consumer position and sends a notification.
-                    atomic::fence(Ordering::SeqCst);
-                    consumer.needs_wakeup = false;
-                }
-                Item::Discard { len } => consumer.consume(len),
-                Item::Data(data) => return Some(RingBufItem { data, consumer }),
-            }
-        }
-        return None;
-
-        enum Item<'a> {
-            Busy,
-            Discard { len: usize },
-            Data(&'a [u8]),
-        }
-
-        fn data_available(
-            producer: &MMap,
-            producer_cache: &mut usize,
-            consumer: &mut ConsumerPos,
-        ) -> bool {
-            let ConsumerPos {
-                pos: consumer,
-                needs_wakeup,
-                ..
-            } = consumer;
-            // Refresh the producer position cache if it appears that the consumer is caught up
-            // with the producer position.
-            if *consumer == *producer_cache {
-                if *needs_wakeup {
-                    // Ensure either this sees a new record or its producer sees the updated
-                    // consumer position and sends a notification.
-                    atomic::fence(Ordering::SeqCst);
-                    *needs_wakeup = false;
-                }
-                *producer_cache = load_producer_pos(producer);
-            }
-
+        // The item returned by the previous call may have published a new consumer position after
+        // this function returned.
+        let mut may_have_published = true;
+        loop {
+            let ConsumerPos { pos, metadata: _ } = consumer;
             // Note that we don't compare the order of the values because the word-sized producer
             // position may overflow and wrap around to 0. Instead we just compare equality and
             // assume that the consumer position is always logically less than the producer
@@ -399,7 +348,38 @@ impl ProducerData {
             // producer position has wrapped around.
             //
             // [1]: https://github.com/torvalds/linux/blob/4b810bf0/kernel/bpf/ringbuf.c#L434-L440
-            *consumer != *producer_cache
+            let caught_up = *pos == *pos_cache;
+
+            if !caught_up {
+                match read_item(data_pages, *mask, consumer) {
+                    Item::Busy => {}
+                    Item::Discard { len } => {
+                        consumer.consume(len);
+                        may_have_published = true;
+                        continue;
+                    }
+                    Item::Data(data) => return Some(RingBufItem { data, consumer }),
+                }
+            }
+
+            if !may_have_published {
+                return None;
+            }
+
+            // Ensure either the next load sees a new record or its producer sees the updated
+            // consumer position and sends a notification.
+            atomic::fence(Ordering::SeqCst);
+            may_have_published = false;
+
+            if caught_up {
+                *pos_cache = load_producer_pos(mmap);
+            }
+        }
+
+        enum Item<'a> {
+            Busy,
+            Discard { len: usize },
+            Data(&'a [u8]),
         }
 
         fn read_item<'data>(data: &'data [u8], mask: u32, pos: &ConsumerPos) -> Item<'data> {

--- a/test/integration-test/src/tests/load.rs
+++ b/test/integration-test/src/tests/load.rs
@@ -67,10 +67,13 @@ fn ringbuffer_btf_map() {
 
     trigger_bpf_program();
 
-    let item = ring_buf.next().unwrap();
-    let item: [u8; 4] = (*item).try_into().unwrap();
-    let val = u32::from_ne_bytes(item);
-    assert_eq!(val, 0xdeadbeef);
+    let mut items = Vec::new();
+    ring_buf.for_each(|item| {
+        let item = item.try_into().unwrap();
+        let val = u32::from_ne_bytes(item);
+        items.push(val);
+    });
+    assert_eq!(items, &[0xdeadbeef]);
 }
 
 #[test_log::test]

--- a/test/integration-test/src/tests/ring_buf.rs
+++ b/test/integration-test/src/tests/ring_buf.rs
@@ -1,5 +1,7 @@
 use std::{
+    ops::ControlFlow,
     os::fd::AsRawFd as _,
+    panic::{AssertUnwindSafe, catch_unwind},
     path::Path,
     sync::{
         Arc,
@@ -9,7 +11,6 @@ use std::{
     time::Duration,
 };
 
-use anyhow::Context as _;
 use assert_matches::assert_matches;
 use aya::{
     Ebpf, EbpfLoader,
@@ -153,21 +154,13 @@ fn ring_buf(#[case] n: usize) {
             }
         }
 
-        let mut seen = Vec::<u64>::new();
-        while seen.len() < expected.len() {
-            if let Some(read) = ring_buf.next() {
-                let read: [u8; 8] = (*read)
-                    .try_into()
-                    .with_context(|| format!("data: {:?}", read.len()))
-                    .unwrap();
-                let arg = u64::from_ne_bytes(read);
-                assert_eq!(arg % 2, 0, "got {arg} from probe");
-                seen.push(arg);
-            }
-        }
-
-        // Make sure that there is nothing else in the ring_buf.
-        assert_matches!(ring_buf.next(), None);
+        let mut seen = Vec::with_capacity(expected.len());
+        ring_buf.for_each(|read| {
+            let read = read.try_into().unwrap();
+            let arg = u64::from_ne_bytes(read);
+            assert_eq!(arg % 2, 0, "got {arg} from probe");
+            seen.push(arg);
+        });
 
         // Ensure that the data that was read matches what was passed, and the rejected count was set
         // properly.
@@ -175,6 +168,40 @@ fn ring_buf(#[case] n: usize) {
         let Registers { dropped, rejected } = regs.get(&0, 0).unwrap();
         assert_eq!(dropped, expected_dropped);
         assert_eq!(rejected, expected_rejected);
+    }
+}
+
+#[test_log::test]
+fn ring_buf_callback_panic() {
+    for &variant in RING_BUF_VARIANTS {
+        let RingBufTest {
+            mut ring_buf,
+            regs,
+            bpf: _bpf,
+        } = RingBufTest::new(variant);
+
+        for _ in 0..RING_BUF_MAX_ENTRIES - 1 {
+            ring_buf_trigger_ebpf_program(0);
+        }
+        assert!(
+            catch_unwind(AssertUnwindSafe(|| {
+                ring_buf.for_each(|_| panic!("callback panic"));
+            }))
+            .is_err()
+        );
+
+        // The callback consumed one record before it panicked, so the producer
+        // must be able to reuse that record's storage.
+        ring_buf_trigger_ebpf_program(0);
+        let count = ring_buf.fold(0, |count, _| count + 1);
+        assert_eq!(count, RING_BUF_MAX_ENTRIES - 1);
+        assert_eq!(
+            regs.get(&0, 0).unwrap(),
+            Registers {
+                dropped: 0,
+                rejected: 0,
+            }
+        );
     }
 }
 
@@ -209,13 +236,13 @@ fn ring_buf_mismatch_size<T>(
         .unwrap();
 
     trigger(value.into());
-    {
-        let read = ring_buf.next().unwrap();
+    let mut items = Vec::new();
+    ring_buf.for_each(|read| {
         assert_eq!(read.len(), size_of::<T>());
-        let decoded = decode(read.as_ref());
-        assert_eq!(decoded, value);
-    }
-    assert_matches!(ring_buf.next(), None);
+        let decoded = decode(read);
+        items.push(decoded);
+    });
+    assert_eq!(items, &[value]);
 }
 
 #[test_log::test]
@@ -228,8 +255,8 @@ fn ring_buf_mismatch_small() {
         ring_buf_trigger_ebpf_program,
         value,
         |read| {
-            let bytes: [u8; 2] = read.try_into().unwrap();
-            u16::from_ne_bytes(bytes)
+            let read = read.try_into().unwrap();
+            u16::from_ne_bytes(read)
         },
     );
 }
@@ -244,8 +271,8 @@ fn ring_buf_mismatch_large() {
         ring_buf_trigger_ebpf_program,
         value,
         |read| {
-            let bytes: [u8; 8] = read.try_into().unwrap();
-            u64::from_ne_bytes(bytes)
+            let read = read.try_into().unwrap();
+            u64::from_ne_bytes(read)
         },
     );
 }
@@ -273,15 +300,12 @@ async fn ring_buf_async_with_drops() {
         // Construct an AsyncFd from the RingBuf in order to receive readiness notifications.
         let mut seen = 0;
         let mut process_ring_buf = |ring_buf: &mut RingBuf<_>| {
-            while let Some(read) = ring_buf.next() {
-                let read: [u8; 8] = (*read)
-                    .try_into()
-                    .with_context(|| format!("data: {:?}", read.len()))
-                    .unwrap();
+            ring_buf.for_each(|read| {
+                let read = read.try_into().unwrap();
                 let arg = u64::from_ne_bytes(read);
                 assert_eq!(arg % 2, 0, "got {arg} from probe");
                 seen += 1;
-            }
+            });
         };
         let mut writer =
             futures::future::try_join_all(data.chunks(8).map(ToOwned::to_owned).map(|v| {
@@ -321,9 +345,6 @@ async fn ring_buf_async_with_drops() {
                 }
             }
         }
-
-        // Make sure that there is nothing else in the ring_buf.
-        assert_matches!(async_fd.into_inner().next(), None);
 
         let max_dropped: u64 =
             u64::try_from(data.len().saturating_sub(RING_BUF_MAX_ENTRIES - 1)).unwrap();
@@ -395,23 +416,17 @@ async fn ring_buf_async_no_drop() {
             while seen.len() < expected_len {
                 let mut guard = async_fd.readable_mut().await.unwrap();
                 let ring_buf = guard.get_inner_mut();
-                while let Some(read) = ring_buf.next() {
-                    let read: [u8; 8] = (*read)
-                        .try_into()
-                        .with_context(|| format!("data: {:?}", read.len()))
-                        .unwrap();
+                ring_buf.for_each(|read| {
+                    let read = read.try_into().unwrap();
                     let arg = u64::from_ne_bytes(read);
                     seen.push(arg);
-                }
+                });
                 guard.clear_ready();
             }
-            (seen, async_fd.into_inner())
+            seen
         };
-        let (writer, (seen, mut ring_buf)) = futures::future::join(writer, reader).await;
+        let (writer, seen) = futures::future::join(writer, reader).await;
         writer.unwrap();
-
-        // Make sure that there is nothing else in the ring_buf.
-        assert_matches!(ring_buf.next(), None);
 
         // Ensure that the data that was read matches what was passed.
         assert_eq!(&seen, &expected);
@@ -450,10 +465,10 @@ fn ring_buf_epoll_wakeup() {
         let writer = WriterThread::spawn();
         while total_events < WriterThread::NUM_MESSAGES {
             epoll::wait(epoll_fd, -1, &mut epoll_event_buf).unwrap();
-            while let Some(read) = ring_buf.next() {
+            ring_buf.for_each(|read| {
                 assert_eq!(read.len(), 8);
                 total_events += 1;
-            }
+            });
         }
         writer.join();
     }
@@ -475,11 +490,11 @@ async fn ring_buf_asyncfd_events() {
         let writer = WriterThread::spawn();
         while total_events < WriterThread::NUM_MESSAGES {
             let mut guard = async_fd.readable_mut().await.unwrap();
-            let rb = guard.get_inner_mut();
-            while let Some(read) = rb.next() {
+            let ring_buf = guard.get_inner_mut();
+            ring_buf.for_each(|read| {
                 assert_eq!(read.len(), 8);
                 total_events += 1;
-            }
+            });
             guard.clear_ready();
         }
         writer.join();
@@ -553,11 +568,22 @@ async fn ring_buf_pinned() {
             ring_buf_trigger_ebpf_program(v);
         }
         let (to_read_before_reopen, to_read_after_reopen) = to_write_before_reopen.split_at(2);
-        for v in to_read_before_reopen {
-            let item = ring_buf.next().unwrap();
-            let item: [u8; 8] = item.as_ref().try_into().unwrap();
-            assert_eq!(item, v.to_ne_bytes());
-        }
+
+        assert_matches!(
+            ring_buf.try_fold(to_read_before_reopen, |to_read, item| {
+                assert_matches!(to_read, [v, to_read @ ..] => {
+                    let item: [u8; 8] = item.as_ref().try_into().unwrap();
+                    assert_eq!(item, v.to_ne_bytes());
+                    if to_read.is_empty() {
+                        ControlFlow::Break(())
+                    } else {
+                        ControlFlow::Continue(to_read)
+                    }
+                })
+            }),
+            ControlFlow::Break(())
+        );
+
         drop(ring_buf);
         drop(bpf);
 
@@ -581,15 +607,17 @@ async fn ring_buf_pinned() {
         }
         // Read both the data that was written before the ring buffer was reopened and the data that
         // was written after it was reopened.
-        for v in to_read_after_reopen
-            .iter()
-            .chain(to_write_after_reopen.iter())
-        {
-            let item = ring_buf.next().unwrap();
-            let item: [u8; 8] = item.as_ref().try_into().unwrap();
-            assert_eq!(item, v.to_ne_bytes());
-        }
-        // Make sure there is nothing else in the ring buffer.
-        assert_matches!(ring_buf.next(), None);
+        let mut iter = ring_buf.fold(
+            to_read_after_reopen
+                .iter()
+                .chain(to_write_after_reopen.iter()),
+            |mut iter, item| {
+                let v = iter.next().unwrap();
+                let item = item.try_into().unwrap();
+                assert_eq!(u64::from_ne_bytes(item), *v);
+                iter
+            },
+        );
+        assert_eq!(iter.next(), None);
     }
 }

--- a/test/integration-test/src/tests/uprobe_cookie.rs
+++ b/test/integration-test/src/tests/uprobe_cookie.rs
@@ -59,15 +59,10 @@ fn test_uprobe_cookie() {
     const EXP: &[u64] = &[1, 2, 1, 3];
 
     let mut seen = Vec::new();
-    while let Some(read) = ring_buf.next() {
-        let read = read.as_ref();
-        match read.try_into() {
-            Ok(read) => seen.push(u64::from_ne_bytes(read)),
-            Err(std::array::TryFromSliceError { .. }) => {
-                panic!("invalid ring buffer data: {read:x?}")
-            }
-        }
-    }
+    ring_buf.for_each(|read| {
+        let read = read.try_into().unwrap();
+        seen.push(u64::from_ne_bytes(read));
+    });
     assert_eq!(seen, EXP);
 }
 

--- a/xtask/public-api/aya.txt
+++ b/xtask/public-api/aya.txt
@@ -559,7 +559,10 @@ impl<T, V> core::panic::unwind_safe::UnwindSafe for aya::maps::queue::Queue<T, V
 pub mod aya::maps::ring_buf
 pub struct aya::maps::ring_buf::RingBuf<T>
 impl<T> aya::maps::ring_buf::RingBuf<T>
+pub fn aya::maps::ring_buf::RingBuf<T>::fold<C, F>(&mut self, C, F) -> C where F: core::ops::function::FnMut(C, &[u8]) -> C
+pub fn aya::maps::ring_buf::RingBuf<T>::for_each<F>(&mut self, F) where F: core::ops::function::FnMut(&[u8])
 pub fn aya::maps::ring_buf::RingBuf<T>::next(&mut self) -> core::option::Option<aya::maps::ring_buf::RingBufItem<'_>>
+pub fn aya::maps::ring_buf::RingBuf<T>::try_fold<B, C, F>(&mut self, C, F) -> core::ops::control_flow::ControlFlow<B, C> where F: core::ops::function::FnMut(C, &[u8]) -> core::ops::control_flow::ControlFlow<B, C>
 impl core::convert::TryFrom<aya::maps::Map> for aya::maps::ring_buf::RingBuf<aya::maps::MapData>
 pub type aya::maps::ring_buf::RingBuf<aya::maps::MapData>::Error = aya::maps::MapError
 pub fn aya::maps::ring_buf::RingBuf<aya::maps::MapData>::try_from(aya::maps::Map) -> core::result::Result<Self, Self::Error>
@@ -1994,7 +1997,10 @@ impl<T> core::panic::unwind_safe::RefUnwindSafe for aya::maps::ReusePortSockArra
 impl<T> core::panic::unwind_safe::UnwindSafe for aya::maps::ReusePortSockArray<T> where T: core::panic::unwind_safe::UnwindSafe
 pub struct aya::maps::RingBuf<T>
 impl<T> aya::maps::ring_buf::RingBuf<T>
+pub fn aya::maps::ring_buf::RingBuf<T>::fold<C, F>(&mut self, C, F) -> C where F: core::ops::function::FnMut(C, &[u8]) -> C
+pub fn aya::maps::ring_buf::RingBuf<T>::for_each<F>(&mut self, F) where F: core::ops::function::FnMut(&[u8])
 pub fn aya::maps::ring_buf::RingBuf<T>::next(&mut self) -> core::option::Option<aya::maps::ring_buf::RingBufItem<'_>>
+pub fn aya::maps::ring_buf::RingBuf<T>::try_fold<B, C, F>(&mut self, C, F) -> core::ops::control_flow::ControlFlow<B, C> where F: core::ops::function::FnMut(C, &[u8]) -> core::ops::control_flow::ControlFlow<B, C>
 impl core::convert::TryFrom<aya::maps::Map> for aya::maps::ring_buf::RingBuf<aya::maps::MapData>
 pub type aya::maps::ring_buf::RingBuf<aya::maps::MapData>::Error = aya::maps::MapError
 pub fn aya::maps::ring_buf::RingBuf<aya::maps::MapData>::try_from(aya::maps::Map) -> core::result::Result<Self, Self::Error>


### PR DESCRIPTION
This implementation should have lower overhead than `RingBuffer::next` and
by avoiding the overhead associated with `RingBufItem`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aya-rs/aya/1479)
<!-- Reviewable:end -->
