### PR TITLE
aya-ebpf: use correct types for BPF helper return values

### DIFF
--- a/ebpf/aya-ebpf/src/btf_maps/bloom_filter.rs
+++ b/ebpf/aya-ebpf/src/btf_maps/bloom_filter.rs
@@ -1,7 +1,5 @@
 use core::{borrow::Borrow, ptr};
 
-use aya_ebpf_cty::c_long;
-
 use crate::{
     btf_maps::btf_map_def,
     helpers::{bpf_map_peek_elem, bpf_map_push_elem},
@@ -35,20 +33,20 @@ impl<T, const MAX_ENTRIES: usize, const FLAGS: usize, const HASH_FUNCS: usize>
     BloomFilter<T, MAX_ENTRIES, FLAGS, HASH_FUNCS>
 {
     #[inline(always)]
-    pub fn contains(&self, value: impl Borrow<T>) -> Result<(), c_long> {
+    pub fn contains(&self, value: impl Borrow<T>) -> Result<(), i32> {
         let value = ptr::from_ref(value.borrow());
         match unsafe { bpf_map_peek_elem(self.as_ptr(), value.cast_mut().cast()) } {
             0 => Ok(()),
-            ret => Err(ret),
+            ret => Err(ret as i32),
         }
     }
 
     #[inline(always)]
-    pub fn insert(&self, value: impl Borrow<T>, flags: u64) -> Result<(), c_long> {
+    pub fn insert(&self, value: impl Borrow<T>, flags: u64) -> Result<(), i32> {
         let value = ptr::from_ref(value.borrow());
         match unsafe { bpf_map_push_elem(self.as_ptr(), value.cast(), flags) } {
             0 => Ok(()),
-            ret => Err(ret),
+            ret => Err(ret as i32),
         }
     }
 }

--- a/ebpf/aya-ebpf/src/btf_maps/ring_buf.rs
+++ b/ebpf/aya-ebpf/src/btf_maps/ring_buf.rs
@@ -89,7 +89,7 @@ impl<T, const MAX_ENTRIES: usize, const FLAGS: usize> RingBuf<T, MAX_ENTRIES, FL
     }
 
     /// Copy `data` to the ring buffer output using the map's `T`.
-    pub fn output(&self, data: impl Borrow<T>, flags: u64) -> Result<(), i64> {
+    pub fn output(&self, data: impl Borrow<T>, flags: u64) -> Result<(), i32> {
         self.output_untyped::<T>(data, flags)
     }
 
@@ -108,7 +108,7 @@ impl<T, const MAX_ENTRIES: usize, const FLAGS: usize> RingBuf<T, MAX_ENTRIES, FL
     ///
     /// [`reserve`]: RingBuf::reserve
     /// [`submit`]: RingBufEntry::submit
-    pub fn output_untyped<U: ?Sized>(&self, data: impl Borrow<U>, flags: u64) -> Result<(), i64> {
+    pub fn output_untyped<U: ?Sized>(&self, data: impl Borrow<U>, flags: u64) -> Result<(), i32> {
         let data = data.borrow();
         assert_eq!(8 % align_of_val(data), 0);
         let ret = unsafe {
@@ -119,6 +119,6 @@ impl<T, const MAX_ENTRIES: usize, const FLAGS: usize> RingBuf<T, MAX_ENTRIES, FL
                 flags,
             )
         };
-        if ret < 0 { Err(ret) } else { Ok(()) }
+        if ret < 0 { Err(ret as i32) } else { Ok(()) }
     }
 }

--- a/ebpf/aya-ebpf/src/helpers.rs
+++ b/ebpf/aya-ebpf/src/helpers.rs
@@ -386,12 +386,12 @@ pub unsafe fn bpf_probe_read_user_str_bytes(src: *const u8, dest: &mut [u8]) -> 
     read_str_bytes(len, dest)
 }
 
-fn read_str_bytes(len: i64, dest: &[u8]) -> Result<&[u8], i32> {
+fn read_str_bytes(len: c_long, dest: &[u8]) -> Result<&[u8], i32> {
     // The lower bound is 0, since it's what is returned for b"\0". See the
     // bpf_probe_read_user_[user|kernel]_bytes_empty integration tests.  The upper bound
     // check is not needed since the helper truncates, but the verifier doesn't
     // know that so we show it the upper bound.
-    if !check_bounds_signed(len, 0, dest.len() as i64) {
+    if !check_bounds_signed(len, 0, dest.len() as c_long) {
         return Err(-1);
     }
 
@@ -772,7 +772,7 @@ impl<T> From<*mut T> for PrintkArg {
 pub unsafe fn bpf_printk_impl<const FMT_LEN: usize, const NUM_ARGS: usize>(
     fmt_ptr: *const u8,
     args: &[PrintkArg; NUM_ARGS],
-) -> i64 {
+) -> c_long {
     // This function can't be wrapped in `helpers.rs` because it has variadic
     // arguments. We also can't turn the definitions in `helpers.rs` into
     // `const`s because MIRI believes casting arbitrary integers to function

--- a/ebpf/aya-ebpf/src/lib.rs
+++ b/ebpf/aya-ebpf/src/lib.rs
@@ -144,7 +144,10 @@ pub const fn bpf_f_adj_room_encap_l2(len: u64) -> u64 {
 /// Check if a value is within a range, using conditional forms compatible with
 /// the verifier.
 #[inline(always)]
-pub fn check_bounds_signed(value: i64, lower: i64, upper: i64) -> bool {
+pub fn check_bounds_signed<T: Into<i64>>(value: T, lower: T, upper: T) -> bool {
+    let value = value.into();
+    let lower = lower.into();
+    let upper = upper.into();
     #[cfg(target_arch = "bpf")]
     unsafe {
         let mut in_bounds = 0u64;

--- a/ebpf/aya-ebpf/src/maps/bloom_filter.rs
+++ b/ebpf/aya-ebpf/src/maps/bloom_filter.rs
@@ -16,18 +16,18 @@ impl<T> BloomFilter<T> {
     map_constructors!((), T, BPF_MAP_TYPE_BLOOM_FILTER, phantom _t);
 
     #[inline]
-    pub fn contains(&self, value: impl Borrow<T>) -> Result<(), i64> {
+    pub fn contains(&self, value: impl Borrow<T>) -> Result<(), i32> {
         let ret = unsafe {
             bpf_map_peek_elem(
                 self.def.as_ptr().cast(),
                 ptr::from_ref(value.borrow()).cast_mut().cast(),
             )
         };
-        (ret == 0).then_some(()).ok_or(ret)
+        (ret == 0).then_some(()).ok_or(ret as i32)
     }
 
     #[inline]
-    pub fn insert(&self, value: impl Borrow<T>, flags: u64) -> Result<(), i64> {
+    pub fn insert(&self, value: impl Borrow<T>, flags: u64) -> Result<(), i32> {
         let ret = unsafe {
             bpf_map_push_elem(
                 self.def.as_ptr().cast(),
@@ -35,6 +35,6 @@ impl<T> BloomFilter<T> {
                 flags,
             )
         };
-        (ret == 0).then_some(()).ok_or(ret)
+        (ret == 0).then_some(()).ok_or(ret as i32)
     }
 }

--- a/ebpf/aya-ebpf/src/maps/queue.rs
+++ b/ebpf/aya-ebpf/src/maps/queue.rs
@@ -15,7 +15,7 @@ pub struct Queue<T> {
 impl<T> Queue<T> {
     map_constructors!((), T, BPF_MAP_TYPE_QUEUE, phantom _t);
 
-    pub fn push(&self, value: impl Borrow<T>, flags: u64) -> Result<(), i64> {
+    pub fn push(&self, value: impl Borrow<T>, flags: u64) -> Result<(), i32> {
         let ret = unsafe {
             bpf_map_push_elem(
                 self.def.as_ptr().cast(),
@@ -23,7 +23,7 @@ impl<T> Queue<T> {
                 flags,
             )
         };
-        (ret == 0).then_some(()).ok_or(ret)
+        (ret == 0).then_some(()).ok_or(ret as i32)
     }
 
     pub fn pop(&self) -> Option<T> {

--- a/ebpf/aya-ebpf/src/maps/ring_buf.rs
+++ b/ebpf/aya-ebpf/src/maps/ring_buf.rs
@@ -192,7 +192,7 @@ impl RingBuf {
     ///
     /// [`reserve`]: RingBuf::reserve
     /// [`submit`]: RingBufEntry::submit
-    pub fn output<T: ?Sized>(&self, data: impl Borrow<T>, flags: u64) -> Result<(), i64> {
+    pub fn output<T: ?Sized>(&self, data: impl Borrow<T>, flags: u64) -> Result<(), i32> {
         let data = data.borrow();
         assert_eq!(8 % align_of_val(data), 0);
         let ret = unsafe {
@@ -203,7 +203,7 @@ impl RingBuf {
                 flags,
             )
         };
-        if ret < 0 { Err(ret) } else { Ok(()) }
+        if ret < 0 { Err(ret as i32) } else { Ok(()) }
     }
 
     /// Query various information about the ring buffer.

--- a/ebpf/aya-ebpf/src/maps/sock_hash.rs
+++ b/ebpf/aya-ebpf/src/maps/sock_hash.rs
@@ -7,6 +7,7 @@ use core::{
 use crate::{
     EbpfContext as _,
     bindings::{bpf_map_type::BPF_MAP_TYPE_SOCKHASH, bpf_sock_ops},
+    cty::c_long,
     helpers::{
         bpf_msg_redirect_hash, bpf_sk_assign, bpf_sk_redirect_hash, bpf_sk_release,
         bpf_sock_hash_update,
@@ -30,7 +31,7 @@ impl<K> SockHash<K> {
         mut key: impl BorrowMut<K>,
         mut sk_ops: impl BorrowMut<bpf_sock_ops>,
         flags: u64,
-    ) -> Result<(), i64> {
+    ) -> Result<(), i32> {
         let ret = unsafe {
             bpf_sock_hash_update(
                 ptr::from_mut(sk_ops.borrow_mut()),
@@ -39,7 +40,7 @@ impl<K> SockHash<K> {
                 flags,
             )
         };
-        (ret == 0).then_some(()).ok_or(ret)
+        (ret == 0).then_some(()).ok_or(ret as i32)
     }
 
     pub fn redirect_msg(
@@ -47,7 +48,7 @@ impl<K> SockHash<K> {
         ctx: impl Borrow<SkMsgContext>,
         mut key: impl BorrowMut<K>,
         flags: u64,
-    ) -> i64 {
+    ) -> c_long {
         unsafe {
             bpf_msg_redirect_hash(
                 ctx.borrow().msg,
@@ -63,7 +64,7 @@ impl<K> SockHash<K> {
         ctx: impl Borrow<SkBuffContext>,
         mut key: impl BorrowMut<K>,
         flags: u64,
-    ) -> i64 {
+    ) -> c_long {
         unsafe {
             bpf_sk_redirect_hash(
                 ctx.borrow().skb.skb,
@@ -82,7 +83,7 @@ impl<K> SockHash<K> {
     ) -> Result<(), u32> {
         let sk = lookup(self.def.as_ptr(), key.borrow()).ok_or(1u32)?;
         let ret = unsafe { bpf_sk_assign(ctx.borrow().as_ptr().cast(), sk.as_ptr(), flags) };
-        let _: i64 = unsafe { bpf_sk_release(sk.as_ptr()) };
+        let _: c_long = unsafe { bpf_sk_release(sk.as_ptr()) };
         match ret {
             0 => Ok(()),
             _ret => Err(1),

--- a/ebpf/aya-ebpf/src/maps/sock_map.rs
+++ b/ebpf/aya-ebpf/src/maps/sock_map.rs
@@ -1,6 +1,7 @@
 use crate::{
     EbpfContext as _,
     bindings::{bpf_map_type::BPF_MAP_TYPE_SOCKMAP, bpf_sock_ops},
+    cty::c_long,
     helpers::{
         bpf_msg_redirect_map, bpf_sk_assign, bpf_sk_redirect_map, bpf_sk_release,
         bpf_sock_map_update,
@@ -24,7 +25,7 @@ impl SockMap {
         mut index: u32,
         sk_ops: *mut bpf_sock_ops,
         flags: u64,
-    ) -> Result<(), i64> {
+    ) -> Result<(), i32> {
         let ret = unsafe {
             bpf_sock_map_update(
                 sk_ops,
@@ -33,16 +34,16 @@ impl SockMap {
                 flags,
             )
         };
-        if ret == 0 { Ok(()) } else { Err(ret) }
+        if ret == 0 { Ok(()) } else { Err(ret as i32) }
     }
 
     #[expect(clippy::missing_safety_doc, reason = "TODO")]
-    pub unsafe fn redirect_msg(&self, ctx: &SkMsgContext, index: u32, flags: u64) -> i64 {
+    pub unsafe fn redirect_msg(&self, ctx: &SkMsgContext, index: u32, flags: u64) -> c_long {
         unsafe { bpf_msg_redirect_map(ctx.as_ptr().cast(), self.def.as_ptr().cast(), index, flags) }
     }
 
     #[expect(clippy::missing_safety_doc, reason = "TODO")]
-    pub unsafe fn redirect_skb(&self, ctx: &SkBuffContext, index: u32, flags: u64) -> i64 {
+    pub unsafe fn redirect_skb(&self, ctx: &SkBuffContext, index: u32, flags: u64) -> c_long {
         unsafe { bpf_sk_redirect_map(ctx.as_ptr().cast(), self.def.as_ptr().cast(), index, flags) }
     }
 
@@ -54,7 +55,7 @@ impl SockMap {
     ) -> Result<(), u32> {
         let sk = lookup(self.def.as_ptr(), &index).ok_or(1u32)?;
         let ret = unsafe { bpf_sk_assign(ctx.as_ptr().cast(), sk.as_ptr(), flags) };
-        let _: i64 = unsafe { bpf_sk_release(sk.as_ptr()) };
+        let _: c_long = unsafe { bpf_sk_release(sk.as_ptr()) };
         match ret {
             0 => Ok(()),
             _ret => Err(1),

--- a/ebpf/aya-ebpf/src/maps/stack.rs
+++ b/ebpf/aya-ebpf/src/maps/stack.rs
@@ -15,7 +15,7 @@ pub struct Stack<T> {
 impl<T> Stack<T> {
     map_constructors!((), T, BPF_MAP_TYPE_STACK, phantom _t);
 
-    pub fn push(&self, value: impl Borrow<T>, flags: u64) -> Result<(), i64> {
+    pub fn push(&self, value: impl Borrow<T>, flags: u64) -> Result<(), i32> {
         let ret = unsafe {
             bpf_map_push_elem(
                 self.def.as_ptr().cast(),
@@ -23,7 +23,7 @@ impl<T> Stack<T> {
                 flags,
             )
         };
-        (ret == 0).then_some(()).ok_or(ret)
+        (ret == 0).then_some(()).ok_or(ret as i32)
     }
 
     pub fn pop(&self) -> Option<T> {

--- a/ebpf/aya-ebpf/src/maps/stack_trace.rs
+++ b/ebpf/aya-ebpf/src/maps/stack_trace.rs
@@ -3,6 +3,7 @@ use core::borrow::Borrow;
 use crate::{
     EbpfContext,
     bindings::bpf_map_type::BPF_MAP_TYPE_STACK_TRACE,
+    cty::c_long,
     helpers::bpf_get_stackid,
     maps::{MapDef, PinningType},
 };
@@ -25,9 +26,9 @@ impl StackTrace {
         &self,
         ctx: impl Borrow<C>,
         flags: u64,
-    ) -> Result<i64, i64> {
+    ) -> Result<c_long, i32> {
         let ret =
             unsafe { bpf_get_stackid(ctx.borrow().as_ptr(), self.def.as_ptr().cast(), flags) };
-        if ret < 0 { Err(ret) } else { Ok(ret) }
+        if ret < 0 { Err(ret as i32) } else { Ok(ret) }
     }
 }

--- a/ebpf/aya-ebpf/src/programs/sk_msg.rs
+++ b/ebpf/aya-ebpf/src/programs/sk_msg.rs
@@ -27,14 +27,14 @@ impl SkMsgContext {
         unsafe { (*self.msg).__bindgen_anon_2.data_end as usize }
     }
 
-    pub fn push_data(&self, start: u32, len: u32, flags: u64) -> Result<(), i64> {
+    pub fn push_data(&self, start: u32, len: u32, flags: u64) -> Result<(), i32> {
         let ret = unsafe { bpf_msg_push_data(self.msg, start, len, flags) };
-        if ret == 0 { Ok(()) } else { Err(ret) }
+        if ret == 0 { Ok(()) } else { Err(ret as i32) }
     }
 
-    pub fn pop_data(&self, start: u32, len: u32, flags: u64) -> Result<(), i64> {
+    pub fn pop_data(&self, start: u32, len: u32, flags: u64) -> Result<(), i32> {
         let ret = unsafe { bpf_msg_pop_data(self.msg, start, len, flags) };
-        if ret == 0 { Ok(()) } else { Err(ret) }
+        if ret == 0 { Ok(()) } else { Err(ret as i32) }
     }
 }
 

--- a/ebpf/aya-ebpf/src/programs/sock_ops.rs
+++ b/ebpf/aya-ebpf/src/programs/sock_ops.rs
@@ -25,9 +25,9 @@ impl SockOpsContext {
         unsafe { (*self.ops).bpf_sock_ops_cb_flags }
     }
 
-    pub fn set_cb_flags(&self, flags: i32) -> Result<(), i64> {
+    pub fn set_cb_flags(&self, flags: i32) -> Result<(), i32> {
         let ret = unsafe { bpf_sock_ops_cb_flags_set(self.ops, flags) };
-        if ret == 0 { Ok(()) } else { Err(ret) }
+        if ret == 0 { Ok(()) } else { Err(ret as i32) }
     }
 
     pub fn remote_ip4(&self) -> u32 {

--- a/test/integration-ebpf/src/bloom_filter.rs
+++ b/test/integration-ebpf/src/bloom_filter.rs
@@ -7,7 +7,6 @@ extern crate ebpf_panic;
 
 use aya_ebpf::{
     btf_maps::{Array as BtfArray, BloomFilter as BtfBloomFilter},
-    cty::c_long,
     macros::{btf_map, map, uprobe},
     maps::{Array as LegacyArray, BloomFilter as LegacyBloomFilter},
     programs::ProbeContext,
@@ -29,10 +28,10 @@ static RESULT_LEGACY: LegacyArray<i32> = LegacyArray::<i32>::with_max_entries(RE
 static FILTER_LEGACY: LegacyBloomFilter<u32> = LegacyBloomFilter::with_max_entries(64, 0);
 
 #[inline(always)]
-const fn map_result(result: Result<(), c_long>) -> i32 {
+const fn map_result(result: Result<(), i32>) -> i32 {
     match result {
         Ok(()) => 0,
-        Err(err) => err as i32,
+        Err(err) => err,
     }
 }
 

--- a/xtask/public-api/aya-ebpf.txt
+++ b/xtask/public-api/aya-ebpf.txt
@@ -42,8 +42,8 @@ pub fn aya_ebpf::btf_maps::array::Array<T, MAX_ENTRIES, FLAGS>::from(t: T) -> T
 pub mod aya_ebpf::btf_maps::bloom_filter
 #[repr(C)] pub struct aya_ebpf::btf_maps::bloom_filter::BloomFilter<T, const MAX_ENTRIES: usize, const FLAGS: usize, const HASH_FUNCS: usize>
 impl<T, const MAX_ENTRIES: usize, const FLAGS: usize, const HASH_FUNCS: usize> aya_ebpf::btf_maps::bloom_filter::BloomFilter<T, MAX_ENTRIES, FLAGS, HASH_FUNCS>
-pub fn aya_ebpf::btf_maps::bloom_filter::BloomFilter<T, MAX_ENTRIES, FLAGS, HASH_FUNCS>::contains(&self, value: impl core::borrow::Borrow<T>) -> core::result::Result<(), aya_ebpf_cty::od::c_long>
-pub fn aya_ebpf::btf_maps::bloom_filter::BloomFilter<T, MAX_ENTRIES, FLAGS, HASH_FUNCS>::insert(&self, value: impl core::borrow::Borrow<T>, flags: u64) -> core::result::Result<(), aya_ebpf_cty::od::c_long>
+pub fn aya_ebpf::btf_maps::bloom_filter::BloomFilter<T, MAX_ENTRIES, FLAGS, HASH_FUNCS>::contains(&self, value: impl core::borrow::Borrow<T>) -> core::result::Result<(), i32>
+pub fn aya_ebpf::btf_maps::bloom_filter::BloomFilter<T, MAX_ENTRIES, FLAGS, HASH_FUNCS>::insert(&self, value: impl core::borrow::Borrow<T>, flags: u64) -> core::result::Result<(), i32>
 impl<T, const MAX_ENTRIES: usize, const FLAGS: usize, const HASH_FUNCS: usize> aya_ebpf::btf_maps::bloom_filter::BloomFilter<T, MAX_ENTRIES, FLAGS, HASH_FUNCS>
 pub const fn aya_ebpf::btf_maps::bloom_filter::BloomFilter<T, MAX_ENTRIES, FLAGS, HASH_FUNCS>::new() -> Self
 impl<T, const MAX_ENTRIES: usize, const FLAGS: usize, const HASH_FUNCS: usize> core::default::Default for aya_ebpf::btf_maps::bloom_filter::BloomFilter<T, MAX_ENTRIES, FLAGS, HASH_FUNCS>
@@ -76,8 +76,8 @@ pub mod aya_ebpf::btf_maps::ring_buf
 impl<T, const MAX_ENTRIES: usize, const FLAGS: usize> aya_ebpf::btf_maps::ring_buf::RingBuf<T, MAX_ENTRIES, FLAGS>
 pub const fn aya_ebpf::btf_maps::ring_buf::RingBuf<T, MAX_ENTRIES, FLAGS>::new() -> Self
 impl<T, const MAX_ENTRIES: usize, const FLAGS: usize> aya_ebpf::btf_maps::ring_buf::RingBuf<T, MAX_ENTRIES, FLAGS>
-pub fn aya_ebpf::btf_maps::ring_buf::RingBuf<T, MAX_ENTRIES, FLAGS>::output(&self, data: impl core::borrow::Borrow<T>, flags: u64) -> core::result::Result<(), i64>
-pub fn aya_ebpf::btf_maps::ring_buf::RingBuf<T, MAX_ENTRIES, FLAGS>::output_untyped<U: ?core::marker::Sized>(&self, data: impl core::borrow::Borrow<U>, flags: u64) -> core::result::Result<(), i64>
+pub fn aya_ebpf::btf_maps::ring_buf::RingBuf<T, MAX_ENTRIES, FLAGS>::output(&self, data: impl core::borrow::Borrow<T>, flags: u64) -> core::result::Result<(), i32>
+pub fn aya_ebpf::btf_maps::ring_buf::RingBuf<T, MAX_ENTRIES, FLAGS>::output_untyped<U: ?core::marker::Sized>(&self, data: impl core::borrow::Borrow<U>, flags: u64) -> core::result::Result<(), i32>
 pub fn aya_ebpf::btf_maps::ring_buf::RingBuf<T, MAX_ENTRIES, FLAGS>::reserve(&self, flags: u64) -> core::option::Option<aya_ebpf::maps::ring_buf::RingBufEntry<T>> where T: 'static
 pub fn aya_ebpf::btf_maps::ring_buf::RingBuf<T, MAX_ENTRIES, FLAGS>::reserve_bytes(&self, size: usize, flags: u64) -> core::option::Option<aya_ebpf::maps::ring_buf::RingBufBytes<'_>>
 pub fn aya_ebpf::btf_maps::ring_buf::RingBuf<T, MAX_ENTRIES, FLAGS>::reserve_untyped<U: 'static>(&self, flags: u64) -> core::option::Option<aya_ebpf::maps::ring_buf::RingBufEntry<U>>
@@ -174,8 +174,8 @@ impl<T> core::convert::From<T> for aya_ebpf::btf_maps::array::Array<T, MAX_ENTRI
 pub fn aya_ebpf::btf_maps::array::Array<T, MAX_ENTRIES, FLAGS>::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf::btf_maps::BloomFilter<T, const MAX_ENTRIES: usize, const FLAGS: usize, const HASH_FUNCS: usize>
 impl<T, const MAX_ENTRIES: usize, const FLAGS: usize, const HASH_FUNCS: usize> aya_ebpf::btf_maps::bloom_filter::BloomFilter<T, MAX_ENTRIES, FLAGS, HASH_FUNCS>
-pub fn aya_ebpf::btf_maps::bloom_filter::BloomFilter<T, MAX_ENTRIES, FLAGS, HASH_FUNCS>::contains(&self, value: impl core::borrow::Borrow<T>) -> core::result::Result<(), aya_ebpf_cty::od::c_long>
-pub fn aya_ebpf::btf_maps::bloom_filter::BloomFilter<T, MAX_ENTRIES, FLAGS, HASH_FUNCS>::insert(&self, value: impl core::borrow::Borrow<T>, flags: u64) -> core::result::Result<(), aya_ebpf_cty::od::c_long>
+pub fn aya_ebpf::btf_maps::bloom_filter::BloomFilter<T, MAX_ENTRIES, FLAGS, HASH_FUNCS>::contains(&self, value: impl core::borrow::Borrow<T>) -> core::result::Result<(), i32>
+pub fn aya_ebpf::btf_maps::bloom_filter::BloomFilter<T, MAX_ENTRIES, FLAGS, HASH_FUNCS>::insert(&self, value: impl core::borrow::Borrow<T>, flags: u64) -> core::result::Result<(), i32>
 impl<T, const MAX_ENTRIES: usize, const FLAGS: usize, const HASH_FUNCS: usize> aya_ebpf::btf_maps::bloom_filter::BloomFilter<T, MAX_ENTRIES, FLAGS, HASH_FUNCS>
 pub const fn aya_ebpf::btf_maps::bloom_filter::BloomFilter<T, MAX_ENTRIES, FLAGS, HASH_FUNCS>::new() -> Self
 impl<T, const MAX_ENTRIES: usize, const FLAGS: usize, const HASH_FUNCS: usize> core::default::Default for aya_ebpf::btf_maps::bloom_filter::BloomFilter<T, MAX_ENTRIES, FLAGS, HASH_FUNCS>
@@ -207,8 +207,8 @@ pub fn aya_ebpf::btf_maps::bloom_filter::BloomFilter<T, MAX_ENTRIES, FLAGS, HASH
 impl<T, const MAX_ENTRIES: usize, const FLAGS: usize> aya_ebpf::btf_maps::ring_buf::RingBuf<T, MAX_ENTRIES, FLAGS>
 pub const fn aya_ebpf::btf_maps::ring_buf::RingBuf<T, MAX_ENTRIES, FLAGS>::new() -> Self
 impl<T, const MAX_ENTRIES: usize, const FLAGS: usize> aya_ebpf::btf_maps::ring_buf::RingBuf<T, MAX_ENTRIES, FLAGS>
-pub fn aya_ebpf::btf_maps::ring_buf::RingBuf<T, MAX_ENTRIES, FLAGS>::output(&self, data: impl core::borrow::Borrow<T>, flags: u64) -> core::result::Result<(), i64>
-pub fn aya_ebpf::btf_maps::ring_buf::RingBuf<T, MAX_ENTRIES, FLAGS>::output_untyped<U: ?core::marker::Sized>(&self, data: impl core::borrow::Borrow<U>, flags: u64) -> core::result::Result<(), i64>
+pub fn aya_ebpf::btf_maps::ring_buf::RingBuf<T, MAX_ENTRIES, FLAGS>::output(&self, data: impl core::borrow::Borrow<T>, flags: u64) -> core::result::Result<(), i32>
+pub fn aya_ebpf::btf_maps::ring_buf::RingBuf<T, MAX_ENTRIES, FLAGS>::output_untyped<U: ?core::marker::Sized>(&self, data: impl core::borrow::Borrow<U>, flags: u64) -> core::result::Result<(), i32>
 pub fn aya_ebpf::btf_maps::ring_buf::RingBuf<T, MAX_ENTRIES, FLAGS>::reserve(&self, flags: u64) -> core::option::Option<aya_ebpf::maps::ring_buf::RingBufEntry<T>> where T: 'static
 pub fn aya_ebpf::btf_maps::ring_buf::RingBuf<T, MAX_ENTRIES, FLAGS>::reserve_bytes(&self, size: usize, flags: u64) -> core::option::Option<aya_ebpf::maps::ring_buf::RingBufBytes<'_>>
 pub fn aya_ebpf::btf_maps::ring_buf::RingBuf<T, MAX_ENTRIES, FLAGS>::reserve_untyped<U: 'static>(&self, flags: u64) -> core::option::Option<aya_ebpf::maps::ring_buf::RingBufEntry<U>>
@@ -325,8 +325,8 @@ pub fn aya_ebpf::maps::array::Array<T>::from(t: T) -> T
 pub mod aya_ebpf::maps::bloom_filter
 #[repr(transparent)] pub struct aya_ebpf::maps::bloom_filter::BloomFilter<T>
 impl<T> aya_ebpf::maps::bloom_filter::BloomFilter<T>
-pub fn aya_ebpf::maps::bloom_filter::BloomFilter<T>::contains(&self, value: impl core::borrow::Borrow<T>) -> core::result::Result<(), i64>
-pub fn aya_ebpf::maps::bloom_filter::BloomFilter<T>::insert(&self, value: impl core::borrow::Borrow<T>, flags: u64) -> core::result::Result<(), i64>
+pub fn aya_ebpf::maps::bloom_filter::BloomFilter<T>::contains(&self, value: impl core::borrow::Borrow<T>) -> core::result::Result<(), i32>
+pub fn aya_ebpf::maps::bloom_filter::BloomFilter<T>::insert(&self, value: impl core::borrow::Borrow<T>, flags: u64) -> core::result::Result<(), i32>
 pub const fn aya_ebpf::maps::bloom_filter::BloomFilter<T>::pinned(max_entries: u32, flags: u32) -> Self
 pub const fn aya_ebpf::maps::bloom_filter::BloomFilter<T>::with_max_entries(max_entries: u32, flags: u32) -> Self
 impl<T> !core::marker::Freeze for aya_ebpf::maps::bloom_filter::BloomFilter<T>
@@ -665,7 +665,7 @@ impl<T> aya_ebpf::maps::queue::Queue<T>
 pub fn aya_ebpf::maps::queue::Queue<T>::peek(&self) -> core::option::Option<T>
 pub const fn aya_ebpf::maps::queue::Queue<T>::pinned(max_entries: u32, flags: u32) -> Self
 pub fn aya_ebpf::maps::queue::Queue<T>::pop(&self) -> core::option::Option<T>
-pub fn aya_ebpf::maps::queue::Queue<T>::push(&self, value: impl core::borrow::Borrow<T>, flags: u64) -> core::result::Result<(), i64>
+pub fn aya_ebpf::maps::queue::Queue<T>::push(&self, value: impl core::borrow::Borrow<T>, flags: u64) -> core::result::Result<(), i32>
 pub const fn aya_ebpf::maps::queue::Queue<T>::with_max_entries(max_entries: u32, flags: u32) -> Self
 impl<T> !core::marker::Freeze for aya_ebpf::maps::queue::Queue<T>
 impl<T> core::marker::Send for aya_ebpf::maps::queue::Queue<T> where T: core::marker::Send
@@ -693,7 +693,7 @@ pub fn aya_ebpf::maps::queue::Queue<T>::from(t: T) -> T
 pub mod aya_ebpf::maps::ring_buf
 #[repr(transparent)] pub struct aya_ebpf::maps::ring_buf::RingBuf
 impl aya_ebpf::maps::ring_buf::RingBuf
-pub fn aya_ebpf::maps::ring_buf::RingBuf::output<T: ?core::marker::Sized>(&self, data: impl core::borrow::Borrow<T>, flags: u64) -> core::result::Result<(), i64>
+pub fn aya_ebpf::maps::ring_buf::RingBuf::output<T: ?core::marker::Sized>(&self, data: impl core::borrow::Borrow<T>, flags: u64) -> core::result::Result<(), i32>
 pub const fn aya_ebpf::maps::ring_buf::RingBuf::pinned(byte_size: u32, flags: u32) -> Self
 pub fn aya_ebpf::maps::ring_buf::RingBuf::query(&self, flags: u64) -> u64
 pub fn aya_ebpf::maps::ring_buf::RingBuf::reserve<T: 'static>(&self, flags: u64) -> core::option::Option<aya_ebpf::maps::ring_buf::RingBufEntry<T>>
@@ -794,10 +794,10 @@ pub mod aya_ebpf::maps::sock_hash
 #[repr(transparent)] pub struct aya_ebpf::maps::sock_hash::SockHash<K>
 impl<K> aya_ebpf::maps::sock_hash::SockHash<K>
 pub const fn aya_ebpf::maps::sock_hash::SockHash<K>::pinned(max_entries: u32, flags: u32) -> Self
-pub fn aya_ebpf::maps::sock_hash::SockHash<K>::redirect_msg(&self, ctx: impl core::borrow::Borrow<aya_ebpf::programs::sk_msg::SkMsgContext>, key: impl core::borrow::BorrowMut<K>, flags: u64) -> i64
+pub fn aya_ebpf::maps::sock_hash::SockHash<K>::redirect_msg(&self, ctx: impl core::borrow::Borrow<aya_ebpf::programs::sk_msg::SkMsgContext>, key: impl core::borrow::BorrowMut<K>, flags: u64) -> aya_ebpf_cty::od::c_long
 pub fn aya_ebpf::maps::sock_hash::SockHash<K>::redirect_sk_lookup(&self, ctx: impl core::borrow::Borrow<aya_ebpf::programs::sk_lookup::SkLookupContext>, key: impl core::borrow::Borrow<K>, flags: u64) -> core::result::Result<(), u32>
-pub fn aya_ebpf::maps::sock_hash::SockHash<K>::redirect_skb(&self, ctx: impl core::borrow::Borrow<aya_ebpf::programs::sk_buff::SkBuffContext>, key: impl core::borrow::BorrowMut<K>, flags: u64) -> i64
-pub fn aya_ebpf::maps::sock_hash::SockHash<K>::update(&self, key: impl core::borrow::BorrowMut<K>, sk_ops: impl core::borrow::BorrowMut<aya_ebpf_bindings::x86_64::bindings::bpf_sock_ops>, flags: u64) -> core::result::Result<(), i64>
+pub fn aya_ebpf::maps::sock_hash::SockHash<K>::redirect_skb(&self, ctx: impl core::borrow::Borrow<aya_ebpf::programs::sk_buff::SkBuffContext>, key: impl core::borrow::BorrowMut<K>, flags: u64) -> aya_ebpf_cty::od::c_long
+pub fn aya_ebpf::maps::sock_hash::SockHash<K>::update(&self, key: impl core::borrow::BorrowMut<K>, sk_ops: impl core::borrow::BorrowMut<aya_ebpf_bindings::x86_64::bindings::bpf_sock_ops>, flags: u64) -> core::result::Result<(), i32>
 pub const fn aya_ebpf::maps::sock_hash::SockHash<K>::with_max_entries(max_entries: u32, flags: u32) -> Self
 impl<K> !core::marker::Freeze for aya_ebpf::maps::sock_hash::SockHash<K>
 impl<K> core::marker::Send for aya_ebpf::maps::sock_hash::SockHash<K> where K: core::marker::Send
@@ -826,10 +826,10 @@ pub mod aya_ebpf::maps::sock_map
 #[repr(transparent)] pub struct aya_ebpf::maps::sock_map::SockMap
 impl aya_ebpf::maps::sock_map::SockMap
 pub const fn aya_ebpf::maps::sock_map::SockMap::pinned(max_entries: u32, flags: u32) -> Self
-pub unsafe fn aya_ebpf::maps::sock_map::SockMap::redirect_msg(&self, ctx: &aya_ebpf::programs::sk_msg::SkMsgContext, index: u32, flags: u64) -> i64
+pub unsafe fn aya_ebpf::maps::sock_map::SockMap::redirect_msg(&self, ctx: &aya_ebpf::programs::sk_msg::SkMsgContext, index: u32, flags: u64) -> aya_ebpf_cty::od::c_long
 pub fn aya_ebpf::maps::sock_map::SockMap::redirect_sk_lookup(&self, ctx: &aya_ebpf::programs::sk_lookup::SkLookupContext, index: u32, flags: u64) -> core::result::Result<(), u32>
-pub unsafe fn aya_ebpf::maps::sock_map::SockMap::redirect_skb(&self, ctx: &aya_ebpf::programs::sk_buff::SkBuffContext, index: u32, flags: u64) -> i64
-pub unsafe fn aya_ebpf::maps::sock_map::SockMap::update(&self, index: u32, sk_ops: *mut aya_ebpf_bindings::x86_64::bindings::bpf_sock_ops, flags: u64) -> core::result::Result<(), i64>
+pub unsafe fn aya_ebpf::maps::sock_map::SockMap::redirect_skb(&self, ctx: &aya_ebpf::programs::sk_buff::SkBuffContext, index: u32, flags: u64) -> aya_ebpf_cty::od::c_long
+pub unsafe fn aya_ebpf::maps::sock_map::SockMap::update(&self, index: u32, sk_ops: *mut aya_ebpf_bindings::x86_64::bindings::bpf_sock_ops, flags: u64) -> core::result::Result<(), i32>
 pub const fn aya_ebpf::maps::sock_map::SockMap::with_max_entries(max_entries: u32, flags: u32) -> Self
 impl !core::marker::Freeze for aya_ebpf::maps::sock_map::SockMap
 impl core::marker::Send for aya_ebpf::maps::sock_map::SockMap
@@ -860,7 +860,7 @@ impl<T> aya_ebpf::maps::stack::Stack<T>
 pub fn aya_ebpf::maps::stack::Stack<T>::peek(&self) -> core::option::Option<T>
 pub const fn aya_ebpf::maps::stack::Stack<T>::pinned(max_entries: u32, flags: u32) -> Self
 pub fn aya_ebpf::maps::stack::Stack<T>::pop(&self) -> core::option::Option<T>
-pub fn aya_ebpf::maps::stack::Stack<T>::push(&self, value: impl core::borrow::Borrow<T>, flags: u64) -> core::result::Result<(), i64>
+pub fn aya_ebpf::maps::stack::Stack<T>::push(&self, value: impl core::borrow::Borrow<T>, flags: u64) -> core::result::Result<(), i32>
 pub const fn aya_ebpf::maps::stack::Stack<T>::with_max_entries(max_entries: u32, flags: u32) -> Self
 impl<T> !core::marker::Freeze for aya_ebpf::maps::stack::Stack<T>
 impl<T> core::marker::Send for aya_ebpf::maps::stack::Stack<T> where T: core::marker::Send
@@ -888,7 +888,7 @@ pub fn aya_ebpf::maps::stack::Stack<T>::from(t: T) -> T
 pub mod aya_ebpf::maps::stack_trace
 #[repr(transparent)] pub struct aya_ebpf::maps::stack_trace::StackTrace
 impl aya_ebpf::maps::stack_trace::StackTrace
-pub unsafe fn aya_ebpf::maps::stack_trace::StackTrace::get_stackid<C: aya_ebpf::EbpfContext>(&self, ctx: impl core::borrow::Borrow<C>, flags: u64) -> core::result::Result<i64, i64>
+pub unsafe fn aya_ebpf::maps::stack_trace::StackTrace::get_stackid<C: aya_ebpf::EbpfContext>(&self, ctx: impl core::borrow::Borrow<C>, flags: u64) -> core::result::Result<aya_ebpf_cty::od::c_long, i32>
 pub const fn aya_ebpf::maps::stack_trace::StackTrace::pinned(max_entries: u32, flags: u32) -> Self
 pub const fn aya_ebpf::maps::stack_trace::StackTrace::with_max_entries(max_entries: u32, flags: u32) -> Self
 impl !core::marker::Freeze for aya_ebpf::maps::stack_trace::StackTrace
@@ -1063,8 +1063,8 @@ impl<T> core::convert::From<T> for aya_ebpf::maps::array::Array<T>
 pub fn aya_ebpf::maps::array::Array<T>::from(t: T) -> T
 #[repr(transparent)] pub struct aya_ebpf::maps::BloomFilter<T>
 impl<T> aya_ebpf::maps::bloom_filter::BloomFilter<T>
-pub fn aya_ebpf::maps::bloom_filter::BloomFilter<T>::contains(&self, value: impl core::borrow::Borrow<T>) -> core::result::Result<(), i64>
-pub fn aya_ebpf::maps::bloom_filter::BloomFilter<T>::insert(&self, value: impl core::borrow::Borrow<T>, flags: u64) -> core::result::Result<(), i64>
+pub fn aya_ebpf::maps::bloom_filter::BloomFilter<T>::contains(&self, value: impl core::borrow::Borrow<T>) -> core::result::Result<(), i32>
+pub fn aya_ebpf::maps::bloom_filter::BloomFilter<T>::insert(&self, value: impl core::borrow::Borrow<T>, flags: u64) -> core::result::Result<(), i32>
 pub const fn aya_ebpf::maps::bloom_filter::BloomFilter<T>::pinned(max_entries: u32, flags: u32) -> Self
 pub const fn aya_ebpf::maps::bloom_filter::BloomFilter<T>::with_max_entries(max_entries: u32, flags: u32) -> Self
 impl<T> !core::marker::Freeze for aya_ebpf::maps::bloom_filter::BloomFilter<T>
@@ -1455,7 +1455,7 @@ impl<T> aya_ebpf::maps::queue::Queue<T>
 pub fn aya_ebpf::maps::queue::Queue<T>::peek(&self) -> core::option::Option<T>
 pub const fn aya_ebpf::maps::queue::Queue<T>::pinned(max_entries: u32, flags: u32) -> Self
 pub fn aya_ebpf::maps::queue::Queue<T>::pop(&self) -> core::option::Option<T>
-pub fn aya_ebpf::maps::queue::Queue<T>::push(&self, value: impl core::borrow::Borrow<T>, flags: u64) -> core::result::Result<(), i64>
+pub fn aya_ebpf::maps::queue::Queue<T>::push(&self, value: impl core::borrow::Borrow<T>, flags: u64) -> core::result::Result<(), i32>
 pub const fn aya_ebpf::maps::queue::Queue<T>::with_max_entries(max_entries: u32, flags: u32) -> Self
 impl<T> !core::marker::Freeze for aya_ebpf::maps::queue::Queue<T>
 impl<T> core::marker::Send for aya_ebpf::maps::queue::Queue<T> where T: core::marker::Send
@@ -1482,7 +1482,7 @@ impl<T> core::convert::From<T> for aya_ebpf::maps::queue::Queue<T>
 pub fn aya_ebpf::maps::queue::Queue<T>::from(t: T) -> T
 #[repr(transparent)] pub struct aya_ebpf::maps::RingBuf
 impl aya_ebpf::maps::ring_buf::RingBuf
-pub fn aya_ebpf::maps::ring_buf::RingBuf::output<T: ?core::marker::Sized>(&self, data: impl core::borrow::Borrow<T>, flags: u64) -> core::result::Result<(), i64>
+pub fn aya_ebpf::maps::ring_buf::RingBuf::output<T: ?core::marker::Sized>(&self, data: impl core::borrow::Borrow<T>, flags: u64) -> core::result::Result<(), i32>
 pub const fn aya_ebpf::maps::ring_buf::RingBuf::pinned(byte_size: u32, flags: u32) -> Self
 pub fn aya_ebpf::maps::ring_buf::RingBuf::query(&self, flags: u64) -> u64
 pub fn aya_ebpf::maps::ring_buf::RingBuf::reserve<T: 'static>(&self, flags: u64) -> core::option::Option<aya_ebpf::maps::ring_buf::RingBufEntry<T>>
@@ -1514,10 +1514,10 @@ pub fn aya_ebpf::maps::ring_buf::RingBuf::from(t: T) -> T
 #[repr(transparent)] pub struct aya_ebpf::maps::SockHash<K>
 impl<K> aya_ebpf::maps::sock_hash::SockHash<K>
 pub const fn aya_ebpf::maps::sock_hash::SockHash<K>::pinned(max_entries: u32, flags: u32) -> Self
-pub fn aya_ebpf::maps::sock_hash::SockHash<K>::redirect_msg(&self, ctx: impl core::borrow::Borrow<aya_ebpf::programs::sk_msg::SkMsgContext>, key: impl core::borrow::BorrowMut<K>, flags: u64) -> i64
+pub fn aya_ebpf::maps::sock_hash::SockHash<K>::redirect_msg(&self, ctx: impl core::borrow::Borrow<aya_ebpf::programs::sk_msg::SkMsgContext>, key: impl core::borrow::BorrowMut<K>, flags: u64) -> aya_ebpf_cty::od::c_long
 pub fn aya_ebpf::maps::sock_hash::SockHash<K>::redirect_sk_lookup(&self, ctx: impl core::borrow::Borrow<aya_ebpf::programs::sk_lookup::SkLookupContext>, key: impl core::borrow::Borrow<K>, flags: u64) -> core::result::Result<(), u32>
-pub fn aya_ebpf::maps::sock_hash::SockHash<K>::redirect_skb(&self, ctx: impl core::borrow::Borrow<aya_ebpf::programs::sk_buff::SkBuffContext>, key: impl core::borrow::BorrowMut<K>, flags: u64) -> i64
-pub fn aya_ebpf::maps::sock_hash::SockHash<K>::update(&self, key: impl core::borrow::BorrowMut<K>, sk_ops: impl core::borrow::BorrowMut<aya_ebpf_bindings::x86_64::bindings::bpf_sock_ops>, flags: u64) -> core::result::Result<(), i64>
+pub fn aya_ebpf::maps::sock_hash::SockHash<K>::redirect_skb(&self, ctx: impl core::borrow::Borrow<aya_ebpf::programs::sk_buff::SkBuffContext>, key: impl core::borrow::BorrowMut<K>, flags: u64) -> aya_ebpf_cty::od::c_long
+pub fn aya_ebpf::maps::sock_hash::SockHash<K>::update(&self, key: impl core::borrow::BorrowMut<K>, sk_ops: impl core::borrow::BorrowMut<aya_ebpf_bindings::x86_64::bindings::bpf_sock_ops>, flags: u64) -> core::result::Result<(), i32>
 pub const fn aya_ebpf::maps::sock_hash::SockHash<K>::with_max_entries(max_entries: u32, flags: u32) -> Self
 impl<K> !core::marker::Freeze for aya_ebpf::maps::sock_hash::SockHash<K>
 impl<K> core::marker::Send for aya_ebpf::maps::sock_hash::SockHash<K> where K: core::marker::Send
@@ -1545,10 +1545,10 @@ pub fn aya_ebpf::maps::sock_hash::SockHash<K>::from(t: T) -> T
 #[repr(transparent)] pub struct aya_ebpf::maps::SockMap
 impl aya_ebpf::maps::sock_map::SockMap
 pub const fn aya_ebpf::maps::sock_map::SockMap::pinned(max_entries: u32, flags: u32) -> Self
-pub unsafe fn aya_ebpf::maps::sock_map::SockMap::redirect_msg(&self, ctx: &aya_ebpf::programs::sk_msg::SkMsgContext, index: u32, flags: u64) -> i64
+pub unsafe fn aya_ebpf::maps::sock_map::SockMap::redirect_msg(&self, ctx: &aya_ebpf::programs::sk_msg::SkMsgContext, index: u32, flags: u64) -> aya_ebpf_cty::od::c_long
 pub fn aya_ebpf::maps::sock_map::SockMap::redirect_sk_lookup(&self, ctx: &aya_ebpf::programs::sk_lookup::SkLookupContext, index: u32, flags: u64) -> core::result::Result<(), u32>
-pub unsafe fn aya_ebpf::maps::sock_map::SockMap::redirect_skb(&self, ctx: &aya_ebpf::programs::sk_buff::SkBuffContext, index: u32, flags: u64) -> i64
-pub unsafe fn aya_ebpf::maps::sock_map::SockMap::update(&self, index: u32, sk_ops: *mut aya_ebpf_bindings::x86_64::bindings::bpf_sock_ops, flags: u64) -> core::result::Result<(), i64>
+pub unsafe fn aya_ebpf::maps::sock_map::SockMap::redirect_skb(&self, ctx: &aya_ebpf::programs::sk_buff::SkBuffContext, index: u32, flags: u64) -> aya_ebpf_cty::od::c_long
+pub unsafe fn aya_ebpf::maps::sock_map::SockMap::update(&self, index: u32, sk_ops: *mut aya_ebpf_bindings::x86_64::bindings::bpf_sock_ops, flags: u64) -> core::result::Result<(), i32>
 pub const fn aya_ebpf::maps::sock_map::SockMap::with_max_entries(max_entries: u32, flags: u32) -> Self
 impl !core::marker::Freeze for aya_ebpf::maps::sock_map::SockMap
 impl core::marker::Send for aya_ebpf::maps::sock_map::SockMap
@@ -1578,7 +1578,7 @@ impl<T> aya_ebpf::maps::stack::Stack<T>
 pub fn aya_ebpf::maps::stack::Stack<T>::peek(&self) -> core::option::Option<T>
 pub const fn aya_ebpf::maps::stack::Stack<T>::pinned(max_entries: u32, flags: u32) -> Self
 pub fn aya_ebpf::maps::stack::Stack<T>::pop(&self) -> core::option::Option<T>
-pub fn aya_ebpf::maps::stack::Stack<T>::push(&self, value: impl core::borrow::Borrow<T>, flags: u64) -> core::result::Result<(), i64>
+pub fn aya_ebpf::maps::stack::Stack<T>::push(&self, value: impl core::borrow::Borrow<T>, flags: u64) -> core::result::Result<(), i32>
 pub const fn aya_ebpf::maps::stack::Stack<T>::with_max_entries(max_entries: u32, flags: u32) -> Self
 impl<T> !core::marker::Freeze for aya_ebpf::maps::stack::Stack<T>
 impl<T> core::marker::Send for aya_ebpf::maps::stack::Stack<T> where T: core::marker::Send
@@ -1605,7 +1605,7 @@ impl<T> core::convert::From<T> for aya_ebpf::maps::stack::Stack<T>
 pub fn aya_ebpf::maps::stack::Stack<T>::from(t: T) -> T
 #[repr(transparent)] pub struct aya_ebpf::maps::StackTrace
 impl aya_ebpf::maps::stack_trace::StackTrace
-pub unsafe fn aya_ebpf::maps::stack_trace::StackTrace::get_stackid<C: aya_ebpf::EbpfContext>(&self, ctx: impl core::borrow::Borrow<C>, flags: u64) -> core::result::Result<i64, i64>
+pub unsafe fn aya_ebpf::maps::stack_trace::StackTrace::get_stackid<C: aya_ebpf::EbpfContext>(&self, ctx: impl core::borrow::Borrow<C>, flags: u64) -> core::result::Result<aya_ebpf_cty::od::c_long, i32>
 pub const fn aya_ebpf::maps::stack_trace::StackTrace::pinned(max_entries: u32, flags: u32) -> Self
 pub const fn aya_ebpf::maps::stack_trace::StackTrace::with_max_entries(max_entries: u32, flags: u32) -> Self
 impl !core::marker::Freeze for aya_ebpf::maps::stack_trace::StackTrace
@@ -2122,8 +2122,8 @@ impl aya_ebpf::programs::sk_msg::SkMsgContext
 pub fn aya_ebpf::programs::sk_msg::SkMsgContext::data(&self) -> usize
 pub fn aya_ebpf::programs::sk_msg::SkMsgContext::data_end(&self) -> usize
 pub const fn aya_ebpf::programs::sk_msg::SkMsgContext::new(msg: *mut aya_ebpf_bindings::x86_64::bindings::sk_msg_md) -> Self
-pub fn aya_ebpf::programs::sk_msg::SkMsgContext::pop_data(&self, start: u32, len: u32, flags: u64) -> core::result::Result<(), i64>
-pub fn aya_ebpf::programs::sk_msg::SkMsgContext::push_data(&self, start: u32, len: u32, flags: u64) -> core::result::Result<(), i64>
+pub fn aya_ebpf::programs::sk_msg::SkMsgContext::pop_data(&self, start: u32, len: u32, flags: u64) -> core::result::Result<(), i32>
+pub fn aya_ebpf::programs::sk_msg::SkMsgContext::push_data(&self, start: u32, len: u32, flags: u64) -> core::result::Result<(), i32>
 pub fn aya_ebpf::programs::sk_msg::SkMsgContext::size(&self) -> u32
 impl aya_ebpf::EbpfContext for aya_ebpf::programs::sk_msg::SkMsgContext
 pub fn aya_ebpf::programs::sk_msg::SkMsgContext::as_ptr(&self) -> *mut core::ffi::c_void
@@ -2240,7 +2240,7 @@ pub fn aya_ebpf::programs::sock_ops::SockOpsContext::op(&self) -> u32
 pub fn aya_ebpf::programs::sock_ops::SockOpsContext::remote_ip4(&self) -> u32
 pub fn aya_ebpf::programs::sock_ops::SockOpsContext::remote_ip6(&self) -> [u32; 4]
 pub fn aya_ebpf::programs::sock_ops::SockOpsContext::remote_port(&self) -> u32
-pub fn aya_ebpf::programs::sock_ops::SockOpsContext::set_cb_flags(&self, flags: i32) -> core::result::Result<(), i64>
+pub fn aya_ebpf::programs::sock_ops::SockOpsContext::set_cb_flags(&self, flags: i32) -> core::result::Result<(), i32>
 pub fn aya_ebpf::programs::sock_ops::SockOpsContext::set_reply(&self, reply: u32)
 impl aya_ebpf::EbpfContext for aya_ebpf::programs::sock_ops::SockOpsContext
 pub fn aya_ebpf::programs::sock_ops::SockOpsContext::as_ptr(&self) -> *mut core::ffi::c_void
@@ -2938,8 +2938,8 @@ impl aya_ebpf::programs::sk_msg::SkMsgContext
 pub fn aya_ebpf::programs::sk_msg::SkMsgContext::data(&self) -> usize
 pub fn aya_ebpf::programs::sk_msg::SkMsgContext::data_end(&self) -> usize
 pub const fn aya_ebpf::programs::sk_msg::SkMsgContext::new(msg: *mut aya_ebpf_bindings::x86_64::bindings::sk_msg_md) -> Self
-pub fn aya_ebpf::programs::sk_msg::SkMsgContext::pop_data(&self, start: u32, len: u32, flags: u64) -> core::result::Result<(), i64>
-pub fn aya_ebpf::programs::sk_msg::SkMsgContext::push_data(&self, start: u32, len: u32, flags: u64) -> core::result::Result<(), i64>
+pub fn aya_ebpf::programs::sk_msg::SkMsgContext::pop_data(&self, start: u32, len: u32, flags: u64) -> core::result::Result<(), i32>
+pub fn aya_ebpf::programs::sk_msg::SkMsgContext::push_data(&self, start: u32, len: u32, flags: u64) -> core::result::Result<(), i32>
 pub fn aya_ebpf::programs::sk_msg::SkMsgContext::size(&self) -> u32
 impl aya_ebpf::EbpfContext for aya_ebpf::programs::sk_msg::SkMsgContext
 pub fn aya_ebpf::programs::sk_msg::SkMsgContext::as_ptr(&self) -> *mut core::ffi::c_void
@@ -3053,7 +3053,7 @@ pub fn aya_ebpf::programs::sock_ops::SockOpsContext::op(&self) -> u32
 pub fn aya_ebpf::programs::sock_ops::SockOpsContext::remote_ip4(&self) -> u32
 pub fn aya_ebpf::programs::sock_ops::SockOpsContext::remote_ip6(&self) -> [u32; 4]
 pub fn aya_ebpf::programs::sock_ops::SockOpsContext::remote_port(&self) -> u32
-pub fn aya_ebpf::programs::sock_ops::SockOpsContext::set_cb_flags(&self, flags: i32) -> core::result::Result<(), i64>
+pub fn aya_ebpf::programs::sock_ops::SockOpsContext::set_cb_flags(&self, flags: i32) -> core::result::Result<(), i32>
 pub fn aya_ebpf::programs::sock_ops::SockOpsContext::set_reply(&self, reply: u32)
 impl aya_ebpf::EbpfContext for aya_ebpf::programs::sock_ops::SockOpsContext
 pub fn aya_ebpf::programs::sock_ops::SockOpsContext::as_ptr(&self) -> *mut core::ffi::c_void
@@ -3467,4 +3467,4 @@ pub fn aya_ebpf::programs::xdp::XdpContext::pid(&self) -> u32
 pub fn aya_ebpf::programs::xdp::XdpContext::tgid(&self) -> u32
 pub fn aya_ebpf::programs::xdp::XdpContext::uid(&self) -> u32
 pub const fn aya_ebpf::bpf_f_adj_room_encap_l2(len: u64) -> u64
-pub fn aya_ebpf::check_bounds_signed(value: i64, lower: i64, upper: i64) -> bool
+pub fn aya_ebpf::check_bounds_signed<T: core::convert::Into<i64>>(value: T, lower: T, upper: T) -> bool


### PR DESCRIPTION
Complete the `i32` errno migration started in 8962fc79. Errno-only
helpers now return `Result<T, i32>`, non-errno helpers (verdicts, byte
counts) return `c_long`, and internal functions receiving raw helper
returns use `c_long`. `check_bounds_signed` now takes `T: Into<i64>`
to accept all signed/unsigned integer types without manual casts.

This fixes compilation on 32-bit armv7 where `c_long` is `i32`, causing
type mismatches with the previously hardcoded `i64` return types.

The split policy follows the rationale from 8962fc79: the aarch64 JIT
doesn't sign-extend helper return values into the upper 32 bits, so
errno codes must be narrowed to `i32` (`MAX_ERRNO = 4095`). Non-errno
returns (verdicts like `SK_PASS`/`SK_DROP`, byte counts, stack IDs)
keep `c_long` to match the BPF helper ABI.

Fixes: #1414

### Added/updated tests?

- [x] No, and this is why: type-only changes with no behavioral difference
      at runtime. Existing integration tests (bloom_filter, ring_buf,
      stack_trace, sock_ops, etc.) already cover all modified code paths
      and pass on both x86_64 and armv7.

### Checklist

- [x] Rust code has been formatted with `cargo +nightly fmt`.
- [x] All clippy lints have been fixed.
- [x] Unit tests are passing locally with `cargo test`.
- [x] The Integration tests are passing locally.
- [x] I have blessed any API changes with `cargo xtask public-api --bless`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aya-rs/aya/1525)
<!-- Reviewable:end -->
