### PR TITLE
Deduplicate PR and branch CI runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,21 @@ env:
   CARGO_TERM_COLOR: always
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  # Cancel older runs for the same branch/PR head.
+  #
+  # `github.ref` differs between push and pull_request events for the same PR
+  # branch (`refs/heads/<branch>` vs `refs/pull/<n>/merge`), so select the
+  # branch key by event type explicitly.
+  group: >-
+    ${{ github.workflow }}-${{ fromJSON(format(
+      '{{"pull_request":{0},"push":{1},"schedule":{1}}}',
+      toJSON(github.event.pull_request.head.repo.full_name),
+      toJSON(github.repository)
+    ))[github.event_name] }}-${{ fromJSON(format(
+      '{{"pull_request":{0},"push":{1},"schedule":{1}}}',
+      toJSON(github.head_ref),
+      toJSON(github.ref_name)
+    ))[github.event_name] }}
   cancel-in-progress: true
 
 permissions: {}


### PR DESCRIPTION
Normalize the workflow concurrency key across push and pull_request
events so updates to a branch with an open PR do not keep two full CI
runs alive.

Use the PR head repository and branch for pull_request events, and the
repository and ref name for push and schedule events. github.ref cannot
be used directly because pull_request runs use refs/pull/<n>/merge.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aya-rs/aya/1521)
<!-- Reviewable:end -->
