### PR TITLE
aya-ebpf: fix bpf_printk! passing pointers instead of values

### DIFF
--- a/ebpf/aya-ebpf/src/helpers.rs
+++ b/ebpf/aya-ebpf/src/helpers.rs
@@ -702,13 +702,13 @@ pub use bpf_printk;
 /// Argument ready to be passed to `printk` BPF helper.
 #[repr(transparent)]
 #[derive(Copy, Clone)]
-pub struct PrintkArg([u8; 8]);
+pub struct PrintkArg(u64);
 
 impl PrintkArg {
     /// Manually construct a `printk` BPF helper argument.
     #[inline]
     pub const fn from_raw(x: u64) -> Self {
-        Self(x.to_ne_bytes())
+        Self(x)
     }
 }
 
@@ -720,31 +720,31 @@ macro_rules! impl_integer_promotion {
             #[expect(clippy::allow_attributes, reason = "macro")]
             #[allow(trivial_numeric_casts, reason = "macro")]
             fn from(x: $ty) -> Self {
-                Self((x as $via).to_ne_bytes())
+                Self(x as $via as u64)
             }
         }
     )*}
 }
 
 impl_integer_promotion!(
-  char:  via usize,
-  u8:    via usize,
-  u16:   via usize,
-  u32:   via usize,
-  u64:   via usize,
-  usize: via usize,
-  i8:    via isize,
-  i16:   via isize,
-  i32:   via isize,
-  i64:   via isize,
-  isize: via isize,
+  char:  via u64,
+  u8:    via u64,
+  u16:   via u64,
+  u32:   via u64,
+  u64:   via u64,
+  usize: via u64,
+  i8:    via i64,
+  i16:   via i64,
+  i32:   via i64,
+  i64:   via i64,
+  isize: via i64,
 );
 
 /// Construct `printk` BPF helper arguments from constant pointers.
 impl<T> From<*const T> for PrintkArg {
     #[inline]
     fn from(x: *const T) -> Self {
-        Self((x as usize).to_ne_bytes())
+        Self(x as usize as u64)
     }
 }
 
@@ -752,7 +752,7 @@ impl<T> From<*const T> for PrintkArg {
 impl<T> From<*mut T> for PrintkArg {
     #[inline]
     fn from(x: *mut T) -> Self {
-        Self((x as usize).to_ne_bytes())
+        Self(x as usize as u64)
     }
 }
 

--- a/ebpf/aya-ebpf/src/helpers.rs
+++ b/ebpf/aya-ebpf/src/helpers.rs
@@ -713,14 +713,14 @@ impl PrintkArg {
 }
 
 macro_rules! impl_integer_promotion {
-    ($($ty:ty : via $via:ty),* $(,)?) => {$(
+    ($($ty:ty : via $via:ty $(=> $cast:ident)?),* $(,)?) => {$(
         /// Create `printk` arguments from integer types.
         impl From<$ty> for PrintkArg {
             #[inline]
             #[expect(clippy::allow_attributes, reason = "macro")]
             #[allow(trivial_numeric_casts, reason = "macro")]
             fn from(x: $ty) -> Self {
-                Self(x as $via as u64)
+                Self((x as $via)$(.$cast())?)
             }
         }
     )*}
@@ -733,11 +733,11 @@ impl_integer_promotion!(
   u32:   via u64,
   u64:   via u64,
   usize: via u64,
-  i8:    via i64,
-  i16:   via i64,
-  i32:   via i64,
-  i64:   via i64,
-  isize: via i64,
+  i8:    via i64 => cast_unsigned,
+  i16:   via i64 => cast_unsigned,
+  i32:   via i64 => cast_unsigned,
+  i64:   via i64 => cast_unsigned,
+  isize: via i64 => cast_unsigned,
 );
 
 /// Construct `printk` BPF helper arguments from constant pointers.


### PR DESCRIPTION
C doesn't have an array value same way Rust does, therefore [u8; 8] passed as an argument to variadic bpf_trace_printk() is actually received as &[u8; 8], resulting in garbage in tracing output.

Fixes https://github.com/aya-rs/aya/issues/1171

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aya-rs/aya/1522)
<!-- Reviewable:end -->
