### PR TITLE
fix unit test faiulre due to path/string mismatch

### DIFF
--- a/aya/src/programs/uprobe.rs
+++ b/aya/src/programs/uprobe.rs
@@ -923,7 +923,7 @@ mod tests {
         assert_matches!(
             find_debug_path_in_object(&main_obj, main_path, "symbol"),
             Ok(path) => {
-                assert_eq!(&*path, "/path/to/main.debug", "path: {}", path.display());
+                assert_eq!(path, Path::new("/path/to/main.debug"), "path: {}", path.display());
             }
         );
     }
@@ -1140,7 +1140,7 @@ mod tests {
         assert_matches!(
             proc_map_libs.find_library_path_by_name(Path::new("libcrypto.so.3.0.9")),
             Ok(Some(path)) => {
-                assert_eq!(path, "/usr/lib64/libcrypto.so.3.0.9", "path: {}", path.display());
+                assert_eq!(path, Path::new("/usr/lib64/libcrypto.so.3.0.9"), "path: {}", path.display());
             }
         );
     }
@@ -1157,7 +1157,7 @@ mod tests {
         assert_matches!(
             proc_map_libs.find_library_path_by_name(Path::new("libcrypto")),
             Ok(Some(path)) => {
-                assert_eq!(path, "/usr/lib64/libcrypto.so.3.0.9", "path: {}", path.display());
+                assert_eq!(path, Path::new("/usr/lib64/libcrypto.so.3.0.9"), "path: {}", path.display());
             }
         );
     }
@@ -1178,7 +1178,7 @@ mod tests {
         assert_matches!(
             proc_map_libs.find_library_path_by_name(Path::new("ld-linux-x86-64.so.2")),
             Ok(Some(path)) => {
-                assert_eq!(path, "/usr/lib64/ld-linux-x86-64.so.2", "path: {}", path.display());
+                assert_eq!(path, Path::new("/usr/lib64/ld-linux-x86-64.so.2"), "path: {}", path.display());
             }
         );
     }


### PR DESCRIPTION
`cargo test` currently fails with errors like the following one:

```
error[E0277]: can't compare `std::path::Path` with `str`
    --> aya/src/programs/uprobe.rs:1160:17
     |
1160 |                 assert_eq!(path, "/usr/lib64/libcrypto.so.3.0.9", "path: {}", path.display());
     |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ no implementation for `std::path::Path == str`
     |
     = help: the trait `PartialEq<str>` is not implemented for `std::path::Path`
     = help: the following other types implement trait `PartialEq<Rhs>`:
               `&std::path::Path` implements `PartialEq<Cow<'_, OsStr>>`
               `&std::path::Path` implements `PartialEq<Cow<'_, std::path::Path>>`
               `&std::path::Path` implements `PartialEq<OsStr>`
               `&std::path::Path` implements `PartialEq<OsString>`
               `&std::path::Path` implements `PartialEq<PathBuf>`
               `std::path::Path` implements `PartialEq<&OsStr>`
               `std::path::Path` implements `PartialEq<Cow<'_, OsStr>>`
               `std::path::Path` implements `PartialEq<Cow<'_, std::path::Path>>`
             and 4 others
     = note: required for `&std::path::Path` to implement `PartialEq<&str>`
     = note: this error originates in the macro `assert_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aya-rs/aya/1513)
<!-- Reviewable:end -->
