### PR TITLE
Align by 8b in `include_bytes_aligned`.

### DIFF
--- a/aya/src/util.rs
+++ b/aya/src/util.rs
@@ -392,17 +392,14 @@ pub(crate) const fn tc_handler_make(major: u32, minor: u32) -> u32 {
 #[macro_export]
 macro_rules! include_bytes_aligned {
     ($path:expr) => {{
-        #[repr(align(32))]
-        pub struct Aligned32;
-
-        #[repr(C)]
+        // All eBPF programs are ELF64 objects (regardless of host target) with 8-byte
+        // aligned headers and all eBPF instructions are 8 bytes each.
+        #[repr(C, align(8))]
         pub struct Aligned<Bytes: ?Sized> {
-            pub _align: [Aligned32; 0],
             pub bytes: Bytes,
         }
 
         const ALIGNED: &Aligned<[u8]> = &Aligned {
-            _align: [],
             bytes: *include_bytes!($path),
         };
 


### PR DESCRIPTION
`include_bytes_aligned` macro is helpful when user wants to read ELF file to some in memory buffer.
Reading elf files is handled in aya-obj, which calls `object::File::parse`. The former reads ELF header to detect `FileKind` (Elf64 or Elf32 and others) by looking into Magic (see https://github.com/gimli-rs/object/blob/main/src/read/mod.rs#L294). For example:

```
> readelf -h xdp-ebpf/agave-xdp-prog                                                  
ELF Header:
  Magic:   7f 45 4c 46 02 01 01 00 00 00 00 00 00 00 00 00
  Class:                             ELF64
```
 
Decodes to:
 
 7f 45 4c 46 = (0x7f 'E' 'L' 'F')
02 = EI_CLASS = ELFCLASS64 (64-bit)
01 = EI_DATA = ELFDATA2LSB (little-endian)
01 = EI_VERSION = EV_CURRENT
00 = EI_OSABI = System V
00 = EI_ABIVERSION
remaining 00 ... 00 = padding

Hence, the max alignment is `8 bytes` and determined by EI_CLASS (02 in the example).
The claim is that ELF64 is more common than ELF32 and enforcing alignment 8b will work for both cases.

Currently, alignment of choice is 32b, which is unnecessary large.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aya-rs/aya/1512)
<!-- Reviewable:end -->
