### PR TITLE
Add `aya-ebpf-cty` to workspace manifest

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ members = [
     # ebpf crates
     "ebpf/aya-ebpf",
     "ebpf/aya-ebpf-bindings",
+    "ebpf/aya-ebpf-cty",
     "ebpf/aya-log-ebpf",
     "test/integration-ebpf",
 ]


### PR DESCRIPTION
<!-- markdownlint-disable first-line-heading -->

<!--
    Thank you for your contribution to Aya! 🎉

    For Work In Progress Pull Requests, please use the Draft PR feature.

    Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Aya Contributing Guide: https://github.com/aya-rs/aya/blob/main/CONTRIBUTING.md
     - 📖 Read the Aya Code of Conduct: https://github.com/aya-rs/aya/blob/main/CODE_OF_CONDUCT.md
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages: https://cbea.ms/git-commit/
     - 📗 Update any related documentation.

-->

<!---
      Summarize the changes you're making here. Detailed information belongs in
      the Git commit messages. If your pull request contains just one commit,
      it's best to use its message as a summary. Otherwise, if there are multiple
      atomic commits, write a summary for the entire PR. Feel free to flag
      anything you think needs a reviewer's attention.
-->
This explicitly adds `aya-ebpf-cty` to the workspace manifest. The crate was only transitively included in the workspace before.
<!--
      If your changes address an issue, link it with the *Fixes* tag so
      the issue gets closed when the PR is merged, for example:

      Fixes: #1234

      If you are only referencing an issue without fully addressing it, feel
      free to link it anywhere in the summary.
-->

Fixes: #1507 

### Added/updated tests?

_We strongly encourage you to add a test for your changes._

- [ ] Yes
- [x] No, and this is why: this does not change functionality.
- [ ] I need help with writing tests

### Checklist

- [x] Rust code has been formatted with `cargo +nightly fmt`.
- [x] All clippy lints have been fixed.
      You can find failing lints with `./clippy.sh`.
- [x] Unit tests are passing locally with `cargo test`.
- [x] The [Integration tests] are passing locally.
- [x] I have blessed any API changes with `cargo xtask public-api --bless`.

[Integration tests]: https://github.com/aya-rs/aya/blob/main/test/README.md

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aya-rs/aya/1508)
<!-- Reviewable:end -->
