### PR TITLE
Fix: panic in from_pin().attach() for cgroup program types

### DIFF
--- a/aya/src/programs/cgroup_sock.rs
+++ b/aya/src/programs/cgroup_sock.rs
@@ -115,7 +115,8 @@ impl CgroupSock {
         path: P,
         attach_type: CgroupSockAttachType,
     ) -> Result<Self, ProgramError> {
-        let data = ProgramData::from_pinned_path(path, VerifierLogLevel::default())?;
+        let mut data = ProgramData::from_pinned_path(path, VerifierLogLevel::default())?;
+        data.expected_attach_type = Some(attach_type.into());
         Ok(Self { data, attach_type })
     }
 }

--- a/aya/src/programs/cgroup_sock_addr.rs
+++ b/aya/src/programs/cgroup_sock_addr.rs
@@ -116,7 +116,8 @@ impl CgroupSockAddr {
         path: P,
         attach_type: CgroupSockAddrAttachType,
     ) -> Result<Self, ProgramError> {
-        let data = ProgramData::from_pinned_path(path, VerifierLogLevel::default())?;
+        let mut data = ProgramData::from_pinned_path(path, VerifierLogLevel::default())?;
+        data.expected_attach_type = Some(attach_type.into());
         Ok(Self { data, attach_type })
     }
 }

--- a/aya/src/programs/cgroup_sockopt.rs
+++ b/aya/src/programs/cgroup_sockopt.rs
@@ -115,7 +115,8 @@ impl CgroupSockopt {
         path: P,
         attach_type: CgroupSockoptAttachType,
     ) -> Result<Self, ProgramError> {
-        let data = ProgramData::from_pinned_path(path, VerifierLogLevel::default())?;
+        let mut data = ProgramData::from_pinned_path(path, VerifierLogLevel::default())?;
+        data.expected_attach_type = Some(attach_type.into());
         Ok(Self { data, attach_type })
     }
 }

--- a/test/integration-test/src/tests.rs
+++ b/test/integration-test/src/tests.rs
@@ -13,6 +13,7 @@ mod bloom_filter;
 mod bpf_probe_read;
 mod btf_maps;
 mod btf_relocations;
+mod cgroup_sock_pinned;
 mod elf;
 mod feature_probe;
 mod info;

--- a/test/integration-test/src/tests/cgroup_sock_pinned.rs
+++ b/test/integration-test/src/tests/cgroup_sock_pinned.rs
@@ -1,0 +1,50 @@
+use std::fs::remove_file;
+
+use aya::{
+    maps::SkStorage,
+    programs::{CgroupAttachMode, CgroupSockAddr, CgroupSockAddrAttachType},
+};
+use test_log::test;
+
+use crate::utils::Cgroup;
+
+#[test]
+fn cgroup_sock_addr_from_pin_attach() {
+    // Test that CgroupSockAddr::from_pin() correctly sets expected_attach_type,
+    // so that attach() does not panic.
+    let mut ebpf = aya::EbpfLoader::new().load(crate::SK_STORAGE).unwrap();
+
+    let storage = ebpf.take_map("SOCKET_STORAGE").unwrap();
+    let _storage =
+        SkStorage::<_, integration_common::sk_storage::Value>::try_from(storage).unwrap();
+
+    let prog = ebpf
+        .program_mut("sk_storage_connect4")
+        .unwrap()
+        .try_into()
+        .unwrap();
+
+    let prog: &mut CgroupSockAddr = prog;
+    prog.load().unwrap();
+
+    // Pin the program to bpffs
+    let pin_path = "/sys/fs/bpf/aya-test-cgroup-sock-addr-from-pin";
+    remove_file(pin_path).ok();
+    prog.pin(pin_path).unwrap();
+
+    // Reload from pinned path via from_pin() - this is the critical path.
+    // Before the fix, expected_attach_type was not set in from_pin(),
+    // causing attach() to panic with unwrap on None.
+    let mut prog = CgroupSockAddr::from_pin(pin_path, CgroupSockAddrAttachType::Connect4).unwrap();
+
+    let root = Cgroup::root();
+    let cgroup = root.create_child("aya-test-cgroup-sock-addr-from-pin");
+    let cgroup_fd = cgroup.fd();
+
+    // This attach() would panic if expected_attach_type was not set by from_pin().
+    let _link_id = prog.attach(cgroup_fd, CgroupAttachMode::Single).unwrap();
+
+    // Clean up
+    drop(cgroup);
+    remove_file(pin_path).ok();
+}


### PR DESCRIPTION
was debugging a user's report about a panic when re-attaching a pinned cgroup program. the issue is that rom_pin doesnt set expected_attach_type on the program data, so calling ttach() later hits an unwrap on None. fixed by setting it in the three affected rom_pin methods (cgroup_sock, cgroup_sockopt, cgroup_sock_addr).

note: tests cant run locally on windows due to aya-obj using unix-only std::os::fd APIs. this is a pre-existing platform constraint, not related to this change.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aya-rs/aya/1516)
<!-- Reviewable:end -->
