### PR TITLE
aya-ebpf: fix bpf_printk argument passing with working test

### DIFF
--- a/ebpf/aya-ebpf/src/helpers.rs
+++ b/ebpf/aya-ebpf/src/helpers.rs
@@ -708,7 +708,6 @@ pub use bpf_printk;
 /// by value in a register.
 #[repr(transparent)]
 #[derive(Copy, Clone)]
-#[doc(hidden)]
 pub struct PrintkArg(u64);
 
 impl PrintkArg {
@@ -725,52 +724,25 @@ macro_rules! impl_unsigned_promotion {
         impl From<$ty> for PrintkArg {
             #[inline]
             fn from(x: $ty) -> Self {
-                Self(u64::from(x))
+                Self(x as $via as u64)
             }
         }
     )*}
 }
 
-impl_unsigned_promotion!(u8, u16, u32);
-
-/// Create `printk` arguments from `u64`.
-impl From<u64> for PrintkArg {
-    #[inline]
-    fn from(x: u64) -> Self {
-        Self(x)
-    }
-}
-
-/// Create `printk` arguments from `usize`.
-impl From<usize> for PrintkArg {
-    #[inline]
-    fn from(x: usize) -> Self {
-        Self(x as u64)
-    }
-}
-
-/// Create `printk` arguments from `char`.
-impl From<char> for PrintkArg {
-    #[inline]
-    fn from(x: char) -> Self {
-        Self(u64::from(u32::from(x)))
-    }
-}
-
-macro_rules! impl_signed_promotion {
-    ($($ty:ty),* $(,)?) => {$(
-        /// Create `printk` arguments from signed integer types.
-        impl From<$ty> for PrintkArg {
-            #[inline]
-            #[expect(clippy::cast_sign_loss, reason = "signed integers are passed as their bit pattern")]
-            fn from(x: $ty) -> Self {
-                Self(x as u64)
-            }
-        }
-    )*}
-}
-
-impl_signed_promotion!(i8, i16, i32, i64, isize);
+impl_integer_promotion!(
+  char:  via u64,
+  u8:    via u64,
+  u16:   via u64,
+  u32:   via u64,
+  u64:   via u64,
+  usize: via u64,
+  i8:    via i64,
+  i16:   via i64,
+  i32:   via i64,
+  i64:   via i64,
+  isize: via i64,
+);
 
 /// Construct `printk` BPF helper arguments from constant pointers.
 impl<T> From<*const T> for PrintkArg {

--- a/ebpf/aya-ebpf/src/helpers.rs
+++ b/ebpf/aya-ebpf/src/helpers.rs
@@ -689,7 +689,7 @@ macro_rules! bpf_printk {
     ($fmt:literal $(,)? $($arg:expr),* $(,)?) => {{
         use $crate::helpers::PrintkArg;
         const FMT: [u8; { $fmt.len() + 1 }] = $crate::helpers::zero_pad_array::<
-            { $fmt.len() }, { $fmt.len() + 1 }>(*$fmt);
+            { $fmt.len() }, { $fmt.len() + 1 }>($fmt);
         let data = [$(PrintkArg::from($arg)),*];
         $crate::helpers::bpf_printk_impl(&FMT, &data)
     }};
@@ -794,7 +794,7 @@ impl<T> From<*mut T> for PrintkArg {
 /// This function serves as a helper for the [`bpf_printk!`] macro.
 #[doc(hidden)]
 pub const fn zero_pad_array<const SRC_LEN: usize, const DST_LEN: usize>(
-    src: [u8; SRC_LEN],
+    src: &[u8; SRC_LEN],
 ) -> [u8; DST_LEN] {
     let mut out: [u8; DST_LEN] = [0u8; DST_LEN];
 

--- a/ebpf/aya-ebpf/src/helpers.rs
+++ b/ebpf/aya-ebpf/src/helpers.rs
@@ -719,12 +719,12 @@ impl PrintkArg {
 }
 
 macro_rules! impl_integer_promotion {
-    ($($ty:ty : via $via:ty $(=> $cast:ident)?),* $(,)?) => {$(
+    ($($ty:ty : $(via $via:ty)? $(=> $cast:ident)?),* $(,)?) => {$(
         /// Create `printk` arguments from integer types.
         impl From<$ty> for PrintkArg {
             #[inline]
             fn from(x: $ty) -> Self {
-                Self((x as $via)$(.$cast())?)
+                Self((x $(as $via)?)$(.$cast())?)
             }
         }
     )*}
@@ -735,12 +735,12 @@ impl_integer_promotion!(
   u8:    via u64,
   u16:   via u64,
   u32:   via u64,
-  u64:   via u64,
+  u64:,
   usize: via u64,
   i8:    via i64 => cast_unsigned,
   i16:   via i64 => cast_unsigned,
   i32:   via i64 => cast_unsigned,
-  i64:   via i64 => cast_unsigned,
+  i64:           => cast_unsigned,
   isize: via i64 => cast_unsigned,
 );
 

--- a/ebpf/aya-ebpf/src/helpers.rs
+++ b/ebpf/aya-ebpf/src/helpers.rs
@@ -700,51 +700,83 @@ macro_rules! bpf_printk {
 pub use bpf_printk;
 
 /// Argument ready to be passed to `printk` BPF helper.
+///
+/// This wraps a `u64` directly (not `[u8; 8]`) to ensure correct ABI handling
+/// when passed as a variadic argument to `bpf_trace_printk`. The C ABI for
+/// variadic functions may handle arrays differently than scalar types, causing
+/// incorrect values to be printed. Using `u64` ensures the value is passed
+/// by value in a register.
 #[repr(transparent)]
 #[derive(Copy, Clone)]
-pub struct PrintkArg([u8; 8]);
+#[doc(hidden)]
+pub struct PrintkArg(u64);
 
 impl PrintkArg {
     /// Manually construct a `printk` BPF helper argument.
     #[inline]
     pub const fn from_raw(x: u64) -> Self {
-        Self(x.to_ne_bytes())
+        Self(x)
     }
 }
 
-macro_rules! impl_integer_promotion {
-    ($($ty:ty : via $via:ty),* $(,)?) => {$(
-        /// Create `printk` arguments from integer types.
+macro_rules! impl_unsigned_promotion {
+    ($($ty:ty),* $(,)?) => {$(
+        /// Create `printk` arguments from unsigned integer types.
         impl From<$ty> for PrintkArg {
             #[inline]
-            #[expect(clippy::allow_attributes, reason = "macro")]
-            #[allow(trivial_numeric_casts, reason = "macro")]
             fn from(x: $ty) -> Self {
-                Self((x as $via).to_ne_bytes())
+                Self(u64::from(x))
             }
         }
     )*}
 }
 
-impl_integer_promotion!(
-  char:  via usize,
-  u8:    via usize,
-  u16:   via usize,
-  u32:   via usize,
-  u64:   via usize,
-  usize: via usize,
-  i8:    via isize,
-  i16:   via isize,
-  i32:   via isize,
-  i64:   via isize,
-  isize: via isize,
-);
+impl_unsigned_promotion!(u8, u16, u32);
+
+/// Create `printk` arguments from `u64`.
+impl From<u64> for PrintkArg {
+    #[inline]
+    fn from(x: u64) -> Self {
+        Self(x)
+    }
+}
+
+/// Create `printk` arguments from `usize`.
+impl From<usize> for PrintkArg {
+    #[inline]
+    fn from(x: usize) -> Self {
+        Self(x as u64)
+    }
+}
+
+/// Create `printk` arguments from `char`.
+impl From<char> for PrintkArg {
+    #[inline]
+    fn from(x: char) -> Self {
+        Self(u64::from(u32::from(x)))
+    }
+}
+
+macro_rules! impl_signed_promotion {
+    ($($ty:ty),* $(,)?) => {$(
+        /// Create `printk` arguments from signed integer types.
+        impl From<$ty> for PrintkArg {
+            #[inline]
+            #[expect(clippy::cast_sign_loss, reason = "signed integers are passed as their bit pattern")]
+            fn from(x: $ty) -> Self {
+                Self(x as u64)
+            }
+        }
+    )*}
+}
+
+impl_signed_promotion!(i8, i16, i32, i64, isize);
 
 /// Construct `printk` BPF helper arguments from constant pointers.
 impl<T> From<*const T> for PrintkArg {
     #[inline]
     fn from(x: *const T) -> Self {
-        Self((x as usize).to_ne_bytes())
+        Self(x as usize as u64)
     }
 }
 
@@ -752,7 +784,7 @@ impl<T> From<*const T> for PrintkArg {
 impl<T> From<*mut T> for PrintkArg {
     #[inline]
     fn from(x: *mut T) -> Self {
-        Self((x as usize).to_ne_bytes())
+        Self(x as usize as u64)
     }
 }
 

--- a/ebpf/aya-ebpf/src/helpers.rs
+++ b/ebpf/aya-ebpf/src/helpers.rs
@@ -718,13 +718,13 @@ impl PrintkArg {
     }
 }
 
-macro_rules! impl_unsigned_promotion {
-    ($($ty:ty),* $(,)?) => {$(
-        /// Create `printk` arguments from unsigned integer types.
+macro_rules! impl_integer_promotion {
+    ($($ty:ty : via $via:ty $(=> $cast:ident)?),* $(,)?) => {$(
+        /// Create `printk` arguments from integer types.
         impl From<$ty> for PrintkArg {
             #[inline]
             fn from(x: $ty) -> Self {
-                Self(x as $via as u64)
+                Self((x as $via)$(.$cast())?)
             }
         }
     )*}
@@ -737,11 +737,11 @@ impl_integer_promotion!(
   u32:   via u64,
   u64:   via u64,
   usize: via u64,
-  i8:    via i64,
-  i16:   via i64,
-  i32:   via i64,
-  i64:   via i64,
-  isize: via i64,
+  i8:    via i64 => cast_unsigned,
+  i16:   via i64 => cast_unsigned,
+  i32:   via i64 => cast_unsigned,
+  i64:   via i64 => cast_unsigned,
+  isize: via i64 => cast_unsigned,
 );
 
 /// Construct `printk` BPF helper arguments from constant pointers.

--- a/test/integration-common/src/lib.rs
+++ b/test/integration-common/src/lib.rs
@@ -80,6 +80,15 @@ pub mod linear_data_structures {
     pub const POP_INDEX: u32 = 1;
 }
 
+pub mod printk {
+    pub const MARKER: &core::ffi::CStr = c"PRINTK_TEST_";
+    pub const TEST_U8: u8 = 42;
+    pub const TEST_U16: u16 = 0x1234;
+    pub const TEST_U32: u32 = 0xDEAD_BEEF;
+    pub const TEST_U64: u64 = 0x0123_4567_89AB_CDEF;
+    pub const TEST_I32: i32 = -12345;
+}
+
 pub mod sk_storage {
     #[derive(Clone, Copy, Debug, Eq, PartialEq)]
     #[repr(C)]

--- a/test/integration-common/src/lib.rs
+++ b/test/integration-common/src/lib.rs
@@ -81,12 +81,18 @@ pub mod linear_data_structures {
 }
 
 pub mod printk {
-    pub const MARKER: &core::ffi::CStr = c"PRINTK_TEST_";
+    pub const MARKER: &core::ffi::CStr = c"PRINTK_TEST";
+    pub const TEST_CHAR: char = '\u{3042}'; // i.e. 'あ'
     pub const TEST_U8: u8 = 42;
     pub const TEST_U16: u16 = 0x1234;
     pub const TEST_U32: u32 = 0xDEAD_BEEF;
     pub const TEST_U64: u64 = 0x0123_4567_89AB_CDEF;
-    pub const TEST_I32: i32 = -12345;
+    pub const TEST_USIZE: usize = usize::MAX;
+    pub const TEST_I8: i8 = -127;
+    pub const TEST_I16: i16 = -32768;
+    pub const TEST_I32: i32 = -0x0808_CAFE;
+    pub const TEST_I64: i64 = -0x0123_4567_89AB_CDEF;
+    pub const TEST_ISIZE: isize = isize::MIN;
 }
 
 pub mod sk_storage {

--- a/test/integration-ebpf/Cargo.toml
+++ b/test/integration-ebpf/Cargo.toml
@@ -119,3 +119,7 @@ path = "src/uprobe_cookie.rs"
 [[bin]]
 name = "perf_event_bp"
 path = "src/perf_event_bp.rs"
+
+[[bin]]
+name = "printk_test"
+path = "src/printk_test.rs"

--- a/test/integration-ebpf/src/printk_test.rs
+++ b/test/integration-ebpf/src/printk_test.rs
@@ -39,7 +39,13 @@ fn test_bpf_printk(_ctx: ProbeContext) {
 
         // test multiple args (# of args <= 3); resulting in bpf_trace_printk()
         bpf_printk!(b"%s_MULTI_printk:%x,%x", m, TEST_U8, TEST_I32);
+    }
+}
 
+#[uprobe]
+fn test_bpf_printk_for_many_args(_ctx: ProbeContext) {
+    let m = MARKER.as_ptr();
+    unsafe {
         // test multiple args (# of args >= 4); resulting in bpf_trace_vprintk()
         bpf_printk!(
             b"%s_MULTI_vprintk:%u,%u,%d,%d",

--- a/test/integration-ebpf/src/printk_test.rs
+++ b/test/integration-ebpf/src/printk_test.rs
@@ -1,0 +1,28 @@
+//! Integration test for `bpf_printk` variadic argument passing.
+//!
+//! This tests that `PrintkArg` correctly passes values to the `bpf_trace_printk`
+//! kernel helper. The C ABI for variadic functions requires scalar values
+//! (not arrays) to be passed by value in registers.
+
+#![no_std]
+#![no_main]
+#![expect(unused_crate_dependencies, reason = "used in other bins")]
+
+use aya_ebpf::{helpers::bpf_printk, macros::uprobe, programs::ProbeContext};
+use integration_common::printk::{MARKER, TEST_I32, TEST_U8, TEST_U16, TEST_U32, TEST_U64};
+#[cfg(not(test))]
+extern crate ebpf_panic;
+
+#[uprobe]
+fn test_bpf_printk(_ctx: ProbeContext) {
+    let m = MARKER.as_ptr();
+    // SAFETY: format strings match the argument types and counts.
+    unsafe {
+        bpf_printk!(b"%sU8:%u", m, TEST_U8);
+        bpf_printk!(b"%sU16:%u", m, TEST_U16);
+        bpf_printk!(b"%sU32:%x", m, TEST_U32);
+        bpf_printk!(b"%sU64:%llx", m, TEST_U64);
+        bpf_printk!(b"%sI32:%d", m, TEST_I32);
+        bpf_printk!(b"%sMULTI:%u,%x", m, TEST_U8, TEST_U32);
+    }
+}

--- a/test/integration-ebpf/src/printk_test.rs
+++ b/test/integration-ebpf/src/printk_test.rs
@@ -1,28 +1,53 @@
-//! Integration test for `bpf_printk` variadic argument passing.
+//! Integration test for `bpf_printk` argument passing.
 //!
-//! This tests that `PrintkArg` correctly passes values to the `bpf_trace_printk`
-//! kernel helper. The C ABI for variadic functions requires scalar values
-//! (not arrays) to be passed by value in registers.
+//! This mainly tests that `PrintkArg` correctly passes values to the variadic `bpf_trace_printk`
+//! helper. It was defined as `PrintkArg([u8;8])` but C doesn't have an array value same way Rust
+//! does, so [u8; 8] passed as an argument to `bpf_trace_printk()` is actually received as &[u8; 8]
+//! resulting in garbage in tracing output.
 
 #![no_std]
 #![no_main]
 #![expect(unused_crate_dependencies, reason = "used in other bins")]
 
 use aya_ebpf::{helpers::bpf_printk, macros::uprobe, programs::ProbeContext};
-use integration_common::printk::{MARKER, TEST_I32, TEST_U8, TEST_U16, TEST_U32, TEST_U64};
+use integration_common::printk::{
+    MARKER, TEST_CHAR, TEST_I8, TEST_I16, TEST_I32, TEST_I64, TEST_ISIZE, TEST_U8, TEST_U16,
+    TEST_U32, TEST_U64, TEST_USIZE,
+};
 #[cfg(not(test))]
 extern crate ebpf_panic;
 
 #[uprobe]
 fn test_bpf_printk(_ctx: ProbeContext) {
     let m = MARKER.as_ptr();
-    // SAFETY: format strings match the argument types and counts.
     unsafe {
-        bpf_printk!(b"%sU8:%u", m, TEST_U8);
-        bpf_printk!(b"%sU16:%u", m, TEST_U16);
-        bpf_printk!(b"%sU32:%x", m, TEST_U32);
-        bpf_printk!(b"%sU64:%llx", m, TEST_U64);
-        bpf_printk!(b"%sI32:%d", m, TEST_I32);
-        bpf_printk!(b"%sMULTI:%u,%x", m, TEST_U8, TEST_U32);
+        // test impl of From<T> trait where T is
+        //  * primitive type
+        //  * pointer type (*const i8, to be specific)
+        //    * %s reads c-style string from the pased pointer
+        bpf_printk!(b"%s_CHAR_AS_U32:%x", m, TEST_CHAR);
+        bpf_printk!(b"%s_U8:%u", m, TEST_U8);
+        bpf_printk!(b"%s_U16:%u", m, TEST_U16);
+        bpf_printk!(b"%s_U32:%x", m, TEST_U32);
+        bpf_printk!(b"%s_U64:%llx", m, TEST_U64);
+        bpf_printk!(b"%s_USIZE:%llu", m, TEST_USIZE);
+        bpf_printk!(b"%s_I8:%d", m, TEST_I8);
+        bpf_printk!(b"%s_I16:%d", m, TEST_I16);
+        bpf_printk!(b"%s_I32:%x", m, TEST_I32);
+        bpf_printk!(b"%s_I64:%llx", m, TEST_I64);
+        bpf_printk!(b"%s_ISIZE:%lld", m, TEST_ISIZE);
+
+        // test multiple args (# of args <= 3); resulting in bpf_trace_printk()
+        bpf_printk!(b"%s_MULTI_printk:%x,%x", m, TEST_U8, TEST_I32);
+
+        // test multiple args (# of args >= 4); resulting in bpf_trace_vprintk()
+        bpf_printk!(
+            b"%s_MULTI_vprintk:%u,%u,%d,%d",
+            m,
+            TEST_U8,
+            TEST_U16,
+            TEST_I8,
+            TEST_I16
+        );
     }
 }

--- a/test/integration-test/Cargo.toml
+++ b/test/integration-test/Cargo.toml
@@ -36,6 +36,8 @@ scopeguard = { workspace = true }
 test-case = { workspace = true }
 test-log = { workspace = true, features = ["log"] }
 tokio = { workspace = true, features = [
+    "fs",
+    "io-util",
     "macros",
     "net",
     "rt-multi-thread",

--- a/test/integration-test/Cargo.toml
+++ b/test/integration-test/Cargo.toml
@@ -27,7 +27,7 @@ integration-common = { path = "../integration-common", features = ["user"] }
 libbpf-rs = { workspace = true, features = ["static", "vendored"] }
 libc = { workspace = true }
 log = { workspace = true }
-nix = { workspace = true, features = ["mount", "sched"] }
+nix = { workspace = true, features = ["mount", "sched", "poll"] }
 object = { workspace = true, features = ["elf", "read_core", "std"] }
 procfs = { workspace = true, features = ["flate2"] }
 rand = { workspace = true, features = ["thread_rng"] }
@@ -36,8 +36,6 @@ scopeguard = { workspace = true }
 test-case = { workspace = true }
 test-log = { workspace = true, features = ["log"] }
 tokio = { workspace = true, features = [
-    "fs",
-    "io-util",
     "macros",
     "net",
     "rt-multi-thread",

--- a/test/integration-test/src/lib.rs
+++ b/test/integration-test/src/lib.rs
@@ -63,6 +63,7 @@ bpf_file!(
     TWO_PROGS => "two_progs",
     XDP_SEC => "xdp_sec",
     UPROBE_COOKIE => "uprobe_cookie",
+    PRINTK_TEST => "printk_test",
 );
 
 #[cfg(test)]

--- a/test/integration-test/src/tests.rs
+++ b/test/integration-test/src/tests.rs
@@ -25,6 +25,7 @@ mod lsm;
 mod map_pin;
 mod maps_disjoint;
 mod perf_event_bp;
+mod printk;
 mod raw_tracepoint;
 mod rbpf;
 mod relocations;

--- a/test/integration-test/src/tests/printk.rs
+++ b/test/integration-test/src/tests/printk.rs
@@ -10,13 +10,13 @@
 
 use std::{
     fs::File,
-    io::{self, BufRead as _, BufReader, Read},
+    io::{self, BufRead as _, BufReader, Lines, Read},
     os::fd::AsFd,
     path::Path,
     time::{Duration, Instant},
 };
 
-use aya::{Ebpf, programs::UProbe};
+use aya::{Ebpf, programs::UProbe, util::KernelVersion};
 use integration_common::printk::{
     MARKER, TEST_CHAR, TEST_I8, TEST_I16, TEST_I32, TEST_I64, TEST_ISIZE, TEST_U8, TEST_U16,
     TEST_U32, TEST_U64, TEST_USIZE,
@@ -25,31 +25,8 @@ use nix::poll::{PollFd, PollFlags, PollTimeout};
 
 #[test_log::test]
 fn bpf_printk_args() {
-    let tracefs_mounts = [
-        Path::new("/sys/kernel/tracing"),
-        Path::new("/sys/kernel/debug/tracing"),
-    ];
-    let tracefs_dir = tracefs_mounts.iter().copied().find(|d| d.is_dir()).unwrap();
-
-    // Clear the trace buffer
-    // (traces emitted by this test might have been left unconsumed)
-    {
-        // Opening for writing with the O_TRUNC flag clears the ring buffer
-        // Reference: https://docs.kernel.org/6.18/trace/ftrace.html#the-file-system
-        let trace_path = tracefs_dir.join("trace");
-        File::options()
-            .write(true)
-            .truncate(true)
-            .open(&trace_path)
-            .unwrap();
-    }
-
-    // Prepare to read trace_pipe with timeout
-    let trace_pipe_path = tracefs_dir.join("trace_pipe");
-    let file = File::open(&trace_pipe_path).unwrap();
-    let reader = TimeoutReader::new(file, Duration::from_millis(100)).unwrap();
-    let actual_trace_lines = BufReader::new(reader).lines();
-    let total_timeout = Duration::from_secs(1);
+    let tracefs_helper =
+        TracefsHelper::new(Duration::from_millis(100), Duration::from_secs(1)).unwrap();
 
     let mut ebpf = Ebpf::load(crate::PRINTK_TEST).unwrap();
     let prog: &mut UProbe = ebpf
@@ -61,11 +38,12 @@ fn bpf_printk_args() {
     prog.attach("trigger_bpf_printk", "/proc/self/exe", None)
         .unwrap();
 
-    // Trigger the BPF program
+    // Clear the trace buffer then trigger the BPF program
+    tracefs_helper.clear_trace_buffer().unwrap();
     trigger_bpf_printk();
 
     let marker = MARKER.to_string_lossy();
-    let expected_traces = [
+    let expected_traces = vec![
         format!("{marker}_CHAR_AS_U32:{:x}", TEST_CHAR as u32),
         format!("{marker}_U8:{TEST_U8}"),
         format!("{marker}_U16:{TEST_U16}"),
@@ -78,52 +56,141 @@ fn bpf_printk_args() {
         format!("{marker}_I64:{TEST_I64:x}"),
         format!("{marker}_ISIZE:{TEST_ISIZE}"),
         format!("{marker}_MULTI_printk:{TEST_U8:x},{TEST_I32:x}"),
-        format!("{marker}_MULTI_vprintk:{TEST_U8},{TEST_U16},{TEST_I8},{TEST_I16}"),
     ];
-    let mut expected_traces = expected_traces.into_iter().peekable();
 
-    let start = Instant::now();
-    for fallible_line in actual_trace_lines {
-        let Some(expected) = expected_traces.peek() else {
-            break; // all test cases have been iterated over
-        };
-        assert!(
-            start.elapsed() < total_timeout,
-            "timed out before finding all test traces"
+    tracefs_helper.assert_line_by_line(&marker, &expected_traces)
+}
+
+#[test_log::test]
+fn bpf_printk_args_many() {
+    let kernel_version = KernelVersion::current().unwrap();
+    if kernel_version < KernelVersion::new(5, 15, 0) {
+        eprintln!(
+            "skipping test on kernel {kernel_version:?}, bpf_trace_vprintk() helper was introduced in 5.15"
         );
-        match fallible_line {
-            Ok(actual_trace) => {
-                if actual_trace.contains(&*marker) {
-                    assert!(
-                        actual_trace.contains(expected),
-                        "failed - expects actual ('{actual_trace}') to contain '{expected}'"
-                    );
-                    expected_traces.next();
+        return;
+    }
+
+    let tracefs_helper =
+        TracefsHelper::new(Duration::from_millis(100), Duration::from_secs(1)).unwrap();
+
+    let mut ebpf = Ebpf::load(crate::PRINTK_TEST).unwrap();
+    let prog: &mut UProbe = ebpf
+        .program_mut("test_bpf_printk_for_many_args")
+        .unwrap()
+        .try_into()
+        .unwrap();
+    prog.load().unwrap();
+    prog.attach("trigger_bpf_printk", "/proc/self/exe", None)
+        .unwrap();
+
+    // Clear the trace buffer then trigger the BPF program
+    tracefs_helper.clear_trace_buffer().unwrap();
+    trigger_bpf_printk();
+
+    let marker = MARKER.to_string_lossy();
+    let expected_traces = vec![format!(
+        "{marker}_MULTI_vprintk:{TEST_U8},{TEST_U16},{TEST_I8},{TEST_I16}"
+    )];
+
+    tracefs_helper.assert_line_by_line(&marker, &expected_traces)
+}
+
+struct TracefsHelper<'a> {
+    tracefs_mount: &'a Path,
+    read_timeout: Duration,
+    verify_timeout: Duration,
+}
+
+impl TracefsHelper<'_> {
+    fn new(read_timeout: Duration, verify_timeout: Duration) -> io::Result<Self> {
+        let tracefs_mount = TracefsHelper::find_tracefs_mount()?;
+        Ok(Self {
+            tracefs_mount,
+            read_timeout,
+            verify_timeout,
+        })
+    }
+
+    fn find_tracefs_mount<'a>() -> io::Result<&'a Path> {
+        let trace_pipe_files = [
+            Path::new("/sys/kernel/tracing/trace_pipe"),
+            Path::new("/sys/kernel/debug/tracing/trace_pipe"),
+        ];
+        trace_pipe_files
+            .iter()
+            .copied()
+            .find(|f| f.is_file())
+            .and_then(|p| p.parent())
+            .ok_or_else(|| io::Error::new(io::ErrorKind::NotFound, "tracefs not found"))
+    }
+
+    fn clear_trace_buffer(&self) -> io::Result<()> {
+        // Opening for writing with the O_TRUNC flag clears the buffer: make sure there is no
+        // traces emitted by the previous run of this test that might have been left unconsumed
+        // Reference: https://docs.kernel.org/6.18/trace/ftrace.html#the-file-system
+        let trace_path = self.tracefs_mount.join("trace");
+        File::options()
+            .write(true)
+            .truncate(true)
+            .open(&trace_path)?;
+        Ok(())
+    }
+
+    fn assert_line_by_line(&self, marker: &str, expected_traces: &[String]) {
+        let actual_trace_lines = self.open_trace_line_stream().unwrap();
+        let mut expected_traces = expected_traces.iter().peekable();
+
+        let start = Instant::now();
+        for fallible_line in actual_trace_lines {
+            let Some(&expected) = expected_traces.peek() else {
+                break; // all test cases have been iterated over
+            };
+            assert!(
+                start.elapsed() < self.verify_timeout,
+                "timed out before finding all test traces"
+            );
+            match fallible_line {
+                Ok(actual_trace) => {
+                    if actual_trace.contains(marker) {
+                        assert!(
+                            actual_trace.contains(expected),
+                            "failed - expects actual ('{actual_trace}') to contain '{expected}'"
+                        );
+                        expected_traces.next();
+                    }
                 }
-            }
-            Err(e) => {
-                assert!(
-                    e.kind() == io::ErrorKind::TimedOut,
-                    "io error raised before finding all test traces: {e}"
-                );
+                Err(e) => {
+                    assert!(
+                        e.kind() == io::ErrorKind::TimedOut,
+                        "io error raised before finding all test traces: {e}"
+                    );
+                }
             }
         }
     }
+
+    fn open_trace_line_stream(&self) -> io::Result<Lines<BufReader<FdReaderWithTimeout<File>>>> {
+        let trace_pipe_path = self.tracefs_mount.join("trace_pipe");
+        let file = File::open(&trace_pipe_path)?;
+        let reader = FdReaderWithTimeout::new(file, self.read_timeout)?;
+        Ok(BufReader::new(reader).lines())
+    }
 }
 
-struct TimeoutReader<T: AsFd + Read> {
+struct FdReaderWithTimeout<T: AsFd + Read> {
     source: T,
     timeout: PollTimeout,
 }
 
-impl<T: AsFd + Read> TimeoutReader<T> {
+impl<T: AsFd + Read> FdReaderWithTimeout<T> {
     fn new(source: T, timeout: Duration) -> io::Result<Self> {
         let timeout = PollTimeout::try_from(timeout).map_err(io::Error::other)?;
         Ok(Self { source, timeout })
     }
 }
 
-impl<T: AsFd + Read> Read for TimeoutReader<T> {
+impl<T: AsFd + Read> Read for FdReaderWithTimeout<T> {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
         let mut fds = [PollFd::new(self.source.as_fd(), PollFlags::POLLIN)];
         loop {

--- a/test/integration-test/src/tests/printk.rs
+++ b/test/integration-test/src/tests/printk.rs
@@ -1,75 +1,155 @@
-//! Integration test for `bpf_printk` variadic argument passing.
+//! Integration test for `bpf_printk` argument passing.
 //!
-//! This test verifies that `PrintkArg` correctly passes values to `bpf_trace_printk`.
-//! It streams from `trace_pipe` to verify the printed values match.
+//! This test verifies that `PrintkArg` correctly passes values to `bpf_trace_printk` and
+//! `bpf_trace_vprintk`. It reads trace events from `trace_pipe` to verify that `bpf-printk()`-ed
+//! values match.
+//!
+//! NOTE: This test requires that no other process is opening `trace_pipe`, as that would prevent
+//! this test from opening the file. The kernel makes sure that only one instance of open fd refers
+//! to the file across the system.
 
-use std::time::Duration;
-
-use aya::{Ebpf, programs::UProbe};
-use integration_common::printk::{MARKER, TEST_I32, TEST_U8, TEST_U16, TEST_U32, TEST_U64};
-use tokio::{
-    io::{AsyncBufReadExt as _, BufReader},
-    time::timeout,
+use std::{
+    fs::File,
+    io::{self, BufRead as _, BufReader, Read},
+    os::fd::AsFd,
+    path::Path,
+    time::{Duration, Instant},
 };
 
-#[tokio::test(flavor = "multi_thread")]
-async fn bpf_printk_variadic_args() {
-    let trace_pipe_path = "/sys/kernel/debug/tracing/trace_pipe";
+use aya::{Ebpf, programs::UProbe};
+use integration_common::printk::{
+    MARKER, TEST_CHAR, TEST_I8, TEST_I16, TEST_I32, TEST_I64, TEST_ISIZE, TEST_U8, TEST_U16,
+    TEST_U32, TEST_U64, TEST_USIZE,
+};
+use nix::poll::{PollFd, PollFlags, PollTimeout};
 
-    let pipe = tokio::fs::File::open(trace_pipe_path)
-        .await
-        .unwrap_or_else(|e| panic!("cannot open {trace_pipe_path}: {e}"));
+#[test_log::test]
+fn bpf_printk_args() {
+    let tracefs_mounts = [
+        Path::new("/sys/kernel/tracing"),
+        Path::new("/sys/kernel/debug/tracing"),
+    ];
+    let tracefs_dir = tracefs_mounts.iter().copied().find(|d| d.is_dir()).unwrap();
 
-    let mut bpf = Ebpf::load(crate::PRINTK_TEST).unwrap();
+    // Clear the trace buffer
+    // (traces emitted by this test might have been left unconsumed)
+    {
+        // Opening for writing with the O_TRUNC flag clears the ring buffer
+        // Reference: https://docs.kernel.org/6.18/trace/ftrace.html#the-file-system
+        let trace_path = tracefs_dir.join("trace");
+        File::options()
+            .write(true)
+            .truncate(true)
+            .open(&trace_path)
+            .unwrap();
+    }
 
-    let prog: &mut UProbe = bpf
+    // Prepare to read trace_pipe with timeout
+    let trace_pipe_path = tracefs_dir.join("trace_pipe");
+    let file = File::open(&trace_pipe_path).unwrap();
+    let reader = TimeoutReader::new(file, Duration::from_millis(100)).unwrap();
+    let actual_trace_lines = BufReader::new(reader).lines();
+    let total_timeout = Duration::from_secs(1);
+
+    let mut ebpf = Ebpf::load(crate::PRINTK_TEST).unwrap();
+    let prog: &mut UProbe = ebpf
         .program_mut("test_bpf_printk")
         .unwrap()
         .try_into()
         .unwrap();
     prog.load().unwrap();
-
     prog.attach("trigger_bpf_printk", "/proc/self/exe", None)
         .unwrap();
 
     // Trigger the BPF program
     trigger_bpf_printk();
 
-    let marker = MARKER.to_str().unwrap();
-    let mut expected = vec![
-        format!("{marker}U8:{TEST_U8}"),
-        format!("{marker}U16:{TEST_U16}"),
-        format!("{marker}U32:{TEST_U32:x}"),
-        format!("{marker}U64:{TEST_U64:x}"),
-        format!("{marker}I32:{TEST_I32}"),
-        format!("{marker}MULTI:{TEST_U8},{TEST_U32:x}"),
+    let marker = MARKER.to_string_lossy();
+    let expected_traces = [
+        format!("{marker}_CHAR_AS_U32:{:x}", TEST_CHAR as u32),
+        format!("{marker}_U8:{TEST_U8}"),
+        format!("{marker}_U16:{TEST_U16}"),
+        format!("{marker}_U32:{TEST_U32:x}"),
+        format!("{marker}_U64:{TEST_U64:x}"),
+        format!("{marker}_USIZE:{TEST_USIZE}"),
+        format!("{marker}_I8:{TEST_I8}"),
+        format!("{marker}_I16:{TEST_I16}"),
+        format!("{marker}_I32:{TEST_I32:x}"),
+        format!("{marker}_I64:{TEST_I64:x}"),
+        format!("{marker}_ISIZE:{TEST_ISIZE}"),
+        format!("{marker}_MULTI_printk:{TEST_U8:x},{TEST_I32:x}"),
+        format!("{marker}_MULTI_vprintk:{TEST_U8},{TEST_U16},{TEST_I8},{TEST_I16}"),
     ];
+    let mut expected_traces = expected_traces.into_iter().peekable();
 
-    let reader = BufReader::new(pipe);
-    let mut lines = reader.lines();
-    let mut trace_lines = Vec::new();
-
-    let result = timeout(Duration::from_secs(5), async {
-        while !expected.is_empty() {
-            let line = lines
-                .next_line()
-                .await
-                .expect("error reading trace_pipe")
-                .expect("trace_pipe closed unexpectedly");
-            if line.contains(marker) {
-                expected.retain(|exp| !line.contains(exp.as_str()));
-                trace_lines.push(line);
+    let start = Instant::now();
+    for fallible_line in actual_trace_lines {
+        let Some(expected) = expected_traces.peek() else {
+            break; // all test cases have been iterated over
+        };
+        assert!(
+            start.elapsed() < total_timeout,
+            "timed out before finding all test traces"
+        );
+        match fallible_line {
+            Ok(actual_trace) => {
+                if actual_trace.contains(&*marker) {
+                    assert!(
+                        actual_trace.contains(expected),
+                        "failed - expects actual ('{actual_trace}') to contain '{expected}'"
+                    );
+                    expected_traces.next();
+                }
+            }
+            Err(e) => {
+                assert!(
+                    e.kind() == io::ErrorKind::TimedOut,
+                    "io error raised before finding all test traces: {e}"
+                );
             }
         }
-    })
-    .await;
+    }
+}
 
-    let trace_content = trace_lines.join("\n");
-    result.unwrap_or_else(|_| {
-        panic!(
-            "timed out waiting for trace output; unsatisfied: {expected:?}\ntrace:\n{trace_content}"
-        )
-    });
+struct TimeoutReader<T: AsFd + Read> {
+    source: T,
+    timeout: PollTimeout,
+}
+
+impl<T: AsFd + Read> TimeoutReader<T> {
+    fn new(source: T, timeout: Duration) -> io::Result<Self> {
+        let timeout = PollTimeout::try_from(timeout).map_err(io::Error::other)?;
+        Ok(Self { source, timeout })
+    }
+}
+
+impl<T: AsFd + Read> Read for TimeoutReader<T> {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        let mut fds = [PollFd::new(self.source.as_fd(), PollFlags::POLLIN)];
+        loop {
+            match nix::poll::poll(&mut fds, self.timeout) {
+                Ok(..0) => panic!("unreachable: error is returned as Result::Err"),
+                Ok(0) => return Err(io::Error::from(io::ErrorKind::TimedOut)),
+                Ok(1..) => {
+                    let fd = &fds[0];
+                    let Some(revents) = fd.revents() else {
+                        continue;
+                    };
+                    if !revents.contains(PollFlags::POLLIN) {
+                        if revents.contains(PollFlags::POLLHUP) {
+                            return Ok(0); // the other end has closed
+                        }
+                        continue;
+                    }
+                    // This remains non-blocking even without O_NONBLOCK:
+                    // * trace_pipe allows only a single open fd (no race)
+                    // * read() is performed only once per readiness event
+                    return self.source.read(buf);
+                }
+                Err(err_no) => return Err(io::Error::other(err_no)),
+            }
+        }
+    }
 }
 
 #[unsafe(no_mangle)]

--- a/test/integration-test/src/tests/printk.rs
+++ b/test/integration-test/src/tests/printk.rs
@@ -1,0 +1,79 @@
+//! Integration test for `bpf_printk` variadic argument passing.
+//!
+//! This test verifies that `PrintkArg` correctly passes values to `bpf_trace_printk`.
+//! It streams from `trace_pipe` to verify the printed values match.
+
+use std::time::Duration;
+
+use aya::{Ebpf, programs::UProbe};
+use integration_common::printk::{MARKER, TEST_I32, TEST_U8, TEST_U16, TEST_U32, TEST_U64};
+use tokio::{
+    io::{AsyncBufReadExt as _, BufReader},
+    time::timeout,
+};
+
+#[tokio::test(flavor = "multi_thread")]
+async fn bpf_printk_variadic_args() {
+    let trace_pipe_path = "/sys/kernel/debug/tracing/trace_pipe";
+
+    let pipe = tokio::fs::File::open(trace_pipe_path)
+        .await
+        .unwrap_or_else(|e| panic!("cannot open {trace_pipe_path}: {e}"));
+
+    let mut bpf = Ebpf::load(crate::PRINTK_TEST).unwrap();
+
+    let prog: &mut UProbe = bpf
+        .program_mut("test_bpf_printk")
+        .unwrap()
+        .try_into()
+        .unwrap();
+    prog.load().unwrap();
+
+    prog.attach("trigger_bpf_printk", "/proc/self/exe", None)
+        .unwrap();
+
+    // Trigger the BPF program
+    trigger_bpf_printk();
+
+    let marker = MARKER.to_str().unwrap();
+    let mut expected = vec![
+        format!("{marker}U8:{TEST_U8}"),
+        format!("{marker}U16:{TEST_U16}"),
+        format!("{marker}U32:{TEST_U32:x}"),
+        format!("{marker}U64:{TEST_U64:x}"),
+        format!("{marker}I32:{TEST_I32}"),
+        format!("{marker}MULTI:{TEST_U8},{TEST_U32:x}"),
+    ];
+
+    let reader = BufReader::new(pipe);
+    let mut lines = reader.lines();
+    let mut trace_lines = Vec::new();
+
+    let result = timeout(Duration::from_secs(5), async {
+        while !expected.is_empty() {
+            let line = lines
+                .next_line()
+                .await
+                .expect("error reading trace_pipe")
+                .expect("trace_pipe closed unexpectedly");
+            if line.contains(marker) {
+                expected.retain(|exp| !line.contains(exp.as_str()));
+                trace_lines.push(line);
+            }
+        }
+    })
+    .await;
+
+    let trace_content = trace_lines.join("\n");
+    result.unwrap_or_else(|_| {
+        panic!(
+            "timed out waiting for trace output; unsatisfied: {expected:?}\ntrace:\n{trace_content}"
+        )
+    });
+}
+
+#[unsafe(no_mangle)]
+#[inline(never)]
+extern "C" fn trigger_bpf_printk() {
+    core::hint::black_box(());
+}

--- a/xtask/public-api/aya-ebpf.txt
+++ b/xtask/public-api/aya-ebpf.txt
@@ -209,6 +209,63 @@ pub fn aya_ebpf::btf_maps::sk_storage::SkStorage<T>::from(t: T) -> T
 pub mod aya_ebpf::helpers
 pub use aya_ebpf::helpers::generated
 pub macro aya_ebpf::helpers::bpf_printk!
+#[repr(transparent)] pub struct aya_ebpf::helpers::PrintkArg(_)
+impl aya_ebpf::helpers::PrintkArg
+pub const fn aya_ebpf::helpers::PrintkArg::from_raw(x: u64) -> Self
+impl core::clone::Clone for aya_ebpf::helpers::PrintkArg
+pub fn aya_ebpf::helpers::PrintkArg::clone(&self) -> aya_ebpf::helpers::PrintkArg
+impl core::convert::From<char> for aya_ebpf::helpers::PrintkArg
+pub fn aya_ebpf::helpers::PrintkArg::from(x: char) -> Self
+impl core::convert::From<i16> for aya_ebpf::helpers::PrintkArg
+pub fn aya_ebpf::helpers::PrintkArg::from(x: i16) -> Self
+impl core::convert::From<i32> for aya_ebpf::helpers::PrintkArg
+pub fn aya_ebpf::helpers::PrintkArg::from(x: i32) -> Self
+impl core::convert::From<i64> for aya_ebpf::helpers::PrintkArg
+pub fn aya_ebpf::helpers::PrintkArg::from(x: i64) -> Self
+impl core::convert::From<i8> for aya_ebpf::helpers::PrintkArg
+pub fn aya_ebpf::helpers::PrintkArg::from(x: i8) -> Self
+impl core::convert::From<isize> for aya_ebpf::helpers::PrintkArg
+pub fn aya_ebpf::helpers::PrintkArg::from(x: isize) -> Self
+impl core::convert::From<u16> for aya_ebpf::helpers::PrintkArg
+pub fn aya_ebpf::helpers::PrintkArg::from(x: u16) -> Self
+impl core::convert::From<u32> for aya_ebpf::helpers::PrintkArg
+pub fn aya_ebpf::helpers::PrintkArg::from(x: u32) -> Self
+impl core::convert::From<u64> for aya_ebpf::helpers::PrintkArg
+pub fn aya_ebpf::helpers::PrintkArg::from(x: u64) -> Self
+impl core::convert::From<u8> for aya_ebpf::helpers::PrintkArg
+pub fn aya_ebpf::helpers::PrintkArg::from(x: u8) -> Self
+impl core::convert::From<usize> for aya_ebpf::helpers::PrintkArg
+pub fn aya_ebpf::helpers::PrintkArg::from(x: usize) -> Self
+impl core::marker::Copy for aya_ebpf::helpers::PrintkArg
+impl<T> core::convert::From<*const T> for aya_ebpf::helpers::PrintkArg
+pub fn aya_ebpf::helpers::PrintkArg::from(x: *const T) -> Self
+impl<T> core::convert::From<*mut T> for aya_ebpf::helpers::PrintkArg
+pub fn aya_ebpf::helpers::PrintkArg::from(x: *mut T) -> Self
+impl core::marker::Freeze for aya_ebpf::helpers::PrintkArg
+impl core::marker::Send for aya_ebpf::helpers::PrintkArg
+impl core::marker::Sync for aya_ebpf::helpers::PrintkArg
+impl core::marker::Unpin for aya_ebpf::helpers::PrintkArg
+impl core::marker::UnsafeUnpin for aya_ebpf::helpers::PrintkArg
+impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::helpers::PrintkArg
+impl core::panic::unwind_safe::UnwindSafe for aya_ebpf::helpers::PrintkArg
+impl<T, U> core::convert::Into<U> for aya_ebpf::helpers::PrintkArg where U: core::convert::From<T>
+pub fn aya_ebpf::helpers::PrintkArg::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for aya_ebpf::helpers::PrintkArg where U: core::convert::Into<T>
+pub type aya_ebpf::helpers::PrintkArg::Error = core::convert::Infallible
+pub fn aya_ebpf::helpers::PrintkArg::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for aya_ebpf::helpers::PrintkArg where U: core::convert::TryFrom<T>
+pub type aya_ebpf::helpers::PrintkArg::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn aya_ebpf::helpers::PrintkArg::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> core::any::Any for aya_ebpf::helpers::PrintkArg where T: 'static + ?core::marker::Sized
+pub fn aya_ebpf::helpers::PrintkArg::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for aya_ebpf::helpers::PrintkArg where T: ?core::marker::Sized
+pub fn aya_ebpf::helpers::PrintkArg::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for aya_ebpf::helpers::PrintkArg where T: ?core::marker::Sized
+pub fn aya_ebpf::helpers::PrintkArg::borrow_mut(&mut self) -> &mut T
+impl<T> core::clone::CloneToUninit for aya_ebpf::helpers::PrintkArg where T: core::clone::Clone
+pub unsafe fn aya_ebpf::helpers::PrintkArg::clone_to_uninit(&self, dest: *mut u8)
+impl<T> core::convert::From<T> for aya_ebpf::helpers::PrintkArg
+pub fn aya_ebpf::helpers::PrintkArg::from(t: T) -> T
 pub const aya_ebpf::helpers::TASK_COMM_LEN: usize
 pub fn aya_ebpf::helpers::bpf_get_current_comm() -> core::result::Result<[u8; 16], i32>
 pub fn aya_ebpf::helpers::bpf_get_current_pid_tgid() -> u64

--- a/xtask/public-api/aya-ebpf.txt
+++ b/xtask/public-api/aya-ebpf.txt
@@ -209,63 +209,6 @@ pub fn aya_ebpf::btf_maps::sk_storage::SkStorage<T>::from(t: T) -> T
 pub mod aya_ebpf::helpers
 pub use aya_ebpf::helpers::generated
 pub macro aya_ebpf::helpers::bpf_printk!
-#[repr(transparent)] pub struct aya_ebpf::helpers::PrintkArg(_)
-impl aya_ebpf::helpers::PrintkArg
-pub const fn aya_ebpf::helpers::PrintkArg::from_raw(x: u64) -> Self
-impl core::clone::Clone for aya_ebpf::helpers::PrintkArg
-pub fn aya_ebpf::helpers::PrintkArg::clone(&self) -> aya_ebpf::helpers::PrintkArg
-impl core::convert::From<char> for aya_ebpf::helpers::PrintkArg
-pub fn aya_ebpf::helpers::PrintkArg::from(x: char) -> Self
-impl core::convert::From<i16> for aya_ebpf::helpers::PrintkArg
-pub fn aya_ebpf::helpers::PrintkArg::from(x: i16) -> Self
-impl core::convert::From<i32> for aya_ebpf::helpers::PrintkArg
-pub fn aya_ebpf::helpers::PrintkArg::from(x: i32) -> Self
-impl core::convert::From<i64> for aya_ebpf::helpers::PrintkArg
-pub fn aya_ebpf::helpers::PrintkArg::from(x: i64) -> Self
-impl core::convert::From<i8> for aya_ebpf::helpers::PrintkArg
-pub fn aya_ebpf::helpers::PrintkArg::from(x: i8) -> Self
-impl core::convert::From<isize> for aya_ebpf::helpers::PrintkArg
-pub fn aya_ebpf::helpers::PrintkArg::from(x: isize) -> Self
-impl core::convert::From<u16> for aya_ebpf::helpers::PrintkArg
-pub fn aya_ebpf::helpers::PrintkArg::from(x: u16) -> Self
-impl core::convert::From<u32> for aya_ebpf::helpers::PrintkArg
-pub fn aya_ebpf::helpers::PrintkArg::from(x: u32) -> Self
-impl core::convert::From<u64> for aya_ebpf::helpers::PrintkArg
-pub fn aya_ebpf::helpers::PrintkArg::from(x: u64) -> Self
-impl core::convert::From<u8> for aya_ebpf::helpers::PrintkArg
-pub fn aya_ebpf::helpers::PrintkArg::from(x: u8) -> Self
-impl core::convert::From<usize> for aya_ebpf::helpers::PrintkArg
-pub fn aya_ebpf::helpers::PrintkArg::from(x: usize) -> Self
-impl core::marker::Copy for aya_ebpf::helpers::PrintkArg
-impl<T> core::convert::From<*const T> for aya_ebpf::helpers::PrintkArg
-pub fn aya_ebpf::helpers::PrintkArg::from(x: *const T) -> Self
-impl<T> core::convert::From<*mut T> for aya_ebpf::helpers::PrintkArg
-pub fn aya_ebpf::helpers::PrintkArg::from(x: *mut T) -> Self
-impl core::marker::Freeze for aya_ebpf::helpers::PrintkArg
-impl core::marker::Send for aya_ebpf::helpers::PrintkArg
-impl core::marker::Sync for aya_ebpf::helpers::PrintkArg
-impl core::marker::Unpin for aya_ebpf::helpers::PrintkArg
-impl core::marker::UnsafeUnpin for aya_ebpf::helpers::PrintkArg
-impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::helpers::PrintkArg
-impl core::panic::unwind_safe::UnwindSafe for aya_ebpf::helpers::PrintkArg
-impl<T, U> core::convert::Into<U> for aya_ebpf::helpers::PrintkArg where U: core::convert::From<T>
-pub fn aya_ebpf::helpers::PrintkArg::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf::helpers::PrintkArg where U: core::convert::Into<T>
-pub type aya_ebpf::helpers::PrintkArg::Error = core::convert::Infallible
-pub fn aya_ebpf::helpers::PrintkArg::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf::helpers::PrintkArg where U: core::convert::TryFrom<T>
-pub type aya_ebpf::helpers::PrintkArg::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf::helpers::PrintkArg::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf::helpers::PrintkArg where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf::helpers::PrintkArg::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf::helpers::PrintkArg where T: ?core::marker::Sized
-pub fn aya_ebpf::helpers::PrintkArg::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf::helpers::PrintkArg where T: ?core::marker::Sized
-pub fn aya_ebpf::helpers::PrintkArg::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf::helpers::PrintkArg where T: core::clone::Clone
-pub unsafe fn aya_ebpf::helpers::PrintkArg::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_ebpf::helpers::PrintkArg
-pub fn aya_ebpf::helpers::PrintkArg::from(t: T) -> T
 pub const aya_ebpf::helpers::TASK_COMM_LEN: usize
 pub fn aya_ebpf::helpers::bpf_get_current_comm() -> core::result::Result<[u8; 16], i32>
 pub fn aya_ebpf::helpers::bpf_get_current_pid_tgid() -> u64


### PR DESCRIPTION
<!-- markdownlint-disable first-line-heading -->

This PR fixes an issue `aya_ebpf::helpers::bpf_printk()` emitting garbage values for arguments passed along with the format specifier such as `%x` to kernel traces.
This is basically a merge of #1451 and #1522 with a working integration test that both PRs lack, added (or rather rewritten).

* #1451 originally fixes the issue but it has been paused while addressing the review comments
* #1522 provides the cleaner way to fix the issue but without test

As a user of this helper, I just intend to move it forward so that the fix (done in #1451 or #1522) gets merged. I've kept their commits as-is to preserve credit. My commits can be squashed into theirs once reviews are complete.

Fixes: #1171


### Added/updated tests?

_We strongly encourage you to add a test for your changes._

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

### Checklist

- [x] Rust code has been formatted with `cargo +nightly fmt`.
- [x] All clippy lints have been fixed.
      You can find failing lints with `./clippy.sh`.
- [x] Unit tests are passing locally with `cargo test`.
- [x] The [Integration tests] are passing locally.
- [x] I have blessed any API changes with `cargo xtask public-api --bless`.

[Integration tests]: https://github.com/aya-rs/aya/blob/main/test/README.md

### (Optional) What GIF best describes this PR or how it makes you feel?

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aya-rs/aya/1523)
<!-- Reviewable:end -->
