### PR TITLE
util: make Align not pub

### DIFF
--- a/aya/src/util.rs
+++ b/aya/src/util.rs
@@ -392,18 +392,19 @@ pub(crate) const fn tc_handler_make(major: u32, minor: u32) -> u32 {
 #[macro_export]
 macro_rules! include_bytes_aligned {
     ($path:expr) => {{
-        // All eBPF programs are ELF64 objects (regardless of host target) with 8-byte
-        // aligned headers and all eBPF instructions are 8 bytes each.
+        // All eBPF programs are ELF64 objects (regardless of host target) with
+        // 8-byte aligned headers and all eBPF instructions are 8 bytes each.
         #[repr(C, align(8))]
-        pub struct Aligned<Bytes: ?Sized> {
-            pub bytes: Bytes,
-        }
+        struct Aligned<T: ?Sized>(T);
 
-        const ALIGNED: &Aligned<[u8]> = &Aligned {
-            bytes: *include_bytes!($path),
-        };
+        // Must be a reference because `Aligned<[u8]>` is not `Sized` and we
+        // can't write `Aligned<[u8; N]>` since `N` is not nameable in the type
+        // in this context (even though the compiler knows it at compile time).
+        const ALIGNED: &Aligned<[u8]> = &Aligned(*include_bytes!($path));
 
-        &ALIGNED.bytes
+        let &Aligned(ref aligned) = ALIGNED;
+
+        aligned
     }};
 }
 


### PR DESCRIPTION
This has no effect, so drop it. Tidy up a bit while I'm here and explain
the use of const refernces.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aya-rs/aya/1514)
<!-- Reviewable:end -->
