### PR TITLE
fix(bloom_filter): simplify BTF map detection and fix peek syscall name

### DIFF
--- a/aya-obj/src/obj.rs
+++ b/aya-obj/src/obj.rs
@@ -1348,7 +1348,10 @@ fn parse_btf_map_def(btf: &Btf, info: &DataSecEntry) -> Result<(String, BtfMapDe
 
 /// Parses a [`bpf_map_info`] into a [`Map`].
 pub const fn parse_map_info(info: bpf_map_info, pinned: PinningType) -> Map {
-    if info.btf_key_type_id != 0 || info.btf_value_type_id != 0 {
+    // Some BTF maps are keyless, for example bloom filters, and may only set
+    // `btf_value_type_id`. Checking the value type avoids treating those maps
+    // as legacy maps.
+    if info.btf_value_type_id != 0 {
         Map::Btf(BtfMap {
             def: BtfMapDef {
                 map_type: info.type_,

--- a/aya/src/maps/bloom_filter.rs
+++ b/aya/src/maps/bloom_filter.rs
@@ -58,7 +58,7 @@ impl<T: Borrow<MapData>, V: Pod> BloomFilter<T, V> {
         let fd = self.inner.borrow().fd().as_fd();
 
         match bpf_map_peek_elem(fd, value.borrow(), flags).map_err(|io_error| SyscallError {
-            call: "bpf_map_lookup_elem",
+            call: "bpf_map_peek_elem",
             io_error,
         })? {
             None => Err(MapError::ElementNotFound),
@@ -183,7 +183,7 @@ mod tests {
 
         assert_matches!(
             bloom_filter.contains(1, 0),
-            Err(MapError::SyscallError(SyscallError { call: "bpf_map_lookup_elem", io_error })) if io_error.raw_os_error() == Some(EFAULT)
+            Err(MapError::SyscallError(SyscallError { call: "bpf_map_peek_elem", io_error })) if io_error.raw_os_error() == Some(EFAULT)
         );
     }
 


### PR DESCRIPTION
Simplify bloom filter BTF map detection and fix the syscall name reported by
`BloomFilter::contains`.

Checking both BTF type IDs in `parse_map_info` is redundant. For keyless BTF
maps such as bloom filters, `btf_value_type_id` is the reliable signal that the
map is BTF-backed, even when `btf_key_type_id` is unset. Using only the value
type keeps the detection logic simpler and avoids treating those maps as legacy
maps.

This also updates `BloomFilter::contains` to report `bpf_map_peek_elem`, which
matches the operation it actually performs.

### Added/updated tests?

- [x] Yes

### Checklist

- [x] Rust code has been formatted with `cargo +nightly fmt`.
- [x] All clippy lints have been fixed.
      You can find failing lints with `./clippy.sh`.
- [x] Unit tests are passing locally with `cargo test`.
- [ ] The [Integration tests] are passing locally.
- [ ] I have blessed any API changes with `cargo xtask public-api --bless`.

Checks run locally:
- `cargo +nightly fmt --all`
- `cargo xtask clippy`
- `cargo test`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aya-rs/aya/1524)
<!-- Reviewable:end -->
