### PR TITLE
integration-test: use native-endian cookie bytes in uprobe_cookie tests

### DIFF
--- a/test/integration-ebpf/src/uprobe_cookie.rs
+++ b/test/integration-ebpf/src/uprobe_cookie.rs
@@ -15,12 +15,8 @@ extern crate ebpf_panic;
 static RING_BUF: RingBuf = RingBuf::with_byte_size(0, 0);
 
 #[uprobe]
-#[expect(
-    clippy::little_endian_bytes,
-    reason = "the eBPF program writes the cookie as little-endian bytes"
-)]
 fn uprobe_cookie(ctx: ProbeContext) {
     let cookie = unsafe { helpers::bpf_get_attach_cookie(ctx.as_ptr()) };
-    let cookie_bytes = cookie.to_le_bytes();
+    let cookie_bytes = cookie.to_ne_bytes();
     let _res = RING_BUF.output::<[u8]>(cookie_bytes, 0);
 }

--- a/test/integration-test/src/tests/uprobe_cookie.rs
+++ b/test/integration-test/src/tests/uprobe_cookie.rs
@@ -6,10 +6,6 @@ use aya::{
 };
 
 #[test_log::test]
-#[expect(
-    clippy::little_endian_bytes,
-    reason = "the eBPF program writes the cookie as little-endian bytes"
-)]
 fn test_uprobe_cookie() {
     let kernel_version = KernelVersion::current().unwrap();
     if kernel_version < KernelVersion::new(5, 15, 0) {
@@ -63,7 +59,7 @@ fn test_uprobe_cookie() {
     while let Some(read) = ring_buf.next() {
         let read = read.as_ref();
         match read.try_into() {
-            Ok(read) => seen.push(u64::from_le_bytes(read)),
+            Ok(read) => seen.push(u64::from_ne_bytes(read)),
             Err(std::array::TryFromSliceError { .. }) => {
                 panic!("invalid ring buffer data: {read:x?}")
             }


### PR DESCRIPTION
E2E integration tests write and read cookie bytes in the same runtime environment, so native-endian encoding is sufficient.

<!-- markdownlint-disable first-line-heading -->

<!--
    Thank you for your contribution to Aya! 🎉

    For Work In Progress Pull Requests, please use the Draft PR feature.

    Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Aya Contributing Guide: https://github.com/aya-rs/aya/blob/main/CONTRIBUTING.md
     - 📖 Read the Aya Code of Conduct: https://github.com/aya-rs/aya/blob/main/CODE_OF_CONDUCT.md
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages: https://cbea.ms/git-commit/
     - 📗 Update any related documentation.

-->

<!---
      Summarize the changes you're making here. Detailed information belongs in
      the Git commit messages. If your pull request contains just one commit,
      it's best to use its message as a summary. Otherwise, if there are multiple
      atomic commits, write a summary for the entire PR. Feel free to flag
      anything you think needs a reviewer's attention.
-->

<!--
      If your changes address an issue, link it with the *Fixes* tag so
      the issue gets closed when the PR is merged, for example:

      Fixes: #1234

      If you are only referencing an issue without fully addressing it, feel
      free to link it anywhere in the summary.
-->

### Added/updated tests?

_We strongly encourage you to add a test for your changes._

- [ ] Yes
- [x] No, and this is why: this change only polishes the existing integration tests
- [ ] I need help with writing tests

### Checklist

- [ ] Rust code has been formatted with `cargo +nightly fmt`.
- [ ] All clippy lints have been fixed.
      You can find failing lints with `./clippy.sh`.
- [ ] Unit tests are passing locally with `cargo test`.
- [ ] The [Integration tests] are passing locally.
- [ ] I have blessed any API changes with `cargo xtask public-api --bless`.

[Integration tests]: https://github.com/aya-rs/aya/blob/main/test/README.md

### (Optional) What GIF best describes this PR or how it makes you feel?

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aya-rs/aya/1527)
<!-- Reviewable:end -->
