### PR TITLE
public-api: omit blanket impls

### DIFF
--- a/xtask/public-api/aya-build.txt
+++ b/xtask/public-api/aya-build.txt
@@ -12,22 +12,6 @@ impl<'a> core::marker::Unpin for aya_build::Toolchain<'a>
 impl<'a> core::marker::UnsafeUnpin for aya_build::Toolchain<'a>
 impl<'a> core::panic::unwind_safe::RefUnwindSafe for aya_build::Toolchain<'a>
 impl<'a> core::panic::unwind_safe::UnwindSafe for aya_build::Toolchain<'a>
-impl<T, U> core::convert::Into<U> for aya_build::Toolchain<'a> where U: core::convert::From<T>
-pub fn aya_build::Toolchain<'a>::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_build::Toolchain<'a> where U: core::convert::Into<T>
-pub type aya_build::Toolchain<'a>::Error = core::convert::Infallible
-pub fn aya_build::Toolchain<'a>::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_build::Toolchain<'a> where U: core::convert::TryFrom<T>
-pub type aya_build::Toolchain<'a>::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_build::Toolchain<'a>::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_build::Toolchain<'a> where T: 'static + ?core::marker::Sized
-pub fn aya_build::Toolchain<'a>::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_build::Toolchain<'a> where T: ?core::marker::Sized
-pub fn aya_build::Toolchain<'a>::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_build::Toolchain<'a> where T: ?core::marker::Sized
-pub fn aya_build::Toolchain<'a>::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya_build::Toolchain<'a>
-pub fn aya_build::Toolchain<'a>::from(t: T) -> T
 pub struct aya_build::Package<'a>
 pub aya_build::Package::features: &'a [&'a str]
 pub aya_build::Package::name: &'a str
@@ -42,21 +26,5 @@ impl<'a> core::marker::Unpin for aya_build::Package<'a>
 impl<'a> core::marker::UnsafeUnpin for aya_build::Package<'a>
 impl<'a> core::panic::unwind_safe::RefUnwindSafe for aya_build::Package<'a>
 impl<'a> core::panic::unwind_safe::UnwindSafe for aya_build::Package<'a>
-impl<T, U> core::convert::Into<U> for aya_build::Package<'a> where U: core::convert::From<T>
-pub fn aya_build::Package<'a>::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_build::Package<'a> where U: core::convert::Into<T>
-pub type aya_build::Package<'a>::Error = core::convert::Infallible
-pub fn aya_build::Package<'a>::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_build::Package<'a> where U: core::convert::TryFrom<T>
-pub type aya_build::Package<'a>::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_build::Package<'a>::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_build::Package<'a> where T: 'static + ?core::marker::Sized
-pub fn aya_build::Package<'a>::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_build::Package<'a> where T: ?core::marker::Sized
-pub fn aya_build::Package<'a>::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_build::Package<'a> where T: ?core::marker::Sized
-pub fn aya_build::Package<'a>::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya_build::Package<'a>
-pub fn aya_build::Package<'a>::from(t: T) -> T
 pub fn aya_build::build_ebpf<'a>(packages: impl core::iter::traits::collect::IntoIterator<Item = aya_build::Package<'a>>, toolchain: aya_build::Toolchain<'a>) -> anyhow::Result<()>
 pub fn aya_build::emit_bpf_target_arch_cfg() -> anyhow::Result<()>

--- a/xtask/public-api/aya-ebpf-bindings.txt
+++ b/xtask/public-api/aya-ebpf-bindings.txt
@@ -532,24 +532,6 @@ impl core::marker::Unpin for aya_ebpf_bindings::bindings::__sk_buff__bindgen_ty_
 impl core::marker::UnsafeUnpin for aya_ebpf_bindings::bindings::__sk_buff__bindgen_ty_1
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf_bindings::bindings::__sk_buff__bindgen_ty_1
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf_bindings::bindings::__sk_buff__bindgen_ty_1
-impl<T, U> core::convert::Into<U> for aya_ebpf_bindings::bindings::__sk_buff__bindgen_ty_1 where U: core::convert::From<T>
-pub fn aya_ebpf_bindings::bindings::__sk_buff__bindgen_ty_1::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf_bindings::bindings::__sk_buff__bindgen_ty_1 where U: core::convert::Into<T>
-pub type aya_ebpf_bindings::bindings::__sk_buff__bindgen_ty_1::Error = core::convert::Infallible
-pub fn aya_ebpf_bindings::bindings::__sk_buff__bindgen_ty_1::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf_bindings::bindings::__sk_buff__bindgen_ty_1 where U: core::convert::TryFrom<T>
-pub type aya_ebpf_bindings::bindings::__sk_buff__bindgen_ty_1::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf_bindings::bindings::__sk_buff__bindgen_ty_1::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf_bindings::bindings::__sk_buff__bindgen_ty_1 where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::__sk_buff__bindgen_ty_1::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::__sk_buff__bindgen_ty_1 where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::__sk_buff__bindgen_ty_1::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::__sk_buff__bindgen_ty_1 where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::__sk_buff__bindgen_ty_1::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::__sk_buff__bindgen_ty_1 where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::__sk_buff__bindgen_ty_1::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::__sk_buff__bindgen_ty_1
-pub fn aya_ebpf_bindings::bindings::__sk_buff__bindgen_ty_1::from(t: T) -> T
 #[repr(C)] pub union aya_ebpf_bindings::bindings::__sk_buff__bindgen_ty_2
 pub aya_ebpf_bindings::bindings::__sk_buff__bindgen_ty_2::_bitfield_1: aya_ebpf_bindings::bindings::__BindgenBitfieldUnit<[u8; 8]>
 pub aya_ebpf_bindings::bindings::__sk_buff__bindgen_ty_2::_bitfield_align_1: [u8; 0]
@@ -566,24 +548,6 @@ impl core::marker::Unpin for aya_ebpf_bindings::bindings::__sk_buff__bindgen_ty_
 impl core::marker::UnsafeUnpin for aya_ebpf_bindings::bindings::__sk_buff__bindgen_ty_2
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf_bindings::bindings::__sk_buff__bindgen_ty_2
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf_bindings::bindings::__sk_buff__bindgen_ty_2
-impl<T, U> core::convert::Into<U> for aya_ebpf_bindings::bindings::__sk_buff__bindgen_ty_2 where U: core::convert::From<T>
-pub fn aya_ebpf_bindings::bindings::__sk_buff__bindgen_ty_2::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf_bindings::bindings::__sk_buff__bindgen_ty_2 where U: core::convert::Into<T>
-pub type aya_ebpf_bindings::bindings::__sk_buff__bindgen_ty_2::Error = core::convert::Infallible
-pub fn aya_ebpf_bindings::bindings::__sk_buff__bindgen_ty_2::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf_bindings::bindings::__sk_buff__bindgen_ty_2 where U: core::convert::TryFrom<T>
-pub type aya_ebpf_bindings::bindings::__sk_buff__bindgen_ty_2::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf_bindings::bindings::__sk_buff__bindgen_ty_2::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf_bindings::bindings::__sk_buff__bindgen_ty_2 where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::__sk_buff__bindgen_ty_2::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::__sk_buff__bindgen_ty_2 where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::__sk_buff__bindgen_ty_2::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::__sk_buff__bindgen_ty_2 where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::__sk_buff__bindgen_ty_2::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::__sk_buff__bindgen_ty_2 where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::__sk_buff__bindgen_ty_2::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::__sk_buff__bindgen_ty_2
-pub fn aya_ebpf_bindings::bindings::__sk_buff__bindgen_ty_2::from(t: T) -> T
 #[repr(C)] pub union aya_ebpf_bindings::bindings::bpf_attr
 pub aya_ebpf_bindings::bindings::bpf_attr::__bindgen_anon_1: aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_1
 pub aya_ebpf_bindings::bindings::bpf_attr::__bindgen_anon_2: aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_2
@@ -615,24 +579,6 @@ impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_attr
 impl core::marker::UnsafeUnpin for aya_ebpf_bindings::bindings::bpf_attr
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf_bindings::bindings::bpf_attr
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf_bindings::bindings::bpf_attr
-impl<T, U> core::convert::Into<U> for aya_ebpf_bindings::bindings::bpf_attr where U: core::convert::From<T>
-pub fn aya_ebpf_bindings::bindings::bpf_attr::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf_bindings::bindings::bpf_attr where U: core::convert::Into<T>
-pub type aya_ebpf_bindings::bindings::bpf_attr::Error = core::convert::Infallible
-pub fn aya_ebpf_bindings::bindings::bpf_attr::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf_bindings::bindings::bpf_attr where U: core::convert::TryFrom<T>
-pub type aya_ebpf_bindings::bindings::bpf_attr::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf_bindings::bindings::bpf_attr::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf_bindings::bindings::bpf_attr where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_attr::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_attr where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_attr::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_attr where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_attr::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_attr where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_attr::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_attr
-pub fn aya_ebpf_bindings::bindings::bpf_attr::from(t: T) -> T
 #[repr(C)] pub union aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_10__bindgen_ty_1
 pub aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_10__bindgen_ty_1::target_fd: aya_ebpf_bindings::bindings::__u32
 pub aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_10__bindgen_ty_1::target_ifindex: aya_ebpf_bindings::bindings::__u32
@@ -646,24 +592,6 @@ impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_1
 impl core::marker::UnsafeUnpin for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_10__bindgen_ty_1
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_10__bindgen_ty_1
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_10__bindgen_ty_1
-impl<T, U> core::convert::Into<U> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_10__bindgen_ty_1 where U: core::convert::From<T>
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_10__bindgen_ty_1::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_10__bindgen_ty_1 where U: core::convert::Into<T>
-pub type aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_10__bindgen_ty_1::Error = core::convert::Infallible
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_10__bindgen_ty_1::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_10__bindgen_ty_1 where U: core::convert::TryFrom<T>
-pub type aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_10__bindgen_ty_1::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_10__bindgen_ty_1::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_10__bindgen_ty_1 where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_10__bindgen_ty_1::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_10__bindgen_ty_1 where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_10__bindgen_ty_1::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_10__bindgen_ty_1 where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_10__bindgen_ty_1::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_10__bindgen_ty_1 where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_10__bindgen_ty_1::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_10__bindgen_ty_1
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_10__bindgen_ty_1::from(t: T) -> T
 #[repr(C)] pub union aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_10__bindgen_ty_2
 pub aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_10__bindgen_ty_2::count: aya_ebpf_bindings::bindings::__u32
 pub aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_10__bindgen_ty_2::prog_cnt: aya_ebpf_bindings::bindings::__u32
@@ -677,24 +605,6 @@ impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_1
 impl core::marker::UnsafeUnpin for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_10__bindgen_ty_2
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_10__bindgen_ty_2
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_10__bindgen_ty_2
-impl<T, U> core::convert::Into<U> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_10__bindgen_ty_2 where U: core::convert::From<T>
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_10__bindgen_ty_2::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_10__bindgen_ty_2 where U: core::convert::Into<T>
-pub type aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_10__bindgen_ty_2::Error = core::convert::Infallible
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_10__bindgen_ty_2::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_10__bindgen_ty_2 where U: core::convert::TryFrom<T>
-pub type aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_10__bindgen_ty_2::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_10__bindgen_ty_2::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_10__bindgen_ty_2 where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_10__bindgen_ty_2::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_10__bindgen_ty_2 where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_10__bindgen_ty_2::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_10__bindgen_ty_2 where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_10__bindgen_ty_2::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_10__bindgen_ty_2 where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_10__bindgen_ty_2::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_10__bindgen_ty_2
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_10__bindgen_ty_2::from(t: T) -> T
 #[repr(C)] pub union aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_1
 pub aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_1::map_fd: aya_ebpf_bindings::bindings::__u32
 pub aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_1::prog_fd: aya_ebpf_bindings::bindings::__u32
@@ -708,24 +618,6 @@ impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_1
 impl core::marker::UnsafeUnpin for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_1
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_1
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_1
-impl<T, U> core::convert::Into<U> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_1 where U: core::convert::From<T>
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_1::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_1 where U: core::convert::Into<T>
-pub type aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_1::Error = core::convert::Infallible
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_1::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_1 where U: core::convert::TryFrom<T>
-pub type aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_1::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_1::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_1 where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_1::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_1 where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_1::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_1 where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_1::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_1 where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_1::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_1
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_1::from(t: T) -> T
 #[repr(C)] pub union aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_2
 pub aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_2::target_fd: aya_ebpf_bindings::bindings::__u32
 pub aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_2::target_ifindex: aya_ebpf_bindings::bindings::__u32
@@ -739,24 +631,6 @@ impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_1
 impl core::marker::UnsafeUnpin for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_2
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_2
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_2
-impl<T, U> core::convert::Into<U> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_2 where U: core::convert::From<T>
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_2::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_2 where U: core::convert::Into<T>
-pub type aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_2::Error = core::convert::Infallible
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_2::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_2 where U: core::convert::TryFrom<T>
-pub type aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_2::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_2::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_2 where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_2::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_2 where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_2::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_2 where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_2::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_2 where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_2::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_2
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_2::from(t: T) -> T
 #[repr(C)] pub union aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3
 pub aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3::__bindgen_anon_1: aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_1
 pub aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3::kprobe_multi: aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_3
@@ -777,24 +651,6 @@ impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_1
 impl core::marker::UnsafeUnpin for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3
-impl<T, U> core::convert::Into<U> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3 where U: core::convert::From<T>
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3 where U: core::convert::Into<T>
-pub type aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3::Error = core::convert::Infallible
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3 where U: core::convert::TryFrom<T>
-pub type aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3 where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3 where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3 where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3 where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3::from(t: T) -> T
 #[repr(C)] pub union aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_6__bindgen_ty_1
 pub aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_6__bindgen_ty_1::relative_fd: aya_ebpf_bindings::bindings::__u32
 pub aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_6__bindgen_ty_1::relative_id: aya_ebpf_bindings::bindings::__u32
@@ -808,24 +664,6 @@ impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_1
 impl core::marker::UnsafeUnpin for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_6__bindgen_ty_1
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_6__bindgen_ty_1
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_6__bindgen_ty_1
-impl<T, U> core::convert::Into<U> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_6__bindgen_ty_1 where U: core::convert::From<T>
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_6__bindgen_ty_1::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_6__bindgen_ty_1 where U: core::convert::Into<T>
-pub type aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_6__bindgen_ty_1::Error = core::convert::Infallible
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_6__bindgen_ty_1::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_6__bindgen_ty_1 where U: core::convert::TryFrom<T>
-pub type aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_6__bindgen_ty_1::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_6__bindgen_ty_1::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_6__bindgen_ty_1 where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_6__bindgen_ty_1::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_6__bindgen_ty_1 where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_6__bindgen_ty_1::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_6__bindgen_ty_1 where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_6__bindgen_ty_1::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_6__bindgen_ty_1 where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_6__bindgen_ty_1::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_6__bindgen_ty_1
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_6__bindgen_ty_1::from(t: T) -> T
 #[repr(C)] pub union aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_8__bindgen_ty_1
 pub aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_8__bindgen_ty_1::relative_fd: aya_ebpf_bindings::bindings::__u32
 pub aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_8__bindgen_ty_1::relative_id: aya_ebpf_bindings::bindings::__u32
@@ -839,24 +677,6 @@ impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_1
 impl core::marker::UnsafeUnpin for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_8__bindgen_ty_1
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_8__bindgen_ty_1
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_8__bindgen_ty_1
-impl<T, U> core::convert::Into<U> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_8__bindgen_ty_1 where U: core::convert::From<T>
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_8__bindgen_ty_1::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_8__bindgen_ty_1 where U: core::convert::Into<T>
-pub type aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_8__bindgen_ty_1::Error = core::convert::Infallible
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_8__bindgen_ty_1::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_8__bindgen_ty_1 where U: core::convert::TryFrom<T>
-pub type aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_8__bindgen_ty_1::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_8__bindgen_ty_1::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_8__bindgen_ty_1 where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_8__bindgen_ty_1::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_8__bindgen_ty_1 where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_8__bindgen_ty_1::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_8__bindgen_ty_1 where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_8__bindgen_ty_1::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_8__bindgen_ty_1 where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_8__bindgen_ty_1::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_8__bindgen_ty_1
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_8__bindgen_ty_1::from(t: T) -> T
 #[repr(C)] pub union aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_15__bindgen_ty_1
 pub aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_15__bindgen_ty_1::new_map_fd: aya_ebpf_bindings::bindings::__u32
 pub aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_15__bindgen_ty_1::new_prog_fd: aya_ebpf_bindings::bindings::__u32
@@ -870,24 +690,6 @@ impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_1
 impl core::marker::UnsafeUnpin for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_15__bindgen_ty_1
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_15__bindgen_ty_1
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_15__bindgen_ty_1
-impl<T, U> core::convert::Into<U> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_15__bindgen_ty_1 where U: core::convert::From<T>
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_15__bindgen_ty_1::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_15__bindgen_ty_1 where U: core::convert::Into<T>
-pub type aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_15__bindgen_ty_1::Error = core::convert::Infallible
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_15__bindgen_ty_1::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_15__bindgen_ty_1 where U: core::convert::TryFrom<T>
-pub type aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_15__bindgen_ty_1::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_15__bindgen_ty_1::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_15__bindgen_ty_1 where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_15__bindgen_ty_1::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_15__bindgen_ty_1 where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_15__bindgen_ty_1::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_15__bindgen_ty_1 where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_15__bindgen_ty_1::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_15__bindgen_ty_1 where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_15__bindgen_ty_1::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_15__bindgen_ty_1
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_15__bindgen_ty_1::from(t: T) -> T
 #[repr(C)] pub union aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_15__bindgen_ty_2
 pub aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_15__bindgen_ty_2::old_map_fd: aya_ebpf_bindings::bindings::__u32
 pub aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_15__bindgen_ty_2::old_prog_fd: aya_ebpf_bindings::bindings::__u32
@@ -901,24 +703,6 @@ impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_1
 impl core::marker::UnsafeUnpin for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_15__bindgen_ty_2
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_15__bindgen_ty_2
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_15__bindgen_ty_2
-impl<T, U> core::convert::Into<U> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_15__bindgen_ty_2 where U: core::convert::From<T>
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_15__bindgen_ty_2::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_15__bindgen_ty_2 where U: core::convert::Into<T>
-pub type aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_15__bindgen_ty_2::Error = core::convert::Infallible
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_15__bindgen_ty_2::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_15__bindgen_ty_2 where U: core::convert::TryFrom<T>
-pub type aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_15__bindgen_ty_2::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_15__bindgen_ty_2::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_15__bindgen_ty_2 where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_15__bindgen_ty_2::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_15__bindgen_ty_2 where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_15__bindgen_ty_2::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_15__bindgen_ty_2 where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_15__bindgen_ty_2::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_15__bindgen_ty_2 where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_15__bindgen_ty_2::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_15__bindgen_ty_2
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_15__bindgen_ty_2::from(t: T) -> T
 #[repr(C)] pub union aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_2__bindgen_ty_1
 pub aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_2__bindgen_ty_1::next_key: aya_ebpf_bindings::bindings::__u64
 pub aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_2__bindgen_ty_1::value: aya_ebpf_bindings::bindings::__u64
@@ -932,24 +716,6 @@ impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_2
 impl core::marker::UnsafeUnpin for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_2__bindgen_ty_1
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_2__bindgen_ty_1
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_2__bindgen_ty_1
-impl<T, U> core::convert::Into<U> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_2__bindgen_ty_1 where U: core::convert::From<T>
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_2__bindgen_ty_1::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_2__bindgen_ty_1 where U: core::convert::Into<T>
-pub type aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_2__bindgen_ty_1::Error = core::convert::Infallible
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_2__bindgen_ty_1::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_2__bindgen_ty_1 where U: core::convert::TryFrom<T>
-pub type aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_2__bindgen_ty_1::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_2__bindgen_ty_1::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_2__bindgen_ty_1 where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_2__bindgen_ty_1::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_2__bindgen_ty_1 where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_2__bindgen_ty_1::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_2__bindgen_ty_1 where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_2__bindgen_ty_1::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_2__bindgen_ty_1 where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_2__bindgen_ty_1::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_2__bindgen_ty_1
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_2__bindgen_ty_1::from(t: T) -> T
 #[repr(C)] pub union aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_4__bindgen_ty_1
 pub aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_4__bindgen_ty_1::attach_btf_obj_fd: aya_ebpf_bindings::bindings::__u32
 pub aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_4__bindgen_ty_1::attach_prog_fd: aya_ebpf_bindings::bindings::__u32
@@ -963,24 +729,6 @@ impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_4
 impl core::marker::UnsafeUnpin for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_4__bindgen_ty_1
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_4__bindgen_ty_1
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_4__bindgen_ty_1
-impl<T, U> core::convert::Into<U> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_4__bindgen_ty_1 where U: core::convert::From<T>
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_4__bindgen_ty_1::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_4__bindgen_ty_1 where U: core::convert::Into<T>
-pub type aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_4__bindgen_ty_1::Error = core::convert::Infallible
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_4__bindgen_ty_1::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_4__bindgen_ty_1 where U: core::convert::TryFrom<T>
-pub type aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_4__bindgen_ty_1::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_4__bindgen_ty_1::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_4__bindgen_ty_1 where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_4__bindgen_ty_1::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_4__bindgen_ty_1 where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_4__bindgen_ty_1::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_4__bindgen_ty_1 where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_4__bindgen_ty_1::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_4__bindgen_ty_1 where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_4__bindgen_ty_1::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_4__bindgen_ty_1
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_4__bindgen_ty_1::from(t: T) -> T
 #[repr(C)] pub union aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_6__bindgen_ty_1
 pub aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_6__bindgen_ty_1::target_fd: aya_ebpf_bindings::bindings::__u32
 pub aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_6__bindgen_ty_1::target_ifindex: aya_ebpf_bindings::bindings::__u32
@@ -994,24 +742,6 @@ impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_6
 impl core::marker::UnsafeUnpin for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_6__bindgen_ty_1
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_6__bindgen_ty_1
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_6__bindgen_ty_1
-impl<T, U> core::convert::Into<U> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_6__bindgen_ty_1 where U: core::convert::From<T>
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_6__bindgen_ty_1::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_6__bindgen_ty_1 where U: core::convert::Into<T>
-pub type aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_6__bindgen_ty_1::Error = core::convert::Infallible
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_6__bindgen_ty_1::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_6__bindgen_ty_1 where U: core::convert::TryFrom<T>
-pub type aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_6__bindgen_ty_1::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_6__bindgen_ty_1::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_6__bindgen_ty_1 where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_6__bindgen_ty_1::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_6__bindgen_ty_1 where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_6__bindgen_ty_1::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_6__bindgen_ty_1 where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_6__bindgen_ty_1::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_6__bindgen_ty_1 where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_6__bindgen_ty_1::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_6__bindgen_ty_1
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_6__bindgen_ty_1::from(t: T) -> T
 #[repr(C)] pub union aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_6__bindgen_ty_2
 pub aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_6__bindgen_ty_2::relative_fd: aya_ebpf_bindings::bindings::__u32
 pub aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_6__bindgen_ty_2::relative_id: aya_ebpf_bindings::bindings::__u32
@@ -1025,24 +755,6 @@ impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_6
 impl core::marker::UnsafeUnpin for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_6__bindgen_ty_2
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_6__bindgen_ty_2
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_6__bindgen_ty_2
-impl<T, U> core::convert::Into<U> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_6__bindgen_ty_2 where U: core::convert::From<T>
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_6__bindgen_ty_2::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_6__bindgen_ty_2 where U: core::convert::Into<T>
-pub type aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_6__bindgen_ty_2::Error = core::convert::Infallible
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_6__bindgen_ty_2::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_6__bindgen_ty_2 where U: core::convert::TryFrom<T>
-pub type aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_6__bindgen_ty_2::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_6__bindgen_ty_2::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_6__bindgen_ty_2 where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_6__bindgen_ty_2::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_6__bindgen_ty_2 where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_6__bindgen_ty_2::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_6__bindgen_ty_2 where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_6__bindgen_ty_2::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_6__bindgen_ty_2 where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_6__bindgen_ty_2::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_6__bindgen_ty_2
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_6__bindgen_ty_2::from(t: T) -> T
 #[repr(C)] pub union aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_8__bindgen_ty_1
 pub aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_8__bindgen_ty_1::btf_id: aya_ebpf_bindings::bindings::__u32
 pub aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_8__bindgen_ty_1::link_id: aya_ebpf_bindings::bindings::__u32
@@ -1059,24 +771,6 @@ impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_8
 impl core::marker::UnsafeUnpin for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_8__bindgen_ty_1
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_8__bindgen_ty_1
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_8__bindgen_ty_1
-impl<T, U> core::convert::Into<U> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_8__bindgen_ty_1 where U: core::convert::From<T>
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_8__bindgen_ty_1::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_8__bindgen_ty_1 where U: core::convert::Into<T>
-pub type aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_8__bindgen_ty_1::Error = core::convert::Infallible
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_8__bindgen_ty_1::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_8__bindgen_ty_1 where U: core::convert::TryFrom<T>
-pub type aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_8__bindgen_ty_1::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_8__bindgen_ty_1::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_8__bindgen_ty_1 where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_8__bindgen_ty_1::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_8__bindgen_ty_1 where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_8__bindgen_ty_1::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_8__bindgen_ty_1 where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_8__bindgen_ty_1::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_8__bindgen_ty_1 where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_8__bindgen_ty_1::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_8__bindgen_ty_1
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_8__bindgen_ty_1::from(t: T) -> T
 #[repr(C)] pub union aya_ebpf_bindings::bindings::bpf_cpumap_val__bindgen_ty_1
 pub aya_ebpf_bindings::bindings::bpf_cpumap_val__bindgen_ty_1::fd: aya_ebpf_cty::ad::c_int
 pub aya_ebpf_bindings::bindings::bpf_cpumap_val__bindgen_ty_1::id: aya_ebpf_bindings::bindings::__u32
@@ -1090,24 +784,6 @@ impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_cpumap_val__bindge
 impl core::marker::UnsafeUnpin for aya_ebpf_bindings::bindings::bpf_cpumap_val__bindgen_ty_1
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf_bindings::bindings::bpf_cpumap_val__bindgen_ty_1
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf_bindings::bindings::bpf_cpumap_val__bindgen_ty_1
-impl<T, U> core::convert::Into<U> for aya_ebpf_bindings::bindings::bpf_cpumap_val__bindgen_ty_1 where U: core::convert::From<T>
-pub fn aya_ebpf_bindings::bindings::bpf_cpumap_val__bindgen_ty_1::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf_bindings::bindings::bpf_cpumap_val__bindgen_ty_1 where U: core::convert::Into<T>
-pub type aya_ebpf_bindings::bindings::bpf_cpumap_val__bindgen_ty_1::Error = core::convert::Infallible
-pub fn aya_ebpf_bindings::bindings::bpf_cpumap_val__bindgen_ty_1::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf_bindings::bindings::bpf_cpumap_val__bindgen_ty_1 where U: core::convert::TryFrom<T>
-pub type aya_ebpf_bindings::bindings::bpf_cpumap_val__bindgen_ty_1::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf_bindings::bindings::bpf_cpumap_val__bindgen_ty_1::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf_bindings::bindings::bpf_cpumap_val__bindgen_ty_1 where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_cpumap_val__bindgen_ty_1::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_cpumap_val__bindgen_ty_1 where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_cpumap_val__bindgen_ty_1::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_cpumap_val__bindgen_ty_1 where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_cpumap_val__bindgen_ty_1::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_cpumap_val__bindgen_ty_1 where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_cpumap_val__bindgen_ty_1::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_cpumap_val__bindgen_ty_1
-pub fn aya_ebpf_bindings::bindings::bpf_cpumap_val__bindgen_ty_1::from(t: T) -> T
 #[repr(C)] pub union aya_ebpf_bindings::bindings::bpf_devmap_val__bindgen_ty_1
 pub aya_ebpf_bindings::bindings::bpf_devmap_val__bindgen_ty_1::fd: aya_ebpf_cty::ad::c_int
 pub aya_ebpf_bindings::bindings::bpf_devmap_val__bindgen_ty_1::id: aya_ebpf_bindings::bindings::__u32
@@ -1121,24 +797,6 @@ impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_devmap_val__bindge
 impl core::marker::UnsafeUnpin for aya_ebpf_bindings::bindings::bpf_devmap_val__bindgen_ty_1
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf_bindings::bindings::bpf_devmap_val__bindgen_ty_1
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf_bindings::bindings::bpf_devmap_val__bindgen_ty_1
-impl<T, U> core::convert::Into<U> for aya_ebpf_bindings::bindings::bpf_devmap_val__bindgen_ty_1 where U: core::convert::From<T>
-pub fn aya_ebpf_bindings::bindings::bpf_devmap_val__bindgen_ty_1::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf_bindings::bindings::bpf_devmap_val__bindgen_ty_1 where U: core::convert::Into<T>
-pub type aya_ebpf_bindings::bindings::bpf_devmap_val__bindgen_ty_1::Error = core::convert::Infallible
-pub fn aya_ebpf_bindings::bindings::bpf_devmap_val__bindgen_ty_1::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf_bindings::bindings::bpf_devmap_val__bindgen_ty_1 where U: core::convert::TryFrom<T>
-pub type aya_ebpf_bindings::bindings::bpf_devmap_val__bindgen_ty_1::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf_bindings::bindings::bpf_devmap_val__bindgen_ty_1::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf_bindings::bindings::bpf_devmap_val__bindgen_ty_1 where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_devmap_val__bindgen_ty_1::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_devmap_val__bindgen_ty_1 where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_devmap_val__bindgen_ty_1::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_devmap_val__bindgen_ty_1 where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_devmap_val__bindgen_ty_1::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_devmap_val__bindgen_ty_1 where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_devmap_val__bindgen_ty_1::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_devmap_val__bindgen_ty_1
-pub fn aya_ebpf_bindings::bindings::bpf_devmap_val__bindgen_ty_1::from(t: T) -> T
 #[repr(C)] pub union aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_1
 pub aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_1::mtu_result: aya_ebpf_bindings::bindings::__u16
 pub aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_1::tot_len: aya_ebpf_bindings::bindings::__u16
@@ -1152,24 +810,6 @@ impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_fib_lookup__bindge
 impl core::marker::UnsafeUnpin for aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_1
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_1
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_1
-impl<T, U> core::convert::Into<U> for aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_1 where U: core::convert::From<T>
-pub fn aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_1::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_1 where U: core::convert::Into<T>
-pub type aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_1::Error = core::convert::Infallible
-pub fn aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_1::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_1 where U: core::convert::TryFrom<T>
-pub type aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_1::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_1::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_1 where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_1::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_1 where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_1::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_1 where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_1::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_1 where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_1::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_1
-pub fn aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_1::from(t: T) -> T
 #[repr(C)] pub union aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_2
 pub aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_2::flowinfo: aya_ebpf_bindings::bindings::__be32
 pub aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_2::rt_metric: aya_ebpf_bindings::bindings::__u32
@@ -1184,24 +824,6 @@ impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_fib_lookup__bindge
 impl core::marker::UnsafeUnpin for aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_2
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_2
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_2
-impl<T, U> core::convert::Into<U> for aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_2 where U: core::convert::From<T>
-pub fn aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_2::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_2 where U: core::convert::Into<T>
-pub type aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_2::Error = core::convert::Infallible
-pub fn aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_2::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_2 where U: core::convert::TryFrom<T>
-pub type aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_2::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_2::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_2 where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_2::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_2 where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_2::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_2 where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_2::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_2 where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_2::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_2
-pub fn aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_2::from(t: T) -> T
 #[repr(C)] pub union aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_3
 pub aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_3::ipv4_src: aya_ebpf_bindings::bindings::__be32
 pub aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_3::ipv6_src: [aya_ebpf_bindings::bindings::__u32; 4]
@@ -1215,24 +837,6 @@ impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_fib_lookup__bindge
 impl core::marker::UnsafeUnpin for aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_3
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_3
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_3
-impl<T, U> core::convert::Into<U> for aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_3 where U: core::convert::From<T>
-pub fn aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_3::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_3 where U: core::convert::Into<T>
-pub type aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_3::Error = core::convert::Infallible
-pub fn aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_3::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_3 where U: core::convert::TryFrom<T>
-pub type aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_3::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_3::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_3 where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_3::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_3 where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_3::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_3 where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_3::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_3 where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_3::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_3
-pub fn aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_3::from(t: T) -> T
 #[repr(C)] pub union aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_4
 pub aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_4::ipv4_dst: aya_ebpf_bindings::bindings::__be32
 pub aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_4::ipv6_dst: [aya_ebpf_bindings::bindings::__u32; 4]
@@ -1246,24 +850,6 @@ impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_fib_lookup__bindge
 impl core::marker::UnsafeUnpin for aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_4
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_4
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_4
-impl<T, U> core::convert::Into<U> for aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_4 where U: core::convert::From<T>
-pub fn aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_4::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_4 where U: core::convert::Into<T>
-pub type aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_4::Error = core::convert::Infallible
-pub fn aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_4::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_4 where U: core::convert::TryFrom<T>
-pub type aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_4::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_4::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_4 where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_4::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_4 where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_4::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_4 where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_4::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_4 where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_4::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_4
-pub fn aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_4::from(t: T) -> T
 #[repr(C)] pub union aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_5
 pub aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_5::__bindgen_anon_1: aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_5__bindgen_ty_1
 pub aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_5::tbid: aya_ebpf_bindings::bindings::__u32
@@ -1277,24 +863,6 @@ impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_fib_lookup__bindge
 impl core::marker::UnsafeUnpin for aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_5
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_5
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_5
-impl<T, U> core::convert::Into<U> for aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_5 where U: core::convert::From<T>
-pub fn aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_5::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_5 where U: core::convert::Into<T>
-pub type aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_5::Error = core::convert::Infallible
-pub fn aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_5::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_5 where U: core::convert::TryFrom<T>
-pub type aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_5::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_5::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_5 where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_5::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_5 where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_5::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_5 where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_5::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_5 where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_5::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_5
-pub fn aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_5::from(t: T) -> T
 #[repr(C)] pub union aya_ebpf_bindings::bindings::bpf_flow_keys__bindgen_ty_1
 pub aya_ebpf_bindings::bindings::bpf_flow_keys__bindgen_ty_1::__bindgen_anon_1: aya_ebpf_bindings::bindings::bpf_flow_keys__bindgen_ty_1__bindgen_ty_1
 pub aya_ebpf_bindings::bindings::bpf_flow_keys__bindgen_ty_1::__bindgen_anon_2: aya_ebpf_bindings::bindings::bpf_flow_keys__bindgen_ty_1__bindgen_ty_2
@@ -1308,24 +876,6 @@ impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_flow_keys__bindgen
 impl core::marker::UnsafeUnpin for aya_ebpf_bindings::bindings::bpf_flow_keys__bindgen_ty_1
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf_bindings::bindings::bpf_flow_keys__bindgen_ty_1
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf_bindings::bindings::bpf_flow_keys__bindgen_ty_1
-impl<T, U> core::convert::Into<U> for aya_ebpf_bindings::bindings::bpf_flow_keys__bindgen_ty_1 where U: core::convert::From<T>
-pub fn aya_ebpf_bindings::bindings::bpf_flow_keys__bindgen_ty_1::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf_bindings::bindings::bpf_flow_keys__bindgen_ty_1 where U: core::convert::Into<T>
-pub type aya_ebpf_bindings::bindings::bpf_flow_keys__bindgen_ty_1::Error = core::convert::Infallible
-pub fn aya_ebpf_bindings::bindings::bpf_flow_keys__bindgen_ty_1::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf_bindings::bindings::bpf_flow_keys__bindgen_ty_1 where U: core::convert::TryFrom<T>
-pub type aya_ebpf_bindings::bindings::bpf_flow_keys__bindgen_ty_1::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf_bindings::bindings::bpf_flow_keys__bindgen_ty_1::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf_bindings::bindings::bpf_flow_keys__bindgen_ty_1 where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_flow_keys__bindgen_ty_1::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_flow_keys__bindgen_ty_1 where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_flow_keys__bindgen_ty_1::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_flow_keys__bindgen_ty_1 where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_flow_keys__bindgen_ty_1::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_flow_keys__bindgen_ty_1 where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_flow_keys__bindgen_ty_1::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_flow_keys__bindgen_ty_1
-pub fn aya_ebpf_bindings::bindings::bpf_flow_keys__bindgen_ty_1::from(t: T) -> T
 #[repr(C)] pub union aya_ebpf_bindings::bindings::bpf_iter_link_info
 pub aya_ebpf_bindings::bindings::bpf_iter_link_info::cgroup: aya_ebpf_bindings::bindings::bpf_iter_link_info__bindgen_ty_2
 pub aya_ebpf_bindings::bindings::bpf_iter_link_info::map: aya_ebpf_bindings::bindings::bpf_iter_link_info__bindgen_ty_1
@@ -1340,24 +890,6 @@ impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_iter_link_info
 impl core::marker::UnsafeUnpin for aya_ebpf_bindings::bindings::bpf_iter_link_info
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf_bindings::bindings::bpf_iter_link_info
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf_bindings::bindings::bpf_iter_link_info
-impl<T, U> core::convert::Into<U> for aya_ebpf_bindings::bindings::bpf_iter_link_info where U: core::convert::From<T>
-pub fn aya_ebpf_bindings::bindings::bpf_iter_link_info::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf_bindings::bindings::bpf_iter_link_info where U: core::convert::Into<T>
-pub type aya_ebpf_bindings::bindings::bpf_iter_link_info::Error = core::convert::Infallible
-pub fn aya_ebpf_bindings::bindings::bpf_iter_link_info::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf_bindings::bindings::bpf_iter_link_info where U: core::convert::TryFrom<T>
-pub type aya_ebpf_bindings::bindings::bpf_iter_link_info::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf_bindings::bindings::bpf_iter_link_info::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf_bindings::bindings::bpf_iter_link_info where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_iter_link_info::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_iter_link_info where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_iter_link_info::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_iter_link_info where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_iter_link_info::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_iter_link_info where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_iter_link_info::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_iter_link_info
-pub fn aya_ebpf_bindings::bindings::bpf_iter_link_info::from(t: T) -> T
 #[repr(C)] pub union aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1
 pub aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1::cgroup: aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_3
 pub aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1::iter: aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4
@@ -1382,24 +914,6 @@ impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_link_info__bindgen
 impl core::marker::UnsafeUnpin for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1
-impl<T, U> core::convert::Into<U> for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1 where U: core::convert::From<T>
-pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1 where U: core::convert::Into<T>
-pub type aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1::Error = core::convert::Infallible
-pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1 where U: core::convert::TryFrom<T>
-pub type aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1 where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1 where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1 where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1 where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1
-pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1::from(t: T) -> T
 #[repr(C)] pub union aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1
 pub aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1::event: aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_4
 pub aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1::kprobe: aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_2
@@ -1415,24 +929,6 @@ impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_link_info__bindgen
 impl core::marker::UnsafeUnpin for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1
-impl<T, U> core::convert::Into<U> for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1 where U: core::convert::From<T>
-pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1 where U: core::convert::Into<T>
-pub type aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1::Error = core::convert::Infallible
-pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1 where U: core::convert::TryFrom<T>
-pub type aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1 where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1 where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1 where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1 where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1
-pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1::from(t: T) -> T
 #[repr(C)] pub union aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_1
 pub aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_1::map: aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_1__bindgen_ty_1
 impl core::clone::Clone for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_1
@@ -1445,24 +941,6 @@ impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_link_info__bindgen
 impl core::marker::UnsafeUnpin for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_1
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_1
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_1
-impl<T, U> core::convert::Into<U> for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_1 where U: core::convert::From<T>
-pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_1::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_1 where U: core::convert::Into<T>
-pub type aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_1::Error = core::convert::Infallible
-pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_1::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_1 where U: core::convert::TryFrom<T>
-pub type aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_1::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_1::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_1 where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_1::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_1 where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_1::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_1 where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_1::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_1 where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_1::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_1
-pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_1::from(t: T) -> T
 #[repr(C)] pub union aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2
 pub aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2::cgroup: aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2__bindgen_ty_1
 pub aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2::task: aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2__bindgen_ty_2
@@ -1476,24 +954,6 @@ impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_link_info__bindgen
 impl core::marker::UnsafeUnpin for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2
-impl<T, U> core::convert::Into<U> for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2 where U: core::convert::From<T>
-pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2 where U: core::convert::Into<T>
-pub type aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2::Error = core::convert::Infallible
-pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2 where U: core::convert::TryFrom<T>
-pub type aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2 where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2 where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2 where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2 where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2
-pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2::from(t: T) -> T
 #[repr(C)] pub union aya_ebpf_bindings::bindings::bpf_lpm_trie_key_u8__bindgen_ty_1
 pub aya_ebpf_bindings::bindings::bpf_lpm_trie_key_u8__bindgen_ty_1::hdr: aya_ebpf_bindings::bindings::bpf_lpm_trie_key_hdr
 pub aya_ebpf_bindings::bindings::bpf_lpm_trie_key_u8__bindgen_ty_1::prefixlen: aya_ebpf_bindings::bindings::__u32
@@ -1507,24 +967,6 @@ impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_lpm_trie_key_u8__b
 impl core::marker::UnsafeUnpin for aya_ebpf_bindings::bindings::bpf_lpm_trie_key_u8__bindgen_ty_1
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf_bindings::bindings::bpf_lpm_trie_key_u8__bindgen_ty_1
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf_bindings::bindings::bpf_lpm_trie_key_u8__bindgen_ty_1
-impl<T, U> core::convert::Into<U> for aya_ebpf_bindings::bindings::bpf_lpm_trie_key_u8__bindgen_ty_1 where U: core::convert::From<T>
-pub fn aya_ebpf_bindings::bindings::bpf_lpm_trie_key_u8__bindgen_ty_1::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf_bindings::bindings::bpf_lpm_trie_key_u8__bindgen_ty_1 where U: core::convert::Into<T>
-pub type aya_ebpf_bindings::bindings::bpf_lpm_trie_key_u8__bindgen_ty_1::Error = core::convert::Infallible
-pub fn aya_ebpf_bindings::bindings::bpf_lpm_trie_key_u8__bindgen_ty_1::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf_bindings::bindings::bpf_lpm_trie_key_u8__bindgen_ty_1 where U: core::convert::TryFrom<T>
-pub type aya_ebpf_bindings::bindings::bpf_lpm_trie_key_u8__bindgen_ty_1::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf_bindings::bindings::bpf_lpm_trie_key_u8__bindgen_ty_1::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf_bindings::bindings::bpf_lpm_trie_key_u8__bindgen_ty_1 where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_lpm_trie_key_u8__bindgen_ty_1::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_lpm_trie_key_u8__bindgen_ty_1 where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_lpm_trie_key_u8__bindgen_ty_1::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_lpm_trie_key_u8__bindgen_ty_1 where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_lpm_trie_key_u8__bindgen_ty_1::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_lpm_trie_key_u8__bindgen_ty_1 where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_lpm_trie_key_u8__bindgen_ty_1::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_lpm_trie_key_u8__bindgen_ty_1
-pub fn aya_ebpf_bindings::bindings::bpf_lpm_trie_key_u8__bindgen_ty_1::from(t: T) -> T
 #[repr(C)] pub union aya_ebpf_bindings::bindings::bpf_redir_neigh__bindgen_ty_1
 pub aya_ebpf_bindings::bindings::bpf_redir_neigh__bindgen_ty_1::ipv4_nh: aya_ebpf_bindings::bindings::__be32
 pub aya_ebpf_bindings::bindings::bpf_redir_neigh__bindgen_ty_1::ipv6_nh: [aya_ebpf_bindings::bindings::__u32; 4]
@@ -1538,24 +980,6 @@ impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_redir_neigh__bindg
 impl core::marker::UnsafeUnpin for aya_ebpf_bindings::bindings::bpf_redir_neigh__bindgen_ty_1
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf_bindings::bindings::bpf_redir_neigh__bindgen_ty_1
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf_bindings::bindings::bpf_redir_neigh__bindgen_ty_1
-impl<T, U> core::convert::Into<U> for aya_ebpf_bindings::bindings::bpf_redir_neigh__bindgen_ty_1 where U: core::convert::From<T>
-pub fn aya_ebpf_bindings::bindings::bpf_redir_neigh__bindgen_ty_1::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf_bindings::bindings::bpf_redir_neigh__bindgen_ty_1 where U: core::convert::Into<T>
-pub type aya_ebpf_bindings::bindings::bpf_redir_neigh__bindgen_ty_1::Error = core::convert::Infallible
-pub fn aya_ebpf_bindings::bindings::bpf_redir_neigh__bindgen_ty_1::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf_bindings::bindings::bpf_redir_neigh__bindgen_ty_1 where U: core::convert::TryFrom<T>
-pub type aya_ebpf_bindings::bindings::bpf_redir_neigh__bindgen_ty_1::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf_bindings::bindings::bpf_redir_neigh__bindgen_ty_1::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf_bindings::bindings::bpf_redir_neigh__bindgen_ty_1 where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_redir_neigh__bindgen_ty_1::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_redir_neigh__bindgen_ty_1 where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_redir_neigh__bindgen_ty_1::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_redir_neigh__bindgen_ty_1 where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_redir_neigh__bindgen_ty_1::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_redir_neigh__bindgen_ty_1 where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_redir_neigh__bindgen_ty_1::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_redir_neigh__bindgen_ty_1
-pub fn aya_ebpf_bindings::bindings::bpf_redir_neigh__bindgen_ty_1::from(t: T) -> T
 #[repr(C)] pub union aya_ebpf_bindings::bindings::bpf_sk_lookup__bindgen_ty_1
 pub aya_ebpf_bindings::bindings::bpf_sk_lookup__bindgen_ty_1::__bindgen_anon_1: aya_ebpf_bindings::bindings::bpf_sk_lookup__bindgen_ty_1__bindgen_ty_1
 pub aya_ebpf_bindings::bindings::bpf_sk_lookup__bindgen_ty_1::cookie: aya_ebpf_bindings::bindings::__u64
@@ -1569,24 +993,6 @@ impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_sk_lookup__bindgen
 impl core::marker::UnsafeUnpin for aya_ebpf_bindings::bindings::bpf_sk_lookup__bindgen_ty_1
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf_bindings::bindings::bpf_sk_lookup__bindgen_ty_1
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf_bindings::bindings::bpf_sk_lookup__bindgen_ty_1
-impl<T, U> core::convert::Into<U> for aya_ebpf_bindings::bindings::bpf_sk_lookup__bindgen_ty_1 where U: core::convert::From<T>
-pub fn aya_ebpf_bindings::bindings::bpf_sk_lookup__bindgen_ty_1::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf_bindings::bindings::bpf_sk_lookup__bindgen_ty_1 where U: core::convert::Into<T>
-pub type aya_ebpf_bindings::bindings::bpf_sk_lookup__bindgen_ty_1::Error = core::convert::Infallible
-pub fn aya_ebpf_bindings::bindings::bpf_sk_lookup__bindgen_ty_1::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf_bindings::bindings::bpf_sk_lookup__bindgen_ty_1 where U: core::convert::TryFrom<T>
-pub type aya_ebpf_bindings::bindings::bpf_sk_lookup__bindgen_ty_1::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf_bindings::bindings::bpf_sk_lookup__bindgen_ty_1::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf_bindings::bindings::bpf_sk_lookup__bindgen_ty_1 where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_sk_lookup__bindgen_ty_1::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_sk_lookup__bindgen_ty_1 where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_sk_lookup__bindgen_ty_1::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_sk_lookup__bindgen_ty_1 where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_sk_lookup__bindgen_ty_1::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_sk_lookup__bindgen_ty_1 where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_sk_lookup__bindgen_ty_1::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_sk_lookup__bindgen_ty_1
-pub fn aya_ebpf_bindings::bindings::bpf_sk_lookup__bindgen_ty_1::from(t: T) -> T
 #[repr(C)] pub union aya_ebpf_bindings::bindings::bpf_sk_lookup__bindgen_ty_1__bindgen_ty_1
 pub aya_ebpf_bindings::bindings::bpf_sk_lookup__bindgen_ty_1__bindgen_ty_1::_bitfield_1: aya_ebpf_bindings::bindings::__BindgenBitfieldUnit<[u8; 8]>
 pub aya_ebpf_bindings::bindings::bpf_sk_lookup__bindgen_ty_1__bindgen_ty_1::_bitfield_align_1: [u8; 0]
@@ -1603,24 +1009,6 @@ impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_sk_lookup__bindgen
 impl core::marker::UnsafeUnpin for aya_ebpf_bindings::bindings::bpf_sk_lookup__bindgen_ty_1__bindgen_ty_1
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf_bindings::bindings::bpf_sk_lookup__bindgen_ty_1__bindgen_ty_1
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf_bindings::bindings::bpf_sk_lookup__bindgen_ty_1__bindgen_ty_1
-impl<T, U> core::convert::Into<U> for aya_ebpf_bindings::bindings::bpf_sk_lookup__bindgen_ty_1__bindgen_ty_1 where U: core::convert::From<T>
-pub fn aya_ebpf_bindings::bindings::bpf_sk_lookup__bindgen_ty_1__bindgen_ty_1::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf_bindings::bindings::bpf_sk_lookup__bindgen_ty_1__bindgen_ty_1 where U: core::convert::Into<T>
-pub type aya_ebpf_bindings::bindings::bpf_sk_lookup__bindgen_ty_1__bindgen_ty_1::Error = core::convert::Infallible
-pub fn aya_ebpf_bindings::bindings::bpf_sk_lookup__bindgen_ty_1__bindgen_ty_1::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf_bindings::bindings::bpf_sk_lookup__bindgen_ty_1__bindgen_ty_1 where U: core::convert::TryFrom<T>
-pub type aya_ebpf_bindings::bindings::bpf_sk_lookup__bindgen_ty_1__bindgen_ty_1::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf_bindings::bindings::bpf_sk_lookup__bindgen_ty_1__bindgen_ty_1::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf_bindings::bindings::bpf_sk_lookup__bindgen_ty_1__bindgen_ty_1 where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_sk_lookup__bindgen_ty_1__bindgen_ty_1::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_sk_lookup__bindgen_ty_1__bindgen_ty_1 where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_sk_lookup__bindgen_ty_1__bindgen_ty_1::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_sk_lookup__bindgen_ty_1__bindgen_ty_1 where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_sk_lookup__bindgen_ty_1__bindgen_ty_1::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_sk_lookup__bindgen_ty_1__bindgen_ty_1 where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_sk_lookup__bindgen_ty_1__bindgen_ty_1::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_sk_lookup__bindgen_ty_1__bindgen_ty_1
-pub fn aya_ebpf_bindings::bindings::bpf_sk_lookup__bindgen_ty_1__bindgen_ty_1::from(t: T) -> T
 #[repr(C)] pub union aya_ebpf_bindings::bindings::bpf_sock_addr__bindgen_ty_1
 pub aya_ebpf_bindings::bindings::bpf_sock_addr__bindgen_ty_1::_bitfield_1: aya_ebpf_bindings::bindings::__BindgenBitfieldUnit<[u8; 8]>
 pub aya_ebpf_bindings::bindings::bpf_sock_addr__bindgen_ty_1::_bitfield_align_1: [u8; 0]
@@ -1637,24 +1025,6 @@ impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_sock_addr__bindgen
 impl core::marker::UnsafeUnpin for aya_ebpf_bindings::bindings::bpf_sock_addr__bindgen_ty_1
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf_bindings::bindings::bpf_sock_addr__bindgen_ty_1
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf_bindings::bindings::bpf_sock_addr__bindgen_ty_1
-impl<T, U> core::convert::Into<U> for aya_ebpf_bindings::bindings::bpf_sock_addr__bindgen_ty_1 where U: core::convert::From<T>
-pub fn aya_ebpf_bindings::bindings::bpf_sock_addr__bindgen_ty_1::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf_bindings::bindings::bpf_sock_addr__bindgen_ty_1 where U: core::convert::Into<T>
-pub type aya_ebpf_bindings::bindings::bpf_sock_addr__bindgen_ty_1::Error = core::convert::Infallible
-pub fn aya_ebpf_bindings::bindings::bpf_sock_addr__bindgen_ty_1::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf_bindings::bindings::bpf_sock_addr__bindgen_ty_1 where U: core::convert::TryFrom<T>
-pub type aya_ebpf_bindings::bindings::bpf_sock_addr__bindgen_ty_1::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf_bindings::bindings::bpf_sock_addr__bindgen_ty_1::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf_bindings::bindings::bpf_sock_addr__bindgen_ty_1 where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_sock_addr__bindgen_ty_1::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_sock_addr__bindgen_ty_1 where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_sock_addr__bindgen_ty_1::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_sock_addr__bindgen_ty_1 where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_sock_addr__bindgen_ty_1::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_sock_addr__bindgen_ty_1 where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_sock_addr__bindgen_ty_1::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_sock_addr__bindgen_ty_1
-pub fn aya_ebpf_bindings::bindings::bpf_sock_addr__bindgen_ty_1::from(t: T) -> T
 #[repr(C)] pub union aya_ebpf_bindings::bindings::bpf_sock_ops__bindgen_ty_1
 pub aya_ebpf_bindings::bindings::bpf_sock_ops__bindgen_ty_1::args: [aya_ebpf_bindings::bindings::__u32; 4]
 pub aya_ebpf_bindings::bindings::bpf_sock_ops__bindgen_ty_1::reply: aya_ebpf_bindings::bindings::__u32
@@ -1669,24 +1039,6 @@ impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_sock_ops__bindgen_
 impl core::marker::UnsafeUnpin for aya_ebpf_bindings::bindings::bpf_sock_ops__bindgen_ty_1
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf_bindings::bindings::bpf_sock_ops__bindgen_ty_1
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf_bindings::bindings::bpf_sock_ops__bindgen_ty_1
-impl<T, U> core::convert::Into<U> for aya_ebpf_bindings::bindings::bpf_sock_ops__bindgen_ty_1 where U: core::convert::From<T>
-pub fn aya_ebpf_bindings::bindings::bpf_sock_ops__bindgen_ty_1::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf_bindings::bindings::bpf_sock_ops__bindgen_ty_1 where U: core::convert::Into<T>
-pub type aya_ebpf_bindings::bindings::bpf_sock_ops__bindgen_ty_1::Error = core::convert::Infallible
-pub fn aya_ebpf_bindings::bindings::bpf_sock_ops__bindgen_ty_1::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf_bindings::bindings::bpf_sock_ops__bindgen_ty_1 where U: core::convert::TryFrom<T>
-pub type aya_ebpf_bindings::bindings::bpf_sock_ops__bindgen_ty_1::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf_bindings::bindings::bpf_sock_ops__bindgen_ty_1::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf_bindings::bindings::bpf_sock_ops__bindgen_ty_1 where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_sock_ops__bindgen_ty_1::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_sock_ops__bindgen_ty_1 where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_sock_ops__bindgen_ty_1::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_sock_ops__bindgen_ty_1 where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_sock_ops__bindgen_ty_1::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_sock_ops__bindgen_ty_1 where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_sock_ops__bindgen_ty_1::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_sock_ops__bindgen_ty_1
-pub fn aya_ebpf_bindings::bindings::bpf_sock_ops__bindgen_ty_1::from(t: T) -> T
 #[repr(C)] pub union aya_ebpf_bindings::bindings::bpf_sock_ops__bindgen_ty_2
 pub aya_ebpf_bindings::bindings::bpf_sock_ops__bindgen_ty_2::_bitfield_1: aya_ebpf_bindings::bindings::__BindgenBitfieldUnit<[u8; 8]>
 pub aya_ebpf_bindings::bindings::bpf_sock_ops__bindgen_ty_2::_bitfield_align_1: [u8; 0]
@@ -1703,24 +1055,6 @@ impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_sock_ops__bindgen_
 impl core::marker::UnsafeUnpin for aya_ebpf_bindings::bindings::bpf_sock_ops__bindgen_ty_2
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf_bindings::bindings::bpf_sock_ops__bindgen_ty_2
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf_bindings::bindings::bpf_sock_ops__bindgen_ty_2
-impl<T, U> core::convert::Into<U> for aya_ebpf_bindings::bindings::bpf_sock_ops__bindgen_ty_2 where U: core::convert::From<T>
-pub fn aya_ebpf_bindings::bindings::bpf_sock_ops__bindgen_ty_2::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf_bindings::bindings::bpf_sock_ops__bindgen_ty_2 where U: core::convert::Into<T>
-pub type aya_ebpf_bindings::bindings::bpf_sock_ops__bindgen_ty_2::Error = core::convert::Infallible
-pub fn aya_ebpf_bindings::bindings::bpf_sock_ops__bindgen_ty_2::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf_bindings::bindings::bpf_sock_ops__bindgen_ty_2 where U: core::convert::TryFrom<T>
-pub type aya_ebpf_bindings::bindings::bpf_sock_ops__bindgen_ty_2::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf_bindings::bindings::bpf_sock_ops__bindgen_ty_2::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf_bindings::bindings::bpf_sock_ops__bindgen_ty_2 where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_sock_ops__bindgen_ty_2::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_sock_ops__bindgen_ty_2 where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_sock_ops__bindgen_ty_2::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_sock_ops__bindgen_ty_2 where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_sock_ops__bindgen_ty_2::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_sock_ops__bindgen_ty_2 where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_sock_ops__bindgen_ty_2::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_sock_ops__bindgen_ty_2
-pub fn aya_ebpf_bindings::bindings::bpf_sock_ops__bindgen_ty_2::from(t: T) -> T
 #[repr(C)] pub union aya_ebpf_bindings::bindings::bpf_sock_ops__bindgen_ty_3
 pub aya_ebpf_bindings::bindings::bpf_sock_ops__bindgen_ty_3::_bitfield_1: aya_ebpf_bindings::bindings::__BindgenBitfieldUnit<[u8; 8]>
 pub aya_ebpf_bindings::bindings::bpf_sock_ops__bindgen_ty_3::_bitfield_align_1: [u8; 0]
@@ -1737,24 +1071,6 @@ impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_sock_ops__bindgen_
 impl core::marker::UnsafeUnpin for aya_ebpf_bindings::bindings::bpf_sock_ops__bindgen_ty_3
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf_bindings::bindings::bpf_sock_ops__bindgen_ty_3
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf_bindings::bindings::bpf_sock_ops__bindgen_ty_3
-impl<T, U> core::convert::Into<U> for aya_ebpf_bindings::bindings::bpf_sock_ops__bindgen_ty_3 where U: core::convert::From<T>
-pub fn aya_ebpf_bindings::bindings::bpf_sock_ops__bindgen_ty_3::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf_bindings::bindings::bpf_sock_ops__bindgen_ty_3 where U: core::convert::Into<T>
-pub type aya_ebpf_bindings::bindings::bpf_sock_ops__bindgen_ty_3::Error = core::convert::Infallible
-pub fn aya_ebpf_bindings::bindings::bpf_sock_ops__bindgen_ty_3::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf_bindings::bindings::bpf_sock_ops__bindgen_ty_3 where U: core::convert::TryFrom<T>
-pub type aya_ebpf_bindings::bindings::bpf_sock_ops__bindgen_ty_3::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf_bindings::bindings::bpf_sock_ops__bindgen_ty_3::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf_bindings::bindings::bpf_sock_ops__bindgen_ty_3 where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_sock_ops__bindgen_ty_3::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_sock_ops__bindgen_ty_3 where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_sock_ops__bindgen_ty_3::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_sock_ops__bindgen_ty_3 where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_sock_ops__bindgen_ty_3::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_sock_ops__bindgen_ty_3 where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_sock_ops__bindgen_ty_3::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_sock_ops__bindgen_ty_3
-pub fn aya_ebpf_bindings::bindings::bpf_sock_ops__bindgen_ty_3::from(t: T) -> T
 #[repr(C)] pub union aya_ebpf_bindings::bindings::bpf_sock_ops__bindgen_ty_4
 pub aya_ebpf_bindings::bindings::bpf_sock_ops__bindgen_ty_4::_bitfield_1: aya_ebpf_bindings::bindings::__BindgenBitfieldUnit<[u8; 8]>
 pub aya_ebpf_bindings::bindings::bpf_sock_ops__bindgen_ty_4::_bitfield_align_1: [u8; 0]
@@ -1771,24 +1087,6 @@ impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_sock_ops__bindgen_
 impl core::marker::UnsafeUnpin for aya_ebpf_bindings::bindings::bpf_sock_ops__bindgen_ty_4
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf_bindings::bindings::bpf_sock_ops__bindgen_ty_4
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf_bindings::bindings::bpf_sock_ops__bindgen_ty_4
-impl<T, U> core::convert::Into<U> for aya_ebpf_bindings::bindings::bpf_sock_ops__bindgen_ty_4 where U: core::convert::From<T>
-pub fn aya_ebpf_bindings::bindings::bpf_sock_ops__bindgen_ty_4::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf_bindings::bindings::bpf_sock_ops__bindgen_ty_4 where U: core::convert::Into<T>
-pub type aya_ebpf_bindings::bindings::bpf_sock_ops__bindgen_ty_4::Error = core::convert::Infallible
-pub fn aya_ebpf_bindings::bindings::bpf_sock_ops__bindgen_ty_4::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf_bindings::bindings::bpf_sock_ops__bindgen_ty_4 where U: core::convert::TryFrom<T>
-pub type aya_ebpf_bindings::bindings::bpf_sock_ops__bindgen_ty_4::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf_bindings::bindings::bpf_sock_ops__bindgen_ty_4::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf_bindings::bindings::bpf_sock_ops__bindgen_ty_4 where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_sock_ops__bindgen_ty_4::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_sock_ops__bindgen_ty_4 where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_sock_ops__bindgen_ty_4::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_sock_ops__bindgen_ty_4 where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_sock_ops__bindgen_ty_4::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_sock_ops__bindgen_ty_4 where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_sock_ops__bindgen_ty_4::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_sock_ops__bindgen_ty_4
-pub fn aya_ebpf_bindings::bindings::bpf_sock_ops__bindgen_ty_4::from(t: T) -> T
 #[repr(C)] pub union aya_ebpf_bindings::bindings::bpf_sock_tuple__bindgen_ty_1
 pub aya_ebpf_bindings::bindings::bpf_sock_tuple__bindgen_ty_1::ipv4: aya_ebpf_bindings::bindings::bpf_sock_tuple__bindgen_ty_1__bindgen_ty_1
 pub aya_ebpf_bindings::bindings::bpf_sock_tuple__bindgen_ty_1::ipv6: aya_ebpf_bindings::bindings::bpf_sock_tuple__bindgen_ty_1__bindgen_ty_2
@@ -1802,24 +1100,6 @@ impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_sock_tuple__bindge
 impl core::marker::UnsafeUnpin for aya_ebpf_bindings::bindings::bpf_sock_tuple__bindgen_ty_1
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf_bindings::bindings::bpf_sock_tuple__bindgen_ty_1
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf_bindings::bindings::bpf_sock_tuple__bindgen_ty_1
-impl<T, U> core::convert::Into<U> for aya_ebpf_bindings::bindings::bpf_sock_tuple__bindgen_ty_1 where U: core::convert::From<T>
-pub fn aya_ebpf_bindings::bindings::bpf_sock_tuple__bindgen_ty_1::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf_bindings::bindings::bpf_sock_tuple__bindgen_ty_1 where U: core::convert::Into<T>
-pub type aya_ebpf_bindings::bindings::bpf_sock_tuple__bindgen_ty_1::Error = core::convert::Infallible
-pub fn aya_ebpf_bindings::bindings::bpf_sock_tuple__bindgen_ty_1::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf_bindings::bindings::bpf_sock_tuple__bindgen_ty_1 where U: core::convert::TryFrom<T>
-pub type aya_ebpf_bindings::bindings::bpf_sock_tuple__bindgen_ty_1::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf_bindings::bindings::bpf_sock_tuple__bindgen_ty_1::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf_bindings::bindings::bpf_sock_tuple__bindgen_ty_1 where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_sock_tuple__bindgen_ty_1::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_sock_tuple__bindgen_ty_1 where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_sock_tuple__bindgen_ty_1::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_sock_tuple__bindgen_ty_1 where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_sock_tuple__bindgen_ty_1::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_sock_tuple__bindgen_ty_1 where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_sock_tuple__bindgen_ty_1::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_sock_tuple__bindgen_ty_1
-pub fn aya_ebpf_bindings::bindings::bpf_sock_tuple__bindgen_ty_1::from(t: T) -> T
 #[repr(C)] pub union aya_ebpf_bindings::bindings::bpf_sockopt__bindgen_ty_1
 pub aya_ebpf_bindings::bindings::bpf_sockopt__bindgen_ty_1::_bitfield_1: aya_ebpf_bindings::bindings::__BindgenBitfieldUnit<[u8; 8]>
 pub aya_ebpf_bindings::bindings::bpf_sockopt__bindgen_ty_1::_bitfield_align_1: [u8; 0]
@@ -1836,24 +1116,6 @@ impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_sockopt__bindgen_t
 impl core::marker::UnsafeUnpin for aya_ebpf_bindings::bindings::bpf_sockopt__bindgen_ty_1
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf_bindings::bindings::bpf_sockopt__bindgen_ty_1
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf_bindings::bindings::bpf_sockopt__bindgen_ty_1
-impl<T, U> core::convert::Into<U> for aya_ebpf_bindings::bindings::bpf_sockopt__bindgen_ty_1 where U: core::convert::From<T>
-pub fn aya_ebpf_bindings::bindings::bpf_sockopt__bindgen_ty_1::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf_bindings::bindings::bpf_sockopt__bindgen_ty_1 where U: core::convert::Into<T>
-pub type aya_ebpf_bindings::bindings::bpf_sockopt__bindgen_ty_1::Error = core::convert::Infallible
-pub fn aya_ebpf_bindings::bindings::bpf_sockopt__bindgen_ty_1::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf_bindings::bindings::bpf_sockopt__bindgen_ty_1 where U: core::convert::TryFrom<T>
-pub type aya_ebpf_bindings::bindings::bpf_sockopt__bindgen_ty_1::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf_bindings::bindings::bpf_sockopt__bindgen_ty_1::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf_bindings::bindings::bpf_sockopt__bindgen_ty_1 where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_sockopt__bindgen_ty_1::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_sockopt__bindgen_ty_1 where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_sockopt__bindgen_ty_1::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_sockopt__bindgen_ty_1 where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_sockopt__bindgen_ty_1::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_sockopt__bindgen_ty_1 where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_sockopt__bindgen_ty_1::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_sockopt__bindgen_ty_1
-pub fn aya_ebpf_bindings::bindings::bpf_sockopt__bindgen_ty_1::from(t: T) -> T
 #[repr(C)] pub union aya_ebpf_bindings::bindings::bpf_sockopt__bindgen_ty_2
 pub aya_ebpf_bindings::bindings::bpf_sockopt__bindgen_ty_2::_bitfield_1: aya_ebpf_bindings::bindings::__BindgenBitfieldUnit<[u8; 8]>
 pub aya_ebpf_bindings::bindings::bpf_sockopt__bindgen_ty_2::_bitfield_align_1: [u8; 0]
@@ -1870,24 +1132,6 @@ impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_sockopt__bindgen_t
 impl core::marker::UnsafeUnpin for aya_ebpf_bindings::bindings::bpf_sockopt__bindgen_ty_2
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf_bindings::bindings::bpf_sockopt__bindgen_ty_2
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf_bindings::bindings::bpf_sockopt__bindgen_ty_2
-impl<T, U> core::convert::Into<U> for aya_ebpf_bindings::bindings::bpf_sockopt__bindgen_ty_2 where U: core::convert::From<T>
-pub fn aya_ebpf_bindings::bindings::bpf_sockopt__bindgen_ty_2::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf_bindings::bindings::bpf_sockopt__bindgen_ty_2 where U: core::convert::Into<T>
-pub type aya_ebpf_bindings::bindings::bpf_sockopt__bindgen_ty_2::Error = core::convert::Infallible
-pub fn aya_ebpf_bindings::bindings::bpf_sockopt__bindgen_ty_2::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf_bindings::bindings::bpf_sockopt__bindgen_ty_2 where U: core::convert::TryFrom<T>
-pub type aya_ebpf_bindings::bindings::bpf_sockopt__bindgen_ty_2::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf_bindings::bindings::bpf_sockopt__bindgen_ty_2::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf_bindings::bindings::bpf_sockopt__bindgen_ty_2 where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_sockopt__bindgen_ty_2::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_sockopt__bindgen_ty_2 where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_sockopt__bindgen_ty_2::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_sockopt__bindgen_ty_2 where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_sockopt__bindgen_ty_2::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_sockopt__bindgen_ty_2 where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_sockopt__bindgen_ty_2::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_sockopt__bindgen_ty_2
-pub fn aya_ebpf_bindings::bindings::bpf_sockopt__bindgen_ty_2::from(t: T) -> T
 #[repr(C)] pub union aya_ebpf_bindings::bindings::bpf_sockopt__bindgen_ty_3
 pub aya_ebpf_bindings::bindings::bpf_sockopt__bindgen_ty_3::_bitfield_1: aya_ebpf_bindings::bindings::__BindgenBitfieldUnit<[u8; 8]>
 pub aya_ebpf_bindings::bindings::bpf_sockopt__bindgen_ty_3::_bitfield_align_1: [u8; 0]
@@ -1904,24 +1148,6 @@ impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_sockopt__bindgen_t
 impl core::marker::UnsafeUnpin for aya_ebpf_bindings::bindings::bpf_sockopt__bindgen_ty_3
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf_bindings::bindings::bpf_sockopt__bindgen_ty_3
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf_bindings::bindings::bpf_sockopt__bindgen_ty_3
-impl<T, U> core::convert::Into<U> for aya_ebpf_bindings::bindings::bpf_sockopt__bindgen_ty_3 where U: core::convert::From<T>
-pub fn aya_ebpf_bindings::bindings::bpf_sockopt__bindgen_ty_3::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf_bindings::bindings::bpf_sockopt__bindgen_ty_3 where U: core::convert::Into<T>
-pub type aya_ebpf_bindings::bindings::bpf_sockopt__bindgen_ty_3::Error = core::convert::Infallible
-pub fn aya_ebpf_bindings::bindings::bpf_sockopt__bindgen_ty_3::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf_bindings::bindings::bpf_sockopt__bindgen_ty_3 where U: core::convert::TryFrom<T>
-pub type aya_ebpf_bindings::bindings::bpf_sockopt__bindgen_ty_3::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf_bindings::bindings::bpf_sockopt__bindgen_ty_3::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf_bindings::bindings::bpf_sockopt__bindgen_ty_3 where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_sockopt__bindgen_ty_3::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_sockopt__bindgen_ty_3 where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_sockopt__bindgen_ty_3::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_sockopt__bindgen_ty_3 where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_sockopt__bindgen_ty_3::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_sockopt__bindgen_ty_3 where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_sockopt__bindgen_ty_3::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_sockopt__bindgen_ty_3
-pub fn aya_ebpf_bindings::bindings::bpf_sockopt__bindgen_ty_3::from(t: T) -> T
 #[repr(C)] pub union aya_ebpf_bindings::bindings::bpf_stack_build_id__bindgen_ty_1
 pub aya_ebpf_bindings::bindings::bpf_stack_build_id__bindgen_ty_1::ip: aya_ebpf_bindings::bindings::__u64
 pub aya_ebpf_bindings::bindings::bpf_stack_build_id__bindgen_ty_1::offset: aya_ebpf_bindings::bindings::__u64
@@ -1935,24 +1161,6 @@ impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_stack_build_id__bi
 impl core::marker::UnsafeUnpin for aya_ebpf_bindings::bindings::bpf_stack_build_id__bindgen_ty_1
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf_bindings::bindings::bpf_stack_build_id__bindgen_ty_1
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf_bindings::bindings::bpf_stack_build_id__bindgen_ty_1
-impl<T, U> core::convert::Into<U> for aya_ebpf_bindings::bindings::bpf_stack_build_id__bindgen_ty_1 where U: core::convert::From<T>
-pub fn aya_ebpf_bindings::bindings::bpf_stack_build_id__bindgen_ty_1::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf_bindings::bindings::bpf_stack_build_id__bindgen_ty_1 where U: core::convert::Into<T>
-pub type aya_ebpf_bindings::bindings::bpf_stack_build_id__bindgen_ty_1::Error = core::convert::Infallible
-pub fn aya_ebpf_bindings::bindings::bpf_stack_build_id__bindgen_ty_1::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf_bindings::bindings::bpf_stack_build_id__bindgen_ty_1 where U: core::convert::TryFrom<T>
-pub type aya_ebpf_bindings::bindings::bpf_stack_build_id__bindgen_ty_1::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf_bindings::bindings::bpf_stack_build_id__bindgen_ty_1::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf_bindings::bindings::bpf_stack_build_id__bindgen_ty_1 where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_stack_build_id__bindgen_ty_1::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_stack_build_id__bindgen_ty_1 where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_stack_build_id__bindgen_ty_1::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_stack_build_id__bindgen_ty_1 where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_stack_build_id__bindgen_ty_1::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_stack_build_id__bindgen_ty_1 where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_stack_build_id__bindgen_ty_1::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_stack_build_id__bindgen_ty_1
-pub fn aya_ebpf_bindings::bindings::bpf_stack_build_id__bindgen_ty_1::from(t: T) -> T
 #[repr(C)] pub union aya_ebpf_bindings::bindings::bpf_tunnel_key__bindgen_ty_1
 pub aya_ebpf_bindings::bindings::bpf_tunnel_key__bindgen_ty_1::remote_ipv4: aya_ebpf_bindings::bindings::__u32
 pub aya_ebpf_bindings::bindings::bpf_tunnel_key__bindgen_ty_1::remote_ipv6: [aya_ebpf_bindings::bindings::__u32; 4]
@@ -1966,24 +1174,6 @@ impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_tunnel_key__bindge
 impl core::marker::UnsafeUnpin for aya_ebpf_bindings::bindings::bpf_tunnel_key__bindgen_ty_1
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf_bindings::bindings::bpf_tunnel_key__bindgen_ty_1
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf_bindings::bindings::bpf_tunnel_key__bindgen_ty_1
-impl<T, U> core::convert::Into<U> for aya_ebpf_bindings::bindings::bpf_tunnel_key__bindgen_ty_1 where U: core::convert::From<T>
-pub fn aya_ebpf_bindings::bindings::bpf_tunnel_key__bindgen_ty_1::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf_bindings::bindings::bpf_tunnel_key__bindgen_ty_1 where U: core::convert::Into<T>
-pub type aya_ebpf_bindings::bindings::bpf_tunnel_key__bindgen_ty_1::Error = core::convert::Infallible
-pub fn aya_ebpf_bindings::bindings::bpf_tunnel_key__bindgen_ty_1::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf_bindings::bindings::bpf_tunnel_key__bindgen_ty_1 where U: core::convert::TryFrom<T>
-pub type aya_ebpf_bindings::bindings::bpf_tunnel_key__bindgen_ty_1::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf_bindings::bindings::bpf_tunnel_key__bindgen_ty_1::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf_bindings::bindings::bpf_tunnel_key__bindgen_ty_1 where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_tunnel_key__bindgen_ty_1::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_tunnel_key__bindgen_ty_1 where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_tunnel_key__bindgen_ty_1::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_tunnel_key__bindgen_ty_1 where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_tunnel_key__bindgen_ty_1::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_tunnel_key__bindgen_ty_1 where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_tunnel_key__bindgen_ty_1::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_tunnel_key__bindgen_ty_1
-pub fn aya_ebpf_bindings::bindings::bpf_tunnel_key__bindgen_ty_1::from(t: T) -> T
 #[repr(C)] pub union aya_ebpf_bindings::bindings::bpf_tunnel_key__bindgen_ty_2
 pub aya_ebpf_bindings::bindings::bpf_tunnel_key__bindgen_ty_2::tunnel_ext: aya_ebpf_bindings::bindings::__u16
 pub aya_ebpf_bindings::bindings::bpf_tunnel_key__bindgen_ty_2::tunnel_flags: aya_ebpf_bindings::bindings::__be16
@@ -1997,24 +1187,6 @@ impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_tunnel_key__bindge
 impl core::marker::UnsafeUnpin for aya_ebpf_bindings::bindings::bpf_tunnel_key__bindgen_ty_2
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf_bindings::bindings::bpf_tunnel_key__bindgen_ty_2
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf_bindings::bindings::bpf_tunnel_key__bindgen_ty_2
-impl<T, U> core::convert::Into<U> for aya_ebpf_bindings::bindings::bpf_tunnel_key__bindgen_ty_2 where U: core::convert::From<T>
-pub fn aya_ebpf_bindings::bindings::bpf_tunnel_key__bindgen_ty_2::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf_bindings::bindings::bpf_tunnel_key__bindgen_ty_2 where U: core::convert::Into<T>
-pub type aya_ebpf_bindings::bindings::bpf_tunnel_key__bindgen_ty_2::Error = core::convert::Infallible
-pub fn aya_ebpf_bindings::bindings::bpf_tunnel_key__bindgen_ty_2::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf_bindings::bindings::bpf_tunnel_key__bindgen_ty_2 where U: core::convert::TryFrom<T>
-pub type aya_ebpf_bindings::bindings::bpf_tunnel_key__bindgen_ty_2::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf_bindings::bindings::bpf_tunnel_key__bindgen_ty_2::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf_bindings::bindings::bpf_tunnel_key__bindgen_ty_2 where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_tunnel_key__bindgen_ty_2::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_tunnel_key__bindgen_ty_2 where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_tunnel_key__bindgen_ty_2::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_tunnel_key__bindgen_ty_2 where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_tunnel_key__bindgen_ty_2::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_tunnel_key__bindgen_ty_2 where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_tunnel_key__bindgen_ty_2::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_tunnel_key__bindgen_ty_2
-pub fn aya_ebpf_bindings::bindings::bpf_tunnel_key__bindgen_ty_2::from(t: T) -> T
 #[repr(C)] pub union aya_ebpf_bindings::bindings::bpf_tunnel_key__bindgen_ty_3
 pub aya_ebpf_bindings::bindings::bpf_tunnel_key__bindgen_ty_3::local_ipv4: aya_ebpf_bindings::bindings::__u32
 pub aya_ebpf_bindings::bindings::bpf_tunnel_key__bindgen_ty_3::local_ipv6: [aya_ebpf_bindings::bindings::__u32; 4]
@@ -2028,24 +1200,6 @@ impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_tunnel_key__bindge
 impl core::marker::UnsafeUnpin for aya_ebpf_bindings::bindings::bpf_tunnel_key__bindgen_ty_3
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf_bindings::bindings::bpf_tunnel_key__bindgen_ty_3
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf_bindings::bindings::bpf_tunnel_key__bindgen_ty_3
-impl<T, U> core::convert::Into<U> for aya_ebpf_bindings::bindings::bpf_tunnel_key__bindgen_ty_3 where U: core::convert::From<T>
-pub fn aya_ebpf_bindings::bindings::bpf_tunnel_key__bindgen_ty_3::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf_bindings::bindings::bpf_tunnel_key__bindgen_ty_3 where U: core::convert::Into<T>
-pub type aya_ebpf_bindings::bindings::bpf_tunnel_key__bindgen_ty_3::Error = core::convert::Infallible
-pub fn aya_ebpf_bindings::bindings::bpf_tunnel_key__bindgen_ty_3::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf_bindings::bindings::bpf_tunnel_key__bindgen_ty_3 where U: core::convert::TryFrom<T>
-pub type aya_ebpf_bindings::bindings::bpf_tunnel_key__bindgen_ty_3::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf_bindings::bindings::bpf_tunnel_key__bindgen_ty_3::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf_bindings::bindings::bpf_tunnel_key__bindgen_ty_3 where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_tunnel_key__bindgen_ty_3::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_tunnel_key__bindgen_ty_3 where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_tunnel_key__bindgen_ty_3::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_tunnel_key__bindgen_ty_3 where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_tunnel_key__bindgen_ty_3::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_tunnel_key__bindgen_ty_3 where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_tunnel_key__bindgen_ty_3::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_tunnel_key__bindgen_ty_3
-pub fn aya_ebpf_bindings::bindings::bpf_tunnel_key__bindgen_ty_3::from(t: T) -> T
 #[repr(C)] pub union aya_ebpf_bindings::bindings::bpf_xfrm_state__bindgen_ty_1
 pub aya_ebpf_bindings::bindings::bpf_xfrm_state__bindgen_ty_1::remote_ipv4: aya_ebpf_bindings::bindings::__u32
 pub aya_ebpf_bindings::bindings::bpf_xfrm_state__bindgen_ty_1::remote_ipv6: [aya_ebpf_bindings::bindings::__u32; 4]
@@ -2059,24 +1213,6 @@ impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_xfrm_state__bindge
 impl core::marker::UnsafeUnpin for aya_ebpf_bindings::bindings::bpf_xfrm_state__bindgen_ty_1
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf_bindings::bindings::bpf_xfrm_state__bindgen_ty_1
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf_bindings::bindings::bpf_xfrm_state__bindgen_ty_1
-impl<T, U> core::convert::Into<U> for aya_ebpf_bindings::bindings::bpf_xfrm_state__bindgen_ty_1 where U: core::convert::From<T>
-pub fn aya_ebpf_bindings::bindings::bpf_xfrm_state__bindgen_ty_1::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf_bindings::bindings::bpf_xfrm_state__bindgen_ty_1 where U: core::convert::Into<T>
-pub type aya_ebpf_bindings::bindings::bpf_xfrm_state__bindgen_ty_1::Error = core::convert::Infallible
-pub fn aya_ebpf_bindings::bindings::bpf_xfrm_state__bindgen_ty_1::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf_bindings::bindings::bpf_xfrm_state__bindgen_ty_1 where U: core::convert::TryFrom<T>
-pub type aya_ebpf_bindings::bindings::bpf_xfrm_state__bindgen_ty_1::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf_bindings::bindings::bpf_xfrm_state__bindgen_ty_1::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf_bindings::bindings::bpf_xfrm_state__bindgen_ty_1 where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_xfrm_state__bindgen_ty_1::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_xfrm_state__bindgen_ty_1 where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_xfrm_state__bindgen_ty_1::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_xfrm_state__bindgen_ty_1 where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_xfrm_state__bindgen_ty_1::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_xfrm_state__bindgen_ty_1 where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_xfrm_state__bindgen_ty_1::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_xfrm_state__bindgen_ty_1
-pub fn aya_ebpf_bindings::bindings::bpf_xfrm_state__bindgen_ty_1::from(t: T) -> T
 #[repr(C)] pub union aya_ebpf_bindings::bindings::sk_msg_md__bindgen_ty_1
 pub aya_ebpf_bindings::bindings::sk_msg_md__bindgen_ty_1::_bitfield_1: aya_ebpf_bindings::bindings::__BindgenBitfieldUnit<[u8; 8]>
 pub aya_ebpf_bindings::bindings::sk_msg_md__bindgen_ty_1::_bitfield_align_1: [u8; 0]
@@ -2093,24 +1229,6 @@ impl core::marker::Unpin for aya_ebpf_bindings::bindings::sk_msg_md__bindgen_ty_
 impl core::marker::UnsafeUnpin for aya_ebpf_bindings::bindings::sk_msg_md__bindgen_ty_1
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf_bindings::bindings::sk_msg_md__bindgen_ty_1
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf_bindings::bindings::sk_msg_md__bindgen_ty_1
-impl<T, U> core::convert::Into<U> for aya_ebpf_bindings::bindings::sk_msg_md__bindgen_ty_1 where U: core::convert::From<T>
-pub fn aya_ebpf_bindings::bindings::sk_msg_md__bindgen_ty_1::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf_bindings::bindings::sk_msg_md__bindgen_ty_1 where U: core::convert::Into<T>
-pub type aya_ebpf_bindings::bindings::sk_msg_md__bindgen_ty_1::Error = core::convert::Infallible
-pub fn aya_ebpf_bindings::bindings::sk_msg_md__bindgen_ty_1::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf_bindings::bindings::sk_msg_md__bindgen_ty_1 where U: core::convert::TryFrom<T>
-pub type aya_ebpf_bindings::bindings::sk_msg_md__bindgen_ty_1::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf_bindings::bindings::sk_msg_md__bindgen_ty_1::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf_bindings::bindings::sk_msg_md__bindgen_ty_1 where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::sk_msg_md__bindgen_ty_1::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::sk_msg_md__bindgen_ty_1 where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::sk_msg_md__bindgen_ty_1::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::sk_msg_md__bindgen_ty_1 where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::sk_msg_md__bindgen_ty_1::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::sk_msg_md__bindgen_ty_1 where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::sk_msg_md__bindgen_ty_1::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::sk_msg_md__bindgen_ty_1
-pub fn aya_ebpf_bindings::bindings::sk_msg_md__bindgen_ty_1::from(t: T) -> T
 #[repr(C)] pub union aya_ebpf_bindings::bindings::sk_msg_md__bindgen_ty_2
 pub aya_ebpf_bindings::bindings::sk_msg_md__bindgen_ty_2::_bitfield_1: aya_ebpf_bindings::bindings::__BindgenBitfieldUnit<[u8; 8]>
 pub aya_ebpf_bindings::bindings::sk_msg_md__bindgen_ty_2::_bitfield_align_1: [u8; 0]
@@ -2127,24 +1245,6 @@ impl core::marker::Unpin for aya_ebpf_bindings::bindings::sk_msg_md__bindgen_ty_
 impl core::marker::UnsafeUnpin for aya_ebpf_bindings::bindings::sk_msg_md__bindgen_ty_2
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf_bindings::bindings::sk_msg_md__bindgen_ty_2
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf_bindings::bindings::sk_msg_md__bindgen_ty_2
-impl<T, U> core::convert::Into<U> for aya_ebpf_bindings::bindings::sk_msg_md__bindgen_ty_2 where U: core::convert::From<T>
-pub fn aya_ebpf_bindings::bindings::sk_msg_md__bindgen_ty_2::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf_bindings::bindings::sk_msg_md__bindgen_ty_2 where U: core::convert::Into<T>
-pub type aya_ebpf_bindings::bindings::sk_msg_md__bindgen_ty_2::Error = core::convert::Infallible
-pub fn aya_ebpf_bindings::bindings::sk_msg_md__bindgen_ty_2::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf_bindings::bindings::sk_msg_md__bindgen_ty_2 where U: core::convert::TryFrom<T>
-pub type aya_ebpf_bindings::bindings::sk_msg_md__bindgen_ty_2::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf_bindings::bindings::sk_msg_md__bindgen_ty_2::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf_bindings::bindings::sk_msg_md__bindgen_ty_2 where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::sk_msg_md__bindgen_ty_2::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::sk_msg_md__bindgen_ty_2 where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::sk_msg_md__bindgen_ty_2::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::sk_msg_md__bindgen_ty_2 where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::sk_msg_md__bindgen_ty_2::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::sk_msg_md__bindgen_ty_2 where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::sk_msg_md__bindgen_ty_2::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::sk_msg_md__bindgen_ty_2
-pub fn aya_ebpf_bindings::bindings::sk_msg_md__bindgen_ty_2::from(t: T) -> T
 #[repr(C)] pub union aya_ebpf_bindings::bindings::sk_msg_md__bindgen_ty_3
 pub aya_ebpf_bindings::bindings::sk_msg_md__bindgen_ty_3::_bitfield_1: aya_ebpf_bindings::bindings::__BindgenBitfieldUnit<[u8; 8]>
 pub aya_ebpf_bindings::bindings::sk_msg_md__bindgen_ty_3::_bitfield_align_1: [u8; 0]
@@ -2161,24 +1261,6 @@ impl core::marker::Unpin for aya_ebpf_bindings::bindings::sk_msg_md__bindgen_ty_
 impl core::marker::UnsafeUnpin for aya_ebpf_bindings::bindings::sk_msg_md__bindgen_ty_3
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf_bindings::bindings::sk_msg_md__bindgen_ty_3
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf_bindings::bindings::sk_msg_md__bindgen_ty_3
-impl<T, U> core::convert::Into<U> for aya_ebpf_bindings::bindings::sk_msg_md__bindgen_ty_3 where U: core::convert::From<T>
-pub fn aya_ebpf_bindings::bindings::sk_msg_md__bindgen_ty_3::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf_bindings::bindings::sk_msg_md__bindgen_ty_3 where U: core::convert::Into<T>
-pub type aya_ebpf_bindings::bindings::sk_msg_md__bindgen_ty_3::Error = core::convert::Infallible
-pub fn aya_ebpf_bindings::bindings::sk_msg_md__bindgen_ty_3::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf_bindings::bindings::sk_msg_md__bindgen_ty_3 where U: core::convert::TryFrom<T>
-pub type aya_ebpf_bindings::bindings::sk_msg_md__bindgen_ty_3::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf_bindings::bindings::sk_msg_md__bindgen_ty_3::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf_bindings::bindings::sk_msg_md__bindgen_ty_3 where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::sk_msg_md__bindgen_ty_3::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::sk_msg_md__bindgen_ty_3 where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::sk_msg_md__bindgen_ty_3::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::sk_msg_md__bindgen_ty_3 where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::sk_msg_md__bindgen_ty_3::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::sk_msg_md__bindgen_ty_3 where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::sk_msg_md__bindgen_ty_3::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::sk_msg_md__bindgen_ty_3
-pub fn aya_ebpf_bindings::bindings::sk_msg_md__bindgen_ty_3::from(t: T) -> T
 #[repr(C)] pub union aya_ebpf_bindings::bindings::sk_reuseport_md__bindgen_ty_1
 pub aya_ebpf_bindings::bindings::sk_reuseport_md__bindgen_ty_1::_bitfield_1: aya_ebpf_bindings::bindings::__BindgenBitfieldUnit<[u8; 8]>
 pub aya_ebpf_bindings::bindings::sk_reuseport_md__bindgen_ty_1::_bitfield_align_1: [u8; 0]
@@ -2195,24 +1277,6 @@ impl core::marker::Unpin for aya_ebpf_bindings::bindings::sk_reuseport_md__bindg
 impl core::marker::UnsafeUnpin for aya_ebpf_bindings::bindings::sk_reuseport_md__bindgen_ty_1
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf_bindings::bindings::sk_reuseport_md__bindgen_ty_1
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf_bindings::bindings::sk_reuseport_md__bindgen_ty_1
-impl<T, U> core::convert::Into<U> for aya_ebpf_bindings::bindings::sk_reuseport_md__bindgen_ty_1 where U: core::convert::From<T>
-pub fn aya_ebpf_bindings::bindings::sk_reuseport_md__bindgen_ty_1::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf_bindings::bindings::sk_reuseport_md__bindgen_ty_1 where U: core::convert::Into<T>
-pub type aya_ebpf_bindings::bindings::sk_reuseport_md__bindgen_ty_1::Error = core::convert::Infallible
-pub fn aya_ebpf_bindings::bindings::sk_reuseport_md__bindgen_ty_1::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf_bindings::bindings::sk_reuseport_md__bindgen_ty_1 where U: core::convert::TryFrom<T>
-pub type aya_ebpf_bindings::bindings::sk_reuseport_md__bindgen_ty_1::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf_bindings::bindings::sk_reuseport_md__bindgen_ty_1::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf_bindings::bindings::sk_reuseport_md__bindgen_ty_1 where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::sk_reuseport_md__bindgen_ty_1::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::sk_reuseport_md__bindgen_ty_1 where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::sk_reuseport_md__bindgen_ty_1::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::sk_reuseport_md__bindgen_ty_1 where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::sk_reuseport_md__bindgen_ty_1::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::sk_reuseport_md__bindgen_ty_1 where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::sk_reuseport_md__bindgen_ty_1::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::sk_reuseport_md__bindgen_ty_1
-pub fn aya_ebpf_bindings::bindings::sk_reuseport_md__bindgen_ty_1::from(t: T) -> T
 #[repr(C)] pub union aya_ebpf_bindings::bindings::sk_reuseport_md__bindgen_ty_2
 pub aya_ebpf_bindings::bindings::sk_reuseport_md__bindgen_ty_2::_bitfield_1: aya_ebpf_bindings::bindings::__BindgenBitfieldUnit<[u8; 8]>
 pub aya_ebpf_bindings::bindings::sk_reuseport_md__bindgen_ty_2::_bitfield_align_1: [u8; 0]
@@ -2229,24 +1293,6 @@ impl core::marker::Unpin for aya_ebpf_bindings::bindings::sk_reuseport_md__bindg
 impl core::marker::UnsafeUnpin for aya_ebpf_bindings::bindings::sk_reuseport_md__bindgen_ty_2
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf_bindings::bindings::sk_reuseport_md__bindgen_ty_2
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf_bindings::bindings::sk_reuseport_md__bindgen_ty_2
-impl<T, U> core::convert::Into<U> for aya_ebpf_bindings::bindings::sk_reuseport_md__bindgen_ty_2 where U: core::convert::From<T>
-pub fn aya_ebpf_bindings::bindings::sk_reuseport_md__bindgen_ty_2::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf_bindings::bindings::sk_reuseport_md__bindgen_ty_2 where U: core::convert::Into<T>
-pub type aya_ebpf_bindings::bindings::sk_reuseport_md__bindgen_ty_2::Error = core::convert::Infallible
-pub fn aya_ebpf_bindings::bindings::sk_reuseport_md__bindgen_ty_2::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf_bindings::bindings::sk_reuseport_md__bindgen_ty_2 where U: core::convert::TryFrom<T>
-pub type aya_ebpf_bindings::bindings::sk_reuseport_md__bindgen_ty_2::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf_bindings::bindings::sk_reuseport_md__bindgen_ty_2::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf_bindings::bindings::sk_reuseport_md__bindgen_ty_2 where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::sk_reuseport_md__bindgen_ty_2::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::sk_reuseport_md__bindgen_ty_2 where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::sk_reuseport_md__bindgen_ty_2::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::sk_reuseport_md__bindgen_ty_2 where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::sk_reuseport_md__bindgen_ty_2::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::sk_reuseport_md__bindgen_ty_2 where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::sk_reuseport_md__bindgen_ty_2::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::sk_reuseport_md__bindgen_ty_2
-pub fn aya_ebpf_bindings::bindings::sk_reuseport_md__bindgen_ty_2::from(t: T) -> T
 #[repr(C)] pub union aya_ebpf_bindings::bindings::sk_reuseport_md__bindgen_ty_3
 pub aya_ebpf_bindings::bindings::sk_reuseport_md__bindgen_ty_3::_bitfield_1: aya_ebpf_bindings::bindings::__BindgenBitfieldUnit<[u8; 8]>
 pub aya_ebpf_bindings::bindings::sk_reuseport_md__bindgen_ty_3::_bitfield_align_1: [u8; 0]
@@ -2263,24 +1309,6 @@ impl core::marker::Unpin for aya_ebpf_bindings::bindings::sk_reuseport_md__bindg
 impl core::marker::UnsafeUnpin for aya_ebpf_bindings::bindings::sk_reuseport_md__bindgen_ty_3
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf_bindings::bindings::sk_reuseport_md__bindgen_ty_3
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf_bindings::bindings::sk_reuseport_md__bindgen_ty_3
-impl<T, U> core::convert::Into<U> for aya_ebpf_bindings::bindings::sk_reuseport_md__bindgen_ty_3 where U: core::convert::From<T>
-pub fn aya_ebpf_bindings::bindings::sk_reuseport_md__bindgen_ty_3::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf_bindings::bindings::sk_reuseport_md__bindgen_ty_3 where U: core::convert::Into<T>
-pub type aya_ebpf_bindings::bindings::sk_reuseport_md__bindgen_ty_3::Error = core::convert::Infallible
-pub fn aya_ebpf_bindings::bindings::sk_reuseport_md__bindgen_ty_3::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf_bindings::bindings::sk_reuseport_md__bindgen_ty_3 where U: core::convert::TryFrom<T>
-pub type aya_ebpf_bindings::bindings::sk_reuseport_md__bindgen_ty_3::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf_bindings::bindings::sk_reuseport_md__bindgen_ty_3::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf_bindings::bindings::sk_reuseport_md__bindgen_ty_3 where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::sk_reuseport_md__bindgen_ty_3::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::sk_reuseport_md__bindgen_ty_3 where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::sk_reuseport_md__bindgen_ty_3::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::sk_reuseport_md__bindgen_ty_3 where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::sk_reuseport_md__bindgen_ty_3::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::sk_reuseport_md__bindgen_ty_3 where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::sk_reuseport_md__bindgen_ty_3::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::sk_reuseport_md__bindgen_ty_3
-pub fn aya_ebpf_bindings::bindings::sk_reuseport_md__bindgen_ty_3::from(t: T) -> T
 #[repr(C)] pub union aya_ebpf_bindings::bindings::sk_reuseport_md__bindgen_ty_4
 pub aya_ebpf_bindings::bindings::sk_reuseport_md__bindgen_ty_4::_bitfield_1: aya_ebpf_bindings::bindings::__BindgenBitfieldUnit<[u8; 8]>
 pub aya_ebpf_bindings::bindings::sk_reuseport_md__bindgen_ty_4::_bitfield_align_1: [u8; 0]
@@ -2297,24 +1325,6 @@ impl core::marker::Unpin for aya_ebpf_bindings::bindings::sk_reuseport_md__bindg
 impl core::marker::UnsafeUnpin for aya_ebpf_bindings::bindings::sk_reuseport_md__bindgen_ty_4
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf_bindings::bindings::sk_reuseport_md__bindgen_ty_4
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf_bindings::bindings::sk_reuseport_md__bindgen_ty_4
-impl<T, U> core::convert::Into<U> for aya_ebpf_bindings::bindings::sk_reuseport_md__bindgen_ty_4 where U: core::convert::From<T>
-pub fn aya_ebpf_bindings::bindings::sk_reuseport_md__bindgen_ty_4::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf_bindings::bindings::sk_reuseport_md__bindgen_ty_4 where U: core::convert::Into<T>
-pub type aya_ebpf_bindings::bindings::sk_reuseport_md__bindgen_ty_4::Error = core::convert::Infallible
-pub fn aya_ebpf_bindings::bindings::sk_reuseport_md__bindgen_ty_4::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf_bindings::bindings::sk_reuseport_md__bindgen_ty_4 where U: core::convert::TryFrom<T>
-pub type aya_ebpf_bindings::bindings::sk_reuseport_md__bindgen_ty_4::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf_bindings::bindings::sk_reuseport_md__bindgen_ty_4::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf_bindings::bindings::sk_reuseport_md__bindgen_ty_4 where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::sk_reuseport_md__bindgen_ty_4::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::sk_reuseport_md__bindgen_ty_4 where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::sk_reuseport_md__bindgen_ty_4::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::sk_reuseport_md__bindgen_ty_4 where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::sk_reuseport_md__bindgen_ty_4::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::sk_reuseport_md__bindgen_ty_4 where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::sk_reuseport_md__bindgen_ty_4::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::sk_reuseport_md__bindgen_ty_4
-pub fn aya_ebpf_bindings::bindings::sk_reuseport_md__bindgen_ty_4::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::__BindgenBitfieldUnit<Storage>
 impl<Storage> aya_ebpf_bindings::bindings::__BindgenBitfieldUnit<Storage> where Storage: core::convert::AsRef<[u8]> + core::convert::AsMut<[u8]>
 pub fn aya_ebpf_bindings::bindings::__BindgenBitfieldUnit<Storage>::get(&self, bit_offset: usize, bit_width: u8) -> u64
@@ -2351,24 +1361,6 @@ impl<Storage> core::marker::Unpin for aya_ebpf_bindings::bindings::__BindgenBitf
 impl<Storage> core::marker::UnsafeUnpin for aya_ebpf_bindings::bindings::__BindgenBitfieldUnit<Storage> where Storage: core::marker::UnsafeUnpin
 impl<Storage> core::panic::unwind_safe::RefUnwindSafe for aya_ebpf_bindings::bindings::__BindgenBitfieldUnit<Storage> where Storage: core::panic::unwind_safe::RefUnwindSafe
 impl<Storage> core::panic::unwind_safe::UnwindSafe for aya_ebpf_bindings::bindings::__BindgenBitfieldUnit<Storage> where Storage: core::panic::unwind_safe::UnwindSafe
-impl<T, U> core::convert::Into<U> for aya_ebpf_bindings::bindings::__BindgenBitfieldUnit<Storage> where U: core::convert::From<T>
-pub fn aya_ebpf_bindings::bindings::__BindgenBitfieldUnit<Storage>::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf_bindings::bindings::__BindgenBitfieldUnit<Storage> where U: core::convert::Into<T>
-pub type aya_ebpf_bindings::bindings::__BindgenBitfieldUnit<Storage>::Error = core::convert::Infallible
-pub fn aya_ebpf_bindings::bindings::__BindgenBitfieldUnit<Storage>::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf_bindings::bindings::__BindgenBitfieldUnit<Storage> where U: core::convert::TryFrom<T>
-pub type aya_ebpf_bindings::bindings::__BindgenBitfieldUnit<Storage>::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf_bindings::bindings::__BindgenBitfieldUnit<Storage>::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf_bindings::bindings::__BindgenBitfieldUnit<Storage> where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::__BindgenBitfieldUnit<Storage>::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::__BindgenBitfieldUnit<Storage> where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::__BindgenBitfieldUnit<Storage>::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::__BindgenBitfieldUnit<Storage> where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::__BindgenBitfieldUnit<Storage>::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::__BindgenBitfieldUnit<Storage> where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::__BindgenBitfieldUnit<Storage>::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::__BindgenBitfieldUnit<Storage>
-pub fn aya_ebpf_bindings::bindings::__BindgenBitfieldUnit<Storage>::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::__IncompleteArrayField<T>(_, _)
 impl<T> aya_ebpf_bindings::bindings::__IncompleteArrayField<T>
 pub fn aya_ebpf_bindings::bindings::__IncompleteArrayField<T>::as_mut_ptr(&mut self) -> *mut T
@@ -2387,22 +1379,6 @@ impl<T> core::marker::Unpin for aya_ebpf_bindings::bindings::__IncompleteArrayFi
 impl<T> core::marker::UnsafeUnpin for aya_ebpf_bindings::bindings::__IncompleteArrayField<T> where T: core::marker::UnsafeUnpin
 impl<T> core::panic::unwind_safe::RefUnwindSafe for aya_ebpf_bindings::bindings::__IncompleteArrayField<T> where T: core::panic::unwind_safe::RefUnwindSafe
 impl<T> core::panic::unwind_safe::UnwindSafe for aya_ebpf_bindings::bindings::__IncompleteArrayField<T> where T: core::panic::unwind_safe::UnwindSafe
-impl<T, U> core::convert::Into<U> for aya_ebpf_bindings::bindings::__IncompleteArrayField<T> where U: core::convert::From<T>
-pub fn aya_ebpf_bindings::bindings::__IncompleteArrayField<T>::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf_bindings::bindings::__IncompleteArrayField<T> where U: core::convert::Into<T>
-pub type aya_ebpf_bindings::bindings::__IncompleteArrayField<T>::Error = core::convert::Infallible
-pub fn aya_ebpf_bindings::bindings::__IncompleteArrayField<T>::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf_bindings::bindings::__IncompleteArrayField<T> where U: core::convert::TryFrom<T>
-pub type aya_ebpf_bindings::bindings::__IncompleteArrayField<T>::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf_bindings::bindings::__IncompleteArrayField<T>::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf_bindings::bindings::__IncompleteArrayField<T> where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::__IncompleteArrayField<T>::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::__IncompleteArrayField<T> where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::__IncompleteArrayField<T>::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::__IncompleteArrayField<T> where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::__IncompleteArrayField<T>::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::__IncompleteArrayField<T>
-pub fn aya_ebpf_bindings::bindings::__IncompleteArrayField<T>::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::__sk_buff
 pub aya_ebpf_bindings::bindings::__sk_buff::__bindgen_anon_1: aya_ebpf_bindings::bindings::__sk_buff__bindgen_ty_1
 pub aya_ebpf_bindings::bindings::__sk_buff::__bindgen_anon_2: aya_ebpf_bindings::bindings::__sk_buff__bindgen_ty_2
@@ -2452,24 +1428,6 @@ impl core::marker::Unpin for aya_ebpf_bindings::bindings::__sk_buff
 impl core::marker::UnsafeUnpin for aya_ebpf_bindings::bindings::__sk_buff
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf_bindings::bindings::__sk_buff
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf_bindings::bindings::__sk_buff
-impl<T, U> core::convert::Into<U> for aya_ebpf_bindings::bindings::__sk_buff where U: core::convert::From<T>
-pub fn aya_ebpf_bindings::bindings::__sk_buff::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf_bindings::bindings::__sk_buff where U: core::convert::Into<T>
-pub type aya_ebpf_bindings::bindings::__sk_buff::Error = core::convert::Infallible
-pub fn aya_ebpf_bindings::bindings::__sk_buff::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf_bindings::bindings::__sk_buff where U: core::convert::TryFrom<T>
-pub type aya_ebpf_bindings::bindings::__sk_buff::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf_bindings::bindings::__sk_buff::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf_bindings::bindings::__sk_buff where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::__sk_buff::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::__sk_buff where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::__sk_buff::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::__sk_buff where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::__sk_buff::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::__sk_buff where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::__sk_buff::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::__sk_buff
-pub fn aya_ebpf_bindings::bindings::__sk_buff::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_1
 pub aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_1::btf_fd: aya_ebpf_bindings::bindings::__u32
 pub aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_1::btf_key_type_id: aya_ebpf_bindings::bindings::__u32
@@ -2499,24 +1457,6 @@ impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_1
 impl core::marker::UnsafeUnpin for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_1
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_1
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_1
-impl<T, U> core::convert::Into<U> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_1 where U: core::convert::From<T>
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_1::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_1 where U: core::convert::Into<T>
-pub type aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_1::Error = core::convert::Infallible
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_1::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_1 where U: core::convert::TryFrom<T>
-pub type aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_1::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_1::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_1 where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_1::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_1 where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_1::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_1 where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_1::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_1 where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_1::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_1
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_1::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_10
 pub aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_10::__bindgen_anon_1: aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_10__bindgen_ty_1
 pub aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_10::__bindgen_anon_2: aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_10__bindgen_ty_2
@@ -2542,24 +1482,6 @@ impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_1
 impl core::marker::UnsafeUnpin for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_10
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_10
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_10
-impl<T, U> core::convert::Into<U> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_10 where U: core::convert::From<T>
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_10::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_10 where U: core::convert::Into<T>
-pub type aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_10::Error = core::convert::Infallible
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_10::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_10 where U: core::convert::TryFrom<T>
-pub type aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_10::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_10::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_10 where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_10::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_10 where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_10::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_10 where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_10::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_10 where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_10::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_10
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_10::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_11
 pub aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_11::_bitfield_1: aya_ebpf_bindings::bindings::__BindgenBitfieldUnit<[u8; 4]>
 pub aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_11::_bitfield_align_1: [u8; 0]
@@ -2580,24 +1502,6 @@ impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_1
 impl core::marker::UnsafeUnpin for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_11
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_11
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_11
-impl<T, U> core::convert::Into<U> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_11 where U: core::convert::From<T>
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_11::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_11 where U: core::convert::Into<T>
-pub type aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_11::Error = core::convert::Infallible
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_11::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_11 where U: core::convert::TryFrom<T>
-pub type aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_11::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_11::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_11 where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_11::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_11 where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_11::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_11 where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_11::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_11 where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_11::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_11
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_11::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_12
 pub aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_12::btf: aya_ebpf_bindings::bindings::__u64
 pub aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_12::btf_flags: aya_ebpf_bindings::bindings::__u32
@@ -2619,24 +1523,6 @@ impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_1
 impl core::marker::UnsafeUnpin for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_12
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_12
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_12
-impl<T, U> core::convert::Into<U> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_12 where U: core::convert::From<T>
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_12::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_12 where U: core::convert::Into<T>
-pub type aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_12::Error = core::convert::Infallible
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_12::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_12 where U: core::convert::TryFrom<T>
-pub type aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_12::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_12::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_12 where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_12::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_12 where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_12::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_12 where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_12::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_12 where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_12::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_12
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_12::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_13
 pub aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_13::buf: aya_ebpf_bindings::bindings::__u64
 pub aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_13::buf_len: aya_ebpf_bindings::bindings::__u32
@@ -2659,24 +1545,6 @@ impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_1
 impl core::marker::UnsafeUnpin for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_13
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_13
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_13
-impl<T, U> core::convert::Into<U> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_13 where U: core::convert::From<T>
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_13::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_13 where U: core::convert::Into<T>
-pub type aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_13::Error = core::convert::Infallible
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_13::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_13 where U: core::convert::TryFrom<T>
-pub type aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_13::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_13::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_13 where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_13::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_13 where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_13::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_13 where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_13::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_13 where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_13::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_13
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_13::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14
 pub aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14::__bindgen_anon_1: aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_1
 pub aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14::__bindgen_anon_2: aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_2
@@ -2693,24 +1561,6 @@ impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_1
 impl core::marker::UnsafeUnpin for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14
-impl<T, U> core::convert::Into<U> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14 where U: core::convert::From<T>
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14 where U: core::convert::Into<T>
-pub type aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14::Error = core::convert::Infallible
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14 where U: core::convert::TryFrom<T>
-pub type aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14 where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14 where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14 where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14 where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_1
 pub aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_1::iter_info: aya_ebpf_bindings::bindings::__u64
 pub aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_1::iter_info_len: aya_ebpf_bindings::bindings::__u32
@@ -2726,24 +1576,6 @@ impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_1
 impl core::marker::UnsafeUnpin for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_1
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_1
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_1
-impl<T, U> core::convert::Into<U> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_1 where U: core::convert::From<T>
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_1::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_1 where U: core::convert::Into<T>
-pub type aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_1::Error = core::convert::Infallible
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_1::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_1 where U: core::convert::TryFrom<T>
-pub type aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_1::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_1::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_1 where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_1::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_1 where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_1::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_1 where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_1::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_1 where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_1::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_1
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_1::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_2
 pub aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_2::bpf_cookie: aya_ebpf_bindings::bindings::__u64
 impl core::clone::Clone for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_2
@@ -2758,24 +1590,6 @@ impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_1
 impl core::marker::UnsafeUnpin for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_2
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_2
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_2
-impl<T, U> core::convert::Into<U> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_2 where U: core::convert::From<T>
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_2::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_2 where U: core::convert::Into<T>
-pub type aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_2::Error = core::convert::Infallible
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_2::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_2 where U: core::convert::TryFrom<T>
-pub type aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_2::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_2::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_2 where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_2::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_2 where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_2::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_2 where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_2::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_2 where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_2::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_2
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_2::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_3
 pub aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_3::addrs: aya_ebpf_bindings::bindings::__u64
 pub aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_3::cnt: aya_ebpf_bindings::bindings::__u32
@@ -2794,24 +1608,6 @@ impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_1
 impl core::marker::UnsafeUnpin for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_3
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_3
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_3
-impl<T, U> core::convert::Into<U> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_3 where U: core::convert::From<T>
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_3::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_3 where U: core::convert::Into<T>
-pub type aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_3::Error = core::convert::Infallible
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_3::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_3 where U: core::convert::TryFrom<T>
-pub type aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_3::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_3::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_3 where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_3::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_3 where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_3::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_3 where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_3::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_3 where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_3::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_3
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_3::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_4
 pub aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_4::cookie: aya_ebpf_bindings::bindings::__u64
 pub aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_4::target_btf_id: aya_ebpf_bindings::bindings::__u32
@@ -2827,24 +1623,6 @@ impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_1
 impl core::marker::UnsafeUnpin for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_4
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_4
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_4
-impl<T, U> core::convert::Into<U> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_4 where U: core::convert::From<T>
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_4::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_4 where U: core::convert::Into<T>
-pub type aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_4::Error = core::convert::Infallible
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_4::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_4 where U: core::convert::TryFrom<T>
-pub type aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_4::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_4::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_4 where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_4::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_4 where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_4::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_4 where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_4::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_4 where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_4::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_4
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_4::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_5
 pub aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_5::flags: aya_ebpf_bindings::bindings::__u32
 pub aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_5::hooknum: aya_ebpf_bindings::bindings::__u32
@@ -2862,24 +1640,6 @@ impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_1
 impl core::marker::UnsafeUnpin for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_5
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_5
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_5
-impl<T, U> core::convert::Into<U> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_5 where U: core::convert::From<T>
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_5::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_5 where U: core::convert::Into<T>
-pub type aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_5::Error = core::convert::Infallible
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_5::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_5 where U: core::convert::TryFrom<T>
-pub type aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_5::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_5::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_5 where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_5::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_5 where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_5::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_5 where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_5::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_5 where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_5::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_5
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_5::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_6
 pub aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_6::__bindgen_anon_1: aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_6__bindgen_ty_1
 pub aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_6::expected_revision: aya_ebpf_bindings::bindings::__u64
@@ -2893,24 +1653,6 @@ impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_1
 impl core::marker::UnsafeUnpin for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_6
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_6
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_6
-impl<T, U> core::convert::Into<U> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_6 where U: core::convert::From<T>
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_6::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_6 where U: core::convert::Into<T>
-pub type aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_6::Error = core::convert::Infallible
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_6::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_6 where U: core::convert::TryFrom<T>
-pub type aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_6::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_6::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_6 where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_6::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_6 where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_6::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_6 where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_6::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_6 where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_6::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_6
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_6::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_7
 pub aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_7::cnt: aya_ebpf_bindings::bindings::__u32
 pub aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_7::cookies: aya_ebpf_bindings::bindings::__u64
@@ -2931,24 +1673,6 @@ impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_1
 impl core::marker::UnsafeUnpin for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_7
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_7
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_7
-impl<T, U> core::convert::Into<U> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_7 where U: core::convert::From<T>
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_7::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_7 where U: core::convert::Into<T>
-pub type aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_7::Error = core::convert::Infallible
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_7::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_7 where U: core::convert::TryFrom<T>
-pub type aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_7::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_7::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_7 where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_7::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_7 where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_7::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_7 where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_7::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_7 where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_7::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_7
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_7::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_8
 pub aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_8::__bindgen_anon_1: aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_8__bindgen_ty_1
 pub aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_8::expected_revision: aya_ebpf_bindings::bindings::__u64
@@ -2962,24 +1686,6 @@ impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_1
 impl core::marker::UnsafeUnpin for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_8
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_8
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_8
-impl<T, U> core::convert::Into<U> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_8 where U: core::convert::From<T>
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_8::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_8 where U: core::convert::Into<T>
-pub type aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_8::Error = core::convert::Infallible
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_8::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_8 where U: core::convert::TryFrom<T>
-pub type aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_8::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_8::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_8 where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_8::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_8 where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_8::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_8 where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_8::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_8 where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_8::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_8
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_8::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_15
 pub aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_15::__bindgen_anon_1: aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_15__bindgen_ty_1
 pub aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_15::__bindgen_anon_2: aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_15__bindgen_ty_2
@@ -2995,24 +1701,6 @@ impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_1
 impl core::marker::UnsafeUnpin for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_15
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_15
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_15
-impl<T, U> core::convert::Into<U> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_15 where U: core::convert::From<T>
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_15::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_15 where U: core::convert::Into<T>
-pub type aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_15::Error = core::convert::Infallible
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_15::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_15 where U: core::convert::TryFrom<T>
-pub type aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_15::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_15::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_15 where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_15::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_15 where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_15::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_15 where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_15::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_15 where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_15::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_15
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_15::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_16
 pub aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_16::link_fd: aya_ebpf_bindings::bindings::__u32
 impl core::clone::Clone for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_16
@@ -3027,24 +1715,6 @@ impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_1
 impl core::marker::UnsafeUnpin for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_16
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_16
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_16
-impl<T, U> core::convert::Into<U> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_16 where U: core::convert::From<T>
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_16::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_16 where U: core::convert::Into<T>
-pub type aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_16::Error = core::convert::Infallible
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_16::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_16 where U: core::convert::TryFrom<T>
-pub type aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_16::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_16::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_16 where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_16::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_16 where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_16::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_16 where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_16::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_16 where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_16::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_16
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_16::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_17
 pub aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_17::type_: aya_ebpf_bindings::bindings::__u32
 impl core::clone::Clone for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_17
@@ -3059,24 +1729,6 @@ impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_1
 impl core::marker::UnsafeUnpin for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_17
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_17
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_17
-impl<T, U> core::convert::Into<U> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_17 where U: core::convert::From<T>
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_17::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_17 where U: core::convert::Into<T>
-pub type aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_17::Error = core::convert::Infallible
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_17::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_17 where U: core::convert::TryFrom<T>
-pub type aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_17::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_17::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_17 where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_17::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_17 where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_17::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_17 where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_17::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_17 where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_17::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_17
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_17::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_18
 pub aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_18::flags: aya_ebpf_bindings::bindings::__u32
 pub aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_18::link_fd: aya_ebpf_bindings::bindings::__u32
@@ -3092,24 +1744,6 @@ impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_1
 impl core::marker::UnsafeUnpin for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_18
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_18
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_18
-impl<T, U> core::convert::Into<U> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_18 where U: core::convert::From<T>
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_18::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_18 where U: core::convert::Into<T>
-pub type aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_18::Error = core::convert::Infallible
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_18::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_18 where U: core::convert::TryFrom<T>
-pub type aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_18::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_18::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_18 where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_18::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_18 where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_18::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_18 where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_18::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_18 where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_18::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_18
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_18::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_19
 pub aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_19::flags: aya_ebpf_bindings::bindings::__u32
 pub aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_19::map_fd: aya_ebpf_bindings::bindings::__u32
@@ -3126,24 +1760,6 @@ impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_1
 impl core::marker::UnsafeUnpin for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_19
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_19
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_19
-impl<T, U> core::convert::Into<U> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_19 where U: core::convert::From<T>
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_19::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_19 where U: core::convert::Into<T>
-pub type aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_19::Error = core::convert::Infallible
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_19::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_19 where U: core::convert::TryFrom<T>
-pub type aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_19::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_19::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_19 where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_19::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_19 where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_19::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_19 where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_19::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_19 where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_19::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_19
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_19::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_2
 pub aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_2::__bindgen_anon_1: aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_2__bindgen_ty_1
 pub aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_2::flags: aya_ebpf_bindings::bindings::__u64
@@ -3159,24 +1775,6 @@ impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_2
 impl core::marker::UnsafeUnpin for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_2
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_2
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_2
-impl<T, U> core::convert::Into<U> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_2 where U: core::convert::From<T>
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_2::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_2 where U: core::convert::Into<T>
-pub type aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_2::Error = core::convert::Infallible
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_2::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_2 where U: core::convert::TryFrom<T>
-pub type aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_2::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_2::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_2 where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_2::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_2 where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_2::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_2 where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_2::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_2 where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_2::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_2
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_2::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_20
 pub aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_20::bpffs_fd: aya_ebpf_bindings::bindings::__u32
 pub aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_20::flags: aya_ebpf_bindings::bindings::__u32
@@ -3192,24 +1790,6 @@ impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_2
 impl core::marker::UnsafeUnpin for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_20
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_20
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_20
-impl<T, U> core::convert::Into<U> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_20 where U: core::convert::From<T>
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_20::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_20 where U: core::convert::Into<T>
-pub type aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_20::Error = core::convert::Infallible
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_20::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_20 where U: core::convert::TryFrom<T>
-pub type aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_20::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_20::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_20 where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_20::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_20 where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_20::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_20 where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_20::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_20 where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_20::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_20
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_20::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_3
 pub aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_3::count: aya_ebpf_bindings::bindings::__u32
 pub aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_3::elem_flags: aya_ebpf_bindings::bindings::__u64
@@ -3231,24 +1811,6 @@ impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_3
 impl core::marker::UnsafeUnpin for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_3
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_3
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_3
-impl<T, U> core::convert::Into<U> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_3 where U: core::convert::From<T>
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_3::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_3 where U: core::convert::Into<T>
-pub type aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_3::Error = core::convert::Infallible
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_3::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_3 where U: core::convert::TryFrom<T>
-pub type aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_3::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_3::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_3 where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_3::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_3 where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_3::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_3 where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_3::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_3 where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_3::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_3
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_3::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_4
 pub aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_4::__bindgen_anon_1: aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_4__bindgen_ty_1
 pub aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_4::attach_btf_id: aya_ebpf_bindings::bindings::__u32
@@ -3287,24 +1849,6 @@ impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_4
 impl core::marker::UnsafeUnpin for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_4
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_4
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_4
-impl<T, U> core::convert::Into<U> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_4 where U: core::convert::From<T>
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_4::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_4 where U: core::convert::Into<T>
-pub type aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_4::Error = core::convert::Infallible
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_4::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_4 where U: core::convert::TryFrom<T>
-pub type aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_4::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_4::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_4 where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_4::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_4 where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_4::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_4 where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_4::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_4 where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_4::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_4
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_4::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_5
 pub aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_5::bpf_fd: aya_ebpf_bindings::bindings::__u32
 pub aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_5::file_flags: aya_ebpf_bindings::bindings::__u32
@@ -3322,24 +1866,6 @@ impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_5
 impl core::marker::UnsafeUnpin for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_5
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_5
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_5
-impl<T, U> core::convert::Into<U> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_5 where U: core::convert::From<T>
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_5::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_5 where U: core::convert::Into<T>
-pub type aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_5::Error = core::convert::Infallible
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_5::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_5 where U: core::convert::TryFrom<T>
-pub type aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_5::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_5::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_5 where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_5::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_5 where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_5::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_5 where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_5::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_5 where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_5::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_5
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_5::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_6
 pub aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_6::__bindgen_anon_1: aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_6__bindgen_ty_1
 pub aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_6::__bindgen_anon_2: aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_6__bindgen_ty_2
@@ -3358,24 +1884,6 @@ impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_6
 impl core::marker::UnsafeUnpin for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_6
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_6
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_6
-impl<T, U> core::convert::Into<U> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_6 where U: core::convert::From<T>
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_6::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_6 where U: core::convert::Into<T>
-pub type aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_6::Error = core::convert::Infallible
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_6::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_6 where U: core::convert::TryFrom<T>
-pub type aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_6::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_6::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_6 where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_6::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_6 where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_6::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_6 where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_6::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_6 where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_6::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_6
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_6::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_7
 pub aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_7::batch_size: aya_ebpf_bindings::bindings::__u32
 pub aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_7::cpu: aya_ebpf_bindings::bindings::__u32
@@ -3404,24 +1912,6 @@ impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_7
 impl core::marker::UnsafeUnpin for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_7
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_7
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_7
-impl<T, U> core::convert::Into<U> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_7 where U: core::convert::From<T>
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_7::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_7 where U: core::convert::Into<T>
-pub type aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_7::Error = core::convert::Infallible
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_7::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_7 where U: core::convert::TryFrom<T>
-pub type aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_7::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_7::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_7 where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_7::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_7 where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_7::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_7 where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_7::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_7 where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_7::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_7
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_7::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_8
 pub aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_8::__bindgen_anon_1: aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_8__bindgen_ty_1
 pub aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_8::next_id: aya_ebpf_bindings::bindings::__u32
@@ -3436,24 +1926,6 @@ impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_8
 impl core::marker::UnsafeUnpin for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_8
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_8
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_8
-impl<T, U> core::convert::Into<U> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_8 where U: core::convert::From<T>
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_8::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_8 where U: core::convert::Into<T>
-pub type aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_8::Error = core::convert::Infallible
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_8::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_8 where U: core::convert::TryFrom<T>
-pub type aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_8::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_8::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_8 where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_8::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_8 where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_8::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_8 where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_8::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_8 where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_8::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_8
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_8::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_9
 pub aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_9::bpf_fd: aya_ebpf_bindings::bindings::__u32
 pub aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_9::info: aya_ebpf_bindings::bindings::__u64
@@ -3470,24 +1942,6 @@ impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_9
 impl core::marker::UnsafeUnpin for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_9
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_9
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_9
-impl<T, U> core::convert::Into<U> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_9 where U: core::convert::From<T>
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_9::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_9 where U: core::convert::Into<T>
-pub type aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_9::Error = core::convert::Infallible
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_9::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_9 where U: core::convert::TryFrom<T>
-pub type aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_9::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_9::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_9 where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_9::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_9 where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_9::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_9 where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_9::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_9 where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_9::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_9
-pub fn aya_ebpf_bindings::bindings::bpf_attr__bindgen_ty_9::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::bpf_btf_info
 pub aya_ebpf_bindings::bindings::bpf_btf_info::btf: aya_ebpf_bindings::bindings::__u64
 pub aya_ebpf_bindings::bindings::bpf_btf_info::btf_size: aya_ebpf_bindings::bindings::__u32
@@ -3507,24 +1961,6 @@ impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_btf_info
 impl core::marker::UnsafeUnpin for aya_ebpf_bindings::bindings::bpf_btf_info
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf_bindings::bindings::bpf_btf_info
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf_bindings::bindings::bpf_btf_info
-impl<T, U> core::convert::Into<U> for aya_ebpf_bindings::bindings::bpf_btf_info where U: core::convert::From<T>
-pub fn aya_ebpf_bindings::bindings::bpf_btf_info::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf_bindings::bindings::bpf_btf_info where U: core::convert::Into<T>
-pub type aya_ebpf_bindings::bindings::bpf_btf_info::Error = core::convert::Infallible
-pub fn aya_ebpf_bindings::bindings::bpf_btf_info::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf_bindings::bindings::bpf_btf_info where U: core::convert::TryFrom<T>
-pub type aya_ebpf_bindings::bindings::bpf_btf_info::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf_bindings::bindings::bpf_btf_info::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf_bindings::bindings::bpf_btf_info where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_btf_info::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_btf_info where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_btf_info::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_btf_info where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_btf_info::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_btf_info where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_btf_info::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_btf_info
-pub fn aya_ebpf_bindings::bindings::bpf_btf_info::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::bpf_cgroup_dev_ctx
 pub aya_ebpf_bindings::bindings::bpf_cgroup_dev_ctx::access_type: aya_ebpf_bindings::bindings::__u32
 pub aya_ebpf_bindings::bindings::bpf_cgroup_dev_ctx::major: aya_ebpf_bindings::bindings::__u32
@@ -3541,24 +1977,6 @@ impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_cgroup_dev_ctx
 impl core::marker::UnsafeUnpin for aya_ebpf_bindings::bindings::bpf_cgroup_dev_ctx
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf_bindings::bindings::bpf_cgroup_dev_ctx
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf_bindings::bindings::bpf_cgroup_dev_ctx
-impl<T, U> core::convert::Into<U> for aya_ebpf_bindings::bindings::bpf_cgroup_dev_ctx where U: core::convert::From<T>
-pub fn aya_ebpf_bindings::bindings::bpf_cgroup_dev_ctx::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf_bindings::bindings::bpf_cgroup_dev_ctx where U: core::convert::Into<T>
-pub type aya_ebpf_bindings::bindings::bpf_cgroup_dev_ctx::Error = core::convert::Infallible
-pub fn aya_ebpf_bindings::bindings::bpf_cgroup_dev_ctx::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf_bindings::bindings::bpf_cgroup_dev_ctx where U: core::convert::TryFrom<T>
-pub type aya_ebpf_bindings::bindings::bpf_cgroup_dev_ctx::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf_bindings::bindings::bpf_cgroup_dev_ctx::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf_bindings::bindings::bpf_cgroup_dev_ctx where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_cgroup_dev_ctx::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_cgroup_dev_ctx where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_cgroup_dev_ctx::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_cgroup_dev_ctx where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_cgroup_dev_ctx::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_cgroup_dev_ctx where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_cgroup_dev_ctx::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_cgroup_dev_ctx
-pub fn aya_ebpf_bindings::bindings::bpf_cgroup_dev_ctx::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::bpf_cgroup_storage_key
 pub aya_ebpf_bindings::bindings::bpf_cgroup_storage_key::attach_type: aya_ebpf_bindings::bindings::__u32
 pub aya_ebpf_bindings::bindings::bpf_cgroup_storage_key::cgroup_inode_id: aya_ebpf_bindings::bindings::__u64
@@ -3574,24 +1992,6 @@ impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_cgroup_storage_key
 impl core::marker::UnsafeUnpin for aya_ebpf_bindings::bindings::bpf_cgroup_storage_key
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf_bindings::bindings::bpf_cgroup_storage_key
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf_bindings::bindings::bpf_cgroup_storage_key
-impl<T, U> core::convert::Into<U> for aya_ebpf_bindings::bindings::bpf_cgroup_storage_key where U: core::convert::From<T>
-pub fn aya_ebpf_bindings::bindings::bpf_cgroup_storage_key::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf_bindings::bindings::bpf_cgroup_storage_key where U: core::convert::Into<T>
-pub type aya_ebpf_bindings::bindings::bpf_cgroup_storage_key::Error = core::convert::Infallible
-pub fn aya_ebpf_bindings::bindings::bpf_cgroup_storage_key::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf_bindings::bindings::bpf_cgroup_storage_key where U: core::convert::TryFrom<T>
-pub type aya_ebpf_bindings::bindings::bpf_cgroup_storage_key::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf_bindings::bindings::bpf_cgroup_storage_key::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf_bindings::bindings::bpf_cgroup_storage_key where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_cgroup_storage_key::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_cgroup_storage_key where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_cgroup_storage_key::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_cgroup_storage_key where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_cgroup_storage_key::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_cgroup_storage_key where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_cgroup_storage_key::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_cgroup_storage_key
-pub fn aya_ebpf_bindings::bindings::bpf_cgroup_storage_key::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::bpf_core_relo
 pub aya_ebpf_bindings::bindings::bpf_core_relo::access_str_off: aya_ebpf_bindings::bindings::__u32
 pub aya_ebpf_bindings::bindings::bpf_core_relo::insn_off: aya_ebpf_bindings::bindings::__u32
@@ -3609,24 +2009,6 @@ impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_core_relo
 impl core::marker::UnsafeUnpin for aya_ebpf_bindings::bindings::bpf_core_relo
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf_bindings::bindings::bpf_core_relo
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf_bindings::bindings::bpf_core_relo
-impl<T, U> core::convert::Into<U> for aya_ebpf_bindings::bindings::bpf_core_relo where U: core::convert::From<T>
-pub fn aya_ebpf_bindings::bindings::bpf_core_relo::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf_bindings::bindings::bpf_core_relo where U: core::convert::Into<T>
-pub type aya_ebpf_bindings::bindings::bpf_core_relo::Error = core::convert::Infallible
-pub fn aya_ebpf_bindings::bindings::bpf_core_relo::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf_bindings::bindings::bpf_core_relo where U: core::convert::TryFrom<T>
-pub type aya_ebpf_bindings::bindings::bpf_core_relo::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf_bindings::bindings::bpf_core_relo::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf_bindings::bindings::bpf_core_relo where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_core_relo::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_core_relo where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_core_relo::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_core_relo where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_core_relo::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_core_relo where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_core_relo::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_core_relo
-pub fn aya_ebpf_bindings::bindings::bpf_core_relo::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::bpf_cpumap_val
 pub aya_ebpf_bindings::bindings::bpf_cpumap_val::bpf_prog: aya_ebpf_bindings::bindings::bpf_cpumap_val__bindgen_ty_1
 pub aya_ebpf_bindings::bindings::bpf_cpumap_val::qsize: aya_ebpf_bindings::bindings::__u32
@@ -3640,24 +2022,6 @@ impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_cpumap_val
 impl core::marker::UnsafeUnpin for aya_ebpf_bindings::bindings::bpf_cpumap_val
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf_bindings::bindings::bpf_cpumap_val
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf_bindings::bindings::bpf_cpumap_val
-impl<T, U> core::convert::Into<U> for aya_ebpf_bindings::bindings::bpf_cpumap_val where U: core::convert::From<T>
-pub fn aya_ebpf_bindings::bindings::bpf_cpumap_val::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf_bindings::bindings::bpf_cpumap_val where U: core::convert::Into<T>
-pub type aya_ebpf_bindings::bindings::bpf_cpumap_val::Error = core::convert::Infallible
-pub fn aya_ebpf_bindings::bindings::bpf_cpumap_val::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf_bindings::bindings::bpf_cpumap_val where U: core::convert::TryFrom<T>
-pub type aya_ebpf_bindings::bindings::bpf_cpumap_val::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf_bindings::bindings::bpf_cpumap_val::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf_bindings::bindings::bpf_cpumap_val where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_cpumap_val::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_cpumap_val where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_cpumap_val::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_cpumap_val where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_cpumap_val::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_cpumap_val where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_cpumap_val::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_cpumap_val
-pub fn aya_ebpf_bindings::bindings::bpf_cpumap_val::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::bpf_devmap_val
 pub aya_ebpf_bindings::bindings::bpf_devmap_val::bpf_prog: aya_ebpf_bindings::bindings::bpf_devmap_val__bindgen_ty_1
 pub aya_ebpf_bindings::bindings::bpf_devmap_val::ifindex: aya_ebpf_bindings::bindings::__u32
@@ -3671,24 +2035,6 @@ impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_devmap_val
 impl core::marker::UnsafeUnpin for aya_ebpf_bindings::bindings::bpf_devmap_val
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf_bindings::bindings::bpf_devmap_val
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf_bindings::bindings::bpf_devmap_val
-impl<T, U> core::convert::Into<U> for aya_ebpf_bindings::bindings::bpf_devmap_val where U: core::convert::From<T>
-pub fn aya_ebpf_bindings::bindings::bpf_devmap_val::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf_bindings::bindings::bpf_devmap_val where U: core::convert::Into<T>
-pub type aya_ebpf_bindings::bindings::bpf_devmap_val::Error = core::convert::Infallible
-pub fn aya_ebpf_bindings::bindings::bpf_devmap_val::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf_bindings::bindings::bpf_devmap_val where U: core::convert::TryFrom<T>
-pub type aya_ebpf_bindings::bindings::bpf_devmap_val::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf_bindings::bindings::bpf_devmap_val::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf_bindings::bindings::bpf_devmap_val where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_devmap_val::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_devmap_val where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_devmap_val::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_devmap_val where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_devmap_val::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_devmap_val where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_devmap_val::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_devmap_val
-pub fn aya_ebpf_bindings::bindings::bpf_devmap_val::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::bpf_dynptr
 pub aya_ebpf_bindings::bindings::bpf_dynptr::__opaque: [aya_ebpf_bindings::bindings::__u64; 2]
 impl core::clone::Clone for aya_ebpf_bindings::bindings::bpf_dynptr
@@ -3703,24 +2049,6 @@ impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_dynptr
 impl core::marker::UnsafeUnpin for aya_ebpf_bindings::bindings::bpf_dynptr
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf_bindings::bindings::bpf_dynptr
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf_bindings::bindings::bpf_dynptr
-impl<T, U> core::convert::Into<U> for aya_ebpf_bindings::bindings::bpf_dynptr where U: core::convert::From<T>
-pub fn aya_ebpf_bindings::bindings::bpf_dynptr::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf_bindings::bindings::bpf_dynptr where U: core::convert::Into<T>
-pub type aya_ebpf_bindings::bindings::bpf_dynptr::Error = core::convert::Infallible
-pub fn aya_ebpf_bindings::bindings::bpf_dynptr::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf_bindings::bindings::bpf_dynptr where U: core::convert::TryFrom<T>
-pub type aya_ebpf_bindings::bindings::bpf_dynptr::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf_bindings::bindings::bpf_dynptr::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf_bindings::bindings::bpf_dynptr where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_dynptr::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_dynptr where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_dynptr::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_dynptr where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_dynptr::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_dynptr where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_dynptr::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_dynptr
-pub fn aya_ebpf_bindings::bindings::bpf_dynptr::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::bpf_fib_lookup
 pub aya_ebpf_bindings::bindings::bpf_fib_lookup::__bindgen_anon_1: aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_1
 pub aya_ebpf_bindings::bindings::bpf_fib_lookup::__bindgen_anon_2: aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_2
@@ -3744,24 +2072,6 @@ impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_fib_lookup
 impl core::marker::UnsafeUnpin for aya_ebpf_bindings::bindings::bpf_fib_lookup
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf_bindings::bindings::bpf_fib_lookup
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf_bindings::bindings::bpf_fib_lookup
-impl<T, U> core::convert::Into<U> for aya_ebpf_bindings::bindings::bpf_fib_lookup where U: core::convert::From<T>
-pub fn aya_ebpf_bindings::bindings::bpf_fib_lookup::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf_bindings::bindings::bpf_fib_lookup where U: core::convert::Into<T>
-pub type aya_ebpf_bindings::bindings::bpf_fib_lookup::Error = core::convert::Infallible
-pub fn aya_ebpf_bindings::bindings::bpf_fib_lookup::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf_bindings::bindings::bpf_fib_lookup where U: core::convert::TryFrom<T>
-pub type aya_ebpf_bindings::bindings::bpf_fib_lookup::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf_bindings::bindings::bpf_fib_lookup::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf_bindings::bindings::bpf_fib_lookup where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_fib_lookup::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_fib_lookup where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_fib_lookup::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_fib_lookup where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_fib_lookup::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_fib_lookup where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_fib_lookup::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_fib_lookup
-pub fn aya_ebpf_bindings::bindings::bpf_fib_lookup::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_5__bindgen_ty_1
 pub aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_5__bindgen_ty_1::h_vlan_TCI: aya_ebpf_bindings::bindings::__be16
 pub aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_5__bindgen_ty_1::h_vlan_proto: aya_ebpf_bindings::bindings::__be16
@@ -3777,24 +2087,6 @@ impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_fib_lookup__bindge
 impl core::marker::UnsafeUnpin for aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_5__bindgen_ty_1
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_5__bindgen_ty_1
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_5__bindgen_ty_1
-impl<T, U> core::convert::Into<U> for aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_5__bindgen_ty_1 where U: core::convert::From<T>
-pub fn aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_5__bindgen_ty_1::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_5__bindgen_ty_1 where U: core::convert::Into<T>
-pub type aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_5__bindgen_ty_1::Error = core::convert::Infallible
-pub fn aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_5__bindgen_ty_1::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_5__bindgen_ty_1 where U: core::convert::TryFrom<T>
-pub type aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_5__bindgen_ty_1::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_5__bindgen_ty_1::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_5__bindgen_ty_1 where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_5__bindgen_ty_1::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_5__bindgen_ty_1 where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_5__bindgen_ty_1::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_5__bindgen_ty_1 where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_5__bindgen_ty_1::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_5__bindgen_ty_1 where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_5__bindgen_ty_1::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_5__bindgen_ty_1
-pub fn aya_ebpf_bindings::bindings::bpf_fib_lookup__bindgen_ty_5__bindgen_ty_1::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::bpf_flow_keys
 pub aya_ebpf_bindings::bindings::bpf_flow_keys::__bindgen_anon_1: aya_ebpf_bindings::bindings::bpf_flow_keys__bindgen_ty_1
 pub aya_ebpf_bindings::bindings::bpf_flow_keys::addr_proto: aya_ebpf_bindings::bindings::__u16
@@ -3819,24 +2111,6 @@ impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_flow_keys
 impl core::marker::UnsafeUnpin for aya_ebpf_bindings::bindings::bpf_flow_keys
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf_bindings::bindings::bpf_flow_keys
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf_bindings::bindings::bpf_flow_keys
-impl<T, U> core::convert::Into<U> for aya_ebpf_bindings::bindings::bpf_flow_keys where U: core::convert::From<T>
-pub fn aya_ebpf_bindings::bindings::bpf_flow_keys::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf_bindings::bindings::bpf_flow_keys where U: core::convert::Into<T>
-pub type aya_ebpf_bindings::bindings::bpf_flow_keys::Error = core::convert::Infallible
-pub fn aya_ebpf_bindings::bindings::bpf_flow_keys::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf_bindings::bindings::bpf_flow_keys where U: core::convert::TryFrom<T>
-pub type aya_ebpf_bindings::bindings::bpf_flow_keys::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf_bindings::bindings::bpf_flow_keys::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf_bindings::bindings::bpf_flow_keys where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_flow_keys::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_flow_keys where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_flow_keys::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_flow_keys where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_flow_keys::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_flow_keys where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_flow_keys::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_flow_keys
-pub fn aya_ebpf_bindings::bindings::bpf_flow_keys::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::bpf_flow_keys__bindgen_ty_1__bindgen_ty_1
 pub aya_ebpf_bindings::bindings::bpf_flow_keys__bindgen_ty_1__bindgen_ty_1::ipv4_dst: aya_ebpf_bindings::bindings::__be32
 pub aya_ebpf_bindings::bindings::bpf_flow_keys__bindgen_ty_1__bindgen_ty_1::ipv4_src: aya_ebpf_bindings::bindings::__be32
@@ -3852,24 +2126,6 @@ impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_flow_keys__bindgen
 impl core::marker::UnsafeUnpin for aya_ebpf_bindings::bindings::bpf_flow_keys__bindgen_ty_1__bindgen_ty_1
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf_bindings::bindings::bpf_flow_keys__bindgen_ty_1__bindgen_ty_1
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf_bindings::bindings::bpf_flow_keys__bindgen_ty_1__bindgen_ty_1
-impl<T, U> core::convert::Into<U> for aya_ebpf_bindings::bindings::bpf_flow_keys__bindgen_ty_1__bindgen_ty_1 where U: core::convert::From<T>
-pub fn aya_ebpf_bindings::bindings::bpf_flow_keys__bindgen_ty_1__bindgen_ty_1::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf_bindings::bindings::bpf_flow_keys__bindgen_ty_1__bindgen_ty_1 where U: core::convert::Into<T>
-pub type aya_ebpf_bindings::bindings::bpf_flow_keys__bindgen_ty_1__bindgen_ty_1::Error = core::convert::Infallible
-pub fn aya_ebpf_bindings::bindings::bpf_flow_keys__bindgen_ty_1__bindgen_ty_1::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf_bindings::bindings::bpf_flow_keys__bindgen_ty_1__bindgen_ty_1 where U: core::convert::TryFrom<T>
-pub type aya_ebpf_bindings::bindings::bpf_flow_keys__bindgen_ty_1__bindgen_ty_1::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf_bindings::bindings::bpf_flow_keys__bindgen_ty_1__bindgen_ty_1::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf_bindings::bindings::bpf_flow_keys__bindgen_ty_1__bindgen_ty_1 where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_flow_keys__bindgen_ty_1__bindgen_ty_1::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_flow_keys__bindgen_ty_1__bindgen_ty_1 where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_flow_keys__bindgen_ty_1__bindgen_ty_1::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_flow_keys__bindgen_ty_1__bindgen_ty_1 where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_flow_keys__bindgen_ty_1__bindgen_ty_1::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_flow_keys__bindgen_ty_1__bindgen_ty_1 where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_flow_keys__bindgen_ty_1__bindgen_ty_1::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_flow_keys__bindgen_ty_1__bindgen_ty_1
-pub fn aya_ebpf_bindings::bindings::bpf_flow_keys__bindgen_ty_1__bindgen_ty_1::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::bpf_flow_keys__bindgen_ty_1__bindgen_ty_2
 pub aya_ebpf_bindings::bindings::bpf_flow_keys__bindgen_ty_1__bindgen_ty_2::ipv6_dst: [aya_ebpf_bindings::bindings::__u32; 4]
 pub aya_ebpf_bindings::bindings::bpf_flow_keys__bindgen_ty_1__bindgen_ty_2::ipv6_src: [aya_ebpf_bindings::bindings::__u32; 4]
@@ -3885,24 +2141,6 @@ impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_flow_keys__bindgen
 impl core::marker::UnsafeUnpin for aya_ebpf_bindings::bindings::bpf_flow_keys__bindgen_ty_1__bindgen_ty_2
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf_bindings::bindings::bpf_flow_keys__bindgen_ty_1__bindgen_ty_2
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf_bindings::bindings::bpf_flow_keys__bindgen_ty_1__bindgen_ty_2
-impl<T, U> core::convert::Into<U> for aya_ebpf_bindings::bindings::bpf_flow_keys__bindgen_ty_1__bindgen_ty_2 where U: core::convert::From<T>
-pub fn aya_ebpf_bindings::bindings::bpf_flow_keys__bindgen_ty_1__bindgen_ty_2::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf_bindings::bindings::bpf_flow_keys__bindgen_ty_1__bindgen_ty_2 where U: core::convert::Into<T>
-pub type aya_ebpf_bindings::bindings::bpf_flow_keys__bindgen_ty_1__bindgen_ty_2::Error = core::convert::Infallible
-pub fn aya_ebpf_bindings::bindings::bpf_flow_keys__bindgen_ty_1__bindgen_ty_2::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf_bindings::bindings::bpf_flow_keys__bindgen_ty_1__bindgen_ty_2 where U: core::convert::TryFrom<T>
-pub type aya_ebpf_bindings::bindings::bpf_flow_keys__bindgen_ty_1__bindgen_ty_2::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf_bindings::bindings::bpf_flow_keys__bindgen_ty_1__bindgen_ty_2::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf_bindings::bindings::bpf_flow_keys__bindgen_ty_1__bindgen_ty_2 where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_flow_keys__bindgen_ty_1__bindgen_ty_2::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_flow_keys__bindgen_ty_1__bindgen_ty_2 where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_flow_keys__bindgen_ty_1__bindgen_ty_2::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_flow_keys__bindgen_ty_1__bindgen_ty_2 where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_flow_keys__bindgen_ty_1__bindgen_ty_2::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_flow_keys__bindgen_ty_1__bindgen_ty_2 where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_flow_keys__bindgen_ty_1__bindgen_ty_2::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_flow_keys__bindgen_ty_1__bindgen_ty_2
-pub fn aya_ebpf_bindings::bindings::bpf_flow_keys__bindgen_ty_1__bindgen_ty_2::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::bpf_func_info
 pub aya_ebpf_bindings::bindings::bpf_func_info::insn_off: aya_ebpf_bindings::bindings::__u32
 pub aya_ebpf_bindings::bindings::bpf_func_info::type_id: aya_ebpf_bindings::bindings::__u32
@@ -3918,24 +2156,6 @@ impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_func_info
 impl core::marker::UnsafeUnpin for aya_ebpf_bindings::bindings::bpf_func_info
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf_bindings::bindings::bpf_func_info
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf_bindings::bindings::bpf_func_info
-impl<T, U> core::convert::Into<U> for aya_ebpf_bindings::bindings::bpf_func_info where U: core::convert::From<T>
-pub fn aya_ebpf_bindings::bindings::bpf_func_info::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf_bindings::bindings::bpf_func_info where U: core::convert::Into<T>
-pub type aya_ebpf_bindings::bindings::bpf_func_info::Error = core::convert::Infallible
-pub fn aya_ebpf_bindings::bindings::bpf_func_info::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf_bindings::bindings::bpf_func_info where U: core::convert::TryFrom<T>
-pub type aya_ebpf_bindings::bindings::bpf_func_info::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf_bindings::bindings::bpf_func_info::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf_bindings::bindings::bpf_func_info where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_func_info::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_func_info where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_func_info::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_func_info where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_func_info::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_func_info where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_func_info::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_func_info
-pub fn aya_ebpf_bindings::bindings::bpf_func_info::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::bpf_insn
 pub aya_ebpf_bindings::bindings::bpf_insn::_bitfield_1: aya_ebpf_bindings::bindings::__BindgenBitfieldUnit<[u8; 1]>
 pub aya_ebpf_bindings::bindings::bpf_insn::_bitfield_align_1: [u8; 0]
@@ -3964,24 +2184,6 @@ impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_insn
 impl core::marker::UnsafeUnpin for aya_ebpf_bindings::bindings::bpf_insn
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf_bindings::bindings::bpf_insn
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf_bindings::bindings::bpf_insn
-impl<T, U> core::convert::Into<U> for aya_ebpf_bindings::bindings::bpf_insn where U: core::convert::From<T>
-pub fn aya_ebpf_bindings::bindings::bpf_insn::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf_bindings::bindings::bpf_insn where U: core::convert::Into<T>
-pub type aya_ebpf_bindings::bindings::bpf_insn::Error = core::convert::Infallible
-pub fn aya_ebpf_bindings::bindings::bpf_insn::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf_bindings::bindings::bpf_insn where U: core::convert::TryFrom<T>
-pub type aya_ebpf_bindings::bindings::bpf_insn::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf_bindings::bindings::bpf_insn::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf_bindings::bindings::bpf_insn where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_insn::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_insn where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_insn::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_insn where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_insn::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_insn where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_insn::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_insn
-pub fn aya_ebpf_bindings::bindings::bpf_insn::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::bpf_iter_link_info__bindgen_ty_1
 pub aya_ebpf_bindings::bindings::bpf_iter_link_info__bindgen_ty_1::map_fd: aya_ebpf_bindings::bindings::__u32
 impl core::clone::Clone for aya_ebpf_bindings::bindings::bpf_iter_link_info__bindgen_ty_1
@@ -3996,24 +2198,6 @@ impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_iter_link_info__bi
 impl core::marker::UnsafeUnpin for aya_ebpf_bindings::bindings::bpf_iter_link_info__bindgen_ty_1
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf_bindings::bindings::bpf_iter_link_info__bindgen_ty_1
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf_bindings::bindings::bpf_iter_link_info__bindgen_ty_1
-impl<T, U> core::convert::Into<U> for aya_ebpf_bindings::bindings::bpf_iter_link_info__bindgen_ty_1 where U: core::convert::From<T>
-pub fn aya_ebpf_bindings::bindings::bpf_iter_link_info__bindgen_ty_1::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf_bindings::bindings::bpf_iter_link_info__bindgen_ty_1 where U: core::convert::Into<T>
-pub type aya_ebpf_bindings::bindings::bpf_iter_link_info__bindgen_ty_1::Error = core::convert::Infallible
-pub fn aya_ebpf_bindings::bindings::bpf_iter_link_info__bindgen_ty_1::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf_bindings::bindings::bpf_iter_link_info__bindgen_ty_1 where U: core::convert::TryFrom<T>
-pub type aya_ebpf_bindings::bindings::bpf_iter_link_info__bindgen_ty_1::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf_bindings::bindings::bpf_iter_link_info__bindgen_ty_1::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf_bindings::bindings::bpf_iter_link_info__bindgen_ty_1 where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_iter_link_info__bindgen_ty_1::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_iter_link_info__bindgen_ty_1 where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_iter_link_info__bindgen_ty_1::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_iter_link_info__bindgen_ty_1 where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_iter_link_info__bindgen_ty_1::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_iter_link_info__bindgen_ty_1 where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_iter_link_info__bindgen_ty_1::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_iter_link_info__bindgen_ty_1
-pub fn aya_ebpf_bindings::bindings::bpf_iter_link_info__bindgen_ty_1::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::bpf_iter_link_info__bindgen_ty_2
 pub aya_ebpf_bindings::bindings::bpf_iter_link_info__bindgen_ty_2::cgroup_fd: aya_ebpf_bindings::bindings::__u32
 pub aya_ebpf_bindings::bindings::bpf_iter_link_info__bindgen_ty_2::cgroup_id: aya_ebpf_bindings::bindings::__u64
@@ -4030,24 +2214,6 @@ impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_iter_link_info__bi
 impl core::marker::UnsafeUnpin for aya_ebpf_bindings::bindings::bpf_iter_link_info__bindgen_ty_2
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf_bindings::bindings::bpf_iter_link_info__bindgen_ty_2
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf_bindings::bindings::bpf_iter_link_info__bindgen_ty_2
-impl<T, U> core::convert::Into<U> for aya_ebpf_bindings::bindings::bpf_iter_link_info__bindgen_ty_2 where U: core::convert::From<T>
-pub fn aya_ebpf_bindings::bindings::bpf_iter_link_info__bindgen_ty_2::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf_bindings::bindings::bpf_iter_link_info__bindgen_ty_2 where U: core::convert::Into<T>
-pub type aya_ebpf_bindings::bindings::bpf_iter_link_info__bindgen_ty_2::Error = core::convert::Infallible
-pub fn aya_ebpf_bindings::bindings::bpf_iter_link_info__bindgen_ty_2::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf_bindings::bindings::bpf_iter_link_info__bindgen_ty_2 where U: core::convert::TryFrom<T>
-pub type aya_ebpf_bindings::bindings::bpf_iter_link_info__bindgen_ty_2::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf_bindings::bindings::bpf_iter_link_info__bindgen_ty_2::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf_bindings::bindings::bpf_iter_link_info__bindgen_ty_2 where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_iter_link_info__bindgen_ty_2::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_iter_link_info__bindgen_ty_2 where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_iter_link_info__bindgen_ty_2::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_iter_link_info__bindgen_ty_2 where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_iter_link_info__bindgen_ty_2::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_iter_link_info__bindgen_ty_2 where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_iter_link_info__bindgen_ty_2::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_iter_link_info__bindgen_ty_2
-pub fn aya_ebpf_bindings::bindings::bpf_iter_link_info__bindgen_ty_2::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::bpf_iter_link_info__bindgen_ty_3
 pub aya_ebpf_bindings::bindings::bpf_iter_link_info__bindgen_ty_3::pid: aya_ebpf_bindings::bindings::__u32
 pub aya_ebpf_bindings::bindings::bpf_iter_link_info__bindgen_ty_3::pid_fd: aya_ebpf_bindings::bindings::__u32
@@ -4064,24 +2230,6 @@ impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_iter_link_info__bi
 impl core::marker::UnsafeUnpin for aya_ebpf_bindings::bindings::bpf_iter_link_info__bindgen_ty_3
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf_bindings::bindings::bpf_iter_link_info__bindgen_ty_3
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf_bindings::bindings::bpf_iter_link_info__bindgen_ty_3
-impl<T, U> core::convert::Into<U> for aya_ebpf_bindings::bindings::bpf_iter_link_info__bindgen_ty_3 where U: core::convert::From<T>
-pub fn aya_ebpf_bindings::bindings::bpf_iter_link_info__bindgen_ty_3::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf_bindings::bindings::bpf_iter_link_info__bindgen_ty_3 where U: core::convert::Into<T>
-pub type aya_ebpf_bindings::bindings::bpf_iter_link_info__bindgen_ty_3::Error = core::convert::Infallible
-pub fn aya_ebpf_bindings::bindings::bpf_iter_link_info__bindgen_ty_3::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf_bindings::bindings::bpf_iter_link_info__bindgen_ty_3 where U: core::convert::TryFrom<T>
-pub type aya_ebpf_bindings::bindings::bpf_iter_link_info__bindgen_ty_3::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf_bindings::bindings::bpf_iter_link_info__bindgen_ty_3::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf_bindings::bindings::bpf_iter_link_info__bindgen_ty_3 where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_iter_link_info__bindgen_ty_3::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_iter_link_info__bindgen_ty_3 where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_iter_link_info__bindgen_ty_3::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_iter_link_info__bindgen_ty_3 where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_iter_link_info__bindgen_ty_3::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_iter_link_info__bindgen_ty_3 where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_iter_link_info__bindgen_ty_3::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_iter_link_info__bindgen_ty_3
-pub fn aya_ebpf_bindings::bindings::bpf_iter_link_info__bindgen_ty_3::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::bpf_iter_num
 pub aya_ebpf_bindings::bindings::bpf_iter_num::__opaque: [aya_ebpf_bindings::bindings::__u64; 1]
 impl core::clone::Clone for aya_ebpf_bindings::bindings::bpf_iter_num
@@ -4096,24 +2244,6 @@ impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_iter_num
 impl core::marker::UnsafeUnpin for aya_ebpf_bindings::bindings::bpf_iter_num
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf_bindings::bindings::bpf_iter_num
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf_bindings::bindings::bpf_iter_num
-impl<T, U> core::convert::Into<U> for aya_ebpf_bindings::bindings::bpf_iter_num where U: core::convert::From<T>
-pub fn aya_ebpf_bindings::bindings::bpf_iter_num::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf_bindings::bindings::bpf_iter_num where U: core::convert::Into<T>
-pub type aya_ebpf_bindings::bindings::bpf_iter_num::Error = core::convert::Infallible
-pub fn aya_ebpf_bindings::bindings::bpf_iter_num::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf_bindings::bindings::bpf_iter_num where U: core::convert::TryFrom<T>
-pub type aya_ebpf_bindings::bindings::bpf_iter_num::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf_bindings::bindings::bpf_iter_num::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf_bindings::bindings::bpf_iter_num where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_iter_num::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_iter_num where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_iter_num::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_iter_num where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_iter_num::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_iter_num where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_iter_num::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_iter_num
-pub fn aya_ebpf_bindings::bindings::bpf_iter_num::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::bpf_line_info
 pub aya_ebpf_bindings::bindings::bpf_line_info::file_name_off: aya_ebpf_bindings::bindings::__u32
 pub aya_ebpf_bindings::bindings::bpf_line_info::insn_off: aya_ebpf_bindings::bindings::__u32
@@ -4131,24 +2261,6 @@ impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_line_info
 impl core::marker::UnsafeUnpin for aya_ebpf_bindings::bindings::bpf_line_info
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf_bindings::bindings::bpf_line_info
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf_bindings::bindings::bpf_line_info
-impl<T, U> core::convert::Into<U> for aya_ebpf_bindings::bindings::bpf_line_info where U: core::convert::From<T>
-pub fn aya_ebpf_bindings::bindings::bpf_line_info::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf_bindings::bindings::bpf_line_info where U: core::convert::Into<T>
-pub type aya_ebpf_bindings::bindings::bpf_line_info::Error = core::convert::Infallible
-pub fn aya_ebpf_bindings::bindings::bpf_line_info::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf_bindings::bindings::bpf_line_info where U: core::convert::TryFrom<T>
-pub type aya_ebpf_bindings::bindings::bpf_line_info::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf_bindings::bindings::bpf_line_info::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf_bindings::bindings::bpf_line_info where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_line_info::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_line_info where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_line_info::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_line_info where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_line_info::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_line_info where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_line_info::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_line_info
-pub fn aya_ebpf_bindings::bindings::bpf_line_info::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::bpf_link_info
 pub aya_ebpf_bindings::bindings::bpf_link_info::__bindgen_anon_1: aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1
 pub aya_ebpf_bindings::bindings::bpf_link_info::id: aya_ebpf_bindings::bindings::__u32
@@ -4164,24 +2276,6 @@ impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_link_info
 impl core::marker::UnsafeUnpin for aya_ebpf_bindings::bindings::bpf_link_info
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf_bindings::bindings::bpf_link_info
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf_bindings::bindings::bpf_link_info
-impl<T, U> core::convert::Into<U> for aya_ebpf_bindings::bindings::bpf_link_info where U: core::convert::From<T>
-pub fn aya_ebpf_bindings::bindings::bpf_link_info::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf_bindings::bindings::bpf_link_info where U: core::convert::Into<T>
-pub type aya_ebpf_bindings::bindings::bpf_link_info::Error = core::convert::Infallible
-pub fn aya_ebpf_bindings::bindings::bpf_link_info::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf_bindings::bindings::bpf_link_info where U: core::convert::TryFrom<T>
-pub type aya_ebpf_bindings::bindings::bpf_link_info::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf_bindings::bindings::bpf_link_info::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf_bindings::bindings::bpf_link_info where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_link_info::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_link_info where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_link_info::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_link_info where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_link_info::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_link_info where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_link_info::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_link_info
-pub fn aya_ebpf_bindings::bindings::bpf_link_info::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_1
 pub aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_1::tp_name: aya_ebpf_bindings::bindings::__u64
 pub aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_1::tp_name_len: aya_ebpf_bindings::bindings::__u32
@@ -4197,24 +2291,6 @@ impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_link_info__bindgen
 impl core::marker::UnsafeUnpin for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_1
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_1
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_1
-impl<T, U> core::convert::Into<U> for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_1 where U: core::convert::From<T>
-pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_1::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_1 where U: core::convert::Into<T>
-pub type aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_1::Error = core::convert::Infallible
-pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_1::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_1 where U: core::convert::TryFrom<T>
-pub type aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_1::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_1::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_1 where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_1::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_1 where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_1::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_1 where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_1::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_1 where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_1::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_1
-pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_1::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_10
 pub aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_10::cookies: aya_ebpf_bindings::bindings::__u64
 pub aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_10::count: aya_ebpf_bindings::bindings::__u32
@@ -4236,24 +2312,6 @@ impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_link_info__bindgen
 impl core::marker::UnsafeUnpin for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_10
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_10
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_10
-impl<T, U> core::convert::Into<U> for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_10 where U: core::convert::From<T>
-pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_10::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_10 where U: core::convert::Into<T>
-pub type aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_10::Error = core::convert::Infallible
-pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_10::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_10 where U: core::convert::TryFrom<T>
-pub type aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_10::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_10::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_10 where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_10::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_10 where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_10::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_10 where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_10::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_10 where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_10::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_10
-pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_10::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_11
 pub aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_11::__bindgen_anon_1: aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1
 pub aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_11::_bitfield_1: aya_ebpf_bindings::bindings::__BindgenBitfieldUnit<[u8; 4]>
@@ -4271,24 +2329,6 @@ impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_link_info__bindgen
 impl core::marker::UnsafeUnpin for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_11
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_11
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_11
-impl<T, U> core::convert::Into<U> for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_11 where U: core::convert::From<T>
-pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_11::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_11 where U: core::convert::Into<T>
-pub type aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_11::Error = core::convert::Infallible
-pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_11::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_11 where U: core::convert::TryFrom<T>
-pub type aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_11::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_11::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_11 where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_11::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_11 where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_11::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_11 where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_11::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_11 where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_11::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_11
-pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_11::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_1
 pub aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_1::cookie: aya_ebpf_bindings::bindings::__u64
 pub aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_1::file_name: aya_ebpf_bindings::bindings::__u64
@@ -4306,24 +2346,6 @@ impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_link_info__bindgen
 impl core::marker::UnsafeUnpin for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_1
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_1
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_1
-impl<T, U> core::convert::Into<U> for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_1 where U: core::convert::From<T>
-pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_1::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_1 where U: core::convert::Into<T>
-pub type aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_1::Error = core::convert::Infallible
-pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_1::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_1 where U: core::convert::TryFrom<T>
-pub type aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_1::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_1::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_1 where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_1::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_1 where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_1::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_1 where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_1::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_1 where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_1::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_1
-pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_1::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_2
 pub aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_2::addr: aya_ebpf_bindings::bindings::__u64
 pub aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_2::cookie: aya_ebpf_bindings::bindings::__u64
@@ -4343,24 +2365,6 @@ impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_link_info__bindgen
 impl core::marker::UnsafeUnpin for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_2
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_2
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_2
-impl<T, U> core::convert::Into<U> for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_2 where U: core::convert::From<T>
-pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_2::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_2 where U: core::convert::Into<T>
-pub type aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_2::Error = core::convert::Infallible
-pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_2::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_2 where U: core::convert::TryFrom<T>
-pub type aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_2::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_2::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_2 where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_2::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_2 where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_2::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_2 where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_2::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_2 where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_2::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_2
-pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_2::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_3
 pub aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_3::_bitfield_1: aya_ebpf_bindings::bindings::__BindgenBitfieldUnit<[u8; 4]>
 pub aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_3::_bitfield_align_1: [u8; 0]
@@ -4381,24 +2385,6 @@ impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_link_info__bindgen
 impl core::marker::UnsafeUnpin for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_3
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_3
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_3
-impl<T, U> core::convert::Into<U> for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_3 where U: core::convert::From<T>
-pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_3::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_3 where U: core::convert::Into<T>
-pub type aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_3::Error = core::convert::Infallible
-pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_3::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_3 where U: core::convert::TryFrom<T>
-pub type aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_3::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_3::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_3 where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_3::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_3 where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_3::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_3 where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_3::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_3 where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_3::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_3
-pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_3::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_4
 pub aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_4::_bitfield_1: aya_ebpf_bindings::bindings::__BindgenBitfieldUnit<[u8; 4]>
 pub aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_4::_bitfield_align_1: [u8; 0]
@@ -4419,24 +2405,6 @@ impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_link_info__bindgen
 impl core::marker::UnsafeUnpin for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_4
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_4
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_4
-impl<T, U> core::convert::Into<U> for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_4 where U: core::convert::From<T>
-pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_4::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_4 where U: core::convert::Into<T>
-pub type aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_4::Error = core::convert::Infallible
-pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_4::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_4 where U: core::convert::TryFrom<T>
-pub type aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_4::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_4::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_4 where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_4::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_4 where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_4::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_4 where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_4::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_4 where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_4::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_4
-pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_4::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_12
 pub aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_12::attach_type: aya_ebpf_bindings::bindings::__u32
 pub aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_12::ifindex: aya_ebpf_bindings::bindings::__u32
@@ -4452,24 +2420,6 @@ impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_link_info__bindgen
 impl core::marker::UnsafeUnpin for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_12
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_12
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_12
-impl<T, U> core::convert::Into<U> for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_12 where U: core::convert::From<T>
-pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_12::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_12 where U: core::convert::Into<T>
-pub type aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_12::Error = core::convert::Infallible
-pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_12::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_12 where U: core::convert::TryFrom<T>
-pub type aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_12::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_12::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_12 where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_12::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_12 where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_12::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_12 where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_12::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_12 where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_12::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_12
-pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_12::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_13
 pub aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_13::attach_type: aya_ebpf_bindings::bindings::__u32
 pub aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_13::ifindex: aya_ebpf_bindings::bindings::__u32
@@ -4485,24 +2435,6 @@ impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_link_info__bindgen
 impl core::marker::UnsafeUnpin for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_13
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_13
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_13
-impl<T, U> core::convert::Into<U> for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_13 where U: core::convert::From<T>
-pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_13::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_13 where U: core::convert::Into<T>
-pub type aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_13::Error = core::convert::Infallible
-pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_13::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_13 where U: core::convert::TryFrom<T>
-pub type aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_13::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_13::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_13 where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_13::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_13 where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_13::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_13 where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_13::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_13 where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_13::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_13
-pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_13::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_2
 pub aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_2::attach_type: aya_ebpf_bindings::bindings::__u32
 pub aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_2::target_btf_id: aya_ebpf_bindings::bindings::__u32
@@ -4519,24 +2451,6 @@ impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_link_info__bindgen
 impl core::marker::UnsafeUnpin for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_2
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_2
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_2
-impl<T, U> core::convert::Into<U> for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_2 where U: core::convert::From<T>
-pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_2::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_2 where U: core::convert::Into<T>
-pub type aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_2::Error = core::convert::Infallible
-pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_2::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_2 where U: core::convert::TryFrom<T>
-pub type aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_2::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_2::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_2 where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_2::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_2 where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_2::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_2 where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_2::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_2 where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_2::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_2
-pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_2::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_3
 pub aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_3::attach_type: aya_ebpf_bindings::bindings::__u32
 pub aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_3::cgroup_id: aya_ebpf_bindings::bindings::__u64
@@ -4552,24 +2466,6 @@ impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_link_info__bindgen
 impl core::marker::UnsafeUnpin for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_3
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_3
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_3
-impl<T, U> core::convert::Into<U> for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_3 where U: core::convert::From<T>
-pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_3::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_3 where U: core::convert::Into<T>
-pub type aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_3::Error = core::convert::Infallible
-pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_3::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_3 where U: core::convert::TryFrom<T>
-pub type aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_3::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_3::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_3 where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_3::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_3 where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_3::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_3 where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_3::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_3 where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_3::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_3
-pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_3::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4
 pub aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4::__bindgen_anon_1: aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_1
 pub aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4::__bindgen_anon_2: aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2
@@ -4585,24 +2481,6 @@ impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_link_info__bindgen
 impl core::marker::UnsafeUnpin for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4
-impl<T, U> core::convert::Into<U> for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4 where U: core::convert::From<T>
-pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4 where U: core::convert::Into<T>
-pub type aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4::Error = core::convert::Infallible
-pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4 where U: core::convert::TryFrom<T>
-pub type aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4 where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4 where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4 where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4 where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4
-pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_1__bindgen_ty_1
 pub aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_1__bindgen_ty_1::map_id: aya_ebpf_bindings::bindings::__u32
 impl core::clone::Clone for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_1__bindgen_ty_1
@@ -4617,24 +2495,6 @@ impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_link_info__bindgen
 impl core::marker::UnsafeUnpin for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_1__bindgen_ty_1
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_1__bindgen_ty_1
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_1__bindgen_ty_1
-impl<T, U> core::convert::Into<U> for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_1__bindgen_ty_1 where U: core::convert::From<T>
-pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_1__bindgen_ty_1::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_1__bindgen_ty_1 where U: core::convert::Into<T>
-pub type aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_1__bindgen_ty_1::Error = core::convert::Infallible
-pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_1__bindgen_ty_1::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_1__bindgen_ty_1 where U: core::convert::TryFrom<T>
-pub type aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_1__bindgen_ty_1::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_1__bindgen_ty_1::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_1__bindgen_ty_1 where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_1__bindgen_ty_1::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_1__bindgen_ty_1 where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_1__bindgen_ty_1::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_1__bindgen_ty_1 where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_1__bindgen_ty_1::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_1__bindgen_ty_1 where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_1__bindgen_ty_1::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_1__bindgen_ty_1
-pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_1__bindgen_ty_1::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2__bindgen_ty_1
 pub aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2__bindgen_ty_1::cgroup_id: aya_ebpf_bindings::bindings::__u64
 pub aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2__bindgen_ty_1::order: aya_ebpf_bindings::bindings::__u32
@@ -4650,24 +2510,6 @@ impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_link_info__bindgen
 impl core::marker::UnsafeUnpin for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2__bindgen_ty_1
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2__bindgen_ty_1
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2__bindgen_ty_1
-impl<T, U> core::convert::Into<U> for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2__bindgen_ty_1 where U: core::convert::From<T>
-pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2__bindgen_ty_1::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2__bindgen_ty_1 where U: core::convert::Into<T>
-pub type aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2__bindgen_ty_1::Error = core::convert::Infallible
-pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2__bindgen_ty_1::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2__bindgen_ty_1 where U: core::convert::TryFrom<T>
-pub type aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2__bindgen_ty_1::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2__bindgen_ty_1::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2__bindgen_ty_1 where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2__bindgen_ty_1::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2__bindgen_ty_1 where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2__bindgen_ty_1::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2__bindgen_ty_1 where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2__bindgen_ty_1::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2__bindgen_ty_1 where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2__bindgen_ty_1::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2__bindgen_ty_1
-pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2__bindgen_ty_1::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2__bindgen_ty_2
 pub aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2__bindgen_ty_2::pid: aya_ebpf_bindings::bindings::__u32
 pub aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2__bindgen_ty_2::tid: aya_ebpf_bindings::bindings::__u32
@@ -4683,24 +2525,6 @@ impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_link_info__bindgen
 impl core::marker::UnsafeUnpin for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2__bindgen_ty_2
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2__bindgen_ty_2
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2__bindgen_ty_2
-impl<T, U> core::convert::Into<U> for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2__bindgen_ty_2 where U: core::convert::From<T>
-pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2__bindgen_ty_2::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2__bindgen_ty_2 where U: core::convert::Into<T>
-pub type aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2__bindgen_ty_2::Error = core::convert::Infallible
-pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2__bindgen_ty_2::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2__bindgen_ty_2 where U: core::convert::TryFrom<T>
-pub type aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2__bindgen_ty_2::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2__bindgen_ty_2::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2__bindgen_ty_2 where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2__bindgen_ty_2::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2__bindgen_ty_2 where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2__bindgen_ty_2::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2__bindgen_ty_2 where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2__bindgen_ty_2::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2__bindgen_ty_2 where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2__bindgen_ty_2::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2__bindgen_ty_2
-pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2__bindgen_ty_2::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_5
 pub aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_5::attach_type: aya_ebpf_bindings::bindings::__u32
 pub aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_5::netns_ino: aya_ebpf_bindings::bindings::__u32
@@ -4716,24 +2540,6 @@ impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_link_info__bindgen
 impl core::marker::UnsafeUnpin for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_5
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_5
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_5
-impl<T, U> core::convert::Into<U> for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_5 where U: core::convert::From<T>
-pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_5::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_5 where U: core::convert::Into<T>
-pub type aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_5::Error = core::convert::Infallible
-pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_5::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_5 where U: core::convert::TryFrom<T>
-pub type aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_5::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_5::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_5 where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_5::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_5 where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_5::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_5 where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_5::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_5 where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_5::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_5
-pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_5::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_6
 pub aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_6::ifindex: aya_ebpf_bindings::bindings::__u32
 impl core::clone::Clone for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_6
@@ -4748,24 +2554,6 @@ impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_link_info__bindgen
 impl core::marker::UnsafeUnpin for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_6
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_6
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_6
-impl<T, U> core::convert::Into<U> for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_6 where U: core::convert::From<T>
-pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_6::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_6 where U: core::convert::Into<T>
-pub type aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_6::Error = core::convert::Infallible
-pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_6::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_6 where U: core::convert::TryFrom<T>
-pub type aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_6::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_6::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_6 where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_6::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_6 where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_6::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_6 where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_6::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_6 where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_6::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_6
-pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_6::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_7
 pub aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_7::map_id: aya_ebpf_bindings::bindings::__u32
 impl core::clone::Clone for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_7
@@ -4780,24 +2568,6 @@ impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_link_info__bindgen
 impl core::marker::UnsafeUnpin for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_7
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_7
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_7
-impl<T, U> core::convert::Into<U> for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_7 where U: core::convert::From<T>
-pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_7::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_7 where U: core::convert::Into<T>
-pub type aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_7::Error = core::convert::Infallible
-pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_7::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_7 where U: core::convert::TryFrom<T>
-pub type aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_7::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_7::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_7 where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_7::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_7 where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_7::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_7 where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_7::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_7 where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_7::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_7
-pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_7::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_8
 pub aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_8::flags: aya_ebpf_bindings::bindings::__u32
 pub aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_8::hooknum: aya_ebpf_bindings::bindings::__u32
@@ -4815,24 +2585,6 @@ impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_link_info__bindgen
 impl core::marker::UnsafeUnpin for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_8
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_8
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_8
-impl<T, U> core::convert::Into<U> for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_8 where U: core::convert::From<T>
-pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_8::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_8 where U: core::convert::Into<T>
-pub type aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_8::Error = core::convert::Infallible
-pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_8::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_8 where U: core::convert::TryFrom<T>
-pub type aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_8::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_8::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_8 where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_8::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_8 where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_8::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_8 where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_8::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_8 where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_8::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_8
-pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_8::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_9
 pub aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_9::addrs: aya_ebpf_bindings::bindings::__u64
 pub aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_9::cookies: aya_ebpf_bindings::bindings::__u64
@@ -4851,24 +2603,6 @@ impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_link_info__bindgen
 impl core::marker::UnsafeUnpin for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_9
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_9
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_9
-impl<T, U> core::convert::Into<U> for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_9 where U: core::convert::From<T>
-pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_9::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_9 where U: core::convert::Into<T>
-pub type aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_9::Error = core::convert::Infallible
-pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_9::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_9 where U: core::convert::TryFrom<T>
-pub type aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_9::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_9::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_9 where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_9::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_9 where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_9::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_9 where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_9::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_9 where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_9::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_9
-pub fn aya_ebpf_bindings::bindings::bpf_link_info__bindgen_ty_1__bindgen_ty_9::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::bpf_list_head
 pub aya_ebpf_bindings::bindings::bpf_list_head::__opaque: [aya_ebpf_bindings::bindings::__u64; 2]
 impl core::clone::Clone for aya_ebpf_bindings::bindings::bpf_list_head
@@ -4883,24 +2617,6 @@ impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_list_head
 impl core::marker::UnsafeUnpin for aya_ebpf_bindings::bindings::bpf_list_head
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf_bindings::bindings::bpf_list_head
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf_bindings::bindings::bpf_list_head
-impl<T, U> core::convert::Into<U> for aya_ebpf_bindings::bindings::bpf_list_head where U: core::convert::From<T>
-pub fn aya_ebpf_bindings::bindings::bpf_list_head::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf_bindings::bindings::bpf_list_head where U: core::convert::Into<T>
-pub type aya_ebpf_bindings::bindings::bpf_list_head::Error = core::convert::Infallible
-pub fn aya_ebpf_bindings::bindings::bpf_list_head::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf_bindings::bindings::bpf_list_head where U: core::convert::TryFrom<T>
-pub type aya_ebpf_bindings::bindings::bpf_list_head::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf_bindings::bindings::bpf_list_head::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf_bindings::bindings::bpf_list_head where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_list_head::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_list_head where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_list_head::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_list_head where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_list_head::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_list_head where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_list_head::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_list_head
-pub fn aya_ebpf_bindings::bindings::bpf_list_head::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::bpf_list_node
 pub aya_ebpf_bindings::bindings::bpf_list_node::__opaque: [aya_ebpf_bindings::bindings::__u64; 3]
 impl core::clone::Clone for aya_ebpf_bindings::bindings::bpf_list_node
@@ -4915,24 +2631,6 @@ impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_list_node
 impl core::marker::UnsafeUnpin for aya_ebpf_bindings::bindings::bpf_list_node
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf_bindings::bindings::bpf_list_node
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf_bindings::bindings::bpf_list_node
-impl<T, U> core::convert::Into<U> for aya_ebpf_bindings::bindings::bpf_list_node where U: core::convert::From<T>
-pub fn aya_ebpf_bindings::bindings::bpf_list_node::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf_bindings::bindings::bpf_list_node where U: core::convert::Into<T>
-pub type aya_ebpf_bindings::bindings::bpf_list_node::Error = core::convert::Infallible
-pub fn aya_ebpf_bindings::bindings::bpf_list_node::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf_bindings::bindings::bpf_list_node where U: core::convert::TryFrom<T>
-pub type aya_ebpf_bindings::bindings::bpf_list_node::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf_bindings::bindings::bpf_list_node::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf_bindings::bindings::bpf_list_node where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_list_node::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_list_node where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_list_node::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_list_node where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_list_node::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_list_node where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_list_node::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_list_node
-pub fn aya_ebpf_bindings::bindings::bpf_list_node::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::bpf_lpm_trie_key
 pub aya_ebpf_bindings::bindings::bpf_lpm_trie_key::data: aya_ebpf_bindings::bindings::__IncompleteArrayField<aya_ebpf_bindings::bindings::__u8>
 pub aya_ebpf_bindings::bindings::bpf_lpm_trie_key::prefixlen: aya_ebpf_bindings::bindings::__u32
@@ -4945,22 +2643,6 @@ impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_lpm_trie_key
 impl core::marker::UnsafeUnpin for aya_ebpf_bindings::bindings::bpf_lpm_trie_key
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf_bindings::bindings::bpf_lpm_trie_key
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf_bindings::bindings::bpf_lpm_trie_key
-impl<T, U> core::convert::Into<U> for aya_ebpf_bindings::bindings::bpf_lpm_trie_key where U: core::convert::From<T>
-pub fn aya_ebpf_bindings::bindings::bpf_lpm_trie_key::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf_bindings::bindings::bpf_lpm_trie_key where U: core::convert::Into<T>
-pub type aya_ebpf_bindings::bindings::bpf_lpm_trie_key::Error = core::convert::Infallible
-pub fn aya_ebpf_bindings::bindings::bpf_lpm_trie_key::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf_bindings::bindings::bpf_lpm_trie_key where U: core::convert::TryFrom<T>
-pub type aya_ebpf_bindings::bindings::bpf_lpm_trie_key::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf_bindings::bindings::bpf_lpm_trie_key::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf_bindings::bindings::bpf_lpm_trie_key where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_lpm_trie_key::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_lpm_trie_key where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_lpm_trie_key::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_lpm_trie_key where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_lpm_trie_key::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_lpm_trie_key
-pub fn aya_ebpf_bindings::bindings::bpf_lpm_trie_key::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::bpf_lpm_trie_key_hdr
 pub aya_ebpf_bindings::bindings::bpf_lpm_trie_key_hdr::prefixlen: aya_ebpf_bindings::bindings::__u32
 impl core::clone::Clone for aya_ebpf_bindings::bindings::bpf_lpm_trie_key_hdr
@@ -4975,24 +2657,6 @@ impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_lpm_trie_key_hdr
 impl core::marker::UnsafeUnpin for aya_ebpf_bindings::bindings::bpf_lpm_trie_key_hdr
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf_bindings::bindings::bpf_lpm_trie_key_hdr
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf_bindings::bindings::bpf_lpm_trie_key_hdr
-impl<T, U> core::convert::Into<U> for aya_ebpf_bindings::bindings::bpf_lpm_trie_key_hdr where U: core::convert::From<T>
-pub fn aya_ebpf_bindings::bindings::bpf_lpm_trie_key_hdr::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf_bindings::bindings::bpf_lpm_trie_key_hdr where U: core::convert::Into<T>
-pub type aya_ebpf_bindings::bindings::bpf_lpm_trie_key_hdr::Error = core::convert::Infallible
-pub fn aya_ebpf_bindings::bindings::bpf_lpm_trie_key_hdr::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf_bindings::bindings::bpf_lpm_trie_key_hdr where U: core::convert::TryFrom<T>
-pub type aya_ebpf_bindings::bindings::bpf_lpm_trie_key_hdr::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf_bindings::bindings::bpf_lpm_trie_key_hdr::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf_bindings::bindings::bpf_lpm_trie_key_hdr where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_lpm_trie_key_hdr::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_lpm_trie_key_hdr where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_lpm_trie_key_hdr::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_lpm_trie_key_hdr where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_lpm_trie_key_hdr::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_lpm_trie_key_hdr where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_lpm_trie_key_hdr::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_lpm_trie_key_hdr
-pub fn aya_ebpf_bindings::bindings::bpf_lpm_trie_key_hdr::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::bpf_lpm_trie_key_u8
 pub aya_ebpf_bindings::bindings::bpf_lpm_trie_key_u8::__bindgen_anon_1: aya_ebpf_bindings::bindings::bpf_lpm_trie_key_u8__bindgen_ty_1
 pub aya_ebpf_bindings::bindings::bpf_lpm_trie_key_u8::data: aya_ebpf_bindings::bindings::__IncompleteArrayField<aya_ebpf_bindings::bindings::__u8>
@@ -5003,22 +2667,6 @@ impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_lpm_trie_key_u8
 impl core::marker::UnsafeUnpin for aya_ebpf_bindings::bindings::bpf_lpm_trie_key_u8
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf_bindings::bindings::bpf_lpm_trie_key_u8
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf_bindings::bindings::bpf_lpm_trie_key_u8
-impl<T, U> core::convert::Into<U> for aya_ebpf_bindings::bindings::bpf_lpm_trie_key_u8 where U: core::convert::From<T>
-pub fn aya_ebpf_bindings::bindings::bpf_lpm_trie_key_u8::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf_bindings::bindings::bpf_lpm_trie_key_u8 where U: core::convert::Into<T>
-pub type aya_ebpf_bindings::bindings::bpf_lpm_trie_key_u8::Error = core::convert::Infallible
-pub fn aya_ebpf_bindings::bindings::bpf_lpm_trie_key_u8::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf_bindings::bindings::bpf_lpm_trie_key_u8 where U: core::convert::TryFrom<T>
-pub type aya_ebpf_bindings::bindings::bpf_lpm_trie_key_u8::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf_bindings::bindings::bpf_lpm_trie_key_u8::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf_bindings::bindings::bpf_lpm_trie_key_u8 where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_lpm_trie_key_u8::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_lpm_trie_key_u8 where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_lpm_trie_key_u8::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_lpm_trie_key_u8 where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_lpm_trie_key_u8::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_lpm_trie_key_u8
-pub fn aya_ebpf_bindings::bindings::bpf_lpm_trie_key_u8::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::bpf_map_def
 pub aya_ebpf_bindings::bindings::bpf_map_def::id: aya_ebpf_cty::ad::c_uint
 pub aya_ebpf_bindings::bindings::bpf_map_def::key_size: aya_ebpf_cty::ad::c_uint
@@ -5034,22 +2682,6 @@ impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_map_def
 impl core::marker::UnsafeUnpin for aya_ebpf_bindings::bindings::bpf_map_def
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf_bindings::bindings::bpf_map_def
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf_bindings::bindings::bpf_map_def
-impl<T, U> core::convert::Into<U> for aya_ebpf_bindings::bindings::bpf_map_def where U: core::convert::From<T>
-pub fn aya_ebpf_bindings::bindings::bpf_map_def::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf_bindings::bindings::bpf_map_def where U: core::convert::Into<T>
-pub type aya_ebpf_bindings::bindings::bpf_map_def::Error = core::convert::Infallible
-pub fn aya_ebpf_bindings::bindings::bpf_map_def::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf_bindings::bindings::bpf_map_def where U: core::convert::TryFrom<T>
-pub type aya_ebpf_bindings::bindings::bpf_map_def::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf_bindings::bindings::bpf_map_def::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf_bindings::bindings::bpf_map_def where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_map_def::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_map_def where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_map_def::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_map_def where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_map_def::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_map_def
-pub fn aya_ebpf_bindings::bindings::bpf_map_def::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::bpf_map_info
 pub aya_ebpf_bindings::bindings::bpf_map_info::btf_id: aya_ebpf_bindings::bindings::__u32
 pub aya_ebpf_bindings::bindings::bpf_map_info::btf_key_type_id: aya_ebpf_bindings::bindings::__u32
@@ -5079,24 +2711,6 @@ impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_map_info
 impl core::marker::UnsafeUnpin for aya_ebpf_bindings::bindings::bpf_map_info
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf_bindings::bindings::bpf_map_info
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf_bindings::bindings::bpf_map_info
-impl<T, U> core::convert::Into<U> for aya_ebpf_bindings::bindings::bpf_map_info where U: core::convert::From<T>
-pub fn aya_ebpf_bindings::bindings::bpf_map_info::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf_bindings::bindings::bpf_map_info where U: core::convert::Into<T>
-pub type aya_ebpf_bindings::bindings::bpf_map_info::Error = core::convert::Infallible
-pub fn aya_ebpf_bindings::bindings::bpf_map_info::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf_bindings::bindings::bpf_map_info where U: core::convert::TryFrom<T>
-pub type aya_ebpf_bindings::bindings::bpf_map_info::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf_bindings::bindings::bpf_map_info::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf_bindings::bindings::bpf_map_info where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_map_info::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_map_info where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_map_info::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_map_info where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_map_info::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_map_info where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_map_info::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_map_info
-pub fn aya_ebpf_bindings::bindings::bpf_map_info::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::bpf_perf_event_data
 pub aya_ebpf_bindings::bindings::bpf_perf_event_data::addr: aya_ebpf_bindings::bindings::__u64
 pub aya_ebpf_bindings::bindings::bpf_perf_event_data::regs: aya_ebpf_bindings::bindings::bpf_user_pt_regs_t
@@ -5113,24 +2727,6 @@ impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_perf_event_data
 impl core::marker::UnsafeUnpin for aya_ebpf_bindings::bindings::bpf_perf_event_data
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf_bindings::bindings::bpf_perf_event_data
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf_bindings::bindings::bpf_perf_event_data
-impl<T, U> core::convert::Into<U> for aya_ebpf_bindings::bindings::bpf_perf_event_data where U: core::convert::From<T>
-pub fn aya_ebpf_bindings::bindings::bpf_perf_event_data::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf_bindings::bindings::bpf_perf_event_data where U: core::convert::Into<T>
-pub type aya_ebpf_bindings::bindings::bpf_perf_event_data::Error = core::convert::Infallible
-pub fn aya_ebpf_bindings::bindings::bpf_perf_event_data::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf_bindings::bindings::bpf_perf_event_data where U: core::convert::TryFrom<T>
-pub type aya_ebpf_bindings::bindings::bpf_perf_event_data::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf_bindings::bindings::bpf_perf_event_data::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf_bindings::bindings::bpf_perf_event_data where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_perf_event_data::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_perf_event_data where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_perf_event_data::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_perf_event_data where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_perf_event_data::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_perf_event_data where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_perf_event_data::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_perf_event_data
-pub fn aya_ebpf_bindings::bindings::bpf_perf_event_data::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::bpf_perf_event_value
 pub aya_ebpf_bindings::bindings::bpf_perf_event_value::counter: aya_ebpf_bindings::bindings::__u64
 pub aya_ebpf_bindings::bindings::bpf_perf_event_value::enabled: aya_ebpf_bindings::bindings::__u64
@@ -5147,24 +2743,6 @@ impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_perf_event_value
 impl core::marker::UnsafeUnpin for aya_ebpf_bindings::bindings::bpf_perf_event_value
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf_bindings::bindings::bpf_perf_event_value
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf_bindings::bindings::bpf_perf_event_value
-impl<T, U> core::convert::Into<U> for aya_ebpf_bindings::bindings::bpf_perf_event_value where U: core::convert::From<T>
-pub fn aya_ebpf_bindings::bindings::bpf_perf_event_value::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf_bindings::bindings::bpf_perf_event_value where U: core::convert::Into<T>
-pub type aya_ebpf_bindings::bindings::bpf_perf_event_value::Error = core::convert::Infallible
-pub fn aya_ebpf_bindings::bindings::bpf_perf_event_value::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf_bindings::bindings::bpf_perf_event_value where U: core::convert::TryFrom<T>
-pub type aya_ebpf_bindings::bindings::bpf_perf_event_value::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf_bindings::bindings::bpf_perf_event_value::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf_bindings::bindings::bpf_perf_event_value where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_perf_event_value::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_perf_event_value where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_perf_event_value::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_perf_event_value where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_perf_event_value::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_perf_event_value where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_perf_event_value::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_perf_event_value
-pub fn aya_ebpf_bindings::bindings::bpf_perf_event_value::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::bpf_pidns_info
 pub aya_ebpf_bindings::bindings::bpf_pidns_info::pid: aya_ebpf_bindings::bindings::__u32
 pub aya_ebpf_bindings::bindings::bpf_pidns_info::tgid: aya_ebpf_bindings::bindings::__u32
@@ -5180,24 +2758,6 @@ impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_pidns_info
 impl core::marker::UnsafeUnpin for aya_ebpf_bindings::bindings::bpf_pidns_info
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf_bindings::bindings::bpf_pidns_info
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf_bindings::bindings::bpf_pidns_info
-impl<T, U> core::convert::Into<U> for aya_ebpf_bindings::bindings::bpf_pidns_info where U: core::convert::From<T>
-pub fn aya_ebpf_bindings::bindings::bpf_pidns_info::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf_bindings::bindings::bpf_pidns_info where U: core::convert::Into<T>
-pub type aya_ebpf_bindings::bindings::bpf_pidns_info::Error = core::convert::Infallible
-pub fn aya_ebpf_bindings::bindings::bpf_pidns_info::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf_bindings::bindings::bpf_pidns_info where U: core::convert::TryFrom<T>
-pub type aya_ebpf_bindings::bindings::bpf_pidns_info::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf_bindings::bindings::bpf_pidns_info::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf_bindings::bindings::bpf_pidns_info where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_pidns_info::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_pidns_info where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_pidns_info::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_pidns_info where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_pidns_info::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_pidns_info where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_pidns_info::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_pidns_info
-pub fn aya_ebpf_bindings::bindings::bpf_pidns_info::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::bpf_prog_info
 pub aya_ebpf_bindings::bindings::bpf_prog_info::_bitfield_1: aya_ebpf_bindings::bindings::__BindgenBitfieldUnit<[u8; 4]>
 pub aya_ebpf_bindings::bindings::bpf_prog_info::_bitfield_align_1: [u8; 0]
@@ -5256,24 +2816,6 @@ impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_prog_info
 impl core::marker::UnsafeUnpin for aya_ebpf_bindings::bindings::bpf_prog_info
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf_bindings::bindings::bpf_prog_info
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf_bindings::bindings::bpf_prog_info
-impl<T, U> core::convert::Into<U> for aya_ebpf_bindings::bindings::bpf_prog_info where U: core::convert::From<T>
-pub fn aya_ebpf_bindings::bindings::bpf_prog_info::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf_bindings::bindings::bpf_prog_info where U: core::convert::Into<T>
-pub type aya_ebpf_bindings::bindings::bpf_prog_info::Error = core::convert::Infallible
-pub fn aya_ebpf_bindings::bindings::bpf_prog_info::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf_bindings::bindings::bpf_prog_info where U: core::convert::TryFrom<T>
-pub type aya_ebpf_bindings::bindings::bpf_prog_info::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf_bindings::bindings::bpf_prog_info::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf_bindings::bindings::bpf_prog_info where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_prog_info::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_prog_info where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_prog_info::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_prog_info where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_prog_info::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_prog_info where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_prog_info::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_prog_info
-pub fn aya_ebpf_bindings::bindings::bpf_prog_info::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::bpf_raw_tracepoint_args
 pub aya_ebpf_bindings::bindings::bpf_raw_tracepoint_args::args: aya_ebpf_bindings::bindings::__IncompleteArrayField<aya_ebpf_bindings::bindings::__u64>
 impl core::fmt::Debug for aya_ebpf_bindings::bindings::bpf_raw_tracepoint_args
@@ -5285,22 +2827,6 @@ impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_raw_tracepoint_arg
 impl core::marker::UnsafeUnpin for aya_ebpf_bindings::bindings::bpf_raw_tracepoint_args
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf_bindings::bindings::bpf_raw_tracepoint_args
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf_bindings::bindings::bpf_raw_tracepoint_args
-impl<T, U> core::convert::Into<U> for aya_ebpf_bindings::bindings::bpf_raw_tracepoint_args where U: core::convert::From<T>
-pub fn aya_ebpf_bindings::bindings::bpf_raw_tracepoint_args::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf_bindings::bindings::bpf_raw_tracepoint_args where U: core::convert::Into<T>
-pub type aya_ebpf_bindings::bindings::bpf_raw_tracepoint_args::Error = core::convert::Infallible
-pub fn aya_ebpf_bindings::bindings::bpf_raw_tracepoint_args::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf_bindings::bindings::bpf_raw_tracepoint_args where U: core::convert::TryFrom<T>
-pub type aya_ebpf_bindings::bindings::bpf_raw_tracepoint_args::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf_bindings::bindings::bpf_raw_tracepoint_args::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf_bindings::bindings::bpf_raw_tracepoint_args where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_raw_tracepoint_args::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_raw_tracepoint_args where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_raw_tracepoint_args::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_raw_tracepoint_args where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_raw_tracepoint_args::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_raw_tracepoint_args
-pub fn aya_ebpf_bindings::bindings::bpf_raw_tracepoint_args::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::bpf_rb_node
 pub aya_ebpf_bindings::bindings::bpf_rb_node::__opaque: [aya_ebpf_bindings::bindings::__u64; 4]
 impl core::clone::Clone for aya_ebpf_bindings::bindings::bpf_rb_node
@@ -5315,24 +2841,6 @@ impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_rb_node
 impl core::marker::UnsafeUnpin for aya_ebpf_bindings::bindings::bpf_rb_node
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf_bindings::bindings::bpf_rb_node
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf_bindings::bindings::bpf_rb_node
-impl<T, U> core::convert::Into<U> for aya_ebpf_bindings::bindings::bpf_rb_node where U: core::convert::From<T>
-pub fn aya_ebpf_bindings::bindings::bpf_rb_node::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf_bindings::bindings::bpf_rb_node where U: core::convert::Into<T>
-pub type aya_ebpf_bindings::bindings::bpf_rb_node::Error = core::convert::Infallible
-pub fn aya_ebpf_bindings::bindings::bpf_rb_node::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf_bindings::bindings::bpf_rb_node where U: core::convert::TryFrom<T>
-pub type aya_ebpf_bindings::bindings::bpf_rb_node::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf_bindings::bindings::bpf_rb_node::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf_bindings::bindings::bpf_rb_node where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_rb_node::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_rb_node where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_rb_node::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_rb_node where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_rb_node::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_rb_node where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_rb_node::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_rb_node
-pub fn aya_ebpf_bindings::bindings::bpf_rb_node::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::bpf_rb_root
 pub aya_ebpf_bindings::bindings::bpf_rb_root::__opaque: [aya_ebpf_bindings::bindings::__u64; 2]
 impl core::clone::Clone for aya_ebpf_bindings::bindings::bpf_rb_root
@@ -5347,24 +2855,6 @@ impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_rb_root
 impl core::marker::UnsafeUnpin for aya_ebpf_bindings::bindings::bpf_rb_root
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf_bindings::bindings::bpf_rb_root
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf_bindings::bindings::bpf_rb_root
-impl<T, U> core::convert::Into<U> for aya_ebpf_bindings::bindings::bpf_rb_root where U: core::convert::From<T>
-pub fn aya_ebpf_bindings::bindings::bpf_rb_root::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf_bindings::bindings::bpf_rb_root where U: core::convert::Into<T>
-pub type aya_ebpf_bindings::bindings::bpf_rb_root::Error = core::convert::Infallible
-pub fn aya_ebpf_bindings::bindings::bpf_rb_root::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf_bindings::bindings::bpf_rb_root where U: core::convert::TryFrom<T>
-pub type aya_ebpf_bindings::bindings::bpf_rb_root::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf_bindings::bindings::bpf_rb_root::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf_bindings::bindings::bpf_rb_root where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_rb_root::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_rb_root where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_rb_root::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_rb_root where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_rb_root::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_rb_root where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_rb_root::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_rb_root
-pub fn aya_ebpf_bindings::bindings::bpf_rb_root::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::bpf_redir_neigh
 pub aya_ebpf_bindings::bindings::bpf_redir_neigh::__bindgen_anon_1: aya_ebpf_bindings::bindings::bpf_redir_neigh__bindgen_ty_1
 pub aya_ebpf_bindings::bindings::bpf_redir_neigh::nh_family: aya_ebpf_bindings::bindings::__u32
@@ -5378,24 +2868,6 @@ impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_redir_neigh
 impl core::marker::UnsafeUnpin for aya_ebpf_bindings::bindings::bpf_redir_neigh
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf_bindings::bindings::bpf_redir_neigh
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf_bindings::bindings::bpf_redir_neigh
-impl<T, U> core::convert::Into<U> for aya_ebpf_bindings::bindings::bpf_redir_neigh where U: core::convert::From<T>
-pub fn aya_ebpf_bindings::bindings::bpf_redir_neigh::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf_bindings::bindings::bpf_redir_neigh where U: core::convert::Into<T>
-pub type aya_ebpf_bindings::bindings::bpf_redir_neigh::Error = core::convert::Infallible
-pub fn aya_ebpf_bindings::bindings::bpf_redir_neigh::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf_bindings::bindings::bpf_redir_neigh where U: core::convert::TryFrom<T>
-pub type aya_ebpf_bindings::bindings::bpf_redir_neigh::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf_bindings::bindings::bpf_redir_neigh::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf_bindings::bindings::bpf_redir_neigh where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_redir_neigh::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_redir_neigh where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_redir_neigh::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_redir_neigh where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_redir_neigh::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_redir_neigh where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_redir_neigh::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_redir_neigh
-pub fn aya_ebpf_bindings::bindings::bpf_redir_neigh::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::bpf_refcount
 pub aya_ebpf_bindings::bindings::bpf_refcount::__opaque: [aya_ebpf_bindings::bindings::__u32; 1]
 impl core::clone::Clone for aya_ebpf_bindings::bindings::bpf_refcount
@@ -5410,24 +2882,6 @@ impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_refcount
 impl core::marker::UnsafeUnpin for aya_ebpf_bindings::bindings::bpf_refcount
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf_bindings::bindings::bpf_refcount
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf_bindings::bindings::bpf_refcount
-impl<T, U> core::convert::Into<U> for aya_ebpf_bindings::bindings::bpf_refcount where U: core::convert::From<T>
-pub fn aya_ebpf_bindings::bindings::bpf_refcount::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf_bindings::bindings::bpf_refcount where U: core::convert::Into<T>
-pub type aya_ebpf_bindings::bindings::bpf_refcount::Error = core::convert::Infallible
-pub fn aya_ebpf_bindings::bindings::bpf_refcount::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf_bindings::bindings::bpf_refcount where U: core::convert::TryFrom<T>
-pub type aya_ebpf_bindings::bindings::bpf_refcount::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf_bindings::bindings::bpf_refcount::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf_bindings::bindings::bpf_refcount where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_refcount::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_refcount where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_refcount::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_refcount where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_refcount::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_refcount where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_refcount::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_refcount
-pub fn aya_ebpf_bindings::bindings::bpf_refcount::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::bpf_sk_lookup
 pub aya_ebpf_bindings::bindings::bpf_sk_lookup::__bindgen_anon_1: aya_ebpf_bindings::bindings::bpf_sk_lookup__bindgen_ty_1
 pub aya_ebpf_bindings::bindings::bpf_sk_lookup::_bitfield_1: aya_ebpf_bindings::bindings::__BindgenBitfieldUnit<[u8; 2]>
@@ -5453,24 +2907,6 @@ impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_sk_lookup
 impl core::marker::UnsafeUnpin for aya_ebpf_bindings::bindings::bpf_sk_lookup
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf_bindings::bindings::bpf_sk_lookup
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf_bindings::bindings::bpf_sk_lookup
-impl<T, U> core::convert::Into<U> for aya_ebpf_bindings::bindings::bpf_sk_lookup where U: core::convert::From<T>
-pub fn aya_ebpf_bindings::bindings::bpf_sk_lookup::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf_bindings::bindings::bpf_sk_lookup where U: core::convert::Into<T>
-pub type aya_ebpf_bindings::bindings::bpf_sk_lookup::Error = core::convert::Infallible
-pub fn aya_ebpf_bindings::bindings::bpf_sk_lookup::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf_bindings::bindings::bpf_sk_lookup where U: core::convert::TryFrom<T>
-pub type aya_ebpf_bindings::bindings::bpf_sk_lookup::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf_bindings::bindings::bpf_sk_lookup::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf_bindings::bindings::bpf_sk_lookup where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_sk_lookup::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_sk_lookup where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_sk_lookup::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_sk_lookup where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_sk_lookup::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_sk_lookup where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_sk_lookup::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_sk_lookup
-pub fn aya_ebpf_bindings::bindings::bpf_sk_lookup::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::bpf_sock
 pub aya_ebpf_bindings::bindings::bpf_sock::_bitfield_1: aya_ebpf_bindings::bindings::__BindgenBitfieldUnit<[u8; 2]>
 pub aya_ebpf_bindings::bindings::bpf_sock::_bitfield_align_1: [u8; 0]
@@ -5502,24 +2938,6 @@ impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_sock
 impl core::marker::UnsafeUnpin for aya_ebpf_bindings::bindings::bpf_sock
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf_bindings::bindings::bpf_sock
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf_bindings::bindings::bpf_sock
-impl<T, U> core::convert::Into<U> for aya_ebpf_bindings::bindings::bpf_sock where U: core::convert::From<T>
-pub fn aya_ebpf_bindings::bindings::bpf_sock::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf_bindings::bindings::bpf_sock where U: core::convert::Into<T>
-pub type aya_ebpf_bindings::bindings::bpf_sock::Error = core::convert::Infallible
-pub fn aya_ebpf_bindings::bindings::bpf_sock::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf_bindings::bindings::bpf_sock where U: core::convert::TryFrom<T>
-pub type aya_ebpf_bindings::bindings::bpf_sock::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf_bindings::bindings::bpf_sock::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf_bindings::bindings::bpf_sock where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_sock::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_sock where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_sock::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_sock where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_sock::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_sock where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_sock::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_sock
-pub fn aya_ebpf_bindings::bindings::bpf_sock::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::bpf_sock_addr
 pub aya_ebpf_bindings::bindings::bpf_sock_addr::__bindgen_anon_1: aya_ebpf_bindings::bindings::bpf_sock_addr__bindgen_ty_1
 pub aya_ebpf_bindings::bindings::bpf_sock_addr::family: aya_ebpf_bindings::bindings::__u32
@@ -5541,24 +2959,6 @@ impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_sock_addr
 impl core::marker::UnsafeUnpin for aya_ebpf_bindings::bindings::bpf_sock_addr
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf_bindings::bindings::bpf_sock_addr
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf_bindings::bindings::bpf_sock_addr
-impl<T, U> core::convert::Into<U> for aya_ebpf_bindings::bindings::bpf_sock_addr where U: core::convert::From<T>
-pub fn aya_ebpf_bindings::bindings::bpf_sock_addr::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf_bindings::bindings::bpf_sock_addr where U: core::convert::Into<T>
-pub type aya_ebpf_bindings::bindings::bpf_sock_addr::Error = core::convert::Infallible
-pub fn aya_ebpf_bindings::bindings::bpf_sock_addr::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf_bindings::bindings::bpf_sock_addr where U: core::convert::TryFrom<T>
-pub type aya_ebpf_bindings::bindings::bpf_sock_addr::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf_bindings::bindings::bpf_sock_addr::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf_bindings::bindings::bpf_sock_addr where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_sock_addr::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_sock_addr where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_sock_addr::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_sock_addr where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_sock_addr::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_sock_addr where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_sock_addr::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_sock_addr
-pub fn aya_ebpf_bindings::bindings::bpf_sock_addr::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::bpf_sock_ops
 pub aya_ebpf_bindings::bindings::bpf_sock_ops::__bindgen_anon_1: aya_ebpf_bindings::bindings::bpf_sock_ops__bindgen_ty_1
 pub aya_ebpf_bindings::bindings::bpf_sock_ops::__bindgen_anon_2: aya_ebpf_bindings::bindings::bpf_sock_ops__bindgen_ty_2
@@ -5611,24 +3011,6 @@ impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_sock_ops
 impl core::marker::UnsafeUnpin for aya_ebpf_bindings::bindings::bpf_sock_ops
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf_bindings::bindings::bpf_sock_ops
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf_bindings::bindings::bpf_sock_ops
-impl<T, U> core::convert::Into<U> for aya_ebpf_bindings::bindings::bpf_sock_ops where U: core::convert::From<T>
-pub fn aya_ebpf_bindings::bindings::bpf_sock_ops::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf_bindings::bindings::bpf_sock_ops where U: core::convert::Into<T>
-pub type aya_ebpf_bindings::bindings::bpf_sock_ops::Error = core::convert::Infallible
-pub fn aya_ebpf_bindings::bindings::bpf_sock_ops::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf_bindings::bindings::bpf_sock_ops where U: core::convert::TryFrom<T>
-pub type aya_ebpf_bindings::bindings::bpf_sock_ops::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf_bindings::bindings::bpf_sock_ops::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf_bindings::bindings::bpf_sock_ops where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_sock_ops::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_sock_ops where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_sock_ops::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_sock_ops where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_sock_ops::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_sock_ops where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_sock_ops::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_sock_ops
-pub fn aya_ebpf_bindings::bindings::bpf_sock_ops::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::bpf_sock_tuple
 pub aya_ebpf_bindings::bindings::bpf_sock_tuple::__bindgen_anon_1: aya_ebpf_bindings::bindings::bpf_sock_tuple__bindgen_ty_1
 impl core::clone::Clone for aya_ebpf_bindings::bindings::bpf_sock_tuple
@@ -5641,24 +3023,6 @@ impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_sock_tuple
 impl core::marker::UnsafeUnpin for aya_ebpf_bindings::bindings::bpf_sock_tuple
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf_bindings::bindings::bpf_sock_tuple
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf_bindings::bindings::bpf_sock_tuple
-impl<T, U> core::convert::Into<U> for aya_ebpf_bindings::bindings::bpf_sock_tuple where U: core::convert::From<T>
-pub fn aya_ebpf_bindings::bindings::bpf_sock_tuple::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf_bindings::bindings::bpf_sock_tuple where U: core::convert::Into<T>
-pub type aya_ebpf_bindings::bindings::bpf_sock_tuple::Error = core::convert::Infallible
-pub fn aya_ebpf_bindings::bindings::bpf_sock_tuple::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf_bindings::bindings::bpf_sock_tuple where U: core::convert::TryFrom<T>
-pub type aya_ebpf_bindings::bindings::bpf_sock_tuple::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf_bindings::bindings::bpf_sock_tuple::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf_bindings::bindings::bpf_sock_tuple where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_sock_tuple::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_sock_tuple where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_sock_tuple::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_sock_tuple where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_sock_tuple::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_sock_tuple where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_sock_tuple::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_sock_tuple
-pub fn aya_ebpf_bindings::bindings::bpf_sock_tuple::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::bpf_sock_tuple__bindgen_ty_1__bindgen_ty_1
 pub aya_ebpf_bindings::bindings::bpf_sock_tuple__bindgen_ty_1__bindgen_ty_1::daddr: aya_ebpf_bindings::bindings::__be32
 pub aya_ebpf_bindings::bindings::bpf_sock_tuple__bindgen_ty_1__bindgen_ty_1::dport: aya_ebpf_bindings::bindings::__be16
@@ -5676,24 +3040,6 @@ impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_sock_tuple__bindge
 impl core::marker::UnsafeUnpin for aya_ebpf_bindings::bindings::bpf_sock_tuple__bindgen_ty_1__bindgen_ty_1
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf_bindings::bindings::bpf_sock_tuple__bindgen_ty_1__bindgen_ty_1
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf_bindings::bindings::bpf_sock_tuple__bindgen_ty_1__bindgen_ty_1
-impl<T, U> core::convert::Into<U> for aya_ebpf_bindings::bindings::bpf_sock_tuple__bindgen_ty_1__bindgen_ty_1 where U: core::convert::From<T>
-pub fn aya_ebpf_bindings::bindings::bpf_sock_tuple__bindgen_ty_1__bindgen_ty_1::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf_bindings::bindings::bpf_sock_tuple__bindgen_ty_1__bindgen_ty_1 where U: core::convert::Into<T>
-pub type aya_ebpf_bindings::bindings::bpf_sock_tuple__bindgen_ty_1__bindgen_ty_1::Error = core::convert::Infallible
-pub fn aya_ebpf_bindings::bindings::bpf_sock_tuple__bindgen_ty_1__bindgen_ty_1::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf_bindings::bindings::bpf_sock_tuple__bindgen_ty_1__bindgen_ty_1 where U: core::convert::TryFrom<T>
-pub type aya_ebpf_bindings::bindings::bpf_sock_tuple__bindgen_ty_1__bindgen_ty_1::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf_bindings::bindings::bpf_sock_tuple__bindgen_ty_1__bindgen_ty_1::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf_bindings::bindings::bpf_sock_tuple__bindgen_ty_1__bindgen_ty_1 where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_sock_tuple__bindgen_ty_1__bindgen_ty_1::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_sock_tuple__bindgen_ty_1__bindgen_ty_1 where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_sock_tuple__bindgen_ty_1__bindgen_ty_1::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_sock_tuple__bindgen_ty_1__bindgen_ty_1 where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_sock_tuple__bindgen_ty_1__bindgen_ty_1::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_sock_tuple__bindgen_ty_1__bindgen_ty_1 where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_sock_tuple__bindgen_ty_1__bindgen_ty_1::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_sock_tuple__bindgen_ty_1__bindgen_ty_1
-pub fn aya_ebpf_bindings::bindings::bpf_sock_tuple__bindgen_ty_1__bindgen_ty_1::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::bpf_sock_tuple__bindgen_ty_1__bindgen_ty_2
 pub aya_ebpf_bindings::bindings::bpf_sock_tuple__bindgen_ty_1__bindgen_ty_2::daddr: [aya_ebpf_bindings::bindings::__be32; 4]
 pub aya_ebpf_bindings::bindings::bpf_sock_tuple__bindgen_ty_1__bindgen_ty_2::dport: aya_ebpf_bindings::bindings::__be16
@@ -5711,24 +3057,6 @@ impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_sock_tuple__bindge
 impl core::marker::UnsafeUnpin for aya_ebpf_bindings::bindings::bpf_sock_tuple__bindgen_ty_1__bindgen_ty_2
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf_bindings::bindings::bpf_sock_tuple__bindgen_ty_1__bindgen_ty_2
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf_bindings::bindings::bpf_sock_tuple__bindgen_ty_1__bindgen_ty_2
-impl<T, U> core::convert::Into<U> for aya_ebpf_bindings::bindings::bpf_sock_tuple__bindgen_ty_1__bindgen_ty_2 where U: core::convert::From<T>
-pub fn aya_ebpf_bindings::bindings::bpf_sock_tuple__bindgen_ty_1__bindgen_ty_2::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf_bindings::bindings::bpf_sock_tuple__bindgen_ty_1__bindgen_ty_2 where U: core::convert::Into<T>
-pub type aya_ebpf_bindings::bindings::bpf_sock_tuple__bindgen_ty_1__bindgen_ty_2::Error = core::convert::Infallible
-pub fn aya_ebpf_bindings::bindings::bpf_sock_tuple__bindgen_ty_1__bindgen_ty_2::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf_bindings::bindings::bpf_sock_tuple__bindgen_ty_1__bindgen_ty_2 where U: core::convert::TryFrom<T>
-pub type aya_ebpf_bindings::bindings::bpf_sock_tuple__bindgen_ty_1__bindgen_ty_2::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf_bindings::bindings::bpf_sock_tuple__bindgen_ty_1__bindgen_ty_2::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf_bindings::bindings::bpf_sock_tuple__bindgen_ty_1__bindgen_ty_2 where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_sock_tuple__bindgen_ty_1__bindgen_ty_2::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_sock_tuple__bindgen_ty_1__bindgen_ty_2 where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_sock_tuple__bindgen_ty_1__bindgen_ty_2::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_sock_tuple__bindgen_ty_1__bindgen_ty_2 where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_sock_tuple__bindgen_ty_1__bindgen_ty_2::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_sock_tuple__bindgen_ty_1__bindgen_ty_2 where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_sock_tuple__bindgen_ty_1__bindgen_ty_2::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_sock_tuple__bindgen_ty_1__bindgen_ty_2
-pub fn aya_ebpf_bindings::bindings::bpf_sock_tuple__bindgen_ty_1__bindgen_ty_2::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::bpf_sockopt
 pub aya_ebpf_bindings::bindings::bpf_sockopt::__bindgen_anon_1: aya_ebpf_bindings::bindings::bpf_sockopt__bindgen_ty_1
 pub aya_ebpf_bindings::bindings::bpf_sockopt::__bindgen_anon_2: aya_ebpf_bindings::bindings::bpf_sockopt__bindgen_ty_2
@@ -5747,24 +3075,6 @@ impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_sockopt
 impl core::marker::UnsafeUnpin for aya_ebpf_bindings::bindings::bpf_sockopt
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf_bindings::bindings::bpf_sockopt
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf_bindings::bindings::bpf_sockopt
-impl<T, U> core::convert::Into<U> for aya_ebpf_bindings::bindings::bpf_sockopt where U: core::convert::From<T>
-pub fn aya_ebpf_bindings::bindings::bpf_sockopt::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf_bindings::bindings::bpf_sockopt where U: core::convert::Into<T>
-pub type aya_ebpf_bindings::bindings::bpf_sockopt::Error = core::convert::Infallible
-pub fn aya_ebpf_bindings::bindings::bpf_sockopt::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf_bindings::bindings::bpf_sockopt where U: core::convert::TryFrom<T>
-pub type aya_ebpf_bindings::bindings::bpf_sockopt::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf_bindings::bindings::bpf_sockopt::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf_bindings::bindings::bpf_sockopt where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_sockopt::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_sockopt where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_sockopt::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_sockopt where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_sockopt::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_sockopt where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_sockopt::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_sockopt
-pub fn aya_ebpf_bindings::bindings::bpf_sockopt::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::bpf_spin_lock
 pub aya_ebpf_bindings::bindings::bpf_spin_lock::val: aya_ebpf_bindings::bindings::__u32
 impl core::clone::Clone for aya_ebpf_bindings::bindings::bpf_spin_lock
@@ -5779,24 +3089,6 @@ impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_spin_lock
 impl core::marker::UnsafeUnpin for aya_ebpf_bindings::bindings::bpf_spin_lock
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf_bindings::bindings::bpf_spin_lock
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf_bindings::bindings::bpf_spin_lock
-impl<T, U> core::convert::Into<U> for aya_ebpf_bindings::bindings::bpf_spin_lock where U: core::convert::From<T>
-pub fn aya_ebpf_bindings::bindings::bpf_spin_lock::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf_bindings::bindings::bpf_spin_lock where U: core::convert::Into<T>
-pub type aya_ebpf_bindings::bindings::bpf_spin_lock::Error = core::convert::Infallible
-pub fn aya_ebpf_bindings::bindings::bpf_spin_lock::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf_bindings::bindings::bpf_spin_lock where U: core::convert::TryFrom<T>
-pub type aya_ebpf_bindings::bindings::bpf_spin_lock::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf_bindings::bindings::bpf_spin_lock::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf_bindings::bindings::bpf_spin_lock where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_spin_lock::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_spin_lock where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_spin_lock::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_spin_lock where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_spin_lock::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_spin_lock where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_spin_lock::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_spin_lock
-pub fn aya_ebpf_bindings::bindings::bpf_spin_lock::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::bpf_stack_build_id
 pub aya_ebpf_bindings::bindings::bpf_stack_build_id::__bindgen_anon_1: aya_ebpf_bindings::bindings::bpf_stack_build_id__bindgen_ty_1
 pub aya_ebpf_bindings::bindings::bpf_stack_build_id::build_id: [aya_ebpf_cty::c_uchar; 20]
@@ -5811,24 +3103,6 @@ impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_stack_build_id
 impl core::marker::UnsafeUnpin for aya_ebpf_bindings::bindings::bpf_stack_build_id
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf_bindings::bindings::bpf_stack_build_id
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf_bindings::bindings::bpf_stack_build_id
-impl<T, U> core::convert::Into<U> for aya_ebpf_bindings::bindings::bpf_stack_build_id where U: core::convert::From<T>
-pub fn aya_ebpf_bindings::bindings::bpf_stack_build_id::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf_bindings::bindings::bpf_stack_build_id where U: core::convert::Into<T>
-pub type aya_ebpf_bindings::bindings::bpf_stack_build_id::Error = core::convert::Infallible
-pub fn aya_ebpf_bindings::bindings::bpf_stack_build_id::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf_bindings::bindings::bpf_stack_build_id where U: core::convert::TryFrom<T>
-pub type aya_ebpf_bindings::bindings::bpf_stack_build_id::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf_bindings::bindings::bpf_stack_build_id::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf_bindings::bindings::bpf_stack_build_id where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_stack_build_id::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_stack_build_id where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_stack_build_id::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_stack_build_id where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_stack_build_id::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_stack_build_id where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_stack_build_id::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_stack_build_id
-pub fn aya_ebpf_bindings::bindings::bpf_stack_build_id::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::bpf_sysctl
 pub aya_ebpf_bindings::bindings::bpf_sysctl::file_pos: aya_ebpf_bindings::bindings::__u32
 pub aya_ebpf_bindings::bindings::bpf_sysctl::write: aya_ebpf_bindings::bindings::__u32
@@ -5844,24 +3118,6 @@ impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_sysctl
 impl core::marker::UnsafeUnpin for aya_ebpf_bindings::bindings::bpf_sysctl
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf_bindings::bindings::bpf_sysctl
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf_bindings::bindings::bpf_sysctl
-impl<T, U> core::convert::Into<U> for aya_ebpf_bindings::bindings::bpf_sysctl where U: core::convert::From<T>
-pub fn aya_ebpf_bindings::bindings::bpf_sysctl::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf_bindings::bindings::bpf_sysctl where U: core::convert::Into<T>
-pub type aya_ebpf_bindings::bindings::bpf_sysctl::Error = core::convert::Infallible
-pub fn aya_ebpf_bindings::bindings::bpf_sysctl::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf_bindings::bindings::bpf_sysctl where U: core::convert::TryFrom<T>
-pub type aya_ebpf_bindings::bindings::bpf_sysctl::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf_bindings::bindings::bpf_sysctl::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf_bindings::bindings::bpf_sysctl where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_sysctl::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_sysctl where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_sysctl::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_sysctl where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_sysctl::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_sysctl where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_sysctl::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_sysctl
-pub fn aya_ebpf_bindings::bindings::bpf_sysctl::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::bpf_tcp_sock
 pub aya_ebpf_bindings::bindings::bpf_tcp_sock::bytes_acked: aya_ebpf_bindings::bindings::__u64
 pub aya_ebpf_bindings::bindings::bpf_tcp_sock::bytes_received: aya_ebpf_bindings::bindings::__u64
@@ -5901,24 +3157,6 @@ impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_tcp_sock
 impl core::marker::UnsafeUnpin for aya_ebpf_bindings::bindings::bpf_tcp_sock
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf_bindings::bindings::bpf_tcp_sock
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf_bindings::bindings::bpf_tcp_sock
-impl<T, U> core::convert::Into<U> for aya_ebpf_bindings::bindings::bpf_tcp_sock where U: core::convert::From<T>
-pub fn aya_ebpf_bindings::bindings::bpf_tcp_sock::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf_bindings::bindings::bpf_tcp_sock where U: core::convert::Into<T>
-pub type aya_ebpf_bindings::bindings::bpf_tcp_sock::Error = core::convert::Infallible
-pub fn aya_ebpf_bindings::bindings::bpf_tcp_sock::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf_bindings::bindings::bpf_tcp_sock where U: core::convert::TryFrom<T>
-pub type aya_ebpf_bindings::bindings::bpf_tcp_sock::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf_bindings::bindings::bpf_tcp_sock::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf_bindings::bindings::bpf_tcp_sock where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_tcp_sock::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_tcp_sock where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_tcp_sock::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_tcp_sock where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_tcp_sock::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_tcp_sock where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_tcp_sock::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_tcp_sock
-pub fn aya_ebpf_bindings::bindings::bpf_tcp_sock::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::bpf_timer
 pub aya_ebpf_bindings::bindings::bpf_timer::__opaque: [aya_ebpf_bindings::bindings::__u64; 2]
 impl core::clone::Clone for aya_ebpf_bindings::bindings::bpf_timer
@@ -5933,24 +3171,6 @@ impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_timer
 impl core::marker::UnsafeUnpin for aya_ebpf_bindings::bindings::bpf_timer
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf_bindings::bindings::bpf_timer
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf_bindings::bindings::bpf_timer
-impl<T, U> core::convert::Into<U> for aya_ebpf_bindings::bindings::bpf_timer where U: core::convert::From<T>
-pub fn aya_ebpf_bindings::bindings::bpf_timer::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf_bindings::bindings::bpf_timer where U: core::convert::Into<T>
-pub type aya_ebpf_bindings::bindings::bpf_timer::Error = core::convert::Infallible
-pub fn aya_ebpf_bindings::bindings::bpf_timer::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf_bindings::bindings::bpf_timer where U: core::convert::TryFrom<T>
-pub type aya_ebpf_bindings::bindings::bpf_timer::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf_bindings::bindings::bpf_timer::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf_bindings::bindings::bpf_timer where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_timer::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_timer where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_timer::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_timer where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_timer::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_timer where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_timer::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_timer
-pub fn aya_ebpf_bindings::bindings::bpf_timer::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::bpf_tunnel_key
 pub aya_ebpf_bindings::bindings::bpf_tunnel_key::__bindgen_anon_1: aya_ebpf_bindings::bindings::bpf_tunnel_key__bindgen_ty_1
 pub aya_ebpf_bindings::bindings::bpf_tunnel_key::__bindgen_anon_2: aya_ebpf_bindings::bindings::bpf_tunnel_key__bindgen_ty_2
@@ -5969,24 +3189,6 @@ impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_tunnel_key
 impl core::marker::UnsafeUnpin for aya_ebpf_bindings::bindings::bpf_tunnel_key
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf_bindings::bindings::bpf_tunnel_key
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf_bindings::bindings::bpf_tunnel_key
-impl<T, U> core::convert::Into<U> for aya_ebpf_bindings::bindings::bpf_tunnel_key where U: core::convert::From<T>
-pub fn aya_ebpf_bindings::bindings::bpf_tunnel_key::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf_bindings::bindings::bpf_tunnel_key where U: core::convert::Into<T>
-pub type aya_ebpf_bindings::bindings::bpf_tunnel_key::Error = core::convert::Infallible
-pub fn aya_ebpf_bindings::bindings::bpf_tunnel_key::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf_bindings::bindings::bpf_tunnel_key where U: core::convert::TryFrom<T>
-pub type aya_ebpf_bindings::bindings::bpf_tunnel_key::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf_bindings::bindings::bpf_tunnel_key::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf_bindings::bindings::bpf_tunnel_key where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_tunnel_key::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_tunnel_key where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_tunnel_key::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_tunnel_key where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_tunnel_key::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_tunnel_key where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_tunnel_key::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_tunnel_key
-pub fn aya_ebpf_bindings::bindings::bpf_tunnel_key::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::bpf_xdp_sock
 pub aya_ebpf_bindings::bindings::bpf_xdp_sock::queue_id: aya_ebpf_bindings::bindings::__u32
 impl core::clone::Clone for aya_ebpf_bindings::bindings::bpf_xdp_sock
@@ -6001,24 +3203,6 @@ impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_xdp_sock
 impl core::marker::UnsafeUnpin for aya_ebpf_bindings::bindings::bpf_xdp_sock
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf_bindings::bindings::bpf_xdp_sock
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf_bindings::bindings::bpf_xdp_sock
-impl<T, U> core::convert::Into<U> for aya_ebpf_bindings::bindings::bpf_xdp_sock where U: core::convert::From<T>
-pub fn aya_ebpf_bindings::bindings::bpf_xdp_sock::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf_bindings::bindings::bpf_xdp_sock where U: core::convert::Into<T>
-pub type aya_ebpf_bindings::bindings::bpf_xdp_sock::Error = core::convert::Infallible
-pub fn aya_ebpf_bindings::bindings::bpf_xdp_sock::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf_bindings::bindings::bpf_xdp_sock where U: core::convert::TryFrom<T>
-pub type aya_ebpf_bindings::bindings::bpf_xdp_sock::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf_bindings::bindings::bpf_xdp_sock::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf_bindings::bindings::bpf_xdp_sock where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_xdp_sock::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_xdp_sock where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_xdp_sock::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_xdp_sock where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_xdp_sock::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_xdp_sock where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_xdp_sock::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_xdp_sock
-pub fn aya_ebpf_bindings::bindings::bpf_xdp_sock::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::bpf_xfrm_state
 pub aya_ebpf_bindings::bindings::bpf_xfrm_state::__bindgen_anon_1: aya_ebpf_bindings::bindings::bpf_xfrm_state__bindgen_ty_1
 pub aya_ebpf_bindings::bindings::bpf_xfrm_state::ext: aya_ebpf_bindings::bindings::__u16
@@ -6035,24 +3219,6 @@ impl core::marker::Unpin for aya_ebpf_bindings::bindings::bpf_xfrm_state
 impl core::marker::UnsafeUnpin for aya_ebpf_bindings::bindings::bpf_xfrm_state
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf_bindings::bindings::bpf_xfrm_state
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf_bindings::bindings::bpf_xfrm_state
-impl<T, U> core::convert::Into<U> for aya_ebpf_bindings::bindings::bpf_xfrm_state where U: core::convert::From<T>
-pub fn aya_ebpf_bindings::bindings::bpf_xfrm_state::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf_bindings::bindings::bpf_xfrm_state where U: core::convert::Into<T>
-pub type aya_ebpf_bindings::bindings::bpf_xfrm_state::Error = core::convert::Infallible
-pub fn aya_ebpf_bindings::bindings::bpf_xfrm_state::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf_bindings::bindings::bpf_xfrm_state where U: core::convert::TryFrom<T>
-pub type aya_ebpf_bindings::bindings::bpf_xfrm_state::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf_bindings::bindings::bpf_xfrm_state::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf_bindings::bindings::bpf_xfrm_state where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_xfrm_state::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::bpf_xfrm_state where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_xfrm_state::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::bpf_xfrm_state where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::bpf_xfrm_state::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::bpf_xfrm_state where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::bpf_xfrm_state::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::bpf_xfrm_state
-pub fn aya_ebpf_bindings::bindings::bpf_xfrm_state::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::btf_ptr
 pub aya_ebpf_bindings::bindings::btf_ptr::flags: aya_ebpf_bindings::bindings::__u32
 pub aya_ebpf_bindings::bindings::btf_ptr::ptr: *mut aya_ebpf_cty::c_void
@@ -6069,24 +3235,6 @@ impl core::marker::Unpin for aya_ebpf_bindings::bindings::btf_ptr
 impl core::marker::UnsafeUnpin for aya_ebpf_bindings::bindings::btf_ptr
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf_bindings::bindings::btf_ptr
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf_bindings::bindings::btf_ptr
-impl<T, U> core::convert::Into<U> for aya_ebpf_bindings::bindings::btf_ptr where U: core::convert::From<T>
-pub fn aya_ebpf_bindings::bindings::btf_ptr::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf_bindings::bindings::btf_ptr where U: core::convert::Into<T>
-pub type aya_ebpf_bindings::bindings::btf_ptr::Error = core::convert::Infallible
-pub fn aya_ebpf_bindings::bindings::btf_ptr::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf_bindings::bindings::btf_ptr where U: core::convert::TryFrom<T>
-pub type aya_ebpf_bindings::bindings::btf_ptr::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf_bindings::bindings::btf_ptr::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf_bindings::bindings::btf_ptr where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::btf_ptr::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::btf_ptr where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::btf_ptr::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::btf_ptr where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::btf_ptr::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::btf_ptr where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::btf_ptr::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::btf_ptr
-pub fn aya_ebpf_bindings::bindings::btf_ptr::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::cgroup
 impl core::clone::Clone for aya_ebpf_bindings::bindings::cgroup
 pub fn aya_ebpf_bindings::bindings::cgroup::clone(&self) -> aya_ebpf_bindings::bindings::cgroup
@@ -6100,24 +3248,6 @@ impl core::marker::Unpin for aya_ebpf_bindings::bindings::cgroup
 impl core::marker::UnsafeUnpin for aya_ebpf_bindings::bindings::cgroup
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf_bindings::bindings::cgroup
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf_bindings::bindings::cgroup
-impl<T, U> core::convert::Into<U> for aya_ebpf_bindings::bindings::cgroup where U: core::convert::From<T>
-pub fn aya_ebpf_bindings::bindings::cgroup::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf_bindings::bindings::cgroup where U: core::convert::Into<T>
-pub type aya_ebpf_bindings::bindings::cgroup::Error = core::convert::Infallible
-pub fn aya_ebpf_bindings::bindings::cgroup::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf_bindings::bindings::cgroup where U: core::convert::TryFrom<T>
-pub type aya_ebpf_bindings::bindings::cgroup::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf_bindings::bindings::cgroup::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf_bindings::bindings::cgroup where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::cgroup::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::cgroup where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::cgroup::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::cgroup where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::cgroup::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::cgroup where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::cgroup::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::cgroup
-pub fn aya_ebpf_bindings::bindings::cgroup::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::file
 impl core::clone::Clone for aya_ebpf_bindings::bindings::file
 pub fn aya_ebpf_bindings::bindings::file::clone(&self) -> aya_ebpf_bindings::bindings::file
@@ -6131,24 +3261,6 @@ impl core::marker::Unpin for aya_ebpf_bindings::bindings::file
 impl core::marker::UnsafeUnpin for aya_ebpf_bindings::bindings::file
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf_bindings::bindings::file
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf_bindings::bindings::file
-impl<T, U> core::convert::Into<U> for aya_ebpf_bindings::bindings::file where U: core::convert::From<T>
-pub fn aya_ebpf_bindings::bindings::file::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf_bindings::bindings::file where U: core::convert::Into<T>
-pub type aya_ebpf_bindings::bindings::file::Error = core::convert::Infallible
-pub fn aya_ebpf_bindings::bindings::file::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf_bindings::bindings::file where U: core::convert::TryFrom<T>
-pub type aya_ebpf_bindings::bindings::file::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf_bindings::bindings::file::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf_bindings::bindings::file where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::file::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::file where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::file::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::file where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::file::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::file where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::file::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::file
-pub fn aya_ebpf_bindings::bindings::file::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::inode
 impl core::clone::Clone for aya_ebpf_bindings::bindings::inode
 pub fn aya_ebpf_bindings::bindings::inode::clone(&self) -> aya_ebpf_bindings::bindings::inode
@@ -6162,24 +3274,6 @@ impl core::marker::Unpin for aya_ebpf_bindings::bindings::inode
 impl core::marker::UnsafeUnpin for aya_ebpf_bindings::bindings::inode
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf_bindings::bindings::inode
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf_bindings::bindings::inode
-impl<T, U> core::convert::Into<U> for aya_ebpf_bindings::bindings::inode where U: core::convert::From<T>
-pub fn aya_ebpf_bindings::bindings::inode::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf_bindings::bindings::inode where U: core::convert::Into<T>
-pub type aya_ebpf_bindings::bindings::inode::Error = core::convert::Infallible
-pub fn aya_ebpf_bindings::bindings::inode::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf_bindings::bindings::inode where U: core::convert::TryFrom<T>
-pub type aya_ebpf_bindings::bindings::inode::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf_bindings::bindings::inode::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf_bindings::bindings::inode where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::inode::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::inode where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::inode::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::inode where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::inode::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::inode where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::inode::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::inode
-pub fn aya_ebpf_bindings::bindings::inode::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::iphdr
 impl core::clone::Clone for aya_ebpf_bindings::bindings::iphdr
 pub fn aya_ebpf_bindings::bindings::iphdr::clone(&self) -> aya_ebpf_bindings::bindings::iphdr
@@ -6193,24 +3287,6 @@ impl core::marker::Unpin for aya_ebpf_bindings::bindings::iphdr
 impl core::marker::UnsafeUnpin for aya_ebpf_bindings::bindings::iphdr
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf_bindings::bindings::iphdr
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf_bindings::bindings::iphdr
-impl<T, U> core::convert::Into<U> for aya_ebpf_bindings::bindings::iphdr where U: core::convert::From<T>
-pub fn aya_ebpf_bindings::bindings::iphdr::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf_bindings::bindings::iphdr where U: core::convert::Into<T>
-pub type aya_ebpf_bindings::bindings::iphdr::Error = core::convert::Infallible
-pub fn aya_ebpf_bindings::bindings::iphdr::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf_bindings::bindings::iphdr where U: core::convert::TryFrom<T>
-pub type aya_ebpf_bindings::bindings::iphdr::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf_bindings::bindings::iphdr::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf_bindings::bindings::iphdr where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::iphdr::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::iphdr where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::iphdr::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::iphdr where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::iphdr::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::iphdr where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::iphdr::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::iphdr
-pub fn aya_ebpf_bindings::bindings::iphdr::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::ipv6hdr
 impl core::clone::Clone for aya_ebpf_bindings::bindings::ipv6hdr
 pub fn aya_ebpf_bindings::bindings::ipv6hdr::clone(&self) -> aya_ebpf_bindings::bindings::ipv6hdr
@@ -6224,24 +3300,6 @@ impl core::marker::Unpin for aya_ebpf_bindings::bindings::ipv6hdr
 impl core::marker::UnsafeUnpin for aya_ebpf_bindings::bindings::ipv6hdr
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf_bindings::bindings::ipv6hdr
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf_bindings::bindings::ipv6hdr
-impl<T, U> core::convert::Into<U> for aya_ebpf_bindings::bindings::ipv6hdr where U: core::convert::From<T>
-pub fn aya_ebpf_bindings::bindings::ipv6hdr::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf_bindings::bindings::ipv6hdr where U: core::convert::Into<T>
-pub type aya_ebpf_bindings::bindings::ipv6hdr::Error = core::convert::Infallible
-pub fn aya_ebpf_bindings::bindings::ipv6hdr::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf_bindings::bindings::ipv6hdr where U: core::convert::TryFrom<T>
-pub type aya_ebpf_bindings::bindings::ipv6hdr::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf_bindings::bindings::ipv6hdr::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf_bindings::bindings::ipv6hdr where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::ipv6hdr::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::ipv6hdr where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::ipv6hdr::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::ipv6hdr where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::ipv6hdr::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::ipv6hdr where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::ipv6hdr::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::ipv6hdr
-pub fn aya_ebpf_bindings::bindings::ipv6hdr::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::linux_binprm
 impl core::clone::Clone for aya_ebpf_bindings::bindings::linux_binprm
 pub fn aya_ebpf_bindings::bindings::linux_binprm::clone(&self) -> aya_ebpf_bindings::bindings::linux_binprm
@@ -6255,24 +3313,6 @@ impl core::marker::Unpin for aya_ebpf_bindings::bindings::linux_binprm
 impl core::marker::UnsafeUnpin for aya_ebpf_bindings::bindings::linux_binprm
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf_bindings::bindings::linux_binprm
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf_bindings::bindings::linux_binprm
-impl<T, U> core::convert::Into<U> for aya_ebpf_bindings::bindings::linux_binprm where U: core::convert::From<T>
-pub fn aya_ebpf_bindings::bindings::linux_binprm::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf_bindings::bindings::linux_binprm where U: core::convert::Into<T>
-pub type aya_ebpf_bindings::bindings::linux_binprm::Error = core::convert::Infallible
-pub fn aya_ebpf_bindings::bindings::linux_binprm::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf_bindings::bindings::linux_binprm where U: core::convert::TryFrom<T>
-pub type aya_ebpf_bindings::bindings::linux_binprm::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf_bindings::bindings::linux_binprm::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf_bindings::bindings::linux_binprm where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::linux_binprm::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::linux_binprm where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::linux_binprm::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::linux_binprm where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::linux_binprm::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::linux_binprm where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::linux_binprm::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::linux_binprm
-pub fn aya_ebpf_bindings::bindings::linux_binprm::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::mptcp_sock
 impl core::clone::Clone for aya_ebpf_bindings::bindings::mptcp_sock
 pub fn aya_ebpf_bindings::bindings::mptcp_sock::clone(&self) -> aya_ebpf_bindings::bindings::mptcp_sock
@@ -6286,24 +3326,6 @@ impl core::marker::Unpin for aya_ebpf_bindings::bindings::mptcp_sock
 impl core::marker::UnsafeUnpin for aya_ebpf_bindings::bindings::mptcp_sock
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf_bindings::bindings::mptcp_sock
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf_bindings::bindings::mptcp_sock
-impl<T, U> core::convert::Into<U> for aya_ebpf_bindings::bindings::mptcp_sock where U: core::convert::From<T>
-pub fn aya_ebpf_bindings::bindings::mptcp_sock::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf_bindings::bindings::mptcp_sock where U: core::convert::Into<T>
-pub type aya_ebpf_bindings::bindings::mptcp_sock::Error = core::convert::Infallible
-pub fn aya_ebpf_bindings::bindings::mptcp_sock::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf_bindings::bindings::mptcp_sock where U: core::convert::TryFrom<T>
-pub type aya_ebpf_bindings::bindings::mptcp_sock::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf_bindings::bindings::mptcp_sock::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf_bindings::bindings::mptcp_sock where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::mptcp_sock::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::mptcp_sock where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::mptcp_sock::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::mptcp_sock where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::mptcp_sock::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::mptcp_sock where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::mptcp_sock::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::mptcp_sock
-pub fn aya_ebpf_bindings::bindings::mptcp_sock::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::path
 impl core::clone::Clone for aya_ebpf_bindings::bindings::path
 pub fn aya_ebpf_bindings::bindings::path::clone(&self) -> aya_ebpf_bindings::bindings::path
@@ -6317,24 +3339,6 @@ impl core::marker::Unpin for aya_ebpf_bindings::bindings::path
 impl core::marker::UnsafeUnpin for aya_ebpf_bindings::bindings::path
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf_bindings::bindings::path
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf_bindings::bindings::path
-impl<T, U> core::convert::Into<U> for aya_ebpf_bindings::bindings::path where U: core::convert::From<T>
-pub fn aya_ebpf_bindings::bindings::path::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf_bindings::bindings::path where U: core::convert::Into<T>
-pub type aya_ebpf_bindings::bindings::path::Error = core::convert::Infallible
-pub fn aya_ebpf_bindings::bindings::path::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf_bindings::bindings::path where U: core::convert::TryFrom<T>
-pub type aya_ebpf_bindings::bindings::path::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf_bindings::bindings::path::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf_bindings::bindings::path where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::path::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::path where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::path::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::path where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::path::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::path where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::path::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::path
-pub fn aya_ebpf_bindings::bindings::path::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::pt_regs
 pub aya_ebpf_bindings::bindings::pt_regs::cs: aya_ebpf_cty::od::c_ulong
 pub aya_ebpf_bindings::bindings::pt_regs::eflags: aya_ebpf_cty::od::c_ulong
@@ -6369,24 +3373,6 @@ impl core::marker::Unpin for aya_ebpf_bindings::bindings::pt_regs
 impl core::marker::UnsafeUnpin for aya_ebpf_bindings::bindings::pt_regs
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf_bindings::bindings::pt_regs
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf_bindings::bindings::pt_regs
-impl<T, U> core::convert::Into<U> for aya_ebpf_bindings::bindings::pt_regs where U: core::convert::From<T>
-pub fn aya_ebpf_bindings::bindings::pt_regs::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf_bindings::bindings::pt_regs where U: core::convert::Into<T>
-pub type aya_ebpf_bindings::bindings::pt_regs::Error = core::convert::Infallible
-pub fn aya_ebpf_bindings::bindings::pt_regs::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf_bindings::bindings::pt_regs where U: core::convert::TryFrom<T>
-pub type aya_ebpf_bindings::bindings::pt_regs::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf_bindings::bindings::pt_regs::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf_bindings::bindings::pt_regs where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::pt_regs::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::pt_regs where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::pt_regs::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::pt_regs where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::pt_regs::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::pt_regs where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::pt_regs::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::pt_regs
-pub fn aya_ebpf_bindings::bindings::pt_regs::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::seq_file
 impl core::clone::Clone for aya_ebpf_bindings::bindings::seq_file
 pub fn aya_ebpf_bindings::bindings::seq_file::clone(&self) -> aya_ebpf_bindings::bindings::seq_file
@@ -6400,24 +3386,6 @@ impl core::marker::Unpin for aya_ebpf_bindings::bindings::seq_file
 impl core::marker::UnsafeUnpin for aya_ebpf_bindings::bindings::seq_file
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf_bindings::bindings::seq_file
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf_bindings::bindings::seq_file
-impl<T, U> core::convert::Into<U> for aya_ebpf_bindings::bindings::seq_file where U: core::convert::From<T>
-pub fn aya_ebpf_bindings::bindings::seq_file::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf_bindings::bindings::seq_file where U: core::convert::Into<T>
-pub type aya_ebpf_bindings::bindings::seq_file::Error = core::convert::Infallible
-pub fn aya_ebpf_bindings::bindings::seq_file::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf_bindings::bindings::seq_file where U: core::convert::TryFrom<T>
-pub type aya_ebpf_bindings::bindings::seq_file::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf_bindings::bindings::seq_file::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf_bindings::bindings::seq_file where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::seq_file::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::seq_file where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::seq_file::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::seq_file where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::seq_file::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::seq_file where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::seq_file::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::seq_file
-pub fn aya_ebpf_bindings::bindings::seq_file::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::sk_msg_md
 pub aya_ebpf_bindings::bindings::sk_msg_md::__bindgen_anon_1: aya_ebpf_bindings::bindings::sk_msg_md__bindgen_ty_1
 pub aya_ebpf_bindings::bindings::sk_msg_md::__bindgen_anon_2: aya_ebpf_bindings::bindings::sk_msg_md__bindgen_ty_2
@@ -6440,24 +3408,6 @@ impl core::marker::Unpin for aya_ebpf_bindings::bindings::sk_msg_md
 impl core::marker::UnsafeUnpin for aya_ebpf_bindings::bindings::sk_msg_md
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf_bindings::bindings::sk_msg_md
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf_bindings::bindings::sk_msg_md
-impl<T, U> core::convert::Into<U> for aya_ebpf_bindings::bindings::sk_msg_md where U: core::convert::From<T>
-pub fn aya_ebpf_bindings::bindings::sk_msg_md::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf_bindings::bindings::sk_msg_md where U: core::convert::Into<T>
-pub type aya_ebpf_bindings::bindings::sk_msg_md::Error = core::convert::Infallible
-pub fn aya_ebpf_bindings::bindings::sk_msg_md::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf_bindings::bindings::sk_msg_md where U: core::convert::TryFrom<T>
-pub type aya_ebpf_bindings::bindings::sk_msg_md::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf_bindings::bindings::sk_msg_md::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf_bindings::bindings::sk_msg_md where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::sk_msg_md::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::sk_msg_md where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::sk_msg_md::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::sk_msg_md where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::sk_msg_md::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::sk_msg_md where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::sk_msg_md::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::sk_msg_md
-pub fn aya_ebpf_bindings::bindings::sk_msg_md::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::sk_reuseport_md
 pub aya_ebpf_bindings::bindings::sk_reuseport_md::__bindgen_anon_1: aya_ebpf_bindings::bindings::sk_reuseport_md__bindgen_ty_1
 pub aya_ebpf_bindings::bindings::sk_reuseport_md::__bindgen_anon_2: aya_ebpf_bindings::bindings::sk_reuseport_md__bindgen_ty_2
@@ -6478,24 +3428,6 @@ impl core::marker::Unpin for aya_ebpf_bindings::bindings::sk_reuseport_md
 impl core::marker::UnsafeUnpin for aya_ebpf_bindings::bindings::sk_reuseport_md
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf_bindings::bindings::sk_reuseport_md
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf_bindings::bindings::sk_reuseport_md
-impl<T, U> core::convert::Into<U> for aya_ebpf_bindings::bindings::sk_reuseport_md where U: core::convert::From<T>
-pub fn aya_ebpf_bindings::bindings::sk_reuseport_md::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf_bindings::bindings::sk_reuseport_md where U: core::convert::Into<T>
-pub type aya_ebpf_bindings::bindings::sk_reuseport_md::Error = core::convert::Infallible
-pub fn aya_ebpf_bindings::bindings::sk_reuseport_md::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf_bindings::bindings::sk_reuseport_md where U: core::convert::TryFrom<T>
-pub type aya_ebpf_bindings::bindings::sk_reuseport_md::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf_bindings::bindings::sk_reuseport_md::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf_bindings::bindings::sk_reuseport_md where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::sk_reuseport_md::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::sk_reuseport_md where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::sk_reuseport_md::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::sk_reuseport_md where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::sk_reuseport_md::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::sk_reuseport_md where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::sk_reuseport_md::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::sk_reuseport_md
-pub fn aya_ebpf_bindings::bindings::sk_reuseport_md::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::sockaddr
 pub aya_ebpf_bindings::bindings::sockaddr::sa_data: [aya_ebpf_cty::ad::c_char; 14]
 pub aya_ebpf_bindings::bindings::sockaddr::sa_family: aya_ebpf_bindings::bindings::sa_family_t
@@ -6511,24 +3443,6 @@ impl core::marker::Unpin for aya_ebpf_bindings::bindings::sockaddr
 impl core::marker::UnsafeUnpin for aya_ebpf_bindings::bindings::sockaddr
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf_bindings::bindings::sockaddr
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf_bindings::bindings::sockaddr
-impl<T, U> core::convert::Into<U> for aya_ebpf_bindings::bindings::sockaddr where U: core::convert::From<T>
-pub fn aya_ebpf_bindings::bindings::sockaddr::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf_bindings::bindings::sockaddr where U: core::convert::Into<T>
-pub type aya_ebpf_bindings::bindings::sockaddr::Error = core::convert::Infallible
-pub fn aya_ebpf_bindings::bindings::sockaddr::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf_bindings::bindings::sockaddr where U: core::convert::TryFrom<T>
-pub type aya_ebpf_bindings::bindings::sockaddr::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf_bindings::bindings::sockaddr::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf_bindings::bindings::sockaddr where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::sockaddr::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::sockaddr where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::sockaddr::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::sockaddr where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::sockaddr::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::sockaddr where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::sockaddr::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::sockaddr
-pub fn aya_ebpf_bindings::bindings::sockaddr::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::socket
 impl core::clone::Clone for aya_ebpf_bindings::bindings::socket
 pub fn aya_ebpf_bindings::bindings::socket::clone(&self) -> aya_ebpf_bindings::bindings::socket
@@ -6542,24 +3456,6 @@ impl core::marker::Unpin for aya_ebpf_bindings::bindings::socket
 impl core::marker::UnsafeUnpin for aya_ebpf_bindings::bindings::socket
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf_bindings::bindings::socket
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf_bindings::bindings::socket
-impl<T, U> core::convert::Into<U> for aya_ebpf_bindings::bindings::socket where U: core::convert::From<T>
-pub fn aya_ebpf_bindings::bindings::socket::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf_bindings::bindings::socket where U: core::convert::Into<T>
-pub type aya_ebpf_bindings::bindings::socket::Error = core::convert::Infallible
-pub fn aya_ebpf_bindings::bindings::socket::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf_bindings::bindings::socket where U: core::convert::TryFrom<T>
-pub type aya_ebpf_bindings::bindings::socket::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf_bindings::bindings::socket::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf_bindings::bindings::socket where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::socket::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::socket where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::socket::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::socket where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::socket::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::socket where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::socket::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::socket
-pub fn aya_ebpf_bindings::bindings::socket::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::task_struct
 impl core::clone::Clone for aya_ebpf_bindings::bindings::task_struct
 pub fn aya_ebpf_bindings::bindings::task_struct::clone(&self) -> aya_ebpf_bindings::bindings::task_struct
@@ -6573,24 +3469,6 @@ impl core::marker::Unpin for aya_ebpf_bindings::bindings::task_struct
 impl core::marker::UnsafeUnpin for aya_ebpf_bindings::bindings::task_struct
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf_bindings::bindings::task_struct
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf_bindings::bindings::task_struct
-impl<T, U> core::convert::Into<U> for aya_ebpf_bindings::bindings::task_struct where U: core::convert::From<T>
-pub fn aya_ebpf_bindings::bindings::task_struct::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf_bindings::bindings::task_struct where U: core::convert::Into<T>
-pub type aya_ebpf_bindings::bindings::task_struct::Error = core::convert::Infallible
-pub fn aya_ebpf_bindings::bindings::task_struct::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf_bindings::bindings::task_struct where U: core::convert::TryFrom<T>
-pub type aya_ebpf_bindings::bindings::task_struct::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf_bindings::bindings::task_struct::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf_bindings::bindings::task_struct where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::task_struct::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::task_struct where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::task_struct::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::task_struct where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::task_struct::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::task_struct where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::task_struct::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::task_struct
-pub fn aya_ebpf_bindings::bindings::task_struct::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::tcp6_sock
 impl core::clone::Clone for aya_ebpf_bindings::bindings::tcp6_sock
 pub fn aya_ebpf_bindings::bindings::tcp6_sock::clone(&self) -> aya_ebpf_bindings::bindings::tcp6_sock
@@ -6604,24 +3482,6 @@ impl core::marker::Unpin for aya_ebpf_bindings::bindings::tcp6_sock
 impl core::marker::UnsafeUnpin for aya_ebpf_bindings::bindings::tcp6_sock
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf_bindings::bindings::tcp6_sock
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf_bindings::bindings::tcp6_sock
-impl<T, U> core::convert::Into<U> for aya_ebpf_bindings::bindings::tcp6_sock where U: core::convert::From<T>
-pub fn aya_ebpf_bindings::bindings::tcp6_sock::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf_bindings::bindings::tcp6_sock where U: core::convert::Into<T>
-pub type aya_ebpf_bindings::bindings::tcp6_sock::Error = core::convert::Infallible
-pub fn aya_ebpf_bindings::bindings::tcp6_sock::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf_bindings::bindings::tcp6_sock where U: core::convert::TryFrom<T>
-pub type aya_ebpf_bindings::bindings::tcp6_sock::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf_bindings::bindings::tcp6_sock::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf_bindings::bindings::tcp6_sock where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::tcp6_sock::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::tcp6_sock where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::tcp6_sock::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::tcp6_sock where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::tcp6_sock::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::tcp6_sock where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::tcp6_sock::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::tcp6_sock
-pub fn aya_ebpf_bindings::bindings::tcp6_sock::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::tcp_request_sock
 impl core::clone::Clone for aya_ebpf_bindings::bindings::tcp_request_sock
 pub fn aya_ebpf_bindings::bindings::tcp_request_sock::clone(&self) -> aya_ebpf_bindings::bindings::tcp_request_sock
@@ -6635,24 +3495,6 @@ impl core::marker::Unpin for aya_ebpf_bindings::bindings::tcp_request_sock
 impl core::marker::UnsafeUnpin for aya_ebpf_bindings::bindings::tcp_request_sock
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf_bindings::bindings::tcp_request_sock
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf_bindings::bindings::tcp_request_sock
-impl<T, U> core::convert::Into<U> for aya_ebpf_bindings::bindings::tcp_request_sock where U: core::convert::From<T>
-pub fn aya_ebpf_bindings::bindings::tcp_request_sock::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf_bindings::bindings::tcp_request_sock where U: core::convert::Into<T>
-pub type aya_ebpf_bindings::bindings::tcp_request_sock::Error = core::convert::Infallible
-pub fn aya_ebpf_bindings::bindings::tcp_request_sock::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf_bindings::bindings::tcp_request_sock where U: core::convert::TryFrom<T>
-pub type aya_ebpf_bindings::bindings::tcp_request_sock::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf_bindings::bindings::tcp_request_sock::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf_bindings::bindings::tcp_request_sock where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::tcp_request_sock::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::tcp_request_sock where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::tcp_request_sock::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::tcp_request_sock where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::tcp_request_sock::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::tcp_request_sock where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::tcp_request_sock::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::tcp_request_sock
-pub fn aya_ebpf_bindings::bindings::tcp_request_sock::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::tcp_sock
 impl core::clone::Clone for aya_ebpf_bindings::bindings::tcp_sock
 pub fn aya_ebpf_bindings::bindings::tcp_sock::clone(&self) -> aya_ebpf_bindings::bindings::tcp_sock
@@ -6666,24 +3508,6 @@ impl core::marker::Unpin for aya_ebpf_bindings::bindings::tcp_sock
 impl core::marker::UnsafeUnpin for aya_ebpf_bindings::bindings::tcp_sock
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf_bindings::bindings::tcp_sock
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf_bindings::bindings::tcp_sock
-impl<T, U> core::convert::Into<U> for aya_ebpf_bindings::bindings::tcp_sock where U: core::convert::From<T>
-pub fn aya_ebpf_bindings::bindings::tcp_sock::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf_bindings::bindings::tcp_sock where U: core::convert::Into<T>
-pub type aya_ebpf_bindings::bindings::tcp_sock::Error = core::convert::Infallible
-pub fn aya_ebpf_bindings::bindings::tcp_sock::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf_bindings::bindings::tcp_sock where U: core::convert::TryFrom<T>
-pub type aya_ebpf_bindings::bindings::tcp_sock::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf_bindings::bindings::tcp_sock::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf_bindings::bindings::tcp_sock where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::tcp_sock::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::tcp_sock where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::tcp_sock::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::tcp_sock where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::tcp_sock::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::tcp_sock where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::tcp_sock::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::tcp_sock
-pub fn aya_ebpf_bindings::bindings::tcp_sock::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::tcp_timewait_sock
 impl core::clone::Clone for aya_ebpf_bindings::bindings::tcp_timewait_sock
 pub fn aya_ebpf_bindings::bindings::tcp_timewait_sock::clone(&self) -> aya_ebpf_bindings::bindings::tcp_timewait_sock
@@ -6697,24 +3521,6 @@ impl core::marker::Unpin for aya_ebpf_bindings::bindings::tcp_timewait_sock
 impl core::marker::UnsafeUnpin for aya_ebpf_bindings::bindings::tcp_timewait_sock
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf_bindings::bindings::tcp_timewait_sock
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf_bindings::bindings::tcp_timewait_sock
-impl<T, U> core::convert::Into<U> for aya_ebpf_bindings::bindings::tcp_timewait_sock where U: core::convert::From<T>
-pub fn aya_ebpf_bindings::bindings::tcp_timewait_sock::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf_bindings::bindings::tcp_timewait_sock where U: core::convert::Into<T>
-pub type aya_ebpf_bindings::bindings::tcp_timewait_sock::Error = core::convert::Infallible
-pub fn aya_ebpf_bindings::bindings::tcp_timewait_sock::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf_bindings::bindings::tcp_timewait_sock where U: core::convert::TryFrom<T>
-pub type aya_ebpf_bindings::bindings::tcp_timewait_sock::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf_bindings::bindings::tcp_timewait_sock::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf_bindings::bindings::tcp_timewait_sock where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::tcp_timewait_sock::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::tcp_timewait_sock where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::tcp_timewait_sock::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::tcp_timewait_sock where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::tcp_timewait_sock::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::tcp_timewait_sock where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::tcp_timewait_sock::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::tcp_timewait_sock
-pub fn aya_ebpf_bindings::bindings::tcp_timewait_sock::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::tcphdr
 impl core::clone::Clone for aya_ebpf_bindings::bindings::tcphdr
 pub fn aya_ebpf_bindings::bindings::tcphdr::clone(&self) -> aya_ebpf_bindings::bindings::tcphdr
@@ -6728,24 +3534,6 @@ impl core::marker::Unpin for aya_ebpf_bindings::bindings::tcphdr
 impl core::marker::UnsafeUnpin for aya_ebpf_bindings::bindings::tcphdr
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf_bindings::bindings::tcphdr
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf_bindings::bindings::tcphdr
-impl<T, U> core::convert::Into<U> for aya_ebpf_bindings::bindings::tcphdr where U: core::convert::From<T>
-pub fn aya_ebpf_bindings::bindings::tcphdr::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf_bindings::bindings::tcphdr where U: core::convert::Into<T>
-pub type aya_ebpf_bindings::bindings::tcphdr::Error = core::convert::Infallible
-pub fn aya_ebpf_bindings::bindings::tcphdr::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf_bindings::bindings::tcphdr where U: core::convert::TryFrom<T>
-pub type aya_ebpf_bindings::bindings::tcphdr::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf_bindings::bindings::tcphdr::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf_bindings::bindings::tcphdr where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::tcphdr::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::tcphdr where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::tcphdr::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::tcphdr where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::tcphdr::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::tcphdr where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::tcphdr::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::tcphdr
-pub fn aya_ebpf_bindings::bindings::tcphdr::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::udp6_sock
 impl core::clone::Clone for aya_ebpf_bindings::bindings::udp6_sock
 pub fn aya_ebpf_bindings::bindings::udp6_sock::clone(&self) -> aya_ebpf_bindings::bindings::udp6_sock
@@ -6759,24 +3547,6 @@ impl core::marker::Unpin for aya_ebpf_bindings::bindings::udp6_sock
 impl core::marker::UnsafeUnpin for aya_ebpf_bindings::bindings::udp6_sock
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf_bindings::bindings::udp6_sock
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf_bindings::bindings::udp6_sock
-impl<T, U> core::convert::Into<U> for aya_ebpf_bindings::bindings::udp6_sock where U: core::convert::From<T>
-pub fn aya_ebpf_bindings::bindings::udp6_sock::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf_bindings::bindings::udp6_sock where U: core::convert::Into<T>
-pub type aya_ebpf_bindings::bindings::udp6_sock::Error = core::convert::Infallible
-pub fn aya_ebpf_bindings::bindings::udp6_sock::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf_bindings::bindings::udp6_sock where U: core::convert::TryFrom<T>
-pub type aya_ebpf_bindings::bindings::udp6_sock::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf_bindings::bindings::udp6_sock::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf_bindings::bindings::udp6_sock where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::udp6_sock::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::udp6_sock where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::udp6_sock::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::udp6_sock where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::udp6_sock::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::udp6_sock where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::udp6_sock::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::udp6_sock
-pub fn aya_ebpf_bindings::bindings::udp6_sock::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::unix_sock
 impl core::clone::Clone for aya_ebpf_bindings::bindings::unix_sock
 pub fn aya_ebpf_bindings::bindings::unix_sock::clone(&self) -> aya_ebpf_bindings::bindings::unix_sock
@@ -6790,24 +3560,6 @@ impl core::marker::Unpin for aya_ebpf_bindings::bindings::unix_sock
 impl core::marker::UnsafeUnpin for aya_ebpf_bindings::bindings::unix_sock
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf_bindings::bindings::unix_sock
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf_bindings::bindings::unix_sock
-impl<T, U> core::convert::Into<U> for aya_ebpf_bindings::bindings::unix_sock where U: core::convert::From<T>
-pub fn aya_ebpf_bindings::bindings::unix_sock::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf_bindings::bindings::unix_sock where U: core::convert::Into<T>
-pub type aya_ebpf_bindings::bindings::unix_sock::Error = core::convert::Infallible
-pub fn aya_ebpf_bindings::bindings::unix_sock::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf_bindings::bindings::unix_sock where U: core::convert::TryFrom<T>
-pub type aya_ebpf_bindings::bindings::unix_sock::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf_bindings::bindings::unix_sock::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf_bindings::bindings::unix_sock where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::unix_sock::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::unix_sock where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::unix_sock::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::unix_sock where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::unix_sock::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::unix_sock where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::unix_sock::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::unix_sock
-pub fn aya_ebpf_bindings::bindings::unix_sock::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf_bindings::bindings::xdp_md
 pub aya_ebpf_bindings::bindings::xdp_md::data: aya_ebpf_bindings::bindings::__u32
 pub aya_ebpf_bindings::bindings::xdp_md::data_end: aya_ebpf_bindings::bindings::__u32
@@ -6827,24 +3579,6 @@ impl core::marker::Unpin for aya_ebpf_bindings::bindings::xdp_md
 impl core::marker::UnsafeUnpin for aya_ebpf_bindings::bindings::xdp_md
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf_bindings::bindings::xdp_md
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf_bindings::bindings::xdp_md
-impl<T, U> core::convert::Into<U> for aya_ebpf_bindings::bindings::xdp_md where U: core::convert::From<T>
-pub fn aya_ebpf_bindings::bindings::xdp_md::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf_bindings::bindings::xdp_md where U: core::convert::Into<T>
-pub type aya_ebpf_bindings::bindings::xdp_md::Error = core::convert::Infallible
-pub fn aya_ebpf_bindings::bindings::xdp_md::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf_bindings::bindings::xdp_md where U: core::convert::TryFrom<T>
-pub type aya_ebpf_bindings::bindings::xdp_md::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf_bindings::bindings::xdp_md::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf_bindings::bindings::xdp_md where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::xdp_md::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf_bindings::bindings::xdp_md where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::xdp_md::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf_bindings::bindings::xdp_md where T: ?core::marker::Sized
-pub fn aya_ebpf_bindings::bindings::xdp_md::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_ebpf_bindings::bindings::xdp_md where T: core::clone::Clone
-pub unsafe fn aya_ebpf_bindings::bindings::xdp_md::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_ebpf_bindings::bindings::xdp_md
-pub fn aya_ebpf_bindings::bindings::xdp_md::from(t: T) -> T
 pub const aya_ebpf_bindings::bindings::BPF_ABS: u32
 pub const aya_ebpf_bindings::bindings::BPF_ADD: u32
 pub const aya_ebpf_bindings::bindings::BPF_ADJ_ROOM_ENCAP_L2_MASK: aya_ebpf_bindings::bindings::_bindgen_ty_18

--- a/xtask/public-api/aya-ebpf.txt
+++ b/xtask/public-api/aya-ebpf.txt
@@ -23,22 +23,6 @@ impl<T, const MAX_ENTRIES: usize, const FLAGS: usize> core::marker::Unpin for ay
 impl<T, const MAX_ENTRIES: usize, const FLAGS: usize> core::marker::UnsafeUnpin for aya_ebpf::btf_maps::array::Array<T, MAX_ENTRIES, FLAGS>
 impl<T, const MAX_ENTRIES: usize, const FLAGS: usize> core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::btf_maps::array::Array<T, MAX_ENTRIES, FLAGS> where T: core::panic::unwind_safe::RefUnwindSafe
 impl<T, const MAX_ENTRIES: usize, const FLAGS: usize> core::panic::unwind_safe::UnwindSafe for aya_ebpf::btf_maps::array::Array<T, MAX_ENTRIES, FLAGS> where T: core::panic::unwind_safe::RefUnwindSafe
-impl<T, U> core::convert::Into<U> for aya_ebpf::btf_maps::array::Array<T, MAX_ENTRIES, FLAGS> where U: core::convert::From<T>
-pub fn aya_ebpf::btf_maps::array::Array<T, MAX_ENTRIES, FLAGS>::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf::btf_maps::array::Array<T, MAX_ENTRIES, FLAGS> where U: core::convert::Into<T>
-pub type aya_ebpf::btf_maps::array::Array<T, MAX_ENTRIES, FLAGS>::Error = core::convert::Infallible
-pub fn aya_ebpf::btf_maps::array::Array<T, MAX_ENTRIES, FLAGS>::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf::btf_maps::array::Array<T, MAX_ENTRIES, FLAGS> where U: core::convert::TryFrom<T>
-pub type aya_ebpf::btf_maps::array::Array<T, MAX_ENTRIES, FLAGS>::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf::btf_maps::array::Array<T, MAX_ENTRIES, FLAGS>::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf::btf_maps::array::Array<T, MAX_ENTRIES, FLAGS> where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf::btf_maps::array::Array<T, MAX_ENTRIES, FLAGS>::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf::btf_maps::array::Array<T, MAX_ENTRIES, FLAGS> where T: ?core::marker::Sized
-pub fn aya_ebpf::btf_maps::array::Array<T, MAX_ENTRIES, FLAGS>::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf::btf_maps::array::Array<T, MAX_ENTRIES, FLAGS> where T: ?core::marker::Sized
-pub fn aya_ebpf::btf_maps::array::Array<T, MAX_ENTRIES, FLAGS>::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya_ebpf::btf_maps::array::Array<T, MAX_ENTRIES, FLAGS>
-pub fn aya_ebpf::btf_maps::array::Array<T, MAX_ENTRIES, FLAGS>::from(t: T) -> T
 pub mod aya_ebpf::btf_maps::bloom_filter
 #[repr(C)] pub struct aya_ebpf::btf_maps::bloom_filter::BloomFilter<T, const MAX_ENTRIES: usize, const FLAGS: usize, const HASH_FUNCS: usize>
 impl<T, const MAX_ENTRIES: usize, const FLAGS: usize, const HASH_FUNCS: usize> aya_ebpf::btf_maps::bloom_filter::BloomFilter<T, MAX_ENTRIES, FLAGS, HASH_FUNCS>
@@ -55,22 +39,6 @@ impl<T, const MAX_ENTRIES: usize, const FLAGS: usize, const HASH_FUNCS: usize> c
 impl<T, const MAX_ENTRIES: usize, const FLAGS: usize, const HASH_FUNCS: usize> core::marker::UnsafeUnpin for aya_ebpf::btf_maps::bloom_filter::BloomFilter<T, MAX_ENTRIES, FLAGS, HASH_FUNCS>
 impl<T, const MAX_ENTRIES: usize, const FLAGS: usize, const HASH_FUNCS: usize> core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::btf_maps::bloom_filter::BloomFilter<T, MAX_ENTRIES, FLAGS, HASH_FUNCS> where T: core::panic::unwind_safe::RefUnwindSafe
 impl<T, const MAX_ENTRIES: usize, const FLAGS: usize, const HASH_FUNCS: usize> core::panic::unwind_safe::UnwindSafe for aya_ebpf::btf_maps::bloom_filter::BloomFilter<T, MAX_ENTRIES, FLAGS, HASH_FUNCS> where T: core::panic::unwind_safe::RefUnwindSafe
-impl<T, U> core::convert::Into<U> for aya_ebpf::btf_maps::bloom_filter::BloomFilter<T, MAX_ENTRIES, FLAGS, HASH_FUNCS> where U: core::convert::From<T>
-pub fn aya_ebpf::btf_maps::bloom_filter::BloomFilter<T, MAX_ENTRIES, FLAGS, HASH_FUNCS>::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf::btf_maps::bloom_filter::BloomFilter<T, MAX_ENTRIES, FLAGS, HASH_FUNCS> where U: core::convert::Into<T>
-pub type aya_ebpf::btf_maps::bloom_filter::BloomFilter<T, MAX_ENTRIES, FLAGS, HASH_FUNCS>::Error = core::convert::Infallible
-pub fn aya_ebpf::btf_maps::bloom_filter::BloomFilter<T, MAX_ENTRIES, FLAGS, HASH_FUNCS>::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf::btf_maps::bloom_filter::BloomFilter<T, MAX_ENTRIES, FLAGS, HASH_FUNCS> where U: core::convert::TryFrom<T>
-pub type aya_ebpf::btf_maps::bloom_filter::BloomFilter<T, MAX_ENTRIES, FLAGS, HASH_FUNCS>::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf::btf_maps::bloom_filter::BloomFilter<T, MAX_ENTRIES, FLAGS, HASH_FUNCS>::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf::btf_maps::bloom_filter::BloomFilter<T, MAX_ENTRIES, FLAGS, HASH_FUNCS> where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf::btf_maps::bloom_filter::BloomFilter<T, MAX_ENTRIES, FLAGS, HASH_FUNCS>::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf::btf_maps::bloom_filter::BloomFilter<T, MAX_ENTRIES, FLAGS, HASH_FUNCS> where T: ?core::marker::Sized
-pub fn aya_ebpf::btf_maps::bloom_filter::BloomFilter<T, MAX_ENTRIES, FLAGS, HASH_FUNCS>::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf::btf_maps::bloom_filter::BloomFilter<T, MAX_ENTRIES, FLAGS, HASH_FUNCS> where T: ?core::marker::Sized
-pub fn aya_ebpf::btf_maps::bloom_filter::BloomFilter<T, MAX_ENTRIES, FLAGS, HASH_FUNCS>::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya_ebpf::btf_maps::bloom_filter::BloomFilter<T, MAX_ENTRIES, FLAGS, HASH_FUNCS>
-pub fn aya_ebpf::btf_maps::bloom_filter::BloomFilter<T, MAX_ENTRIES, FLAGS, HASH_FUNCS>::from(t: T) -> T
 pub mod aya_ebpf::btf_maps::ring_buf
 #[repr(C)] pub struct aya_ebpf::btf_maps::ring_buf::RingBuf<T, const MAX_ENTRIES: usize, const FLAGS: usize>
 impl<T, const MAX_ENTRIES: usize, const FLAGS: usize> aya_ebpf::btf_maps::ring_buf::RingBuf<T, MAX_ENTRIES, FLAGS>
@@ -90,22 +58,6 @@ impl<T, const MAX_ENTRIES: usize, const FLAGS: usize> core::marker::Unpin for ay
 impl<T, const MAX_ENTRIES: usize, const FLAGS: usize> core::marker::UnsafeUnpin for aya_ebpf::btf_maps::ring_buf::RingBuf<T, MAX_ENTRIES, FLAGS>
 impl<T, const MAX_ENTRIES: usize, const FLAGS: usize> core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::btf_maps::ring_buf::RingBuf<T, MAX_ENTRIES, FLAGS> where T: core::panic::unwind_safe::RefUnwindSafe
 impl<T, const MAX_ENTRIES: usize, const FLAGS: usize> core::panic::unwind_safe::UnwindSafe for aya_ebpf::btf_maps::ring_buf::RingBuf<T, MAX_ENTRIES, FLAGS> where T: core::panic::unwind_safe::RefUnwindSafe
-impl<T, U> core::convert::Into<U> for aya_ebpf::btf_maps::ring_buf::RingBuf<T, MAX_ENTRIES, FLAGS> where U: core::convert::From<T>
-pub fn aya_ebpf::btf_maps::ring_buf::RingBuf<T, MAX_ENTRIES, FLAGS>::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf::btf_maps::ring_buf::RingBuf<T, MAX_ENTRIES, FLAGS> where U: core::convert::Into<T>
-pub type aya_ebpf::btf_maps::ring_buf::RingBuf<T, MAX_ENTRIES, FLAGS>::Error = core::convert::Infallible
-pub fn aya_ebpf::btf_maps::ring_buf::RingBuf<T, MAX_ENTRIES, FLAGS>::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf::btf_maps::ring_buf::RingBuf<T, MAX_ENTRIES, FLAGS> where U: core::convert::TryFrom<T>
-pub type aya_ebpf::btf_maps::ring_buf::RingBuf<T, MAX_ENTRIES, FLAGS>::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf::btf_maps::ring_buf::RingBuf<T, MAX_ENTRIES, FLAGS>::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf::btf_maps::ring_buf::RingBuf<T, MAX_ENTRIES, FLAGS> where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf::btf_maps::ring_buf::RingBuf<T, MAX_ENTRIES, FLAGS>::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf::btf_maps::ring_buf::RingBuf<T, MAX_ENTRIES, FLAGS> where T: ?core::marker::Sized
-pub fn aya_ebpf::btf_maps::ring_buf::RingBuf<T, MAX_ENTRIES, FLAGS>::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf::btf_maps::ring_buf::RingBuf<T, MAX_ENTRIES, FLAGS> where T: ?core::marker::Sized
-pub fn aya_ebpf::btf_maps::ring_buf::RingBuf<T, MAX_ENTRIES, FLAGS>::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya_ebpf::btf_maps::ring_buf::RingBuf<T, MAX_ENTRIES, FLAGS>
-pub fn aya_ebpf::btf_maps::ring_buf::RingBuf<T, MAX_ENTRIES, FLAGS>::from(t: T) -> T
 pub mod aya_ebpf::btf_maps::sk_storage
 #[repr(C)] pub struct aya_ebpf::btf_maps::sk_storage::SkStorage<T>
 impl<T> aya_ebpf::btf_maps::sk_storage::SkStorage<T>
@@ -123,22 +75,6 @@ impl<T> core::marker::Unpin for aya_ebpf::btf_maps::sk_storage::SkStorage<T>
 impl<T> core::marker::UnsafeUnpin for aya_ebpf::btf_maps::sk_storage::SkStorage<T>
 impl<T> core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::btf_maps::sk_storage::SkStorage<T> where T: core::panic::unwind_safe::RefUnwindSafe
 impl<T> core::panic::unwind_safe::UnwindSafe for aya_ebpf::btf_maps::sk_storage::SkStorage<T> where T: core::panic::unwind_safe::RefUnwindSafe
-impl<T, U> core::convert::Into<U> for aya_ebpf::btf_maps::sk_storage::SkStorage<T> where U: core::convert::From<T>
-pub fn aya_ebpf::btf_maps::sk_storage::SkStorage<T>::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf::btf_maps::sk_storage::SkStorage<T> where U: core::convert::Into<T>
-pub type aya_ebpf::btf_maps::sk_storage::SkStorage<T>::Error = core::convert::Infallible
-pub fn aya_ebpf::btf_maps::sk_storage::SkStorage<T>::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf::btf_maps::sk_storage::SkStorage<T> where U: core::convert::TryFrom<T>
-pub type aya_ebpf::btf_maps::sk_storage::SkStorage<T>::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf::btf_maps::sk_storage::SkStorage<T>::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf::btf_maps::sk_storage::SkStorage<T> where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf::btf_maps::sk_storage::SkStorage<T>::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf::btf_maps::sk_storage::SkStorage<T> where T: ?core::marker::Sized
-pub fn aya_ebpf::btf_maps::sk_storage::SkStorage<T>::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf::btf_maps::sk_storage::SkStorage<T> where T: ?core::marker::Sized
-pub fn aya_ebpf::btf_maps::sk_storage::SkStorage<T>::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya_ebpf::btf_maps::sk_storage::SkStorage<T>
-pub fn aya_ebpf::btf_maps::sk_storage::SkStorage<T>::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf::btf_maps::Array<T, const MAX_ENTRIES: usize, const FLAGS: usize>
 impl<T, const MAX_ENTRIES: usize, const FLAGS: usize> aya_ebpf::btf_maps::array::Array<T, MAX_ENTRIES, FLAGS>
 pub fn aya_ebpf::btf_maps::array::Array<T, MAX_ENTRIES, FLAGS>::get(&self, index: u32) -> core::option::Option<&T>
@@ -156,22 +92,6 @@ impl<T, const MAX_ENTRIES: usize, const FLAGS: usize> core::marker::Unpin for ay
 impl<T, const MAX_ENTRIES: usize, const FLAGS: usize> core::marker::UnsafeUnpin for aya_ebpf::btf_maps::array::Array<T, MAX_ENTRIES, FLAGS>
 impl<T, const MAX_ENTRIES: usize, const FLAGS: usize> core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::btf_maps::array::Array<T, MAX_ENTRIES, FLAGS> where T: core::panic::unwind_safe::RefUnwindSafe
 impl<T, const MAX_ENTRIES: usize, const FLAGS: usize> core::panic::unwind_safe::UnwindSafe for aya_ebpf::btf_maps::array::Array<T, MAX_ENTRIES, FLAGS> where T: core::panic::unwind_safe::RefUnwindSafe
-impl<T, U> core::convert::Into<U> for aya_ebpf::btf_maps::array::Array<T, MAX_ENTRIES, FLAGS> where U: core::convert::From<T>
-pub fn aya_ebpf::btf_maps::array::Array<T, MAX_ENTRIES, FLAGS>::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf::btf_maps::array::Array<T, MAX_ENTRIES, FLAGS> where U: core::convert::Into<T>
-pub type aya_ebpf::btf_maps::array::Array<T, MAX_ENTRIES, FLAGS>::Error = core::convert::Infallible
-pub fn aya_ebpf::btf_maps::array::Array<T, MAX_ENTRIES, FLAGS>::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf::btf_maps::array::Array<T, MAX_ENTRIES, FLAGS> where U: core::convert::TryFrom<T>
-pub type aya_ebpf::btf_maps::array::Array<T, MAX_ENTRIES, FLAGS>::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf::btf_maps::array::Array<T, MAX_ENTRIES, FLAGS>::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf::btf_maps::array::Array<T, MAX_ENTRIES, FLAGS> where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf::btf_maps::array::Array<T, MAX_ENTRIES, FLAGS>::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf::btf_maps::array::Array<T, MAX_ENTRIES, FLAGS> where T: ?core::marker::Sized
-pub fn aya_ebpf::btf_maps::array::Array<T, MAX_ENTRIES, FLAGS>::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf::btf_maps::array::Array<T, MAX_ENTRIES, FLAGS> where T: ?core::marker::Sized
-pub fn aya_ebpf::btf_maps::array::Array<T, MAX_ENTRIES, FLAGS>::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya_ebpf::btf_maps::array::Array<T, MAX_ENTRIES, FLAGS>
-pub fn aya_ebpf::btf_maps::array::Array<T, MAX_ENTRIES, FLAGS>::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf::btf_maps::BloomFilter<T, const MAX_ENTRIES: usize, const FLAGS: usize, const HASH_FUNCS: usize>
 impl<T, const MAX_ENTRIES: usize, const FLAGS: usize, const HASH_FUNCS: usize> aya_ebpf::btf_maps::bloom_filter::BloomFilter<T, MAX_ENTRIES, FLAGS, HASH_FUNCS>
 pub fn aya_ebpf::btf_maps::bloom_filter::BloomFilter<T, MAX_ENTRIES, FLAGS, HASH_FUNCS>::contains(&self, value: impl core::borrow::Borrow<T>) -> core::result::Result<(), aya_ebpf_cty::od::c_long>
@@ -187,22 +107,6 @@ impl<T, const MAX_ENTRIES: usize, const FLAGS: usize, const HASH_FUNCS: usize> c
 impl<T, const MAX_ENTRIES: usize, const FLAGS: usize, const HASH_FUNCS: usize> core::marker::UnsafeUnpin for aya_ebpf::btf_maps::bloom_filter::BloomFilter<T, MAX_ENTRIES, FLAGS, HASH_FUNCS>
 impl<T, const MAX_ENTRIES: usize, const FLAGS: usize, const HASH_FUNCS: usize> core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::btf_maps::bloom_filter::BloomFilter<T, MAX_ENTRIES, FLAGS, HASH_FUNCS> where T: core::panic::unwind_safe::RefUnwindSafe
 impl<T, const MAX_ENTRIES: usize, const FLAGS: usize, const HASH_FUNCS: usize> core::panic::unwind_safe::UnwindSafe for aya_ebpf::btf_maps::bloom_filter::BloomFilter<T, MAX_ENTRIES, FLAGS, HASH_FUNCS> where T: core::panic::unwind_safe::RefUnwindSafe
-impl<T, U> core::convert::Into<U> for aya_ebpf::btf_maps::bloom_filter::BloomFilter<T, MAX_ENTRIES, FLAGS, HASH_FUNCS> where U: core::convert::From<T>
-pub fn aya_ebpf::btf_maps::bloom_filter::BloomFilter<T, MAX_ENTRIES, FLAGS, HASH_FUNCS>::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf::btf_maps::bloom_filter::BloomFilter<T, MAX_ENTRIES, FLAGS, HASH_FUNCS> where U: core::convert::Into<T>
-pub type aya_ebpf::btf_maps::bloom_filter::BloomFilter<T, MAX_ENTRIES, FLAGS, HASH_FUNCS>::Error = core::convert::Infallible
-pub fn aya_ebpf::btf_maps::bloom_filter::BloomFilter<T, MAX_ENTRIES, FLAGS, HASH_FUNCS>::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf::btf_maps::bloom_filter::BloomFilter<T, MAX_ENTRIES, FLAGS, HASH_FUNCS> where U: core::convert::TryFrom<T>
-pub type aya_ebpf::btf_maps::bloom_filter::BloomFilter<T, MAX_ENTRIES, FLAGS, HASH_FUNCS>::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf::btf_maps::bloom_filter::BloomFilter<T, MAX_ENTRIES, FLAGS, HASH_FUNCS>::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf::btf_maps::bloom_filter::BloomFilter<T, MAX_ENTRIES, FLAGS, HASH_FUNCS> where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf::btf_maps::bloom_filter::BloomFilter<T, MAX_ENTRIES, FLAGS, HASH_FUNCS>::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf::btf_maps::bloom_filter::BloomFilter<T, MAX_ENTRIES, FLAGS, HASH_FUNCS> where T: ?core::marker::Sized
-pub fn aya_ebpf::btf_maps::bloom_filter::BloomFilter<T, MAX_ENTRIES, FLAGS, HASH_FUNCS>::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf::btf_maps::bloom_filter::BloomFilter<T, MAX_ENTRIES, FLAGS, HASH_FUNCS> where T: ?core::marker::Sized
-pub fn aya_ebpf::btf_maps::bloom_filter::BloomFilter<T, MAX_ENTRIES, FLAGS, HASH_FUNCS>::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya_ebpf::btf_maps::bloom_filter::BloomFilter<T, MAX_ENTRIES, FLAGS, HASH_FUNCS>
-pub fn aya_ebpf::btf_maps::bloom_filter::BloomFilter<T, MAX_ENTRIES, FLAGS, HASH_FUNCS>::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf::btf_maps::RingBuf<T, const MAX_ENTRIES: usize, const FLAGS: usize>
 impl<T, const MAX_ENTRIES: usize, const FLAGS: usize> aya_ebpf::btf_maps::ring_buf::RingBuf<T, MAX_ENTRIES, FLAGS>
 pub const fn aya_ebpf::btf_maps::ring_buf::RingBuf<T, MAX_ENTRIES, FLAGS>::new() -> Self
@@ -221,22 +125,6 @@ impl<T, const MAX_ENTRIES: usize, const FLAGS: usize> core::marker::Unpin for ay
 impl<T, const MAX_ENTRIES: usize, const FLAGS: usize> core::marker::UnsafeUnpin for aya_ebpf::btf_maps::ring_buf::RingBuf<T, MAX_ENTRIES, FLAGS>
 impl<T, const MAX_ENTRIES: usize, const FLAGS: usize> core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::btf_maps::ring_buf::RingBuf<T, MAX_ENTRIES, FLAGS> where T: core::panic::unwind_safe::RefUnwindSafe
 impl<T, const MAX_ENTRIES: usize, const FLAGS: usize> core::panic::unwind_safe::UnwindSafe for aya_ebpf::btf_maps::ring_buf::RingBuf<T, MAX_ENTRIES, FLAGS> where T: core::panic::unwind_safe::RefUnwindSafe
-impl<T, U> core::convert::Into<U> for aya_ebpf::btf_maps::ring_buf::RingBuf<T, MAX_ENTRIES, FLAGS> where U: core::convert::From<T>
-pub fn aya_ebpf::btf_maps::ring_buf::RingBuf<T, MAX_ENTRIES, FLAGS>::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf::btf_maps::ring_buf::RingBuf<T, MAX_ENTRIES, FLAGS> where U: core::convert::Into<T>
-pub type aya_ebpf::btf_maps::ring_buf::RingBuf<T, MAX_ENTRIES, FLAGS>::Error = core::convert::Infallible
-pub fn aya_ebpf::btf_maps::ring_buf::RingBuf<T, MAX_ENTRIES, FLAGS>::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf::btf_maps::ring_buf::RingBuf<T, MAX_ENTRIES, FLAGS> where U: core::convert::TryFrom<T>
-pub type aya_ebpf::btf_maps::ring_buf::RingBuf<T, MAX_ENTRIES, FLAGS>::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf::btf_maps::ring_buf::RingBuf<T, MAX_ENTRIES, FLAGS>::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf::btf_maps::ring_buf::RingBuf<T, MAX_ENTRIES, FLAGS> where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf::btf_maps::ring_buf::RingBuf<T, MAX_ENTRIES, FLAGS>::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf::btf_maps::ring_buf::RingBuf<T, MAX_ENTRIES, FLAGS> where T: ?core::marker::Sized
-pub fn aya_ebpf::btf_maps::ring_buf::RingBuf<T, MAX_ENTRIES, FLAGS>::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf::btf_maps::ring_buf::RingBuf<T, MAX_ENTRIES, FLAGS> where T: ?core::marker::Sized
-pub fn aya_ebpf::btf_maps::ring_buf::RingBuf<T, MAX_ENTRIES, FLAGS>::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya_ebpf::btf_maps::ring_buf::RingBuf<T, MAX_ENTRIES, FLAGS>
-pub fn aya_ebpf::btf_maps::ring_buf::RingBuf<T, MAX_ENTRIES, FLAGS>::from(t: T) -> T
 #[repr(C)] pub struct aya_ebpf::btf_maps::SkStorage<T>
 impl<T> aya_ebpf::btf_maps::sk_storage::SkStorage<T>
 pub unsafe fn aya_ebpf::btf_maps::sk_storage::SkStorage<T>::delete(&self, sk: *mut aya_ebpf_bindings::x86_64::bindings::bpf_sock) -> core::result::Result<(), i32>
@@ -253,22 +141,6 @@ impl<T> core::marker::Unpin for aya_ebpf::btf_maps::sk_storage::SkStorage<T>
 impl<T> core::marker::UnsafeUnpin for aya_ebpf::btf_maps::sk_storage::SkStorage<T>
 impl<T> core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::btf_maps::sk_storage::SkStorage<T> where T: core::panic::unwind_safe::RefUnwindSafe
 impl<T> core::panic::unwind_safe::UnwindSafe for aya_ebpf::btf_maps::sk_storage::SkStorage<T> where T: core::panic::unwind_safe::RefUnwindSafe
-impl<T, U> core::convert::Into<U> for aya_ebpf::btf_maps::sk_storage::SkStorage<T> where U: core::convert::From<T>
-pub fn aya_ebpf::btf_maps::sk_storage::SkStorage<T>::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf::btf_maps::sk_storage::SkStorage<T> where U: core::convert::Into<T>
-pub type aya_ebpf::btf_maps::sk_storage::SkStorage<T>::Error = core::convert::Infallible
-pub fn aya_ebpf::btf_maps::sk_storage::SkStorage<T>::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf::btf_maps::sk_storage::SkStorage<T> where U: core::convert::TryFrom<T>
-pub type aya_ebpf::btf_maps::sk_storage::SkStorage<T>::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf::btf_maps::sk_storage::SkStorage<T>::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf::btf_maps::sk_storage::SkStorage<T> where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf::btf_maps::sk_storage::SkStorage<T>::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf::btf_maps::sk_storage::SkStorage<T> where T: ?core::marker::Sized
-pub fn aya_ebpf::btf_maps::sk_storage::SkStorage<T>::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf::btf_maps::sk_storage::SkStorage<T> where T: ?core::marker::Sized
-pub fn aya_ebpf::btf_maps::sk_storage::SkStorage<T>::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya_ebpf::btf_maps::sk_storage::SkStorage<T>
-pub fn aya_ebpf::btf_maps::sk_storage::SkStorage<T>::from(t: T) -> T
 pub mod aya_ebpf::helpers
 pub use aya_ebpf::helpers::generated
 pub macro aya_ebpf::helpers::bpf_printk!
@@ -306,22 +178,6 @@ impl<T> core::marker::Unpin for aya_ebpf::maps::array::Array<T> where T: core::m
 impl<T> core::marker::UnsafeUnpin for aya_ebpf::maps::array::Array<T>
 impl<T> !core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::maps::array::Array<T>
 impl<T> core::panic::unwind_safe::UnwindSafe for aya_ebpf::maps::array::Array<T> where T: core::panic::unwind_safe::UnwindSafe
-impl<T, U> core::convert::Into<U> for aya_ebpf::maps::array::Array<T> where U: core::convert::From<T>
-pub fn aya_ebpf::maps::array::Array<T>::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf::maps::array::Array<T> where U: core::convert::Into<T>
-pub type aya_ebpf::maps::array::Array<T>::Error = core::convert::Infallible
-pub fn aya_ebpf::maps::array::Array<T>::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf::maps::array::Array<T> where U: core::convert::TryFrom<T>
-pub type aya_ebpf::maps::array::Array<T>::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf::maps::array::Array<T>::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf::maps::array::Array<T> where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf::maps::array::Array<T>::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf::maps::array::Array<T> where T: ?core::marker::Sized
-pub fn aya_ebpf::maps::array::Array<T>::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf::maps::array::Array<T> where T: ?core::marker::Sized
-pub fn aya_ebpf::maps::array::Array<T>::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya_ebpf::maps::array::Array<T>
-pub fn aya_ebpf::maps::array::Array<T>::from(t: T) -> T
 pub mod aya_ebpf::maps::bloom_filter
 #[repr(transparent)] pub struct aya_ebpf::maps::bloom_filter::BloomFilter<T>
 impl<T> aya_ebpf::maps::bloom_filter::BloomFilter<T>
@@ -336,22 +192,6 @@ impl<T> core::marker::Unpin for aya_ebpf::maps::bloom_filter::BloomFilter<T> whe
 impl<T> core::marker::UnsafeUnpin for aya_ebpf::maps::bloom_filter::BloomFilter<T>
 impl<T> !core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::maps::bloom_filter::BloomFilter<T>
 impl<T> core::panic::unwind_safe::UnwindSafe for aya_ebpf::maps::bloom_filter::BloomFilter<T> where T: core::panic::unwind_safe::UnwindSafe
-impl<T, U> core::convert::Into<U> for aya_ebpf::maps::bloom_filter::BloomFilter<T> where U: core::convert::From<T>
-pub fn aya_ebpf::maps::bloom_filter::BloomFilter<T>::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf::maps::bloom_filter::BloomFilter<T> where U: core::convert::Into<T>
-pub type aya_ebpf::maps::bloom_filter::BloomFilter<T>::Error = core::convert::Infallible
-pub fn aya_ebpf::maps::bloom_filter::BloomFilter<T>::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf::maps::bloom_filter::BloomFilter<T> where U: core::convert::TryFrom<T>
-pub type aya_ebpf::maps::bloom_filter::BloomFilter<T>::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf::maps::bloom_filter::BloomFilter<T>::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf::maps::bloom_filter::BloomFilter<T> where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf::maps::bloom_filter::BloomFilter<T>::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf::maps::bloom_filter::BloomFilter<T> where T: ?core::marker::Sized
-pub fn aya_ebpf::maps::bloom_filter::BloomFilter<T>::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf::maps::bloom_filter::BloomFilter<T> where T: ?core::marker::Sized
-pub fn aya_ebpf::maps::bloom_filter::BloomFilter<T>::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya_ebpf::maps::bloom_filter::BloomFilter<T>
-pub fn aya_ebpf::maps::bloom_filter::BloomFilter<T>::from(t: T) -> T
 pub mod aya_ebpf::maps::hash_map
 #[repr(transparent)] pub struct aya_ebpf::maps::hash_map::HashMap<K, V>
 impl<K, V> aya_ebpf::maps::hash_map::HashMap<K, V>
@@ -369,22 +209,6 @@ impl<K, V> core::marker::Unpin for aya_ebpf::maps::hash_map::HashMap<K, V> where
 impl<K, V> core::marker::UnsafeUnpin for aya_ebpf::maps::hash_map::HashMap<K, V>
 impl<K, V> !core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::maps::hash_map::HashMap<K, V>
 impl<K, V> core::panic::unwind_safe::UnwindSafe for aya_ebpf::maps::hash_map::HashMap<K, V> where K: core::panic::unwind_safe::UnwindSafe, V: core::panic::unwind_safe::UnwindSafe
-impl<T, U> core::convert::Into<U> for aya_ebpf::maps::hash_map::HashMap<K, V> where U: core::convert::From<T>
-pub fn aya_ebpf::maps::hash_map::HashMap<K, V>::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf::maps::hash_map::HashMap<K, V> where U: core::convert::Into<T>
-pub type aya_ebpf::maps::hash_map::HashMap<K, V>::Error = core::convert::Infallible
-pub fn aya_ebpf::maps::hash_map::HashMap<K, V>::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf::maps::hash_map::HashMap<K, V> where U: core::convert::TryFrom<T>
-pub type aya_ebpf::maps::hash_map::HashMap<K, V>::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf::maps::hash_map::HashMap<K, V>::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf::maps::hash_map::HashMap<K, V> where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf::maps::hash_map::HashMap<K, V>::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf::maps::hash_map::HashMap<K, V> where T: ?core::marker::Sized
-pub fn aya_ebpf::maps::hash_map::HashMap<K, V>::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf::maps::hash_map::HashMap<K, V> where T: ?core::marker::Sized
-pub fn aya_ebpf::maps::hash_map::HashMap<K, V>::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya_ebpf::maps::hash_map::HashMap<K, V>
-pub fn aya_ebpf::maps::hash_map::HashMap<K, V>::from(t: T) -> T
 #[repr(transparent)] pub struct aya_ebpf::maps::hash_map::LruHashMap<K, V>
 impl<K, V> aya_ebpf::maps::hash_map::LruHashMap<K, V>
 pub unsafe fn aya_ebpf::maps::hash_map::LruHashMap<K, V>::get(&self, key: impl core::borrow::Borrow<K>) -> core::option::Option<&V>
@@ -401,22 +225,6 @@ impl<K, V> core::marker::Unpin for aya_ebpf::maps::hash_map::LruHashMap<K, V> wh
 impl<K, V> core::marker::UnsafeUnpin for aya_ebpf::maps::hash_map::LruHashMap<K, V>
 impl<K, V> !core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::maps::hash_map::LruHashMap<K, V>
 impl<K, V> core::panic::unwind_safe::UnwindSafe for aya_ebpf::maps::hash_map::LruHashMap<K, V> where K: core::panic::unwind_safe::UnwindSafe, V: core::panic::unwind_safe::UnwindSafe
-impl<T, U> core::convert::Into<U> for aya_ebpf::maps::hash_map::LruHashMap<K, V> where U: core::convert::From<T>
-pub fn aya_ebpf::maps::hash_map::LruHashMap<K, V>::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf::maps::hash_map::LruHashMap<K, V> where U: core::convert::Into<T>
-pub type aya_ebpf::maps::hash_map::LruHashMap<K, V>::Error = core::convert::Infallible
-pub fn aya_ebpf::maps::hash_map::LruHashMap<K, V>::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf::maps::hash_map::LruHashMap<K, V> where U: core::convert::TryFrom<T>
-pub type aya_ebpf::maps::hash_map::LruHashMap<K, V>::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf::maps::hash_map::LruHashMap<K, V>::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf::maps::hash_map::LruHashMap<K, V> where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf::maps::hash_map::LruHashMap<K, V>::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf::maps::hash_map::LruHashMap<K, V> where T: ?core::marker::Sized
-pub fn aya_ebpf::maps::hash_map::LruHashMap<K, V>::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf::maps::hash_map::LruHashMap<K, V> where T: ?core::marker::Sized
-pub fn aya_ebpf::maps::hash_map::LruHashMap<K, V>::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya_ebpf::maps::hash_map::LruHashMap<K, V>
-pub fn aya_ebpf::maps::hash_map::LruHashMap<K, V>::from(t: T) -> T
 #[repr(transparent)] pub struct aya_ebpf::maps::hash_map::LruPerCpuHashMap<K, V>
 impl<K, V> aya_ebpf::maps::hash_map::LruPerCpuHashMap<K, V>
 pub unsafe fn aya_ebpf::maps::hash_map::LruPerCpuHashMap<K, V>::get(&self, key: impl core::borrow::Borrow<K>) -> core::option::Option<&V>
@@ -433,22 +241,6 @@ impl<K, V> core::marker::Unpin for aya_ebpf::maps::hash_map::LruPerCpuHashMap<K,
 impl<K, V> core::marker::UnsafeUnpin for aya_ebpf::maps::hash_map::LruPerCpuHashMap<K, V>
 impl<K, V> !core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::maps::hash_map::LruPerCpuHashMap<K, V>
 impl<K, V> core::panic::unwind_safe::UnwindSafe for aya_ebpf::maps::hash_map::LruPerCpuHashMap<K, V> where K: core::panic::unwind_safe::UnwindSafe, V: core::panic::unwind_safe::UnwindSafe
-impl<T, U> core::convert::Into<U> for aya_ebpf::maps::hash_map::LruPerCpuHashMap<K, V> where U: core::convert::From<T>
-pub fn aya_ebpf::maps::hash_map::LruPerCpuHashMap<K, V>::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf::maps::hash_map::LruPerCpuHashMap<K, V> where U: core::convert::Into<T>
-pub type aya_ebpf::maps::hash_map::LruPerCpuHashMap<K, V>::Error = core::convert::Infallible
-pub fn aya_ebpf::maps::hash_map::LruPerCpuHashMap<K, V>::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf::maps::hash_map::LruPerCpuHashMap<K, V> where U: core::convert::TryFrom<T>
-pub type aya_ebpf::maps::hash_map::LruPerCpuHashMap<K, V>::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf::maps::hash_map::LruPerCpuHashMap<K, V>::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf::maps::hash_map::LruPerCpuHashMap<K, V> where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf::maps::hash_map::LruPerCpuHashMap<K, V>::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf::maps::hash_map::LruPerCpuHashMap<K, V> where T: ?core::marker::Sized
-pub fn aya_ebpf::maps::hash_map::LruPerCpuHashMap<K, V>::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf::maps::hash_map::LruPerCpuHashMap<K, V> where T: ?core::marker::Sized
-pub fn aya_ebpf::maps::hash_map::LruPerCpuHashMap<K, V>::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya_ebpf::maps::hash_map::LruPerCpuHashMap<K, V>
-pub fn aya_ebpf::maps::hash_map::LruPerCpuHashMap<K, V>::from(t: T) -> T
 #[repr(transparent)] pub struct aya_ebpf::maps::hash_map::PerCpuHashMap<K, V>
 impl<K, V> aya_ebpf::maps::hash_map::PerCpuHashMap<K, V>
 pub unsafe fn aya_ebpf::maps::hash_map::PerCpuHashMap<K, V>::get(&self, key: impl core::borrow::Borrow<K>) -> core::option::Option<&V>
@@ -465,22 +257,6 @@ impl<K, V> core::marker::Unpin for aya_ebpf::maps::hash_map::PerCpuHashMap<K, V>
 impl<K, V> core::marker::UnsafeUnpin for aya_ebpf::maps::hash_map::PerCpuHashMap<K, V>
 impl<K, V> !core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::maps::hash_map::PerCpuHashMap<K, V>
 impl<K, V> core::panic::unwind_safe::UnwindSafe for aya_ebpf::maps::hash_map::PerCpuHashMap<K, V> where K: core::panic::unwind_safe::UnwindSafe, V: core::panic::unwind_safe::UnwindSafe
-impl<T, U> core::convert::Into<U> for aya_ebpf::maps::hash_map::PerCpuHashMap<K, V> where U: core::convert::From<T>
-pub fn aya_ebpf::maps::hash_map::PerCpuHashMap<K, V>::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf::maps::hash_map::PerCpuHashMap<K, V> where U: core::convert::Into<T>
-pub type aya_ebpf::maps::hash_map::PerCpuHashMap<K, V>::Error = core::convert::Infallible
-pub fn aya_ebpf::maps::hash_map::PerCpuHashMap<K, V>::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf::maps::hash_map::PerCpuHashMap<K, V> where U: core::convert::TryFrom<T>
-pub type aya_ebpf::maps::hash_map::PerCpuHashMap<K, V>::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf::maps::hash_map::PerCpuHashMap<K, V>::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf::maps::hash_map::PerCpuHashMap<K, V> where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf::maps::hash_map::PerCpuHashMap<K, V>::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf::maps::hash_map::PerCpuHashMap<K, V> where T: ?core::marker::Sized
-pub fn aya_ebpf::maps::hash_map::PerCpuHashMap<K, V>::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf::maps::hash_map::PerCpuHashMap<K, V> where T: ?core::marker::Sized
-pub fn aya_ebpf::maps::hash_map::PerCpuHashMap<K, V>::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya_ebpf::maps::hash_map::PerCpuHashMap<K, V>
-pub fn aya_ebpf::maps::hash_map::PerCpuHashMap<K, V>::from(t: T) -> T
 pub mod aya_ebpf::maps::lpm_trie
 #[repr(C, packed(1))] pub struct aya_ebpf::maps::lpm_trie::Key<K>
 pub aya_ebpf::maps::lpm_trie::Key::data: K
@@ -494,22 +270,6 @@ impl<K> core::marker::Unpin for aya_ebpf::maps::lpm_trie::Key<K> where K: core::
 impl<K> core::marker::UnsafeUnpin for aya_ebpf::maps::lpm_trie::Key<K> where K: core::marker::UnsafeUnpin
 impl<K> core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::maps::lpm_trie::Key<K> where K: core::panic::unwind_safe::RefUnwindSafe
 impl<K> core::panic::unwind_safe::UnwindSafe for aya_ebpf::maps::lpm_trie::Key<K> where K: core::panic::unwind_safe::UnwindSafe
-impl<T, U> core::convert::Into<U> for aya_ebpf::maps::lpm_trie::Key<K> where U: core::convert::From<T>
-pub fn aya_ebpf::maps::lpm_trie::Key<K>::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf::maps::lpm_trie::Key<K> where U: core::convert::Into<T>
-pub type aya_ebpf::maps::lpm_trie::Key<K>::Error = core::convert::Infallible
-pub fn aya_ebpf::maps::lpm_trie::Key<K>::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf::maps::lpm_trie::Key<K> where U: core::convert::TryFrom<T>
-pub type aya_ebpf::maps::lpm_trie::Key<K>::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf::maps::lpm_trie::Key<K>::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf::maps::lpm_trie::Key<K> where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf::maps::lpm_trie::Key<K>::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf::maps::lpm_trie::Key<K> where T: ?core::marker::Sized
-pub fn aya_ebpf::maps::lpm_trie::Key<K>::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf::maps::lpm_trie::Key<K> where T: ?core::marker::Sized
-pub fn aya_ebpf::maps::lpm_trie::Key<K>::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya_ebpf::maps::lpm_trie::Key<K>
-pub fn aya_ebpf::maps::lpm_trie::Key<K>::from(t: T) -> T
 #[repr(transparent)] pub struct aya_ebpf::maps::lpm_trie::LpmTrie<K, V>
 impl<K, V> aya_ebpf::maps::lpm_trie::LpmTrie<K, V>
 pub fn aya_ebpf::maps::lpm_trie::LpmTrie<K, V>::get(&self, key: impl core::borrow::Borrow<aya_ebpf::maps::lpm_trie::Key<K>>) -> core::option::Option<&V>
@@ -524,22 +284,6 @@ impl<K, V> core::marker::Unpin for aya_ebpf::maps::lpm_trie::LpmTrie<K, V> where
 impl<K, V> core::marker::UnsafeUnpin for aya_ebpf::maps::lpm_trie::LpmTrie<K, V>
 impl<K, V> !core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::maps::lpm_trie::LpmTrie<K, V>
 impl<K, V> core::panic::unwind_safe::UnwindSafe for aya_ebpf::maps::lpm_trie::LpmTrie<K, V> where K: core::panic::unwind_safe::UnwindSafe, V: core::panic::unwind_safe::UnwindSafe
-impl<T, U> core::convert::Into<U> for aya_ebpf::maps::lpm_trie::LpmTrie<K, V> where U: core::convert::From<T>
-pub fn aya_ebpf::maps::lpm_trie::LpmTrie<K, V>::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf::maps::lpm_trie::LpmTrie<K, V> where U: core::convert::Into<T>
-pub type aya_ebpf::maps::lpm_trie::LpmTrie<K, V>::Error = core::convert::Infallible
-pub fn aya_ebpf::maps::lpm_trie::LpmTrie<K, V>::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf::maps::lpm_trie::LpmTrie<K, V> where U: core::convert::TryFrom<T>
-pub type aya_ebpf::maps::lpm_trie::LpmTrie<K, V>::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf::maps::lpm_trie::LpmTrie<K, V>::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf::maps::lpm_trie::LpmTrie<K, V> where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf::maps::lpm_trie::LpmTrie<K, V>::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf::maps::lpm_trie::LpmTrie<K, V> where T: ?core::marker::Sized
-pub fn aya_ebpf::maps::lpm_trie::LpmTrie<K, V>::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf::maps::lpm_trie::LpmTrie<K, V> where T: ?core::marker::Sized
-pub fn aya_ebpf::maps::lpm_trie::LpmTrie<K, V>::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya_ebpf::maps::lpm_trie::LpmTrie<K, V>
-pub fn aya_ebpf::maps::lpm_trie::LpmTrie<K, V>::from(t: T) -> T
 pub mod aya_ebpf::maps::per_cpu_array
 #[repr(transparent)] pub struct aya_ebpf::maps::per_cpu_array::PerCpuArray<T>
 impl<T> aya_ebpf::maps::per_cpu_array::PerCpuArray<T>
@@ -555,22 +299,6 @@ impl<T> core::marker::Unpin for aya_ebpf::maps::per_cpu_array::PerCpuArray<T> wh
 impl<T> core::marker::UnsafeUnpin for aya_ebpf::maps::per_cpu_array::PerCpuArray<T>
 impl<T> !core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::maps::per_cpu_array::PerCpuArray<T>
 impl<T> core::panic::unwind_safe::UnwindSafe for aya_ebpf::maps::per_cpu_array::PerCpuArray<T> where T: core::panic::unwind_safe::UnwindSafe
-impl<T, U> core::convert::Into<U> for aya_ebpf::maps::per_cpu_array::PerCpuArray<T> where U: core::convert::From<T>
-pub fn aya_ebpf::maps::per_cpu_array::PerCpuArray<T>::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf::maps::per_cpu_array::PerCpuArray<T> where U: core::convert::Into<T>
-pub type aya_ebpf::maps::per_cpu_array::PerCpuArray<T>::Error = core::convert::Infallible
-pub fn aya_ebpf::maps::per_cpu_array::PerCpuArray<T>::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf::maps::per_cpu_array::PerCpuArray<T> where U: core::convert::TryFrom<T>
-pub type aya_ebpf::maps::per_cpu_array::PerCpuArray<T>::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf::maps::per_cpu_array::PerCpuArray<T>::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf::maps::per_cpu_array::PerCpuArray<T> where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf::maps::per_cpu_array::PerCpuArray<T>::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf::maps::per_cpu_array::PerCpuArray<T> where T: ?core::marker::Sized
-pub fn aya_ebpf::maps::per_cpu_array::PerCpuArray<T>::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf::maps::per_cpu_array::PerCpuArray<T> where T: ?core::marker::Sized
-pub fn aya_ebpf::maps::per_cpu_array::PerCpuArray<T>::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya_ebpf::maps::per_cpu_array::PerCpuArray<T>
-pub fn aya_ebpf::maps::per_cpu_array::PerCpuArray<T>::from(t: T) -> T
 pub mod aya_ebpf::maps::perf
 #[repr(transparent)] pub struct aya_ebpf::maps::perf::PerfEventArray<T>
 impl<T> aya_ebpf::maps::PerfEventArray<T>
@@ -585,22 +313,6 @@ impl<T> core::marker::Unpin for aya_ebpf::maps::PerfEventArray<T> where T: core:
 impl<T> core::marker::UnsafeUnpin for aya_ebpf::maps::PerfEventArray<T>
 impl<T> !core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::maps::PerfEventArray<T>
 impl<T> core::panic::unwind_safe::UnwindSafe for aya_ebpf::maps::PerfEventArray<T> where T: core::panic::unwind_safe::UnwindSafe
-impl<T, U> core::convert::Into<U> for aya_ebpf::maps::PerfEventArray<T> where U: core::convert::From<T>
-pub fn aya_ebpf::maps::PerfEventArray<T>::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf::maps::PerfEventArray<T> where U: core::convert::Into<T>
-pub type aya_ebpf::maps::PerfEventArray<T>::Error = core::convert::Infallible
-pub fn aya_ebpf::maps::PerfEventArray<T>::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf::maps::PerfEventArray<T> where U: core::convert::TryFrom<T>
-pub type aya_ebpf::maps::PerfEventArray<T>::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf::maps::PerfEventArray<T>::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf::maps::PerfEventArray<T> where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf::maps::PerfEventArray<T>::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf::maps::PerfEventArray<T> where T: ?core::marker::Sized
-pub fn aya_ebpf::maps::PerfEventArray<T>::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf::maps::PerfEventArray<T> where T: ?core::marker::Sized
-pub fn aya_ebpf::maps::PerfEventArray<T>::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya_ebpf::maps::PerfEventArray<T>
-pub fn aya_ebpf::maps::PerfEventArray<T>::from(t: T) -> T
 #[repr(transparent)] pub struct aya_ebpf::maps::perf::PerfEventByteArray
 impl aya_ebpf::maps::PerfEventByteArray
 pub const fn aya_ebpf::maps::PerfEventByteArray::new(flags: u32) -> Self
@@ -614,22 +326,6 @@ impl core::marker::Unpin for aya_ebpf::maps::PerfEventByteArray
 impl core::marker::UnsafeUnpin for aya_ebpf::maps::PerfEventByteArray
 impl !core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::maps::PerfEventByteArray
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf::maps::PerfEventByteArray
-impl<T, U> core::convert::Into<U> for aya_ebpf::maps::PerfEventByteArray where U: core::convert::From<T>
-pub fn aya_ebpf::maps::PerfEventByteArray::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf::maps::PerfEventByteArray where U: core::convert::Into<T>
-pub type aya_ebpf::maps::PerfEventByteArray::Error = core::convert::Infallible
-pub fn aya_ebpf::maps::PerfEventByteArray::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf::maps::PerfEventByteArray where U: core::convert::TryFrom<T>
-pub type aya_ebpf::maps::PerfEventByteArray::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf::maps::PerfEventByteArray::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf::maps::PerfEventByteArray where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf::maps::PerfEventByteArray::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf::maps::PerfEventByteArray where T: ?core::marker::Sized
-pub fn aya_ebpf::maps::PerfEventByteArray::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf::maps::PerfEventByteArray where T: ?core::marker::Sized
-pub fn aya_ebpf::maps::PerfEventByteArray::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya_ebpf::maps::PerfEventByteArray
-pub fn aya_ebpf::maps::PerfEventByteArray::from(t: T) -> T
 pub mod aya_ebpf::maps::program_array
 #[repr(transparent)] pub struct aya_ebpf::maps::program_array::ProgramArray
 impl aya_ebpf::maps::program_array::ProgramArray
@@ -643,22 +339,6 @@ impl core::marker::Unpin for aya_ebpf::maps::program_array::ProgramArray
 impl core::marker::UnsafeUnpin for aya_ebpf::maps::program_array::ProgramArray
 impl !core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::maps::program_array::ProgramArray
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf::maps::program_array::ProgramArray
-impl<T, U> core::convert::Into<U> for aya_ebpf::maps::program_array::ProgramArray where U: core::convert::From<T>
-pub fn aya_ebpf::maps::program_array::ProgramArray::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf::maps::program_array::ProgramArray where U: core::convert::Into<T>
-pub type aya_ebpf::maps::program_array::ProgramArray::Error = core::convert::Infallible
-pub fn aya_ebpf::maps::program_array::ProgramArray::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf::maps::program_array::ProgramArray where U: core::convert::TryFrom<T>
-pub type aya_ebpf::maps::program_array::ProgramArray::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf::maps::program_array::ProgramArray::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf::maps::program_array::ProgramArray where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf::maps::program_array::ProgramArray::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf::maps::program_array::ProgramArray where T: ?core::marker::Sized
-pub fn aya_ebpf::maps::program_array::ProgramArray::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf::maps::program_array::ProgramArray where T: ?core::marker::Sized
-pub fn aya_ebpf::maps::program_array::ProgramArray::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya_ebpf::maps::program_array::ProgramArray
-pub fn aya_ebpf::maps::program_array::ProgramArray::from(t: T) -> T
 pub mod aya_ebpf::maps::queue
 #[repr(transparent)] pub struct aya_ebpf::maps::queue::Queue<T>
 impl<T> aya_ebpf::maps::queue::Queue<T>
@@ -674,22 +354,6 @@ impl<T> core::marker::Unpin for aya_ebpf::maps::queue::Queue<T> where T: core::m
 impl<T> core::marker::UnsafeUnpin for aya_ebpf::maps::queue::Queue<T>
 impl<T> !core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::maps::queue::Queue<T>
 impl<T> core::panic::unwind_safe::UnwindSafe for aya_ebpf::maps::queue::Queue<T> where T: core::panic::unwind_safe::UnwindSafe
-impl<T, U> core::convert::Into<U> for aya_ebpf::maps::queue::Queue<T> where U: core::convert::From<T>
-pub fn aya_ebpf::maps::queue::Queue<T>::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf::maps::queue::Queue<T> where U: core::convert::Into<T>
-pub type aya_ebpf::maps::queue::Queue<T>::Error = core::convert::Infallible
-pub fn aya_ebpf::maps::queue::Queue<T>::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf::maps::queue::Queue<T> where U: core::convert::TryFrom<T>
-pub type aya_ebpf::maps::queue::Queue<T>::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf::maps::queue::Queue<T>::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf::maps::queue::Queue<T> where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf::maps::queue::Queue<T>::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf::maps::queue::Queue<T> where T: ?core::marker::Sized
-pub fn aya_ebpf::maps::queue::Queue<T>::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf::maps::queue::Queue<T> where T: ?core::marker::Sized
-pub fn aya_ebpf::maps::queue::Queue<T>::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya_ebpf::maps::queue::Queue<T>
-pub fn aya_ebpf::maps::queue::Queue<T>::from(t: T) -> T
 pub mod aya_ebpf::maps::ring_buf
 #[repr(transparent)] pub struct aya_ebpf::maps::ring_buf::RingBuf
 impl aya_ebpf::maps::ring_buf::RingBuf
@@ -706,22 +370,6 @@ impl core::marker::Unpin for aya_ebpf::maps::ring_buf::RingBuf
 impl core::marker::UnsafeUnpin for aya_ebpf::maps::ring_buf::RingBuf
 impl !core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::maps::ring_buf::RingBuf
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf::maps::ring_buf::RingBuf
-impl<T, U> core::convert::Into<U> for aya_ebpf::maps::ring_buf::RingBuf where U: core::convert::From<T>
-pub fn aya_ebpf::maps::ring_buf::RingBuf::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf::maps::ring_buf::RingBuf where U: core::convert::Into<T>
-pub type aya_ebpf::maps::ring_buf::RingBuf::Error = core::convert::Infallible
-pub fn aya_ebpf::maps::ring_buf::RingBuf::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf::maps::ring_buf::RingBuf where U: core::convert::TryFrom<T>
-pub type aya_ebpf::maps::ring_buf::RingBuf::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf::maps::ring_buf::RingBuf::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf::maps::ring_buf::RingBuf where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf::maps::ring_buf::RingBuf::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf::maps::ring_buf::RingBuf where T: ?core::marker::Sized
-pub fn aya_ebpf::maps::ring_buf::RingBuf::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf::maps::ring_buf::RingBuf where T: ?core::marker::Sized
-pub fn aya_ebpf::maps::ring_buf::RingBuf::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya_ebpf::maps::ring_buf::RingBuf
-pub fn aya_ebpf::maps::ring_buf::RingBuf::from(t: T) -> T
 pub struct aya_ebpf::maps::ring_buf::RingBufBytes<'a>(_)
 impl aya_ebpf::maps::ring_buf::RingBufBytes<'_>
 pub fn aya_ebpf::maps::ring_buf::RingBufBytes<'_>::discard(self, flags: u64)
@@ -738,24 +386,6 @@ impl<'a> core::marker::Unpin for aya_ebpf::maps::ring_buf::RingBufBytes<'a>
 impl<'a> core::marker::UnsafeUnpin for aya_ebpf::maps::ring_buf::RingBufBytes<'a>
 impl<'a> core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::maps::ring_buf::RingBufBytes<'a>
 impl<'a> !core::panic::unwind_safe::UnwindSafe for aya_ebpf::maps::ring_buf::RingBufBytes<'a>
-impl<P, T> core::ops::deref::Receiver for aya_ebpf::maps::ring_buf::RingBufBytes<'a> where P: core::ops::deref::Deref<Target = T> + ?core::marker::Sized, T: ?core::marker::Sized
-pub type aya_ebpf::maps::ring_buf::RingBufBytes<'a>::Target = T
-impl<T, U> core::convert::Into<U> for aya_ebpf::maps::ring_buf::RingBufBytes<'a> where U: core::convert::From<T>
-pub fn aya_ebpf::maps::ring_buf::RingBufBytes<'a>::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf::maps::ring_buf::RingBufBytes<'a> where U: core::convert::Into<T>
-pub type aya_ebpf::maps::ring_buf::RingBufBytes<'a>::Error = core::convert::Infallible
-pub fn aya_ebpf::maps::ring_buf::RingBufBytes<'a>::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf::maps::ring_buf::RingBufBytes<'a> where U: core::convert::TryFrom<T>
-pub type aya_ebpf::maps::ring_buf::RingBufBytes<'a>::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf::maps::ring_buf::RingBufBytes<'a>::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf::maps::ring_buf::RingBufBytes<'a> where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf::maps::ring_buf::RingBufBytes<'a>::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf::maps::ring_buf::RingBufBytes<'a> where T: ?core::marker::Sized
-pub fn aya_ebpf::maps::ring_buf::RingBufBytes<'a>::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf::maps::ring_buf::RingBufBytes<'a> where T: ?core::marker::Sized
-pub fn aya_ebpf::maps::ring_buf::RingBufBytes<'a>::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya_ebpf::maps::ring_buf::RingBufBytes<'a>
-pub fn aya_ebpf::maps::ring_buf::RingBufBytes<'a>::from(t: T) -> T
 pub struct aya_ebpf::maps::ring_buf::RingBufEntry<T: 'static>(_)
 impl<T> aya_ebpf::maps::ring_buf::RingBufEntry<T>
 pub fn aya_ebpf::maps::ring_buf::RingBufEntry<T>::discard(self, flags: u64)
@@ -772,24 +402,6 @@ impl<T> core::marker::Unpin for aya_ebpf::maps::ring_buf::RingBufEntry<T>
 impl<T> core::marker::UnsafeUnpin for aya_ebpf::maps::ring_buf::RingBufEntry<T>
 impl<T> core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::maps::ring_buf::RingBufEntry<T> where T: core::panic::unwind_safe::RefUnwindSafe
 impl<T> !core::panic::unwind_safe::UnwindSafe for aya_ebpf::maps::ring_buf::RingBufEntry<T>
-impl<P, T> core::ops::deref::Receiver for aya_ebpf::maps::ring_buf::RingBufEntry<T> where P: core::ops::deref::Deref<Target = T> + ?core::marker::Sized, T: ?core::marker::Sized
-pub type aya_ebpf::maps::ring_buf::RingBufEntry<T>::Target = T
-impl<T, U> core::convert::Into<U> for aya_ebpf::maps::ring_buf::RingBufEntry<T> where U: core::convert::From<T>
-pub fn aya_ebpf::maps::ring_buf::RingBufEntry<T>::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf::maps::ring_buf::RingBufEntry<T> where U: core::convert::Into<T>
-pub type aya_ebpf::maps::ring_buf::RingBufEntry<T>::Error = core::convert::Infallible
-pub fn aya_ebpf::maps::ring_buf::RingBufEntry<T>::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf::maps::ring_buf::RingBufEntry<T> where U: core::convert::TryFrom<T>
-pub type aya_ebpf::maps::ring_buf::RingBufEntry<T>::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf::maps::ring_buf::RingBufEntry<T>::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf::maps::ring_buf::RingBufEntry<T> where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf::maps::ring_buf::RingBufEntry<T>::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf::maps::ring_buf::RingBufEntry<T> where T: ?core::marker::Sized
-pub fn aya_ebpf::maps::ring_buf::RingBufEntry<T>::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf::maps::ring_buf::RingBufEntry<T> where T: ?core::marker::Sized
-pub fn aya_ebpf::maps::ring_buf::RingBufEntry<T>::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya_ebpf::maps::ring_buf::RingBufEntry<T>
-pub fn aya_ebpf::maps::ring_buf::RingBufEntry<T>::from(t: T) -> T
 pub mod aya_ebpf::maps::sock_hash
 #[repr(transparent)] pub struct aya_ebpf::maps::sock_hash::SockHash<K>
 impl<K> aya_ebpf::maps::sock_hash::SockHash<K>
@@ -806,22 +418,6 @@ impl<K> core::marker::Unpin for aya_ebpf::maps::sock_hash::SockHash<K> where K: 
 impl<K> core::marker::UnsafeUnpin for aya_ebpf::maps::sock_hash::SockHash<K>
 impl<K> !core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::maps::sock_hash::SockHash<K>
 impl<K> core::panic::unwind_safe::UnwindSafe for aya_ebpf::maps::sock_hash::SockHash<K> where K: core::panic::unwind_safe::UnwindSafe
-impl<T, U> core::convert::Into<U> for aya_ebpf::maps::sock_hash::SockHash<K> where U: core::convert::From<T>
-pub fn aya_ebpf::maps::sock_hash::SockHash<K>::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf::maps::sock_hash::SockHash<K> where U: core::convert::Into<T>
-pub type aya_ebpf::maps::sock_hash::SockHash<K>::Error = core::convert::Infallible
-pub fn aya_ebpf::maps::sock_hash::SockHash<K>::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf::maps::sock_hash::SockHash<K> where U: core::convert::TryFrom<T>
-pub type aya_ebpf::maps::sock_hash::SockHash<K>::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf::maps::sock_hash::SockHash<K>::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf::maps::sock_hash::SockHash<K> where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf::maps::sock_hash::SockHash<K>::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf::maps::sock_hash::SockHash<K> where T: ?core::marker::Sized
-pub fn aya_ebpf::maps::sock_hash::SockHash<K>::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf::maps::sock_hash::SockHash<K> where T: ?core::marker::Sized
-pub fn aya_ebpf::maps::sock_hash::SockHash<K>::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya_ebpf::maps::sock_hash::SockHash<K>
-pub fn aya_ebpf::maps::sock_hash::SockHash<K>::from(t: T) -> T
 pub mod aya_ebpf::maps::sock_map
 #[repr(transparent)] pub struct aya_ebpf::maps::sock_map::SockMap
 impl aya_ebpf::maps::sock_map::SockMap
@@ -838,22 +434,6 @@ impl core::marker::Unpin for aya_ebpf::maps::sock_map::SockMap
 impl core::marker::UnsafeUnpin for aya_ebpf::maps::sock_map::SockMap
 impl !core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::maps::sock_map::SockMap
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf::maps::sock_map::SockMap
-impl<T, U> core::convert::Into<U> for aya_ebpf::maps::sock_map::SockMap where U: core::convert::From<T>
-pub fn aya_ebpf::maps::sock_map::SockMap::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf::maps::sock_map::SockMap where U: core::convert::Into<T>
-pub type aya_ebpf::maps::sock_map::SockMap::Error = core::convert::Infallible
-pub fn aya_ebpf::maps::sock_map::SockMap::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf::maps::sock_map::SockMap where U: core::convert::TryFrom<T>
-pub type aya_ebpf::maps::sock_map::SockMap::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf::maps::sock_map::SockMap::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf::maps::sock_map::SockMap where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf::maps::sock_map::SockMap::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf::maps::sock_map::SockMap where T: ?core::marker::Sized
-pub fn aya_ebpf::maps::sock_map::SockMap::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf::maps::sock_map::SockMap where T: ?core::marker::Sized
-pub fn aya_ebpf::maps::sock_map::SockMap::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya_ebpf::maps::sock_map::SockMap
-pub fn aya_ebpf::maps::sock_map::SockMap::from(t: T) -> T
 pub mod aya_ebpf::maps::stack
 #[repr(transparent)] pub struct aya_ebpf::maps::stack::Stack<T>
 impl<T> aya_ebpf::maps::stack::Stack<T>
@@ -869,22 +449,6 @@ impl<T> core::marker::Unpin for aya_ebpf::maps::stack::Stack<T> where T: core::m
 impl<T> core::marker::UnsafeUnpin for aya_ebpf::maps::stack::Stack<T>
 impl<T> !core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::maps::stack::Stack<T>
 impl<T> core::panic::unwind_safe::UnwindSafe for aya_ebpf::maps::stack::Stack<T> where T: core::panic::unwind_safe::UnwindSafe
-impl<T, U> core::convert::Into<U> for aya_ebpf::maps::stack::Stack<T> where U: core::convert::From<T>
-pub fn aya_ebpf::maps::stack::Stack<T>::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf::maps::stack::Stack<T> where U: core::convert::Into<T>
-pub type aya_ebpf::maps::stack::Stack<T>::Error = core::convert::Infallible
-pub fn aya_ebpf::maps::stack::Stack<T>::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf::maps::stack::Stack<T> where U: core::convert::TryFrom<T>
-pub type aya_ebpf::maps::stack::Stack<T>::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf::maps::stack::Stack<T>::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf::maps::stack::Stack<T> where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf::maps::stack::Stack<T>::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf::maps::stack::Stack<T> where T: ?core::marker::Sized
-pub fn aya_ebpf::maps::stack::Stack<T>::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf::maps::stack::Stack<T> where T: ?core::marker::Sized
-pub fn aya_ebpf::maps::stack::Stack<T>::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya_ebpf::maps::stack::Stack<T>
-pub fn aya_ebpf::maps::stack::Stack<T>::from(t: T) -> T
 pub mod aya_ebpf::maps::stack_trace
 #[repr(transparent)] pub struct aya_ebpf::maps::stack_trace::StackTrace
 impl aya_ebpf::maps::stack_trace::StackTrace
@@ -898,22 +462,6 @@ impl core::marker::Unpin for aya_ebpf::maps::stack_trace::StackTrace
 impl core::marker::UnsafeUnpin for aya_ebpf::maps::stack_trace::StackTrace
 impl !core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::maps::stack_trace::StackTrace
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf::maps::stack_trace::StackTrace
-impl<T, U> core::convert::Into<U> for aya_ebpf::maps::stack_trace::StackTrace where U: core::convert::From<T>
-pub fn aya_ebpf::maps::stack_trace::StackTrace::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf::maps::stack_trace::StackTrace where U: core::convert::Into<T>
-pub type aya_ebpf::maps::stack_trace::StackTrace::Error = core::convert::Infallible
-pub fn aya_ebpf::maps::stack_trace::StackTrace::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf::maps::stack_trace::StackTrace where U: core::convert::TryFrom<T>
-pub type aya_ebpf::maps::stack_trace::StackTrace::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf::maps::stack_trace::StackTrace::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf::maps::stack_trace::StackTrace where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf::maps::stack_trace::StackTrace::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf::maps::stack_trace::StackTrace where T: ?core::marker::Sized
-pub fn aya_ebpf::maps::stack_trace::StackTrace::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf::maps::stack_trace::StackTrace where T: ?core::marker::Sized
-pub fn aya_ebpf::maps::stack_trace::StackTrace::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya_ebpf::maps::stack_trace::StackTrace
-pub fn aya_ebpf::maps::stack_trace::StackTrace::from(t: T) -> T
 pub mod aya_ebpf::maps::xdp
 #[repr(transparent)] pub struct aya_ebpf::maps::xdp::CpuMap
 impl aya_ebpf::maps::CpuMap
@@ -927,22 +475,6 @@ impl core::marker::Unpin for aya_ebpf::maps::CpuMap
 impl core::marker::UnsafeUnpin for aya_ebpf::maps::CpuMap
 impl !core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::maps::CpuMap
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf::maps::CpuMap
-impl<T, U> core::convert::Into<U> for aya_ebpf::maps::CpuMap where U: core::convert::From<T>
-pub fn aya_ebpf::maps::CpuMap::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf::maps::CpuMap where U: core::convert::Into<T>
-pub type aya_ebpf::maps::CpuMap::Error = core::convert::Infallible
-pub fn aya_ebpf::maps::CpuMap::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf::maps::CpuMap where U: core::convert::TryFrom<T>
-pub type aya_ebpf::maps::CpuMap::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf::maps::CpuMap::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf::maps::CpuMap where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf::maps::CpuMap::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf::maps::CpuMap where T: ?core::marker::Sized
-pub fn aya_ebpf::maps::CpuMap::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf::maps::CpuMap where T: ?core::marker::Sized
-pub fn aya_ebpf::maps::CpuMap::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya_ebpf::maps::CpuMap
-pub fn aya_ebpf::maps::CpuMap::from(t: T) -> T
 #[repr(transparent)] pub struct aya_ebpf::maps::xdp::DevMap
 impl aya_ebpf::maps::DevMap
 pub fn aya_ebpf::maps::DevMap::get(&self, index: u32) -> core::option::Option<aya_ebpf::maps::xdp::dev_map::DevMapValue>
@@ -956,22 +488,6 @@ impl core::marker::Unpin for aya_ebpf::maps::DevMap
 impl core::marker::UnsafeUnpin for aya_ebpf::maps::DevMap
 impl !core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::maps::DevMap
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf::maps::DevMap
-impl<T, U> core::convert::Into<U> for aya_ebpf::maps::DevMap where U: core::convert::From<T>
-pub fn aya_ebpf::maps::DevMap::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf::maps::DevMap where U: core::convert::Into<T>
-pub type aya_ebpf::maps::DevMap::Error = core::convert::Infallible
-pub fn aya_ebpf::maps::DevMap::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf::maps::DevMap where U: core::convert::TryFrom<T>
-pub type aya_ebpf::maps::DevMap::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf::maps::DevMap::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf::maps::DevMap where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf::maps::DevMap::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf::maps::DevMap where T: ?core::marker::Sized
-pub fn aya_ebpf::maps::DevMap::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf::maps::DevMap where T: ?core::marker::Sized
-pub fn aya_ebpf::maps::DevMap::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya_ebpf::maps::DevMap
-pub fn aya_ebpf::maps::DevMap::from(t: T) -> T
 #[repr(transparent)] pub struct aya_ebpf::maps::xdp::DevMapHash
 impl aya_ebpf::maps::DevMapHash
 pub fn aya_ebpf::maps::DevMapHash::get(&self, key: u32) -> core::option::Option<aya_ebpf::maps::xdp::dev_map::DevMapValue>
@@ -985,22 +501,6 @@ impl core::marker::Unpin for aya_ebpf::maps::DevMapHash
 impl core::marker::UnsafeUnpin for aya_ebpf::maps::DevMapHash
 impl !core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::maps::DevMapHash
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf::maps::DevMapHash
-impl<T, U> core::convert::Into<U> for aya_ebpf::maps::DevMapHash where U: core::convert::From<T>
-pub fn aya_ebpf::maps::DevMapHash::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf::maps::DevMapHash where U: core::convert::Into<T>
-pub type aya_ebpf::maps::DevMapHash::Error = core::convert::Infallible
-pub fn aya_ebpf::maps::DevMapHash::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf::maps::DevMapHash where U: core::convert::TryFrom<T>
-pub type aya_ebpf::maps::DevMapHash::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf::maps::DevMapHash::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf::maps::DevMapHash where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf::maps::DevMapHash::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf::maps::DevMapHash where T: ?core::marker::Sized
-pub fn aya_ebpf::maps::DevMapHash::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf::maps::DevMapHash where T: ?core::marker::Sized
-pub fn aya_ebpf::maps::DevMapHash::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya_ebpf::maps::DevMapHash
-pub fn aya_ebpf::maps::DevMapHash::from(t: T) -> T
 #[repr(transparent)] pub struct aya_ebpf::maps::xdp::XskMap
 impl aya_ebpf::maps::XskMap
 pub fn aya_ebpf::maps::XskMap::get(&self, index: u32) -> core::option::Option<u32>
@@ -1014,22 +514,6 @@ impl core::marker::Unpin for aya_ebpf::maps::XskMap
 impl core::marker::UnsafeUnpin for aya_ebpf::maps::XskMap
 impl !core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::maps::XskMap
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf::maps::XskMap
-impl<T, U> core::convert::Into<U> for aya_ebpf::maps::XskMap where U: core::convert::From<T>
-pub fn aya_ebpf::maps::XskMap::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf::maps::XskMap where U: core::convert::Into<T>
-pub type aya_ebpf::maps::XskMap::Error = core::convert::Infallible
-pub fn aya_ebpf::maps::XskMap::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf::maps::XskMap where U: core::convert::TryFrom<T>
-pub type aya_ebpf::maps::XskMap::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf::maps::XskMap::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf::maps::XskMap where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf::maps::XskMap::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf::maps::XskMap where T: ?core::marker::Sized
-pub fn aya_ebpf::maps::XskMap::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf::maps::XskMap where T: ?core::marker::Sized
-pub fn aya_ebpf::maps::XskMap::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya_ebpf::maps::XskMap
-pub fn aya_ebpf::maps::XskMap::from(t: T) -> T
 #[repr(transparent)] pub struct aya_ebpf::maps::Array<T>
 impl<T> aya_ebpf::maps::array::Array<T>
 pub fn aya_ebpf::maps::array::Array<T>::get(&self, index: u32) -> core::option::Option<&T>
@@ -1045,22 +529,6 @@ impl<T> core::marker::Unpin for aya_ebpf::maps::array::Array<T> where T: core::m
 impl<T> core::marker::UnsafeUnpin for aya_ebpf::maps::array::Array<T>
 impl<T> !core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::maps::array::Array<T>
 impl<T> core::panic::unwind_safe::UnwindSafe for aya_ebpf::maps::array::Array<T> where T: core::panic::unwind_safe::UnwindSafe
-impl<T, U> core::convert::Into<U> for aya_ebpf::maps::array::Array<T> where U: core::convert::From<T>
-pub fn aya_ebpf::maps::array::Array<T>::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf::maps::array::Array<T> where U: core::convert::Into<T>
-pub type aya_ebpf::maps::array::Array<T>::Error = core::convert::Infallible
-pub fn aya_ebpf::maps::array::Array<T>::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf::maps::array::Array<T> where U: core::convert::TryFrom<T>
-pub type aya_ebpf::maps::array::Array<T>::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf::maps::array::Array<T>::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf::maps::array::Array<T> where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf::maps::array::Array<T>::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf::maps::array::Array<T> where T: ?core::marker::Sized
-pub fn aya_ebpf::maps::array::Array<T>::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf::maps::array::Array<T> where T: ?core::marker::Sized
-pub fn aya_ebpf::maps::array::Array<T>::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya_ebpf::maps::array::Array<T>
-pub fn aya_ebpf::maps::array::Array<T>::from(t: T) -> T
 #[repr(transparent)] pub struct aya_ebpf::maps::BloomFilter<T>
 impl<T> aya_ebpf::maps::bloom_filter::BloomFilter<T>
 pub fn aya_ebpf::maps::bloom_filter::BloomFilter<T>::contains(&self, value: impl core::borrow::Borrow<T>) -> core::result::Result<(), i64>
@@ -1074,22 +542,6 @@ impl<T> core::marker::Unpin for aya_ebpf::maps::bloom_filter::BloomFilter<T> whe
 impl<T> core::marker::UnsafeUnpin for aya_ebpf::maps::bloom_filter::BloomFilter<T>
 impl<T> !core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::maps::bloom_filter::BloomFilter<T>
 impl<T> core::panic::unwind_safe::UnwindSafe for aya_ebpf::maps::bloom_filter::BloomFilter<T> where T: core::panic::unwind_safe::UnwindSafe
-impl<T, U> core::convert::Into<U> for aya_ebpf::maps::bloom_filter::BloomFilter<T> where U: core::convert::From<T>
-pub fn aya_ebpf::maps::bloom_filter::BloomFilter<T>::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf::maps::bloom_filter::BloomFilter<T> where U: core::convert::Into<T>
-pub type aya_ebpf::maps::bloom_filter::BloomFilter<T>::Error = core::convert::Infallible
-pub fn aya_ebpf::maps::bloom_filter::BloomFilter<T>::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf::maps::bloom_filter::BloomFilter<T> where U: core::convert::TryFrom<T>
-pub type aya_ebpf::maps::bloom_filter::BloomFilter<T>::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf::maps::bloom_filter::BloomFilter<T>::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf::maps::bloom_filter::BloomFilter<T> where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf::maps::bloom_filter::BloomFilter<T>::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf::maps::bloom_filter::BloomFilter<T> where T: ?core::marker::Sized
-pub fn aya_ebpf::maps::bloom_filter::BloomFilter<T>::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf::maps::bloom_filter::BloomFilter<T> where T: ?core::marker::Sized
-pub fn aya_ebpf::maps::bloom_filter::BloomFilter<T>::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya_ebpf::maps::bloom_filter::BloomFilter<T>
-pub fn aya_ebpf::maps::bloom_filter::BloomFilter<T>::from(t: T) -> T
 #[repr(transparent)] pub struct aya_ebpf::maps::CpuMap
 impl aya_ebpf::maps::CpuMap
 pub const fn aya_ebpf::maps::CpuMap::pinned(max_entries: u32, flags: u32) -> Self
@@ -1102,22 +554,6 @@ impl core::marker::Unpin for aya_ebpf::maps::CpuMap
 impl core::marker::UnsafeUnpin for aya_ebpf::maps::CpuMap
 impl !core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::maps::CpuMap
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf::maps::CpuMap
-impl<T, U> core::convert::Into<U> for aya_ebpf::maps::CpuMap where U: core::convert::From<T>
-pub fn aya_ebpf::maps::CpuMap::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf::maps::CpuMap where U: core::convert::Into<T>
-pub type aya_ebpf::maps::CpuMap::Error = core::convert::Infallible
-pub fn aya_ebpf::maps::CpuMap::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf::maps::CpuMap where U: core::convert::TryFrom<T>
-pub type aya_ebpf::maps::CpuMap::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf::maps::CpuMap::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf::maps::CpuMap where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf::maps::CpuMap::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf::maps::CpuMap where T: ?core::marker::Sized
-pub fn aya_ebpf::maps::CpuMap::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf::maps::CpuMap where T: ?core::marker::Sized
-pub fn aya_ebpf::maps::CpuMap::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya_ebpf::maps::CpuMap
-pub fn aya_ebpf::maps::CpuMap::from(t: T) -> T
 #[repr(transparent)] pub struct aya_ebpf::maps::DevMap
 impl aya_ebpf::maps::DevMap
 pub fn aya_ebpf::maps::DevMap::get(&self, index: u32) -> core::option::Option<aya_ebpf::maps::xdp::dev_map::DevMapValue>
@@ -1131,22 +567,6 @@ impl core::marker::Unpin for aya_ebpf::maps::DevMap
 impl core::marker::UnsafeUnpin for aya_ebpf::maps::DevMap
 impl !core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::maps::DevMap
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf::maps::DevMap
-impl<T, U> core::convert::Into<U> for aya_ebpf::maps::DevMap where U: core::convert::From<T>
-pub fn aya_ebpf::maps::DevMap::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf::maps::DevMap where U: core::convert::Into<T>
-pub type aya_ebpf::maps::DevMap::Error = core::convert::Infallible
-pub fn aya_ebpf::maps::DevMap::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf::maps::DevMap where U: core::convert::TryFrom<T>
-pub type aya_ebpf::maps::DevMap::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf::maps::DevMap::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf::maps::DevMap where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf::maps::DevMap::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf::maps::DevMap where T: ?core::marker::Sized
-pub fn aya_ebpf::maps::DevMap::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf::maps::DevMap where T: ?core::marker::Sized
-pub fn aya_ebpf::maps::DevMap::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya_ebpf::maps::DevMap
-pub fn aya_ebpf::maps::DevMap::from(t: T) -> T
 #[repr(transparent)] pub struct aya_ebpf::maps::DevMapHash
 impl aya_ebpf::maps::DevMapHash
 pub fn aya_ebpf::maps::DevMapHash::get(&self, key: u32) -> core::option::Option<aya_ebpf::maps::xdp::dev_map::DevMapValue>
@@ -1160,22 +580,6 @@ impl core::marker::Unpin for aya_ebpf::maps::DevMapHash
 impl core::marker::UnsafeUnpin for aya_ebpf::maps::DevMapHash
 impl !core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::maps::DevMapHash
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf::maps::DevMapHash
-impl<T, U> core::convert::Into<U> for aya_ebpf::maps::DevMapHash where U: core::convert::From<T>
-pub fn aya_ebpf::maps::DevMapHash::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf::maps::DevMapHash where U: core::convert::Into<T>
-pub type aya_ebpf::maps::DevMapHash::Error = core::convert::Infallible
-pub fn aya_ebpf::maps::DevMapHash::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf::maps::DevMapHash where U: core::convert::TryFrom<T>
-pub type aya_ebpf::maps::DevMapHash::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf::maps::DevMapHash::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf::maps::DevMapHash where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf::maps::DevMapHash::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf::maps::DevMapHash where T: ?core::marker::Sized
-pub fn aya_ebpf::maps::DevMapHash::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf::maps::DevMapHash where T: ?core::marker::Sized
-pub fn aya_ebpf::maps::DevMapHash::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya_ebpf::maps::DevMapHash
-pub fn aya_ebpf::maps::DevMapHash::from(t: T) -> T
 #[repr(transparent)] pub struct aya_ebpf::maps::HashMap<K, V>
 impl<K, V> aya_ebpf::maps::hash_map::HashMap<K, V>
 pub unsafe fn aya_ebpf::maps::hash_map::HashMap<K, V>::get(&self, key: impl core::borrow::Borrow<K>) -> core::option::Option<&V>
@@ -1192,22 +596,6 @@ impl<K, V> core::marker::Unpin for aya_ebpf::maps::hash_map::HashMap<K, V> where
 impl<K, V> core::marker::UnsafeUnpin for aya_ebpf::maps::hash_map::HashMap<K, V>
 impl<K, V> !core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::maps::hash_map::HashMap<K, V>
 impl<K, V> core::panic::unwind_safe::UnwindSafe for aya_ebpf::maps::hash_map::HashMap<K, V> where K: core::panic::unwind_safe::UnwindSafe, V: core::panic::unwind_safe::UnwindSafe
-impl<T, U> core::convert::Into<U> for aya_ebpf::maps::hash_map::HashMap<K, V> where U: core::convert::From<T>
-pub fn aya_ebpf::maps::hash_map::HashMap<K, V>::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf::maps::hash_map::HashMap<K, V> where U: core::convert::Into<T>
-pub type aya_ebpf::maps::hash_map::HashMap<K, V>::Error = core::convert::Infallible
-pub fn aya_ebpf::maps::hash_map::HashMap<K, V>::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf::maps::hash_map::HashMap<K, V> where U: core::convert::TryFrom<T>
-pub type aya_ebpf::maps::hash_map::HashMap<K, V>::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf::maps::hash_map::HashMap<K, V>::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf::maps::hash_map::HashMap<K, V> where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf::maps::hash_map::HashMap<K, V>::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf::maps::hash_map::HashMap<K, V> where T: ?core::marker::Sized
-pub fn aya_ebpf::maps::hash_map::HashMap<K, V>::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf::maps::hash_map::HashMap<K, V> where T: ?core::marker::Sized
-pub fn aya_ebpf::maps::hash_map::HashMap<K, V>::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya_ebpf::maps::hash_map::HashMap<K, V>
-pub fn aya_ebpf::maps::hash_map::HashMap<K, V>::from(t: T) -> T
 #[repr(transparent)] pub struct aya_ebpf::maps::LpmTrie<K, V>
 impl<K, V> aya_ebpf::maps::lpm_trie::LpmTrie<K, V>
 pub fn aya_ebpf::maps::lpm_trie::LpmTrie<K, V>::get(&self, key: impl core::borrow::Borrow<aya_ebpf::maps::lpm_trie::Key<K>>) -> core::option::Option<&V>
@@ -1222,22 +610,6 @@ impl<K, V> core::marker::Unpin for aya_ebpf::maps::lpm_trie::LpmTrie<K, V> where
 impl<K, V> core::marker::UnsafeUnpin for aya_ebpf::maps::lpm_trie::LpmTrie<K, V>
 impl<K, V> !core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::maps::lpm_trie::LpmTrie<K, V>
 impl<K, V> core::panic::unwind_safe::UnwindSafe for aya_ebpf::maps::lpm_trie::LpmTrie<K, V> where K: core::panic::unwind_safe::UnwindSafe, V: core::panic::unwind_safe::UnwindSafe
-impl<T, U> core::convert::Into<U> for aya_ebpf::maps::lpm_trie::LpmTrie<K, V> where U: core::convert::From<T>
-pub fn aya_ebpf::maps::lpm_trie::LpmTrie<K, V>::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf::maps::lpm_trie::LpmTrie<K, V> where U: core::convert::Into<T>
-pub type aya_ebpf::maps::lpm_trie::LpmTrie<K, V>::Error = core::convert::Infallible
-pub fn aya_ebpf::maps::lpm_trie::LpmTrie<K, V>::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf::maps::lpm_trie::LpmTrie<K, V> where U: core::convert::TryFrom<T>
-pub type aya_ebpf::maps::lpm_trie::LpmTrie<K, V>::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf::maps::lpm_trie::LpmTrie<K, V>::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf::maps::lpm_trie::LpmTrie<K, V> where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf::maps::lpm_trie::LpmTrie<K, V>::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf::maps::lpm_trie::LpmTrie<K, V> where T: ?core::marker::Sized
-pub fn aya_ebpf::maps::lpm_trie::LpmTrie<K, V>::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf::maps::lpm_trie::LpmTrie<K, V> where T: ?core::marker::Sized
-pub fn aya_ebpf::maps::lpm_trie::LpmTrie<K, V>::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya_ebpf::maps::lpm_trie::LpmTrie<K, V>
-pub fn aya_ebpf::maps::lpm_trie::LpmTrie<K, V>::from(t: T) -> T
 #[repr(transparent)] pub struct aya_ebpf::maps::LruHashMap<K, V>
 impl<K, V> aya_ebpf::maps::hash_map::LruHashMap<K, V>
 pub unsafe fn aya_ebpf::maps::hash_map::LruHashMap<K, V>::get(&self, key: impl core::borrow::Borrow<K>) -> core::option::Option<&V>
@@ -1254,22 +626,6 @@ impl<K, V> core::marker::Unpin for aya_ebpf::maps::hash_map::LruHashMap<K, V> wh
 impl<K, V> core::marker::UnsafeUnpin for aya_ebpf::maps::hash_map::LruHashMap<K, V>
 impl<K, V> !core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::maps::hash_map::LruHashMap<K, V>
 impl<K, V> core::panic::unwind_safe::UnwindSafe for aya_ebpf::maps::hash_map::LruHashMap<K, V> where K: core::panic::unwind_safe::UnwindSafe, V: core::panic::unwind_safe::UnwindSafe
-impl<T, U> core::convert::Into<U> for aya_ebpf::maps::hash_map::LruHashMap<K, V> where U: core::convert::From<T>
-pub fn aya_ebpf::maps::hash_map::LruHashMap<K, V>::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf::maps::hash_map::LruHashMap<K, V> where U: core::convert::Into<T>
-pub type aya_ebpf::maps::hash_map::LruHashMap<K, V>::Error = core::convert::Infallible
-pub fn aya_ebpf::maps::hash_map::LruHashMap<K, V>::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf::maps::hash_map::LruHashMap<K, V> where U: core::convert::TryFrom<T>
-pub type aya_ebpf::maps::hash_map::LruHashMap<K, V>::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf::maps::hash_map::LruHashMap<K, V>::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf::maps::hash_map::LruHashMap<K, V> where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf::maps::hash_map::LruHashMap<K, V>::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf::maps::hash_map::LruHashMap<K, V> where T: ?core::marker::Sized
-pub fn aya_ebpf::maps::hash_map::LruHashMap<K, V>::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf::maps::hash_map::LruHashMap<K, V> where T: ?core::marker::Sized
-pub fn aya_ebpf::maps::hash_map::LruHashMap<K, V>::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya_ebpf::maps::hash_map::LruHashMap<K, V>
-pub fn aya_ebpf::maps::hash_map::LruHashMap<K, V>::from(t: T) -> T
 #[repr(transparent)] pub struct aya_ebpf::maps::LruPerCpuHashMap<K, V>
 impl<K, V> aya_ebpf::maps::hash_map::LruPerCpuHashMap<K, V>
 pub unsafe fn aya_ebpf::maps::hash_map::LruPerCpuHashMap<K, V>::get(&self, key: impl core::borrow::Borrow<K>) -> core::option::Option<&V>
@@ -1286,22 +642,6 @@ impl<K, V> core::marker::Unpin for aya_ebpf::maps::hash_map::LruPerCpuHashMap<K,
 impl<K, V> core::marker::UnsafeUnpin for aya_ebpf::maps::hash_map::LruPerCpuHashMap<K, V>
 impl<K, V> !core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::maps::hash_map::LruPerCpuHashMap<K, V>
 impl<K, V> core::panic::unwind_safe::UnwindSafe for aya_ebpf::maps::hash_map::LruPerCpuHashMap<K, V> where K: core::panic::unwind_safe::UnwindSafe, V: core::panic::unwind_safe::UnwindSafe
-impl<T, U> core::convert::Into<U> for aya_ebpf::maps::hash_map::LruPerCpuHashMap<K, V> where U: core::convert::From<T>
-pub fn aya_ebpf::maps::hash_map::LruPerCpuHashMap<K, V>::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf::maps::hash_map::LruPerCpuHashMap<K, V> where U: core::convert::Into<T>
-pub type aya_ebpf::maps::hash_map::LruPerCpuHashMap<K, V>::Error = core::convert::Infallible
-pub fn aya_ebpf::maps::hash_map::LruPerCpuHashMap<K, V>::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf::maps::hash_map::LruPerCpuHashMap<K, V> where U: core::convert::TryFrom<T>
-pub type aya_ebpf::maps::hash_map::LruPerCpuHashMap<K, V>::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf::maps::hash_map::LruPerCpuHashMap<K, V>::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf::maps::hash_map::LruPerCpuHashMap<K, V> where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf::maps::hash_map::LruPerCpuHashMap<K, V>::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf::maps::hash_map::LruPerCpuHashMap<K, V> where T: ?core::marker::Sized
-pub fn aya_ebpf::maps::hash_map::LruPerCpuHashMap<K, V>::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf::maps::hash_map::LruPerCpuHashMap<K, V> where T: ?core::marker::Sized
-pub fn aya_ebpf::maps::hash_map::LruPerCpuHashMap<K, V>::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya_ebpf::maps::hash_map::LruPerCpuHashMap<K, V>
-pub fn aya_ebpf::maps::hash_map::LruPerCpuHashMap<K, V>::from(t: T) -> T
 #[repr(transparent)] pub struct aya_ebpf::maps::PerCpuArray<T>
 impl<T> aya_ebpf::maps::per_cpu_array::PerCpuArray<T>
 pub fn aya_ebpf::maps::per_cpu_array::PerCpuArray<T>::get(&self, index: u32) -> core::option::Option<&T>
@@ -1316,22 +656,6 @@ impl<T> core::marker::Unpin for aya_ebpf::maps::per_cpu_array::PerCpuArray<T> wh
 impl<T> core::marker::UnsafeUnpin for aya_ebpf::maps::per_cpu_array::PerCpuArray<T>
 impl<T> !core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::maps::per_cpu_array::PerCpuArray<T>
 impl<T> core::panic::unwind_safe::UnwindSafe for aya_ebpf::maps::per_cpu_array::PerCpuArray<T> where T: core::panic::unwind_safe::UnwindSafe
-impl<T, U> core::convert::Into<U> for aya_ebpf::maps::per_cpu_array::PerCpuArray<T> where U: core::convert::From<T>
-pub fn aya_ebpf::maps::per_cpu_array::PerCpuArray<T>::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf::maps::per_cpu_array::PerCpuArray<T> where U: core::convert::Into<T>
-pub type aya_ebpf::maps::per_cpu_array::PerCpuArray<T>::Error = core::convert::Infallible
-pub fn aya_ebpf::maps::per_cpu_array::PerCpuArray<T>::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf::maps::per_cpu_array::PerCpuArray<T> where U: core::convert::TryFrom<T>
-pub type aya_ebpf::maps::per_cpu_array::PerCpuArray<T>::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf::maps::per_cpu_array::PerCpuArray<T>::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf::maps::per_cpu_array::PerCpuArray<T> where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf::maps::per_cpu_array::PerCpuArray<T>::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf::maps::per_cpu_array::PerCpuArray<T> where T: ?core::marker::Sized
-pub fn aya_ebpf::maps::per_cpu_array::PerCpuArray<T>::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf::maps::per_cpu_array::PerCpuArray<T> where T: ?core::marker::Sized
-pub fn aya_ebpf::maps::per_cpu_array::PerCpuArray<T>::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya_ebpf::maps::per_cpu_array::PerCpuArray<T>
-pub fn aya_ebpf::maps::per_cpu_array::PerCpuArray<T>::from(t: T) -> T
 #[repr(transparent)] pub struct aya_ebpf::maps::PerCpuHashMap<K, V>
 impl<K, V> aya_ebpf::maps::hash_map::PerCpuHashMap<K, V>
 pub unsafe fn aya_ebpf::maps::hash_map::PerCpuHashMap<K, V>::get(&self, key: impl core::borrow::Borrow<K>) -> core::option::Option<&V>
@@ -1348,22 +672,6 @@ impl<K, V> core::marker::Unpin for aya_ebpf::maps::hash_map::PerCpuHashMap<K, V>
 impl<K, V> core::marker::UnsafeUnpin for aya_ebpf::maps::hash_map::PerCpuHashMap<K, V>
 impl<K, V> !core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::maps::hash_map::PerCpuHashMap<K, V>
 impl<K, V> core::panic::unwind_safe::UnwindSafe for aya_ebpf::maps::hash_map::PerCpuHashMap<K, V> where K: core::panic::unwind_safe::UnwindSafe, V: core::panic::unwind_safe::UnwindSafe
-impl<T, U> core::convert::Into<U> for aya_ebpf::maps::hash_map::PerCpuHashMap<K, V> where U: core::convert::From<T>
-pub fn aya_ebpf::maps::hash_map::PerCpuHashMap<K, V>::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf::maps::hash_map::PerCpuHashMap<K, V> where U: core::convert::Into<T>
-pub type aya_ebpf::maps::hash_map::PerCpuHashMap<K, V>::Error = core::convert::Infallible
-pub fn aya_ebpf::maps::hash_map::PerCpuHashMap<K, V>::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf::maps::hash_map::PerCpuHashMap<K, V> where U: core::convert::TryFrom<T>
-pub type aya_ebpf::maps::hash_map::PerCpuHashMap<K, V>::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf::maps::hash_map::PerCpuHashMap<K, V>::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf::maps::hash_map::PerCpuHashMap<K, V> where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf::maps::hash_map::PerCpuHashMap<K, V>::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf::maps::hash_map::PerCpuHashMap<K, V> where T: ?core::marker::Sized
-pub fn aya_ebpf::maps::hash_map::PerCpuHashMap<K, V>::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf::maps::hash_map::PerCpuHashMap<K, V> where T: ?core::marker::Sized
-pub fn aya_ebpf::maps::hash_map::PerCpuHashMap<K, V>::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya_ebpf::maps::hash_map::PerCpuHashMap<K, V>
-pub fn aya_ebpf::maps::hash_map::PerCpuHashMap<K, V>::from(t: T) -> T
 #[repr(transparent)] pub struct aya_ebpf::maps::PerfEventArray<T>
 impl<T> aya_ebpf::maps::PerfEventArray<T>
 pub const fn aya_ebpf::maps::PerfEventArray<T>::new(flags: u32) -> Self
@@ -1377,22 +685,6 @@ impl<T> core::marker::Unpin for aya_ebpf::maps::PerfEventArray<T> where T: core:
 impl<T> core::marker::UnsafeUnpin for aya_ebpf::maps::PerfEventArray<T>
 impl<T> !core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::maps::PerfEventArray<T>
 impl<T> core::panic::unwind_safe::UnwindSafe for aya_ebpf::maps::PerfEventArray<T> where T: core::panic::unwind_safe::UnwindSafe
-impl<T, U> core::convert::Into<U> for aya_ebpf::maps::PerfEventArray<T> where U: core::convert::From<T>
-pub fn aya_ebpf::maps::PerfEventArray<T>::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf::maps::PerfEventArray<T> where U: core::convert::Into<T>
-pub type aya_ebpf::maps::PerfEventArray<T>::Error = core::convert::Infallible
-pub fn aya_ebpf::maps::PerfEventArray<T>::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf::maps::PerfEventArray<T> where U: core::convert::TryFrom<T>
-pub type aya_ebpf::maps::PerfEventArray<T>::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf::maps::PerfEventArray<T>::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf::maps::PerfEventArray<T> where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf::maps::PerfEventArray<T>::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf::maps::PerfEventArray<T> where T: ?core::marker::Sized
-pub fn aya_ebpf::maps::PerfEventArray<T>::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf::maps::PerfEventArray<T> where T: ?core::marker::Sized
-pub fn aya_ebpf::maps::PerfEventArray<T>::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya_ebpf::maps::PerfEventArray<T>
-pub fn aya_ebpf::maps::PerfEventArray<T>::from(t: T) -> T
 #[repr(transparent)] pub struct aya_ebpf::maps::PerfEventByteArray
 impl aya_ebpf::maps::PerfEventByteArray
 pub const fn aya_ebpf::maps::PerfEventByteArray::new(flags: u32) -> Self
@@ -1406,22 +698,6 @@ impl core::marker::Unpin for aya_ebpf::maps::PerfEventByteArray
 impl core::marker::UnsafeUnpin for aya_ebpf::maps::PerfEventByteArray
 impl !core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::maps::PerfEventByteArray
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf::maps::PerfEventByteArray
-impl<T, U> core::convert::Into<U> for aya_ebpf::maps::PerfEventByteArray where U: core::convert::From<T>
-pub fn aya_ebpf::maps::PerfEventByteArray::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf::maps::PerfEventByteArray where U: core::convert::Into<T>
-pub type aya_ebpf::maps::PerfEventByteArray::Error = core::convert::Infallible
-pub fn aya_ebpf::maps::PerfEventByteArray::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf::maps::PerfEventByteArray where U: core::convert::TryFrom<T>
-pub type aya_ebpf::maps::PerfEventByteArray::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf::maps::PerfEventByteArray::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf::maps::PerfEventByteArray where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf::maps::PerfEventByteArray::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf::maps::PerfEventByteArray where T: ?core::marker::Sized
-pub fn aya_ebpf::maps::PerfEventByteArray::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf::maps::PerfEventByteArray where T: ?core::marker::Sized
-pub fn aya_ebpf::maps::PerfEventByteArray::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya_ebpf::maps::PerfEventByteArray
-pub fn aya_ebpf::maps::PerfEventByteArray::from(t: T) -> T
 #[repr(transparent)] pub struct aya_ebpf::maps::ProgramArray
 impl aya_ebpf::maps::program_array::ProgramArray
 pub const fn aya_ebpf::maps::program_array::ProgramArray::pinned(max_entries: u32, flags: u32) -> Self
@@ -1434,22 +710,6 @@ impl core::marker::Unpin for aya_ebpf::maps::program_array::ProgramArray
 impl core::marker::UnsafeUnpin for aya_ebpf::maps::program_array::ProgramArray
 impl !core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::maps::program_array::ProgramArray
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf::maps::program_array::ProgramArray
-impl<T, U> core::convert::Into<U> for aya_ebpf::maps::program_array::ProgramArray where U: core::convert::From<T>
-pub fn aya_ebpf::maps::program_array::ProgramArray::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf::maps::program_array::ProgramArray where U: core::convert::Into<T>
-pub type aya_ebpf::maps::program_array::ProgramArray::Error = core::convert::Infallible
-pub fn aya_ebpf::maps::program_array::ProgramArray::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf::maps::program_array::ProgramArray where U: core::convert::TryFrom<T>
-pub type aya_ebpf::maps::program_array::ProgramArray::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf::maps::program_array::ProgramArray::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf::maps::program_array::ProgramArray where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf::maps::program_array::ProgramArray::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf::maps::program_array::ProgramArray where T: ?core::marker::Sized
-pub fn aya_ebpf::maps::program_array::ProgramArray::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf::maps::program_array::ProgramArray where T: ?core::marker::Sized
-pub fn aya_ebpf::maps::program_array::ProgramArray::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya_ebpf::maps::program_array::ProgramArray
-pub fn aya_ebpf::maps::program_array::ProgramArray::from(t: T) -> T
 #[repr(transparent)] pub struct aya_ebpf::maps::Queue<T>
 impl<T> aya_ebpf::maps::queue::Queue<T>
 pub fn aya_ebpf::maps::queue::Queue<T>::peek(&self) -> core::option::Option<T>
@@ -1464,22 +724,6 @@ impl<T> core::marker::Unpin for aya_ebpf::maps::queue::Queue<T> where T: core::m
 impl<T> core::marker::UnsafeUnpin for aya_ebpf::maps::queue::Queue<T>
 impl<T> !core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::maps::queue::Queue<T>
 impl<T> core::panic::unwind_safe::UnwindSafe for aya_ebpf::maps::queue::Queue<T> where T: core::panic::unwind_safe::UnwindSafe
-impl<T, U> core::convert::Into<U> for aya_ebpf::maps::queue::Queue<T> where U: core::convert::From<T>
-pub fn aya_ebpf::maps::queue::Queue<T>::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf::maps::queue::Queue<T> where U: core::convert::Into<T>
-pub type aya_ebpf::maps::queue::Queue<T>::Error = core::convert::Infallible
-pub fn aya_ebpf::maps::queue::Queue<T>::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf::maps::queue::Queue<T> where U: core::convert::TryFrom<T>
-pub type aya_ebpf::maps::queue::Queue<T>::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf::maps::queue::Queue<T>::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf::maps::queue::Queue<T> where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf::maps::queue::Queue<T>::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf::maps::queue::Queue<T> where T: ?core::marker::Sized
-pub fn aya_ebpf::maps::queue::Queue<T>::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf::maps::queue::Queue<T> where T: ?core::marker::Sized
-pub fn aya_ebpf::maps::queue::Queue<T>::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya_ebpf::maps::queue::Queue<T>
-pub fn aya_ebpf::maps::queue::Queue<T>::from(t: T) -> T
 #[repr(transparent)] pub struct aya_ebpf::maps::RingBuf
 impl aya_ebpf::maps::ring_buf::RingBuf
 pub fn aya_ebpf::maps::ring_buf::RingBuf::output<T: ?core::marker::Sized>(&self, data: impl core::borrow::Borrow<T>, flags: u64) -> core::result::Result<(), i64>
@@ -1495,22 +739,6 @@ impl core::marker::Unpin for aya_ebpf::maps::ring_buf::RingBuf
 impl core::marker::UnsafeUnpin for aya_ebpf::maps::ring_buf::RingBuf
 impl !core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::maps::ring_buf::RingBuf
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf::maps::ring_buf::RingBuf
-impl<T, U> core::convert::Into<U> for aya_ebpf::maps::ring_buf::RingBuf where U: core::convert::From<T>
-pub fn aya_ebpf::maps::ring_buf::RingBuf::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf::maps::ring_buf::RingBuf where U: core::convert::Into<T>
-pub type aya_ebpf::maps::ring_buf::RingBuf::Error = core::convert::Infallible
-pub fn aya_ebpf::maps::ring_buf::RingBuf::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf::maps::ring_buf::RingBuf where U: core::convert::TryFrom<T>
-pub type aya_ebpf::maps::ring_buf::RingBuf::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf::maps::ring_buf::RingBuf::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf::maps::ring_buf::RingBuf where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf::maps::ring_buf::RingBuf::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf::maps::ring_buf::RingBuf where T: ?core::marker::Sized
-pub fn aya_ebpf::maps::ring_buf::RingBuf::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf::maps::ring_buf::RingBuf where T: ?core::marker::Sized
-pub fn aya_ebpf::maps::ring_buf::RingBuf::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya_ebpf::maps::ring_buf::RingBuf
-pub fn aya_ebpf::maps::ring_buf::RingBuf::from(t: T) -> T
 #[repr(transparent)] pub struct aya_ebpf::maps::SockHash<K>
 impl<K> aya_ebpf::maps::sock_hash::SockHash<K>
 pub const fn aya_ebpf::maps::sock_hash::SockHash<K>::pinned(max_entries: u32, flags: u32) -> Self
@@ -1526,22 +754,6 @@ impl<K> core::marker::Unpin for aya_ebpf::maps::sock_hash::SockHash<K> where K: 
 impl<K> core::marker::UnsafeUnpin for aya_ebpf::maps::sock_hash::SockHash<K>
 impl<K> !core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::maps::sock_hash::SockHash<K>
 impl<K> core::panic::unwind_safe::UnwindSafe for aya_ebpf::maps::sock_hash::SockHash<K> where K: core::panic::unwind_safe::UnwindSafe
-impl<T, U> core::convert::Into<U> for aya_ebpf::maps::sock_hash::SockHash<K> where U: core::convert::From<T>
-pub fn aya_ebpf::maps::sock_hash::SockHash<K>::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf::maps::sock_hash::SockHash<K> where U: core::convert::Into<T>
-pub type aya_ebpf::maps::sock_hash::SockHash<K>::Error = core::convert::Infallible
-pub fn aya_ebpf::maps::sock_hash::SockHash<K>::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf::maps::sock_hash::SockHash<K> where U: core::convert::TryFrom<T>
-pub type aya_ebpf::maps::sock_hash::SockHash<K>::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf::maps::sock_hash::SockHash<K>::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf::maps::sock_hash::SockHash<K> where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf::maps::sock_hash::SockHash<K>::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf::maps::sock_hash::SockHash<K> where T: ?core::marker::Sized
-pub fn aya_ebpf::maps::sock_hash::SockHash<K>::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf::maps::sock_hash::SockHash<K> where T: ?core::marker::Sized
-pub fn aya_ebpf::maps::sock_hash::SockHash<K>::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya_ebpf::maps::sock_hash::SockHash<K>
-pub fn aya_ebpf::maps::sock_hash::SockHash<K>::from(t: T) -> T
 #[repr(transparent)] pub struct aya_ebpf::maps::SockMap
 impl aya_ebpf::maps::sock_map::SockMap
 pub const fn aya_ebpf::maps::sock_map::SockMap::pinned(max_entries: u32, flags: u32) -> Self
@@ -1557,22 +769,6 @@ impl core::marker::Unpin for aya_ebpf::maps::sock_map::SockMap
 impl core::marker::UnsafeUnpin for aya_ebpf::maps::sock_map::SockMap
 impl !core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::maps::sock_map::SockMap
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf::maps::sock_map::SockMap
-impl<T, U> core::convert::Into<U> for aya_ebpf::maps::sock_map::SockMap where U: core::convert::From<T>
-pub fn aya_ebpf::maps::sock_map::SockMap::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf::maps::sock_map::SockMap where U: core::convert::Into<T>
-pub type aya_ebpf::maps::sock_map::SockMap::Error = core::convert::Infallible
-pub fn aya_ebpf::maps::sock_map::SockMap::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf::maps::sock_map::SockMap where U: core::convert::TryFrom<T>
-pub type aya_ebpf::maps::sock_map::SockMap::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf::maps::sock_map::SockMap::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf::maps::sock_map::SockMap where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf::maps::sock_map::SockMap::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf::maps::sock_map::SockMap where T: ?core::marker::Sized
-pub fn aya_ebpf::maps::sock_map::SockMap::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf::maps::sock_map::SockMap where T: ?core::marker::Sized
-pub fn aya_ebpf::maps::sock_map::SockMap::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya_ebpf::maps::sock_map::SockMap
-pub fn aya_ebpf::maps::sock_map::SockMap::from(t: T) -> T
 #[repr(transparent)] pub struct aya_ebpf::maps::Stack<T>
 impl<T> aya_ebpf::maps::stack::Stack<T>
 pub fn aya_ebpf::maps::stack::Stack<T>::peek(&self) -> core::option::Option<T>
@@ -1587,22 +783,6 @@ impl<T> core::marker::Unpin for aya_ebpf::maps::stack::Stack<T> where T: core::m
 impl<T> core::marker::UnsafeUnpin for aya_ebpf::maps::stack::Stack<T>
 impl<T> !core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::maps::stack::Stack<T>
 impl<T> core::panic::unwind_safe::UnwindSafe for aya_ebpf::maps::stack::Stack<T> where T: core::panic::unwind_safe::UnwindSafe
-impl<T, U> core::convert::Into<U> for aya_ebpf::maps::stack::Stack<T> where U: core::convert::From<T>
-pub fn aya_ebpf::maps::stack::Stack<T>::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf::maps::stack::Stack<T> where U: core::convert::Into<T>
-pub type aya_ebpf::maps::stack::Stack<T>::Error = core::convert::Infallible
-pub fn aya_ebpf::maps::stack::Stack<T>::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf::maps::stack::Stack<T> where U: core::convert::TryFrom<T>
-pub type aya_ebpf::maps::stack::Stack<T>::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf::maps::stack::Stack<T>::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf::maps::stack::Stack<T> where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf::maps::stack::Stack<T>::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf::maps::stack::Stack<T> where T: ?core::marker::Sized
-pub fn aya_ebpf::maps::stack::Stack<T>::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf::maps::stack::Stack<T> where T: ?core::marker::Sized
-pub fn aya_ebpf::maps::stack::Stack<T>::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya_ebpf::maps::stack::Stack<T>
-pub fn aya_ebpf::maps::stack::Stack<T>::from(t: T) -> T
 #[repr(transparent)] pub struct aya_ebpf::maps::StackTrace
 impl aya_ebpf::maps::stack_trace::StackTrace
 pub unsafe fn aya_ebpf::maps::stack_trace::StackTrace::get_stackid<C: aya_ebpf::EbpfContext>(&self, ctx: impl core::borrow::Borrow<C>, flags: u64) -> core::result::Result<i64, i64>
@@ -1615,22 +795,6 @@ impl core::marker::Unpin for aya_ebpf::maps::stack_trace::StackTrace
 impl core::marker::UnsafeUnpin for aya_ebpf::maps::stack_trace::StackTrace
 impl !core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::maps::stack_trace::StackTrace
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf::maps::stack_trace::StackTrace
-impl<T, U> core::convert::Into<U> for aya_ebpf::maps::stack_trace::StackTrace where U: core::convert::From<T>
-pub fn aya_ebpf::maps::stack_trace::StackTrace::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf::maps::stack_trace::StackTrace where U: core::convert::Into<T>
-pub type aya_ebpf::maps::stack_trace::StackTrace::Error = core::convert::Infallible
-pub fn aya_ebpf::maps::stack_trace::StackTrace::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf::maps::stack_trace::StackTrace where U: core::convert::TryFrom<T>
-pub type aya_ebpf::maps::stack_trace::StackTrace::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf::maps::stack_trace::StackTrace::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf::maps::stack_trace::StackTrace where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf::maps::stack_trace::StackTrace::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf::maps::stack_trace::StackTrace where T: ?core::marker::Sized
-pub fn aya_ebpf::maps::stack_trace::StackTrace::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf::maps::stack_trace::StackTrace where T: ?core::marker::Sized
-pub fn aya_ebpf::maps::stack_trace::StackTrace::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya_ebpf::maps::stack_trace::StackTrace
-pub fn aya_ebpf::maps::stack_trace::StackTrace::from(t: T) -> T
 #[repr(transparent)] pub struct aya_ebpf::maps::XskMap
 impl aya_ebpf::maps::XskMap
 pub fn aya_ebpf::maps::XskMap::get(&self, index: u32) -> core::option::Option<u32>
@@ -1644,22 +808,6 @@ impl core::marker::Unpin for aya_ebpf::maps::XskMap
 impl core::marker::UnsafeUnpin for aya_ebpf::maps::XskMap
 impl !core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::maps::XskMap
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf::maps::XskMap
-impl<T, U> core::convert::Into<U> for aya_ebpf::maps::XskMap where U: core::convert::From<T>
-pub fn aya_ebpf::maps::XskMap::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf::maps::XskMap where U: core::convert::Into<T>
-pub type aya_ebpf::maps::XskMap::Error = core::convert::Infallible
-pub fn aya_ebpf::maps::XskMap::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf::maps::XskMap where U: core::convert::TryFrom<T>
-pub type aya_ebpf::maps::XskMap::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf::maps::XskMap::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf::maps::XskMap where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf::maps::XskMap::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf::maps::XskMap where T: ?core::marker::Sized
-pub fn aya_ebpf::maps::XskMap::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf::maps::XskMap where T: ?core::marker::Sized
-pub fn aya_ebpf::maps::XskMap::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya_ebpf::maps::XskMap
-pub fn aya_ebpf::maps::XskMap::from(t: T) -> T
 pub mod aya_ebpf::programs
 pub mod aya_ebpf::programs::device
 pub struct aya_ebpf::programs::device::DeviceContext
@@ -1680,22 +828,6 @@ impl core::marker::Unpin for aya_ebpf::programs::device::DeviceContext
 impl core::marker::UnsafeUnpin for aya_ebpf::programs::device::DeviceContext
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::programs::device::DeviceContext
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf::programs::device::DeviceContext
-impl<T, U> core::convert::Into<U> for aya_ebpf::programs::device::DeviceContext where U: core::convert::From<T>
-pub fn aya_ebpf::programs::device::DeviceContext::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf::programs::device::DeviceContext where U: core::convert::Into<T>
-pub type aya_ebpf::programs::device::DeviceContext::Error = core::convert::Infallible
-pub fn aya_ebpf::programs::device::DeviceContext::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf::programs::device::DeviceContext where U: core::convert::TryFrom<T>
-pub type aya_ebpf::programs::device::DeviceContext::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf::programs::device::DeviceContext::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf::programs::device::DeviceContext where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf::programs::device::DeviceContext::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf::programs::device::DeviceContext where T: ?core::marker::Sized
-pub fn aya_ebpf::programs::device::DeviceContext::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf::programs::device::DeviceContext where T: ?core::marker::Sized
-pub fn aya_ebpf::programs::device::DeviceContext::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya_ebpf::programs::device::DeviceContext
-pub fn aya_ebpf::programs::device::DeviceContext::from(t: T) -> T
 pub mod aya_ebpf::programs::fentry
 pub struct aya_ebpf::programs::fentry::FEntryContext
 impl aya_ebpf::programs::fentry::FEntryContext
@@ -1715,22 +847,6 @@ impl core::marker::Unpin for aya_ebpf::programs::fentry::FEntryContext
 impl core::marker::UnsafeUnpin for aya_ebpf::programs::fentry::FEntryContext
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::programs::fentry::FEntryContext
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf::programs::fentry::FEntryContext
-impl<T, U> core::convert::Into<U> for aya_ebpf::programs::fentry::FEntryContext where U: core::convert::From<T>
-pub fn aya_ebpf::programs::fentry::FEntryContext::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf::programs::fentry::FEntryContext where U: core::convert::Into<T>
-pub type aya_ebpf::programs::fentry::FEntryContext::Error = core::convert::Infallible
-pub fn aya_ebpf::programs::fentry::FEntryContext::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf::programs::fentry::FEntryContext where U: core::convert::TryFrom<T>
-pub type aya_ebpf::programs::fentry::FEntryContext::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf::programs::fentry::FEntryContext::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf::programs::fentry::FEntryContext where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf::programs::fentry::FEntryContext::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf::programs::fentry::FEntryContext where T: ?core::marker::Sized
-pub fn aya_ebpf::programs::fentry::FEntryContext::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf::programs::fentry::FEntryContext where T: ?core::marker::Sized
-pub fn aya_ebpf::programs::fentry::FEntryContext::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya_ebpf::programs::fentry::FEntryContext
-pub fn aya_ebpf::programs::fentry::FEntryContext::from(t: T) -> T
 pub mod aya_ebpf::programs::fexit
 pub struct aya_ebpf::programs::fexit::FExitContext
 impl aya_ebpf::programs::fexit::FExitContext
@@ -1750,22 +866,6 @@ impl core::marker::Unpin for aya_ebpf::programs::fexit::FExitContext
 impl core::marker::UnsafeUnpin for aya_ebpf::programs::fexit::FExitContext
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::programs::fexit::FExitContext
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf::programs::fexit::FExitContext
-impl<T, U> core::convert::Into<U> for aya_ebpf::programs::fexit::FExitContext where U: core::convert::From<T>
-pub fn aya_ebpf::programs::fexit::FExitContext::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf::programs::fexit::FExitContext where U: core::convert::Into<T>
-pub type aya_ebpf::programs::fexit::FExitContext::Error = core::convert::Infallible
-pub fn aya_ebpf::programs::fexit::FExitContext::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf::programs::fexit::FExitContext where U: core::convert::TryFrom<T>
-pub type aya_ebpf::programs::fexit::FExitContext::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf::programs::fexit::FExitContext::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf::programs::fexit::FExitContext where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf::programs::fexit::FExitContext::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf::programs::fexit::FExitContext where T: ?core::marker::Sized
-pub fn aya_ebpf::programs::fexit::FExitContext::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf::programs::fexit::FExitContext where T: ?core::marker::Sized
-pub fn aya_ebpf::programs::fexit::FExitContext::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya_ebpf::programs::fexit::FExitContext
-pub fn aya_ebpf::programs::fexit::FExitContext::from(t: T) -> T
 pub mod aya_ebpf::programs::flow_dissector
 pub struct aya_ebpf::programs::flow_dissector::FlowDissectorContext
 impl aya_ebpf::programs::flow_dissector::FlowDissectorContext
@@ -1788,22 +888,6 @@ impl core::marker::Unpin for aya_ebpf::programs::flow_dissector::FlowDissectorCo
 impl core::marker::UnsafeUnpin for aya_ebpf::programs::flow_dissector::FlowDissectorContext
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::programs::flow_dissector::FlowDissectorContext
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf::programs::flow_dissector::FlowDissectorContext
-impl<T, U> core::convert::Into<U> for aya_ebpf::programs::flow_dissector::FlowDissectorContext where U: core::convert::From<T>
-pub fn aya_ebpf::programs::flow_dissector::FlowDissectorContext::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf::programs::flow_dissector::FlowDissectorContext where U: core::convert::Into<T>
-pub type aya_ebpf::programs::flow_dissector::FlowDissectorContext::Error = core::convert::Infallible
-pub fn aya_ebpf::programs::flow_dissector::FlowDissectorContext::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf::programs::flow_dissector::FlowDissectorContext where U: core::convert::TryFrom<T>
-pub type aya_ebpf::programs::flow_dissector::FlowDissectorContext::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf::programs::flow_dissector::FlowDissectorContext::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf::programs::flow_dissector::FlowDissectorContext where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf::programs::flow_dissector::FlowDissectorContext::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf::programs::flow_dissector::FlowDissectorContext where T: ?core::marker::Sized
-pub fn aya_ebpf::programs::flow_dissector::FlowDissectorContext::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf::programs::flow_dissector::FlowDissectorContext where T: ?core::marker::Sized
-pub fn aya_ebpf::programs::flow_dissector::FlowDissectorContext::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya_ebpf::programs::flow_dissector::FlowDissectorContext
-pub fn aya_ebpf::programs::flow_dissector::FlowDissectorContext::from(t: T) -> T
 pub mod aya_ebpf::programs::lsm
 pub struct aya_ebpf::programs::lsm::LsmContext
 impl aya_ebpf::programs::lsm::LsmContext
@@ -1823,22 +907,6 @@ impl core::marker::Unpin for aya_ebpf::programs::lsm::LsmContext
 impl core::marker::UnsafeUnpin for aya_ebpf::programs::lsm::LsmContext
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::programs::lsm::LsmContext
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf::programs::lsm::LsmContext
-impl<T, U> core::convert::Into<U> for aya_ebpf::programs::lsm::LsmContext where U: core::convert::From<T>
-pub fn aya_ebpf::programs::lsm::LsmContext::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf::programs::lsm::LsmContext where U: core::convert::Into<T>
-pub type aya_ebpf::programs::lsm::LsmContext::Error = core::convert::Infallible
-pub fn aya_ebpf::programs::lsm::LsmContext::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf::programs::lsm::LsmContext where U: core::convert::TryFrom<T>
-pub type aya_ebpf::programs::lsm::LsmContext::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf::programs::lsm::LsmContext::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf::programs::lsm::LsmContext where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf::programs::lsm::LsmContext::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf::programs::lsm::LsmContext where T: ?core::marker::Sized
-pub fn aya_ebpf::programs::lsm::LsmContext::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf::programs::lsm::LsmContext where T: ?core::marker::Sized
-pub fn aya_ebpf::programs::lsm::LsmContext::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya_ebpf::programs::lsm::LsmContext
-pub fn aya_ebpf::programs::lsm::LsmContext::from(t: T) -> T
 pub mod aya_ebpf::programs::perf_event
 pub struct aya_ebpf::programs::perf_event::PerfEventContext
 pub aya_ebpf::programs::perf_event::PerfEventContext::ctx: *mut aya_ebpf_bindings::x86_64::bindings::bpf_perf_event_data
@@ -1858,22 +926,6 @@ impl core::marker::Unpin for aya_ebpf::programs::perf_event::PerfEventContext
 impl core::marker::UnsafeUnpin for aya_ebpf::programs::perf_event::PerfEventContext
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::programs::perf_event::PerfEventContext
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf::programs::perf_event::PerfEventContext
-impl<T, U> core::convert::Into<U> for aya_ebpf::programs::perf_event::PerfEventContext where U: core::convert::From<T>
-pub fn aya_ebpf::programs::perf_event::PerfEventContext::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf::programs::perf_event::PerfEventContext where U: core::convert::Into<T>
-pub type aya_ebpf::programs::perf_event::PerfEventContext::Error = core::convert::Infallible
-pub fn aya_ebpf::programs::perf_event::PerfEventContext::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf::programs::perf_event::PerfEventContext where U: core::convert::TryFrom<T>
-pub type aya_ebpf::programs::perf_event::PerfEventContext::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf::programs::perf_event::PerfEventContext::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf::programs::perf_event::PerfEventContext where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf::programs::perf_event::PerfEventContext::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf::programs::perf_event::PerfEventContext where T: ?core::marker::Sized
-pub fn aya_ebpf::programs::perf_event::PerfEventContext::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf::programs::perf_event::PerfEventContext where T: ?core::marker::Sized
-pub fn aya_ebpf::programs::perf_event::PerfEventContext::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya_ebpf::programs::perf_event::PerfEventContext
-pub fn aya_ebpf::programs::perf_event::PerfEventContext::from(t: T) -> T
 pub mod aya_ebpf::programs::probe
 pub struct aya_ebpf::programs::probe::ProbeContext
 pub aya_ebpf::programs::probe::ProbeContext::regs: *mut aya_ebpf_bindings::x86_64::bindings::pt_regs
@@ -1894,22 +946,6 @@ impl core::marker::Unpin for aya_ebpf::programs::probe::ProbeContext
 impl core::marker::UnsafeUnpin for aya_ebpf::programs::probe::ProbeContext
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::programs::probe::ProbeContext
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf::programs::probe::ProbeContext
-impl<T, U> core::convert::Into<U> for aya_ebpf::programs::probe::ProbeContext where U: core::convert::From<T>
-pub fn aya_ebpf::programs::probe::ProbeContext::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf::programs::probe::ProbeContext where U: core::convert::Into<T>
-pub type aya_ebpf::programs::probe::ProbeContext::Error = core::convert::Infallible
-pub fn aya_ebpf::programs::probe::ProbeContext::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf::programs::probe::ProbeContext where U: core::convert::TryFrom<T>
-pub type aya_ebpf::programs::probe::ProbeContext::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf::programs::probe::ProbeContext::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf::programs::probe::ProbeContext where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf::programs::probe::ProbeContext::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf::programs::probe::ProbeContext where T: ?core::marker::Sized
-pub fn aya_ebpf::programs::probe::ProbeContext::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf::programs::probe::ProbeContext where T: ?core::marker::Sized
-pub fn aya_ebpf::programs::probe::ProbeContext::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya_ebpf::programs::probe::ProbeContext
-pub fn aya_ebpf::programs::probe::ProbeContext::from(t: T) -> T
 pub mod aya_ebpf::programs::raw_tracepoint
 pub struct aya_ebpf::programs::raw_tracepoint::RawTracePointContext
 impl aya_ebpf::programs::raw_tracepoint::RawTracePointContext
@@ -1929,22 +965,6 @@ impl core::marker::Unpin for aya_ebpf::programs::raw_tracepoint::RawTracePointCo
 impl core::marker::UnsafeUnpin for aya_ebpf::programs::raw_tracepoint::RawTracePointContext
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::programs::raw_tracepoint::RawTracePointContext
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf::programs::raw_tracepoint::RawTracePointContext
-impl<T, U> core::convert::Into<U> for aya_ebpf::programs::raw_tracepoint::RawTracePointContext where U: core::convert::From<T>
-pub fn aya_ebpf::programs::raw_tracepoint::RawTracePointContext::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf::programs::raw_tracepoint::RawTracePointContext where U: core::convert::Into<T>
-pub type aya_ebpf::programs::raw_tracepoint::RawTracePointContext::Error = core::convert::Infallible
-pub fn aya_ebpf::programs::raw_tracepoint::RawTracePointContext::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf::programs::raw_tracepoint::RawTracePointContext where U: core::convert::TryFrom<T>
-pub type aya_ebpf::programs::raw_tracepoint::RawTracePointContext::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf::programs::raw_tracepoint::RawTracePointContext::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf::programs::raw_tracepoint::RawTracePointContext where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf::programs::raw_tracepoint::RawTracePointContext::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf::programs::raw_tracepoint::RawTracePointContext where T: ?core::marker::Sized
-pub fn aya_ebpf::programs::raw_tracepoint::RawTracePointContext::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf::programs::raw_tracepoint::RawTracePointContext where T: ?core::marker::Sized
-pub fn aya_ebpf::programs::raw_tracepoint::RawTracePointContext::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya_ebpf::programs::raw_tracepoint::RawTracePointContext
-pub fn aya_ebpf::programs::raw_tracepoint::RawTracePointContext::from(t: T) -> T
 pub mod aya_ebpf::programs::retprobe
 pub struct aya_ebpf::programs::retprobe::RetProbeContext
 pub aya_ebpf::programs::retprobe::RetProbeContext::regs: *mut aya_ebpf_bindings::x86_64::bindings::pt_regs
@@ -1965,22 +985,6 @@ impl core::marker::Unpin for aya_ebpf::programs::retprobe::RetProbeContext
 impl core::marker::UnsafeUnpin for aya_ebpf::programs::retprobe::RetProbeContext
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::programs::retprobe::RetProbeContext
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf::programs::retprobe::RetProbeContext
-impl<T, U> core::convert::Into<U> for aya_ebpf::programs::retprobe::RetProbeContext where U: core::convert::From<T>
-pub fn aya_ebpf::programs::retprobe::RetProbeContext::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf::programs::retprobe::RetProbeContext where U: core::convert::Into<T>
-pub type aya_ebpf::programs::retprobe::RetProbeContext::Error = core::convert::Infallible
-pub fn aya_ebpf::programs::retprobe::RetProbeContext::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf::programs::retprobe::RetProbeContext where U: core::convert::TryFrom<T>
-pub type aya_ebpf::programs::retprobe::RetProbeContext::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf::programs::retprobe::RetProbeContext::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf::programs::retprobe::RetProbeContext where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf::programs::retprobe::RetProbeContext::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf::programs::retprobe::RetProbeContext where T: ?core::marker::Sized
-pub fn aya_ebpf::programs::retprobe::RetProbeContext::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf::programs::retprobe::RetProbeContext where T: ?core::marker::Sized
-pub fn aya_ebpf::programs::retprobe::RetProbeContext::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya_ebpf::programs::retprobe::RetProbeContext
-pub fn aya_ebpf::programs::retprobe::RetProbeContext::from(t: T) -> T
 pub mod aya_ebpf::programs::sk_buff
 pub struct aya_ebpf::programs::sk_buff::SkBuff
 pub aya_ebpf::programs::sk_buff::SkBuff::skb: *mut aya_ebpf_bindings::x86_64::bindings::__sk_buff
@@ -2016,22 +1020,6 @@ impl core::marker::Unpin for aya_ebpf::programs::sk_buff::SkBuff
 impl core::marker::UnsafeUnpin for aya_ebpf::programs::sk_buff::SkBuff
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::programs::sk_buff::SkBuff
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf::programs::sk_buff::SkBuff
-impl<T, U> core::convert::Into<U> for aya_ebpf::programs::sk_buff::SkBuff where U: core::convert::From<T>
-pub fn aya_ebpf::programs::sk_buff::SkBuff::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf::programs::sk_buff::SkBuff where U: core::convert::Into<T>
-pub type aya_ebpf::programs::sk_buff::SkBuff::Error = core::convert::Infallible
-pub fn aya_ebpf::programs::sk_buff::SkBuff::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf::programs::sk_buff::SkBuff where U: core::convert::TryFrom<T>
-pub type aya_ebpf::programs::sk_buff::SkBuff::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf::programs::sk_buff::SkBuff::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf::programs::sk_buff::SkBuff where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf::programs::sk_buff::SkBuff::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf::programs::sk_buff::SkBuff where T: ?core::marker::Sized
-pub fn aya_ebpf::programs::sk_buff::SkBuff::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf::programs::sk_buff::SkBuff where T: ?core::marker::Sized
-pub fn aya_ebpf::programs::sk_buff::SkBuff::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya_ebpf::programs::sk_buff::SkBuff
-pub fn aya_ebpf::programs::sk_buff::SkBuff::from(t: T) -> T
 pub struct aya_ebpf::programs::sk_buff::SkBuffContext
 pub aya_ebpf::programs::sk_buff::SkBuffContext::skb: aya_ebpf::programs::sk_buff::SkBuff
 impl aya_ebpf::programs::sk_buff::SkBuffContext
@@ -2064,22 +1052,6 @@ impl core::marker::Unpin for aya_ebpf::programs::sk_buff::SkBuffContext
 impl core::marker::UnsafeUnpin for aya_ebpf::programs::sk_buff::SkBuffContext
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::programs::sk_buff::SkBuffContext
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf::programs::sk_buff::SkBuffContext
-impl<T, U> core::convert::Into<U> for aya_ebpf::programs::sk_buff::SkBuffContext where U: core::convert::From<T>
-pub fn aya_ebpf::programs::sk_buff::SkBuffContext::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf::programs::sk_buff::SkBuffContext where U: core::convert::Into<T>
-pub type aya_ebpf::programs::sk_buff::SkBuffContext::Error = core::convert::Infallible
-pub fn aya_ebpf::programs::sk_buff::SkBuffContext::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf::programs::sk_buff::SkBuffContext where U: core::convert::TryFrom<T>
-pub type aya_ebpf::programs::sk_buff::SkBuffContext::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf::programs::sk_buff::SkBuffContext::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf::programs::sk_buff::SkBuffContext where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf::programs::sk_buff::SkBuffContext::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf::programs::sk_buff::SkBuffContext where T: ?core::marker::Sized
-pub fn aya_ebpf::programs::sk_buff::SkBuffContext::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf::programs::sk_buff::SkBuffContext where T: ?core::marker::Sized
-pub fn aya_ebpf::programs::sk_buff::SkBuffContext::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya_ebpf::programs::sk_buff::SkBuffContext
-pub fn aya_ebpf::programs::sk_buff::SkBuffContext::from(t: T) -> T
 pub mod aya_ebpf::programs::sk_lookup
 pub struct aya_ebpf::programs::sk_lookup::SkLookupContext
 pub aya_ebpf::programs::sk_lookup::SkLookupContext::lookup: *mut aya_ebpf_bindings::x86_64::bindings::bpf_sk_lookup
@@ -2099,22 +1071,6 @@ impl core::marker::Unpin for aya_ebpf::programs::sk_lookup::SkLookupContext
 impl core::marker::UnsafeUnpin for aya_ebpf::programs::sk_lookup::SkLookupContext
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::programs::sk_lookup::SkLookupContext
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf::programs::sk_lookup::SkLookupContext
-impl<T, U> core::convert::Into<U> for aya_ebpf::programs::sk_lookup::SkLookupContext where U: core::convert::From<T>
-pub fn aya_ebpf::programs::sk_lookup::SkLookupContext::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf::programs::sk_lookup::SkLookupContext where U: core::convert::Into<T>
-pub type aya_ebpf::programs::sk_lookup::SkLookupContext::Error = core::convert::Infallible
-pub fn aya_ebpf::programs::sk_lookup::SkLookupContext::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf::programs::sk_lookup::SkLookupContext where U: core::convert::TryFrom<T>
-pub type aya_ebpf::programs::sk_lookup::SkLookupContext::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf::programs::sk_lookup::SkLookupContext::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf::programs::sk_lookup::SkLookupContext where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf::programs::sk_lookup::SkLookupContext::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf::programs::sk_lookup::SkLookupContext where T: ?core::marker::Sized
-pub fn aya_ebpf::programs::sk_lookup::SkLookupContext::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf::programs::sk_lookup::SkLookupContext where T: ?core::marker::Sized
-pub fn aya_ebpf::programs::sk_lookup::SkLookupContext::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya_ebpf::programs::sk_lookup::SkLookupContext
-pub fn aya_ebpf::programs::sk_lookup::SkLookupContext::from(t: T) -> T
 pub mod aya_ebpf::programs::sk_msg
 pub struct aya_ebpf::programs::sk_msg::SkMsgContext
 pub aya_ebpf::programs::sk_msg::SkMsgContext::msg: *mut aya_ebpf_bindings::x86_64::bindings::sk_msg_md
@@ -2139,22 +1095,6 @@ impl core::marker::Unpin for aya_ebpf::programs::sk_msg::SkMsgContext
 impl core::marker::UnsafeUnpin for aya_ebpf::programs::sk_msg::SkMsgContext
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::programs::sk_msg::SkMsgContext
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf::programs::sk_msg::SkMsgContext
-impl<T, U> core::convert::Into<U> for aya_ebpf::programs::sk_msg::SkMsgContext where U: core::convert::From<T>
-pub fn aya_ebpf::programs::sk_msg::SkMsgContext::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf::programs::sk_msg::SkMsgContext where U: core::convert::Into<T>
-pub type aya_ebpf::programs::sk_msg::SkMsgContext::Error = core::convert::Infallible
-pub fn aya_ebpf::programs::sk_msg::SkMsgContext::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf::programs::sk_msg::SkMsgContext where U: core::convert::TryFrom<T>
-pub type aya_ebpf::programs::sk_msg::SkMsgContext::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf::programs::sk_msg::SkMsgContext::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf::programs::sk_msg::SkMsgContext where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf::programs::sk_msg::SkMsgContext::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf::programs::sk_msg::SkMsgContext where T: ?core::marker::Sized
-pub fn aya_ebpf::programs::sk_msg::SkMsgContext::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf::programs::sk_msg::SkMsgContext where T: ?core::marker::Sized
-pub fn aya_ebpf::programs::sk_msg::SkMsgContext::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya_ebpf::programs::sk_msg::SkMsgContext
-pub fn aya_ebpf::programs::sk_msg::SkMsgContext::from(t: T) -> T
 pub mod aya_ebpf::programs::sock
 pub struct aya_ebpf::programs::sock::SockContext
 pub aya_ebpf::programs::sock::SockContext::sock: *mut aya_ebpf_bindings::x86_64::bindings::bpf_sock
@@ -2174,22 +1114,6 @@ impl core::marker::Unpin for aya_ebpf::programs::sock::SockContext
 impl core::marker::UnsafeUnpin for aya_ebpf::programs::sock::SockContext
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::programs::sock::SockContext
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf::programs::sock::SockContext
-impl<T, U> core::convert::Into<U> for aya_ebpf::programs::sock::SockContext where U: core::convert::From<T>
-pub fn aya_ebpf::programs::sock::SockContext::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf::programs::sock::SockContext where U: core::convert::Into<T>
-pub type aya_ebpf::programs::sock::SockContext::Error = core::convert::Infallible
-pub fn aya_ebpf::programs::sock::SockContext::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf::programs::sock::SockContext where U: core::convert::TryFrom<T>
-pub type aya_ebpf::programs::sock::SockContext::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf::programs::sock::SockContext::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf::programs::sock::SockContext where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf::programs::sock::SockContext::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf::programs::sock::SockContext where T: ?core::marker::Sized
-pub fn aya_ebpf::programs::sock::SockContext::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf::programs::sock::SockContext where T: ?core::marker::Sized
-pub fn aya_ebpf::programs::sock::SockContext::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya_ebpf::programs::sock::SockContext
-pub fn aya_ebpf::programs::sock::SockContext::from(t: T) -> T
 pub mod aya_ebpf::programs::sock_addr
 pub struct aya_ebpf::programs::sock_addr::SockAddrContext
 pub aya_ebpf::programs::sock_addr::SockAddrContext::sock_addr: *mut aya_ebpf_bindings::x86_64::bindings::bpf_sock_addr
@@ -2209,22 +1133,6 @@ impl core::marker::Unpin for aya_ebpf::programs::sock_addr::SockAddrContext
 impl core::marker::UnsafeUnpin for aya_ebpf::programs::sock_addr::SockAddrContext
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::programs::sock_addr::SockAddrContext
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf::programs::sock_addr::SockAddrContext
-impl<T, U> core::convert::Into<U> for aya_ebpf::programs::sock_addr::SockAddrContext where U: core::convert::From<T>
-pub fn aya_ebpf::programs::sock_addr::SockAddrContext::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf::programs::sock_addr::SockAddrContext where U: core::convert::Into<T>
-pub type aya_ebpf::programs::sock_addr::SockAddrContext::Error = core::convert::Infallible
-pub fn aya_ebpf::programs::sock_addr::SockAddrContext::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf::programs::sock_addr::SockAddrContext where U: core::convert::TryFrom<T>
-pub type aya_ebpf::programs::sock_addr::SockAddrContext::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf::programs::sock_addr::SockAddrContext::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf::programs::sock_addr::SockAddrContext where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf::programs::sock_addr::SockAddrContext::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf::programs::sock_addr::SockAddrContext where T: ?core::marker::Sized
-pub fn aya_ebpf::programs::sock_addr::SockAddrContext::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf::programs::sock_addr::SockAddrContext where T: ?core::marker::Sized
-pub fn aya_ebpf::programs::sock_addr::SockAddrContext::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya_ebpf::programs::sock_addr::SockAddrContext
-pub fn aya_ebpf::programs::sock_addr::SockAddrContext::from(t: T) -> T
 pub mod aya_ebpf::programs::sock_ops
 pub struct aya_ebpf::programs::sock_ops::SockOpsContext
 pub aya_ebpf::programs::sock_ops::SockOpsContext::ops: *mut aya_ebpf_bindings::x86_64::bindings::bpf_sock_ops
@@ -2256,22 +1164,6 @@ impl core::marker::Unpin for aya_ebpf::programs::sock_ops::SockOpsContext
 impl core::marker::UnsafeUnpin for aya_ebpf::programs::sock_ops::SockOpsContext
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::programs::sock_ops::SockOpsContext
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf::programs::sock_ops::SockOpsContext
-impl<T, U> core::convert::Into<U> for aya_ebpf::programs::sock_ops::SockOpsContext where U: core::convert::From<T>
-pub fn aya_ebpf::programs::sock_ops::SockOpsContext::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf::programs::sock_ops::SockOpsContext where U: core::convert::Into<T>
-pub type aya_ebpf::programs::sock_ops::SockOpsContext::Error = core::convert::Infallible
-pub fn aya_ebpf::programs::sock_ops::SockOpsContext::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf::programs::sock_ops::SockOpsContext where U: core::convert::TryFrom<T>
-pub type aya_ebpf::programs::sock_ops::SockOpsContext::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf::programs::sock_ops::SockOpsContext::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf::programs::sock_ops::SockOpsContext where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf::programs::sock_ops::SockOpsContext::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf::programs::sock_ops::SockOpsContext where T: ?core::marker::Sized
-pub fn aya_ebpf::programs::sock_ops::SockOpsContext::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf::programs::sock_ops::SockOpsContext where T: ?core::marker::Sized
-pub fn aya_ebpf::programs::sock_ops::SockOpsContext::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya_ebpf::programs::sock_ops::SockOpsContext
-pub fn aya_ebpf::programs::sock_ops::SockOpsContext::from(t: T) -> T
 pub mod aya_ebpf::programs::sockopt
 pub struct aya_ebpf::programs::sockopt::SockoptContext
 pub aya_ebpf::programs::sockopt::SockoptContext::sockopt: *mut aya_ebpf_bindings::x86_64::bindings::bpf_sockopt
@@ -2291,22 +1183,6 @@ impl core::marker::Unpin for aya_ebpf::programs::sockopt::SockoptContext
 impl core::marker::UnsafeUnpin for aya_ebpf::programs::sockopt::SockoptContext
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::programs::sockopt::SockoptContext
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf::programs::sockopt::SockoptContext
-impl<T, U> core::convert::Into<U> for aya_ebpf::programs::sockopt::SockoptContext where U: core::convert::From<T>
-pub fn aya_ebpf::programs::sockopt::SockoptContext::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf::programs::sockopt::SockoptContext where U: core::convert::Into<T>
-pub type aya_ebpf::programs::sockopt::SockoptContext::Error = core::convert::Infallible
-pub fn aya_ebpf::programs::sockopt::SockoptContext::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf::programs::sockopt::SockoptContext where U: core::convert::TryFrom<T>
-pub type aya_ebpf::programs::sockopt::SockoptContext::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf::programs::sockopt::SockoptContext::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf::programs::sockopt::SockoptContext where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf::programs::sockopt::SockoptContext::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf::programs::sockopt::SockoptContext where T: ?core::marker::Sized
-pub fn aya_ebpf::programs::sockopt::SockoptContext::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf::programs::sockopt::SockoptContext where T: ?core::marker::Sized
-pub fn aya_ebpf::programs::sockopt::SockoptContext::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya_ebpf::programs::sockopt::SockoptContext
-pub fn aya_ebpf::programs::sockopt::SockoptContext::from(t: T) -> T
 pub mod aya_ebpf::programs::sysctl
 pub struct aya_ebpf::programs::sysctl::SysctlContext
 pub aya_ebpf::programs::sysctl::SysctlContext::sysctl: *mut aya_ebpf_bindings::x86_64::bindings::bpf_sysctl
@@ -2326,22 +1202,6 @@ impl core::marker::Unpin for aya_ebpf::programs::sysctl::SysctlContext
 impl core::marker::UnsafeUnpin for aya_ebpf::programs::sysctl::SysctlContext
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::programs::sysctl::SysctlContext
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf::programs::sysctl::SysctlContext
-impl<T, U> core::convert::Into<U> for aya_ebpf::programs::sysctl::SysctlContext where U: core::convert::From<T>
-pub fn aya_ebpf::programs::sysctl::SysctlContext::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf::programs::sysctl::SysctlContext where U: core::convert::Into<T>
-pub type aya_ebpf::programs::sysctl::SysctlContext::Error = core::convert::Infallible
-pub fn aya_ebpf::programs::sysctl::SysctlContext::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf::programs::sysctl::SysctlContext where U: core::convert::TryFrom<T>
-pub type aya_ebpf::programs::sysctl::SysctlContext::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf::programs::sysctl::SysctlContext::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf::programs::sysctl::SysctlContext where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf::programs::sysctl::SysctlContext::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf::programs::sysctl::SysctlContext where T: ?core::marker::Sized
-pub fn aya_ebpf::programs::sysctl::SysctlContext::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf::programs::sysctl::SysctlContext where T: ?core::marker::Sized
-pub fn aya_ebpf::programs::sysctl::SysctlContext::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya_ebpf::programs::sysctl::SysctlContext
-pub fn aya_ebpf::programs::sysctl::SysctlContext::from(t: T) -> T
 pub mod aya_ebpf::programs::tc
 pub struct aya_ebpf::programs::tc::TcContext
 pub aya_ebpf::programs::tc::TcContext::skb: aya_ebpf::programs::sk_buff::SkBuff
@@ -2378,22 +1238,6 @@ impl core::marker::Unpin for aya_ebpf::programs::tc::TcContext
 impl core::marker::UnsafeUnpin for aya_ebpf::programs::tc::TcContext
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::programs::tc::TcContext
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf::programs::tc::TcContext
-impl<T, U> core::convert::Into<U> for aya_ebpf::programs::tc::TcContext where U: core::convert::From<T>
-pub fn aya_ebpf::programs::tc::TcContext::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf::programs::tc::TcContext where U: core::convert::Into<T>
-pub type aya_ebpf::programs::tc::TcContext::Error = core::convert::Infallible
-pub fn aya_ebpf::programs::tc::TcContext::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf::programs::tc::TcContext where U: core::convert::TryFrom<T>
-pub type aya_ebpf::programs::tc::TcContext::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf::programs::tc::TcContext::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf::programs::tc::TcContext where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf::programs::tc::TcContext::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf::programs::tc::TcContext where T: ?core::marker::Sized
-pub fn aya_ebpf::programs::tc::TcContext::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf::programs::tc::TcContext where T: ?core::marker::Sized
-pub fn aya_ebpf::programs::tc::TcContext::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya_ebpf::programs::tc::TcContext
-pub fn aya_ebpf::programs::tc::TcContext::from(t: T) -> T
 pub mod aya_ebpf::programs::tp_btf
 pub struct aya_ebpf::programs::tp_btf::BtfTracePointContext
 impl aya_ebpf::programs::tp_btf::BtfTracePointContext
@@ -2413,22 +1257,6 @@ impl core::marker::Unpin for aya_ebpf::programs::tp_btf::BtfTracePointContext
 impl core::marker::UnsafeUnpin for aya_ebpf::programs::tp_btf::BtfTracePointContext
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::programs::tp_btf::BtfTracePointContext
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf::programs::tp_btf::BtfTracePointContext
-impl<T, U> core::convert::Into<U> for aya_ebpf::programs::tp_btf::BtfTracePointContext where U: core::convert::From<T>
-pub fn aya_ebpf::programs::tp_btf::BtfTracePointContext::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf::programs::tp_btf::BtfTracePointContext where U: core::convert::Into<T>
-pub type aya_ebpf::programs::tp_btf::BtfTracePointContext::Error = core::convert::Infallible
-pub fn aya_ebpf::programs::tp_btf::BtfTracePointContext::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf::programs::tp_btf::BtfTracePointContext where U: core::convert::TryFrom<T>
-pub type aya_ebpf::programs::tp_btf::BtfTracePointContext::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf::programs::tp_btf::BtfTracePointContext::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf::programs::tp_btf::BtfTracePointContext where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf::programs::tp_btf::BtfTracePointContext::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf::programs::tp_btf::BtfTracePointContext where T: ?core::marker::Sized
-pub fn aya_ebpf::programs::tp_btf::BtfTracePointContext::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf::programs::tp_btf::BtfTracePointContext where T: ?core::marker::Sized
-pub fn aya_ebpf::programs::tp_btf::BtfTracePointContext::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya_ebpf::programs::tp_btf::BtfTracePointContext
-pub fn aya_ebpf::programs::tp_btf::BtfTracePointContext::from(t: T) -> T
 pub mod aya_ebpf::programs::tracepoint
 pub struct aya_ebpf::programs::tracepoint::TracePointContext
 impl aya_ebpf::programs::tracepoint::TracePointContext
@@ -2448,22 +1276,6 @@ impl core::marker::Unpin for aya_ebpf::programs::tracepoint::TracePointContext
 impl core::marker::UnsafeUnpin for aya_ebpf::programs::tracepoint::TracePointContext
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::programs::tracepoint::TracePointContext
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf::programs::tracepoint::TracePointContext
-impl<T, U> core::convert::Into<U> for aya_ebpf::programs::tracepoint::TracePointContext where U: core::convert::From<T>
-pub fn aya_ebpf::programs::tracepoint::TracePointContext::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf::programs::tracepoint::TracePointContext where U: core::convert::Into<T>
-pub type aya_ebpf::programs::tracepoint::TracePointContext::Error = core::convert::Infallible
-pub fn aya_ebpf::programs::tracepoint::TracePointContext::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf::programs::tracepoint::TracePointContext where U: core::convert::TryFrom<T>
-pub type aya_ebpf::programs::tracepoint::TracePointContext::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf::programs::tracepoint::TracePointContext::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf::programs::tracepoint::TracePointContext where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf::programs::tracepoint::TracePointContext::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf::programs::tracepoint::TracePointContext where T: ?core::marker::Sized
-pub fn aya_ebpf::programs::tracepoint::TracePointContext::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf::programs::tracepoint::TracePointContext where T: ?core::marker::Sized
-pub fn aya_ebpf::programs::tracepoint::TracePointContext::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya_ebpf::programs::tracepoint::TracePointContext
-pub fn aya_ebpf::programs::tracepoint::TracePointContext::from(t: T) -> T
 pub mod aya_ebpf::programs::xdp
 pub struct aya_ebpf::programs::xdp::XdpContext
 pub aya_ebpf::programs::xdp::XdpContext::ctx: *mut aya_ebpf_bindings::x86_64::bindings::xdp_md
@@ -2489,22 +1301,6 @@ impl core::marker::Unpin for aya_ebpf::programs::xdp::XdpContext
 impl core::marker::UnsafeUnpin for aya_ebpf::programs::xdp::XdpContext
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::programs::xdp::XdpContext
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf::programs::xdp::XdpContext
-impl<T, U> core::convert::Into<U> for aya_ebpf::programs::xdp::XdpContext where U: core::convert::From<T>
-pub fn aya_ebpf::programs::xdp::XdpContext::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf::programs::xdp::XdpContext where U: core::convert::Into<T>
-pub type aya_ebpf::programs::xdp::XdpContext::Error = core::convert::Infallible
-pub fn aya_ebpf::programs::xdp::XdpContext::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf::programs::xdp::XdpContext where U: core::convert::TryFrom<T>
-pub type aya_ebpf::programs::xdp::XdpContext::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf::programs::xdp::XdpContext::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf::programs::xdp::XdpContext where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf::programs::xdp::XdpContext::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf::programs::xdp::XdpContext where T: ?core::marker::Sized
-pub fn aya_ebpf::programs::xdp::XdpContext::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf::programs::xdp::XdpContext where T: ?core::marker::Sized
-pub fn aya_ebpf::programs::xdp::XdpContext::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya_ebpf::programs::xdp::XdpContext
-pub fn aya_ebpf::programs::xdp::XdpContext::from(t: T) -> T
 pub struct aya_ebpf::programs::BtfTracePointContext
 impl aya_ebpf::programs::tp_btf::BtfTracePointContext
 pub fn aya_ebpf::programs::tp_btf::BtfTracePointContext::arg<T: aya_ebpf::Argument>(&self, n: usize) -> T
@@ -2523,22 +1319,6 @@ impl core::marker::Unpin for aya_ebpf::programs::tp_btf::BtfTracePointContext
 impl core::marker::UnsafeUnpin for aya_ebpf::programs::tp_btf::BtfTracePointContext
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::programs::tp_btf::BtfTracePointContext
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf::programs::tp_btf::BtfTracePointContext
-impl<T, U> core::convert::Into<U> for aya_ebpf::programs::tp_btf::BtfTracePointContext where U: core::convert::From<T>
-pub fn aya_ebpf::programs::tp_btf::BtfTracePointContext::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf::programs::tp_btf::BtfTracePointContext where U: core::convert::Into<T>
-pub type aya_ebpf::programs::tp_btf::BtfTracePointContext::Error = core::convert::Infallible
-pub fn aya_ebpf::programs::tp_btf::BtfTracePointContext::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf::programs::tp_btf::BtfTracePointContext where U: core::convert::TryFrom<T>
-pub type aya_ebpf::programs::tp_btf::BtfTracePointContext::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf::programs::tp_btf::BtfTracePointContext::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf::programs::tp_btf::BtfTracePointContext where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf::programs::tp_btf::BtfTracePointContext::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf::programs::tp_btf::BtfTracePointContext where T: ?core::marker::Sized
-pub fn aya_ebpf::programs::tp_btf::BtfTracePointContext::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf::programs::tp_btf::BtfTracePointContext where T: ?core::marker::Sized
-pub fn aya_ebpf::programs::tp_btf::BtfTracePointContext::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya_ebpf::programs::tp_btf::BtfTracePointContext
-pub fn aya_ebpf::programs::tp_btf::BtfTracePointContext::from(t: T) -> T
 pub struct aya_ebpf::programs::DeviceContext
 pub aya_ebpf::programs::DeviceContext::device: *mut aya_ebpf_bindings::x86_64::bindings::bpf_cgroup_dev_ctx
 impl aya_ebpf::programs::device::DeviceContext
@@ -2557,22 +1337,6 @@ impl core::marker::Unpin for aya_ebpf::programs::device::DeviceContext
 impl core::marker::UnsafeUnpin for aya_ebpf::programs::device::DeviceContext
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::programs::device::DeviceContext
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf::programs::device::DeviceContext
-impl<T, U> core::convert::Into<U> for aya_ebpf::programs::device::DeviceContext where U: core::convert::From<T>
-pub fn aya_ebpf::programs::device::DeviceContext::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf::programs::device::DeviceContext where U: core::convert::Into<T>
-pub type aya_ebpf::programs::device::DeviceContext::Error = core::convert::Infallible
-pub fn aya_ebpf::programs::device::DeviceContext::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf::programs::device::DeviceContext where U: core::convert::TryFrom<T>
-pub type aya_ebpf::programs::device::DeviceContext::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf::programs::device::DeviceContext::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf::programs::device::DeviceContext where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf::programs::device::DeviceContext::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf::programs::device::DeviceContext where T: ?core::marker::Sized
-pub fn aya_ebpf::programs::device::DeviceContext::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf::programs::device::DeviceContext where T: ?core::marker::Sized
-pub fn aya_ebpf::programs::device::DeviceContext::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya_ebpf::programs::device::DeviceContext
-pub fn aya_ebpf::programs::device::DeviceContext::from(t: T) -> T
 pub struct aya_ebpf::programs::FEntryContext
 impl aya_ebpf::programs::fentry::FEntryContext
 pub fn aya_ebpf::programs::fentry::FEntryContext::arg<T: aya_ebpf::Argument>(&self, n: usize) -> T
@@ -2591,22 +1355,6 @@ impl core::marker::Unpin for aya_ebpf::programs::fentry::FEntryContext
 impl core::marker::UnsafeUnpin for aya_ebpf::programs::fentry::FEntryContext
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::programs::fentry::FEntryContext
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf::programs::fentry::FEntryContext
-impl<T, U> core::convert::Into<U> for aya_ebpf::programs::fentry::FEntryContext where U: core::convert::From<T>
-pub fn aya_ebpf::programs::fentry::FEntryContext::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf::programs::fentry::FEntryContext where U: core::convert::Into<T>
-pub type aya_ebpf::programs::fentry::FEntryContext::Error = core::convert::Infallible
-pub fn aya_ebpf::programs::fentry::FEntryContext::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf::programs::fentry::FEntryContext where U: core::convert::TryFrom<T>
-pub type aya_ebpf::programs::fentry::FEntryContext::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf::programs::fentry::FEntryContext::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf::programs::fentry::FEntryContext where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf::programs::fentry::FEntryContext::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf::programs::fentry::FEntryContext where T: ?core::marker::Sized
-pub fn aya_ebpf::programs::fentry::FEntryContext::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf::programs::fentry::FEntryContext where T: ?core::marker::Sized
-pub fn aya_ebpf::programs::fentry::FEntryContext::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya_ebpf::programs::fentry::FEntryContext
-pub fn aya_ebpf::programs::fentry::FEntryContext::from(t: T) -> T
 pub struct aya_ebpf::programs::FExitContext
 impl aya_ebpf::programs::fexit::FExitContext
 pub fn aya_ebpf::programs::fexit::FExitContext::arg<T: aya_ebpf::Argument>(&self, n: usize) -> T
@@ -2625,22 +1373,6 @@ impl core::marker::Unpin for aya_ebpf::programs::fexit::FExitContext
 impl core::marker::UnsafeUnpin for aya_ebpf::programs::fexit::FExitContext
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::programs::fexit::FExitContext
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf::programs::fexit::FExitContext
-impl<T, U> core::convert::Into<U> for aya_ebpf::programs::fexit::FExitContext where U: core::convert::From<T>
-pub fn aya_ebpf::programs::fexit::FExitContext::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf::programs::fexit::FExitContext where U: core::convert::Into<T>
-pub type aya_ebpf::programs::fexit::FExitContext::Error = core::convert::Infallible
-pub fn aya_ebpf::programs::fexit::FExitContext::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf::programs::fexit::FExitContext where U: core::convert::TryFrom<T>
-pub type aya_ebpf::programs::fexit::FExitContext::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf::programs::fexit::FExitContext::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf::programs::fexit::FExitContext where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf::programs::fexit::FExitContext::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf::programs::fexit::FExitContext where T: ?core::marker::Sized
-pub fn aya_ebpf::programs::fexit::FExitContext::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf::programs::fexit::FExitContext where T: ?core::marker::Sized
-pub fn aya_ebpf::programs::fexit::FExitContext::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya_ebpf::programs::fexit::FExitContext
-pub fn aya_ebpf::programs::fexit::FExitContext::from(t: T) -> T
 pub struct aya_ebpf::programs::FlowDissectorContext
 impl aya_ebpf::programs::flow_dissector::FlowDissectorContext
 pub fn aya_ebpf::programs::flow_dissector::FlowDissectorContext::data(&self) -> usize
@@ -2662,22 +1394,6 @@ impl core::marker::Unpin for aya_ebpf::programs::flow_dissector::FlowDissectorCo
 impl core::marker::UnsafeUnpin for aya_ebpf::programs::flow_dissector::FlowDissectorContext
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::programs::flow_dissector::FlowDissectorContext
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf::programs::flow_dissector::FlowDissectorContext
-impl<T, U> core::convert::Into<U> for aya_ebpf::programs::flow_dissector::FlowDissectorContext where U: core::convert::From<T>
-pub fn aya_ebpf::programs::flow_dissector::FlowDissectorContext::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf::programs::flow_dissector::FlowDissectorContext where U: core::convert::Into<T>
-pub type aya_ebpf::programs::flow_dissector::FlowDissectorContext::Error = core::convert::Infallible
-pub fn aya_ebpf::programs::flow_dissector::FlowDissectorContext::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf::programs::flow_dissector::FlowDissectorContext where U: core::convert::TryFrom<T>
-pub type aya_ebpf::programs::flow_dissector::FlowDissectorContext::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf::programs::flow_dissector::FlowDissectorContext::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf::programs::flow_dissector::FlowDissectorContext where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf::programs::flow_dissector::FlowDissectorContext::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf::programs::flow_dissector::FlowDissectorContext where T: ?core::marker::Sized
-pub fn aya_ebpf::programs::flow_dissector::FlowDissectorContext::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf::programs::flow_dissector::FlowDissectorContext where T: ?core::marker::Sized
-pub fn aya_ebpf::programs::flow_dissector::FlowDissectorContext::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya_ebpf::programs::flow_dissector::FlowDissectorContext
-pub fn aya_ebpf::programs::flow_dissector::FlowDissectorContext::from(t: T) -> T
 pub struct aya_ebpf::programs::LsmContext
 impl aya_ebpf::programs::lsm::LsmContext
 pub fn aya_ebpf::programs::lsm::LsmContext::arg<T: aya_ebpf::Argument>(&self, n: usize) -> T
@@ -2696,22 +1412,6 @@ impl core::marker::Unpin for aya_ebpf::programs::lsm::LsmContext
 impl core::marker::UnsafeUnpin for aya_ebpf::programs::lsm::LsmContext
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::programs::lsm::LsmContext
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf::programs::lsm::LsmContext
-impl<T, U> core::convert::Into<U> for aya_ebpf::programs::lsm::LsmContext where U: core::convert::From<T>
-pub fn aya_ebpf::programs::lsm::LsmContext::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf::programs::lsm::LsmContext where U: core::convert::Into<T>
-pub type aya_ebpf::programs::lsm::LsmContext::Error = core::convert::Infallible
-pub fn aya_ebpf::programs::lsm::LsmContext::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf::programs::lsm::LsmContext where U: core::convert::TryFrom<T>
-pub type aya_ebpf::programs::lsm::LsmContext::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf::programs::lsm::LsmContext::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf::programs::lsm::LsmContext where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf::programs::lsm::LsmContext::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf::programs::lsm::LsmContext where T: ?core::marker::Sized
-pub fn aya_ebpf::programs::lsm::LsmContext::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf::programs::lsm::LsmContext where T: ?core::marker::Sized
-pub fn aya_ebpf::programs::lsm::LsmContext::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya_ebpf::programs::lsm::LsmContext
-pub fn aya_ebpf::programs::lsm::LsmContext::from(t: T) -> T
 pub struct aya_ebpf::programs::PerfEventContext
 pub aya_ebpf::programs::PerfEventContext::ctx: *mut aya_ebpf_bindings::x86_64::bindings::bpf_perf_event_data
 impl aya_ebpf::programs::perf_event::PerfEventContext
@@ -2730,22 +1430,6 @@ impl core::marker::Unpin for aya_ebpf::programs::perf_event::PerfEventContext
 impl core::marker::UnsafeUnpin for aya_ebpf::programs::perf_event::PerfEventContext
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::programs::perf_event::PerfEventContext
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf::programs::perf_event::PerfEventContext
-impl<T, U> core::convert::Into<U> for aya_ebpf::programs::perf_event::PerfEventContext where U: core::convert::From<T>
-pub fn aya_ebpf::programs::perf_event::PerfEventContext::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf::programs::perf_event::PerfEventContext where U: core::convert::Into<T>
-pub type aya_ebpf::programs::perf_event::PerfEventContext::Error = core::convert::Infallible
-pub fn aya_ebpf::programs::perf_event::PerfEventContext::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf::programs::perf_event::PerfEventContext where U: core::convert::TryFrom<T>
-pub type aya_ebpf::programs::perf_event::PerfEventContext::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf::programs::perf_event::PerfEventContext::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf::programs::perf_event::PerfEventContext where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf::programs::perf_event::PerfEventContext::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf::programs::perf_event::PerfEventContext where T: ?core::marker::Sized
-pub fn aya_ebpf::programs::perf_event::PerfEventContext::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf::programs::perf_event::PerfEventContext where T: ?core::marker::Sized
-pub fn aya_ebpf::programs::perf_event::PerfEventContext::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya_ebpf::programs::perf_event::PerfEventContext
-pub fn aya_ebpf::programs::perf_event::PerfEventContext::from(t: T) -> T
 pub struct aya_ebpf::programs::ProbeContext
 pub aya_ebpf::programs::ProbeContext::regs: *mut aya_ebpf_bindings::x86_64::bindings::pt_regs
 impl aya_ebpf::programs::probe::ProbeContext
@@ -2765,22 +1449,6 @@ impl core::marker::Unpin for aya_ebpf::programs::probe::ProbeContext
 impl core::marker::UnsafeUnpin for aya_ebpf::programs::probe::ProbeContext
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::programs::probe::ProbeContext
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf::programs::probe::ProbeContext
-impl<T, U> core::convert::Into<U> for aya_ebpf::programs::probe::ProbeContext where U: core::convert::From<T>
-pub fn aya_ebpf::programs::probe::ProbeContext::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf::programs::probe::ProbeContext where U: core::convert::Into<T>
-pub type aya_ebpf::programs::probe::ProbeContext::Error = core::convert::Infallible
-pub fn aya_ebpf::programs::probe::ProbeContext::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf::programs::probe::ProbeContext where U: core::convert::TryFrom<T>
-pub type aya_ebpf::programs::probe::ProbeContext::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf::programs::probe::ProbeContext::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf::programs::probe::ProbeContext where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf::programs::probe::ProbeContext::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf::programs::probe::ProbeContext where T: ?core::marker::Sized
-pub fn aya_ebpf::programs::probe::ProbeContext::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf::programs::probe::ProbeContext where T: ?core::marker::Sized
-pub fn aya_ebpf::programs::probe::ProbeContext::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya_ebpf::programs::probe::ProbeContext
-pub fn aya_ebpf::programs::probe::ProbeContext::from(t: T) -> T
 pub struct aya_ebpf::programs::RawTracePointContext
 impl aya_ebpf::programs::raw_tracepoint::RawTracePointContext
 pub fn aya_ebpf::programs::raw_tracepoint::RawTracePointContext::arg<T: aya_ebpf::Argument>(&self, n: usize) -> T
@@ -2799,22 +1467,6 @@ impl core::marker::Unpin for aya_ebpf::programs::raw_tracepoint::RawTracePointCo
 impl core::marker::UnsafeUnpin for aya_ebpf::programs::raw_tracepoint::RawTracePointContext
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::programs::raw_tracepoint::RawTracePointContext
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf::programs::raw_tracepoint::RawTracePointContext
-impl<T, U> core::convert::Into<U> for aya_ebpf::programs::raw_tracepoint::RawTracePointContext where U: core::convert::From<T>
-pub fn aya_ebpf::programs::raw_tracepoint::RawTracePointContext::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf::programs::raw_tracepoint::RawTracePointContext where U: core::convert::Into<T>
-pub type aya_ebpf::programs::raw_tracepoint::RawTracePointContext::Error = core::convert::Infallible
-pub fn aya_ebpf::programs::raw_tracepoint::RawTracePointContext::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf::programs::raw_tracepoint::RawTracePointContext where U: core::convert::TryFrom<T>
-pub type aya_ebpf::programs::raw_tracepoint::RawTracePointContext::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf::programs::raw_tracepoint::RawTracePointContext::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf::programs::raw_tracepoint::RawTracePointContext where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf::programs::raw_tracepoint::RawTracePointContext::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf::programs::raw_tracepoint::RawTracePointContext where T: ?core::marker::Sized
-pub fn aya_ebpf::programs::raw_tracepoint::RawTracePointContext::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf::programs::raw_tracepoint::RawTracePointContext where T: ?core::marker::Sized
-pub fn aya_ebpf::programs::raw_tracepoint::RawTracePointContext::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya_ebpf::programs::raw_tracepoint::RawTracePointContext
-pub fn aya_ebpf::programs::raw_tracepoint::RawTracePointContext::from(t: T) -> T
 pub struct aya_ebpf::programs::RetProbeContext
 pub aya_ebpf::programs::RetProbeContext::regs: *mut aya_ebpf_bindings::x86_64::bindings::pt_regs
 impl aya_ebpf::programs::retprobe::RetProbeContext
@@ -2834,22 +1486,6 @@ impl core::marker::Unpin for aya_ebpf::programs::retprobe::RetProbeContext
 impl core::marker::UnsafeUnpin for aya_ebpf::programs::retprobe::RetProbeContext
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::programs::retprobe::RetProbeContext
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf::programs::retprobe::RetProbeContext
-impl<T, U> core::convert::Into<U> for aya_ebpf::programs::retprobe::RetProbeContext where U: core::convert::From<T>
-pub fn aya_ebpf::programs::retprobe::RetProbeContext::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf::programs::retprobe::RetProbeContext where U: core::convert::Into<T>
-pub type aya_ebpf::programs::retprobe::RetProbeContext::Error = core::convert::Infallible
-pub fn aya_ebpf::programs::retprobe::RetProbeContext::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf::programs::retprobe::RetProbeContext where U: core::convert::TryFrom<T>
-pub type aya_ebpf::programs::retprobe::RetProbeContext::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf::programs::retprobe::RetProbeContext::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf::programs::retprobe::RetProbeContext where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf::programs::retprobe::RetProbeContext::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf::programs::retprobe::RetProbeContext where T: ?core::marker::Sized
-pub fn aya_ebpf::programs::retprobe::RetProbeContext::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf::programs::retprobe::RetProbeContext where T: ?core::marker::Sized
-pub fn aya_ebpf::programs::retprobe::RetProbeContext::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya_ebpf::programs::retprobe::RetProbeContext
-pub fn aya_ebpf::programs::retprobe::RetProbeContext::from(t: T) -> T
 pub struct aya_ebpf::programs::SkBuffContext
 pub aya_ebpf::programs::SkBuffContext::skb: aya_ebpf::programs::sk_buff::SkBuff
 impl aya_ebpf::programs::sk_buff::SkBuffContext
@@ -2882,22 +1518,6 @@ impl core::marker::Unpin for aya_ebpf::programs::sk_buff::SkBuffContext
 impl core::marker::UnsafeUnpin for aya_ebpf::programs::sk_buff::SkBuffContext
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::programs::sk_buff::SkBuffContext
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf::programs::sk_buff::SkBuffContext
-impl<T, U> core::convert::Into<U> for aya_ebpf::programs::sk_buff::SkBuffContext where U: core::convert::From<T>
-pub fn aya_ebpf::programs::sk_buff::SkBuffContext::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf::programs::sk_buff::SkBuffContext where U: core::convert::Into<T>
-pub type aya_ebpf::programs::sk_buff::SkBuffContext::Error = core::convert::Infallible
-pub fn aya_ebpf::programs::sk_buff::SkBuffContext::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf::programs::sk_buff::SkBuffContext where U: core::convert::TryFrom<T>
-pub type aya_ebpf::programs::sk_buff::SkBuffContext::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf::programs::sk_buff::SkBuffContext::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf::programs::sk_buff::SkBuffContext where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf::programs::sk_buff::SkBuffContext::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf::programs::sk_buff::SkBuffContext where T: ?core::marker::Sized
-pub fn aya_ebpf::programs::sk_buff::SkBuffContext::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf::programs::sk_buff::SkBuffContext where T: ?core::marker::Sized
-pub fn aya_ebpf::programs::sk_buff::SkBuffContext::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya_ebpf::programs::sk_buff::SkBuffContext
-pub fn aya_ebpf::programs::sk_buff::SkBuffContext::from(t: T) -> T
 pub struct aya_ebpf::programs::SkLookupContext
 pub aya_ebpf::programs::SkLookupContext::lookup: *mut aya_ebpf_bindings::x86_64::bindings::bpf_sk_lookup
 impl aya_ebpf::programs::sk_lookup::SkLookupContext
@@ -2916,22 +1536,6 @@ impl core::marker::Unpin for aya_ebpf::programs::sk_lookup::SkLookupContext
 impl core::marker::UnsafeUnpin for aya_ebpf::programs::sk_lookup::SkLookupContext
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::programs::sk_lookup::SkLookupContext
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf::programs::sk_lookup::SkLookupContext
-impl<T, U> core::convert::Into<U> for aya_ebpf::programs::sk_lookup::SkLookupContext where U: core::convert::From<T>
-pub fn aya_ebpf::programs::sk_lookup::SkLookupContext::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf::programs::sk_lookup::SkLookupContext where U: core::convert::Into<T>
-pub type aya_ebpf::programs::sk_lookup::SkLookupContext::Error = core::convert::Infallible
-pub fn aya_ebpf::programs::sk_lookup::SkLookupContext::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf::programs::sk_lookup::SkLookupContext where U: core::convert::TryFrom<T>
-pub type aya_ebpf::programs::sk_lookup::SkLookupContext::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf::programs::sk_lookup::SkLookupContext::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf::programs::sk_lookup::SkLookupContext where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf::programs::sk_lookup::SkLookupContext::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf::programs::sk_lookup::SkLookupContext where T: ?core::marker::Sized
-pub fn aya_ebpf::programs::sk_lookup::SkLookupContext::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf::programs::sk_lookup::SkLookupContext where T: ?core::marker::Sized
-pub fn aya_ebpf::programs::sk_lookup::SkLookupContext::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya_ebpf::programs::sk_lookup::SkLookupContext
-pub fn aya_ebpf::programs::sk_lookup::SkLookupContext::from(t: T) -> T
 pub struct aya_ebpf::programs::SkMsgContext
 pub aya_ebpf::programs::SkMsgContext::msg: *mut aya_ebpf_bindings::x86_64::bindings::sk_msg_md
 impl aya_ebpf::programs::sk_msg::SkMsgContext
@@ -2955,22 +1559,6 @@ impl core::marker::Unpin for aya_ebpf::programs::sk_msg::SkMsgContext
 impl core::marker::UnsafeUnpin for aya_ebpf::programs::sk_msg::SkMsgContext
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::programs::sk_msg::SkMsgContext
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf::programs::sk_msg::SkMsgContext
-impl<T, U> core::convert::Into<U> for aya_ebpf::programs::sk_msg::SkMsgContext where U: core::convert::From<T>
-pub fn aya_ebpf::programs::sk_msg::SkMsgContext::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf::programs::sk_msg::SkMsgContext where U: core::convert::Into<T>
-pub type aya_ebpf::programs::sk_msg::SkMsgContext::Error = core::convert::Infallible
-pub fn aya_ebpf::programs::sk_msg::SkMsgContext::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf::programs::sk_msg::SkMsgContext where U: core::convert::TryFrom<T>
-pub type aya_ebpf::programs::sk_msg::SkMsgContext::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf::programs::sk_msg::SkMsgContext::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf::programs::sk_msg::SkMsgContext where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf::programs::sk_msg::SkMsgContext::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf::programs::sk_msg::SkMsgContext where T: ?core::marker::Sized
-pub fn aya_ebpf::programs::sk_msg::SkMsgContext::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf::programs::sk_msg::SkMsgContext where T: ?core::marker::Sized
-pub fn aya_ebpf::programs::sk_msg::SkMsgContext::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya_ebpf::programs::sk_msg::SkMsgContext
-pub fn aya_ebpf::programs::sk_msg::SkMsgContext::from(t: T) -> T
 pub struct aya_ebpf::programs::SockAddrContext
 pub aya_ebpf::programs::SockAddrContext::sock_addr: *mut aya_ebpf_bindings::x86_64::bindings::bpf_sock_addr
 impl aya_ebpf::programs::sock_addr::SockAddrContext
@@ -2989,22 +1577,6 @@ impl core::marker::Unpin for aya_ebpf::programs::sock_addr::SockAddrContext
 impl core::marker::UnsafeUnpin for aya_ebpf::programs::sock_addr::SockAddrContext
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::programs::sock_addr::SockAddrContext
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf::programs::sock_addr::SockAddrContext
-impl<T, U> core::convert::Into<U> for aya_ebpf::programs::sock_addr::SockAddrContext where U: core::convert::From<T>
-pub fn aya_ebpf::programs::sock_addr::SockAddrContext::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf::programs::sock_addr::SockAddrContext where U: core::convert::Into<T>
-pub type aya_ebpf::programs::sock_addr::SockAddrContext::Error = core::convert::Infallible
-pub fn aya_ebpf::programs::sock_addr::SockAddrContext::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf::programs::sock_addr::SockAddrContext where U: core::convert::TryFrom<T>
-pub type aya_ebpf::programs::sock_addr::SockAddrContext::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf::programs::sock_addr::SockAddrContext::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf::programs::sock_addr::SockAddrContext where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf::programs::sock_addr::SockAddrContext::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf::programs::sock_addr::SockAddrContext where T: ?core::marker::Sized
-pub fn aya_ebpf::programs::sock_addr::SockAddrContext::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf::programs::sock_addr::SockAddrContext where T: ?core::marker::Sized
-pub fn aya_ebpf::programs::sock_addr::SockAddrContext::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya_ebpf::programs::sock_addr::SockAddrContext
-pub fn aya_ebpf::programs::sock_addr::SockAddrContext::from(t: T) -> T
 pub struct aya_ebpf::programs::SockContext
 pub aya_ebpf::programs::SockContext::sock: *mut aya_ebpf_bindings::x86_64::bindings::bpf_sock
 impl aya_ebpf::programs::sock::SockContext
@@ -3023,22 +1595,6 @@ impl core::marker::Unpin for aya_ebpf::programs::sock::SockContext
 impl core::marker::UnsafeUnpin for aya_ebpf::programs::sock::SockContext
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::programs::sock::SockContext
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf::programs::sock::SockContext
-impl<T, U> core::convert::Into<U> for aya_ebpf::programs::sock::SockContext where U: core::convert::From<T>
-pub fn aya_ebpf::programs::sock::SockContext::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf::programs::sock::SockContext where U: core::convert::Into<T>
-pub type aya_ebpf::programs::sock::SockContext::Error = core::convert::Infallible
-pub fn aya_ebpf::programs::sock::SockContext::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf::programs::sock::SockContext where U: core::convert::TryFrom<T>
-pub type aya_ebpf::programs::sock::SockContext::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf::programs::sock::SockContext::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf::programs::sock::SockContext where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf::programs::sock::SockContext::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf::programs::sock::SockContext where T: ?core::marker::Sized
-pub fn aya_ebpf::programs::sock::SockContext::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf::programs::sock::SockContext where T: ?core::marker::Sized
-pub fn aya_ebpf::programs::sock::SockContext::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya_ebpf::programs::sock::SockContext
-pub fn aya_ebpf::programs::sock::SockContext::from(t: T) -> T
 pub struct aya_ebpf::programs::SockOpsContext
 pub aya_ebpf::programs::SockOpsContext::ops: *mut aya_ebpf_bindings::x86_64::bindings::bpf_sock_ops
 impl aya_ebpf::programs::sock_ops::SockOpsContext
@@ -3069,22 +1625,6 @@ impl core::marker::Unpin for aya_ebpf::programs::sock_ops::SockOpsContext
 impl core::marker::UnsafeUnpin for aya_ebpf::programs::sock_ops::SockOpsContext
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::programs::sock_ops::SockOpsContext
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf::programs::sock_ops::SockOpsContext
-impl<T, U> core::convert::Into<U> for aya_ebpf::programs::sock_ops::SockOpsContext where U: core::convert::From<T>
-pub fn aya_ebpf::programs::sock_ops::SockOpsContext::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf::programs::sock_ops::SockOpsContext where U: core::convert::Into<T>
-pub type aya_ebpf::programs::sock_ops::SockOpsContext::Error = core::convert::Infallible
-pub fn aya_ebpf::programs::sock_ops::SockOpsContext::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf::programs::sock_ops::SockOpsContext where U: core::convert::TryFrom<T>
-pub type aya_ebpf::programs::sock_ops::SockOpsContext::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf::programs::sock_ops::SockOpsContext::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf::programs::sock_ops::SockOpsContext where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf::programs::sock_ops::SockOpsContext::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf::programs::sock_ops::SockOpsContext where T: ?core::marker::Sized
-pub fn aya_ebpf::programs::sock_ops::SockOpsContext::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf::programs::sock_ops::SockOpsContext where T: ?core::marker::Sized
-pub fn aya_ebpf::programs::sock_ops::SockOpsContext::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya_ebpf::programs::sock_ops::SockOpsContext
-pub fn aya_ebpf::programs::sock_ops::SockOpsContext::from(t: T) -> T
 pub struct aya_ebpf::programs::SockoptContext
 pub aya_ebpf::programs::SockoptContext::sockopt: *mut aya_ebpf_bindings::x86_64::bindings::bpf_sockopt
 impl aya_ebpf::programs::sockopt::SockoptContext
@@ -3103,22 +1643,6 @@ impl core::marker::Unpin for aya_ebpf::programs::sockopt::SockoptContext
 impl core::marker::UnsafeUnpin for aya_ebpf::programs::sockopt::SockoptContext
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::programs::sockopt::SockoptContext
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf::programs::sockopt::SockoptContext
-impl<T, U> core::convert::Into<U> for aya_ebpf::programs::sockopt::SockoptContext where U: core::convert::From<T>
-pub fn aya_ebpf::programs::sockopt::SockoptContext::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf::programs::sockopt::SockoptContext where U: core::convert::Into<T>
-pub type aya_ebpf::programs::sockopt::SockoptContext::Error = core::convert::Infallible
-pub fn aya_ebpf::programs::sockopt::SockoptContext::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf::programs::sockopt::SockoptContext where U: core::convert::TryFrom<T>
-pub type aya_ebpf::programs::sockopt::SockoptContext::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf::programs::sockopt::SockoptContext::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf::programs::sockopt::SockoptContext where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf::programs::sockopt::SockoptContext::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf::programs::sockopt::SockoptContext where T: ?core::marker::Sized
-pub fn aya_ebpf::programs::sockopt::SockoptContext::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf::programs::sockopt::SockoptContext where T: ?core::marker::Sized
-pub fn aya_ebpf::programs::sockopt::SockoptContext::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya_ebpf::programs::sockopt::SockoptContext
-pub fn aya_ebpf::programs::sockopt::SockoptContext::from(t: T) -> T
 pub struct aya_ebpf::programs::SysctlContext
 pub aya_ebpf::programs::SysctlContext::sysctl: *mut aya_ebpf_bindings::x86_64::bindings::bpf_sysctl
 impl aya_ebpf::programs::sysctl::SysctlContext
@@ -3137,22 +1661,6 @@ impl core::marker::Unpin for aya_ebpf::programs::sysctl::SysctlContext
 impl core::marker::UnsafeUnpin for aya_ebpf::programs::sysctl::SysctlContext
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::programs::sysctl::SysctlContext
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf::programs::sysctl::SysctlContext
-impl<T, U> core::convert::Into<U> for aya_ebpf::programs::sysctl::SysctlContext where U: core::convert::From<T>
-pub fn aya_ebpf::programs::sysctl::SysctlContext::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf::programs::sysctl::SysctlContext where U: core::convert::Into<T>
-pub type aya_ebpf::programs::sysctl::SysctlContext::Error = core::convert::Infallible
-pub fn aya_ebpf::programs::sysctl::SysctlContext::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf::programs::sysctl::SysctlContext where U: core::convert::TryFrom<T>
-pub type aya_ebpf::programs::sysctl::SysctlContext::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf::programs::sysctl::SysctlContext::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf::programs::sysctl::SysctlContext where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf::programs::sysctl::SysctlContext::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf::programs::sysctl::SysctlContext where T: ?core::marker::Sized
-pub fn aya_ebpf::programs::sysctl::SysctlContext::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf::programs::sysctl::SysctlContext where T: ?core::marker::Sized
-pub fn aya_ebpf::programs::sysctl::SysctlContext::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya_ebpf::programs::sysctl::SysctlContext
-pub fn aya_ebpf::programs::sysctl::SysctlContext::from(t: T) -> T
 pub struct aya_ebpf::programs::TcContext
 pub aya_ebpf::programs::TcContext::skb: aya_ebpf::programs::sk_buff::SkBuff
 impl aya_ebpf::programs::tc::TcContext
@@ -3188,22 +1696,6 @@ impl core::marker::Unpin for aya_ebpf::programs::tc::TcContext
 impl core::marker::UnsafeUnpin for aya_ebpf::programs::tc::TcContext
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::programs::tc::TcContext
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf::programs::tc::TcContext
-impl<T, U> core::convert::Into<U> for aya_ebpf::programs::tc::TcContext where U: core::convert::From<T>
-pub fn aya_ebpf::programs::tc::TcContext::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf::programs::tc::TcContext where U: core::convert::Into<T>
-pub type aya_ebpf::programs::tc::TcContext::Error = core::convert::Infallible
-pub fn aya_ebpf::programs::tc::TcContext::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf::programs::tc::TcContext where U: core::convert::TryFrom<T>
-pub type aya_ebpf::programs::tc::TcContext::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf::programs::tc::TcContext::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf::programs::tc::TcContext where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf::programs::tc::TcContext::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf::programs::tc::TcContext where T: ?core::marker::Sized
-pub fn aya_ebpf::programs::tc::TcContext::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf::programs::tc::TcContext where T: ?core::marker::Sized
-pub fn aya_ebpf::programs::tc::TcContext::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya_ebpf::programs::tc::TcContext
-pub fn aya_ebpf::programs::tc::TcContext::from(t: T) -> T
 pub struct aya_ebpf::programs::TracePointContext
 impl aya_ebpf::programs::tracepoint::TracePointContext
 pub const fn aya_ebpf::programs::tracepoint::TracePointContext::new(ctx: *mut core::ffi::c_void) -> Self
@@ -3222,22 +1714,6 @@ impl core::marker::Unpin for aya_ebpf::programs::tracepoint::TracePointContext
 impl core::marker::UnsafeUnpin for aya_ebpf::programs::tracepoint::TracePointContext
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::programs::tracepoint::TracePointContext
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf::programs::tracepoint::TracePointContext
-impl<T, U> core::convert::Into<U> for aya_ebpf::programs::tracepoint::TracePointContext where U: core::convert::From<T>
-pub fn aya_ebpf::programs::tracepoint::TracePointContext::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf::programs::tracepoint::TracePointContext where U: core::convert::Into<T>
-pub type aya_ebpf::programs::tracepoint::TracePointContext::Error = core::convert::Infallible
-pub fn aya_ebpf::programs::tracepoint::TracePointContext::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf::programs::tracepoint::TracePointContext where U: core::convert::TryFrom<T>
-pub type aya_ebpf::programs::tracepoint::TracePointContext::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf::programs::tracepoint::TracePointContext::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf::programs::tracepoint::TracePointContext where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf::programs::tracepoint::TracePointContext::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf::programs::tracepoint::TracePointContext where T: ?core::marker::Sized
-pub fn aya_ebpf::programs::tracepoint::TracePointContext::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf::programs::tracepoint::TracePointContext where T: ?core::marker::Sized
-pub fn aya_ebpf::programs::tracepoint::TracePointContext::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya_ebpf::programs::tracepoint::TracePointContext
-pub fn aya_ebpf::programs::tracepoint::TracePointContext::from(t: T) -> T
 pub struct aya_ebpf::programs::XdpContext
 pub aya_ebpf::programs::XdpContext::ctx: *mut aya_ebpf_bindings::x86_64::bindings::xdp_md
 impl aya_ebpf::programs::xdp::XdpContext
@@ -3262,22 +1738,6 @@ impl core::marker::Unpin for aya_ebpf::programs::xdp::XdpContext
 impl core::marker::UnsafeUnpin for aya_ebpf::programs::xdp::XdpContext
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::programs::xdp::XdpContext
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf::programs::xdp::XdpContext
-impl<T, U> core::convert::Into<U> for aya_ebpf::programs::xdp::XdpContext where U: core::convert::From<T>
-pub fn aya_ebpf::programs::xdp::XdpContext::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf::programs::xdp::XdpContext where U: core::convert::Into<T>
-pub type aya_ebpf::programs::xdp::XdpContext::Error = core::convert::Infallible
-pub fn aya_ebpf::programs::xdp::XdpContext::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf::programs::xdp::XdpContext where U: core::convert::TryFrom<T>
-pub type aya_ebpf::programs::xdp::XdpContext::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf::programs::xdp::XdpContext::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf::programs::xdp::XdpContext where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf::programs::xdp::XdpContext::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf::programs::xdp::XdpContext where T: ?core::marker::Sized
-pub fn aya_ebpf::programs::xdp::XdpContext::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf::programs::xdp::XdpContext where T: ?core::marker::Sized
-pub fn aya_ebpf::programs::xdp::XdpContext::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya_ebpf::programs::xdp::XdpContext
-pub fn aya_ebpf::programs::xdp::XdpContext::from(t: T) -> T
 pub macro aya_ebpf::bpf_printk!
 #[repr(transparent)] pub struct aya_ebpf::Global<T>
 impl<T> aya_ebpf::Global<T> where T: core::marker::Copy
@@ -3293,22 +1753,6 @@ impl<T> core::marker::Unpin for aya_ebpf::Global<T> where T: core::marker::Unpin
 impl<T> core::marker::UnsafeUnpin for aya_ebpf::Global<T> where T: core::marker::UnsafeUnpin
 impl<T> core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::Global<T> where T: core::panic::unwind_safe::RefUnwindSafe
 impl<T> core::panic::unwind_safe::UnwindSafe for aya_ebpf::Global<T> where T: core::panic::unwind_safe::UnwindSafe
-impl<T, U> core::convert::Into<U> for aya_ebpf::Global<T> where U: core::convert::From<T>
-pub fn aya_ebpf::Global<T>::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_ebpf::Global<T> where U: core::convert::Into<T>
-pub type aya_ebpf::Global<T>::Error = core::convert::Infallible
-pub fn aya_ebpf::Global<T>::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_ebpf::Global<T> where U: core::convert::TryFrom<T>
-pub type aya_ebpf::Global<T>::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_ebpf::Global<T>::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_ebpf::Global<T> where T: 'static + ?core::marker::Sized
-pub fn aya_ebpf::Global<T>::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_ebpf::Global<T> where T: ?core::marker::Sized
-pub fn aya_ebpf::Global<T>::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_ebpf::Global<T> where T: ?core::marker::Sized
-pub fn aya_ebpf::Global<T>::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya_ebpf::Global<T>
-pub fn aya_ebpf::Global<T>::from(t: T) -> T
 pub const aya_ebpf::TASK_COMM_LEN: usize
 pub trait aya_ebpf::Argument: aya_ebpf::args::sealed::Argument
 impl<T: aya_ebpf::args::sealed::Argument> aya_ebpf::Argument for T

--- a/xtask/public-api/aya-log-common.txt
+++ b/xtask/public-api/aya-log-common.txt
@@ -36,24 +36,6 @@ impl core::marker::Unpin for aya_log_common::ArgumentKind
 impl core::marker::UnsafeUnpin for aya_log_common::ArgumentKind
 impl core::panic::unwind_safe::RefUnwindSafe for aya_log_common::ArgumentKind
 impl core::panic::unwind_safe::UnwindSafe for aya_log_common::ArgumentKind
-impl<T, U> core::convert::Into<U> for aya_log_common::ArgumentKind where U: core::convert::From<T>
-pub fn aya_log_common::ArgumentKind::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_log_common::ArgumentKind where U: core::convert::Into<T>
-pub type aya_log_common::ArgumentKind::Error = core::convert::Infallible
-pub fn aya_log_common::ArgumentKind::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_log_common::ArgumentKind where U: core::convert::TryFrom<T>
-pub type aya_log_common::ArgumentKind::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_log_common::ArgumentKind::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_log_common::ArgumentKind where T: 'static + ?core::marker::Sized
-pub fn aya_log_common::ArgumentKind::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_log_common::ArgumentKind where T: ?core::marker::Sized
-pub fn aya_log_common::ArgumentKind::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_log_common::ArgumentKind where T: ?core::marker::Sized
-pub fn aya_log_common::ArgumentKind::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_log_common::ArgumentKind where T: core::clone::Clone
-pub unsafe fn aya_log_common::ArgumentKind::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_log_common::ArgumentKind
-pub fn aya_log_common::ArgumentKind::from(t: T) -> T
 #[repr(u8)] pub enum aya_log_common::DisplayHint
 pub aya_log_common::DisplayHint::Default = 1
 pub aya_log_common::DisplayHint::Ip
@@ -82,24 +64,6 @@ impl core::marker::Unpin for aya_log_common::DisplayHint
 impl core::marker::UnsafeUnpin for aya_log_common::DisplayHint
 impl core::panic::unwind_safe::RefUnwindSafe for aya_log_common::DisplayHint
 impl core::panic::unwind_safe::UnwindSafe for aya_log_common::DisplayHint
-impl<T, U> core::convert::Into<U> for aya_log_common::DisplayHint where U: core::convert::From<T>
-pub fn aya_log_common::DisplayHint::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_log_common::DisplayHint where U: core::convert::Into<T>
-pub type aya_log_common::DisplayHint::Error = core::convert::Infallible
-pub fn aya_log_common::DisplayHint::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_log_common::DisplayHint where U: core::convert::TryFrom<T>
-pub type aya_log_common::DisplayHint::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_log_common::DisplayHint::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_log_common::DisplayHint where T: 'static + ?core::marker::Sized
-pub fn aya_log_common::DisplayHint::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_log_common::DisplayHint where T: ?core::marker::Sized
-pub fn aya_log_common::DisplayHint::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_log_common::DisplayHint where T: ?core::marker::Sized
-pub fn aya_log_common::DisplayHint::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_log_common::DisplayHint where T: core::clone::Clone
-pub unsafe fn aya_log_common::DisplayHint::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_log_common::DisplayHint
-pub fn aya_log_common::DisplayHint::from(t: T) -> T
 #[repr(u8)] pub enum aya_log_common::Level
 pub aya_log_common::Level::Debug
 pub aya_log_common::Level::Error = 1
@@ -126,24 +90,6 @@ impl core::marker::Unpin for aya_log_common::Level
 impl core::marker::UnsafeUnpin for aya_log_common::Level
 impl core::panic::unwind_safe::RefUnwindSafe for aya_log_common::Level
 impl core::panic::unwind_safe::UnwindSafe for aya_log_common::Level
-impl<T, U> core::convert::Into<U> for aya_log_common::Level where U: core::convert::From<T>
-pub fn aya_log_common::Level::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_log_common::Level where U: core::convert::Into<T>
-pub type aya_log_common::Level::Error = core::convert::Infallible
-pub fn aya_log_common::Level::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_log_common::Level where U: core::convert::TryFrom<T>
-pub type aya_log_common::Level::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_log_common::Level::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_log_common::Level where T: 'static + ?core::marker::Sized
-pub fn aya_log_common::Level::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_log_common::Level where T: ?core::marker::Sized
-pub fn aya_log_common::Level::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_log_common::Level where T: ?core::marker::Sized
-pub fn aya_log_common::Level::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_log_common::Level where T: core::clone::Clone
-pub unsafe fn aya_log_common::Level::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_log_common::Level
-pub fn aya_log_common::Level::from(t: T) -> T
 #[repr(u8)] pub enum aya_log_common::RecordFieldKind
 pub aya_log_common::RecordFieldKind::File
 pub aya_log_common::RecordFieldKind::Level
@@ -165,24 +111,6 @@ impl core::marker::Unpin for aya_log_common::RecordFieldKind
 impl core::marker::UnsafeUnpin for aya_log_common::RecordFieldKind
 impl core::panic::unwind_safe::RefUnwindSafe for aya_log_common::RecordFieldKind
 impl core::panic::unwind_safe::UnwindSafe for aya_log_common::RecordFieldKind
-impl<T, U> core::convert::Into<U> for aya_log_common::RecordFieldKind where U: core::convert::From<T>
-pub fn aya_log_common::RecordFieldKind::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_log_common::RecordFieldKind where U: core::convert::Into<T>
-pub type aya_log_common::RecordFieldKind::Error = core::convert::Infallible
-pub fn aya_log_common::RecordFieldKind::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_log_common::RecordFieldKind where U: core::convert::TryFrom<T>
-pub type aya_log_common::RecordFieldKind::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_log_common::RecordFieldKind::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_log_common::RecordFieldKind where T: 'static + ?core::marker::Sized
-pub fn aya_log_common::RecordFieldKind::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_log_common::RecordFieldKind where T: ?core::marker::Sized
-pub fn aya_log_common::RecordFieldKind::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_log_common::RecordFieldKind where T: ?core::marker::Sized
-pub fn aya_log_common::RecordFieldKind::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_log_common::RecordFieldKind where T: core::clone::Clone
-pub unsafe fn aya_log_common::RecordFieldKind::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_log_common::RecordFieldKind
-pub fn aya_log_common::RecordFieldKind::from(t: T) -> T
 pub trait aya_log_common::Argument: aya_log_common::sealed::Sealed
 pub fn aya_log_common::Argument::as_argument(&self) -> (aya_log_common::ArgumentKind, impl core::convert::AsRef<[u8]>)
 impl aya_log_common::Argument for &[u8]

--- a/xtask/public-api/aya-log-parser.txt
+++ b/xtask/public-api/aya-log-parser.txt
@@ -17,28 +17,6 @@ impl core::marker::Unpin for aya_log_parser::Fragment
 impl core::marker::UnsafeUnpin for aya_log_parser::Fragment
 impl core::panic::unwind_safe::RefUnwindSafe for aya_log_parser::Fragment
 impl core::panic::unwind_safe::UnwindSafe for aya_log_parser::Fragment
-impl<T, U> core::convert::Into<U> for aya_log_parser::Fragment where U: core::convert::From<T>
-pub fn aya_log_parser::Fragment::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_log_parser::Fragment where U: core::convert::Into<T>
-pub type aya_log_parser::Fragment::Error = core::convert::Infallible
-pub fn aya_log_parser::Fragment::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_log_parser::Fragment where U: core::convert::TryFrom<T>
-pub type aya_log_parser::Fragment::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_log_parser::Fragment::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya_log_parser::Fragment where T: core::clone::Clone
-pub type aya_log_parser::Fragment::Owned = T
-pub fn aya_log_parser::Fragment::clone_into(&self, target: &mut T)
-pub fn aya_log_parser::Fragment::to_owned(&self) -> T
-impl<T> core::any::Any for aya_log_parser::Fragment where T: 'static + ?core::marker::Sized
-pub fn aya_log_parser::Fragment::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_log_parser::Fragment where T: ?core::marker::Sized
-pub fn aya_log_parser::Fragment::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_log_parser::Fragment where T: ?core::marker::Sized
-pub fn aya_log_parser::Fragment::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_log_parser::Fragment where T: core::clone::Clone
-pub unsafe fn aya_log_parser::Fragment::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_log_parser::Fragment
-pub fn aya_log_parser::Fragment::from(t: T) -> T
 pub struct aya_log_parser::Parameter
 pub aya_log_parser::Parameter::hint: aya_log_common::DisplayHint
 impl core::clone::Clone for aya_log_parser::Parameter
@@ -56,26 +34,4 @@ impl core::marker::Unpin for aya_log_parser::Parameter
 impl core::marker::UnsafeUnpin for aya_log_parser::Parameter
 impl core::panic::unwind_safe::RefUnwindSafe for aya_log_parser::Parameter
 impl core::panic::unwind_safe::UnwindSafe for aya_log_parser::Parameter
-impl<T, U> core::convert::Into<U> for aya_log_parser::Parameter where U: core::convert::From<T>
-pub fn aya_log_parser::Parameter::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_log_parser::Parameter where U: core::convert::Into<T>
-pub type aya_log_parser::Parameter::Error = core::convert::Infallible
-pub fn aya_log_parser::Parameter::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_log_parser::Parameter where U: core::convert::TryFrom<T>
-pub type aya_log_parser::Parameter::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_log_parser::Parameter::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya_log_parser::Parameter where T: core::clone::Clone
-pub type aya_log_parser::Parameter::Owned = T
-pub fn aya_log_parser::Parameter::clone_into(&self, target: &mut T)
-pub fn aya_log_parser::Parameter::to_owned(&self) -> T
-impl<T> core::any::Any for aya_log_parser::Parameter where T: 'static + ?core::marker::Sized
-pub fn aya_log_parser::Parameter::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_log_parser::Parameter where T: ?core::marker::Sized
-pub fn aya_log_parser::Parameter::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_log_parser::Parameter where T: ?core::marker::Sized
-pub fn aya_log_parser::Parameter::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_log_parser::Parameter where T: core::clone::Clone
-pub unsafe fn aya_log_parser::Parameter::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_log_parser::Parameter
-pub fn aya_log_parser::Parameter::from(t: T) -> T
 pub fn aya_log_parser::parse(format_string: &str) -> core::result::Result<alloc::vec::Vec<aya_log_parser::Fragment>, alloc::string::String>

--- a/xtask/public-api/aya-log.txt
+++ b/xtask/public-api/aya-log.txt
@@ -22,24 +22,6 @@ impl core::marker::Unpin for aya_log::Error
 impl core::marker::UnsafeUnpin for aya_log::Error
 impl !core::panic::unwind_safe::RefUnwindSafe for aya_log::Error
 impl !core::panic::unwind_safe::UnwindSafe for aya_log::Error
-impl<T, U> core::convert::Into<U> for aya_log::Error where U: core::convert::From<T>
-pub fn aya_log::Error::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_log::Error where U: core::convert::Into<T>
-pub type aya_log::Error::Error = core::convert::Infallible
-pub fn aya_log::Error::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_log::Error where U: core::convert::TryFrom<T>
-pub type aya_log::Error::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_log::Error::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::string::ToString for aya_log::Error where T: core::fmt::Display + ?core::marker::Sized
-pub fn aya_log::Error::to_string(&self) -> alloc::string::String
-impl<T> core::any::Any for aya_log::Error where T: 'static + ?core::marker::Sized
-pub fn aya_log::Error::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_log::Error where T: ?core::marker::Sized
-pub fn aya_log::Error::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_log::Error where T: ?core::marker::Sized
-pub fn aya_log::Error::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya_log::Error
-pub fn aya_log::Error::from(t: T) -> T
 pub struct aya_log::DefaultFormatter
 impl<T> aya_log::Formatter<T> for aya_log::DefaultFormatter where T: alloc::string::ToString
 pub fn aya_log::DefaultFormatter::format(v: T) -> alloc::string::String
@@ -50,22 +32,6 @@ impl core::marker::Unpin for aya_log::DefaultFormatter
 impl core::marker::UnsafeUnpin for aya_log::DefaultFormatter
 impl core::panic::unwind_safe::RefUnwindSafe for aya_log::DefaultFormatter
 impl core::panic::unwind_safe::UnwindSafe for aya_log::DefaultFormatter
-impl<T, U> core::convert::Into<U> for aya_log::DefaultFormatter where U: core::convert::From<T>
-pub fn aya_log::DefaultFormatter::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_log::DefaultFormatter where U: core::convert::Into<T>
-pub type aya_log::DefaultFormatter::Error = core::convert::Infallible
-pub fn aya_log::DefaultFormatter::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_log::DefaultFormatter where U: core::convert::TryFrom<T>
-pub type aya_log::DefaultFormatter::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_log::DefaultFormatter::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_log::DefaultFormatter where T: 'static + ?core::marker::Sized
-pub fn aya_log::DefaultFormatter::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_log::DefaultFormatter where T: ?core::marker::Sized
-pub fn aya_log::DefaultFormatter::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_log::DefaultFormatter where T: ?core::marker::Sized
-pub fn aya_log::DefaultFormatter::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya_log::DefaultFormatter
-pub fn aya_log::DefaultFormatter::from(t: T) -> T
 pub struct aya_log::EbpfLogger<T>
 impl aya_log::EbpfLogger<&'static dyn log::Log>
 pub fn aya_log::EbpfLogger<&'static dyn log::Log>::init(bpf: &mut aya::bpf::Ebpf) -> core::result::Result<Self, aya_log::Error>
@@ -85,22 +51,6 @@ impl<T> core::marker::Unpin for aya_log::EbpfLogger<T> where T: core::marker::Un
 impl<T> core::marker::UnsafeUnpin for aya_log::EbpfLogger<T> where T: core::marker::UnsafeUnpin
 impl<T> core::panic::unwind_safe::RefUnwindSafe for aya_log::EbpfLogger<T> where T: core::panic::unwind_safe::RefUnwindSafe
 impl<T> core::panic::unwind_safe::UnwindSafe for aya_log::EbpfLogger<T> where T: core::panic::unwind_safe::UnwindSafe
-impl<T, U> core::convert::Into<U> for aya_log::EbpfLogger<T> where U: core::convert::From<T>
-pub fn aya_log::EbpfLogger<T>::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_log::EbpfLogger<T> where U: core::convert::Into<T>
-pub type aya_log::EbpfLogger<T>::Error = core::convert::Infallible
-pub fn aya_log::EbpfLogger<T>::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_log::EbpfLogger<T> where U: core::convert::TryFrom<T>
-pub type aya_log::EbpfLogger<T>::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_log::EbpfLogger<T>::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_log::EbpfLogger<T> where T: 'static + ?core::marker::Sized
-pub fn aya_log::EbpfLogger<T>::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_log::EbpfLogger<T> where T: ?core::marker::Sized
-pub fn aya_log::EbpfLogger<T>::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_log::EbpfLogger<T> where T: ?core::marker::Sized
-pub fn aya_log::EbpfLogger<T>::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya_log::EbpfLogger<T>
-pub fn aya_log::EbpfLogger<T>::from(t: T) -> T
 pub struct aya_log::Ipv4Formatter
 impl<T> aya_log::Formatter<T> for aya_log::Ipv4Formatter where T: core::convert::Into<core::net::ip_addr::Ipv4Addr>
 pub fn aya_log::Ipv4Formatter::format(v: T) -> alloc::string::String
@@ -111,22 +61,6 @@ impl core::marker::Unpin for aya_log::Ipv4Formatter
 impl core::marker::UnsafeUnpin for aya_log::Ipv4Formatter
 impl core::panic::unwind_safe::RefUnwindSafe for aya_log::Ipv4Formatter
 impl core::panic::unwind_safe::UnwindSafe for aya_log::Ipv4Formatter
-impl<T, U> core::convert::Into<U> for aya_log::Ipv4Formatter where U: core::convert::From<T>
-pub fn aya_log::Ipv4Formatter::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_log::Ipv4Formatter where U: core::convert::Into<T>
-pub type aya_log::Ipv4Formatter::Error = core::convert::Infallible
-pub fn aya_log::Ipv4Formatter::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_log::Ipv4Formatter where U: core::convert::TryFrom<T>
-pub type aya_log::Ipv4Formatter::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_log::Ipv4Formatter::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_log::Ipv4Formatter where T: 'static + ?core::marker::Sized
-pub fn aya_log::Ipv4Formatter::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_log::Ipv4Formatter where T: ?core::marker::Sized
-pub fn aya_log::Ipv4Formatter::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_log::Ipv4Formatter where T: ?core::marker::Sized
-pub fn aya_log::Ipv4Formatter::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya_log::Ipv4Formatter
-pub fn aya_log::Ipv4Formatter::from(t: T) -> T
 pub struct aya_log::Ipv6Formatter
 impl<T> aya_log::Formatter<T> for aya_log::Ipv6Formatter where T: core::convert::Into<core::net::ip_addr::Ipv6Addr>
 pub fn aya_log::Ipv6Formatter::format(v: T) -> alloc::string::String
@@ -137,22 +71,6 @@ impl core::marker::Unpin for aya_log::Ipv6Formatter
 impl core::marker::UnsafeUnpin for aya_log::Ipv6Formatter
 impl core::panic::unwind_safe::RefUnwindSafe for aya_log::Ipv6Formatter
 impl core::panic::unwind_safe::UnwindSafe for aya_log::Ipv6Formatter
-impl<T, U> core::convert::Into<U> for aya_log::Ipv6Formatter where U: core::convert::From<T>
-pub fn aya_log::Ipv6Formatter::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_log::Ipv6Formatter where U: core::convert::Into<T>
-pub type aya_log::Ipv6Formatter::Error = core::convert::Infallible
-pub fn aya_log::Ipv6Formatter::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_log::Ipv6Formatter where U: core::convert::TryFrom<T>
-pub type aya_log::Ipv6Formatter::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_log::Ipv6Formatter::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_log::Ipv6Formatter where T: 'static + ?core::marker::Sized
-pub fn aya_log::Ipv6Formatter::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_log::Ipv6Formatter where T: ?core::marker::Sized
-pub fn aya_log::Ipv6Formatter::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_log::Ipv6Formatter where T: ?core::marker::Sized
-pub fn aya_log::Ipv6Formatter::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya_log::Ipv6Formatter
-pub fn aya_log::Ipv6Formatter::from(t: T) -> T
 pub struct aya_log::LowerHexBytesFormatter
 impl aya_log::Formatter<&[u8]> for aya_log::LowerHexBytesFormatter
 pub fn aya_log::LowerHexBytesFormatter::format(v: &[u8]) -> alloc::string::String
@@ -163,22 +81,6 @@ impl core::marker::Unpin for aya_log::LowerHexBytesFormatter
 impl core::marker::UnsafeUnpin for aya_log::LowerHexBytesFormatter
 impl core::panic::unwind_safe::RefUnwindSafe for aya_log::LowerHexBytesFormatter
 impl core::panic::unwind_safe::UnwindSafe for aya_log::LowerHexBytesFormatter
-impl<T, U> core::convert::Into<U> for aya_log::LowerHexBytesFormatter where U: core::convert::From<T>
-pub fn aya_log::LowerHexBytesFormatter::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_log::LowerHexBytesFormatter where U: core::convert::Into<T>
-pub type aya_log::LowerHexBytesFormatter::Error = core::convert::Infallible
-pub fn aya_log::LowerHexBytesFormatter::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_log::LowerHexBytesFormatter where U: core::convert::TryFrom<T>
-pub type aya_log::LowerHexBytesFormatter::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_log::LowerHexBytesFormatter::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_log::LowerHexBytesFormatter where T: 'static + ?core::marker::Sized
-pub fn aya_log::LowerHexBytesFormatter::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_log::LowerHexBytesFormatter where T: ?core::marker::Sized
-pub fn aya_log::LowerHexBytesFormatter::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_log::LowerHexBytesFormatter where T: ?core::marker::Sized
-pub fn aya_log::LowerHexBytesFormatter::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya_log::LowerHexBytesFormatter
-pub fn aya_log::LowerHexBytesFormatter::from(t: T) -> T
 pub struct aya_log::LowerHexFormatter
 impl<T> aya_log::Formatter<T> for aya_log::LowerHexFormatter where T: core::fmt::LowerHex
 pub fn aya_log::LowerHexFormatter::format(v: T) -> alloc::string::String
@@ -189,22 +91,6 @@ impl core::marker::Unpin for aya_log::LowerHexFormatter
 impl core::marker::UnsafeUnpin for aya_log::LowerHexFormatter
 impl core::panic::unwind_safe::RefUnwindSafe for aya_log::LowerHexFormatter
 impl core::panic::unwind_safe::UnwindSafe for aya_log::LowerHexFormatter
-impl<T, U> core::convert::Into<U> for aya_log::LowerHexFormatter where U: core::convert::From<T>
-pub fn aya_log::LowerHexFormatter::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_log::LowerHexFormatter where U: core::convert::Into<T>
-pub type aya_log::LowerHexFormatter::Error = core::convert::Infallible
-pub fn aya_log::LowerHexFormatter::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_log::LowerHexFormatter where U: core::convert::TryFrom<T>
-pub type aya_log::LowerHexFormatter::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_log::LowerHexFormatter::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_log::LowerHexFormatter where T: 'static + ?core::marker::Sized
-pub fn aya_log::LowerHexFormatter::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_log::LowerHexFormatter where T: ?core::marker::Sized
-pub fn aya_log::LowerHexFormatter::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_log::LowerHexFormatter where T: ?core::marker::Sized
-pub fn aya_log::LowerHexFormatter::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya_log::LowerHexFormatter
-pub fn aya_log::LowerHexFormatter::from(t: T) -> T
 pub struct aya_log::LowerMacFormatter
 impl aya_log::Formatter<[u8; 6]> for aya_log::LowerMacFormatter
 pub fn aya_log::LowerMacFormatter::format(v: [u8; 6]) -> alloc::string::String
@@ -215,22 +101,6 @@ impl core::marker::Unpin for aya_log::LowerMacFormatter
 impl core::marker::UnsafeUnpin for aya_log::LowerMacFormatter
 impl core::panic::unwind_safe::RefUnwindSafe for aya_log::LowerMacFormatter
 impl core::panic::unwind_safe::UnwindSafe for aya_log::LowerMacFormatter
-impl<T, U> core::convert::Into<U> for aya_log::LowerMacFormatter where U: core::convert::From<T>
-pub fn aya_log::LowerMacFormatter::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_log::LowerMacFormatter where U: core::convert::Into<T>
-pub type aya_log::LowerMacFormatter::Error = core::convert::Infallible
-pub fn aya_log::LowerMacFormatter::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_log::LowerMacFormatter where U: core::convert::TryFrom<T>
-pub type aya_log::LowerMacFormatter::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_log::LowerMacFormatter::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_log::LowerMacFormatter where T: 'static + ?core::marker::Sized
-pub fn aya_log::LowerMacFormatter::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_log::LowerMacFormatter where T: ?core::marker::Sized
-pub fn aya_log::LowerMacFormatter::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_log::LowerMacFormatter where T: ?core::marker::Sized
-pub fn aya_log::LowerMacFormatter::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya_log::LowerMacFormatter
-pub fn aya_log::LowerMacFormatter::from(t: T) -> T
 pub struct aya_log::PointerFormatter
 impl<T> aya_log::Formatter<*const T> for aya_log::PointerFormatter
 pub fn aya_log::PointerFormatter::format(v: *const T) -> alloc::string::String
@@ -243,22 +113,6 @@ impl core::marker::Unpin for aya_log::PointerFormatter
 impl core::marker::UnsafeUnpin for aya_log::PointerFormatter
 impl core::panic::unwind_safe::RefUnwindSafe for aya_log::PointerFormatter
 impl core::panic::unwind_safe::UnwindSafe for aya_log::PointerFormatter
-impl<T, U> core::convert::Into<U> for aya_log::PointerFormatter where U: core::convert::From<T>
-pub fn aya_log::PointerFormatter::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_log::PointerFormatter where U: core::convert::Into<T>
-pub type aya_log::PointerFormatter::Error = core::convert::Infallible
-pub fn aya_log::PointerFormatter::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_log::PointerFormatter where U: core::convert::TryFrom<T>
-pub type aya_log::PointerFormatter::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_log::PointerFormatter::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_log::PointerFormatter where T: 'static + ?core::marker::Sized
-pub fn aya_log::PointerFormatter::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_log::PointerFormatter where T: ?core::marker::Sized
-pub fn aya_log::PointerFormatter::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_log::PointerFormatter where T: ?core::marker::Sized
-pub fn aya_log::PointerFormatter::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya_log::PointerFormatter
-pub fn aya_log::PointerFormatter::from(t: T) -> T
 pub struct aya_log::UpperHexBytesFormatter
 impl aya_log::Formatter<&[u8]> for aya_log::UpperHexBytesFormatter
 pub fn aya_log::UpperHexBytesFormatter::format(v: &[u8]) -> alloc::string::String
@@ -269,22 +123,6 @@ impl core::marker::Unpin for aya_log::UpperHexBytesFormatter
 impl core::marker::UnsafeUnpin for aya_log::UpperHexBytesFormatter
 impl core::panic::unwind_safe::RefUnwindSafe for aya_log::UpperHexBytesFormatter
 impl core::panic::unwind_safe::UnwindSafe for aya_log::UpperHexBytesFormatter
-impl<T, U> core::convert::Into<U> for aya_log::UpperHexBytesFormatter where U: core::convert::From<T>
-pub fn aya_log::UpperHexBytesFormatter::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_log::UpperHexBytesFormatter where U: core::convert::Into<T>
-pub type aya_log::UpperHexBytesFormatter::Error = core::convert::Infallible
-pub fn aya_log::UpperHexBytesFormatter::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_log::UpperHexBytesFormatter where U: core::convert::TryFrom<T>
-pub type aya_log::UpperHexBytesFormatter::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_log::UpperHexBytesFormatter::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_log::UpperHexBytesFormatter where T: 'static + ?core::marker::Sized
-pub fn aya_log::UpperHexBytesFormatter::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_log::UpperHexBytesFormatter where T: ?core::marker::Sized
-pub fn aya_log::UpperHexBytesFormatter::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_log::UpperHexBytesFormatter where T: ?core::marker::Sized
-pub fn aya_log::UpperHexBytesFormatter::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya_log::UpperHexBytesFormatter
-pub fn aya_log::UpperHexBytesFormatter::from(t: T) -> T
 pub struct aya_log::UpperHexFormatter
 impl<T> aya_log::Formatter<T> for aya_log::UpperHexFormatter where T: core::fmt::UpperHex
 pub fn aya_log::UpperHexFormatter::format(v: T) -> alloc::string::String
@@ -295,22 +133,6 @@ impl core::marker::Unpin for aya_log::UpperHexFormatter
 impl core::marker::UnsafeUnpin for aya_log::UpperHexFormatter
 impl core::panic::unwind_safe::RefUnwindSafe for aya_log::UpperHexFormatter
 impl core::panic::unwind_safe::UnwindSafe for aya_log::UpperHexFormatter
-impl<T, U> core::convert::Into<U> for aya_log::UpperHexFormatter where U: core::convert::From<T>
-pub fn aya_log::UpperHexFormatter::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_log::UpperHexFormatter where U: core::convert::Into<T>
-pub type aya_log::UpperHexFormatter::Error = core::convert::Infallible
-pub fn aya_log::UpperHexFormatter::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_log::UpperHexFormatter where U: core::convert::TryFrom<T>
-pub type aya_log::UpperHexFormatter::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_log::UpperHexFormatter::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_log::UpperHexFormatter where T: 'static + ?core::marker::Sized
-pub fn aya_log::UpperHexFormatter::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_log::UpperHexFormatter where T: ?core::marker::Sized
-pub fn aya_log::UpperHexFormatter::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_log::UpperHexFormatter where T: ?core::marker::Sized
-pub fn aya_log::UpperHexFormatter::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya_log::UpperHexFormatter
-pub fn aya_log::UpperHexFormatter::from(t: T) -> T
 pub struct aya_log::UpperMacFormatter
 impl aya_log::Formatter<[u8; 6]> for aya_log::UpperMacFormatter
 pub fn aya_log::UpperMacFormatter::format(v: [u8; 6]) -> alloc::string::String
@@ -321,22 +143,6 @@ impl core::marker::Unpin for aya_log::UpperMacFormatter
 impl core::marker::UnsafeUnpin for aya_log::UpperMacFormatter
 impl core::panic::unwind_safe::RefUnwindSafe for aya_log::UpperMacFormatter
 impl core::panic::unwind_safe::UnwindSafe for aya_log::UpperMacFormatter
-impl<T, U> core::convert::Into<U> for aya_log::UpperMacFormatter where U: core::convert::From<T>
-pub fn aya_log::UpperMacFormatter::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_log::UpperMacFormatter where U: core::convert::Into<T>
-pub type aya_log::UpperMacFormatter::Error = core::convert::Infallible
-pub fn aya_log::UpperMacFormatter::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_log::UpperMacFormatter where U: core::convert::TryFrom<T>
-pub type aya_log::UpperMacFormatter::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_log::UpperMacFormatter::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_log::UpperMacFormatter where T: 'static + ?core::marker::Sized
-pub fn aya_log::UpperMacFormatter::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_log::UpperMacFormatter where T: ?core::marker::Sized
-pub fn aya_log::UpperMacFormatter::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_log::UpperMacFormatter where T: ?core::marker::Sized
-pub fn aya_log::UpperMacFormatter::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya_log::UpperMacFormatter
-pub fn aya_log::UpperMacFormatter::from(t: T) -> T
 pub const aya_log::LEVEL: &str
 pub trait aya_log::Formatter<T>
 pub fn aya_log::Formatter::format(v: T) -> alloc::string::String

--- a/xtask/public-api/aya-obj.txt
+++ b/xtask/public-api/aya-obj.txt
@@ -53,24 +53,6 @@ impl core::marker::Unpin for aya_obj::btf::BtfError
 impl core::marker::UnsafeUnpin for aya_obj::btf::BtfError
 impl !core::panic::unwind_safe::RefUnwindSafe for aya_obj::btf::BtfError
 impl !core::panic::unwind_safe::UnwindSafe for aya_obj::btf::BtfError
-impl<T, U> core::convert::Into<U> for aya_obj::btf::BtfError where U: core::convert::From<T>
-pub fn aya_obj::btf::BtfError::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_obj::btf::BtfError where U: core::convert::Into<T>
-pub type aya_obj::btf::BtfError::Error = core::convert::Infallible
-pub fn aya_obj::btf::BtfError::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_obj::btf::BtfError where U: core::convert::TryFrom<T>
-pub type aya_obj::btf::BtfError::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_obj::btf::BtfError::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::string::ToString for aya_obj::btf::BtfError where T: core::fmt::Display + ?core::marker::Sized
-pub fn aya_obj::btf::BtfError::to_string(&self) -> alloc::string::String
-impl<T> core::any::Any for aya_obj::btf::BtfError where T: 'static + ?core::marker::Sized
-pub fn aya_obj::btf::BtfError::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_obj::btf::BtfError where T: ?core::marker::Sized
-pub fn aya_obj::btf::BtfError::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_obj::btf::BtfError where T: ?core::marker::Sized
-pub fn aya_obj::btf::BtfError::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya_obj::btf::BtfError
-pub fn aya_obj::btf::BtfError::from(t: T) -> T
 #[repr(u32)] pub enum aya_obj::btf::BtfKind
 pub aya_obj::btf::BtfKind::Array = 3
 pub aya_obj::btf::BtfKind::Const = 10
@@ -115,30 +97,6 @@ impl core::marker::Unpin for aya_obj::btf::BtfKind
 impl core::marker::UnsafeUnpin for aya_obj::btf::BtfKind
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::btf::BtfKind
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::btf::BtfKind
-impl<T, U> core::convert::Into<U> for aya_obj::btf::BtfKind where U: core::convert::From<T>
-pub fn aya_obj::btf::BtfKind::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_obj::btf::BtfKind where U: core::convert::Into<T>
-pub type aya_obj::btf::BtfKind::Error = core::convert::Infallible
-pub fn aya_obj::btf::BtfKind::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_obj::btf::BtfKind where U: core::convert::TryFrom<T>
-pub type aya_obj::btf::BtfKind::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_obj::btf::BtfKind::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya_obj::btf::BtfKind where T: core::clone::Clone
-pub type aya_obj::btf::BtfKind::Owned = T
-pub fn aya_obj::btf::BtfKind::clone_into(&self, target: &mut T)
-pub fn aya_obj::btf::BtfKind::to_owned(&self) -> T
-impl<T> alloc::string::ToString for aya_obj::btf::BtfKind where T: core::fmt::Display + ?core::marker::Sized
-pub fn aya_obj::btf::BtfKind::to_string(&self) -> alloc::string::String
-impl<T> core::any::Any for aya_obj::btf::BtfKind where T: 'static + ?core::marker::Sized
-pub fn aya_obj::btf::BtfKind::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_obj::btf::BtfKind where T: ?core::marker::Sized
-pub fn aya_obj::btf::BtfKind::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_obj::btf::BtfKind where T: ?core::marker::Sized
-pub fn aya_obj::btf::BtfKind::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::btf::BtfKind where T: core::clone::Clone
-pub unsafe fn aya_obj::btf::BtfKind::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_obj::btf::BtfKind
-pub fn aya_obj::btf::BtfKind::from(t: T) -> T
 pub enum aya_obj::btf::BtfType
 pub aya_obj::btf::BtfType::Array(aya_obj::btf::Array)
 pub aya_obj::btf::BtfType::Const(aya_obj::btf::Const)
@@ -171,28 +129,6 @@ impl core::marker::Unpin for aya_obj::btf::BtfType
 impl core::marker::UnsafeUnpin for aya_obj::btf::BtfType
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::btf::BtfType
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::btf::BtfType
-impl<T, U> core::convert::Into<U> for aya_obj::btf::BtfType where U: core::convert::From<T>
-pub fn aya_obj::btf::BtfType::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_obj::btf::BtfType where U: core::convert::Into<T>
-pub type aya_obj::btf::BtfType::Error = core::convert::Infallible
-pub fn aya_obj::btf::BtfType::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_obj::btf::BtfType where U: core::convert::TryFrom<T>
-pub type aya_obj::btf::BtfType::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_obj::btf::BtfType::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya_obj::btf::BtfType where T: core::clone::Clone
-pub type aya_obj::btf::BtfType::Owned = T
-pub fn aya_obj::btf::BtfType::clone_into(&self, target: &mut T)
-pub fn aya_obj::btf::BtfType::to_owned(&self) -> T
-impl<T> core::any::Any for aya_obj::btf::BtfType where T: 'static + ?core::marker::Sized
-pub fn aya_obj::btf::BtfType::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_obj::btf::BtfType where T: ?core::marker::Sized
-pub fn aya_obj::btf::BtfType::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_obj::btf::BtfType where T: ?core::marker::Sized
-pub fn aya_obj::btf::BtfType::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::btf::BtfType where T: core::clone::Clone
-pub unsafe fn aya_obj::btf::BtfType::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_obj::btf::BtfType
-pub fn aya_obj::btf::BtfType::from(t: T) -> T
 #[repr(u32)] pub enum aya_obj::btf::FuncLinkage
 pub aya_obj::btf::FuncLinkage::Extern = 2
 pub aya_obj::btf::FuncLinkage::Global = 1
@@ -215,28 +151,6 @@ impl core::marker::Unpin for aya_obj::btf::FuncLinkage
 impl core::marker::UnsafeUnpin for aya_obj::btf::FuncLinkage
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::btf::FuncLinkage
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::btf::FuncLinkage
-impl<T, U> core::convert::Into<U> for aya_obj::btf::FuncLinkage where U: core::convert::From<T>
-pub fn aya_obj::btf::FuncLinkage::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_obj::btf::FuncLinkage where U: core::convert::Into<T>
-pub type aya_obj::btf::FuncLinkage::Error = core::convert::Infallible
-pub fn aya_obj::btf::FuncLinkage::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_obj::btf::FuncLinkage where U: core::convert::TryFrom<T>
-pub type aya_obj::btf::FuncLinkage::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_obj::btf::FuncLinkage::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya_obj::btf::FuncLinkage where T: core::clone::Clone
-pub type aya_obj::btf::FuncLinkage::Owned = T
-pub fn aya_obj::btf::FuncLinkage::clone_into(&self, target: &mut T)
-pub fn aya_obj::btf::FuncLinkage::to_owned(&self) -> T
-impl<T> core::any::Any for aya_obj::btf::FuncLinkage where T: 'static + ?core::marker::Sized
-pub fn aya_obj::btf::FuncLinkage::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_obj::btf::FuncLinkage where T: ?core::marker::Sized
-pub fn aya_obj::btf::FuncLinkage::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_obj::btf::FuncLinkage where T: ?core::marker::Sized
-pub fn aya_obj::btf::FuncLinkage::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::btf::FuncLinkage where T: core::clone::Clone
-pub unsafe fn aya_obj::btf::FuncLinkage::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_obj::btf::FuncLinkage
-pub fn aya_obj::btf::FuncLinkage::from(t: T) -> T
 #[repr(u32)] pub enum aya_obj::btf::IntEncoding
 pub aya_obj::btf::IntEncoding::Bool = 4
 pub aya_obj::btf::IntEncoding::Char = 2
@@ -260,28 +174,6 @@ impl core::marker::Unpin for aya_obj::btf::IntEncoding
 impl core::marker::UnsafeUnpin for aya_obj::btf::IntEncoding
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::btf::IntEncoding
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::btf::IntEncoding
-impl<T, U> core::convert::Into<U> for aya_obj::btf::IntEncoding where U: core::convert::From<T>
-pub fn aya_obj::btf::IntEncoding::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_obj::btf::IntEncoding where U: core::convert::Into<T>
-pub type aya_obj::btf::IntEncoding::Error = core::convert::Infallible
-pub fn aya_obj::btf::IntEncoding::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_obj::btf::IntEncoding where U: core::convert::TryFrom<T>
-pub type aya_obj::btf::IntEncoding::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_obj::btf::IntEncoding::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya_obj::btf::IntEncoding where T: core::clone::Clone
-pub type aya_obj::btf::IntEncoding::Owned = T
-pub fn aya_obj::btf::IntEncoding::clone_into(&self, target: &mut T)
-pub fn aya_obj::btf::IntEncoding::to_owned(&self) -> T
-impl<T> core::any::Any for aya_obj::btf::IntEncoding where T: 'static + ?core::marker::Sized
-pub fn aya_obj::btf::IntEncoding::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_obj::btf::IntEncoding where T: ?core::marker::Sized
-pub fn aya_obj::btf::IntEncoding::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_obj::btf::IntEncoding where T: ?core::marker::Sized
-pub fn aya_obj::btf::IntEncoding::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::btf::IntEncoding where T: core::clone::Clone
-pub unsafe fn aya_obj::btf::IntEncoding::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_obj::btf::IntEncoding
-pub fn aya_obj::btf::IntEncoding::from(t: T) -> T
 #[repr(u32)] pub enum aya_obj::btf::VarLinkage
 pub aya_obj::btf::VarLinkage::Extern
 pub aya_obj::btf::VarLinkage::Global
@@ -304,28 +196,6 @@ impl core::marker::Unpin for aya_obj::btf::VarLinkage
 impl core::marker::UnsafeUnpin for aya_obj::btf::VarLinkage
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::btf::VarLinkage
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::btf::VarLinkage
-impl<T, U> core::convert::Into<U> for aya_obj::btf::VarLinkage where U: core::convert::From<T>
-pub fn aya_obj::btf::VarLinkage::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_obj::btf::VarLinkage where U: core::convert::Into<T>
-pub type aya_obj::btf::VarLinkage::Error = core::convert::Infallible
-pub fn aya_obj::btf::VarLinkage::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_obj::btf::VarLinkage where U: core::convert::TryFrom<T>
-pub type aya_obj::btf::VarLinkage::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_obj::btf::VarLinkage::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya_obj::btf::VarLinkage where T: core::clone::Clone
-pub type aya_obj::btf::VarLinkage::Owned = T
-pub fn aya_obj::btf::VarLinkage::clone_into(&self, target: &mut T)
-pub fn aya_obj::btf::VarLinkage::to_owned(&self) -> T
-impl<T> core::any::Any for aya_obj::btf::VarLinkage where T: 'static + ?core::marker::Sized
-pub fn aya_obj::btf::VarLinkage::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_obj::btf::VarLinkage where T: ?core::marker::Sized
-pub fn aya_obj::btf::VarLinkage::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_obj::btf::VarLinkage where T: ?core::marker::Sized
-pub fn aya_obj::btf::VarLinkage::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::btf::VarLinkage where T: core::clone::Clone
-pub unsafe fn aya_obj::btf::VarLinkage::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_obj::btf::VarLinkage
-pub fn aya_obj::btf::VarLinkage::from(t: T) -> T
 #[repr(C)] pub struct aya_obj::btf::Array
 impl core::clone::Clone for aya_obj::btf::Array
 pub fn aya_obj::btf::Array::clone(&self) -> aya_obj::btf::Array
@@ -338,28 +208,6 @@ impl core::marker::Unpin for aya_obj::btf::Array
 impl core::marker::UnsafeUnpin for aya_obj::btf::Array
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::btf::Array
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::btf::Array
-impl<T, U> core::convert::Into<U> for aya_obj::btf::Array where U: core::convert::From<T>
-pub fn aya_obj::btf::Array::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_obj::btf::Array where U: core::convert::Into<T>
-pub type aya_obj::btf::Array::Error = core::convert::Infallible
-pub fn aya_obj::btf::Array::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_obj::btf::Array where U: core::convert::TryFrom<T>
-pub type aya_obj::btf::Array::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_obj::btf::Array::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya_obj::btf::Array where T: core::clone::Clone
-pub type aya_obj::btf::Array::Owned = T
-pub fn aya_obj::btf::Array::clone_into(&self, target: &mut T)
-pub fn aya_obj::btf::Array::to_owned(&self) -> T
-impl<T> core::any::Any for aya_obj::btf::Array where T: 'static + ?core::marker::Sized
-pub fn aya_obj::btf::Array::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_obj::btf::Array where T: ?core::marker::Sized
-pub fn aya_obj::btf::Array::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_obj::btf::Array where T: ?core::marker::Sized
-pub fn aya_obj::btf::Array::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::btf::Array where T: core::clone::Clone
-pub unsafe fn aya_obj::btf::Array::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_obj::btf::Array
-pub fn aya_obj::btf::Array::from(t: T) -> T
 pub struct aya_obj::btf::Btf
 impl aya_obj::btf::Btf
 pub fn aya_obj::btf::Btf::add_string(&mut self, name: &str) -> u32
@@ -383,28 +231,6 @@ impl core::marker::Unpin for aya_obj::btf::Btf
 impl core::marker::UnsafeUnpin for aya_obj::btf::Btf
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::btf::Btf
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::btf::Btf
-impl<T, U> core::convert::Into<U> for aya_obj::btf::Btf where U: core::convert::From<T>
-pub fn aya_obj::btf::Btf::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_obj::btf::Btf where U: core::convert::Into<T>
-pub type aya_obj::btf::Btf::Error = core::convert::Infallible
-pub fn aya_obj::btf::Btf::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_obj::btf::Btf where U: core::convert::TryFrom<T>
-pub type aya_obj::btf::Btf::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_obj::btf::Btf::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya_obj::btf::Btf where T: core::clone::Clone
-pub type aya_obj::btf::Btf::Owned = T
-pub fn aya_obj::btf::Btf::clone_into(&self, target: &mut T)
-pub fn aya_obj::btf::Btf::to_owned(&self) -> T
-impl<T> core::any::Any for aya_obj::btf::Btf where T: 'static + ?core::marker::Sized
-pub fn aya_obj::btf::Btf::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_obj::btf::Btf where T: ?core::marker::Sized
-pub fn aya_obj::btf::Btf::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_obj::btf::Btf where T: ?core::marker::Sized
-pub fn aya_obj::btf::Btf::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::btf::Btf where T: core::clone::Clone
-pub unsafe fn aya_obj::btf::Btf::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_obj::btf::Btf
-pub fn aya_obj::btf::Btf::from(t: T) -> T
 #[repr(C)] pub struct aya_obj::btf::BtfEnum
 pub aya_obj::btf::BtfEnum::name_offset: u32
 pub aya_obj::btf::BtfEnum::value: u32
@@ -421,28 +247,6 @@ impl core::marker::Unpin for aya_obj::btf::BtfEnum
 impl core::marker::UnsafeUnpin for aya_obj::btf::BtfEnum
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::btf::BtfEnum
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::btf::BtfEnum
-impl<T, U> core::convert::Into<U> for aya_obj::btf::BtfEnum where U: core::convert::From<T>
-pub fn aya_obj::btf::BtfEnum::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_obj::btf::BtfEnum where U: core::convert::Into<T>
-pub type aya_obj::btf::BtfEnum::Error = core::convert::Infallible
-pub fn aya_obj::btf::BtfEnum::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_obj::btf::BtfEnum where U: core::convert::TryFrom<T>
-pub type aya_obj::btf::BtfEnum::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_obj::btf::BtfEnum::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya_obj::btf::BtfEnum where T: core::clone::Clone
-pub type aya_obj::btf::BtfEnum::Owned = T
-pub fn aya_obj::btf::BtfEnum::clone_into(&self, target: &mut T)
-pub fn aya_obj::btf::BtfEnum::to_owned(&self) -> T
-impl<T> core::any::Any for aya_obj::btf::BtfEnum where T: 'static + ?core::marker::Sized
-pub fn aya_obj::btf::BtfEnum::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_obj::btf::BtfEnum where T: ?core::marker::Sized
-pub fn aya_obj::btf::BtfEnum::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_obj::btf::BtfEnum where T: ?core::marker::Sized
-pub fn aya_obj::btf::BtfEnum::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::btf::BtfEnum where T: core::clone::Clone
-pub unsafe fn aya_obj::btf::BtfEnum::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_obj::btf::BtfEnum
-pub fn aya_obj::btf::BtfEnum::from(t: T) -> T
 #[repr(C)] pub struct aya_obj::btf::BtfEnum64
 impl aya_obj::btf::BtfEnum64
 pub const fn aya_obj::btf::BtfEnum64::new(name_offset: u32, value: u64) -> Self
@@ -458,28 +262,6 @@ impl core::marker::Unpin for aya_obj::btf::BtfEnum64
 impl core::marker::UnsafeUnpin for aya_obj::btf::BtfEnum64
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::btf::BtfEnum64
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::btf::BtfEnum64
-impl<T, U> core::convert::Into<U> for aya_obj::btf::BtfEnum64 where U: core::convert::From<T>
-pub fn aya_obj::btf::BtfEnum64::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_obj::btf::BtfEnum64 where U: core::convert::Into<T>
-pub type aya_obj::btf::BtfEnum64::Error = core::convert::Infallible
-pub fn aya_obj::btf::BtfEnum64::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_obj::btf::BtfEnum64 where U: core::convert::TryFrom<T>
-pub type aya_obj::btf::BtfEnum64::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_obj::btf::BtfEnum64::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya_obj::btf::BtfEnum64 where T: core::clone::Clone
-pub type aya_obj::btf::BtfEnum64::Owned = T
-pub fn aya_obj::btf::BtfEnum64::clone_into(&self, target: &mut T)
-pub fn aya_obj::btf::BtfEnum64::to_owned(&self) -> T
-impl<T> core::any::Any for aya_obj::btf::BtfEnum64 where T: 'static + ?core::marker::Sized
-pub fn aya_obj::btf::BtfEnum64::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_obj::btf::BtfEnum64 where T: ?core::marker::Sized
-pub fn aya_obj::btf::BtfEnum64::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_obj::btf::BtfEnum64 where T: ?core::marker::Sized
-pub fn aya_obj::btf::BtfEnum64::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::btf::BtfEnum64 where T: core::clone::Clone
-pub unsafe fn aya_obj::btf::BtfEnum64::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_obj::btf::BtfEnum64
-pub fn aya_obj::btf::BtfEnum64::from(t: T) -> T
 pub struct aya_obj::btf::BtfExt
 impl core::clone::Clone for aya_obj::btf::BtfExt
 pub fn aya_obj::btf::BtfExt::clone(&self) -> aya_obj::btf::BtfExt
@@ -492,28 +274,6 @@ impl core::marker::Unpin for aya_obj::btf::BtfExt
 impl core::marker::UnsafeUnpin for aya_obj::btf::BtfExt
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::btf::BtfExt
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::btf::BtfExt
-impl<T, U> core::convert::Into<U> for aya_obj::btf::BtfExt where U: core::convert::From<T>
-pub fn aya_obj::btf::BtfExt::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_obj::btf::BtfExt where U: core::convert::Into<T>
-pub type aya_obj::btf::BtfExt::Error = core::convert::Infallible
-pub fn aya_obj::btf::BtfExt::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_obj::btf::BtfExt where U: core::convert::TryFrom<T>
-pub type aya_obj::btf::BtfExt::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_obj::btf::BtfExt::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya_obj::btf::BtfExt where T: core::clone::Clone
-pub type aya_obj::btf::BtfExt::Owned = T
-pub fn aya_obj::btf::BtfExt::clone_into(&self, target: &mut T)
-pub fn aya_obj::btf::BtfExt::to_owned(&self) -> T
-impl<T> core::any::Any for aya_obj::btf::BtfExt where T: 'static + ?core::marker::Sized
-pub fn aya_obj::btf::BtfExt::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_obj::btf::BtfExt where T: ?core::marker::Sized
-pub fn aya_obj::btf::BtfExt::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_obj::btf::BtfExt where T: ?core::marker::Sized
-pub fn aya_obj::btf::BtfExt::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::btf::BtfExt where T: core::clone::Clone
-pub unsafe fn aya_obj::btf::BtfExt::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_obj::btf::BtfExt
-pub fn aya_obj::btf::BtfExt::from(t: T) -> T
 pub struct aya_obj::btf::BtfFeatures
 impl aya_obj::btf::BtfFeatures
 pub const fn aya_obj::btf::BtfFeatures::btf_datasec(&self) -> bool
@@ -536,22 +296,6 @@ impl core::marker::Unpin for aya_obj::btf::BtfFeatures
 impl core::marker::UnsafeUnpin for aya_obj::btf::BtfFeatures
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::btf::BtfFeatures
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::btf::BtfFeatures
-impl<T, U> core::convert::Into<U> for aya_obj::btf::BtfFeatures where U: core::convert::From<T>
-pub fn aya_obj::btf::BtfFeatures::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_obj::btf::BtfFeatures where U: core::convert::Into<T>
-pub type aya_obj::btf::BtfFeatures::Error = core::convert::Infallible
-pub fn aya_obj::btf::BtfFeatures::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_obj::btf::BtfFeatures where U: core::convert::TryFrom<T>
-pub type aya_obj::btf::BtfFeatures::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_obj::btf::BtfFeatures::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_obj::btf::BtfFeatures where T: 'static + ?core::marker::Sized
-pub fn aya_obj::btf::BtfFeatures::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_obj::btf::BtfFeatures where T: ?core::marker::Sized
-pub fn aya_obj::btf::BtfFeatures::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_obj::btf::BtfFeatures where T: ?core::marker::Sized
-pub fn aya_obj::btf::BtfFeatures::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya_obj::btf::BtfFeatures
-pub fn aya_obj::btf::BtfFeatures::from(t: T) -> T
 #[repr(C)] pub struct aya_obj::btf::BtfParam
 pub aya_obj::btf::BtfParam::btf_type: u32
 pub aya_obj::btf::BtfParam::name_offset: u32
@@ -566,28 +310,6 @@ impl core::marker::Unpin for aya_obj::btf::BtfParam
 impl core::marker::UnsafeUnpin for aya_obj::btf::BtfParam
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::btf::BtfParam
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::btf::BtfParam
-impl<T, U> core::convert::Into<U> for aya_obj::btf::BtfParam where U: core::convert::From<T>
-pub fn aya_obj::btf::BtfParam::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_obj::btf::BtfParam where U: core::convert::Into<T>
-pub type aya_obj::btf::BtfParam::Error = core::convert::Infallible
-pub fn aya_obj::btf::BtfParam::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_obj::btf::BtfParam where U: core::convert::TryFrom<T>
-pub type aya_obj::btf::BtfParam::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_obj::btf::BtfParam::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya_obj::btf::BtfParam where T: core::clone::Clone
-pub type aya_obj::btf::BtfParam::Owned = T
-pub fn aya_obj::btf::BtfParam::clone_into(&self, target: &mut T)
-pub fn aya_obj::btf::BtfParam::to_owned(&self) -> T
-impl<T> core::any::Any for aya_obj::btf::BtfParam where T: 'static + ?core::marker::Sized
-pub fn aya_obj::btf::BtfParam::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_obj::btf::BtfParam where T: ?core::marker::Sized
-pub fn aya_obj::btf::BtfParam::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_obj::btf::BtfParam where T: ?core::marker::Sized
-pub fn aya_obj::btf::BtfParam::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::btf::BtfParam where T: core::clone::Clone
-pub unsafe fn aya_obj::btf::BtfParam::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_obj::btf::BtfParam
-pub fn aya_obj::btf::BtfParam::from(t: T) -> T
 pub struct aya_obj::btf::BtfRelocationError
 pub aya_obj::btf::BtfRelocationError::section: alloc::string::String
 impl core::error::Error for aya_obj::btf::BtfRelocationError
@@ -603,24 +325,6 @@ impl core::marker::Unpin for aya_obj::btf::BtfRelocationError
 impl core::marker::UnsafeUnpin for aya_obj::btf::BtfRelocationError
 impl !core::panic::unwind_safe::RefUnwindSafe for aya_obj::btf::BtfRelocationError
 impl !core::panic::unwind_safe::UnwindSafe for aya_obj::btf::BtfRelocationError
-impl<T, U> core::convert::Into<U> for aya_obj::btf::BtfRelocationError where U: core::convert::From<T>
-pub fn aya_obj::btf::BtfRelocationError::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_obj::btf::BtfRelocationError where U: core::convert::Into<T>
-pub type aya_obj::btf::BtfRelocationError::Error = core::convert::Infallible
-pub fn aya_obj::btf::BtfRelocationError::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_obj::btf::BtfRelocationError where U: core::convert::TryFrom<T>
-pub type aya_obj::btf::BtfRelocationError::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_obj::btf::BtfRelocationError::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::string::ToString for aya_obj::btf::BtfRelocationError where T: core::fmt::Display + ?core::marker::Sized
-pub fn aya_obj::btf::BtfRelocationError::to_string(&self) -> alloc::string::String
-impl<T> core::any::Any for aya_obj::btf::BtfRelocationError where T: 'static + ?core::marker::Sized
-pub fn aya_obj::btf::BtfRelocationError::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_obj::btf::BtfRelocationError where T: ?core::marker::Sized
-pub fn aya_obj::btf::BtfRelocationError::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_obj::btf::BtfRelocationError where T: ?core::marker::Sized
-pub fn aya_obj::btf::BtfRelocationError::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya_obj::btf::BtfRelocationError
-pub fn aya_obj::btf::BtfRelocationError::from(t: T) -> T
 #[repr(C)] pub struct aya_obj::btf::Const
 impl core::clone::Clone for aya_obj::btf::Const
 pub fn aya_obj::btf::Const::clone(&self) -> aya_obj::btf::Const
@@ -633,28 +337,6 @@ impl core::marker::Unpin for aya_obj::btf::Const
 impl core::marker::UnsafeUnpin for aya_obj::btf::Const
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::btf::Const
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::btf::Const
-impl<T, U> core::convert::Into<U> for aya_obj::btf::Const where U: core::convert::From<T>
-pub fn aya_obj::btf::Const::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_obj::btf::Const where U: core::convert::Into<T>
-pub type aya_obj::btf::Const::Error = core::convert::Infallible
-pub fn aya_obj::btf::Const::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_obj::btf::Const where U: core::convert::TryFrom<T>
-pub type aya_obj::btf::Const::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_obj::btf::Const::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya_obj::btf::Const where T: core::clone::Clone
-pub type aya_obj::btf::Const::Owned = T
-pub fn aya_obj::btf::Const::clone_into(&self, target: &mut T)
-pub fn aya_obj::btf::Const::to_owned(&self) -> T
-impl<T> core::any::Any for aya_obj::btf::Const where T: 'static + ?core::marker::Sized
-pub fn aya_obj::btf::Const::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_obj::btf::Const where T: ?core::marker::Sized
-pub fn aya_obj::btf::Const::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_obj::btf::Const where T: ?core::marker::Sized
-pub fn aya_obj::btf::Const::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::btf::Const where T: core::clone::Clone
-pub unsafe fn aya_obj::btf::Const::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_obj::btf::Const
-pub fn aya_obj::btf::Const::from(t: T) -> T
 #[repr(C)] pub struct aya_obj::btf::DataSec
 impl aya_obj::btf::DataSec
 pub const fn aya_obj::btf::DataSec::new(name_offset: u32, entries: alloc::vec::Vec<aya_obj::btf::DataSecEntry>, size: u32) -> Self
@@ -669,28 +351,6 @@ impl core::marker::Unpin for aya_obj::btf::DataSec
 impl core::marker::UnsafeUnpin for aya_obj::btf::DataSec
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::btf::DataSec
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::btf::DataSec
-impl<T, U> core::convert::Into<U> for aya_obj::btf::DataSec where U: core::convert::From<T>
-pub fn aya_obj::btf::DataSec::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_obj::btf::DataSec where U: core::convert::Into<T>
-pub type aya_obj::btf::DataSec::Error = core::convert::Infallible
-pub fn aya_obj::btf::DataSec::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_obj::btf::DataSec where U: core::convert::TryFrom<T>
-pub type aya_obj::btf::DataSec::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_obj::btf::DataSec::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya_obj::btf::DataSec where T: core::clone::Clone
-pub type aya_obj::btf::DataSec::Owned = T
-pub fn aya_obj::btf::DataSec::clone_into(&self, target: &mut T)
-pub fn aya_obj::btf::DataSec::to_owned(&self) -> T
-impl<T> core::any::Any for aya_obj::btf::DataSec where T: 'static + ?core::marker::Sized
-pub fn aya_obj::btf::DataSec::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_obj::btf::DataSec where T: ?core::marker::Sized
-pub fn aya_obj::btf::DataSec::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_obj::btf::DataSec where T: ?core::marker::Sized
-pub fn aya_obj::btf::DataSec::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::btf::DataSec where T: core::clone::Clone
-pub unsafe fn aya_obj::btf::DataSec::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_obj::btf::DataSec
-pub fn aya_obj::btf::DataSec::from(t: T) -> T
 #[repr(C)] pub struct aya_obj::btf::DataSecEntry
 pub aya_obj::btf::DataSecEntry::btf_type: u32
 pub aya_obj::btf::DataSecEntry::offset: u32
@@ -706,28 +366,6 @@ impl core::marker::Unpin for aya_obj::btf::DataSecEntry
 impl core::marker::UnsafeUnpin for aya_obj::btf::DataSecEntry
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::btf::DataSecEntry
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::btf::DataSecEntry
-impl<T, U> core::convert::Into<U> for aya_obj::btf::DataSecEntry where U: core::convert::From<T>
-pub fn aya_obj::btf::DataSecEntry::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_obj::btf::DataSecEntry where U: core::convert::Into<T>
-pub type aya_obj::btf::DataSecEntry::Error = core::convert::Infallible
-pub fn aya_obj::btf::DataSecEntry::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_obj::btf::DataSecEntry where U: core::convert::TryFrom<T>
-pub type aya_obj::btf::DataSecEntry::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_obj::btf::DataSecEntry::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya_obj::btf::DataSecEntry where T: core::clone::Clone
-pub type aya_obj::btf::DataSecEntry::Owned = T
-pub fn aya_obj::btf::DataSecEntry::clone_into(&self, target: &mut T)
-pub fn aya_obj::btf::DataSecEntry::to_owned(&self) -> T
-impl<T> core::any::Any for aya_obj::btf::DataSecEntry where T: 'static + ?core::marker::Sized
-pub fn aya_obj::btf::DataSecEntry::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_obj::btf::DataSecEntry where T: ?core::marker::Sized
-pub fn aya_obj::btf::DataSecEntry::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_obj::btf::DataSecEntry where T: ?core::marker::Sized
-pub fn aya_obj::btf::DataSecEntry::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::btf::DataSecEntry where T: core::clone::Clone
-pub unsafe fn aya_obj::btf::DataSecEntry::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_obj::btf::DataSecEntry
-pub fn aya_obj::btf::DataSecEntry::from(t: T) -> T
 #[repr(C)] pub struct aya_obj::btf::DeclTag
 impl aya_obj::btf::DeclTag
 pub const fn aya_obj::btf::DeclTag::new(name_offset: u32, btf_type: u32, component_index: i32) -> Self
@@ -742,28 +380,6 @@ impl core::marker::Unpin for aya_obj::btf::DeclTag
 impl core::marker::UnsafeUnpin for aya_obj::btf::DeclTag
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::btf::DeclTag
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::btf::DeclTag
-impl<T, U> core::convert::Into<U> for aya_obj::btf::DeclTag where U: core::convert::From<T>
-pub fn aya_obj::btf::DeclTag::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_obj::btf::DeclTag where U: core::convert::Into<T>
-pub type aya_obj::btf::DeclTag::Error = core::convert::Infallible
-pub fn aya_obj::btf::DeclTag::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_obj::btf::DeclTag where U: core::convert::TryFrom<T>
-pub type aya_obj::btf::DeclTag::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_obj::btf::DeclTag::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya_obj::btf::DeclTag where T: core::clone::Clone
-pub type aya_obj::btf::DeclTag::Owned = T
-pub fn aya_obj::btf::DeclTag::clone_into(&self, target: &mut T)
-pub fn aya_obj::btf::DeclTag::to_owned(&self) -> T
-impl<T> core::any::Any for aya_obj::btf::DeclTag where T: 'static + ?core::marker::Sized
-pub fn aya_obj::btf::DeclTag::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_obj::btf::DeclTag where T: ?core::marker::Sized
-pub fn aya_obj::btf::DeclTag::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_obj::btf::DeclTag where T: ?core::marker::Sized
-pub fn aya_obj::btf::DeclTag::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::btf::DeclTag where T: core::clone::Clone
-pub unsafe fn aya_obj::btf::DeclTag::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_obj::btf::DeclTag
-pub fn aya_obj::btf::DeclTag::from(t: T) -> T
 #[repr(C)] pub struct aya_obj::btf::Enum
 impl aya_obj::btf::Enum
 pub const fn aya_obj::btf::Enum::new(name_offset: u32, signed: bool, variants: alloc::vec::Vec<aya_obj::btf::BtfEnum>) -> Self
@@ -778,28 +394,6 @@ impl core::marker::Unpin for aya_obj::btf::Enum
 impl core::marker::UnsafeUnpin for aya_obj::btf::Enum
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::btf::Enum
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::btf::Enum
-impl<T, U> core::convert::Into<U> for aya_obj::btf::Enum where U: core::convert::From<T>
-pub fn aya_obj::btf::Enum::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_obj::btf::Enum where U: core::convert::Into<T>
-pub type aya_obj::btf::Enum::Error = core::convert::Infallible
-pub fn aya_obj::btf::Enum::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_obj::btf::Enum where U: core::convert::TryFrom<T>
-pub type aya_obj::btf::Enum::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_obj::btf::Enum::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya_obj::btf::Enum where T: core::clone::Clone
-pub type aya_obj::btf::Enum::Owned = T
-pub fn aya_obj::btf::Enum::clone_into(&self, target: &mut T)
-pub fn aya_obj::btf::Enum::to_owned(&self) -> T
-impl<T> core::any::Any for aya_obj::btf::Enum where T: 'static + ?core::marker::Sized
-pub fn aya_obj::btf::Enum::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_obj::btf::Enum where T: ?core::marker::Sized
-pub fn aya_obj::btf::Enum::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_obj::btf::Enum where T: ?core::marker::Sized
-pub fn aya_obj::btf::Enum::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::btf::Enum where T: core::clone::Clone
-pub unsafe fn aya_obj::btf::Enum::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_obj::btf::Enum
-pub fn aya_obj::btf::Enum::from(t: T) -> T
 #[repr(C)] pub struct aya_obj::btf::Enum64
 impl aya_obj::btf::Enum64
 pub const fn aya_obj::btf::Enum64::new(name_offset: u32, signed: bool, variants: alloc::vec::Vec<aya_obj::btf::BtfEnum64>) -> Self
@@ -814,28 +408,6 @@ impl core::marker::Unpin for aya_obj::btf::Enum64
 impl core::marker::UnsafeUnpin for aya_obj::btf::Enum64
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::btf::Enum64
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::btf::Enum64
-impl<T, U> core::convert::Into<U> for aya_obj::btf::Enum64 where U: core::convert::From<T>
-pub fn aya_obj::btf::Enum64::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_obj::btf::Enum64 where U: core::convert::Into<T>
-pub type aya_obj::btf::Enum64::Error = core::convert::Infallible
-pub fn aya_obj::btf::Enum64::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_obj::btf::Enum64 where U: core::convert::TryFrom<T>
-pub type aya_obj::btf::Enum64::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_obj::btf::Enum64::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya_obj::btf::Enum64 where T: core::clone::Clone
-pub type aya_obj::btf::Enum64::Owned = T
-pub fn aya_obj::btf::Enum64::clone_into(&self, target: &mut T)
-pub fn aya_obj::btf::Enum64::to_owned(&self) -> T
-impl<T> core::any::Any for aya_obj::btf::Enum64 where T: 'static + ?core::marker::Sized
-pub fn aya_obj::btf::Enum64::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_obj::btf::Enum64 where T: ?core::marker::Sized
-pub fn aya_obj::btf::Enum64::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_obj::btf::Enum64 where T: ?core::marker::Sized
-pub fn aya_obj::btf::Enum64::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::btf::Enum64 where T: core::clone::Clone
-pub unsafe fn aya_obj::btf::Enum64::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_obj::btf::Enum64
-pub fn aya_obj::btf::Enum64::from(t: T) -> T
 #[repr(C)] pub struct aya_obj::btf::Float
 impl aya_obj::btf::Float
 pub const fn aya_obj::btf::Float::new(name_offset: u32, size: u32) -> Self
@@ -850,28 +422,6 @@ impl core::marker::Unpin for aya_obj::btf::Float
 impl core::marker::UnsafeUnpin for aya_obj::btf::Float
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::btf::Float
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::btf::Float
-impl<T, U> core::convert::Into<U> for aya_obj::btf::Float where U: core::convert::From<T>
-pub fn aya_obj::btf::Float::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_obj::btf::Float where U: core::convert::Into<T>
-pub type aya_obj::btf::Float::Error = core::convert::Infallible
-pub fn aya_obj::btf::Float::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_obj::btf::Float where U: core::convert::TryFrom<T>
-pub type aya_obj::btf::Float::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_obj::btf::Float::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya_obj::btf::Float where T: core::clone::Clone
-pub type aya_obj::btf::Float::Owned = T
-pub fn aya_obj::btf::Float::clone_into(&self, target: &mut T)
-pub fn aya_obj::btf::Float::to_owned(&self) -> T
-impl<T> core::any::Any for aya_obj::btf::Float where T: 'static + ?core::marker::Sized
-pub fn aya_obj::btf::Float::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_obj::btf::Float where T: ?core::marker::Sized
-pub fn aya_obj::btf::Float::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_obj::btf::Float where T: ?core::marker::Sized
-pub fn aya_obj::btf::Float::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::btf::Float where T: core::clone::Clone
-pub unsafe fn aya_obj::btf::Float::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_obj::btf::Float
-pub fn aya_obj::btf::Float::from(t: T) -> T
 #[repr(C)] pub struct aya_obj::btf::Func
 impl aya_obj::btf::Func
 pub const fn aya_obj::btf::Func::new(name_offset: u32, proto: u32, linkage: aya_obj::btf::FuncLinkage) -> Self
@@ -886,28 +436,6 @@ impl core::marker::Unpin for aya_obj::btf::Func
 impl core::marker::UnsafeUnpin for aya_obj::btf::Func
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::btf::Func
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::btf::Func
-impl<T, U> core::convert::Into<U> for aya_obj::btf::Func where U: core::convert::From<T>
-pub fn aya_obj::btf::Func::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_obj::btf::Func where U: core::convert::Into<T>
-pub type aya_obj::btf::Func::Error = core::convert::Infallible
-pub fn aya_obj::btf::Func::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_obj::btf::Func where U: core::convert::TryFrom<T>
-pub type aya_obj::btf::Func::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_obj::btf::Func::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya_obj::btf::Func where T: core::clone::Clone
-pub type aya_obj::btf::Func::Owned = T
-pub fn aya_obj::btf::Func::clone_into(&self, target: &mut T)
-pub fn aya_obj::btf::Func::to_owned(&self) -> T
-impl<T> core::any::Any for aya_obj::btf::Func where T: 'static + ?core::marker::Sized
-pub fn aya_obj::btf::Func::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_obj::btf::Func where T: ?core::marker::Sized
-pub fn aya_obj::btf::Func::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_obj::btf::Func where T: ?core::marker::Sized
-pub fn aya_obj::btf::Func::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::btf::Func where T: core::clone::Clone
-pub unsafe fn aya_obj::btf::Func::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_obj::btf::Func
-pub fn aya_obj::btf::Func::from(t: T) -> T
 pub struct aya_obj::btf::FuncInfo
 pub aya_obj::btf::FuncInfo::data: std::collections::hash::map::HashMap<alloc::string::String, aya_obj::btf::FuncSecInfo>
 impl core::clone::Clone for aya_obj::btf::FuncInfo
@@ -921,28 +449,6 @@ impl core::marker::Unpin for aya_obj::btf::FuncInfo
 impl core::marker::UnsafeUnpin for aya_obj::btf::FuncInfo
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::btf::FuncInfo
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::btf::FuncInfo
-impl<T, U> core::convert::Into<U> for aya_obj::btf::FuncInfo where U: core::convert::From<T>
-pub fn aya_obj::btf::FuncInfo::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_obj::btf::FuncInfo where U: core::convert::Into<T>
-pub type aya_obj::btf::FuncInfo::Error = core::convert::Infallible
-pub fn aya_obj::btf::FuncInfo::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_obj::btf::FuncInfo where U: core::convert::TryFrom<T>
-pub type aya_obj::btf::FuncInfo::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_obj::btf::FuncInfo::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya_obj::btf::FuncInfo where T: core::clone::Clone
-pub type aya_obj::btf::FuncInfo::Owned = T
-pub fn aya_obj::btf::FuncInfo::clone_into(&self, target: &mut T)
-pub fn aya_obj::btf::FuncInfo::to_owned(&self) -> T
-impl<T> core::any::Any for aya_obj::btf::FuncInfo where T: 'static + ?core::marker::Sized
-pub fn aya_obj::btf::FuncInfo::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_obj::btf::FuncInfo where T: ?core::marker::Sized
-pub fn aya_obj::btf::FuncInfo::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_obj::btf::FuncInfo where T: ?core::marker::Sized
-pub fn aya_obj::btf::FuncInfo::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::btf::FuncInfo where T: core::clone::Clone
-pub unsafe fn aya_obj::btf::FuncInfo::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_obj::btf::FuncInfo
-pub fn aya_obj::btf::FuncInfo::from(t: T) -> T
 #[repr(C)] pub struct aya_obj::btf::FuncProto
 impl aya_obj::btf::FuncProto
 pub const fn aya_obj::btf::FuncProto::new(params: alloc::vec::Vec<aya_obj::btf::BtfParam>, return_type: u32) -> Self
@@ -957,28 +463,6 @@ impl core::marker::Unpin for aya_obj::btf::FuncProto
 impl core::marker::UnsafeUnpin for aya_obj::btf::FuncProto
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::btf::FuncProto
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::btf::FuncProto
-impl<T, U> core::convert::Into<U> for aya_obj::btf::FuncProto where U: core::convert::From<T>
-pub fn aya_obj::btf::FuncProto::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_obj::btf::FuncProto where U: core::convert::Into<T>
-pub type aya_obj::btf::FuncProto::Error = core::convert::Infallible
-pub fn aya_obj::btf::FuncProto::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_obj::btf::FuncProto where U: core::convert::TryFrom<T>
-pub type aya_obj::btf::FuncProto::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_obj::btf::FuncProto::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya_obj::btf::FuncProto where T: core::clone::Clone
-pub type aya_obj::btf::FuncProto::Owned = T
-pub fn aya_obj::btf::FuncProto::clone_into(&self, target: &mut T)
-pub fn aya_obj::btf::FuncProto::to_owned(&self) -> T
-impl<T> core::any::Any for aya_obj::btf::FuncProto where T: 'static + ?core::marker::Sized
-pub fn aya_obj::btf::FuncProto::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_obj::btf::FuncProto where T: ?core::marker::Sized
-pub fn aya_obj::btf::FuncProto::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_obj::btf::FuncProto where T: ?core::marker::Sized
-pub fn aya_obj::btf::FuncProto::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::btf::FuncProto where T: core::clone::Clone
-pub unsafe fn aya_obj::btf::FuncProto::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_obj::btf::FuncProto
-pub fn aya_obj::btf::FuncProto::from(t: T) -> T
 pub struct aya_obj::btf::FuncSecInfo
 pub aya_obj::btf::FuncSecInfo::func_info: alloc::vec::Vec<aya_obj::generated::bpf_func_info>
 pub aya_obj::btf::FuncSecInfo::num_info: u32
@@ -998,28 +482,6 @@ impl core::marker::Unpin for aya_obj::btf::FuncSecInfo
 impl core::marker::UnsafeUnpin for aya_obj::btf::FuncSecInfo
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::btf::FuncSecInfo
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::btf::FuncSecInfo
-impl<T, U> core::convert::Into<U> for aya_obj::btf::FuncSecInfo where U: core::convert::From<T>
-pub fn aya_obj::btf::FuncSecInfo::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_obj::btf::FuncSecInfo where U: core::convert::Into<T>
-pub type aya_obj::btf::FuncSecInfo::Error = core::convert::Infallible
-pub fn aya_obj::btf::FuncSecInfo::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_obj::btf::FuncSecInfo where U: core::convert::TryFrom<T>
-pub type aya_obj::btf::FuncSecInfo::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_obj::btf::FuncSecInfo::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya_obj::btf::FuncSecInfo where T: core::clone::Clone
-pub type aya_obj::btf::FuncSecInfo::Owned = T
-pub fn aya_obj::btf::FuncSecInfo::clone_into(&self, target: &mut T)
-pub fn aya_obj::btf::FuncSecInfo::to_owned(&self) -> T
-impl<T> core::any::Any for aya_obj::btf::FuncSecInfo where T: 'static + ?core::marker::Sized
-pub fn aya_obj::btf::FuncSecInfo::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_obj::btf::FuncSecInfo where T: ?core::marker::Sized
-pub fn aya_obj::btf::FuncSecInfo::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_obj::btf::FuncSecInfo where T: ?core::marker::Sized
-pub fn aya_obj::btf::FuncSecInfo::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::btf::FuncSecInfo where T: core::clone::Clone
-pub unsafe fn aya_obj::btf::FuncSecInfo::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_obj::btf::FuncSecInfo
-pub fn aya_obj::btf::FuncSecInfo::from(t: T) -> T
 #[repr(C)] pub struct aya_obj::btf::Fwd
 impl core::clone::Clone for aya_obj::btf::Fwd
 pub fn aya_obj::btf::Fwd::clone(&self) -> aya_obj::btf::Fwd
@@ -1032,28 +494,6 @@ impl core::marker::Unpin for aya_obj::btf::Fwd
 impl core::marker::UnsafeUnpin for aya_obj::btf::Fwd
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::btf::Fwd
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::btf::Fwd
-impl<T, U> core::convert::Into<U> for aya_obj::btf::Fwd where U: core::convert::From<T>
-pub fn aya_obj::btf::Fwd::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_obj::btf::Fwd where U: core::convert::Into<T>
-pub type aya_obj::btf::Fwd::Error = core::convert::Infallible
-pub fn aya_obj::btf::Fwd::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_obj::btf::Fwd where U: core::convert::TryFrom<T>
-pub type aya_obj::btf::Fwd::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_obj::btf::Fwd::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya_obj::btf::Fwd where T: core::clone::Clone
-pub type aya_obj::btf::Fwd::Owned = T
-pub fn aya_obj::btf::Fwd::clone_into(&self, target: &mut T)
-pub fn aya_obj::btf::Fwd::to_owned(&self) -> T
-impl<T> core::any::Any for aya_obj::btf::Fwd where T: 'static + ?core::marker::Sized
-pub fn aya_obj::btf::Fwd::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_obj::btf::Fwd where T: ?core::marker::Sized
-pub fn aya_obj::btf::Fwd::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_obj::btf::Fwd where T: ?core::marker::Sized
-pub fn aya_obj::btf::Fwd::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::btf::Fwd where T: core::clone::Clone
-pub unsafe fn aya_obj::btf::Fwd::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_obj::btf::Fwd
-pub fn aya_obj::btf::Fwd::from(t: T) -> T
 #[repr(C)] pub struct aya_obj::btf::Int
 impl aya_obj::btf::Int
 pub const fn aya_obj::btf::Int::new(name_offset: u32, size: u32, encoding: aya_obj::btf::IntEncoding, offset: u32) -> Self
@@ -1068,28 +508,6 @@ impl core::marker::Unpin for aya_obj::btf::Int
 impl core::marker::UnsafeUnpin for aya_obj::btf::Int
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::btf::Int
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::btf::Int
-impl<T, U> core::convert::Into<U> for aya_obj::btf::Int where U: core::convert::From<T>
-pub fn aya_obj::btf::Int::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_obj::btf::Int where U: core::convert::Into<T>
-pub type aya_obj::btf::Int::Error = core::convert::Infallible
-pub fn aya_obj::btf::Int::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_obj::btf::Int where U: core::convert::TryFrom<T>
-pub type aya_obj::btf::Int::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_obj::btf::Int::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya_obj::btf::Int where T: core::clone::Clone
-pub type aya_obj::btf::Int::Owned = T
-pub fn aya_obj::btf::Int::clone_into(&self, target: &mut T)
-pub fn aya_obj::btf::Int::to_owned(&self) -> T
-impl<T> core::any::Any for aya_obj::btf::Int where T: 'static + ?core::marker::Sized
-pub fn aya_obj::btf::Int::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_obj::btf::Int where T: ?core::marker::Sized
-pub fn aya_obj::btf::Int::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_obj::btf::Int where T: ?core::marker::Sized
-pub fn aya_obj::btf::Int::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::btf::Int where T: core::clone::Clone
-pub unsafe fn aya_obj::btf::Int::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_obj::btf::Int
-pub fn aya_obj::btf::Int::from(t: T) -> T
 pub struct aya_obj::btf::LineSecInfo
 pub aya_obj::btf::LineSecInfo::line_info: alloc::vec::Vec<aya_obj::generated::bpf_line_info>
 pub aya_obj::btf::LineSecInfo::num_info: u32
@@ -1109,28 +527,6 @@ impl core::marker::Unpin for aya_obj::btf::LineSecInfo
 impl core::marker::UnsafeUnpin for aya_obj::btf::LineSecInfo
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::btf::LineSecInfo
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::btf::LineSecInfo
-impl<T, U> core::convert::Into<U> for aya_obj::btf::LineSecInfo where U: core::convert::From<T>
-pub fn aya_obj::btf::LineSecInfo::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_obj::btf::LineSecInfo where U: core::convert::Into<T>
-pub type aya_obj::btf::LineSecInfo::Error = core::convert::Infallible
-pub fn aya_obj::btf::LineSecInfo::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_obj::btf::LineSecInfo where U: core::convert::TryFrom<T>
-pub type aya_obj::btf::LineSecInfo::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_obj::btf::LineSecInfo::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya_obj::btf::LineSecInfo where T: core::clone::Clone
-pub type aya_obj::btf::LineSecInfo::Owned = T
-pub fn aya_obj::btf::LineSecInfo::clone_into(&self, target: &mut T)
-pub fn aya_obj::btf::LineSecInfo::to_owned(&self) -> T
-impl<T> core::any::Any for aya_obj::btf::LineSecInfo where T: 'static + ?core::marker::Sized
-pub fn aya_obj::btf::LineSecInfo::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_obj::btf::LineSecInfo where T: ?core::marker::Sized
-pub fn aya_obj::btf::LineSecInfo::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_obj::btf::LineSecInfo where T: ?core::marker::Sized
-pub fn aya_obj::btf::LineSecInfo::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::btf::LineSecInfo where T: core::clone::Clone
-pub unsafe fn aya_obj::btf::LineSecInfo::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_obj::btf::LineSecInfo
-pub fn aya_obj::btf::LineSecInfo::from(t: T) -> T
 #[repr(C)] pub struct aya_obj::btf::Ptr
 impl aya_obj::btf::Ptr
 pub const fn aya_obj::btf::Ptr::new(name_offset: u32, btf_type: u32) -> Self
@@ -1145,28 +541,6 @@ impl core::marker::Unpin for aya_obj::btf::Ptr
 impl core::marker::UnsafeUnpin for aya_obj::btf::Ptr
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::btf::Ptr
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::btf::Ptr
-impl<T, U> core::convert::Into<U> for aya_obj::btf::Ptr where U: core::convert::From<T>
-pub fn aya_obj::btf::Ptr::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_obj::btf::Ptr where U: core::convert::Into<T>
-pub type aya_obj::btf::Ptr::Error = core::convert::Infallible
-pub fn aya_obj::btf::Ptr::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_obj::btf::Ptr where U: core::convert::TryFrom<T>
-pub type aya_obj::btf::Ptr::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_obj::btf::Ptr::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya_obj::btf::Ptr where T: core::clone::Clone
-pub type aya_obj::btf::Ptr::Owned = T
-pub fn aya_obj::btf::Ptr::clone_into(&self, target: &mut T)
-pub fn aya_obj::btf::Ptr::to_owned(&self) -> T
-impl<T> core::any::Any for aya_obj::btf::Ptr where T: 'static + ?core::marker::Sized
-pub fn aya_obj::btf::Ptr::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_obj::btf::Ptr where T: ?core::marker::Sized
-pub fn aya_obj::btf::Ptr::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_obj::btf::Ptr where T: ?core::marker::Sized
-pub fn aya_obj::btf::Ptr::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::btf::Ptr where T: core::clone::Clone
-pub unsafe fn aya_obj::btf::Ptr::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_obj::btf::Ptr
-pub fn aya_obj::btf::Ptr::from(t: T) -> T
 pub struct aya_obj::btf::Restrict
 impl core::clone::Clone for aya_obj::btf::Restrict
 pub fn aya_obj::btf::Restrict::clone(&self) -> aya_obj::btf::Restrict
@@ -1179,28 +553,6 @@ impl core::marker::Unpin for aya_obj::btf::Restrict
 impl core::marker::UnsafeUnpin for aya_obj::btf::Restrict
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::btf::Restrict
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::btf::Restrict
-impl<T, U> core::convert::Into<U> for aya_obj::btf::Restrict where U: core::convert::From<T>
-pub fn aya_obj::btf::Restrict::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_obj::btf::Restrict where U: core::convert::Into<T>
-pub type aya_obj::btf::Restrict::Error = core::convert::Infallible
-pub fn aya_obj::btf::Restrict::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_obj::btf::Restrict where U: core::convert::TryFrom<T>
-pub type aya_obj::btf::Restrict::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_obj::btf::Restrict::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya_obj::btf::Restrict where T: core::clone::Clone
-pub type aya_obj::btf::Restrict::Owned = T
-pub fn aya_obj::btf::Restrict::clone_into(&self, target: &mut T)
-pub fn aya_obj::btf::Restrict::to_owned(&self) -> T
-impl<T> core::any::Any for aya_obj::btf::Restrict where T: 'static + ?core::marker::Sized
-pub fn aya_obj::btf::Restrict::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_obj::btf::Restrict where T: ?core::marker::Sized
-pub fn aya_obj::btf::Restrict::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_obj::btf::Restrict where T: ?core::marker::Sized
-pub fn aya_obj::btf::Restrict::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::btf::Restrict where T: core::clone::Clone
-pub unsafe fn aya_obj::btf::Restrict::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_obj::btf::Restrict
-pub fn aya_obj::btf::Restrict::from(t: T) -> T
 #[repr(C)] pub struct aya_obj::btf::Struct
 impl core::clone::Clone for aya_obj::btf::Struct
 pub fn aya_obj::btf::Struct::clone(&self) -> aya_obj::btf::Struct
@@ -1213,28 +565,6 @@ impl core::marker::Unpin for aya_obj::btf::Struct
 impl core::marker::UnsafeUnpin for aya_obj::btf::Struct
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::btf::Struct
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::btf::Struct
-impl<T, U> core::convert::Into<U> for aya_obj::btf::Struct where U: core::convert::From<T>
-pub fn aya_obj::btf::Struct::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_obj::btf::Struct where U: core::convert::Into<T>
-pub type aya_obj::btf::Struct::Error = core::convert::Infallible
-pub fn aya_obj::btf::Struct::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_obj::btf::Struct where U: core::convert::TryFrom<T>
-pub type aya_obj::btf::Struct::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_obj::btf::Struct::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya_obj::btf::Struct where T: core::clone::Clone
-pub type aya_obj::btf::Struct::Owned = T
-pub fn aya_obj::btf::Struct::clone_into(&self, target: &mut T)
-pub fn aya_obj::btf::Struct::to_owned(&self) -> T
-impl<T> core::any::Any for aya_obj::btf::Struct where T: 'static + ?core::marker::Sized
-pub fn aya_obj::btf::Struct::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_obj::btf::Struct where T: ?core::marker::Sized
-pub fn aya_obj::btf::Struct::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_obj::btf::Struct where T: ?core::marker::Sized
-pub fn aya_obj::btf::Struct::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::btf::Struct where T: core::clone::Clone
-pub unsafe fn aya_obj::btf::Struct::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_obj::btf::Struct
-pub fn aya_obj::btf::Struct::from(t: T) -> T
 #[repr(C)] pub struct aya_obj::btf::TypeTag
 impl aya_obj::btf::TypeTag
 pub const fn aya_obj::btf::TypeTag::new(name_offset: u32, btf_type: u32) -> Self
@@ -1249,28 +579,6 @@ impl core::marker::Unpin for aya_obj::btf::TypeTag
 impl core::marker::UnsafeUnpin for aya_obj::btf::TypeTag
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::btf::TypeTag
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::btf::TypeTag
-impl<T, U> core::convert::Into<U> for aya_obj::btf::TypeTag where U: core::convert::From<T>
-pub fn aya_obj::btf::TypeTag::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_obj::btf::TypeTag where U: core::convert::Into<T>
-pub type aya_obj::btf::TypeTag::Error = core::convert::Infallible
-pub fn aya_obj::btf::TypeTag::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_obj::btf::TypeTag where U: core::convert::TryFrom<T>
-pub type aya_obj::btf::TypeTag::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_obj::btf::TypeTag::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya_obj::btf::TypeTag where T: core::clone::Clone
-pub type aya_obj::btf::TypeTag::Owned = T
-pub fn aya_obj::btf::TypeTag::clone_into(&self, target: &mut T)
-pub fn aya_obj::btf::TypeTag::to_owned(&self) -> T
-impl<T> core::any::Any for aya_obj::btf::TypeTag where T: 'static + ?core::marker::Sized
-pub fn aya_obj::btf::TypeTag::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_obj::btf::TypeTag where T: ?core::marker::Sized
-pub fn aya_obj::btf::TypeTag::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_obj::btf::TypeTag where T: ?core::marker::Sized
-pub fn aya_obj::btf::TypeTag::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::btf::TypeTag where T: core::clone::Clone
-pub unsafe fn aya_obj::btf::TypeTag::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_obj::btf::TypeTag
-pub fn aya_obj::btf::TypeTag::from(t: T) -> T
 #[repr(C)] pub struct aya_obj::btf::Typedef
 impl core::clone::Clone for aya_obj::btf::Typedef
 pub fn aya_obj::btf::Typedef::clone(&self) -> aya_obj::btf::Typedef
@@ -1283,28 +591,6 @@ impl core::marker::Unpin for aya_obj::btf::Typedef
 impl core::marker::UnsafeUnpin for aya_obj::btf::Typedef
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::btf::Typedef
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::btf::Typedef
-impl<T, U> core::convert::Into<U> for aya_obj::btf::Typedef where U: core::convert::From<T>
-pub fn aya_obj::btf::Typedef::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_obj::btf::Typedef where U: core::convert::Into<T>
-pub type aya_obj::btf::Typedef::Error = core::convert::Infallible
-pub fn aya_obj::btf::Typedef::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_obj::btf::Typedef where U: core::convert::TryFrom<T>
-pub type aya_obj::btf::Typedef::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_obj::btf::Typedef::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya_obj::btf::Typedef where T: core::clone::Clone
-pub type aya_obj::btf::Typedef::Owned = T
-pub fn aya_obj::btf::Typedef::clone_into(&self, target: &mut T)
-pub fn aya_obj::btf::Typedef::to_owned(&self) -> T
-impl<T> core::any::Any for aya_obj::btf::Typedef where T: 'static + ?core::marker::Sized
-pub fn aya_obj::btf::Typedef::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_obj::btf::Typedef where T: ?core::marker::Sized
-pub fn aya_obj::btf::Typedef::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_obj::btf::Typedef where T: ?core::marker::Sized
-pub fn aya_obj::btf::Typedef::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::btf::Typedef where T: core::clone::Clone
-pub unsafe fn aya_obj::btf::Typedef::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_obj::btf::Typedef
-pub fn aya_obj::btf::Typedef::from(t: T) -> T
 #[repr(C)] pub struct aya_obj::btf::Union
 impl core::clone::Clone for aya_obj::btf::Union
 pub fn aya_obj::btf::Union::clone(&self) -> aya_obj::btf::Union
@@ -1317,28 +603,6 @@ impl core::marker::Unpin for aya_obj::btf::Union
 impl core::marker::UnsafeUnpin for aya_obj::btf::Union
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::btf::Union
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::btf::Union
-impl<T, U> core::convert::Into<U> for aya_obj::btf::Union where U: core::convert::From<T>
-pub fn aya_obj::btf::Union::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_obj::btf::Union where U: core::convert::Into<T>
-pub type aya_obj::btf::Union::Error = core::convert::Infallible
-pub fn aya_obj::btf::Union::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_obj::btf::Union where U: core::convert::TryFrom<T>
-pub type aya_obj::btf::Union::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_obj::btf::Union::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya_obj::btf::Union where T: core::clone::Clone
-pub type aya_obj::btf::Union::Owned = T
-pub fn aya_obj::btf::Union::clone_into(&self, target: &mut T)
-pub fn aya_obj::btf::Union::to_owned(&self) -> T
-impl<T> core::any::Any for aya_obj::btf::Union where T: 'static + ?core::marker::Sized
-pub fn aya_obj::btf::Union::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_obj::btf::Union where T: ?core::marker::Sized
-pub fn aya_obj::btf::Union::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_obj::btf::Union where T: ?core::marker::Sized
-pub fn aya_obj::btf::Union::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::btf::Union where T: core::clone::Clone
-pub unsafe fn aya_obj::btf::Union::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_obj::btf::Union
-pub fn aya_obj::btf::Union::from(t: T) -> T
 #[repr(C)] pub struct aya_obj::btf::Var
 impl aya_obj::btf::Var
 pub const fn aya_obj::btf::Var::new(name_offset: u32, btf_type: u32, linkage: aya_obj::btf::VarLinkage) -> Self
@@ -1353,28 +617,6 @@ impl core::marker::Unpin for aya_obj::btf::Var
 impl core::marker::UnsafeUnpin for aya_obj::btf::Var
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::btf::Var
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::btf::Var
-impl<T, U> core::convert::Into<U> for aya_obj::btf::Var where U: core::convert::From<T>
-pub fn aya_obj::btf::Var::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_obj::btf::Var where U: core::convert::Into<T>
-pub type aya_obj::btf::Var::Error = core::convert::Infallible
-pub fn aya_obj::btf::Var::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_obj::btf::Var where U: core::convert::TryFrom<T>
-pub type aya_obj::btf::Var::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_obj::btf::Var::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya_obj::btf::Var where T: core::clone::Clone
-pub type aya_obj::btf::Var::Owned = T
-pub fn aya_obj::btf::Var::clone_into(&self, target: &mut T)
-pub fn aya_obj::btf::Var::to_owned(&self) -> T
-impl<T> core::any::Any for aya_obj::btf::Var where T: 'static + ?core::marker::Sized
-pub fn aya_obj::btf::Var::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_obj::btf::Var where T: ?core::marker::Sized
-pub fn aya_obj::btf::Var::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_obj::btf::Var where T: ?core::marker::Sized
-pub fn aya_obj::btf::Var::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::btf::Var where T: core::clone::Clone
-pub unsafe fn aya_obj::btf::Var::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_obj::btf::Var
-pub fn aya_obj::btf::Var::from(t: T) -> T
 #[repr(C)] pub struct aya_obj::btf::Volatile
 impl core::clone::Clone for aya_obj::btf::Volatile
 pub fn aya_obj::btf::Volatile::clone(&self) -> aya_obj::btf::Volatile
@@ -1387,28 +629,6 @@ impl core::marker::Unpin for aya_obj::btf::Volatile
 impl core::marker::UnsafeUnpin for aya_obj::btf::Volatile
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::btf::Volatile
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::btf::Volatile
-impl<T, U> core::convert::Into<U> for aya_obj::btf::Volatile where U: core::convert::From<T>
-pub fn aya_obj::btf::Volatile::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_obj::btf::Volatile where U: core::convert::Into<T>
-pub type aya_obj::btf::Volatile::Error = core::convert::Infallible
-pub fn aya_obj::btf::Volatile::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_obj::btf::Volatile where U: core::convert::TryFrom<T>
-pub type aya_obj::btf::Volatile::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_obj::btf::Volatile::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya_obj::btf::Volatile where T: core::clone::Clone
-pub type aya_obj::btf::Volatile::Owned = T
-pub fn aya_obj::btf::Volatile::clone_into(&self, target: &mut T)
-pub fn aya_obj::btf::Volatile::to_owned(&self) -> T
-impl<T> core::any::Any for aya_obj::btf::Volatile where T: 'static + ?core::marker::Sized
-pub fn aya_obj::btf::Volatile::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_obj::btf::Volatile where T: ?core::marker::Sized
-pub fn aya_obj::btf::Volatile::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_obj::btf::Volatile where T: ?core::marker::Sized
-pub fn aya_obj::btf::Volatile::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::btf::Volatile where T: core::clone::Clone
-pub unsafe fn aya_obj::btf::Volatile::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_obj::btf::Volatile
-pub fn aya_obj::btf::Volatile::from(t: T) -> T
 pub mod aya_obj::generated
 pub mod aya_obj::generated::bpf_core_relo_kind
 pub const aya_obj::generated::bpf_core_relo_kind::BPF_CORE_ENUMVAL_EXISTS: aya_obj::generated::bpf_core_relo_kind::Type
@@ -1456,28 +676,6 @@ impl core::marker::Unpin for aya_obj::generated::_bindgen_ty_1
 impl core::marker::UnsafeUnpin for aya_obj::generated::_bindgen_ty_1
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::generated::_bindgen_ty_1
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::generated::_bindgen_ty_1
-impl<T, U> core::convert::Into<U> for aya_obj::generated::_bindgen_ty_1 where U: core::convert::From<T>
-pub fn aya_obj::generated::_bindgen_ty_1::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_obj::generated::_bindgen_ty_1 where U: core::convert::Into<T>
-pub type aya_obj::generated::_bindgen_ty_1::Error = core::convert::Infallible
-pub fn aya_obj::generated::_bindgen_ty_1::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_obj::generated::_bindgen_ty_1 where U: core::convert::TryFrom<T>
-pub type aya_obj::generated::_bindgen_ty_1::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_obj::generated::_bindgen_ty_1::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya_obj::generated::_bindgen_ty_1 where T: core::clone::Clone
-pub type aya_obj::generated::_bindgen_ty_1::Owned = T
-pub fn aya_obj::generated::_bindgen_ty_1::clone_into(&self, target: &mut T)
-pub fn aya_obj::generated::_bindgen_ty_1::to_owned(&self) -> T
-impl<T> core::any::Any for aya_obj::generated::_bindgen_ty_1 where T: 'static + ?core::marker::Sized
-pub fn aya_obj::generated::_bindgen_ty_1::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_obj::generated::_bindgen_ty_1 where T: ?core::marker::Sized
-pub fn aya_obj::generated::_bindgen_ty_1::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::_bindgen_ty_1 where T: ?core::marker::Sized
-pub fn aya_obj::generated::_bindgen_ty_1::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::_bindgen_ty_1 where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::_bindgen_ty_1::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_obj::generated::_bindgen_ty_1
-pub fn aya_obj::generated::_bindgen_ty_1::from(t: T) -> T
 #[repr(u32)] pub enum aya_obj::generated::_bindgen_ty_16
 pub aya_obj::generated::_bindgen_ty_16::BPF_CSUM_LEVEL_DEC = 2
 pub aya_obj::generated::_bindgen_ty_16::BPF_CSUM_LEVEL_INC = 1
@@ -1501,28 +699,6 @@ impl core::marker::Unpin for aya_obj::generated::_bindgen_ty_16
 impl core::marker::UnsafeUnpin for aya_obj::generated::_bindgen_ty_16
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::generated::_bindgen_ty_16
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::generated::_bindgen_ty_16
-impl<T, U> core::convert::Into<U> for aya_obj::generated::_bindgen_ty_16 where U: core::convert::From<T>
-pub fn aya_obj::generated::_bindgen_ty_16::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_obj::generated::_bindgen_ty_16 where U: core::convert::Into<T>
-pub type aya_obj::generated::_bindgen_ty_16::Error = core::convert::Infallible
-pub fn aya_obj::generated::_bindgen_ty_16::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_obj::generated::_bindgen_ty_16 where U: core::convert::TryFrom<T>
-pub type aya_obj::generated::_bindgen_ty_16::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_obj::generated::_bindgen_ty_16::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya_obj::generated::_bindgen_ty_16 where T: core::clone::Clone
-pub type aya_obj::generated::_bindgen_ty_16::Owned = T
-pub fn aya_obj::generated::_bindgen_ty_16::clone_into(&self, target: &mut T)
-pub fn aya_obj::generated::_bindgen_ty_16::to_owned(&self) -> T
-impl<T> core::any::Any for aya_obj::generated::_bindgen_ty_16 where T: 'static + ?core::marker::Sized
-pub fn aya_obj::generated::_bindgen_ty_16::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_obj::generated::_bindgen_ty_16 where T: ?core::marker::Sized
-pub fn aya_obj::generated::_bindgen_ty_16::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::_bindgen_ty_16 where T: ?core::marker::Sized
-pub fn aya_obj::generated::_bindgen_ty_16::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::_bindgen_ty_16 where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::_bindgen_ty_16::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_obj::generated::_bindgen_ty_16
-pub fn aya_obj::generated::_bindgen_ty_16::from(t: T) -> T
 #[repr(u32)] pub enum aya_obj::generated::_bindgen_ty_18
 pub aya_obj::generated::_bindgen_ty_18::BPF_ADJ_ROOM_ENCAP_L2_MASK = 255
 pub aya_obj::generated::_bindgen_ty_18::BPF_ADJ_ROOM_ENCAP_L2_SHIFT = 56
@@ -1544,28 +720,6 @@ impl core::marker::Unpin for aya_obj::generated::_bindgen_ty_18
 impl core::marker::UnsafeUnpin for aya_obj::generated::_bindgen_ty_18
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::generated::_bindgen_ty_18
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::generated::_bindgen_ty_18
-impl<T, U> core::convert::Into<U> for aya_obj::generated::_bindgen_ty_18 where U: core::convert::From<T>
-pub fn aya_obj::generated::_bindgen_ty_18::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_obj::generated::_bindgen_ty_18 where U: core::convert::Into<T>
-pub type aya_obj::generated::_bindgen_ty_18::Error = core::convert::Infallible
-pub fn aya_obj::generated::_bindgen_ty_18::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_obj::generated::_bindgen_ty_18 where U: core::convert::TryFrom<T>
-pub type aya_obj::generated::_bindgen_ty_18::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_obj::generated::_bindgen_ty_18::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya_obj::generated::_bindgen_ty_18 where T: core::clone::Clone
-pub type aya_obj::generated::_bindgen_ty_18::Owned = T
-pub fn aya_obj::generated::_bindgen_ty_18::clone_into(&self, target: &mut T)
-pub fn aya_obj::generated::_bindgen_ty_18::to_owned(&self) -> T
-impl<T> core::any::Any for aya_obj::generated::_bindgen_ty_18 where T: 'static + ?core::marker::Sized
-pub fn aya_obj::generated::_bindgen_ty_18::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_obj::generated::_bindgen_ty_18 where T: ?core::marker::Sized
-pub fn aya_obj::generated::_bindgen_ty_18::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::_bindgen_ty_18 where T: ?core::marker::Sized
-pub fn aya_obj::generated::_bindgen_ty_18::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::_bindgen_ty_18 where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::_bindgen_ty_18::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_obj::generated::_bindgen_ty_18
-pub fn aya_obj::generated::_bindgen_ty_18::from(t: T) -> T
 #[repr(u32)] pub enum aya_obj::generated::_bindgen_ty_20
 pub aya_obj::generated::_bindgen_ty_20::BPF_LOCAL_STORAGE_GET_F_CREATE = 1
 impl core::clone::Clone for aya_obj::generated::_bindgen_ty_20
@@ -1586,28 +740,6 @@ impl core::marker::Unpin for aya_obj::generated::_bindgen_ty_20
 impl core::marker::UnsafeUnpin for aya_obj::generated::_bindgen_ty_20
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::generated::_bindgen_ty_20
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::generated::_bindgen_ty_20
-impl<T, U> core::convert::Into<U> for aya_obj::generated::_bindgen_ty_20 where U: core::convert::From<T>
-pub fn aya_obj::generated::_bindgen_ty_20::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_obj::generated::_bindgen_ty_20 where U: core::convert::Into<T>
-pub type aya_obj::generated::_bindgen_ty_20::Error = core::convert::Infallible
-pub fn aya_obj::generated::_bindgen_ty_20::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_obj::generated::_bindgen_ty_20 where U: core::convert::TryFrom<T>
-pub type aya_obj::generated::_bindgen_ty_20::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_obj::generated::_bindgen_ty_20::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya_obj::generated::_bindgen_ty_20 where T: core::clone::Clone
-pub type aya_obj::generated::_bindgen_ty_20::Owned = T
-pub fn aya_obj::generated::_bindgen_ty_20::clone_into(&self, target: &mut T)
-pub fn aya_obj::generated::_bindgen_ty_20::to_owned(&self) -> T
-impl<T> core::any::Any for aya_obj::generated::_bindgen_ty_20 where T: 'static + ?core::marker::Sized
-pub fn aya_obj::generated::_bindgen_ty_20::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_obj::generated::_bindgen_ty_20 where T: ?core::marker::Sized
-pub fn aya_obj::generated::_bindgen_ty_20::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::_bindgen_ty_20 where T: ?core::marker::Sized
-pub fn aya_obj::generated::_bindgen_ty_20::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::_bindgen_ty_20 where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::_bindgen_ty_20::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_obj::generated::_bindgen_ty_20
-pub fn aya_obj::generated::_bindgen_ty_20::from(t: T) -> T
 #[repr(u32)] pub enum aya_obj::generated::_bindgen_ty_22
 pub aya_obj::generated::_bindgen_ty_22::BPF_RB_FORCE_WAKEUP = 2
 pub aya_obj::generated::_bindgen_ty_22::BPF_RB_NO_WAKEUP = 1
@@ -1629,28 +761,6 @@ impl core::marker::Unpin for aya_obj::generated::_bindgen_ty_22
 impl core::marker::UnsafeUnpin for aya_obj::generated::_bindgen_ty_22
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::generated::_bindgen_ty_22
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::generated::_bindgen_ty_22
-impl<T, U> core::convert::Into<U> for aya_obj::generated::_bindgen_ty_22 where U: core::convert::From<T>
-pub fn aya_obj::generated::_bindgen_ty_22::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_obj::generated::_bindgen_ty_22 where U: core::convert::Into<T>
-pub type aya_obj::generated::_bindgen_ty_22::Error = core::convert::Infallible
-pub fn aya_obj::generated::_bindgen_ty_22::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_obj::generated::_bindgen_ty_22 where U: core::convert::TryFrom<T>
-pub type aya_obj::generated::_bindgen_ty_22::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_obj::generated::_bindgen_ty_22::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya_obj::generated::_bindgen_ty_22 where T: core::clone::Clone
-pub type aya_obj::generated::_bindgen_ty_22::Owned = T
-pub fn aya_obj::generated::_bindgen_ty_22::clone_into(&self, target: &mut T)
-pub fn aya_obj::generated::_bindgen_ty_22::to_owned(&self) -> T
-impl<T> core::any::Any for aya_obj::generated::_bindgen_ty_22 where T: 'static + ?core::marker::Sized
-pub fn aya_obj::generated::_bindgen_ty_22::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_obj::generated::_bindgen_ty_22 where T: ?core::marker::Sized
-pub fn aya_obj::generated::_bindgen_ty_22::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::_bindgen_ty_22 where T: ?core::marker::Sized
-pub fn aya_obj::generated::_bindgen_ty_22::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::_bindgen_ty_22 where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::_bindgen_ty_22::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_obj::generated::_bindgen_ty_22
-pub fn aya_obj::generated::_bindgen_ty_22::from(t: T) -> T
 #[repr(u32)] pub enum aya_obj::generated::_bindgen_ty_23
 pub aya_obj::generated::_bindgen_ty_23::BPF_RB_AVAIL_DATA = 0
 pub aya_obj::generated::_bindgen_ty_23::BPF_RB_CONS_POS = 2
@@ -1674,28 +784,6 @@ impl core::marker::Unpin for aya_obj::generated::_bindgen_ty_23
 impl core::marker::UnsafeUnpin for aya_obj::generated::_bindgen_ty_23
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::generated::_bindgen_ty_23
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::generated::_bindgen_ty_23
-impl<T, U> core::convert::Into<U> for aya_obj::generated::_bindgen_ty_23 where U: core::convert::From<T>
-pub fn aya_obj::generated::_bindgen_ty_23::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_obj::generated::_bindgen_ty_23 where U: core::convert::Into<T>
-pub type aya_obj::generated::_bindgen_ty_23::Error = core::convert::Infallible
-pub fn aya_obj::generated::_bindgen_ty_23::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_obj::generated::_bindgen_ty_23 where U: core::convert::TryFrom<T>
-pub type aya_obj::generated::_bindgen_ty_23::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_obj::generated::_bindgen_ty_23::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya_obj::generated::_bindgen_ty_23 where T: core::clone::Clone
-pub type aya_obj::generated::_bindgen_ty_23::Owned = T
-pub fn aya_obj::generated::_bindgen_ty_23::clone_into(&self, target: &mut T)
-pub fn aya_obj::generated::_bindgen_ty_23::to_owned(&self) -> T
-impl<T> core::any::Any for aya_obj::generated::_bindgen_ty_23 where T: 'static + ?core::marker::Sized
-pub fn aya_obj::generated::_bindgen_ty_23::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_obj::generated::_bindgen_ty_23 where T: ?core::marker::Sized
-pub fn aya_obj::generated::_bindgen_ty_23::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::_bindgen_ty_23 where T: ?core::marker::Sized
-pub fn aya_obj::generated::_bindgen_ty_23::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::_bindgen_ty_23 where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::_bindgen_ty_23::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_obj::generated::_bindgen_ty_23
-pub fn aya_obj::generated::_bindgen_ty_23::from(t: T) -> T
 #[repr(u32)] pub enum aya_obj::generated::_bindgen_ty_25
 pub aya_obj::generated::_bindgen_ty_25::BPF_SK_LOOKUP_F_NO_REUSEPORT = 2
 pub aya_obj::generated::_bindgen_ty_25::BPF_SK_LOOKUP_F_REPLACE = 1
@@ -1717,28 +805,6 @@ impl core::marker::Unpin for aya_obj::generated::_bindgen_ty_25
 impl core::marker::UnsafeUnpin for aya_obj::generated::_bindgen_ty_25
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::generated::_bindgen_ty_25
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::generated::_bindgen_ty_25
-impl<T, U> core::convert::Into<U> for aya_obj::generated::_bindgen_ty_25 where U: core::convert::From<T>
-pub fn aya_obj::generated::_bindgen_ty_25::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_obj::generated::_bindgen_ty_25 where U: core::convert::Into<T>
-pub type aya_obj::generated::_bindgen_ty_25::Error = core::convert::Infallible
-pub fn aya_obj::generated::_bindgen_ty_25::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_obj::generated::_bindgen_ty_25 where U: core::convert::TryFrom<T>
-pub type aya_obj::generated::_bindgen_ty_25::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_obj::generated::_bindgen_ty_25::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya_obj::generated::_bindgen_ty_25 where T: core::clone::Clone
-pub type aya_obj::generated::_bindgen_ty_25::Owned = T
-pub fn aya_obj::generated::_bindgen_ty_25::clone_into(&self, target: &mut T)
-pub fn aya_obj::generated::_bindgen_ty_25::to_owned(&self) -> T
-impl<T> core::any::Any for aya_obj::generated::_bindgen_ty_25 where T: 'static + ?core::marker::Sized
-pub fn aya_obj::generated::_bindgen_ty_25::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_obj::generated::_bindgen_ty_25 where T: ?core::marker::Sized
-pub fn aya_obj::generated::_bindgen_ty_25::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::_bindgen_ty_25 where T: ?core::marker::Sized
-pub fn aya_obj::generated::_bindgen_ty_25::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::_bindgen_ty_25 where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::_bindgen_ty_25::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_obj::generated::_bindgen_ty_25
-pub fn aya_obj::generated::_bindgen_ty_25::from(t: T) -> T
 #[repr(u32)] pub enum aya_obj::generated::_bindgen_ty_28
 pub aya_obj::generated::_bindgen_ty_28::BPF_SKB_TSTAMP_DELIVERY_MONO = 1
 pub aya_obj::generated::_bindgen_ty_28::BPF_SKB_TSTAMP_UNSPEC = 0
@@ -1760,28 +826,6 @@ impl core::marker::Unpin for aya_obj::generated::_bindgen_ty_28
 impl core::marker::UnsafeUnpin for aya_obj::generated::_bindgen_ty_28
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::generated::_bindgen_ty_28
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::generated::_bindgen_ty_28
-impl<T, U> core::convert::Into<U> for aya_obj::generated::_bindgen_ty_28 where U: core::convert::From<T>
-pub fn aya_obj::generated::_bindgen_ty_28::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_obj::generated::_bindgen_ty_28 where U: core::convert::Into<T>
-pub type aya_obj::generated::_bindgen_ty_28::Error = core::convert::Infallible
-pub fn aya_obj::generated::_bindgen_ty_28::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_obj::generated::_bindgen_ty_28 where U: core::convert::TryFrom<T>
-pub type aya_obj::generated::_bindgen_ty_28::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_obj::generated::_bindgen_ty_28::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya_obj::generated::_bindgen_ty_28 where T: core::clone::Clone
-pub type aya_obj::generated::_bindgen_ty_28::Owned = T
-pub fn aya_obj::generated::_bindgen_ty_28::clone_into(&self, target: &mut T)
-pub fn aya_obj::generated::_bindgen_ty_28::to_owned(&self) -> T
-impl<T> core::any::Any for aya_obj::generated::_bindgen_ty_28 where T: 'static + ?core::marker::Sized
-pub fn aya_obj::generated::_bindgen_ty_28::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_obj::generated::_bindgen_ty_28 where T: ?core::marker::Sized
-pub fn aya_obj::generated::_bindgen_ty_28::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::_bindgen_ty_28 where T: ?core::marker::Sized
-pub fn aya_obj::generated::_bindgen_ty_28::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::_bindgen_ty_28 where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::_bindgen_ty_28::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_obj::generated::_bindgen_ty_28
-pub fn aya_obj::generated::_bindgen_ty_28::from(t: T) -> T
 #[repr(u32)] pub enum aya_obj::generated::_bindgen_ty_29
 pub aya_obj::generated::_bindgen_ty_29::BPF_SOCK_OPS_ALL_CB_FLAGS = 127
 pub aya_obj::generated::_bindgen_ty_29::BPF_SOCK_OPS_PARSE_ALL_HDR_OPT_CB_FLAG = 16
@@ -1809,28 +853,6 @@ impl core::marker::Unpin for aya_obj::generated::_bindgen_ty_29
 impl core::marker::UnsafeUnpin for aya_obj::generated::_bindgen_ty_29
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::generated::_bindgen_ty_29
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::generated::_bindgen_ty_29
-impl<T, U> core::convert::Into<U> for aya_obj::generated::_bindgen_ty_29 where U: core::convert::From<T>
-pub fn aya_obj::generated::_bindgen_ty_29::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_obj::generated::_bindgen_ty_29 where U: core::convert::Into<T>
-pub type aya_obj::generated::_bindgen_ty_29::Error = core::convert::Infallible
-pub fn aya_obj::generated::_bindgen_ty_29::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_obj::generated::_bindgen_ty_29 where U: core::convert::TryFrom<T>
-pub type aya_obj::generated::_bindgen_ty_29::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_obj::generated::_bindgen_ty_29::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya_obj::generated::_bindgen_ty_29 where T: core::clone::Clone
-pub type aya_obj::generated::_bindgen_ty_29::Owned = T
-pub fn aya_obj::generated::_bindgen_ty_29::clone_into(&self, target: &mut T)
-pub fn aya_obj::generated::_bindgen_ty_29::to_owned(&self) -> T
-impl<T> core::any::Any for aya_obj::generated::_bindgen_ty_29 where T: 'static + ?core::marker::Sized
-pub fn aya_obj::generated::_bindgen_ty_29::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_obj::generated::_bindgen_ty_29 where T: ?core::marker::Sized
-pub fn aya_obj::generated::_bindgen_ty_29::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::_bindgen_ty_29 where T: ?core::marker::Sized
-pub fn aya_obj::generated::_bindgen_ty_29::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::_bindgen_ty_29 where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::_bindgen_ty_29::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_obj::generated::_bindgen_ty_29
-pub fn aya_obj::generated::_bindgen_ty_29::from(t: T) -> T
 #[repr(u32)] pub enum aya_obj::generated::_bindgen_ty_30
 pub aya_obj::generated::_bindgen_ty_30::BPF_SOCK_OPS_ACTIVE_ESTABLISHED_CB = 4
 pub aya_obj::generated::_bindgen_ty_30::BPF_SOCK_OPS_BASE_RTT = 7
@@ -1866,28 +888,6 @@ impl core::marker::Unpin for aya_obj::generated::_bindgen_ty_30
 impl core::marker::UnsafeUnpin for aya_obj::generated::_bindgen_ty_30
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::generated::_bindgen_ty_30
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::generated::_bindgen_ty_30
-impl<T, U> core::convert::Into<U> for aya_obj::generated::_bindgen_ty_30 where U: core::convert::From<T>
-pub fn aya_obj::generated::_bindgen_ty_30::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_obj::generated::_bindgen_ty_30 where U: core::convert::Into<T>
-pub type aya_obj::generated::_bindgen_ty_30::Error = core::convert::Infallible
-pub fn aya_obj::generated::_bindgen_ty_30::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_obj::generated::_bindgen_ty_30 where U: core::convert::TryFrom<T>
-pub type aya_obj::generated::_bindgen_ty_30::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_obj::generated::_bindgen_ty_30::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya_obj::generated::_bindgen_ty_30 where T: core::clone::Clone
-pub type aya_obj::generated::_bindgen_ty_30::Owned = T
-pub fn aya_obj::generated::_bindgen_ty_30::clone_into(&self, target: &mut T)
-pub fn aya_obj::generated::_bindgen_ty_30::to_owned(&self) -> T
-impl<T> core::any::Any for aya_obj::generated::_bindgen_ty_30 where T: 'static + ?core::marker::Sized
-pub fn aya_obj::generated::_bindgen_ty_30::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_obj::generated::_bindgen_ty_30 where T: ?core::marker::Sized
-pub fn aya_obj::generated::_bindgen_ty_30::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::_bindgen_ty_30 where T: ?core::marker::Sized
-pub fn aya_obj::generated::_bindgen_ty_30::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::_bindgen_ty_30 where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::_bindgen_ty_30::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_obj::generated::_bindgen_ty_30
-pub fn aya_obj::generated::_bindgen_ty_30::from(t: T) -> T
 #[repr(u32)] pub enum aya_obj::generated::_bindgen_ty_31
 pub aya_obj::generated::_bindgen_ty_31::BPF_TCP_BOUND_INACTIVE = 13
 pub aya_obj::generated::_bindgen_ty_31::BPF_TCP_CLOSE = 7
@@ -1921,28 +921,6 @@ impl core::marker::Unpin for aya_obj::generated::_bindgen_ty_31
 impl core::marker::UnsafeUnpin for aya_obj::generated::_bindgen_ty_31
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::generated::_bindgen_ty_31
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::generated::_bindgen_ty_31
-impl<T, U> core::convert::Into<U> for aya_obj::generated::_bindgen_ty_31 where U: core::convert::From<T>
-pub fn aya_obj::generated::_bindgen_ty_31::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_obj::generated::_bindgen_ty_31 where U: core::convert::Into<T>
-pub type aya_obj::generated::_bindgen_ty_31::Error = core::convert::Infallible
-pub fn aya_obj::generated::_bindgen_ty_31::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_obj::generated::_bindgen_ty_31 where U: core::convert::TryFrom<T>
-pub type aya_obj::generated::_bindgen_ty_31::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_obj::generated::_bindgen_ty_31::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya_obj::generated::_bindgen_ty_31 where T: core::clone::Clone
-pub type aya_obj::generated::_bindgen_ty_31::Owned = T
-pub fn aya_obj::generated::_bindgen_ty_31::clone_into(&self, target: &mut T)
-pub fn aya_obj::generated::_bindgen_ty_31::to_owned(&self) -> T
-impl<T> core::any::Any for aya_obj::generated::_bindgen_ty_31 where T: 'static + ?core::marker::Sized
-pub fn aya_obj::generated::_bindgen_ty_31::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_obj::generated::_bindgen_ty_31 where T: ?core::marker::Sized
-pub fn aya_obj::generated::_bindgen_ty_31::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::_bindgen_ty_31 where T: ?core::marker::Sized
-pub fn aya_obj::generated::_bindgen_ty_31::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::_bindgen_ty_31 where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::_bindgen_ty_31::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_obj::generated::_bindgen_ty_31
-pub fn aya_obj::generated::_bindgen_ty_31::from(t: T) -> T
 #[repr(u32)] pub enum aya_obj::generated::_bindgen_ty_33
 pub aya_obj::generated::_bindgen_ty_33::BPF_LOAD_HDR_OPT_TCP_SYN = 1
 impl core::clone::Clone for aya_obj::generated::_bindgen_ty_33
@@ -1963,28 +941,6 @@ impl core::marker::Unpin for aya_obj::generated::_bindgen_ty_33
 impl core::marker::UnsafeUnpin for aya_obj::generated::_bindgen_ty_33
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::generated::_bindgen_ty_33
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::generated::_bindgen_ty_33
-impl<T, U> core::convert::Into<U> for aya_obj::generated::_bindgen_ty_33 where U: core::convert::From<T>
-pub fn aya_obj::generated::_bindgen_ty_33::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_obj::generated::_bindgen_ty_33 where U: core::convert::Into<T>
-pub type aya_obj::generated::_bindgen_ty_33::Error = core::convert::Infallible
-pub fn aya_obj::generated::_bindgen_ty_33::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_obj::generated::_bindgen_ty_33 where U: core::convert::TryFrom<T>
-pub type aya_obj::generated::_bindgen_ty_33::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_obj::generated::_bindgen_ty_33::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya_obj::generated::_bindgen_ty_33 where T: core::clone::Clone
-pub type aya_obj::generated::_bindgen_ty_33::Owned = T
-pub fn aya_obj::generated::_bindgen_ty_33::clone_into(&self, target: &mut T)
-pub fn aya_obj::generated::_bindgen_ty_33::to_owned(&self) -> T
-impl<T> core::any::Any for aya_obj::generated::_bindgen_ty_33 where T: 'static + ?core::marker::Sized
-pub fn aya_obj::generated::_bindgen_ty_33::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_obj::generated::_bindgen_ty_33 where T: ?core::marker::Sized
-pub fn aya_obj::generated::_bindgen_ty_33::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::_bindgen_ty_33 where T: ?core::marker::Sized
-pub fn aya_obj::generated::_bindgen_ty_33::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::_bindgen_ty_33 where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::_bindgen_ty_33::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_obj::generated::_bindgen_ty_33
-pub fn aya_obj::generated::_bindgen_ty_33::from(t: T) -> T
 #[repr(u32)] pub enum aya_obj::generated::_bindgen_ty_34
 pub aya_obj::generated::_bindgen_ty_34::BPF_WRITE_HDR_TCP_CURRENT_MSS = 1
 pub aya_obj::generated::_bindgen_ty_34::BPF_WRITE_HDR_TCP_SYNACK_COOKIE = 2
@@ -2006,28 +962,6 @@ impl core::marker::Unpin for aya_obj::generated::_bindgen_ty_34
 impl core::marker::UnsafeUnpin for aya_obj::generated::_bindgen_ty_34
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::generated::_bindgen_ty_34
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::generated::_bindgen_ty_34
-impl<T, U> core::convert::Into<U> for aya_obj::generated::_bindgen_ty_34 where U: core::convert::From<T>
-pub fn aya_obj::generated::_bindgen_ty_34::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_obj::generated::_bindgen_ty_34 where U: core::convert::Into<T>
-pub type aya_obj::generated::_bindgen_ty_34::Error = core::convert::Infallible
-pub fn aya_obj::generated::_bindgen_ty_34::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_obj::generated::_bindgen_ty_34 where U: core::convert::TryFrom<T>
-pub type aya_obj::generated::_bindgen_ty_34::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_obj::generated::_bindgen_ty_34::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya_obj::generated::_bindgen_ty_34 where T: core::clone::Clone
-pub type aya_obj::generated::_bindgen_ty_34::Owned = T
-pub fn aya_obj::generated::_bindgen_ty_34::clone_into(&self, target: &mut T)
-pub fn aya_obj::generated::_bindgen_ty_34::to_owned(&self) -> T
-impl<T> core::any::Any for aya_obj::generated::_bindgen_ty_34 where T: 'static + ?core::marker::Sized
-pub fn aya_obj::generated::_bindgen_ty_34::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_obj::generated::_bindgen_ty_34 where T: ?core::marker::Sized
-pub fn aya_obj::generated::_bindgen_ty_34::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::_bindgen_ty_34 where T: ?core::marker::Sized
-pub fn aya_obj::generated::_bindgen_ty_34::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::_bindgen_ty_34 where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::_bindgen_ty_34::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_obj::generated::_bindgen_ty_34
-pub fn aya_obj::generated::_bindgen_ty_34::from(t: T) -> T
 #[repr(u32)] pub enum aya_obj::generated::_bindgen_ty_35
 pub aya_obj::generated::_bindgen_ty_35::BPF_DEVCG_ACC_MKNOD = 1
 pub aya_obj::generated::_bindgen_ty_35::BPF_DEVCG_ACC_READ = 2
@@ -2050,28 +984,6 @@ impl core::marker::Unpin for aya_obj::generated::_bindgen_ty_35
 impl core::marker::UnsafeUnpin for aya_obj::generated::_bindgen_ty_35
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::generated::_bindgen_ty_35
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::generated::_bindgen_ty_35
-impl<T, U> core::convert::Into<U> for aya_obj::generated::_bindgen_ty_35 where U: core::convert::From<T>
-pub fn aya_obj::generated::_bindgen_ty_35::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_obj::generated::_bindgen_ty_35 where U: core::convert::Into<T>
-pub type aya_obj::generated::_bindgen_ty_35::Error = core::convert::Infallible
-pub fn aya_obj::generated::_bindgen_ty_35::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_obj::generated::_bindgen_ty_35 where U: core::convert::TryFrom<T>
-pub type aya_obj::generated::_bindgen_ty_35::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_obj::generated::_bindgen_ty_35::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya_obj::generated::_bindgen_ty_35 where T: core::clone::Clone
-pub type aya_obj::generated::_bindgen_ty_35::Owned = T
-pub fn aya_obj::generated::_bindgen_ty_35::clone_into(&self, target: &mut T)
-pub fn aya_obj::generated::_bindgen_ty_35::to_owned(&self) -> T
-impl<T> core::any::Any for aya_obj::generated::_bindgen_ty_35 where T: 'static + ?core::marker::Sized
-pub fn aya_obj::generated::_bindgen_ty_35::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_obj::generated::_bindgen_ty_35 where T: ?core::marker::Sized
-pub fn aya_obj::generated::_bindgen_ty_35::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::_bindgen_ty_35 where T: ?core::marker::Sized
-pub fn aya_obj::generated::_bindgen_ty_35::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::_bindgen_ty_35 where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::_bindgen_ty_35::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_obj::generated::_bindgen_ty_35
-pub fn aya_obj::generated::_bindgen_ty_35::from(t: T) -> T
 #[repr(u32)] pub enum aya_obj::generated::_bindgen_ty_36
 pub aya_obj::generated::_bindgen_ty_36::BPF_DEVCG_DEV_BLOCK = 1
 pub aya_obj::generated::_bindgen_ty_36::BPF_DEVCG_DEV_CHAR = 2
@@ -2093,28 +1005,6 @@ impl core::marker::Unpin for aya_obj::generated::_bindgen_ty_36
 impl core::marker::UnsafeUnpin for aya_obj::generated::_bindgen_ty_36
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::generated::_bindgen_ty_36
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::generated::_bindgen_ty_36
-impl<T, U> core::convert::Into<U> for aya_obj::generated::_bindgen_ty_36 where U: core::convert::From<T>
-pub fn aya_obj::generated::_bindgen_ty_36::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_obj::generated::_bindgen_ty_36 where U: core::convert::Into<T>
-pub type aya_obj::generated::_bindgen_ty_36::Error = core::convert::Infallible
-pub fn aya_obj::generated::_bindgen_ty_36::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_obj::generated::_bindgen_ty_36 where U: core::convert::TryFrom<T>
-pub type aya_obj::generated::_bindgen_ty_36::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_obj::generated::_bindgen_ty_36::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya_obj::generated::_bindgen_ty_36 where T: core::clone::Clone
-pub type aya_obj::generated::_bindgen_ty_36::Owned = T
-pub fn aya_obj::generated::_bindgen_ty_36::clone_into(&self, target: &mut T)
-pub fn aya_obj::generated::_bindgen_ty_36::to_owned(&self) -> T
-impl<T> core::any::Any for aya_obj::generated::_bindgen_ty_36 where T: 'static + ?core::marker::Sized
-pub fn aya_obj::generated::_bindgen_ty_36::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_obj::generated::_bindgen_ty_36 where T: ?core::marker::Sized
-pub fn aya_obj::generated::_bindgen_ty_36::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::_bindgen_ty_36 where T: ?core::marker::Sized
-pub fn aya_obj::generated::_bindgen_ty_36::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::_bindgen_ty_36 where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::_bindgen_ty_36::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_obj::generated::_bindgen_ty_36
-pub fn aya_obj::generated::_bindgen_ty_36::from(t: T) -> T
 #[repr(u32)] pub enum aya_obj::generated::_bindgen_ty_37
 pub aya_obj::generated::_bindgen_ty_37::BPF_FIB_LOOKUP_DIRECT = 1
 pub aya_obj::generated::_bindgen_ty_37::BPF_FIB_LOOKUP_OUTPUT = 2
@@ -2139,28 +1029,6 @@ impl core::marker::Unpin for aya_obj::generated::_bindgen_ty_37
 impl core::marker::UnsafeUnpin for aya_obj::generated::_bindgen_ty_37
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::generated::_bindgen_ty_37
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::generated::_bindgen_ty_37
-impl<T, U> core::convert::Into<U> for aya_obj::generated::_bindgen_ty_37 where U: core::convert::From<T>
-pub fn aya_obj::generated::_bindgen_ty_37::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_obj::generated::_bindgen_ty_37 where U: core::convert::Into<T>
-pub type aya_obj::generated::_bindgen_ty_37::Error = core::convert::Infallible
-pub fn aya_obj::generated::_bindgen_ty_37::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_obj::generated::_bindgen_ty_37 where U: core::convert::TryFrom<T>
-pub type aya_obj::generated::_bindgen_ty_37::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_obj::generated::_bindgen_ty_37::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya_obj::generated::_bindgen_ty_37 where T: core::clone::Clone
-pub type aya_obj::generated::_bindgen_ty_37::Owned = T
-pub fn aya_obj::generated::_bindgen_ty_37::clone_into(&self, target: &mut T)
-pub fn aya_obj::generated::_bindgen_ty_37::to_owned(&self) -> T
-impl<T> core::any::Any for aya_obj::generated::_bindgen_ty_37 where T: 'static + ?core::marker::Sized
-pub fn aya_obj::generated::_bindgen_ty_37::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_obj::generated::_bindgen_ty_37 where T: ?core::marker::Sized
-pub fn aya_obj::generated::_bindgen_ty_37::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::_bindgen_ty_37 where T: ?core::marker::Sized
-pub fn aya_obj::generated::_bindgen_ty_37::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::_bindgen_ty_37 where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::_bindgen_ty_37::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_obj::generated::_bindgen_ty_37
-pub fn aya_obj::generated::_bindgen_ty_37::from(t: T) -> T
 #[repr(u32)] pub enum aya_obj::generated::_bindgen_ty_38
 pub aya_obj::generated::_bindgen_ty_38::BPF_FIB_LKUP_RET_BLACKHOLE = 1
 pub aya_obj::generated::_bindgen_ty_38::BPF_FIB_LKUP_RET_FRAG_NEEDED = 8
@@ -2190,28 +1058,6 @@ impl core::marker::Unpin for aya_obj::generated::_bindgen_ty_38
 impl core::marker::UnsafeUnpin for aya_obj::generated::_bindgen_ty_38
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::generated::_bindgen_ty_38
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::generated::_bindgen_ty_38
-impl<T, U> core::convert::Into<U> for aya_obj::generated::_bindgen_ty_38 where U: core::convert::From<T>
-pub fn aya_obj::generated::_bindgen_ty_38::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_obj::generated::_bindgen_ty_38 where U: core::convert::Into<T>
-pub type aya_obj::generated::_bindgen_ty_38::Error = core::convert::Infallible
-pub fn aya_obj::generated::_bindgen_ty_38::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_obj::generated::_bindgen_ty_38 where U: core::convert::TryFrom<T>
-pub type aya_obj::generated::_bindgen_ty_38::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_obj::generated::_bindgen_ty_38::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya_obj::generated::_bindgen_ty_38 where T: core::clone::Clone
-pub type aya_obj::generated::_bindgen_ty_38::Owned = T
-pub fn aya_obj::generated::_bindgen_ty_38::clone_into(&self, target: &mut T)
-pub fn aya_obj::generated::_bindgen_ty_38::to_owned(&self) -> T
-impl<T> core::any::Any for aya_obj::generated::_bindgen_ty_38 where T: 'static + ?core::marker::Sized
-pub fn aya_obj::generated::_bindgen_ty_38::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_obj::generated::_bindgen_ty_38 where T: ?core::marker::Sized
-pub fn aya_obj::generated::_bindgen_ty_38::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::_bindgen_ty_38 where T: ?core::marker::Sized
-pub fn aya_obj::generated::_bindgen_ty_38::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::_bindgen_ty_38 where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::_bindgen_ty_38::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_obj::generated::_bindgen_ty_38
-pub fn aya_obj::generated::_bindgen_ty_38::from(t: T) -> T
 #[repr(u32)] pub enum aya_obj::generated::_bindgen_ty_39
 pub aya_obj::generated::_bindgen_ty_39::BPF_FLOW_DISSECTOR_F_PARSE_1ST_FRAG = 1
 pub aya_obj::generated::_bindgen_ty_39::BPF_FLOW_DISSECTOR_F_STOP_AT_ENCAP = 4
@@ -2234,28 +1080,6 @@ impl core::marker::Unpin for aya_obj::generated::_bindgen_ty_39
 impl core::marker::UnsafeUnpin for aya_obj::generated::_bindgen_ty_39
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::generated::_bindgen_ty_39
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::generated::_bindgen_ty_39
-impl<T, U> core::convert::Into<U> for aya_obj::generated::_bindgen_ty_39 where U: core::convert::From<T>
-pub fn aya_obj::generated::_bindgen_ty_39::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_obj::generated::_bindgen_ty_39 where U: core::convert::Into<T>
-pub type aya_obj::generated::_bindgen_ty_39::Error = core::convert::Infallible
-pub fn aya_obj::generated::_bindgen_ty_39::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_obj::generated::_bindgen_ty_39 where U: core::convert::TryFrom<T>
-pub type aya_obj::generated::_bindgen_ty_39::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_obj::generated::_bindgen_ty_39::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya_obj::generated::_bindgen_ty_39 where T: core::clone::Clone
-pub type aya_obj::generated::_bindgen_ty_39::Owned = T
-pub fn aya_obj::generated::_bindgen_ty_39::clone_into(&self, target: &mut T)
-pub fn aya_obj::generated::_bindgen_ty_39::to_owned(&self) -> T
-impl<T> core::any::Any for aya_obj::generated::_bindgen_ty_39 where T: 'static + ?core::marker::Sized
-pub fn aya_obj::generated::_bindgen_ty_39::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_obj::generated::_bindgen_ty_39 where T: ?core::marker::Sized
-pub fn aya_obj::generated::_bindgen_ty_39::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::_bindgen_ty_39 where T: ?core::marker::Sized
-pub fn aya_obj::generated::_bindgen_ty_39::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::_bindgen_ty_39 where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::_bindgen_ty_39::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_obj::generated::_bindgen_ty_39
-pub fn aya_obj::generated::_bindgen_ty_39::from(t: T) -> T
 #[repr(u32)] pub enum aya_obj::generated::bpf_attach_type
 pub aya_obj::generated::bpf_attach_type::BPF_CGROUP_DEVICE = 6
 pub aya_obj::generated::bpf_attach_type::BPF_CGROUP_GETSOCKOPT = 21
@@ -2347,28 +1171,6 @@ impl core::marker::Unpin for aya_obj::generated::bpf_attach_type
 impl core::marker::UnsafeUnpin for aya_obj::generated::bpf_attach_type
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::generated::bpf_attach_type
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::generated::bpf_attach_type
-impl<T, U> core::convert::Into<U> for aya_obj::generated::bpf_attach_type where U: core::convert::From<T>
-pub fn aya_obj::generated::bpf_attach_type::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_obj::generated::bpf_attach_type where U: core::convert::Into<T>
-pub type aya_obj::generated::bpf_attach_type::Error = core::convert::Infallible
-pub fn aya_obj::generated::bpf_attach_type::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_obj::generated::bpf_attach_type where U: core::convert::TryFrom<T>
-pub type aya_obj::generated::bpf_attach_type::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_obj::generated::bpf_attach_type::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya_obj::generated::bpf_attach_type where T: core::clone::Clone
-pub type aya_obj::generated::bpf_attach_type::Owned = T
-pub fn aya_obj::generated::bpf_attach_type::clone_into(&self, target: &mut T)
-pub fn aya_obj::generated::bpf_attach_type::to_owned(&self) -> T
-impl<T> core::any::Any for aya_obj::generated::bpf_attach_type where T: 'static + ?core::marker::Sized
-pub fn aya_obj::generated::bpf_attach_type::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_obj::generated::bpf_attach_type where T: ?core::marker::Sized
-pub fn aya_obj::generated::bpf_attach_type::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::bpf_attach_type where T: ?core::marker::Sized
-pub fn aya_obj::generated::bpf_attach_type::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_attach_type where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::bpf_attach_type::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_obj::generated::bpf_attach_type
-pub fn aya_obj::generated::bpf_attach_type::from(t: T) -> T
 #[repr(u32)] pub enum aya_obj::generated::bpf_cgroup_iter_order
 pub aya_obj::generated::bpf_cgroup_iter_order::BPF_CGROUP_ITER_ANCESTORS_UP = 4
 pub aya_obj::generated::bpf_cgroup_iter_order::BPF_CGROUP_ITER_DESCENDANTS_POST = 3
@@ -2393,28 +1195,6 @@ impl core::marker::Unpin for aya_obj::generated::bpf_cgroup_iter_order
 impl core::marker::UnsafeUnpin for aya_obj::generated::bpf_cgroup_iter_order
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::generated::bpf_cgroup_iter_order
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::generated::bpf_cgroup_iter_order
-impl<T, U> core::convert::Into<U> for aya_obj::generated::bpf_cgroup_iter_order where U: core::convert::From<T>
-pub fn aya_obj::generated::bpf_cgroup_iter_order::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_obj::generated::bpf_cgroup_iter_order where U: core::convert::Into<T>
-pub type aya_obj::generated::bpf_cgroup_iter_order::Error = core::convert::Infallible
-pub fn aya_obj::generated::bpf_cgroup_iter_order::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_obj::generated::bpf_cgroup_iter_order where U: core::convert::TryFrom<T>
-pub type aya_obj::generated::bpf_cgroup_iter_order::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_obj::generated::bpf_cgroup_iter_order::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya_obj::generated::bpf_cgroup_iter_order where T: core::clone::Clone
-pub type aya_obj::generated::bpf_cgroup_iter_order::Owned = T
-pub fn aya_obj::generated::bpf_cgroup_iter_order::clone_into(&self, target: &mut T)
-pub fn aya_obj::generated::bpf_cgroup_iter_order::to_owned(&self) -> T
-impl<T> core::any::Any for aya_obj::generated::bpf_cgroup_iter_order where T: 'static + ?core::marker::Sized
-pub fn aya_obj::generated::bpf_cgroup_iter_order::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_obj::generated::bpf_cgroup_iter_order where T: ?core::marker::Sized
-pub fn aya_obj::generated::bpf_cgroup_iter_order::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::bpf_cgroup_iter_order where T: ?core::marker::Sized
-pub fn aya_obj::generated::bpf_cgroup_iter_order::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_cgroup_iter_order where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::bpf_cgroup_iter_order::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_obj::generated::bpf_cgroup_iter_order
-pub fn aya_obj::generated::bpf_cgroup_iter_order::from(t: T) -> T
 #[repr(u32)] pub enum aya_obj::generated::bpf_cmd
 pub aya_obj::generated::bpf_cmd::BPF_BTF_GET_FD_BY_ID = 19
 pub aya_obj::generated::bpf_cmd::BPF_BTF_GET_NEXT_ID = 23
@@ -2474,28 +1254,6 @@ impl core::marker::Unpin for aya_obj::generated::bpf_cmd
 impl core::marker::UnsafeUnpin for aya_obj::generated::bpf_cmd
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::generated::bpf_cmd
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::generated::bpf_cmd
-impl<T, U> core::convert::Into<U> for aya_obj::generated::bpf_cmd where U: core::convert::From<T>
-pub fn aya_obj::generated::bpf_cmd::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_obj::generated::bpf_cmd where U: core::convert::Into<T>
-pub type aya_obj::generated::bpf_cmd::Error = core::convert::Infallible
-pub fn aya_obj::generated::bpf_cmd::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_obj::generated::bpf_cmd where U: core::convert::TryFrom<T>
-pub type aya_obj::generated::bpf_cmd::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_obj::generated::bpf_cmd::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya_obj::generated::bpf_cmd where T: core::clone::Clone
-pub type aya_obj::generated::bpf_cmd::Owned = T
-pub fn aya_obj::generated::bpf_cmd::clone_into(&self, target: &mut T)
-pub fn aya_obj::generated::bpf_cmd::to_owned(&self) -> T
-impl<T> core::any::Any for aya_obj::generated::bpf_cmd where T: 'static + ?core::marker::Sized
-pub fn aya_obj::generated::bpf_cmd::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_obj::generated::bpf_cmd where T: ?core::marker::Sized
-pub fn aya_obj::generated::bpf_cmd::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::bpf_cmd where T: ?core::marker::Sized
-pub fn aya_obj::generated::bpf_cmd::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_cmd where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::bpf_cmd::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_obj::generated::bpf_cmd
-pub fn aya_obj::generated::bpf_cmd::from(t: T) -> T
 #[repr(u32)] pub enum aya_obj::generated::bpf_func_id
 pub aya_obj::generated::bpf_func_id::BPF_FUNC_bind = 64
 pub aya_obj::generated::bpf_func_id::BPF_FUNC_bprm_opts_set = 159
@@ -2728,28 +1486,6 @@ impl core::marker::Unpin for aya_obj::generated::bpf_func_id
 impl core::marker::UnsafeUnpin for aya_obj::generated::bpf_func_id
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::generated::bpf_func_id
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::generated::bpf_func_id
-impl<T, U> core::convert::Into<U> for aya_obj::generated::bpf_func_id where U: core::convert::From<T>
-pub fn aya_obj::generated::bpf_func_id::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_obj::generated::bpf_func_id where U: core::convert::Into<T>
-pub type aya_obj::generated::bpf_func_id::Error = core::convert::Infallible
-pub fn aya_obj::generated::bpf_func_id::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_obj::generated::bpf_func_id where U: core::convert::TryFrom<T>
-pub type aya_obj::generated::bpf_func_id::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_obj::generated::bpf_func_id::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya_obj::generated::bpf_func_id where T: core::clone::Clone
-pub type aya_obj::generated::bpf_func_id::Owned = T
-pub fn aya_obj::generated::bpf_func_id::clone_into(&self, target: &mut T)
-pub fn aya_obj::generated::bpf_func_id::to_owned(&self) -> T
-impl<T> core::any::Any for aya_obj::generated::bpf_func_id where T: 'static + ?core::marker::Sized
-pub fn aya_obj::generated::bpf_func_id::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_obj::generated::bpf_func_id where T: ?core::marker::Sized
-pub fn aya_obj::generated::bpf_func_id::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::bpf_func_id where T: ?core::marker::Sized
-pub fn aya_obj::generated::bpf_func_id::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_func_id where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::bpf_func_id::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_obj::generated::bpf_func_id
-pub fn aya_obj::generated::bpf_func_id::from(t: T) -> T
 #[repr(u32)] pub enum aya_obj::generated::bpf_link_type
 pub aya_obj::generated::bpf_link_type::BPF_LINK_TYPE_CGROUP = 3
 pub aya_obj::generated::bpf_link_type::BPF_LINK_TYPE_ITER = 4
@@ -2787,28 +1523,6 @@ impl core::marker::Unpin for aya_obj::generated::bpf_link_type
 impl core::marker::UnsafeUnpin for aya_obj::generated::bpf_link_type
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::generated::bpf_link_type
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::generated::bpf_link_type
-impl<T, U> core::convert::Into<U> for aya_obj::generated::bpf_link_type where U: core::convert::From<T>
-pub fn aya_obj::generated::bpf_link_type::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_obj::generated::bpf_link_type where U: core::convert::Into<T>
-pub type aya_obj::generated::bpf_link_type::Error = core::convert::Infallible
-pub fn aya_obj::generated::bpf_link_type::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_obj::generated::bpf_link_type where U: core::convert::TryFrom<T>
-pub type aya_obj::generated::bpf_link_type::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_obj::generated::bpf_link_type::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya_obj::generated::bpf_link_type where T: core::clone::Clone
-pub type aya_obj::generated::bpf_link_type::Owned = T
-pub fn aya_obj::generated::bpf_link_type::clone_into(&self, target: &mut T)
-pub fn aya_obj::generated::bpf_link_type::to_owned(&self) -> T
-impl<T> core::any::Any for aya_obj::generated::bpf_link_type where T: 'static + ?core::marker::Sized
-pub fn aya_obj::generated::bpf_link_type::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_obj::generated::bpf_link_type where T: ?core::marker::Sized
-pub fn aya_obj::generated::bpf_link_type::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::bpf_link_type where T: ?core::marker::Sized
-pub fn aya_obj::generated::bpf_link_type::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_link_type where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::bpf_link_type::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_obj::generated::bpf_link_type
-pub fn aya_obj::generated::bpf_link_type::from(t: T) -> T
 #[repr(u32)] pub enum aya_obj::generated::bpf_map_type
 pub aya_obj::generated::bpf_map_type::BPF_MAP_TYPE_ARENA = 33
 pub aya_obj::generated::bpf_map_type::BPF_MAP_TYPE_ARRAY = 2
@@ -2870,28 +1584,6 @@ impl core::marker::Unpin for aya_obj::generated::bpf_map_type
 impl core::marker::UnsafeUnpin for aya_obj::generated::bpf_map_type
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::generated::bpf_map_type
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::generated::bpf_map_type
-impl<T, U> core::convert::Into<U> for aya_obj::generated::bpf_map_type where U: core::convert::From<T>
-pub fn aya_obj::generated::bpf_map_type::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_obj::generated::bpf_map_type where U: core::convert::Into<T>
-pub type aya_obj::generated::bpf_map_type::Error = core::convert::Infallible
-pub fn aya_obj::generated::bpf_map_type::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_obj::generated::bpf_map_type where U: core::convert::TryFrom<T>
-pub type aya_obj::generated::bpf_map_type::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_obj::generated::bpf_map_type::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya_obj::generated::bpf_map_type where T: core::clone::Clone
-pub type aya_obj::generated::bpf_map_type::Owned = T
-pub fn aya_obj::generated::bpf_map_type::clone_into(&self, target: &mut T)
-pub fn aya_obj::generated::bpf_map_type::to_owned(&self) -> T
-impl<T> core::any::Any for aya_obj::generated::bpf_map_type where T: 'static + ?core::marker::Sized
-pub fn aya_obj::generated::bpf_map_type::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_obj::generated::bpf_map_type where T: ?core::marker::Sized
-pub fn aya_obj::generated::bpf_map_type::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::bpf_map_type where T: ?core::marker::Sized
-pub fn aya_obj::generated::bpf_map_type::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_map_type where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::bpf_map_type::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_obj::generated::bpf_map_type
-pub fn aya_obj::generated::bpf_map_type::from(t: T) -> T
 #[repr(u32)] pub enum aya_obj::generated::bpf_perf_event_type
 pub aya_obj::generated::bpf_perf_event_type::BPF_PERF_EVENT_EVENT = 6
 pub aya_obj::generated::bpf_perf_event_type::BPF_PERF_EVENT_KPROBE = 3
@@ -2918,28 +1610,6 @@ impl core::marker::Unpin for aya_obj::generated::bpf_perf_event_type
 impl core::marker::UnsafeUnpin for aya_obj::generated::bpf_perf_event_type
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::generated::bpf_perf_event_type
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::generated::bpf_perf_event_type
-impl<T, U> core::convert::Into<U> for aya_obj::generated::bpf_perf_event_type where U: core::convert::From<T>
-pub fn aya_obj::generated::bpf_perf_event_type::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_obj::generated::bpf_perf_event_type where U: core::convert::Into<T>
-pub type aya_obj::generated::bpf_perf_event_type::Error = core::convert::Infallible
-pub fn aya_obj::generated::bpf_perf_event_type::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_obj::generated::bpf_perf_event_type where U: core::convert::TryFrom<T>
-pub type aya_obj::generated::bpf_perf_event_type::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_obj::generated::bpf_perf_event_type::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya_obj::generated::bpf_perf_event_type where T: core::clone::Clone
-pub type aya_obj::generated::bpf_perf_event_type::Owned = T
-pub fn aya_obj::generated::bpf_perf_event_type::clone_into(&self, target: &mut T)
-pub fn aya_obj::generated::bpf_perf_event_type::to_owned(&self) -> T
-impl<T> core::any::Any for aya_obj::generated::bpf_perf_event_type where T: 'static + ?core::marker::Sized
-pub fn aya_obj::generated::bpf_perf_event_type::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_obj::generated::bpf_perf_event_type where T: ?core::marker::Sized
-pub fn aya_obj::generated::bpf_perf_event_type::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::bpf_perf_event_type where T: ?core::marker::Sized
-pub fn aya_obj::generated::bpf_perf_event_type::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_perf_event_type where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::bpf_perf_event_type::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_obj::generated::bpf_perf_event_type
-pub fn aya_obj::generated::bpf_perf_event_type::from(t: T) -> T
 #[repr(u32)] pub enum aya_obj::generated::bpf_prog_type
 pub aya_obj::generated::bpf_prog_type::BPF_PROG_TYPE_CGROUP_DEVICE = 15
 pub aya_obj::generated::bpf_prog_type::BPF_PROG_TYPE_CGROUP_SKB = 8
@@ -2996,28 +1666,6 @@ impl core::marker::Unpin for aya_obj::generated::bpf_prog_type
 impl core::marker::UnsafeUnpin for aya_obj::generated::bpf_prog_type
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::generated::bpf_prog_type
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::generated::bpf_prog_type
-impl<T, U> core::convert::Into<U> for aya_obj::generated::bpf_prog_type where U: core::convert::From<T>
-pub fn aya_obj::generated::bpf_prog_type::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_obj::generated::bpf_prog_type where U: core::convert::Into<T>
-pub type aya_obj::generated::bpf_prog_type::Error = core::convert::Infallible
-pub fn aya_obj::generated::bpf_prog_type::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_obj::generated::bpf_prog_type where U: core::convert::TryFrom<T>
-pub type aya_obj::generated::bpf_prog_type::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_obj::generated::bpf_prog_type::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya_obj::generated::bpf_prog_type where T: core::clone::Clone
-pub type aya_obj::generated::bpf_prog_type::Owned = T
-pub fn aya_obj::generated::bpf_prog_type::clone_into(&self, target: &mut T)
-pub fn aya_obj::generated::bpf_prog_type::to_owned(&self) -> T
-impl<T> core::any::Any for aya_obj::generated::bpf_prog_type where T: 'static + ?core::marker::Sized
-pub fn aya_obj::generated::bpf_prog_type::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_obj::generated::bpf_prog_type where T: ?core::marker::Sized
-pub fn aya_obj::generated::bpf_prog_type::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::bpf_prog_type where T: ?core::marker::Sized
-pub fn aya_obj::generated::bpf_prog_type::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_prog_type where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::bpf_prog_type::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_obj::generated::bpf_prog_type
-pub fn aya_obj::generated::bpf_prog_type::from(t: T) -> T
 #[repr(u32)] pub enum aya_obj::generated::bpf_stats_type
 pub aya_obj::generated::bpf_stats_type::BPF_STATS_RUN_TIME = 0
 impl core::clone::Clone for aya_obj::generated::bpf_stats_type
@@ -3038,28 +1686,6 @@ impl core::marker::Unpin for aya_obj::generated::bpf_stats_type
 impl core::marker::UnsafeUnpin for aya_obj::generated::bpf_stats_type
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::generated::bpf_stats_type
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::generated::bpf_stats_type
-impl<T, U> core::convert::Into<U> for aya_obj::generated::bpf_stats_type where U: core::convert::From<T>
-pub fn aya_obj::generated::bpf_stats_type::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_obj::generated::bpf_stats_type where U: core::convert::Into<T>
-pub type aya_obj::generated::bpf_stats_type::Error = core::convert::Infallible
-pub fn aya_obj::generated::bpf_stats_type::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_obj::generated::bpf_stats_type where U: core::convert::TryFrom<T>
-pub type aya_obj::generated::bpf_stats_type::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_obj::generated::bpf_stats_type::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya_obj::generated::bpf_stats_type where T: core::clone::Clone
-pub type aya_obj::generated::bpf_stats_type::Owned = T
-pub fn aya_obj::generated::bpf_stats_type::clone_into(&self, target: &mut T)
-pub fn aya_obj::generated::bpf_stats_type::to_owned(&self) -> T
-impl<T> core::any::Any for aya_obj::generated::bpf_stats_type where T: 'static + ?core::marker::Sized
-pub fn aya_obj::generated::bpf_stats_type::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_obj::generated::bpf_stats_type where T: ?core::marker::Sized
-pub fn aya_obj::generated::bpf_stats_type::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::bpf_stats_type where T: ?core::marker::Sized
-pub fn aya_obj::generated::bpf_stats_type::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_stats_type where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::bpf_stats_type::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_obj::generated::bpf_stats_type
-pub fn aya_obj::generated::bpf_stats_type::from(t: T) -> T
 #[repr(u32)] pub enum aya_obj::generated::bpf_task_fd_type
 pub aya_obj::generated::bpf_task_fd_type::BPF_FD_TYPE_KPROBE = 2
 pub aya_obj::generated::bpf_task_fd_type::BPF_FD_TYPE_KRETPROBE = 3
@@ -3085,28 +1711,6 @@ impl core::marker::Unpin for aya_obj::generated::bpf_task_fd_type
 impl core::marker::UnsafeUnpin for aya_obj::generated::bpf_task_fd_type
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::generated::bpf_task_fd_type
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::generated::bpf_task_fd_type
-impl<T, U> core::convert::Into<U> for aya_obj::generated::bpf_task_fd_type where U: core::convert::From<T>
-pub fn aya_obj::generated::bpf_task_fd_type::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_obj::generated::bpf_task_fd_type where U: core::convert::Into<T>
-pub type aya_obj::generated::bpf_task_fd_type::Error = core::convert::Infallible
-pub fn aya_obj::generated::bpf_task_fd_type::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_obj::generated::bpf_task_fd_type where U: core::convert::TryFrom<T>
-pub type aya_obj::generated::bpf_task_fd_type::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_obj::generated::bpf_task_fd_type::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya_obj::generated::bpf_task_fd_type where T: core::clone::Clone
-pub type aya_obj::generated::bpf_task_fd_type::Owned = T
-pub fn aya_obj::generated::bpf_task_fd_type::clone_into(&self, target: &mut T)
-pub fn aya_obj::generated::bpf_task_fd_type::to_owned(&self) -> T
-impl<T> core::any::Any for aya_obj::generated::bpf_task_fd_type where T: 'static + ?core::marker::Sized
-pub fn aya_obj::generated::bpf_task_fd_type::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_obj::generated::bpf_task_fd_type where T: ?core::marker::Sized
-pub fn aya_obj::generated::bpf_task_fd_type::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::bpf_task_fd_type where T: ?core::marker::Sized
-pub fn aya_obj::generated::bpf_task_fd_type::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_task_fd_type where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::bpf_task_fd_type::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_obj::generated::bpf_task_fd_type
-pub fn aya_obj::generated::bpf_task_fd_type::from(t: T) -> T
 #[repr(u32)] pub enum aya_obj::generated::btf_func_linkage
 pub aya_obj::generated::btf_func_linkage::BTF_FUNC_EXTERN = 2
 pub aya_obj::generated::btf_func_linkage::BTF_FUNC_GLOBAL = 1
@@ -3129,28 +1733,6 @@ impl core::marker::Unpin for aya_obj::generated::btf_func_linkage
 impl core::marker::UnsafeUnpin for aya_obj::generated::btf_func_linkage
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::generated::btf_func_linkage
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::generated::btf_func_linkage
-impl<T, U> core::convert::Into<U> for aya_obj::generated::btf_func_linkage where U: core::convert::From<T>
-pub fn aya_obj::generated::btf_func_linkage::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_obj::generated::btf_func_linkage where U: core::convert::Into<T>
-pub type aya_obj::generated::btf_func_linkage::Error = core::convert::Infallible
-pub fn aya_obj::generated::btf_func_linkage::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_obj::generated::btf_func_linkage where U: core::convert::TryFrom<T>
-pub type aya_obj::generated::btf_func_linkage::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_obj::generated::btf_func_linkage::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya_obj::generated::btf_func_linkage where T: core::clone::Clone
-pub type aya_obj::generated::btf_func_linkage::Owned = T
-pub fn aya_obj::generated::btf_func_linkage::clone_into(&self, target: &mut T)
-pub fn aya_obj::generated::btf_func_linkage::to_owned(&self) -> T
-impl<T> core::any::Any for aya_obj::generated::btf_func_linkage where T: 'static + ?core::marker::Sized
-pub fn aya_obj::generated::btf_func_linkage::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_obj::generated::btf_func_linkage where T: ?core::marker::Sized
-pub fn aya_obj::generated::btf_func_linkage::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::btf_func_linkage where T: ?core::marker::Sized
-pub fn aya_obj::generated::btf_func_linkage::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::btf_func_linkage where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::btf_func_linkage::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_obj::generated::btf_func_linkage
-pub fn aya_obj::generated::btf_func_linkage::from(t: T) -> T
 #[repr(u32)] pub enum aya_obj::generated::nf_inet_hooks
 pub aya_obj::generated::nf_inet_hooks::NF_INET_FORWARD = 2
 pub aya_obj::generated::nf_inet_hooks::NF_INET_LOCAL_IN = 1
@@ -3178,28 +1760,6 @@ impl core::marker::Unpin for aya_obj::generated::nf_inet_hooks
 impl core::marker::UnsafeUnpin for aya_obj::generated::nf_inet_hooks
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::generated::nf_inet_hooks
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::generated::nf_inet_hooks
-impl<T, U> core::convert::Into<U> for aya_obj::generated::nf_inet_hooks where U: core::convert::From<T>
-pub fn aya_obj::generated::nf_inet_hooks::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_obj::generated::nf_inet_hooks where U: core::convert::Into<T>
-pub type aya_obj::generated::nf_inet_hooks::Error = core::convert::Infallible
-pub fn aya_obj::generated::nf_inet_hooks::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_obj::generated::nf_inet_hooks where U: core::convert::TryFrom<T>
-pub type aya_obj::generated::nf_inet_hooks::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_obj::generated::nf_inet_hooks::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya_obj::generated::nf_inet_hooks where T: core::clone::Clone
-pub type aya_obj::generated::nf_inet_hooks::Owned = T
-pub fn aya_obj::generated::nf_inet_hooks::clone_into(&self, target: &mut T)
-pub fn aya_obj::generated::nf_inet_hooks::to_owned(&self) -> T
-impl<T> core::any::Any for aya_obj::generated::nf_inet_hooks where T: 'static + ?core::marker::Sized
-pub fn aya_obj::generated::nf_inet_hooks::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_obj::generated::nf_inet_hooks where T: ?core::marker::Sized
-pub fn aya_obj::generated::nf_inet_hooks::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::nf_inet_hooks where T: ?core::marker::Sized
-pub fn aya_obj::generated::nf_inet_hooks::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::nf_inet_hooks where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::nf_inet_hooks::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_obj::generated::nf_inet_hooks
-pub fn aya_obj::generated::nf_inet_hooks::from(t: T) -> T
 #[repr(u32)] pub enum aya_obj::generated::nlmsgerr_attrs
 pub aya_obj::generated::nlmsgerr_attrs::NLMSGERR_ATTR_COOKIE = 3
 pub aya_obj::generated::nlmsgerr_attrs::NLMSGERR_ATTR_MSG = 1
@@ -3226,28 +1786,6 @@ impl core::marker::Unpin for aya_obj::generated::nlmsgerr_attrs
 impl core::marker::UnsafeUnpin for aya_obj::generated::nlmsgerr_attrs
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::generated::nlmsgerr_attrs
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::generated::nlmsgerr_attrs
-impl<T, U> core::convert::Into<U> for aya_obj::generated::nlmsgerr_attrs where U: core::convert::From<T>
-pub fn aya_obj::generated::nlmsgerr_attrs::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_obj::generated::nlmsgerr_attrs where U: core::convert::Into<T>
-pub type aya_obj::generated::nlmsgerr_attrs::Error = core::convert::Infallible
-pub fn aya_obj::generated::nlmsgerr_attrs::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_obj::generated::nlmsgerr_attrs where U: core::convert::TryFrom<T>
-pub type aya_obj::generated::nlmsgerr_attrs::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_obj::generated::nlmsgerr_attrs::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya_obj::generated::nlmsgerr_attrs where T: core::clone::Clone
-pub type aya_obj::generated::nlmsgerr_attrs::Owned = T
-pub fn aya_obj::generated::nlmsgerr_attrs::clone_into(&self, target: &mut T)
-pub fn aya_obj::generated::nlmsgerr_attrs::to_owned(&self) -> T
-impl<T> core::any::Any for aya_obj::generated::nlmsgerr_attrs where T: 'static + ?core::marker::Sized
-pub fn aya_obj::generated::nlmsgerr_attrs::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_obj::generated::nlmsgerr_attrs where T: ?core::marker::Sized
-pub fn aya_obj::generated::nlmsgerr_attrs::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::nlmsgerr_attrs where T: ?core::marker::Sized
-pub fn aya_obj::generated::nlmsgerr_attrs::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::nlmsgerr_attrs where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::nlmsgerr_attrs::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_obj::generated::nlmsgerr_attrs
-pub fn aya_obj::generated::nlmsgerr_attrs::from(t: T) -> T
 #[repr(u32)] pub enum aya_obj::generated::perf_event_sample_format
 pub aya_obj::generated::perf_event_sample_format::PERF_SAMPLE_ADDR = 8
 pub aya_obj::generated::perf_event_sample_format::PERF_SAMPLE_AUX = 1048576
@@ -3293,28 +1831,6 @@ impl core::marker::Unpin for aya_obj::generated::perf_event_sample_format
 impl core::marker::UnsafeUnpin for aya_obj::generated::perf_event_sample_format
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::generated::perf_event_sample_format
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::generated::perf_event_sample_format
-impl<T, U> core::convert::Into<U> for aya_obj::generated::perf_event_sample_format where U: core::convert::From<T>
-pub fn aya_obj::generated::perf_event_sample_format::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_obj::generated::perf_event_sample_format where U: core::convert::Into<T>
-pub type aya_obj::generated::perf_event_sample_format::Error = core::convert::Infallible
-pub fn aya_obj::generated::perf_event_sample_format::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_obj::generated::perf_event_sample_format where U: core::convert::TryFrom<T>
-pub type aya_obj::generated::perf_event_sample_format::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_obj::generated::perf_event_sample_format::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya_obj::generated::perf_event_sample_format where T: core::clone::Clone
-pub type aya_obj::generated::perf_event_sample_format::Owned = T
-pub fn aya_obj::generated::perf_event_sample_format::clone_into(&self, target: &mut T)
-pub fn aya_obj::generated::perf_event_sample_format::to_owned(&self) -> T
-impl<T> core::any::Any for aya_obj::generated::perf_event_sample_format where T: 'static + ?core::marker::Sized
-pub fn aya_obj::generated::perf_event_sample_format::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_obj::generated::perf_event_sample_format where T: ?core::marker::Sized
-pub fn aya_obj::generated::perf_event_sample_format::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::perf_event_sample_format where T: ?core::marker::Sized
-pub fn aya_obj::generated::perf_event_sample_format::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::perf_event_sample_format where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::perf_event_sample_format::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_obj::generated::perf_event_sample_format
-pub fn aya_obj::generated::perf_event_sample_format::from(t: T) -> T
 #[repr(u32)] pub enum aya_obj::generated::perf_event_type
 pub aya_obj::generated::perf_event_type::PERF_RECORD_AUX = 11
 pub aya_obj::generated::perf_event_type::PERF_RECORD_AUX_OUTPUT_HW_ID = 21
@@ -3356,28 +1872,6 @@ impl core::marker::Unpin for aya_obj::generated::perf_event_type
 impl core::marker::UnsafeUnpin for aya_obj::generated::perf_event_type
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::generated::perf_event_type
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::generated::perf_event_type
-impl<T, U> core::convert::Into<U> for aya_obj::generated::perf_event_type where U: core::convert::From<T>
-pub fn aya_obj::generated::perf_event_type::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_obj::generated::perf_event_type where U: core::convert::Into<T>
-pub type aya_obj::generated::perf_event_type::Error = core::convert::Infallible
-pub fn aya_obj::generated::perf_event_type::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_obj::generated::perf_event_type where U: core::convert::TryFrom<T>
-pub type aya_obj::generated::perf_event_type::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_obj::generated::perf_event_type::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya_obj::generated::perf_event_type where T: core::clone::Clone
-pub type aya_obj::generated::perf_event_type::Owned = T
-pub fn aya_obj::generated::perf_event_type::clone_into(&self, target: &mut T)
-pub fn aya_obj::generated::perf_event_type::to_owned(&self) -> T
-impl<T> core::any::Any for aya_obj::generated::perf_event_type where T: 'static + ?core::marker::Sized
-pub fn aya_obj::generated::perf_event_type::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_obj::generated::perf_event_type where T: ?core::marker::Sized
-pub fn aya_obj::generated::perf_event_type::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::perf_event_type where T: ?core::marker::Sized
-pub fn aya_obj::generated::perf_event_type::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::perf_event_type where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::perf_event_type::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_obj::generated::perf_event_type
-pub fn aya_obj::generated::perf_event_type::from(t: T) -> T
 #[repr(u32)] pub enum aya_obj::generated::perf_hw_cache_id
 pub aya_obj::generated::perf_hw_cache_id::PERF_COUNT_HW_CACHE_BPU = 5
 pub aya_obj::generated::perf_hw_cache_id::PERF_COUNT_HW_CACHE_DTLB = 3
@@ -3405,28 +1899,6 @@ impl core::marker::Unpin for aya_obj::generated::perf_hw_cache_id
 impl core::marker::UnsafeUnpin for aya_obj::generated::perf_hw_cache_id
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::generated::perf_hw_cache_id
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::generated::perf_hw_cache_id
-impl<T, U> core::convert::Into<U> for aya_obj::generated::perf_hw_cache_id where U: core::convert::From<T>
-pub fn aya_obj::generated::perf_hw_cache_id::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_obj::generated::perf_hw_cache_id where U: core::convert::Into<T>
-pub type aya_obj::generated::perf_hw_cache_id::Error = core::convert::Infallible
-pub fn aya_obj::generated::perf_hw_cache_id::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_obj::generated::perf_hw_cache_id where U: core::convert::TryFrom<T>
-pub type aya_obj::generated::perf_hw_cache_id::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_obj::generated::perf_hw_cache_id::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya_obj::generated::perf_hw_cache_id where T: core::clone::Clone
-pub type aya_obj::generated::perf_hw_cache_id::Owned = T
-pub fn aya_obj::generated::perf_hw_cache_id::clone_into(&self, target: &mut T)
-pub fn aya_obj::generated::perf_hw_cache_id::to_owned(&self) -> T
-impl<T> core::any::Any for aya_obj::generated::perf_hw_cache_id where T: 'static + ?core::marker::Sized
-pub fn aya_obj::generated::perf_hw_cache_id::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_obj::generated::perf_hw_cache_id where T: ?core::marker::Sized
-pub fn aya_obj::generated::perf_hw_cache_id::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::perf_hw_cache_id where T: ?core::marker::Sized
-pub fn aya_obj::generated::perf_hw_cache_id::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::perf_hw_cache_id where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::perf_hw_cache_id::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_obj::generated::perf_hw_cache_id
-pub fn aya_obj::generated::perf_hw_cache_id::from(t: T) -> T
 #[repr(u32)] pub enum aya_obj::generated::perf_hw_cache_op_id
 pub aya_obj::generated::perf_hw_cache_op_id::PERF_COUNT_HW_CACHE_OP_MAX = 3
 pub aya_obj::generated::perf_hw_cache_op_id::PERF_COUNT_HW_CACHE_OP_PREFETCH = 2
@@ -3450,28 +1922,6 @@ impl core::marker::Unpin for aya_obj::generated::perf_hw_cache_op_id
 impl core::marker::UnsafeUnpin for aya_obj::generated::perf_hw_cache_op_id
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::generated::perf_hw_cache_op_id
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::generated::perf_hw_cache_op_id
-impl<T, U> core::convert::Into<U> for aya_obj::generated::perf_hw_cache_op_id where U: core::convert::From<T>
-pub fn aya_obj::generated::perf_hw_cache_op_id::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_obj::generated::perf_hw_cache_op_id where U: core::convert::Into<T>
-pub type aya_obj::generated::perf_hw_cache_op_id::Error = core::convert::Infallible
-pub fn aya_obj::generated::perf_hw_cache_op_id::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_obj::generated::perf_hw_cache_op_id where U: core::convert::TryFrom<T>
-pub type aya_obj::generated::perf_hw_cache_op_id::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_obj::generated::perf_hw_cache_op_id::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya_obj::generated::perf_hw_cache_op_id where T: core::clone::Clone
-pub type aya_obj::generated::perf_hw_cache_op_id::Owned = T
-pub fn aya_obj::generated::perf_hw_cache_op_id::clone_into(&self, target: &mut T)
-pub fn aya_obj::generated::perf_hw_cache_op_id::to_owned(&self) -> T
-impl<T> core::any::Any for aya_obj::generated::perf_hw_cache_op_id where T: 'static + ?core::marker::Sized
-pub fn aya_obj::generated::perf_hw_cache_op_id::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_obj::generated::perf_hw_cache_op_id where T: ?core::marker::Sized
-pub fn aya_obj::generated::perf_hw_cache_op_id::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::perf_hw_cache_op_id where T: ?core::marker::Sized
-pub fn aya_obj::generated::perf_hw_cache_op_id::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::perf_hw_cache_op_id where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::perf_hw_cache_op_id::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_obj::generated::perf_hw_cache_op_id
-pub fn aya_obj::generated::perf_hw_cache_op_id::from(t: T) -> T
 #[repr(u32)] pub enum aya_obj::generated::perf_hw_cache_op_result_id
 pub aya_obj::generated::perf_hw_cache_op_result_id::PERF_COUNT_HW_CACHE_RESULT_ACCESS = 0
 pub aya_obj::generated::perf_hw_cache_op_result_id::PERF_COUNT_HW_CACHE_RESULT_MAX = 2
@@ -3494,28 +1944,6 @@ impl core::marker::Unpin for aya_obj::generated::perf_hw_cache_op_result_id
 impl core::marker::UnsafeUnpin for aya_obj::generated::perf_hw_cache_op_result_id
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::generated::perf_hw_cache_op_result_id
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::generated::perf_hw_cache_op_result_id
-impl<T, U> core::convert::Into<U> for aya_obj::generated::perf_hw_cache_op_result_id where U: core::convert::From<T>
-pub fn aya_obj::generated::perf_hw_cache_op_result_id::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_obj::generated::perf_hw_cache_op_result_id where U: core::convert::Into<T>
-pub type aya_obj::generated::perf_hw_cache_op_result_id::Error = core::convert::Infallible
-pub fn aya_obj::generated::perf_hw_cache_op_result_id::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_obj::generated::perf_hw_cache_op_result_id where U: core::convert::TryFrom<T>
-pub type aya_obj::generated::perf_hw_cache_op_result_id::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_obj::generated::perf_hw_cache_op_result_id::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya_obj::generated::perf_hw_cache_op_result_id where T: core::clone::Clone
-pub type aya_obj::generated::perf_hw_cache_op_result_id::Owned = T
-pub fn aya_obj::generated::perf_hw_cache_op_result_id::clone_into(&self, target: &mut T)
-pub fn aya_obj::generated::perf_hw_cache_op_result_id::to_owned(&self) -> T
-impl<T> core::any::Any for aya_obj::generated::perf_hw_cache_op_result_id where T: 'static + ?core::marker::Sized
-pub fn aya_obj::generated::perf_hw_cache_op_result_id::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_obj::generated::perf_hw_cache_op_result_id where T: ?core::marker::Sized
-pub fn aya_obj::generated::perf_hw_cache_op_result_id::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::perf_hw_cache_op_result_id where T: ?core::marker::Sized
-pub fn aya_obj::generated::perf_hw_cache_op_result_id::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::perf_hw_cache_op_result_id where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::perf_hw_cache_op_result_id::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_obj::generated::perf_hw_cache_op_result_id
-pub fn aya_obj::generated::perf_hw_cache_op_result_id::from(t: T) -> T
 #[repr(u32)] pub enum aya_obj::generated::perf_hw_id
 pub aya_obj::generated::perf_hw_id::PERF_COUNT_HW_BRANCH_INSTRUCTIONS = 4
 pub aya_obj::generated::perf_hw_id::PERF_COUNT_HW_BRANCH_MISSES = 5
@@ -3546,28 +1974,6 @@ impl core::marker::Unpin for aya_obj::generated::perf_hw_id
 impl core::marker::UnsafeUnpin for aya_obj::generated::perf_hw_id
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::generated::perf_hw_id
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::generated::perf_hw_id
-impl<T, U> core::convert::Into<U> for aya_obj::generated::perf_hw_id where U: core::convert::From<T>
-pub fn aya_obj::generated::perf_hw_id::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_obj::generated::perf_hw_id where U: core::convert::Into<T>
-pub type aya_obj::generated::perf_hw_id::Error = core::convert::Infallible
-pub fn aya_obj::generated::perf_hw_id::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_obj::generated::perf_hw_id where U: core::convert::TryFrom<T>
-pub type aya_obj::generated::perf_hw_id::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_obj::generated::perf_hw_id::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya_obj::generated::perf_hw_id where T: core::clone::Clone
-pub type aya_obj::generated::perf_hw_id::Owned = T
-pub fn aya_obj::generated::perf_hw_id::clone_into(&self, target: &mut T)
-pub fn aya_obj::generated::perf_hw_id::to_owned(&self) -> T
-impl<T> core::any::Any for aya_obj::generated::perf_hw_id where T: 'static + ?core::marker::Sized
-pub fn aya_obj::generated::perf_hw_id::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_obj::generated::perf_hw_id where T: ?core::marker::Sized
-pub fn aya_obj::generated::perf_hw_id::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::perf_hw_id where T: ?core::marker::Sized
-pub fn aya_obj::generated::perf_hw_id::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::perf_hw_id where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::perf_hw_id::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_obj::generated::perf_hw_id
-pub fn aya_obj::generated::perf_hw_id::from(t: T) -> T
 #[repr(u32)] pub enum aya_obj::generated::perf_sw_ids
 pub aya_obj::generated::perf_sw_ids::PERF_COUNT_SW_ALIGNMENT_FAULTS = 7
 pub aya_obj::generated::perf_sw_ids::PERF_COUNT_SW_BPF_OUTPUT = 10
@@ -3600,28 +2006,6 @@ impl core::marker::Unpin for aya_obj::generated::perf_sw_ids
 impl core::marker::UnsafeUnpin for aya_obj::generated::perf_sw_ids
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::generated::perf_sw_ids
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::generated::perf_sw_ids
-impl<T, U> core::convert::Into<U> for aya_obj::generated::perf_sw_ids where U: core::convert::From<T>
-pub fn aya_obj::generated::perf_sw_ids::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_obj::generated::perf_sw_ids where U: core::convert::Into<T>
-pub type aya_obj::generated::perf_sw_ids::Error = core::convert::Infallible
-pub fn aya_obj::generated::perf_sw_ids::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_obj::generated::perf_sw_ids where U: core::convert::TryFrom<T>
-pub type aya_obj::generated::perf_sw_ids::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_obj::generated::perf_sw_ids::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya_obj::generated::perf_sw_ids where T: core::clone::Clone
-pub type aya_obj::generated::perf_sw_ids::Owned = T
-pub fn aya_obj::generated::perf_sw_ids::clone_into(&self, target: &mut T)
-pub fn aya_obj::generated::perf_sw_ids::to_owned(&self) -> T
-impl<T> core::any::Any for aya_obj::generated::perf_sw_ids where T: 'static + ?core::marker::Sized
-pub fn aya_obj::generated::perf_sw_ids::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_obj::generated::perf_sw_ids where T: ?core::marker::Sized
-pub fn aya_obj::generated::perf_sw_ids::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::perf_sw_ids where T: ?core::marker::Sized
-pub fn aya_obj::generated::perf_sw_ids::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::perf_sw_ids where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::perf_sw_ids::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_obj::generated::perf_sw_ids
-pub fn aya_obj::generated::perf_sw_ids::from(t: T) -> T
 #[repr(u32)] pub enum aya_obj::generated::perf_type_id
 pub aya_obj::generated::perf_type_id::PERF_TYPE_BREAKPOINT = 5
 pub aya_obj::generated::perf_type_id::PERF_TYPE_HARDWARE = 0
@@ -3648,28 +2032,6 @@ impl core::marker::Unpin for aya_obj::generated::perf_type_id
 impl core::marker::UnsafeUnpin for aya_obj::generated::perf_type_id
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::generated::perf_type_id
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::generated::perf_type_id
-impl<T, U> core::convert::Into<U> for aya_obj::generated::perf_type_id where U: core::convert::From<T>
-pub fn aya_obj::generated::perf_type_id::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_obj::generated::perf_type_id where U: core::convert::Into<T>
-pub type aya_obj::generated::perf_type_id::Error = core::convert::Infallible
-pub fn aya_obj::generated::perf_type_id::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_obj::generated::perf_type_id where U: core::convert::TryFrom<T>
-pub type aya_obj::generated::perf_type_id::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_obj::generated::perf_type_id::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya_obj::generated::perf_type_id where T: core::clone::Clone
-pub type aya_obj::generated::perf_type_id::Owned = T
-pub fn aya_obj::generated::perf_type_id::clone_into(&self, target: &mut T)
-pub fn aya_obj::generated::perf_type_id::to_owned(&self) -> T
-impl<T> core::any::Any for aya_obj::generated::perf_type_id where T: 'static + ?core::marker::Sized
-pub fn aya_obj::generated::perf_type_id::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_obj::generated::perf_type_id where T: ?core::marker::Sized
-pub fn aya_obj::generated::perf_type_id::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::perf_type_id where T: ?core::marker::Sized
-pub fn aya_obj::generated::perf_type_id::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::perf_type_id where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::perf_type_id::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_obj::generated::perf_type_id
-pub fn aya_obj::generated::perf_type_id::from(t: T) -> T
 #[repr(C)] pub union aya_obj::generated::bpf_attr
 pub aya_obj::generated::bpf_attr::__bindgen_anon_1: aya_obj::generated::bpf_attr__bindgen_ty_1
 pub aya_obj::generated::bpf_attr::__bindgen_anon_2: aya_obj::generated::bpf_attr__bindgen_ty_2
@@ -3701,28 +2063,6 @@ impl core::marker::Unpin for aya_obj::generated::bpf_attr
 impl core::marker::UnsafeUnpin for aya_obj::generated::bpf_attr
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::generated::bpf_attr
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::generated::bpf_attr
-impl<T, U> core::convert::Into<U> for aya_obj::generated::bpf_attr where U: core::convert::From<T>
-pub fn aya_obj::generated::bpf_attr::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_obj::generated::bpf_attr where U: core::convert::Into<T>
-pub type aya_obj::generated::bpf_attr::Error = core::convert::Infallible
-pub fn aya_obj::generated::bpf_attr::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_obj::generated::bpf_attr where U: core::convert::TryFrom<T>
-pub type aya_obj::generated::bpf_attr::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_obj::generated::bpf_attr::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya_obj::generated::bpf_attr where T: core::clone::Clone
-pub type aya_obj::generated::bpf_attr::Owned = T
-pub fn aya_obj::generated::bpf_attr::clone_into(&self, target: &mut T)
-pub fn aya_obj::generated::bpf_attr::to_owned(&self) -> T
-impl<T> core::any::Any for aya_obj::generated::bpf_attr where T: 'static + ?core::marker::Sized
-pub fn aya_obj::generated::bpf_attr::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_obj::generated::bpf_attr where T: ?core::marker::Sized
-pub fn aya_obj::generated::bpf_attr::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::bpf_attr where T: ?core::marker::Sized
-pub fn aya_obj::generated::bpf_attr::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_attr where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::bpf_attr::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_obj::generated::bpf_attr
-pub fn aya_obj::generated::bpf_attr::from(t: T) -> T
 #[repr(C)] pub union aya_obj::generated::bpf_attr__bindgen_ty_10__bindgen_ty_1
 pub aya_obj::generated::bpf_attr__bindgen_ty_10__bindgen_ty_1::target_fd: aya_obj::generated::__u32
 pub aya_obj::generated::bpf_attr__bindgen_ty_10__bindgen_ty_1::target_ifindex: aya_obj::generated::__u32
@@ -3736,28 +2076,6 @@ impl core::marker::Unpin for aya_obj::generated::bpf_attr__bindgen_ty_10__bindge
 impl core::marker::UnsafeUnpin for aya_obj::generated::bpf_attr__bindgen_ty_10__bindgen_ty_1
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::generated::bpf_attr__bindgen_ty_10__bindgen_ty_1
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::generated::bpf_attr__bindgen_ty_10__bindgen_ty_1
-impl<T, U> core::convert::Into<U> for aya_obj::generated::bpf_attr__bindgen_ty_10__bindgen_ty_1 where U: core::convert::From<T>
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_10__bindgen_ty_1::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_obj::generated::bpf_attr__bindgen_ty_10__bindgen_ty_1 where U: core::convert::Into<T>
-pub type aya_obj::generated::bpf_attr__bindgen_ty_10__bindgen_ty_1::Error = core::convert::Infallible
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_10__bindgen_ty_1::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_obj::generated::bpf_attr__bindgen_ty_10__bindgen_ty_1 where U: core::convert::TryFrom<T>
-pub type aya_obj::generated::bpf_attr__bindgen_ty_10__bindgen_ty_1::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_10__bindgen_ty_1::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya_obj::generated::bpf_attr__bindgen_ty_10__bindgen_ty_1 where T: core::clone::Clone
-pub type aya_obj::generated::bpf_attr__bindgen_ty_10__bindgen_ty_1::Owned = T
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_10__bindgen_ty_1::clone_into(&self, target: &mut T)
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_10__bindgen_ty_1::to_owned(&self) -> T
-impl<T> core::any::Any for aya_obj::generated::bpf_attr__bindgen_ty_10__bindgen_ty_1 where T: 'static + ?core::marker::Sized
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_10__bindgen_ty_1::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_obj::generated::bpf_attr__bindgen_ty_10__bindgen_ty_1 where T: ?core::marker::Sized
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_10__bindgen_ty_1::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::bpf_attr__bindgen_ty_10__bindgen_ty_1 where T: ?core::marker::Sized
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_10__bindgen_ty_1::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_attr__bindgen_ty_10__bindgen_ty_1 where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::bpf_attr__bindgen_ty_10__bindgen_ty_1::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_obj::generated::bpf_attr__bindgen_ty_10__bindgen_ty_1
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_10__bindgen_ty_1::from(t: T) -> T
 #[repr(C)] pub union aya_obj::generated::bpf_attr__bindgen_ty_10__bindgen_ty_2
 pub aya_obj::generated::bpf_attr__bindgen_ty_10__bindgen_ty_2::count: aya_obj::generated::__u32
 pub aya_obj::generated::bpf_attr__bindgen_ty_10__bindgen_ty_2::prog_cnt: aya_obj::generated::__u32
@@ -3771,28 +2089,6 @@ impl core::marker::Unpin for aya_obj::generated::bpf_attr__bindgen_ty_10__bindge
 impl core::marker::UnsafeUnpin for aya_obj::generated::bpf_attr__bindgen_ty_10__bindgen_ty_2
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::generated::bpf_attr__bindgen_ty_10__bindgen_ty_2
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::generated::bpf_attr__bindgen_ty_10__bindgen_ty_2
-impl<T, U> core::convert::Into<U> for aya_obj::generated::bpf_attr__bindgen_ty_10__bindgen_ty_2 where U: core::convert::From<T>
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_10__bindgen_ty_2::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_obj::generated::bpf_attr__bindgen_ty_10__bindgen_ty_2 where U: core::convert::Into<T>
-pub type aya_obj::generated::bpf_attr__bindgen_ty_10__bindgen_ty_2::Error = core::convert::Infallible
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_10__bindgen_ty_2::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_obj::generated::bpf_attr__bindgen_ty_10__bindgen_ty_2 where U: core::convert::TryFrom<T>
-pub type aya_obj::generated::bpf_attr__bindgen_ty_10__bindgen_ty_2::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_10__bindgen_ty_2::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya_obj::generated::bpf_attr__bindgen_ty_10__bindgen_ty_2 where T: core::clone::Clone
-pub type aya_obj::generated::bpf_attr__bindgen_ty_10__bindgen_ty_2::Owned = T
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_10__bindgen_ty_2::clone_into(&self, target: &mut T)
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_10__bindgen_ty_2::to_owned(&self) -> T
-impl<T> core::any::Any for aya_obj::generated::bpf_attr__bindgen_ty_10__bindgen_ty_2 where T: 'static + ?core::marker::Sized
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_10__bindgen_ty_2::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_obj::generated::bpf_attr__bindgen_ty_10__bindgen_ty_2 where T: ?core::marker::Sized
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_10__bindgen_ty_2::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::bpf_attr__bindgen_ty_10__bindgen_ty_2 where T: ?core::marker::Sized
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_10__bindgen_ty_2::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_attr__bindgen_ty_10__bindgen_ty_2 where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::bpf_attr__bindgen_ty_10__bindgen_ty_2::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_obj::generated::bpf_attr__bindgen_ty_10__bindgen_ty_2
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_10__bindgen_ty_2::from(t: T) -> T
 #[repr(C)] pub union aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_1
 pub aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_1::map_fd: aya_obj::generated::__u32
 pub aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_1::prog_fd: aya_obj::generated::__u32
@@ -3806,28 +2102,6 @@ impl core::marker::Unpin for aya_obj::generated::bpf_attr__bindgen_ty_14__bindge
 impl core::marker::UnsafeUnpin for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_1
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_1
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_1
-impl<T, U> core::convert::Into<U> for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_1 where U: core::convert::From<T>
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_1::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_1 where U: core::convert::Into<T>
-pub type aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_1::Error = core::convert::Infallible
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_1::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_1 where U: core::convert::TryFrom<T>
-pub type aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_1::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_1::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_1 where T: core::clone::Clone
-pub type aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_1::Owned = T
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_1::clone_into(&self, target: &mut T)
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_1::to_owned(&self) -> T
-impl<T> core::any::Any for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_1 where T: 'static + ?core::marker::Sized
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_1::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_1 where T: ?core::marker::Sized
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_1::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_1 where T: ?core::marker::Sized
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_1::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_1 where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_1::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_1
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_1::from(t: T) -> T
 #[repr(C)] pub union aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_2
 pub aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_2::target_fd: aya_obj::generated::__u32
 pub aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_2::target_ifindex: aya_obj::generated::__u32
@@ -3841,28 +2115,6 @@ impl core::marker::Unpin for aya_obj::generated::bpf_attr__bindgen_ty_14__bindge
 impl core::marker::UnsafeUnpin for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_2
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_2
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_2
-impl<T, U> core::convert::Into<U> for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_2 where U: core::convert::From<T>
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_2::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_2 where U: core::convert::Into<T>
-pub type aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_2::Error = core::convert::Infallible
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_2::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_2 where U: core::convert::TryFrom<T>
-pub type aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_2::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_2::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_2 where T: core::clone::Clone
-pub type aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_2::Owned = T
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_2::clone_into(&self, target: &mut T)
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_2::to_owned(&self) -> T
-impl<T> core::any::Any for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_2 where T: 'static + ?core::marker::Sized
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_2::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_2 where T: ?core::marker::Sized
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_2::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_2 where T: ?core::marker::Sized
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_2::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_2 where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_2::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_2
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_2::from(t: T) -> T
 #[repr(C)] pub union aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3
 pub aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3::__bindgen_anon_1: aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_1
 pub aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3::kprobe_multi: aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_3
@@ -3883,28 +2135,6 @@ impl core::marker::Unpin for aya_obj::generated::bpf_attr__bindgen_ty_14__bindge
 impl core::marker::UnsafeUnpin for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3
-impl<T, U> core::convert::Into<U> for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3 where U: core::convert::From<T>
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3 where U: core::convert::Into<T>
-pub type aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3::Error = core::convert::Infallible
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3 where U: core::convert::TryFrom<T>
-pub type aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3 where T: core::clone::Clone
-pub type aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3::Owned = T
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3::clone_into(&self, target: &mut T)
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3::to_owned(&self) -> T
-impl<T> core::any::Any for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3 where T: 'static + ?core::marker::Sized
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3 where T: ?core::marker::Sized
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3 where T: ?core::marker::Sized
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3 where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3::from(t: T) -> T
 #[repr(C)] pub union aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_6__bindgen_ty_1
 pub aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_6__bindgen_ty_1::relative_fd: aya_obj::generated::__u32
 pub aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_6__bindgen_ty_1::relative_id: aya_obj::generated::__u32
@@ -3918,28 +2148,6 @@ impl core::marker::Unpin for aya_obj::generated::bpf_attr__bindgen_ty_14__bindge
 impl core::marker::UnsafeUnpin for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_6__bindgen_ty_1
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_6__bindgen_ty_1
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_6__bindgen_ty_1
-impl<T, U> core::convert::Into<U> for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_6__bindgen_ty_1 where U: core::convert::From<T>
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_6__bindgen_ty_1::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_6__bindgen_ty_1 where U: core::convert::Into<T>
-pub type aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_6__bindgen_ty_1::Error = core::convert::Infallible
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_6__bindgen_ty_1::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_6__bindgen_ty_1 where U: core::convert::TryFrom<T>
-pub type aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_6__bindgen_ty_1::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_6__bindgen_ty_1::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_6__bindgen_ty_1 where T: core::clone::Clone
-pub type aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_6__bindgen_ty_1::Owned = T
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_6__bindgen_ty_1::clone_into(&self, target: &mut T)
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_6__bindgen_ty_1::to_owned(&self) -> T
-impl<T> core::any::Any for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_6__bindgen_ty_1 where T: 'static + ?core::marker::Sized
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_6__bindgen_ty_1::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_6__bindgen_ty_1 where T: ?core::marker::Sized
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_6__bindgen_ty_1::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_6__bindgen_ty_1 where T: ?core::marker::Sized
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_6__bindgen_ty_1::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_6__bindgen_ty_1 where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_6__bindgen_ty_1::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_6__bindgen_ty_1
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_6__bindgen_ty_1::from(t: T) -> T
 #[repr(C)] pub union aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_8__bindgen_ty_1
 pub aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_8__bindgen_ty_1::relative_fd: aya_obj::generated::__u32
 pub aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_8__bindgen_ty_1::relative_id: aya_obj::generated::__u32
@@ -3953,28 +2161,6 @@ impl core::marker::Unpin for aya_obj::generated::bpf_attr__bindgen_ty_14__bindge
 impl core::marker::UnsafeUnpin for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_8__bindgen_ty_1
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_8__bindgen_ty_1
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_8__bindgen_ty_1
-impl<T, U> core::convert::Into<U> for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_8__bindgen_ty_1 where U: core::convert::From<T>
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_8__bindgen_ty_1::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_8__bindgen_ty_1 where U: core::convert::Into<T>
-pub type aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_8__bindgen_ty_1::Error = core::convert::Infallible
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_8__bindgen_ty_1::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_8__bindgen_ty_1 where U: core::convert::TryFrom<T>
-pub type aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_8__bindgen_ty_1::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_8__bindgen_ty_1::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_8__bindgen_ty_1 where T: core::clone::Clone
-pub type aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_8__bindgen_ty_1::Owned = T
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_8__bindgen_ty_1::clone_into(&self, target: &mut T)
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_8__bindgen_ty_1::to_owned(&self) -> T
-impl<T> core::any::Any for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_8__bindgen_ty_1 where T: 'static + ?core::marker::Sized
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_8__bindgen_ty_1::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_8__bindgen_ty_1 where T: ?core::marker::Sized
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_8__bindgen_ty_1::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_8__bindgen_ty_1 where T: ?core::marker::Sized
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_8__bindgen_ty_1::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_8__bindgen_ty_1 where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_8__bindgen_ty_1::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_8__bindgen_ty_1
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_8__bindgen_ty_1::from(t: T) -> T
 #[repr(C)] pub union aya_obj::generated::bpf_attr__bindgen_ty_15__bindgen_ty_1
 pub aya_obj::generated::bpf_attr__bindgen_ty_15__bindgen_ty_1::new_map_fd: aya_obj::generated::__u32
 pub aya_obj::generated::bpf_attr__bindgen_ty_15__bindgen_ty_1::new_prog_fd: aya_obj::generated::__u32
@@ -3988,28 +2174,6 @@ impl core::marker::Unpin for aya_obj::generated::bpf_attr__bindgen_ty_15__bindge
 impl core::marker::UnsafeUnpin for aya_obj::generated::bpf_attr__bindgen_ty_15__bindgen_ty_1
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::generated::bpf_attr__bindgen_ty_15__bindgen_ty_1
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::generated::bpf_attr__bindgen_ty_15__bindgen_ty_1
-impl<T, U> core::convert::Into<U> for aya_obj::generated::bpf_attr__bindgen_ty_15__bindgen_ty_1 where U: core::convert::From<T>
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_15__bindgen_ty_1::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_obj::generated::bpf_attr__bindgen_ty_15__bindgen_ty_1 where U: core::convert::Into<T>
-pub type aya_obj::generated::bpf_attr__bindgen_ty_15__bindgen_ty_1::Error = core::convert::Infallible
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_15__bindgen_ty_1::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_obj::generated::bpf_attr__bindgen_ty_15__bindgen_ty_1 where U: core::convert::TryFrom<T>
-pub type aya_obj::generated::bpf_attr__bindgen_ty_15__bindgen_ty_1::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_15__bindgen_ty_1::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya_obj::generated::bpf_attr__bindgen_ty_15__bindgen_ty_1 where T: core::clone::Clone
-pub type aya_obj::generated::bpf_attr__bindgen_ty_15__bindgen_ty_1::Owned = T
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_15__bindgen_ty_1::clone_into(&self, target: &mut T)
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_15__bindgen_ty_1::to_owned(&self) -> T
-impl<T> core::any::Any for aya_obj::generated::bpf_attr__bindgen_ty_15__bindgen_ty_1 where T: 'static + ?core::marker::Sized
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_15__bindgen_ty_1::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_obj::generated::bpf_attr__bindgen_ty_15__bindgen_ty_1 where T: ?core::marker::Sized
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_15__bindgen_ty_1::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::bpf_attr__bindgen_ty_15__bindgen_ty_1 where T: ?core::marker::Sized
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_15__bindgen_ty_1::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_attr__bindgen_ty_15__bindgen_ty_1 where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::bpf_attr__bindgen_ty_15__bindgen_ty_1::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_obj::generated::bpf_attr__bindgen_ty_15__bindgen_ty_1
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_15__bindgen_ty_1::from(t: T) -> T
 #[repr(C)] pub union aya_obj::generated::bpf_attr__bindgen_ty_15__bindgen_ty_2
 pub aya_obj::generated::bpf_attr__bindgen_ty_15__bindgen_ty_2::old_map_fd: aya_obj::generated::__u32
 pub aya_obj::generated::bpf_attr__bindgen_ty_15__bindgen_ty_2::old_prog_fd: aya_obj::generated::__u32
@@ -4023,28 +2187,6 @@ impl core::marker::Unpin for aya_obj::generated::bpf_attr__bindgen_ty_15__bindge
 impl core::marker::UnsafeUnpin for aya_obj::generated::bpf_attr__bindgen_ty_15__bindgen_ty_2
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::generated::bpf_attr__bindgen_ty_15__bindgen_ty_2
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::generated::bpf_attr__bindgen_ty_15__bindgen_ty_2
-impl<T, U> core::convert::Into<U> for aya_obj::generated::bpf_attr__bindgen_ty_15__bindgen_ty_2 where U: core::convert::From<T>
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_15__bindgen_ty_2::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_obj::generated::bpf_attr__bindgen_ty_15__bindgen_ty_2 where U: core::convert::Into<T>
-pub type aya_obj::generated::bpf_attr__bindgen_ty_15__bindgen_ty_2::Error = core::convert::Infallible
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_15__bindgen_ty_2::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_obj::generated::bpf_attr__bindgen_ty_15__bindgen_ty_2 where U: core::convert::TryFrom<T>
-pub type aya_obj::generated::bpf_attr__bindgen_ty_15__bindgen_ty_2::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_15__bindgen_ty_2::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya_obj::generated::bpf_attr__bindgen_ty_15__bindgen_ty_2 where T: core::clone::Clone
-pub type aya_obj::generated::bpf_attr__bindgen_ty_15__bindgen_ty_2::Owned = T
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_15__bindgen_ty_2::clone_into(&self, target: &mut T)
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_15__bindgen_ty_2::to_owned(&self) -> T
-impl<T> core::any::Any for aya_obj::generated::bpf_attr__bindgen_ty_15__bindgen_ty_2 where T: 'static + ?core::marker::Sized
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_15__bindgen_ty_2::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_obj::generated::bpf_attr__bindgen_ty_15__bindgen_ty_2 where T: ?core::marker::Sized
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_15__bindgen_ty_2::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::bpf_attr__bindgen_ty_15__bindgen_ty_2 where T: ?core::marker::Sized
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_15__bindgen_ty_2::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_attr__bindgen_ty_15__bindgen_ty_2 where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::bpf_attr__bindgen_ty_15__bindgen_ty_2::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_obj::generated::bpf_attr__bindgen_ty_15__bindgen_ty_2
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_15__bindgen_ty_2::from(t: T) -> T
 #[repr(C)] pub union aya_obj::generated::bpf_attr__bindgen_ty_2__bindgen_ty_1
 pub aya_obj::generated::bpf_attr__bindgen_ty_2__bindgen_ty_1::next_key: aya_obj::generated::__u64
 pub aya_obj::generated::bpf_attr__bindgen_ty_2__bindgen_ty_1::value: aya_obj::generated::__u64
@@ -4058,28 +2200,6 @@ impl core::marker::Unpin for aya_obj::generated::bpf_attr__bindgen_ty_2__bindgen
 impl core::marker::UnsafeUnpin for aya_obj::generated::bpf_attr__bindgen_ty_2__bindgen_ty_1
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::generated::bpf_attr__bindgen_ty_2__bindgen_ty_1
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::generated::bpf_attr__bindgen_ty_2__bindgen_ty_1
-impl<T, U> core::convert::Into<U> for aya_obj::generated::bpf_attr__bindgen_ty_2__bindgen_ty_1 where U: core::convert::From<T>
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_2__bindgen_ty_1::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_obj::generated::bpf_attr__bindgen_ty_2__bindgen_ty_1 where U: core::convert::Into<T>
-pub type aya_obj::generated::bpf_attr__bindgen_ty_2__bindgen_ty_1::Error = core::convert::Infallible
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_2__bindgen_ty_1::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_obj::generated::bpf_attr__bindgen_ty_2__bindgen_ty_1 where U: core::convert::TryFrom<T>
-pub type aya_obj::generated::bpf_attr__bindgen_ty_2__bindgen_ty_1::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_2__bindgen_ty_1::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya_obj::generated::bpf_attr__bindgen_ty_2__bindgen_ty_1 where T: core::clone::Clone
-pub type aya_obj::generated::bpf_attr__bindgen_ty_2__bindgen_ty_1::Owned = T
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_2__bindgen_ty_1::clone_into(&self, target: &mut T)
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_2__bindgen_ty_1::to_owned(&self) -> T
-impl<T> core::any::Any for aya_obj::generated::bpf_attr__bindgen_ty_2__bindgen_ty_1 where T: 'static + ?core::marker::Sized
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_2__bindgen_ty_1::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_obj::generated::bpf_attr__bindgen_ty_2__bindgen_ty_1 where T: ?core::marker::Sized
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_2__bindgen_ty_1::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::bpf_attr__bindgen_ty_2__bindgen_ty_1 where T: ?core::marker::Sized
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_2__bindgen_ty_1::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_attr__bindgen_ty_2__bindgen_ty_1 where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::bpf_attr__bindgen_ty_2__bindgen_ty_1::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_obj::generated::bpf_attr__bindgen_ty_2__bindgen_ty_1
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_2__bindgen_ty_1::from(t: T) -> T
 #[repr(C)] pub union aya_obj::generated::bpf_attr__bindgen_ty_4__bindgen_ty_1
 pub aya_obj::generated::bpf_attr__bindgen_ty_4__bindgen_ty_1::attach_btf_obj_fd: aya_obj::generated::__u32
 pub aya_obj::generated::bpf_attr__bindgen_ty_4__bindgen_ty_1::attach_prog_fd: aya_obj::generated::__u32
@@ -4093,28 +2213,6 @@ impl core::marker::Unpin for aya_obj::generated::bpf_attr__bindgen_ty_4__bindgen
 impl core::marker::UnsafeUnpin for aya_obj::generated::bpf_attr__bindgen_ty_4__bindgen_ty_1
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::generated::bpf_attr__bindgen_ty_4__bindgen_ty_1
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::generated::bpf_attr__bindgen_ty_4__bindgen_ty_1
-impl<T, U> core::convert::Into<U> for aya_obj::generated::bpf_attr__bindgen_ty_4__bindgen_ty_1 where U: core::convert::From<T>
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_4__bindgen_ty_1::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_obj::generated::bpf_attr__bindgen_ty_4__bindgen_ty_1 where U: core::convert::Into<T>
-pub type aya_obj::generated::bpf_attr__bindgen_ty_4__bindgen_ty_1::Error = core::convert::Infallible
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_4__bindgen_ty_1::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_obj::generated::bpf_attr__bindgen_ty_4__bindgen_ty_1 where U: core::convert::TryFrom<T>
-pub type aya_obj::generated::bpf_attr__bindgen_ty_4__bindgen_ty_1::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_4__bindgen_ty_1::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya_obj::generated::bpf_attr__bindgen_ty_4__bindgen_ty_1 where T: core::clone::Clone
-pub type aya_obj::generated::bpf_attr__bindgen_ty_4__bindgen_ty_1::Owned = T
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_4__bindgen_ty_1::clone_into(&self, target: &mut T)
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_4__bindgen_ty_1::to_owned(&self) -> T
-impl<T> core::any::Any for aya_obj::generated::bpf_attr__bindgen_ty_4__bindgen_ty_1 where T: 'static + ?core::marker::Sized
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_4__bindgen_ty_1::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_obj::generated::bpf_attr__bindgen_ty_4__bindgen_ty_1 where T: ?core::marker::Sized
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_4__bindgen_ty_1::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::bpf_attr__bindgen_ty_4__bindgen_ty_1 where T: ?core::marker::Sized
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_4__bindgen_ty_1::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_attr__bindgen_ty_4__bindgen_ty_1 where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::bpf_attr__bindgen_ty_4__bindgen_ty_1::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_obj::generated::bpf_attr__bindgen_ty_4__bindgen_ty_1
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_4__bindgen_ty_1::from(t: T) -> T
 #[repr(C)] pub union aya_obj::generated::bpf_attr__bindgen_ty_6__bindgen_ty_1
 pub aya_obj::generated::bpf_attr__bindgen_ty_6__bindgen_ty_1::target_fd: aya_obj::generated::__u32
 pub aya_obj::generated::bpf_attr__bindgen_ty_6__bindgen_ty_1::target_ifindex: aya_obj::generated::__u32
@@ -4128,28 +2226,6 @@ impl core::marker::Unpin for aya_obj::generated::bpf_attr__bindgen_ty_6__bindgen
 impl core::marker::UnsafeUnpin for aya_obj::generated::bpf_attr__bindgen_ty_6__bindgen_ty_1
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::generated::bpf_attr__bindgen_ty_6__bindgen_ty_1
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::generated::bpf_attr__bindgen_ty_6__bindgen_ty_1
-impl<T, U> core::convert::Into<U> for aya_obj::generated::bpf_attr__bindgen_ty_6__bindgen_ty_1 where U: core::convert::From<T>
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_6__bindgen_ty_1::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_obj::generated::bpf_attr__bindgen_ty_6__bindgen_ty_1 where U: core::convert::Into<T>
-pub type aya_obj::generated::bpf_attr__bindgen_ty_6__bindgen_ty_1::Error = core::convert::Infallible
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_6__bindgen_ty_1::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_obj::generated::bpf_attr__bindgen_ty_6__bindgen_ty_1 where U: core::convert::TryFrom<T>
-pub type aya_obj::generated::bpf_attr__bindgen_ty_6__bindgen_ty_1::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_6__bindgen_ty_1::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya_obj::generated::bpf_attr__bindgen_ty_6__bindgen_ty_1 where T: core::clone::Clone
-pub type aya_obj::generated::bpf_attr__bindgen_ty_6__bindgen_ty_1::Owned = T
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_6__bindgen_ty_1::clone_into(&self, target: &mut T)
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_6__bindgen_ty_1::to_owned(&self) -> T
-impl<T> core::any::Any for aya_obj::generated::bpf_attr__bindgen_ty_6__bindgen_ty_1 where T: 'static + ?core::marker::Sized
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_6__bindgen_ty_1::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_obj::generated::bpf_attr__bindgen_ty_6__bindgen_ty_1 where T: ?core::marker::Sized
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_6__bindgen_ty_1::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::bpf_attr__bindgen_ty_6__bindgen_ty_1 where T: ?core::marker::Sized
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_6__bindgen_ty_1::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_attr__bindgen_ty_6__bindgen_ty_1 where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::bpf_attr__bindgen_ty_6__bindgen_ty_1::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_obj::generated::bpf_attr__bindgen_ty_6__bindgen_ty_1
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_6__bindgen_ty_1::from(t: T) -> T
 #[repr(C)] pub union aya_obj::generated::bpf_attr__bindgen_ty_6__bindgen_ty_2
 pub aya_obj::generated::bpf_attr__bindgen_ty_6__bindgen_ty_2::relative_fd: aya_obj::generated::__u32
 pub aya_obj::generated::bpf_attr__bindgen_ty_6__bindgen_ty_2::relative_id: aya_obj::generated::__u32
@@ -4163,28 +2239,6 @@ impl core::marker::Unpin for aya_obj::generated::bpf_attr__bindgen_ty_6__bindgen
 impl core::marker::UnsafeUnpin for aya_obj::generated::bpf_attr__bindgen_ty_6__bindgen_ty_2
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::generated::bpf_attr__bindgen_ty_6__bindgen_ty_2
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::generated::bpf_attr__bindgen_ty_6__bindgen_ty_2
-impl<T, U> core::convert::Into<U> for aya_obj::generated::bpf_attr__bindgen_ty_6__bindgen_ty_2 where U: core::convert::From<T>
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_6__bindgen_ty_2::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_obj::generated::bpf_attr__bindgen_ty_6__bindgen_ty_2 where U: core::convert::Into<T>
-pub type aya_obj::generated::bpf_attr__bindgen_ty_6__bindgen_ty_2::Error = core::convert::Infallible
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_6__bindgen_ty_2::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_obj::generated::bpf_attr__bindgen_ty_6__bindgen_ty_2 where U: core::convert::TryFrom<T>
-pub type aya_obj::generated::bpf_attr__bindgen_ty_6__bindgen_ty_2::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_6__bindgen_ty_2::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya_obj::generated::bpf_attr__bindgen_ty_6__bindgen_ty_2 where T: core::clone::Clone
-pub type aya_obj::generated::bpf_attr__bindgen_ty_6__bindgen_ty_2::Owned = T
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_6__bindgen_ty_2::clone_into(&self, target: &mut T)
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_6__bindgen_ty_2::to_owned(&self) -> T
-impl<T> core::any::Any for aya_obj::generated::bpf_attr__bindgen_ty_6__bindgen_ty_2 where T: 'static + ?core::marker::Sized
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_6__bindgen_ty_2::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_obj::generated::bpf_attr__bindgen_ty_6__bindgen_ty_2 where T: ?core::marker::Sized
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_6__bindgen_ty_2::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::bpf_attr__bindgen_ty_6__bindgen_ty_2 where T: ?core::marker::Sized
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_6__bindgen_ty_2::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_attr__bindgen_ty_6__bindgen_ty_2 where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::bpf_attr__bindgen_ty_6__bindgen_ty_2::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_obj::generated::bpf_attr__bindgen_ty_6__bindgen_ty_2
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_6__bindgen_ty_2::from(t: T) -> T
 #[repr(C)] pub union aya_obj::generated::bpf_attr__bindgen_ty_8__bindgen_ty_1
 pub aya_obj::generated::bpf_attr__bindgen_ty_8__bindgen_ty_1::btf_id: aya_obj::generated::__u32
 pub aya_obj::generated::bpf_attr__bindgen_ty_8__bindgen_ty_1::link_id: aya_obj::generated::__u32
@@ -4201,28 +2255,6 @@ impl core::marker::Unpin for aya_obj::generated::bpf_attr__bindgen_ty_8__bindgen
 impl core::marker::UnsafeUnpin for aya_obj::generated::bpf_attr__bindgen_ty_8__bindgen_ty_1
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::generated::bpf_attr__bindgen_ty_8__bindgen_ty_1
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::generated::bpf_attr__bindgen_ty_8__bindgen_ty_1
-impl<T, U> core::convert::Into<U> for aya_obj::generated::bpf_attr__bindgen_ty_8__bindgen_ty_1 where U: core::convert::From<T>
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_8__bindgen_ty_1::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_obj::generated::bpf_attr__bindgen_ty_8__bindgen_ty_1 where U: core::convert::Into<T>
-pub type aya_obj::generated::bpf_attr__bindgen_ty_8__bindgen_ty_1::Error = core::convert::Infallible
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_8__bindgen_ty_1::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_obj::generated::bpf_attr__bindgen_ty_8__bindgen_ty_1 where U: core::convert::TryFrom<T>
-pub type aya_obj::generated::bpf_attr__bindgen_ty_8__bindgen_ty_1::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_8__bindgen_ty_1::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya_obj::generated::bpf_attr__bindgen_ty_8__bindgen_ty_1 where T: core::clone::Clone
-pub type aya_obj::generated::bpf_attr__bindgen_ty_8__bindgen_ty_1::Owned = T
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_8__bindgen_ty_1::clone_into(&self, target: &mut T)
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_8__bindgen_ty_1::to_owned(&self) -> T
-impl<T> core::any::Any for aya_obj::generated::bpf_attr__bindgen_ty_8__bindgen_ty_1 where T: 'static + ?core::marker::Sized
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_8__bindgen_ty_1::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_obj::generated::bpf_attr__bindgen_ty_8__bindgen_ty_1 where T: ?core::marker::Sized
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_8__bindgen_ty_1::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::bpf_attr__bindgen_ty_8__bindgen_ty_1 where T: ?core::marker::Sized
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_8__bindgen_ty_1::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_attr__bindgen_ty_8__bindgen_ty_1 where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::bpf_attr__bindgen_ty_8__bindgen_ty_1::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_obj::generated::bpf_attr__bindgen_ty_8__bindgen_ty_1
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_8__bindgen_ty_1::from(t: T) -> T
 #[repr(C)] pub union aya_obj::generated::bpf_cpumap_val__bindgen_ty_1
 pub aya_obj::generated::bpf_cpumap_val__bindgen_ty_1::fd: core::ffi::primitives::c_int
 pub aya_obj::generated::bpf_cpumap_val__bindgen_ty_1::id: aya_obj::generated::__u32
@@ -4236,28 +2268,6 @@ impl core::marker::Unpin for aya_obj::generated::bpf_cpumap_val__bindgen_ty_1
 impl core::marker::UnsafeUnpin for aya_obj::generated::bpf_cpumap_val__bindgen_ty_1
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::generated::bpf_cpumap_val__bindgen_ty_1
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::generated::bpf_cpumap_val__bindgen_ty_1
-impl<T, U> core::convert::Into<U> for aya_obj::generated::bpf_cpumap_val__bindgen_ty_1 where U: core::convert::From<T>
-pub fn aya_obj::generated::bpf_cpumap_val__bindgen_ty_1::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_obj::generated::bpf_cpumap_val__bindgen_ty_1 where U: core::convert::Into<T>
-pub type aya_obj::generated::bpf_cpumap_val__bindgen_ty_1::Error = core::convert::Infallible
-pub fn aya_obj::generated::bpf_cpumap_val__bindgen_ty_1::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_obj::generated::bpf_cpumap_val__bindgen_ty_1 where U: core::convert::TryFrom<T>
-pub type aya_obj::generated::bpf_cpumap_val__bindgen_ty_1::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_obj::generated::bpf_cpumap_val__bindgen_ty_1::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya_obj::generated::bpf_cpumap_val__bindgen_ty_1 where T: core::clone::Clone
-pub type aya_obj::generated::bpf_cpumap_val__bindgen_ty_1::Owned = T
-pub fn aya_obj::generated::bpf_cpumap_val__bindgen_ty_1::clone_into(&self, target: &mut T)
-pub fn aya_obj::generated::bpf_cpumap_val__bindgen_ty_1::to_owned(&self) -> T
-impl<T> core::any::Any for aya_obj::generated::bpf_cpumap_val__bindgen_ty_1 where T: 'static + ?core::marker::Sized
-pub fn aya_obj::generated::bpf_cpumap_val__bindgen_ty_1::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_obj::generated::bpf_cpumap_val__bindgen_ty_1 where T: ?core::marker::Sized
-pub fn aya_obj::generated::bpf_cpumap_val__bindgen_ty_1::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::bpf_cpumap_val__bindgen_ty_1 where T: ?core::marker::Sized
-pub fn aya_obj::generated::bpf_cpumap_val__bindgen_ty_1::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_cpumap_val__bindgen_ty_1 where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::bpf_cpumap_val__bindgen_ty_1::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_obj::generated::bpf_cpumap_val__bindgen_ty_1
-pub fn aya_obj::generated::bpf_cpumap_val__bindgen_ty_1::from(t: T) -> T
 #[repr(C)] pub union aya_obj::generated::bpf_devmap_val__bindgen_ty_1
 pub aya_obj::generated::bpf_devmap_val__bindgen_ty_1::fd: core::ffi::primitives::c_int
 pub aya_obj::generated::bpf_devmap_val__bindgen_ty_1::id: aya_obj::generated::__u32
@@ -4271,28 +2281,6 @@ impl core::marker::Unpin for aya_obj::generated::bpf_devmap_val__bindgen_ty_1
 impl core::marker::UnsafeUnpin for aya_obj::generated::bpf_devmap_val__bindgen_ty_1
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::generated::bpf_devmap_val__bindgen_ty_1
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::generated::bpf_devmap_val__bindgen_ty_1
-impl<T, U> core::convert::Into<U> for aya_obj::generated::bpf_devmap_val__bindgen_ty_1 where U: core::convert::From<T>
-pub fn aya_obj::generated::bpf_devmap_val__bindgen_ty_1::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_obj::generated::bpf_devmap_val__bindgen_ty_1 where U: core::convert::Into<T>
-pub type aya_obj::generated::bpf_devmap_val__bindgen_ty_1::Error = core::convert::Infallible
-pub fn aya_obj::generated::bpf_devmap_val__bindgen_ty_1::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_obj::generated::bpf_devmap_val__bindgen_ty_1 where U: core::convert::TryFrom<T>
-pub type aya_obj::generated::bpf_devmap_val__bindgen_ty_1::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_obj::generated::bpf_devmap_val__bindgen_ty_1::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya_obj::generated::bpf_devmap_val__bindgen_ty_1 where T: core::clone::Clone
-pub type aya_obj::generated::bpf_devmap_val__bindgen_ty_1::Owned = T
-pub fn aya_obj::generated::bpf_devmap_val__bindgen_ty_1::clone_into(&self, target: &mut T)
-pub fn aya_obj::generated::bpf_devmap_val__bindgen_ty_1::to_owned(&self) -> T
-impl<T> core::any::Any for aya_obj::generated::bpf_devmap_val__bindgen_ty_1 where T: 'static + ?core::marker::Sized
-pub fn aya_obj::generated::bpf_devmap_val__bindgen_ty_1::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_obj::generated::bpf_devmap_val__bindgen_ty_1 where T: ?core::marker::Sized
-pub fn aya_obj::generated::bpf_devmap_val__bindgen_ty_1::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::bpf_devmap_val__bindgen_ty_1 where T: ?core::marker::Sized
-pub fn aya_obj::generated::bpf_devmap_val__bindgen_ty_1::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_devmap_val__bindgen_ty_1 where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::bpf_devmap_val__bindgen_ty_1::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_obj::generated::bpf_devmap_val__bindgen_ty_1
-pub fn aya_obj::generated::bpf_devmap_val__bindgen_ty_1::from(t: T) -> T
 #[repr(C)] pub union aya_obj::generated::bpf_link_info__bindgen_ty_1
 pub aya_obj::generated::bpf_link_info__bindgen_ty_1::cgroup: aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_3
 pub aya_obj::generated::bpf_link_info__bindgen_ty_1::iter: aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4
@@ -4317,28 +2305,6 @@ impl core::marker::Unpin for aya_obj::generated::bpf_link_info__bindgen_ty_1
 impl core::marker::UnsafeUnpin for aya_obj::generated::bpf_link_info__bindgen_ty_1
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::generated::bpf_link_info__bindgen_ty_1
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::generated::bpf_link_info__bindgen_ty_1
-impl<T, U> core::convert::Into<U> for aya_obj::generated::bpf_link_info__bindgen_ty_1 where U: core::convert::From<T>
-pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_obj::generated::bpf_link_info__bindgen_ty_1 where U: core::convert::Into<T>
-pub type aya_obj::generated::bpf_link_info__bindgen_ty_1::Error = core::convert::Infallible
-pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_obj::generated::bpf_link_info__bindgen_ty_1 where U: core::convert::TryFrom<T>
-pub type aya_obj::generated::bpf_link_info__bindgen_ty_1::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya_obj::generated::bpf_link_info__bindgen_ty_1 where T: core::clone::Clone
-pub type aya_obj::generated::bpf_link_info__bindgen_ty_1::Owned = T
-pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1::clone_into(&self, target: &mut T)
-pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1::to_owned(&self) -> T
-impl<T> core::any::Any for aya_obj::generated::bpf_link_info__bindgen_ty_1 where T: 'static + ?core::marker::Sized
-pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_obj::generated::bpf_link_info__bindgen_ty_1 where T: ?core::marker::Sized
-pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::bpf_link_info__bindgen_ty_1 where T: ?core::marker::Sized
-pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_link_info__bindgen_ty_1 where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::bpf_link_info__bindgen_ty_1::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_obj::generated::bpf_link_info__bindgen_ty_1
-pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1::from(t: T) -> T
 #[repr(C)] pub union aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1
 pub aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1::event: aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_4
 pub aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1::kprobe: aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_2
@@ -4354,28 +2320,6 @@ impl core::marker::Unpin for aya_obj::generated::bpf_link_info__bindgen_ty_1__bi
 impl core::marker::UnsafeUnpin for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1
-impl<T, U> core::convert::Into<U> for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1 where U: core::convert::From<T>
-pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1 where U: core::convert::Into<T>
-pub type aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1::Error = core::convert::Infallible
-pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1 where U: core::convert::TryFrom<T>
-pub type aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1 where T: core::clone::Clone
-pub type aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1::Owned = T
-pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1::clone_into(&self, target: &mut T)
-pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1::to_owned(&self) -> T
-impl<T> core::any::Any for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1 where T: 'static + ?core::marker::Sized
-pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1 where T: ?core::marker::Sized
-pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1 where T: ?core::marker::Sized
-pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1 where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1
-pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1::from(t: T) -> T
 #[repr(C)] pub union aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_1
 pub aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_1::map: aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_1__bindgen_ty_1
 impl core::clone::Clone for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_1
@@ -4388,28 +2332,6 @@ impl core::marker::Unpin for aya_obj::generated::bpf_link_info__bindgen_ty_1__bi
 impl core::marker::UnsafeUnpin for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_1
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_1
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_1
-impl<T, U> core::convert::Into<U> for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_1 where U: core::convert::From<T>
-pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_1::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_1 where U: core::convert::Into<T>
-pub type aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_1::Error = core::convert::Infallible
-pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_1::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_1 where U: core::convert::TryFrom<T>
-pub type aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_1::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_1::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_1 where T: core::clone::Clone
-pub type aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_1::Owned = T
-pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_1::clone_into(&self, target: &mut T)
-pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_1::to_owned(&self) -> T
-impl<T> core::any::Any for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_1 where T: 'static + ?core::marker::Sized
-pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_1::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_1 where T: ?core::marker::Sized
-pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_1::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_1 where T: ?core::marker::Sized
-pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_1::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_1 where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_1::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_1
-pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_1::from(t: T) -> T
 #[repr(C)] pub union aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2
 pub aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2::cgroup: aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2__bindgen_ty_1
 pub aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2::task: aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2__bindgen_ty_2
@@ -4423,28 +2345,6 @@ impl core::marker::Unpin for aya_obj::generated::bpf_link_info__bindgen_ty_1__bi
 impl core::marker::UnsafeUnpin for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2
-impl<T, U> core::convert::Into<U> for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2 where U: core::convert::From<T>
-pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2 where U: core::convert::Into<T>
-pub type aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2::Error = core::convert::Infallible
-pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2 where U: core::convert::TryFrom<T>
-pub type aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2 where T: core::clone::Clone
-pub type aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2::Owned = T
-pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2::clone_into(&self, target: &mut T)
-pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2::to_owned(&self) -> T
-impl<T> core::any::Any for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2 where T: 'static + ?core::marker::Sized
-pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2 where T: ?core::marker::Sized
-pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2 where T: ?core::marker::Sized
-pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2 where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2
-pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2::from(t: T) -> T
 #[repr(C)] pub union aya_obj::generated::btf_type__bindgen_ty_1
 pub aya_obj::generated::btf_type__bindgen_ty_1::size: aya_obj::generated::__u32
 pub aya_obj::generated::btf_type__bindgen_ty_1::type_: aya_obj::generated::__u32
@@ -4458,28 +2358,6 @@ impl core::marker::Unpin for aya_obj::generated::btf_type__bindgen_ty_1
 impl core::marker::UnsafeUnpin for aya_obj::generated::btf_type__bindgen_ty_1
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::generated::btf_type__bindgen_ty_1
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::generated::btf_type__bindgen_ty_1
-impl<T, U> core::convert::Into<U> for aya_obj::generated::btf_type__bindgen_ty_1 where U: core::convert::From<T>
-pub fn aya_obj::generated::btf_type__bindgen_ty_1::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_obj::generated::btf_type__bindgen_ty_1 where U: core::convert::Into<T>
-pub type aya_obj::generated::btf_type__bindgen_ty_1::Error = core::convert::Infallible
-pub fn aya_obj::generated::btf_type__bindgen_ty_1::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_obj::generated::btf_type__bindgen_ty_1 where U: core::convert::TryFrom<T>
-pub type aya_obj::generated::btf_type__bindgen_ty_1::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_obj::generated::btf_type__bindgen_ty_1::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya_obj::generated::btf_type__bindgen_ty_1 where T: core::clone::Clone
-pub type aya_obj::generated::btf_type__bindgen_ty_1::Owned = T
-pub fn aya_obj::generated::btf_type__bindgen_ty_1::clone_into(&self, target: &mut T)
-pub fn aya_obj::generated::btf_type__bindgen_ty_1::to_owned(&self) -> T
-impl<T> core::any::Any for aya_obj::generated::btf_type__bindgen_ty_1 where T: 'static + ?core::marker::Sized
-pub fn aya_obj::generated::btf_type__bindgen_ty_1::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_obj::generated::btf_type__bindgen_ty_1 where T: ?core::marker::Sized
-pub fn aya_obj::generated::btf_type__bindgen_ty_1::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::btf_type__bindgen_ty_1 where T: ?core::marker::Sized
-pub fn aya_obj::generated::btf_type__bindgen_ty_1::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::btf_type__bindgen_ty_1 where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::btf_type__bindgen_ty_1::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_obj::generated::btf_type__bindgen_ty_1
-pub fn aya_obj::generated::btf_type__bindgen_ty_1::from(t: T) -> T
 #[repr(C)] pub union aya_obj::generated::perf_event_attr__bindgen_ty_1
 pub aya_obj::generated::perf_event_attr__bindgen_ty_1::sample_freq: aya_obj::generated::__u64
 pub aya_obj::generated::perf_event_attr__bindgen_ty_1::sample_period: aya_obj::generated::__u64
@@ -4493,28 +2371,6 @@ impl core::marker::Unpin for aya_obj::generated::perf_event_attr__bindgen_ty_1
 impl core::marker::UnsafeUnpin for aya_obj::generated::perf_event_attr__bindgen_ty_1
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::generated::perf_event_attr__bindgen_ty_1
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::generated::perf_event_attr__bindgen_ty_1
-impl<T, U> core::convert::Into<U> for aya_obj::generated::perf_event_attr__bindgen_ty_1 where U: core::convert::From<T>
-pub fn aya_obj::generated::perf_event_attr__bindgen_ty_1::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_obj::generated::perf_event_attr__bindgen_ty_1 where U: core::convert::Into<T>
-pub type aya_obj::generated::perf_event_attr__bindgen_ty_1::Error = core::convert::Infallible
-pub fn aya_obj::generated::perf_event_attr__bindgen_ty_1::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_obj::generated::perf_event_attr__bindgen_ty_1 where U: core::convert::TryFrom<T>
-pub type aya_obj::generated::perf_event_attr__bindgen_ty_1::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_obj::generated::perf_event_attr__bindgen_ty_1::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya_obj::generated::perf_event_attr__bindgen_ty_1 where T: core::clone::Clone
-pub type aya_obj::generated::perf_event_attr__bindgen_ty_1::Owned = T
-pub fn aya_obj::generated::perf_event_attr__bindgen_ty_1::clone_into(&self, target: &mut T)
-pub fn aya_obj::generated::perf_event_attr__bindgen_ty_1::to_owned(&self) -> T
-impl<T> core::any::Any for aya_obj::generated::perf_event_attr__bindgen_ty_1 where T: 'static + ?core::marker::Sized
-pub fn aya_obj::generated::perf_event_attr__bindgen_ty_1::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_obj::generated::perf_event_attr__bindgen_ty_1 where T: ?core::marker::Sized
-pub fn aya_obj::generated::perf_event_attr__bindgen_ty_1::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::perf_event_attr__bindgen_ty_1 where T: ?core::marker::Sized
-pub fn aya_obj::generated::perf_event_attr__bindgen_ty_1::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::perf_event_attr__bindgen_ty_1 where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::perf_event_attr__bindgen_ty_1::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_obj::generated::perf_event_attr__bindgen_ty_1
-pub fn aya_obj::generated::perf_event_attr__bindgen_ty_1::from(t: T) -> T
 #[repr(C)] pub union aya_obj::generated::perf_event_attr__bindgen_ty_2
 pub aya_obj::generated::perf_event_attr__bindgen_ty_2::wakeup_events: aya_obj::generated::__u32
 pub aya_obj::generated::perf_event_attr__bindgen_ty_2::wakeup_watermark: aya_obj::generated::__u32
@@ -4528,28 +2384,6 @@ impl core::marker::Unpin for aya_obj::generated::perf_event_attr__bindgen_ty_2
 impl core::marker::UnsafeUnpin for aya_obj::generated::perf_event_attr__bindgen_ty_2
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::generated::perf_event_attr__bindgen_ty_2
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::generated::perf_event_attr__bindgen_ty_2
-impl<T, U> core::convert::Into<U> for aya_obj::generated::perf_event_attr__bindgen_ty_2 where U: core::convert::From<T>
-pub fn aya_obj::generated::perf_event_attr__bindgen_ty_2::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_obj::generated::perf_event_attr__bindgen_ty_2 where U: core::convert::Into<T>
-pub type aya_obj::generated::perf_event_attr__bindgen_ty_2::Error = core::convert::Infallible
-pub fn aya_obj::generated::perf_event_attr__bindgen_ty_2::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_obj::generated::perf_event_attr__bindgen_ty_2 where U: core::convert::TryFrom<T>
-pub type aya_obj::generated::perf_event_attr__bindgen_ty_2::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_obj::generated::perf_event_attr__bindgen_ty_2::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya_obj::generated::perf_event_attr__bindgen_ty_2 where T: core::clone::Clone
-pub type aya_obj::generated::perf_event_attr__bindgen_ty_2::Owned = T
-pub fn aya_obj::generated::perf_event_attr__bindgen_ty_2::clone_into(&self, target: &mut T)
-pub fn aya_obj::generated::perf_event_attr__bindgen_ty_2::to_owned(&self) -> T
-impl<T> core::any::Any for aya_obj::generated::perf_event_attr__bindgen_ty_2 where T: 'static + ?core::marker::Sized
-pub fn aya_obj::generated::perf_event_attr__bindgen_ty_2::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_obj::generated::perf_event_attr__bindgen_ty_2 where T: ?core::marker::Sized
-pub fn aya_obj::generated::perf_event_attr__bindgen_ty_2::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::perf_event_attr__bindgen_ty_2 where T: ?core::marker::Sized
-pub fn aya_obj::generated::perf_event_attr__bindgen_ty_2::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::perf_event_attr__bindgen_ty_2 where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::perf_event_attr__bindgen_ty_2::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_obj::generated::perf_event_attr__bindgen_ty_2
-pub fn aya_obj::generated::perf_event_attr__bindgen_ty_2::from(t: T) -> T
 #[repr(C)] pub union aya_obj::generated::perf_event_attr__bindgen_ty_3
 pub aya_obj::generated::perf_event_attr__bindgen_ty_3::bp_addr: aya_obj::generated::__u64
 pub aya_obj::generated::perf_event_attr__bindgen_ty_3::config1: aya_obj::generated::__u64
@@ -4565,28 +2399,6 @@ impl core::marker::Unpin for aya_obj::generated::perf_event_attr__bindgen_ty_3
 impl core::marker::UnsafeUnpin for aya_obj::generated::perf_event_attr__bindgen_ty_3
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::generated::perf_event_attr__bindgen_ty_3
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::generated::perf_event_attr__bindgen_ty_3
-impl<T, U> core::convert::Into<U> for aya_obj::generated::perf_event_attr__bindgen_ty_3 where U: core::convert::From<T>
-pub fn aya_obj::generated::perf_event_attr__bindgen_ty_3::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_obj::generated::perf_event_attr__bindgen_ty_3 where U: core::convert::Into<T>
-pub type aya_obj::generated::perf_event_attr__bindgen_ty_3::Error = core::convert::Infallible
-pub fn aya_obj::generated::perf_event_attr__bindgen_ty_3::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_obj::generated::perf_event_attr__bindgen_ty_3 where U: core::convert::TryFrom<T>
-pub type aya_obj::generated::perf_event_attr__bindgen_ty_3::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_obj::generated::perf_event_attr__bindgen_ty_3::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya_obj::generated::perf_event_attr__bindgen_ty_3 where T: core::clone::Clone
-pub type aya_obj::generated::perf_event_attr__bindgen_ty_3::Owned = T
-pub fn aya_obj::generated::perf_event_attr__bindgen_ty_3::clone_into(&self, target: &mut T)
-pub fn aya_obj::generated::perf_event_attr__bindgen_ty_3::to_owned(&self) -> T
-impl<T> core::any::Any for aya_obj::generated::perf_event_attr__bindgen_ty_3 where T: 'static + ?core::marker::Sized
-pub fn aya_obj::generated::perf_event_attr__bindgen_ty_3::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_obj::generated::perf_event_attr__bindgen_ty_3 where T: ?core::marker::Sized
-pub fn aya_obj::generated::perf_event_attr__bindgen_ty_3::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::perf_event_attr__bindgen_ty_3 where T: ?core::marker::Sized
-pub fn aya_obj::generated::perf_event_attr__bindgen_ty_3::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::perf_event_attr__bindgen_ty_3 where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::perf_event_attr__bindgen_ty_3::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_obj::generated::perf_event_attr__bindgen_ty_3
-pub fn aya_obj::generated::perf_event_attr__bindgen_ty_3::from(t: T) -> T
 #[repr(C)] pub union aya_obj::generated::perf_event_attr__bindgen_ty_4
 pub aya_obj::generated::perf_event_attr__bindgen_ty_4::bp_len: aya_obj::generated::__u64
 pub aya_obj::generated::perf_event_attr__bindgen_ty_4::config2: aya_obj::generated::__u64
@@ -4602,28 +2414,6 @@ impl core::marker::Unpin for aya_obj::generated::perf_event_attr__bindgen_ty_4
 impl core::marker::UnsafeUnpin for aya_obj::generated::perf_event_attr__bindgen_ty_4
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::generated::perf_event_attr__bindgen_ty_4
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::generated::perf_event_attr__bindgen_ty_4
-impl<T, U> core::convert::Into<U> for aya_obj::generated::perf_event_attr__bindgen_ty_4 where U: core::convert::From<T>
-pub fn aya_obj::generated::perf_event_attr__bindgen_ty_4::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_obj::generated::perf_event_attr__bindgen_ty_4 where U: core::convert::Into<T>
-pub type aya_obj::generated::perf_event_attr__bindgen_ty_4::Error = core::convert::Infallible
-pub fn aya_obj::generated::perf_event_attr__bindgen_ty_4::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_obj::generated::perf_event_attr__bindgen_ty_4 where U: core::convert::TryFrom<T>
-pub type aya_obj::generated::perf_event_attr__bindgen_ty_4::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_obj::generated::perf_event_attr__bindgen_ty_4::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya_obj::generated::perf_event_attr__bindgen_ty_4 where T: core::clone::Clone
-pub type aya_obj::generated::perf_event_attr__bindgen_ty_4::Owned = T
-pub fn aya_obj::generated::perf_event_attr__bindgen_ty_4::clone_into(&self, target: &mut T)
-pub fn aya_obj::generated::perf_event_attr__bindgen_ty_4::to_owned(&self) -> T
-impl<T> core::any::Any for aya_obj::generated::perf_event_attr__bindgen_ty_4 where T: 'static + ?core::marker::Sized
-pub fn aya_obj::generated::perf_event_attr__bindgen_ty_4::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_obj::generated::perf_event_attr__bindgen_ty_4 where T: ?core::marker::Sized
-pub fn aya_obj::generated::perf_event_attr__bindgen_ty_4::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::perf_event_attr__bindgen_ty_4 where T: ?core::marker::Sized
-pub fn aya_obj::generated::perf_event_attr__bindgen_ty_4::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::perf_event_attr__bindgen_ty_4 where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::perf_event_attr__bindgen_ty_4::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_obj::generated::perf_event_attr__bindgen_ty_4
-pub fn aya_obj::generated::perf_event_attr__bindgen_ty_4::from(t: T) -> T
 #[repr(C)] pub union aya_obj::generated::perf_event_mmap_page__bindgen_ty_1
 pub aya_obj::generated::perf_event_mmap_page__bindgen_ty_1::__bindgen_anon_1: aya_obj::generated::perf_event_mmap_page__bindgen_ty_1__bindgen_ty_1
 pub aya_obj::generated::perf_event_mmap_page__bindgen_ty_1::capabilities: aya_obj::generated::__u64
@@ -4637,28 +2427,6 @@ impl core::marker::Unpin for aya_obj::generated::perf_event_mmap_page__bindgen_t
 impl core::marker::UnsafeUnpin for aya_obj::generated::perf_event_mmap_page__bindgen_ty_1
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::generated::perf_event_mmap_page__bindgen_ty_1
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::generated::perf_event_mmap_page__bindgen_ty_1
-impl<T, U> core::convert::Into<U> for aya_obj::generated::perf_event_mmap_page__bindgen_ty_1 where U: core::convert::From<T>
-pub fn aya_obj::generated::perf_event_mmap_page__bindgen_ty_1::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_obj::generated::perf_event_mmap_page__bindgen_ty_1 where U: core::convert::Into<T>
-pub type aya_obj::generated::perf_event_mmap_page__bindgen_ty_1::Error = core::convert::Infallible
-pub fn aya_obj::generated::perf_event_mmap_page__bindgen_ty_1::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_obj::generated::perf_event_mmap_page__bindgen_ty_1 where U: core::convert::TryFrom<T>
-pub type aya_obj::generated::perf_event_mmap_page__bindgen_ty_1::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_obj::generated::perf_event_mmap_page__bindgen_ty_1::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya_obj::generated::perf_event_mmap_page__bindgen_ty_1 where T: core::clone::Clone
-pub type aya_obj::generated::perf_event_mmap_page__bindgen_ty_1::Owned = T
-pub fn aya_obj::generated::perf_event_mmap_page__bindgen_ty_1::clone_into(&self, target: &mut T)
-pub fn aya_obj::generated::perf_event_mmap_page__bindgen_ty_1::to_owned(&self) -> T
-impl<T> core::any::Any for aya_obj::generated::perf_event_mmap_page__bindgen_ty_1 where T: 'static + ?core::marker::Sized
-pub fn aya_obj::generated::perf_event_mmap_page__bindgen_ty_1::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_obj::generated::perf_event_mmap_page__bindgen_ty_1 where T: ?core::marker::Sized
-pub fn aya_obj::generated::perf_event_mmap_page__bindgen_ty_1::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::perf_event_mmap_page__bindgen_ty_1 where T: ?core::marker::Sized
-pub fn aya_obj::generated::perf_event_mmap_page__bindgen_ty_1::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::perf_event_mmap_page__bindgen_ty_1 where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::perf_event_mmap_page__bindgen_ty_1::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_obj::generated::perf_event_mmap_page__bindgen_ty_1
-pub fn aya_obj::generated::perf_event_mmap_page__bindgen_ty_1::from(t: T) -> T
 #[repr(C)] pub struct aya_obj::generated::__BindgenBitfieldUnit<Storage>
 impl<Storage> aya_obj::generated::__BindgenBitfieldUnit<Storage> where Storage: core::convert::AsRef<[u8]> + core::convert::AsMut<[u8]>
 pub fn aya_obj::generated::__BindgenBitfieldUnit<Storage>::get(&self, bit_offset: usize, bit_width: u8) -> u64
@@ -4695,28 +2463,6 @@ impl<Storage> core::marker::Unpin for aya_obj::generated::__BindgenBitfieldUnit<
 impl<Storage> core::marker::UnsafeUnpin for aya_obj::generated::__BindgenBitfieldUnit<Storage> where Storage: core::marker::UnsafeUnpin
 impl<Storage> core::panic::unwind_safe::RefUnwindSafe for aya_obj::generated::__BindgenBitfieldUnit<Storage> where Storage: core::panic::unwind_safe::RefUnwindSafe
 impl<Storage> core::panic::unwind_safe::UnwindSafe for aya_obj::generated::__BindgenBitfieldUnit<Storage> where Storage: core::panic::unwind_safe::UnwindSafe
-impl<T, U> core::convert::Into<U> for aya_obj::generated::__BindgenBitfieldUnit<Storage> where U: core::convert::From<T>
-pub fn aya_obj::generated::__BindgenBitfieldUnit<Storage>::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_obj::generated::__BindgenBitfieldUnit<Storage> where U: core::convert::Into<T>
-pub type aya_obj::generated::__BindgenBitfieldUnit<Storage>::Error = core::convert::Infallible
-pub fn aya_obj::generated::__BindgenBitfieldUnit<Storage>::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_obj::generated::__BindgenBitfieldUnit<Storage> where U: core::convert::TryFrom<T>
-pub type aya_obj::generated::__BindgenBitfieldUnit<Storage>::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_obj::generated::__BindgenBitfieldUnit<Storage>::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya_obj::generated::__BindgenBitfieldUnit<Storage> where T: core::clone::Clone
-pub type aya_obj::generated::__BindgenBitfieldUnit<Storage>::Owned = T
-pub fn aya_obj::generated::__BindgenBitfieldUnit<Storage>::clone_into(&self, target: &mut T)
-pub fn aya_obj::generated::__BindgenBitfieldUnit<Storage>::to_owned(&self) -> T
-impl<T> core::any::Any for aya_obj::generated::__BindgenBitfieldUnit<Storage> where T: 'static + ?core::marker::Sized
-pub fn aya_obj::generated::__BindgenBitfieldUnit<Storage>::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_obj::generated::__BindgenBitfieldUnit<Storage> where T: ?core::marker::Sized
-pub fn aya_obj::generated::__BindgenBitfieldUnit<Storage>::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::__BindgenBitfieldUnit<Storage> where T: ?core::marker::Sized
-pub fn aya_obj::generated::__BindgenBitfieldUnit<Storage>::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::__BindgenBitfieldUnit<Storage> where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::__BindgenBitfieldUnit<Storage>::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_obj::generated::__BindgenBitfieldUnit<Storage>
-pub fn aya_obj::generated::__BindgenBitfieldUnit<Storage>::from(t: T) -> T
 #[repr(C)] pub struct aya_obj::generated::__IncompleteArrayField<T>(_, _)
 impl<T> aya_obj::generated::__IncompleteArrayField<T>
 pub fn aya_obj::generated::__IncompleteArrayField<T>::as_mut_ptr(&mut self) -> *mut T
@@ -4735,22 +2481,6 @@ impl<T> core::marker::Unpin for aya_obj::generated::__IncompleteArrayField<T> wh
 impl<T> core::marker::UnsafeUnpin for aya_obj::generated::__IncompleteArrayField<T> where T: core::marker::UnsafeUnpin
 impl<T> core::panic::unwind_safe::RefUnwindSafe for aya_obj::generated::__IncompleteArrayField<T> where T: core::panic::unwind_safe::RefUnwindSafe
 impl<T> core::panic::unwind_safe::UnwindSafe for aya_obj::generated::__IncompleteArrayField<T> where T: core::panic::unwind_safe::UnwindSafe
-impl<T, U> core::convert::Into<U> for aya_obj::generated::__IncompleteArrayField<T> where U: core::convert::From<T>
-pub fn aya_obj::generated::__IncompleteArrayField<T>::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_obj::generated::__IncompleteArrayField<T> where U: core::convert::Into<T>
-pub type aya_obj::generated::__IncompleteArrayField<T>::Error = core::convert::Infallible
-pub fn aya_obj::generated::__IncompleteArrayField<T>::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_obj::generated::__IncompleteArrayField<T> where U: core::convert::TryFrom<T>
-pub type aya_obj::generated::__IncompleteArrayField<T>::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_obj::generated::__IncompleteArrayField<T>::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_obj::generated::__IncompleteArrayField<T> where T: 'static + ?core::marker::Sized
-pub fn aya_obj::generated::__IncompleteArrayField<T>::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_obj::generated::__IncompleteArrayField<T> where T: ?core::marker::Sized
-pub fn aya_obj::generated::__IncompleteArrayField<T>::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::__IncompleteArrayField<T> where T: ?core::marker::Sized
-pub fn aya_obj::generated::__IncompleteArrayField<T>::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya_obj::generated::__IncompleteArrayField<T>
-pub fn aya_obj::generated::__IncompleteArrayField<T>::from(t: T) -> T
 #[repr(C)] pub struct aya_obj::generated::bpf_attr__bindgen_ty_1
 pub aya_obj::generated::bpf_attr__bindgen_ty_1::btf_fd: aya_obj::generated::__u32
 pub aya_obj::generated::bpf_attr__bindgen_ty_1::btf_key_type_id: aya_obj::generated::__u32
@@ -4780,28 +2510,6 @@ impl core::marker::Unpin for aya_obj::generated::bpf_attr__bindgen_ty_1
 impl core::marker::UnsafeUnpin for aya_obj::generated::bpf_attr__bindgen_ty_1
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::generated::bpf_attr__bindgen_ty_1
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::generated::bpf_attr__bindgen_ty_1
-impl<T, U> core::convert::Into<U> for aya_obj::generated::bpf_attr__bindgen_ty_1 where U: core::convert::From<T>
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_1::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_obj::generated::bpf_attr__bindgen_ty_1 where U: core::convert::Into<T>
-pub type aya_obj::generated::bpf_attr__bindgen_ty_1::Error = core::convert::Infallible
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_1::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_obj::generated::bpf_attr__bindgen_ty_1 where U: core::convert::TryFrom<T>
-pub type aya_obj::generated::bpf_attr__bindgen_ty_1::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_1::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya_obj::generated::bpf_attr__bindgen_ty_1 where T: core::clone::Clone
-pub type aya_obj::generated::bpf_attr__bindgen_ty_1::Owned = T
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_1::clone_into(&self, target: &mut T)
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_1::to_owned(&self) -> T
-impl<T> core::any::Any for aya_obj::generated::bpf_attr__bindgen_ty_1 where T: 'static + ?core::marker::Sized
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_1::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_obj::generated::bpf_attr__bindgen_ty_1 where T: ?core::marker::Sized
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_1::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::bpf_attr__bindgen_ty_1 where T: ?core::marker::Sized
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_1::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_attr__bindgen_ty_1 where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::bpf_attr__bindgen_ty_1::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_obj::generated::bpf_attr__bindgen_ty_1
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_1::from(t: T) -> T
 #[repr(C)] pub struct aya_obj::generated::bpf_attr__bindgen_ty_10
 pub aya_obj::generated::bpf_attr__bindgen_ty_10::__bindgen_anon_1: aya_obj::generated::bpf_attr__bindgen_ty_10__bindgen_ty_1
 pub aya_obj::generated::bpf_attr__bindgen_ty_10::__bindgen_anon_2: aya_obj::generated::bpf_attr__bindgen_ty_10__bindgen_ty_2
@@ -4827,28 +2535,6 @@ impl core::marker::Unpin for aya_obj::generated::bpf_attr__bindgen_ty_10
 impl core::marker::UnsafeUnpin for aya_obj::generated::bpf_attr__bindgen_ty_10
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::generated::bpf_attr__bindgen_ty_10
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::generated::bpf_attr__bindgen_ty_10
-impl<T, U> core::convert::Into<U> for aya_obj::generated::bpf_attr__bindgen_ty_10 where U: core::convert::From<T>
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_10::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_obj::generated::bpf_attr__bindgen_ty_10 where U: core::convert::Into<T>
-pub type aya_obj::generated::bpf_attr__bindgen_ty_10::Error = core::convert::Infallible
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_10::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_obj::generated::bpf_attr__bindgen_ty_10 where U: core::convert::TryFrom<T>
-pub type aya_obj::generated::bpf_attr__bindgen_ty_10::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_10::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya_obj::generated::bpf_attr__bindgen_ty_10 where T: core::clone::Clone
-pub type aya_obj::generated::bpf_attr__bindgen_ty_10::Owned = T
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_10::clone_into(&self, target: &mut T)
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_10::to_owned(&self) -> T
-impl<T> core::any::Any for aya_obj::generated::bpf_attr__bindgen_ty_10 where T: 'static + ?core::marker::Sized
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_10::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_obj::generated::bpf_attr__bindgen_ty_10 where T: ?core::marker::Sized
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_10::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::bpf_attr__bindgen_ty_10 where T: ?core::marker::Sized
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_10::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_attr__bindgen_ty_10 where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::bpf_attr__bindgen_ty_10::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_obj::generated::bpf_attr__bindgen_ty_10
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_10::from(t: T) -> T
 #[repr(C)] pub struct aya_obj::generated::bpf_attr__bindgen_ty_11
 pub aya_obj::generated::bpf_attr__bindgen_ty_11::_bitfield_1: aya_obj::generated::__BindgenBitfieldUnit<[u8; 4]>
 pub aya_obj::generated::bpf_attr__bindgen_ty_11::_bitfield_align_1: [u8; 0]
@@ -4869,28 +2555,6 @@ impl core::marker::Unpin for aya_obj::generated::bpf_attr__bindgen_ty_11
 impl core::marker::UnsafeUnpin for aya_obj::generated::bpf_attr__bindgen_ty_11
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::generated::bpf_attr__bindgen_ty_11
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::generated::bpf_attr__bindgen_ty_11
-impl<T, U> core::convert::Into<U> for aya_obj::generated::bpf_attr__bindgen_ty_11 where U: core::convert::From<T>
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_11::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_obj::generated::bpf_attr__bindgen_ty_11 where U: core::convert::Into<T>
-pub type aya_obj::generated::bpf_attr__bindgen_ty_11::Error = core::convert::Infallible
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_11::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_obj::generated::bpf_attr__bindgen_ty_11 where U: core::convert::TryFrom<T>
-pub type aya_obj::generated::bpf_attr__bindgen_ty_11::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_11::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya_obj::generated::bpf_attr__bindgen_ty_11 where T: core::clone::Clone
-pub type aya_obj::generated::bpf_attr__bindgen_ty_11::Owned = T
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_11::clone_into(&self, target: &mut T)
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_11::to_owned(&self) -> T
-impl<T> core::any::Any for aya_obj::generated::bpf_attr__bindgen_ty_11 where T: 'static + ?core::marker::Sized
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_11::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_obj::generated::bpf_attr__bindgen_ty_11 where T: ?core::marker::Sized
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_11::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::bpf_attr__bindgen_ty_11 where T: ?core::marker::Sized
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_11::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_attr__bindgen_ty_11 where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::bpf_attr__bindgen_ty_11::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_obj::generated::bpf_attr__bindgen_ty_11
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_11::from(t: T) -> T
 #[repr(C)] pub struct aya_obj::generated::bpf_attr__bindgen_ty_12
 pub aya_obj::generated::bpf_attr__bindgen_ty_12::btf: aya_obj::generated::__u64
 pub aya_obj::generated::bpf_attr__bindgen_ty_12::btf_flags: aya_obj::generated::__u32
@@ -4912,28 +2576,6 @@ impl core::marker::Unpin for aya_obj::generated::bpf_attr__bindgen_ty_12
 impl core::marker::UnsafeUnpin for aya_obj::generated::bpf_attr__bindgen_ty_12
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::generated::bpf_attr__bindgen_ty_12
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::generated::bpf_attr__bindgen_ty_12
-impl<T, U> core::convert::Into<U> for aya_obj::generated::bpf_attr__bindgen_ty_12 where U: core::convert::From<T>
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_12::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_obj::generated::bpf_attr__bindgen_ty_12 where U: core::convert::Into<T>
-pub type aya_obj::generated::bpf_attr__bindgen_ty_12::Error = core::convert::Infallible
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_12::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_obj::generated::bpf_attr__bindgen_ty_12 where U: core::convert::TryFrom<T>
-pub type aya_obj::generated::bpf_attr__bindgen_ty_12::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_12::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya_obj::generated::bpf_attr__bindgen_ty_12 where T: core::clone::Clone
-pub type aya_obj::generated::bpf_attr__bindgen_ty_12::Owned = T
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_12::clone_into(&self, target: &mut T)
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_12::to_owned(&self) -> T
-impl<T> core::any::Any for aya_obj::generated::bpf_attr__bindgen_ty_12 where T: 'static + ?core::marker::Sized
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_12::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_obj::generated::bpf_attr__bindgen_ty_12 where T: ?core::marker::Sized
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_12::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::bpf_attr__bindgen_ty_12 where T: ?core::marker::Sized
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_12::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_attr__bindgen_ty_12 where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::bpf_attr__bindgen_ty_12::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_obj::generated::bpf_attr__bindgen_ty_12
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_12::from(t: T) -> T
 #[repr(C)] pub struct aya_obj::generated::bpf_attr__bindgen_ty_13
 pub aya_obj::generated::bpf_attr__bindgen_ty_13::buf: aya_obj::generated::__u64
 pub aya_obj::generated::bpf_attr__bindgen_ty_13::buf_len: aya_obj::generated::__u32
@@ -4956,28 +2598,6 @@ impl core::marker::Unpin for aya_obj::generated::bpf_attr__bindgen_ty_13
 impl core::marker::UnsafeUnpin for aya_obj::generated::bpf_attr__bindgen_ty_13
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::generated::bpf_attr__bindgen_ty_13
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::generated::bpf_attr__bindgen_ty_13
-impl<T, U> core::convert::Into<U> for aya_obj::generated::bpf_attr__bindgen_ty_13 where U: core::convert::From<T>
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_13::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_obj::generated::bpf_attr__bindgen_ty_13 where U: core::convert::Into<T>
-pub type aya_obj::generated::bpf_attr__bindgen_ty_13::Error = core::convert::Infallible
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_13::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_obj::generated::bpf_attr__bindgen_ty_13 where U: core::convert::TryFrom<T>
-pub type aya_obj::generated::bpf_attr__bindgen_ty_13::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_13::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya_obj::generated::bpf_attr__bindgen_ty_13 where T: core::clone::Clone
-pub type aya_obj::generated::bpf_attr__bindgen_ty_13::Owned = T
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_13::clone_into(&self, target: &mut T)
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_13::to_owned(&self) -> T
-impl<T> core::any::Any for aya_obj::generated::bpf_attr__bindgen_ty_13 where T: 'static + ?core::marker::Sized
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_13::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_obj::generated::bpf_attr__bindgen_ty_13 where T: ?core::marker::Sized
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_13::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::bpf_attr__bindgen_ty_13 where T: ?core::marker::Sized
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_13::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_attr__bindgen_ty_13 where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::bpf_attr__bindgen_ty_13::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_obj::generated::bpf_attr__bindgen_ty_13
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_13::from(t: T) -> T
 #[repr(C)] pub struct aya_obj::generated::bpf_attr__bindgen_ty_14
 pub aya_obj::generated::bpf_attr__bindgen_ty_14::__bindgen_anon_1: aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_1
 pub aya_obj::generated::bpf_attr__bindgen_ty_14::__bindgen_anon_2: aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_2
@@ -4994,28 +2614,6 @@ impl core::marker::Unpin for aya_obj::generated::bpf_attr__bindgen_ty_14
 impl core::marker::UnsafeUnpin for aya_obj::generated::bpf_attr__bindgen_ty_14
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::generated::bpf_attr__bindgen_ty_14
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::generated::bpf_attr__bindgen_ty_14
-impl<T, U> core::convert::Into<U> for aya_obj::generated::bpf_attr__bindgen_ty_14 where U: core::convert::From<T>
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_14::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_obj::generated::bpf_attr__bindgen_ty_14 where U: core::convert::Into<T>
-pub type aya_obj::generated::bpf_attr__bindgen_ty_14::Error = core::convert::Infallible
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_14::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_obj::generated::bpf_attr__bindgen_ty_14 where U: core::convert::TryFrom<T>
-pub type aya_obj::generated::bpf_attr__bindgen_ty_14::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_14::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya_obj::generated::bpf_attr__bindgen_ty_14 where T: core::clone::Clone
-pub type aya_obj::generated::bpf_attr__bindgen_ty_14::Owned = T
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_14::clone_into(&self, target: &mut T)
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_14::to_owned(&self) -> T
-impl<T> core::any::Any for aya_obj::generated::bpf_attr__bindgen_ty_14 where T: 'static + ?core::marker::Sized
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_14::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_obj::generated::bpf_attr__bindgen_ty_14 where T: ?core::marker::Sized
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_14::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::bpf_attr__bindgen_ty_14 where T: ?core::marker::Sized
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_14::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_attr__bindgen_ty_14 where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::bpf_attr__bindgen_ty_14::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_obj::generated::bpf_attr__bindgen_ty_14
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_14::from(t: T) -> T
 #[repr(C)] pub struct aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_1
 pub aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_1::iter_info: aya_obj::generated::__u64
 pub aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_1::iter_info_len: aya_obj::generated::__u32
@@ -5031,28 +2629,6 @@ impl core::marker::Unpin for aya_obj::generated::bpf_attr__bindgen_ty_14__bindge
 impl core::marker::UnsafeUnpin for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_1
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_1
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_1
-impl<T, U> core::convert::Into<U> for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_1 where U: core::convert::From<T>
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_1::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_1 where U: core::convert::Into<T>
-pub type aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_1::Error = core::convert::Infallible
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_1::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_1 where U: core::convert::TryFrom<T>
-pub type aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_1::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_1::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_1 where T: core::clone::Clone
-pub type aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_1::Owned = T
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_1::clone_into(&self, target: &mut T)
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_1::to_owned(&self) -> T
-impl<T> core::any::Any for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_1 where T: 'static + ?core::marker::Sized
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_1::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_1 where T: ?core::marker::Sized
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_1::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_1 where T: ?core::marker::Sized
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_1::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_1 where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_1::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_1
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_1::from(t: T) -> T
 #[repr(C)] pub struct aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_2
 pub aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_2::bpf_cookie: aya_obj::generated::__u64
 impl core::clone::Clone for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_2
@@ -5067,28 +2643,6 @@ impl core::marker::Unpin for aya_obj::generated::bpf_attr__bindgen_ty_14__bindge
 impl core::marker::UnsafeUnpin for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_2
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_2
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_2
-impl<T, U> core::convert::Into<U> for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_2 where U: core::convert::From<T>
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_2::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_2 where U: core::convert::Into<T>
-pub type aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_2::Error = core::convert::Infallible
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_2::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_2 where U: core::convert::TryFrom<T>
-pub type aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_2::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_2::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_2 where T: core::clone::Clone
-pub type aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_2::Owned = T
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_2::clone_into(&self, target: &mut T)
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_2::to_owned(&self) -> T
-impl<T> core::any::Any for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_2 where T: 'static + ?core::marker::Sized
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_2::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_2 where T: ?core::marker::Sized
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_2::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_2 where T: ?core::marker::Sized
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_2::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_2 where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_2::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_2
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_2::from(t: T) -> T
 #[repr(C)] pub struct aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_3
 pub aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_3::addrs: aya_obj::generated::__u64
 pub aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_3::cnt: aya_obj::generated::__u32
@@ -5107,28 +2661,6 @@ impl core::marker::Unpin for aya_obj::generated::bpf_attr__bindgen_ty_14__bindge
 impl core::marker::UnsafeUnpin for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_3
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_3
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_3
-impl<T, U> core::convert::Into<U> for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_3 where U: core::convert::From<T>
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_3::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_3 where U: core::convert::Into<T>
-pub type aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_3::Error = core::convert::Infallible
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_3::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_3 where U: core::convert::TryFrom<T>
-pub type aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_3::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_3::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_3 where T: core::clone::Clone
-pub type aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_3::Owned = T
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_3::clone_into(&self, target: &mut T)
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_3::to_owned(&self) -> T
-impl<T> core::any::Any for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_3 where T: 'static + ?core::marker::Sized
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_3::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_3 where T: ?core::marker::Sized
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_3::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_3 where T: ?core::marker::Sized
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_3::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_3 where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_3::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_3
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_3::from(t: T) -> T
 #[repr(C)] pub struct aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_4
 pub aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_4::cookie: aya_obj::generated::__u64
 pub aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_4::target_btf_id: aya_obj::generated::__u32
@@ -5144,28 +2676,6 @@ impl core::marker::Unpin for aya_obj::generated::bpf_attr__bindgen_ty_14__bindge
 impl core::marker::UnsafeUnpin for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_4
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_4
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_4
-impl<T, U> core::convert::Into<U> for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_4 where U: core::convert::From<T>
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_4::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_4 where U: core::convert::Into<T>
-pub type aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_4::Error = core::convert::Infallible
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_4::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_4 where U: core::convert::TryFrom<T>
-pub type aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_4::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_4::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_4 where T: core::clone::Clone
-pub type aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_4::Owned = T
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_4::clone_into(&self, target: &mut T)
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_4::to_owned(&self) -> T
-impl<T> core::any::Any for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_4 where T: 'static + ?core::marker::Sized
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_4::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_4 where T: ?core::marker::Sized
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_4::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_4 where T: ?core::marker::Sized
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_4::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_4 where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_4::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_4
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_4::from(t: T) -> T
 #[repr(C)] pub struct aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_5
 pub aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_5::flags: aya_obj::generated::__u32
 pub aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_5::hooknum: aya_obj::generated::__u32
@@ -5183,28 +2693,6 @@ impl core::marker::Unpin for aya_obj::generated::bpf_attr__bindgen_ty_14__bindge
 impl core::marker::UnsafeUnpin for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_5
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_5
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_5
-impl<T, U> core::convert::Into<U> for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_5 where U: core::convert::From<T>
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_5::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_5 where U: core::convert::Into<T>
-pub type aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_5::Error = core::convert::Infallible
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_5::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_5 where U: core::convert::TryFrom<T>
-pub type aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_5::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_5::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_5 where T: core::clone::Clone
-pub type aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_5::Owned = T
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_5::clone_into(&self, target: &mut T)
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_5::to_owned(&self) -> T
-impl<T> core::any::Any for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_5 where T: 'static + ?core::marker::Sized
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_5::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_5 where T: ?core::marker::Sized
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_5::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_5 where T: ?core::marker::Sized
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_5::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_5 where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_5::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_5
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_5::from(t: T) -> T
 #[repr(C)] pub struct aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_6
 pub aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_6::__bindgen_anon_1: aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_6__bindgen_ty_1
 pub aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_6::expected_revision: aya_obj::generated::__u64
@@ -5218,28 +2706,6 @@ impl core::marker::Unpin for aya_obj::generated::bpf_attr__bindgen_ty_14__bindge
 impl core::marker::UnsafeUnpin for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_6
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_6
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_6
-impl<T, U> core::convert::Into<U> for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_6 where U: core::convert::From<T>
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_6::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_6 where U: core::convert::Into<T>
-pub type aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_6::Error = core::convert::Infallible
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_6::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_6 where U: core::convert::TryFrom<T>
-pub type aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_6::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_6::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_6 where T: core::clone::Clone
-pub type aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_6::Owned = T
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_6::clone_into(&self, target: &mut T)
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_6::to_owned(&self) -> T
-impl<T> core::any::Any for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_6 where T: 'static + ?core::marker::Sized
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_6::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_6 where T: ?core::marker::Sized
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_6::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_6 where T: ?core::marker::Sized
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_6::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_6 where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_6::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_6
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_6::from(t: T) -> T
 #[repr(C)] pub struct aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_7
 pub aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_7::cnt: aya_obj::generated::__u32
 pub aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_7::cookies: aya_obj::generated::__u64
@@ -5260,28 +2726,6 @@ impl core::marker::Unpin for aya_obj::generated::bpf_attr__bindgen_ty_14__bindge
 impl core::marker::UnsafeUnpin for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_7
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_7
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_7
-impl<T, U> core::convert::Into<U> for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_7 where U: core::convert::From<T>
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_7::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_7 where U: core::convert::Into<T>
-pub type aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_7::Error = core::convert::Infallible
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_7::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_7 where U: core::convert::TryFrom<T>
-pub type aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_7::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_7::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_7 where T: core::clone::Clone
-pub type aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_7::Owned = T
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_7::clone_into(&self, target: &mut T)
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_7::to_owned(&self) -> T
-impl<T> core::any::Any for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_7 where T: 'static + ?core::marker::Sized
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_7::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_7 where T: ?core::marker::Sized
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_7::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_7 where T: ?core::marker::Sized
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_7::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_7 where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_7::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_7
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_7::from(t: T) -> T
 #[repr(C)] pub struct aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_8
 pub aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_8::__bindgen_anon_1: aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_8__bindgen_ty_1
 pub aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_8::expected_revision: aya_obj::generated::__u64
@@ -5295,28 +2739,6 @@ impl core::marker::Unpin for aya_obj::generated::bpf_attr__bindgen_ty_14__bindge
 impl core::marker::UnsafeUnpin for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_8
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_8
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_8
-impl<T, U> core::convert::Into<U> for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_8 where U: core::convert::From<T>
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_8::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_8 where U: core::convert::Into<T>
-pub type aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_8::Error = core::convert::Infallible
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_8::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_8 where U: core::convert::TryFrom<T>
-pub type aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_8::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_8::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_8 where T: core::clone::Clone
-pub type aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_8::Owned = T
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_8::clone_into(&self, target: &mut T)
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_8::to_owned(&self) -> T
-impl<T> core::any::Any for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_8 where T: 'static + ?core::marker::Sized
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_8::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_8 where T: ?core::marker::Sized
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_8::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_8 where T: ?core::marker::Sized
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_8::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_8 where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_8::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_8
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_14__bindgen_ty_3__bindgen_ty_8::from(t: T) -> T
 #[repr(C)] pub struct aya_obj::generated::bpf_attr__bindgen_ty_15
 pub aya_obj::generated::bpf_attr__bindgen_ty_15::__bindgen_anon_1: aya_obj::generated::bpf_attr__bindgen_ty_15__bindgen_ty_1
 pub aya_obj::generated::bpf_attr__bindgen_ty_15::__bindgen_anon_2: aya_obj::generated::bpf_attr__bindgen_ty_15__bindgen_ty_2
@@ -5332,28 +2754,6 @@ impl core::marker::Unpin for aya_obj::generated::bpf_attr__bindgen_ty_15
 impl core::marker::UnsafeUnpin for aya_obj::generated::bpf_attr__bindgen_ty_15
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::generated::bpf_attr__bindgen_ty_15
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::generated::bpf_attr__bindgen_ty_15
-impl<T, U> core::convert::Into<U> for aya_obj::generated::bpf_attr__bindgen_ty_15 where U: core::convert::From<T>
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_15::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_obj::generated::bpf_attr__bindgen_ty_15 where U: core::convert::Into<T>
-pub type aya_obj::generated::bpf_attr__bindgen_ty_15::Error = core::convert::Infallible
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_15::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_obj::generated::bpf_attr__bindgen_ty_15 where U: core::convert::TryFrom<T>
-pub type aya_obj::generated::bpf_attr__bindgen_ty_15::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_15::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya_obj::generated::bpf_attr__bindgen_ty_15 where T: core::clone::Clone
-pub type aya_obj::generated::bpf_attr__bindgen_ty_15::Owned = T
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_15::clone_into(&self, target: &mut T)
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_15::to_owned(&self) -> T
-impl<T> core::any::Any for aya_obj::generated::bpf_attr__bindgen_ty_15 where T: 'static + ?core::marker::Sized
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_15::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_obj::generated::bpf_attr__bindgen_ty_15 where T: ?core::marker::Sized
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_15::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::bpf_attr__bindgen_ty_15 where T: ?core::marker::Sized
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_15::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_attr__bindgen_ty_15 where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::bpf_attr__bindgen_ty_15::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_obj::generated::bpf_attr__bindgen_ty_15
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_15::from(t: T) -> T
 #[repr(C)] pub struct aya_obj::generated::bpf_attr__bindgen_ty_16
 pub aya_obj::generated::bpf_attr__bindgen_ty_16::link_fd: aya_obj::generated::__u32
 impl core::clone::Clone for aya_obj::generated::bpf_attr__bindgen_ty_16
@@ -5368,28 +2768,6 @@ impl core::marker::Unpin for aya_obj::generated::bpf_attr__bindgen_ty_16
 impl core::marker::UnsafeUnpin for aya_obj::generated::bpf_attr__bindgen_ty_16
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::generated::bpf_attr__bindgen_ty_16
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::generated::bpf_attr__bindgen_ty_16
-impl<T, U> core::convert::Into<U> for aya_obj::generated::bpf_attr__bindgen_ty_16 where U: core::convert::From<T>
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_16::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_obj::generated::bpf_attr__bindgen_ty_16 where U: core::convert::Into<T>
-pub type aya_obj::generated::bpf_attr__bindgen_ty_16::Error = core::convert::Infallible
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_16::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_obj::generated::bpf_attr__bindgen_ty_16 where U: core::convert::TryFrom<T>
-pub type aya_obj::generated::bpf_attr__bindgen_ty_16::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_16::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya_obj::generated::bpf_attr__bindgen_ty_16 where T: core::clone::Clone
-pub type aya_obj::generated::bpf_attr__bindgen_ty_16::Owned = T
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_16::clone_into(&self, target: &mut T)
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_16::to_owned(&self) -> T
-impl<T> core::any::Any for aya_obj::generated::bpf_attr__bindgen_ty_16 where T: 'static + ?core::marker::Sized
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_16::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_obj::generated::bpf_attr__bindgen_ty_16 where T: ?core::marker::Sized
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_16::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::bpf_attr__bindgen_ty_16 where T: ?core::marker::Sized
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_16::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_attr__bindgen_ty_16 where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::bpf_attr__bindgen_ty_16::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_obj::generated::bpf_attr__bindgen_ty_16
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_16::from(t: T) -> T
 #[repr(C)] pub struct aya_obj::generated::bpf_attr__bindgen_ty_17
 pub aya_obj::generated::bpf_attr__bindgen_ty_17::type_: aya_obj::generated::__u32
 impl core::clone::Clone for aya_obj::generated::bpf_attr__bindgen_ty_17
@@ -5404,28 +2782,6 @@ impl core::marker::Unpin for aya_obj::generated::bpf_attr__bindgen_ty_17
 impl core::marker::UnsafeUnpin for aya_obj::generated::bpf_attr__bindgen_ty_17
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::generated::bpf_attr__bindgen_ty_17
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::generated::bpf_attr__bindgen_ty_17
-impl<T, U> core::convert::Into<U> for aya_obj::generated::bpf_attr__bindgen_ty_17 where U: core::convert::From<T>
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_17::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_obj::generated::bpf_attr__bindgen_ty_17 where U: core::convert::Into<T>
-pub type aya_obj::generated::bpf_attr__bindgen_ty_17::Error = core::convert::Infallible
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_17::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_obj::generated::bpf_attr__bindgen_ty_17 where U: core::convert::TryFrom<T>
-pub type aya_obj::generated::bpf_attr__bindgen_ty_17::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_17::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya_obj::generated::bpf_attr__bindgen_ty_17 where T: core::clone::Clone
-pub type aya_obj::generated::bpf_attr__bindgen_ty_17::Owned = T
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_17::clone_into(&self, target: &mut T)
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_17::to_owned(&self) -> T
-impl<T> core::any::Any for aya_obj::generated::bpf_attr__bindgen_ty_17 where T: 'static + ?core::marker::Sized
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_17::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_obj::generated::bpf_attr__bindgen_ty_17 where T: ?core::marker::Sized
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_17::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::bpf_attr__bindgen_ty_17 where T: ?core::marker::Sized
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_17::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_attr__bindgen_ty_17 where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::bpf_attr__bindgen_ty_17::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_obj::generated::bpf_attr__bindgen_ty_17
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_17::from(t: T) -> T
 #[repr(C)] pub struct aya_obj::generated::bpf_attr__bindgen_ty_18
 pub aya_obj::generated::bpf_attr__bindgen_ty_18::flags: aya_obj::generated::__u32
 pub aya_obj::generated::bpf_attr__bindgen_ty_18::link_fd: aya_obj::generated::__u32
@@ -5441,28 +2797,6 @@ impl core::marker::Unpin for aya_obj::generated::bpf_attr__bindgen_ty_18
 impl core::marker::UnsafeUnpin for aya_obj::generated::bpf_attr__bindgen_ty_18
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::generated::bpf_attr__bindgen_ty_18
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::generated::bpf_attr__bindgen_ty_18
-impl<T, U> core::convert::Into<U> for aya_obj::generated::bpf_attr__bindgen_ty_18 where U: core::convert::From<T>
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_18::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_obj::generated::bpf_attr__bindgen_ty_18 where U: core::convert::Into<T>
-pub type aya_obj::generated::bpf_attr__bindgen_ty_18::Error = core::convert::Infallible
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_18::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_obj::generated::bpf_attr__bindgen_ty_18 where U: core::convert::TryFrom<T>
-pub type aya_obj::generated::bpf_attr__bindgen_ty_18::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_18::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya_obj::generated::bpf_attr__bindgen_ty_18 where T: core::clone::Clone
-pub type aya_obj::generated::bpf_attr__bindgen_ty_18::Owned = T
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_18::clone_into(&self, target: &mut T)
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_18::to_owned(&self) -> T
-impl<T> core::any::Any for aya_obj::generated::bpf_attr__bindgen_ty_18 where T: 'static + ?core::marker::Sized
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_18::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_obj::generated::bpf_attr__bindgen_ty_18 where T: ?core::marker::Sized
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_18::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::bpf_attr__bindgen_ty_18 where T: ?core::marker::Sized
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_18::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_attr__bindgen_ty_18 where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::bpf_attr__bindgen_ty_18::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_obj::generated::bpf_attr__bindgen_ty_18
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_18::from(t: T) -> T
 #[repr(C)] pub struct aya_obj::generated::bpf_attr__bindgen_ty_19
 pub aya_obj::generated::bpf_attr__bindgen_ty_19::flags: aya_obj::generated::__u32
 pub aya_obj::generated::bpf_attr__bindgen_ty_19::map_fd: aya_obj::generated::__u32
@@ -5479,28 +2813,6 @@ impl core::marker::Unpin for aya_obj::generated::bpf_attr__bindgen_ty_19
 impl core::marker::UnsafeUnpin for aya_obj::generated::bpf_attr__bindgen_ty_19
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::generated::bpf_attr__bindgen_ty_19
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::generated::bpf_attr__bindgen_ty_19
-impl<T, U> core::convert::Into<U> for aya_obj::generated::bpf_attr__bindgen_ty_19 where U: core::convert::From<T>
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_19::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_obj::generated::bpf_attr__bindgen_ty_19 where U: core::convert::Into<T>
-pub type aya_obj::generated::bpf_attr__bindgen_ty_19::Error = core::convert::Infallible
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_19::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_obj::generated::bpf_attr__bindgen_ty_19 where U: core::convert::TryFrom<T>
-pub type aya_obj::generated::bpf_attr__bindgen_ty_19::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_19::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya_obj::generated::bpf_attr__bindgen_ty_19 where T: core::clone::Clone
-pub type aya_obj::generated::bpf_attr__bindgen_ty_19::Owned = T
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_19::clone_into(&self, target: &mut T)
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_19::to_owned(&self) -> T
-impl<T> core::any::Any for aya_obj::generated::bpf_attr__bindgen_ty_19 where T: 'static + ?core::marker::Sized
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_19::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_obj::generated::bpf_attr__bindgen_ty_19 where T: ?core::marker::Sized
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_19::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::bpf_attr__bindgen_ty_19 where T: ?core::marker::Sized
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_19::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_attr__bindgen_ty_19 where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::bpf_attr__bindgen_ty_19::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_obj::generated::bpf_attr__bindgen_ty_19
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_19::from(t: T) -> T
 #[repr(C)] pub struct aya_obj::generated::bpf_attr__bindgen_ty_2
 pub aya_obj::generated::bpf_attr__bindgen_ty_2::__bindgen_anon_1: aya_obj::generated::bpf_attr__bindgen_ty_2__bindgen_ty_1
 pub aya_obj::generated::bpf_attr__bindgen_ty_2::flags: aya_obj::generated::__u64
@@ -5516,28 +2828,6 @@ impl core::marker::Unpin for aya_obj::generated::bpf_attr__bindgen_ty_2
 impl core::marker::UnsafeUnpin for aya_obj::generated::bpf_attr__bindgen_ty_2
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::generated::bpf_attr__bindgen_ty_2
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::generated::bpf_attr__bindgen_ty_2
-impl<T, U> core::convert::Into<U> for aya_obj::generated::bpf_attr__bindgen_ty_2 where U: core::convert::From<T>
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_2::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_obj::generated::bpf_attr__bindgen_ty_2 where U: core::convert::Into<T>
-pub type aya_obj::generated::bpf_attr__bindgen_ty_2::Error = core::convert::Infallible
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_2::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_obj::generated::bpf_attr__bindgen_ty_2 where U: core::convert::TryFrom<T>
-pub type aya_obj::generated::bpf_attr__bindgen_ty_2::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_2::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya_obj::generated::bpf_attr__bindgen_ty_2 where T: core::clone::Clone
-pub type aya_obj::generated::bpf_attr__bindgen_ty_2::Owned = T
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_2::clone_into(&self, target: &mut T)
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_2::to_owned(&self) -> T
-impl<T> core::any::Any for aya_obj::generated::bpf_attr__bindgen_ty_2 where T: 'static + ?core::marker::Sized
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_2::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_obj::generated::bpf_attr__bindgen_ty_2 where T: ?core::marker::Sized
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_2::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::bpf_attr__bindgen_ty_2 where T: ?core::marker::Sized
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_2::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_attr__bindgen_ty_2 where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::bpf_attr__bindgen_ty_2::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_obj::generated::bpf_attr__bindgen_ty_2
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_2::from(t: T) -> T
 #[repr(C)] pub struct aya_obj::generated::bpf_attr__bindgen_ty_20
 pub aya_obj::generated::bpf_attr__bindgen_ty_20::bpffs_fd: aya_obj::generated::__u32
 pub aya_obj::generated::bpf_attr__bindgen_ty_20::flags: aya_obj::generated::__u32
@@ -5553,28 +2843,6 @@ impl core::marker::Unpin for aya_obj::generated::bpf_attr__bindgen_ty_20
 impl core::marker::UnsafeUnpin for aya_obj::generated::bpf_attr__bindgen_ty_20
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::generated::bpf_attr__bindgen_ty_20
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::generated::bpf_attr__bindgen_ty_20
-impl<T, U> core::convert::Into<U> for aya_obj::generated::bpf_attr__bindgen_ty_20 where U: core::convert::From<T>
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_20::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_obj::generated::bpf_attr__bindgen_ty_20 where U: core::convert::Into<T>
-pub type aya_obj::generated::bpf_attr__bindgen_ty_20::Error = core::convert::Infallible
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_20::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_obj::generated::bpf_attr__bindgen_ty_20 where U: core::convert::TryFrom<T>
-pub type aya_obj::generated::bpf_attr__bindgen_ty_20::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_20::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya_obj::generated::bpf_attr__bindgen_ty_20 where T: core::clone::Clone
-pub type aya_obj::generated::bpf_attr__bindgen_ty_20::Owned = T
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_20::clone_into(&self, target: &mut T)
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_20::to_owned(&self) -> T
-impl<T> core::any::Any for aya_obj::generated::bpf_attr__bindgen_ty_20 where T: 'static + ?core::marker::Sized
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_20::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_obj::generated::bpf_attr__bindgen_ty_20 where T: ?core::marker::Sized
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_20::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::bpf_attr__bindgen_ty_20 where T: ?core::marker::Sized
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_20::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_attr__bindgen_ty_20 where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::bpf_attr__bindgen_ty_20::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_obj::generated::bpf_attr__bindgen_ty_20
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_20::from(t: T) -> T
 #[repr(C)] pub struct aya_obj::generated::bpf_attr__bindgen_ty_3
 pub aya_obj::generated::bpf_attr__bindgen_ty_3::count: aya_obj::generated::__u32
 pub aya_obj::generated::bpf_attr__bindgen_ty_3::elem_flags: aya_obj::generated::__u64
@@ -5596,28 +2864,6 @@ impl core::marker::Unpin for aya_obj::generated::bpf_attr__bindgen_ty_3
 impl core::marker::UnsafeUnpin for aya_obj::generated::bpf_attr__bindgen_ty_3
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::generated::bpf_attr__bindgen_ty_3
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::generated::bpf_attr__bindgen_ty_3
-impl<T, U> core::convert::Into<U> for aya_obj::generated::bpf_attr__bindgen_ty_3 where U: core::convert::From<T>
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_3::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_obj::generated::bpf_attr__bindgen_ty_3 where U: core::convert::Into<T>
-pub type aya_obj::generated::bpf_attr__bindgen_ty_3::Error = core::convert::Infallible
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_3::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_obj::generated::bpf_attr__bindgen_ty_3 where U: core::convert::TryFrom<T>
-pub type aya_obj::generated::bpf_attr__bindgen_ty_3::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_3::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya_obj::generated::bpf_attr__bindgen_ty_3 where T: core::clone::Clone
-pub type aya_obj::generated::bpf_attr__bindgen_ty_3::Owned = T
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_3::clone_into(&self, target: &mut T)
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_3::to_owned(&self) -> T
-impl<T> core::any::Any for aya_obj::generated::bpf_attr__bindgen_ty_3 where T: 'static + ?core::marker::Sized
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_3::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_obj::generated::bpf_attr__bindgen_ty_3 where T: ?core::marker::Sized
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_3::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::bpf_attr__bindgen_ty_3 where T: ?core::marker::Sized
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_3::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_attr__bindgen_ty_3 where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::bpf_attr__bindgen_ty_3::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_obj::generated::bpf_attr__bindgen_ty_3
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_3::from(t: T) -> T
 #[repr(C)] pub struct aya_obj::generated::bpf_attr__bindgen_ty_4
 pub aya_obj::generated::bpf_attr__bindgen_ty_4::__bindgen_anon_1: aya_obj::generated::bpf_attr__bindgen_ty_4__bindgen_ty_1
 pub aya_obj::generated::bpf_attr__bindgen_ty_4::attach_btf_id: aya_obj::generated::__u32
@@ -5656,28 +2902,6 @@ impl core::marker::Unpin for aya_obj::generated::bpf_attr__bindgen_ty_4
 impl core::marker::UnsafeUnpin for aya_obj::generated::bpf_attr__bindgen_ty_4
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::generated::bpf_attr__bindgen_ty_4
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::generated::bpf_attr__bindgen_ty_4
-impl<T, U> core::convert::Into<U> for aya_obj::generated::bpf_attr__bindgen_ty_4 where U: core::convert::From<T>
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_4::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_obj::generated::bpf_attr__bindgen_ty_4 where U: core::convert::Into<T>
-pub type aya_obj::generated::bpf_attr__bindgen_ty_4::Error = core::convert::Infallible
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_4::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_obj::generated::bpf_attr__bindgen_ty_4 where U: core::convert::TryFrom<T>
-pub type aya_obj::generated::bpf_attr__bindgen_ty_4::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_4::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya_obj::generated::bpf_attr__bindgen_ty_4 where T: core::clone::Clone
-pub type aya_obj::generated::bpf_attr__bindgen_ty_4::Owned = T
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_4::clone_into(&self, target: &mut T)
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_4::to_owned(&self) -> T
-impl<T> core::any::Any for aya_obj::generated::bpf_attr__bindgen_ty_4 where T: 'static + ?core::marker::Sized
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_4::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_obj::generated::bpf_attr__bindgen_ty_4 where T: ?core::marker::Sized
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_4::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::bpf_attr__bindgen_ty_4 where T: ?core::marker::Sized
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_4::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_attr__bindgen_ty_4 where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::bpf_attr__bindgen_ty_4::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_obj::generated::bpf_attr__bindgen_ty_4
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_4::from(t: T) -> T
 #[repr(C)] pub struct aya_obj::generated::bpf_attr__bindgen_ty_5
 pub aya_obj::generated::bpf_attr__bindgen_ty_5::bpf_fd: aya_obj::generated::__u32
 pub aya_obj::generated::bpf_attr__bindgen_ty_5::file_flags: aya_obj::generated::__u32
@@ -5695,28 +2919,6 @@ impl core::marker::Unpin for aya_obj::generated::bpf_attr__bindgen_ty_5
 impl core::marker::UnsafeUnpin for aya_obj::generated::bpf_attr__bindgen_ty_5
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::generated::bpf_attr__bindgen_ty_5
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::generated::bpf_attr__bindgen_ty_5
-impl<T, U> core::convert::Into<U> for aya_obj::generated::bpf_attr__bindgen_ty_5 where U: core::convert::From<T>
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_5::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_obj::generated::bpf_attr__bindgen_ty_5 where U: core::convert::Into<T>
-pub type aya_obj::generated::bpf_attr__bindgen_ty_5::Error = core::convert::Infallible
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_5::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_obj::generated::bpf_attr__bindgen_ty_5 where U: core::convert::TryFrom<T>
-pub type aya_obj::generated::bpf_attr__bindgen_ty_5::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_5::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya_obj::generated::bpf_attr__bindgen_ty_5 where T: core::clone::Clone
-pub type aya_obj::generated::bpf_attr__bindgen_ty_5::Owned = T
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_5::clone_into(&self, target: &mut T)
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_5::to_owned(&self) -> T
-impl<T> core::any::Any for aya_obj::generated::bpf_attr__bindgen_ty_5 where T: 'static + ?core::marker::Sized
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_5::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_obj::generated::bpf_attr__bindgen_ty_5 where T: ?core::marker::Sized
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_5::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::bpf_attr__bindgen_ty_5 where T: ?core::marker::Sized
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_5::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_attr__bindgen_ty_5 where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::bpf_attr__bindgen_ty_5::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_obj::generated::bpf_attr__bindgen_ty_5
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_5::from(t: T) -> T
 #[repr(C)] pub struct aya_obj::generated::bpf_attr__bindgen_ty_6
 pub aya_obj::generated::bpf_attr__bindgen_ty_6::__bindgen_anon_1: aya_obj::generated::bpf_attr__bindgen_ty_6__bindgen_ty_1
 pub aya_obj::generated::bpf_attr__bindgen_ty_6::__bindgen_anon_2: aya_obj::generated::bpf_attr__bindgen_ty_6__bindgen_ty_2
@@ -5735,28 +2937,6 @@ impl core::marker::Unpin for aya_obj::generated::bpf_attr__bindgen_ty_6
 impl core::marker::UnsafeUnpin for aya_obj::generated::bpf_attr__bindgen_ty_6
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::generated::bpf_attr__bindgen_ty_6
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::generated::bpf_attr__bindgen_ty_6
-impl<T, U> core::convert::Into<U> for aya_obj::generated::bpf_attr__bindgen_ty_6 where U: core::convert::From<T>
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_6::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_obj::generated::bpf_attr__bindgen_ty_6 where U: core::convert::Into<T>
-pub type aya_obj::generated::bpf_attr__bindgen_ty_6::Error = core::convert::Infallible
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_6::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_obj::generated::bpf_attr__bindgen_ty_6 where U: core::convert::TryFrom<T>
-pub type aya_obj::generated::bpf_attr__bindgen_ty_6::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_6::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya_obj::generated::bpf_attr__bindgen_ty_6 where T: core::clone::Clone
-pub type aya_obj::generated::bpf_attr__bindgen_ty_6::Owned = T
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_6::clone_into(&self, target: &mut T)
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_6::to_owned(&self) -> T
-impl<T> core::any::Any for aya_obj::generated::bpf_attr__bindgen_ty_6 where T: 'static + ?core::marker::Sized
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_6::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_obj::generated::bpf_attr__bindgen_ty_6 where T: ?core::marker::Sized
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_6::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::bpf_attr__bindgen_ty_6 where T: ?core::marker::Sized
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_6::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_attr__bindgen_ty_6 where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::bpf_attr__bindgen_ty_6::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_obj::generated::bpf_attr__bindgen_ty_6
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_6::from(t: T) -> T
 #[repr(C)] pub struct aya_obj::generated::bpf_attr__bindgen_ty_7
 pub aya_obj::generated::bpf_attr__bindgen_ty_7::batch_size: aya_obj::generated::__u32
 pub aya_obj::generated::bpf_attr__bindgen_ty_7::cpu: aya_obj::generated::__u32
@@ -5785,28 +2965,6 @@ impl core::marker::Unpin for aya_obj::generated::bpf_attr__bindgen_ty_7
 impl core::marker::UnsafeUnpin for aya_obj::generated::bpf_attr__bindgen_ty_7
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::generated::bpf_attr__bindgen_ty_7
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::generated::bpf_attr__bindgen_ty_7
-impl<T, U> core::convert::Into<U> for aya_obj::generated::bpf_attr__bindgen_ty_7 where U: core::convert::From<T>
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_7::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_obj::generated::bpf_attr__bindgen_ty_7 where U: core::convert::Into<T>
-pub type aya_obj::generated::bpf_attr__bindgen_ty_7::Error = core::convert::Infallible
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_7::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_obj::generated::bpf_attr__bindgen_ty_7 where U: core::convert::TryFrom<T>
-pub type aya_obj::generated::bpf_attr__bindgen_ty_7::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_7::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya_obj::generated::bpf_attr__bindgen_ty_7 where T: core::clone::Clone
-pub type aya_obj::generated::bpf_attr__bindgen_ty_7::Owned = T
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_7::clone_into(&self, target: &mut T)
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_7::to_owned(&self) -> T
-impl<T> core::any::Any for aya_obj::generated::bpf_attr__bindgen_ty_7 where T: 'static + ?core::marker::Sized
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_7::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_obj::generated::bpf_attr__bindgen_ty_7 where T: ?core::marker::Sized
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_7::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::bpf_attr__bindgen_ty_7 where T: ?core::marker::Sized
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_7::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_attr__bindgen_ty_7 where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::bpf_attr__bindgen_ty_7::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_obj::generated::bpf_attr__bindgen_ty_7
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_7::from(t: T) -> T
 #[repr(C)] pub struct aya_obj::generated::bpf_attr__bindgen_ty_8
 pub aya_obj::generated::bpf_attr__bindgen_ty_8::__bindgen_anon_1: aya_obj::generated::bpf_attr__bindgen_ty_8__bindgen_ty_1
 pub aya_obj::generated::bpf_attr__bindgen_ty_8::next_id: aya_obj::generated::__u32
@@ -5821,28 +2979,6 @@ impl core::marker::Unpin for aya_obj::generated::bpf_attr__bindgen_ty_8
 impl core::marker::UnsafeUnpin for aya_obj::generated::bpf_attr__bindgen_ty_8
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::generated::bpf_attr__bindgen_ty_8
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::generated::bpf_attr__bindgen_ty_8
-impl<T, U> core::convert::Into<U> for aya_obj::generated::bpf_attr__bindgen_ty_8 where U: core::convert::From<T>
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_8::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_obj::generated::bpf_attr__bindgen_ty_8 where U: core::convert::Into<T>
-pub type aya_obj::generated::bpf_attr__bindgen_ty_8::Error = core::convert::Infallible
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_8::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_obj::generated::bpf_attr__bindgen_ty_8 where U: core::convert::TryFrom<T>
-pub type aya_obj::generated::bpf_attr__bindgen_ty_8::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_8::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya_obj::generated::bpf_attr__bindgen_ty_8 where T: core::clone::Clone
-pub type aya_obj::generated::bpf_attr__bindgen_ty_8::Owned = T
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_8::clone_into(&self, target: &mut T)
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_8::to_owned(&self) -> T
-impl<T> core::any::Any for aya_obj::generated::bpf_attr__bindgen_ty_8 where T: 'static + ?core::marker::Sized
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_8::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_obj::generated::bpf_attr__bindgen_ty_8 where T: ?core::marker::Sized
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_8::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::bpf_attr__bindgen_ty_8 where T: ?core::marker::Sized
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_8::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_attr__bindgen_ty_8 where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::bpf_attr__bindgen_ty_8::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_obj::generated::bpf_attr__bindgen_ty_8
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_8::from(t: T) -> T
 #[repr(C)] pub struct aya_obj::generated::bpf_attr__bindgen_ty_9
 pub aya_obj::generated::bpf_attr__bindgen_ty_9::bpf_fd: aya_obj::generated::__u32
 pub aya_obj::generated::bpf_attr__bindgen_ty_9::info: aya_obj::generated::__u64
@@ -5859,28 +2995,6 @@ impl core::marker::Unpin for aya_obj::generated::bpf_attr__bindgen_ty_9
 impl core::marker::UnsafeUnpin for aya_obj::generated::bpf_attr__bindgen_ty_9
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::generated::bpf_attr__bindgen_ty_9
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::generated::bpf_attr__bindgen_ty_9
-impl<T, U> core::convert::Into<U> for aya_obj::generated::bpf_attr__bindgen_ty_9 where U: core::convert::From<T>
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_9::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_obj::generated::bpf_attr__bindgen_ty_9 where U: core::convert::Into<T>
-pub type aya_obj::generated::bpf_attr__bindgen_ty_9::Error = core::convert::Infallible
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_9::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_obj::generated::bpf_attr__bindgen_ty_9 where U: core::convert::TryFrom<T>
-pub type aya_obj::generated::bpf_attr__bindgen_ty_9::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_9::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya_obj::generated::bpf_attr__bindgen_ty_9 where T: core::clone::Clone
-pub type aya_obj::generated::bpf_attr__bindgen_ty_9::Owned = T
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_9::clone_into(&self, target: &mut T)
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_9::to_owned(&self) -> T
-impl<T> core::any::Any for aya_obj::generated::bpf_attr__bindgen_ty_9 where T: 'static + ?core::marker::Sized
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_9::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_obj::generated::bpf_attr__bindgen_ty_9 where T: ?core::marker::Sized
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_9::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::bpf_attr__bindgen_ty_9 where T: ?core::marker::Sized
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_9::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_attr__bindgen_ty_9 where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::bpf_attr__bindgen_ty_9::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_obj::generated::bpf_attr__bindgen_ty_9
-pub fn aya_obj::generated::bpf_attr__bindgen_ty_9::from(t: T) -> T
 #[repr(C)] pub struct aya_obj::generated::bpf_btf_info
 pub aya_obj::generated::bpf_btf_info::btf: aya_obj::generated::__u64
 pub aya_obj::generated::bpf_btf_info::btf_size: aya_obj::generated::__u32
@@ -5900,28 +3014,6 @@ impl core::marker::Unpin for aya_obj::generated::bpf_btf_info
 impl core::marker::UnsafeUnpin for aya_obj::generated::bpf_btf_info
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::generated::bpf_btf_info
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::generated::bpf_btf_info
-impl<T, U> core::convert::Into<U> for aya_obj::generated::bpf_btf_info where U: core::convert::From<T>
-pub fn aya_obj::generated::bpf_btf_info::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_obj::generated::bpf_btf_info where U: core::convert::Into<T>
-pub type aya_obj::generated::bpf_btf_info::Error = core::convert::Infallible
-pub fn aya_obj::generated::bpf_btf_info::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_obj::generated::bpf_btf_info where U: core::convert::TryFrom<T>
-pub type aya_obj::generated::bpf_btf_info::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_obj::generated::bpf_btf_info::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya_obj::generated::bpf_btf_info where T: core::clone::Clone
-pub type aya_obj::generated::bpf_btf_info::Owned = T
-pub fn aya_obj::generated::bpf_btf_info::clone_into(&self, target: &mut T)
-pub fn aya_obj::generated::bpf_btf_info::to_owned(&self) -> T
-impl<T> core::any::Any for aya_obj::generated::bpf_btf_info where T: 'static + ?core::marker::Sized
-pub fn aya_obj::generated::bpf_btf_info::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_obj::generated::bpf_btf_info where T: ?core::marker::Sized
-pub fn aya_obj::generated::bpf_btf_info::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::bpf_btf_info where T: ?core::marker::Sized
-pub fn aya_obj::generated::bpf_btf_info::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_btf_info where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::bpf_btf_info::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_obj::generated::bpf_btf_info
-pub fn aya_obj::generated::bpf_btf_info::from(t: T) -> T
 #[repr(C)] pub struct aya_obj::generated::bpf_core_relo
 pub aya_obj::generated::bpf_core_relo::access_str_off: core::ffi::primitives::c_uint
 pub aya_obj::generated::bpf_core_relo::insn_off: core::ffi::primitives::c_uint
@@ -5939,28 +3031,6 @@ impl core::marker::Unpin for aya_obj::generated::bpf_core_relo
 impl core::marker::UnsafeUnpin for aya_obj::generated::bpf_core_relo
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::generated::bpf_core_relo
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::generated::bpf_core_relo
-impl<T, U> core::convert::Into<U> for aya_obj::generated::bpf_core_relo where U: core::convert::From<T>
-pub fn aya_obj::generated::bpf_core_relo::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_obj::generated::bpf_core_relo where U: core::convert::Into<T>
-pub type aya_obj::generated::bpf_core_relo::Error = core::convert::Infallible
-pub fn aya_obj::generated::bpf_core_relo::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_obj::generated::bpf_core_relo where U: core::convert::TryFrom<T>
-pub type aya_obj::generated::bpf_core_relo::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_obj::generated::bpf_core_relo::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya_obj::generated::bpf_core_relo where T: core::clone::Clone
-pub type aya_obj::generated::bpf_core_relo::Owned = T
-pub fn aya_obj::generated::bpf_core_relo::clone_into(&self, target: &mut T)
-pub fn aya_obj::generated::bpf_core_relo::to_owned(&self) -> T
-impl<T> core::any::Any for aya_obj::generated::bpf_core_relo where T: 'static + ?core::marker::Sized
-pub fn aya_obj::generated::bpf_core_relo::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_obj::generated::bpf_core_relo where T: ?core::marker::Sized
-pub fn aya_obj::generated::bpf_core_relo::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::bpf_core_relo where T: ?core::marker::Sized
-pub fn aya_obj::generated::bpf_core_relo::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_core_relo where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::bpf_core_relo::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_obj::generated::bpf_core_relo
-pub fn aya_obj::generated::bpf_core_relo::from(t: T) -> T
 #[repr(C)] pub struct aya_obj::generated::bpf_cpumap_val
 pub aya_obj::generated::bpf_cpumap_val::bpf_prog: aya_obj::generated::bpf_cpumap_val__bindgen_ty_1
 pub aya_obj::generated::bpf_cpumap_val::qsize: aya_obj::generated::__u32
@@ -5974,28 +3044,6 @@ impl core::marker::Unpin for aya_obj::generated::bpf_cpumap_val
 impl core::marker::UnsafeUnpin for aya_obj::generated::bpf_cpumap_val
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::generated::bpf_cpumap_val
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::generated::bpf_cpumap_val
-impl<T, U> core::convert::Into<U> for aya_obj::generated::bpf_cpumap_val where U: core::convert::From<T>
-pub fn aya_obj::generated::bpf_cpumap_val::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_obj::generated::bpf_cpumap_val where U: core::convert::Into<T>
-pub type aya_obj::generated::bpf_cpumap_val::Error = core::convert::Infallible
-pub fn aya_obj::generated::bpf_cpumap_val::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_obj::generated::bpf_cpumap_val where U: core::convert::TryFrom<T>
-pub type aya_obj::generated::bpf_cpumap_val::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_obj::generated::bpf_cpumap_val::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya_obj::generated::bpf_cpumap_val where T: core::clone::Clone
-pub type aya_obj::generated::bpf_cpumap_val::Owned = T
-pub fn aya_obj::generated::bpf_cpumap_val::clone_into(&self, target: &mut T)
-pub fn aya_obj::generated::bpf_cpumap_val::to_owned(&self) -> T
-impl<T> core::any::Any for aya_obj::generated::bpf_cpumap_val where T: 'static + ?core::marker::Sized
-pub fn aya_obj::generated::bpf_cpumap_val::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_obj::generated::bpf_cpumap_val where T: ?core::marker::Sized
-pub fn aya_obj::generated::bpf_cpumap_val::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::bpf_cpumap_val where T: ?core::marker::Sized
-pub fn aya_obj::generated::bpf_cpumap_val::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_cpumap_val where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::bpf_cpumap_val::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_obj::generated::bpf_cpumap_val
-pub fn aya_obj::generated::bpf_cpumap_val::from(t: T) -> T
 #[repr(C)] pub struct aya_obj::generated::bpf_devmap_val
 pub aya_obj::generated::bpf_devmap_val::bpf_prog: aya_obj::generated::bpf_devmap_val__bindgen_ty_1
 pub aya_obj::generated::bpf_devmap_val::ifindex: aya_obj::generated::__u32
@@ -6009,28 +3057,6 @@ impl core::marker::Unpin for aya_obj::generated::bpf_devmap_val
 impl core::marker::UnsafeUnpin for aya_obj::generated::bpf_devmap_val
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::generated::bpf_devmap_val
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::generated::bpf_devmap_val
-impl<T, U> core::convert::Into<U> for aya_obj::generated::bpf_devmap_val where U: core::convert::From<T>
-pub fn aya_obj::generated::bpf_devmap_val::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_obj::generated::bpf_devmap_val where U: core::convert::Into<T>
-pub type aya_obj::generated::bpf_devmap_val::Error = core::convert::Infallible
-pub fn aya_obj::generated::bpf_devmap_val::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_obj::generated::bpf_devmap_val where U: core::convert::TryFrom<T>
-pub type aya_obj::generated::bpf_devmap_val::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_obj::generated::bpf_devmap_val::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya_obj::generated::bpf_devmap_val where T: core::clone::Clone
-pub type aya_obj::generated::bpf_devmap_val::Owned = T
-pub fn aya_obj::generated::bpf_devmap_val::clone_into(&self, target: &mut T)
-pub fn aya_obj::generated::bpf_devmap_val::to_owned(&self) -> T
-impl<T> core::any::Any for aya_obj::generated::bpf_devmap_val where T: 'static + ?core::marker::Sized
-pub fn aya_obj::generated::bpf_devmap_val::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_obj::generated::bpf_devmap_val where T: ?core::marker::Sized
-pub fn aya_obj::generated::bpf_devmap_val::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::bpf_devmap_val where T: ?core::marker::Sized
-pub fn aya_obj::generated::bpf_devmap_val::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_devmap_val where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::bpf_devmap_val::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_obj::generated::bpf_devmap_val
-pub fn aya_obj::generated::bpf_devmap_val::from(t: T) -> T
 #[repr(C)] pub struct aya_obj::generated::bpf_func_info
 pub aya_obj::generated::bpf_func_info::insn_off: aya_obj::generated::__u32
 pub aya_obj::generated::bpf_func_info::type_id: aya_obj::generated::__u32
@@ -6046,28 +3072,6 @@ impl core::marker::Unpin for aya_obj::generated::bpf_func_info
 impl core::marker::UnsafeUnpin for aya_obj::generated::bpf_func_info
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::generated::bpf_func_info
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::generated::bpf_func_info
-impl<T, U> core::convert::Into<U> for aya_obj::generated::bpf_func_info where U: core::convert::From<T>
-pub fn aya_obj::generated::bpf_func_info::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_obj::generated::bpf_func_info where U: core::convert::Into<T>
-pub type aya_obj::generated::bpf_func_info::Error = core::convert::Infallible
-pub fn aya_obj::generated::bpf_func_info::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_obj::generated::bpf_func_info where U: core::convert::TryFrom<T>
-pub type aya_obj::generated::bpf_func_info::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_obj::generated::bpf_func_info::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya_obj::generated::bpf_func_info where T: core::clone::Clone
-pub type aya_obj::generated::bpf_func_info::Owned = T
-pub fn aya_obj::generated::bpf_func_info::clone_into(&self, target: &mut T)
-pub fn aya_obj::generated::bpf_func_info::to_owned(&self) -> T
-impl<T> core::any::Any for aya_obj::generated::bpf_func_info where T: 'static + ?core::marker::Sized
-pub fn aya_obj::generated::bpf_func_info::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_obj::generated::bpf_func_info where T: ?core::marker::Sized
-pub fn aya_obj::generated::bpf_func_info::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::bpf_func_info where T: ?core::marker::Sized
-pub fn aya_obj::generated::bpf_func_info::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_func_info where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::bpf_func_info::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_obj::generated::bpf_func_info
-pub fn aya_obj::generated::bpf_func_info::from(t: T) -> T
 #[repr(C)] pub struct aya_obj::generated::bpf_insn
 pub aya_obj::generated::bpf_insn::_bitfield_1: aya_obj::generated::__BindgenBitfieldUnit<[u8; 1]>
 pub aya_obj::generated::bpf_insn::_bitfield_align_1: [u8; 0]
@@ -6096,28 +3100,6 @@ impl core::marker::Unpin for aya_obj::generated::bpf_insn
 impl core::marker::UnsafeUnpin for aya_obj::generated::bpf_insn
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::generated::bpf_insn
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::generated::bpf_insn
-impl<T, U> core::convert::Into<U> for aya_obj::generated::bpf_insn where U: core::convert::From<T>
-pub fn aya_obj::generated::bpf_insn::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_obj::generated::bpf_insn where U: core::convert::Into<T>
-pub type aya_obj::generated::bpf_insn::Error = core::convert::Infallible
-pub fn aya_obj::generated::bpf_insn::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_obj::generated::bpf_insn where U: core::convert::TryFrom<T>
-pub type aya_obj::generated::bpf_insn::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_obj::generated::bpf_insn::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya_obj::generated::bpf_insn where T: core::clone::Clone
-pub type aya_obj::generated::bpf_insn::Owned = T
-pub fn aya_obj::generated::bpf_insn::clone_into(&self, target: &mut T)
-pub fn aya_obj::generated::bpf_insn::to_owned(&self) -> T
-impl<T> core::any::Any for aya_obj::generated::bpf_insn where T: 'static + ?core::marker::Sized
-pub fn aya_obj::generated::bpf_insn::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_obj::generated::bpf_insn where T: ?core::marker::Sized
-pub fn aya_obj::generated::bpf_insn::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::bpf_insn where T: ?core::marker::Sized
-pub fn aya_obj::generated::bpf_insn::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_insn where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::bpf_insn::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_obj::generated::bpf_insn
-pub fn aya_obj::generated::bpf_insn::from(t: T) -> T
 #[repr(C)] pub struct aya_obj::generated::bpf_line_info
 pub aya_obj::generated::bpf_line_info::file_name_off: aya_obj::generated::__u32
 pub aya_obj::generated::bpf_line_info::insn_off: aya_obj::generated::__u32
@@ -6135,28 +3117,6 @@ impl core::marker::Unpin for aya_obj::generated::bpf_line_info
 impl core::marker::UnsafeUnpin for aya_obj::generated::bpf_line_info
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::generated::bpf_line_info
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::generated::bpf_line_info
-impl<T, U> core::convert::Into<U> for aya_obj::generated::bpf_line_info where U: core::convert::From<T>
-pub fn aya_obj::generated::bpf_line_info::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_obj::generated::bpf_line_info where U: core::convert::Into<T>
-pub type aya_obj::generated::bpf_line_info::Error = core::convert::Infallible
-pub fn aya_obj::generated::bpf_line_info::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_obj::generated::bpf_line_info where U: core::convert::TryFrom<T>
-pub type aya_obj::generated::bpf_line_info::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_obj::generated::bpf_line_info::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya_obj::generated::bpf_line_info where T: core::clone::Clone
-pub type aya_obj::generated::bpf_line_info::Owned = T
-pub fn aya_obj::generated::bpf_line_info::clone_into(&self, target: &mut T)
-pub fn aya_obj::generated::bpf_line_info::to_owned(&self) -> T
-impl<T> core::any::Any for aya_obj::generated::bpf_line_info where T: 'static + ?core::marker::Sized
-pub fn aya_obj::generated::bpf_line_info::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_obj::generated::bpf_line_info where T: ?core::marker::Sized
-pub fn aya_obj::generated::bpf_line_info::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::bpf_line_info where T: ?core::marker::Sized
-pub fn aya_obj::generated::bpf_line_info::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_line_info where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::bpf_line_info::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_obj::generated::bpf_line_info
-pub fn aya_obj::generated::bpf_line_info::from(t: T) -> T
 #[repr(C)] pub struct aya_obj::generated::bpf_link_info
 pub aya_obj::generated::bpf_link_info::__bindgen_anon_1: aya_obj::generated::bpf_link_info__bindgen_ty_1
 pub aya_obj::generated::bpf_link_info::id: aya_obj::generated::__u32
@@ -6172,28 +3132,6 @@ impl core::marker::Unpin for aya_obj::generated::bpf_link_info
 impl core::marker::UnsafeUnpin for aya_obj::generated::bpf_link_info
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::generated::bpf_link_info
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::generated::bpf_link_info
-impl<T, U> core::convert::Into<U> for aya_obj::generated::bpf_link_info where U: core::convert::From<T>
-pub fn aya_obj::generated::bpf_link_info::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_obj::generated::bpf_link_info where U: core::convert::Into<T>
-pub type aya_obj::generated::bpf_link_info::Error = core::convert::Infallible
-pub fn aya_obj::generated::bpf_link_info::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_obj::generated::bpf_link_info where U: core::convert::TryFrom<T>
-pub type aya_obj::generated::bpf_link_info::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_obj::generated::bpf_link_info::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya_obj::generated::bpf_link_info where T: core::clone::Clone
-pub type aya_obj::generated::bpf_link_info::Owned = T
-pub fn aya_obj::generated::bpf_link_info::clone_into(&self, target: &mut T)
-pub fn aya_obj::generated::bpf_link_info::to_owned(&self) -> T
-impl<T> core::any::Any for aya_obj::generated::bpf_link_info where T: 'static + ?core::marker::Sized
-pub fn aya_obj::generated::bpf_link_info::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_obj::generated::bpf_link_info where T: ?core::marker::Sized
-pub fn aya_obj::generated::bpf_link_info::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::bpf_link_info where T: ?core::marker::Sized
-pub fn aya_obj::generated::bpf_link_info::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_link_info where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::bpf_link_info::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_obj::generated::bpf_link_info
-pub fn aya_obj::generated::bpf_link_info::from(t: T) -> T
 #[repr(C)] pub struct aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_1
 pub aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_1::tp_name: aya_obj::generated::__u64
 pub aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_1::tp_name_len: aya_obj::generated::__u32
@@ -6209,28 +3147,6 @@ impl core::marker::Unpin for aya_obj::generated::bpf_link_info__bindgen_ty_1__bi
 impl core::marker::UnsafeUnpin for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_1
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_1
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_1
-impl<T, U> core::convert::Into<U> for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_1 where U: core::convert::From<T>
-pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_1::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_1 where U: core::convert::Into<T>
-pub type aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_1::Error = core::convert::Infallible
-pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_1::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_1 where U: core::convert::TryFrom<T>
-pub type aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_1::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_1::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_1 where T: core::clone::Clone
-pub type aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_1::Owned = T
-pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_1::clone_into(&self, target: &mut T)
-pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_1::to_owned(&self) -> T
-impl<T> core::any::Any for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_1 where T: 'static + ?core::marker::Sized
-pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_1::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_1 where T: ?core::marker::Sized
-pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_1::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_1 where T: ?core::marker::Sized
-pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_1::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_1 where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_1::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_1
-pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_1::from(t: T) -> T
 #[repr(C)] pub struct aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_10
 pub aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_10::cookies: aya_obj::generated::__u64
 pub aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_10::count: aya_obj::generated::__u32
@@ -6252,28 +3168,6 @@ impl core::marker::Unpin for aya_obj::generated::bpf_link_info__bindgen_ty_1__bi
 impl core::marker::UnsafeUnpin for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_10
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_10
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_10
-impl<T, U> core::convert::Into<U> for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_10 where U: core::convert::From<T>
-pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_10::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_10 where U: core::convert::Into<T>
-pub type aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_10::Error = core::convert::Infallible
-pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_10::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_10 where U: core::convert::TryFrom<T>
-pub type aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_10::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_10::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_10 where T: core::clone::Clone
-pub type aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_10::Owned = T
-pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_10::clone_into(&self, target: &mut T)
-pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_10::to_owned(&self) -> T
-impl<T> core::any::Any for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_10 where T: 'static + ?core::marker::Sized
-pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_10::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_10 where T: ?core::marker::Sized
-pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_10::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_10 where T: ?core::marker::Sized
-pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_10::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_10 where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_10::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_10
-pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_10::from(t: T) -> T
 #[repr(C)] pub struct aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11
 pub aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11::__bindgen_anon_1: aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1
 pub aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11::_bitfield_1: aya_obj::generated::__BindgenBitfieldUnit<[u8; 4]>
@@ -6291,28 +3185,6 @@ impl core::marker::Unpin for aya_obj::generated::bpf_link_info__bindgen_ty_1__bi
 impl core::marker::UnsafeUnpin for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11
-impl<T, U> core::convert::Into<U> for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11 where U: core::convert::From<T>
-pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11 where U: core::convert::Into<T>
-pub type aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11::Error = core::convert::Infallible
-pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11 where U: core::convert::TryFrom<T>
-pub type aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11 where T: core::clone::Clone
-pub type aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11::Owned = T
-pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11::clone_into(&self, target: &mut T)
-pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11::to_owned(&self) -> T
-impl<T> core::any::Any for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11 where T: 'static + ?core::marker::Sized
-pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11 where T: ?core::marker::Sized
-pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11 where T: ?core::marker::Sized
-pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11 where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11
-pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11::from(t: T) -> T
 #[repr(C)] pub struct aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_1
 pub aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_1::cookie: aya_obj::generated::__u64
 pub aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_1::file_name: aya_obj::generated::__u64
@@ -6330,28 +3202,6 @@ impl core::marker::Unpin for aya_obj::generated::bpf_link_info__bindgen_ty_1__bi
 impl core::marker::UnsafeUnpin for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_1
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_1
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_1
-impl<T, U> core::convert::Into<U> for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_1 where U: core::convert::From<T>
-pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_1::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_1 where U: core::convert::Into<T>
-pub type aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_1::Error = core::convert::Infallible
-pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_1::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_1 where U: core::convert::TryFrom<T>
-pub type aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_1::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_1::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_1 where T: core::clone::Clone
-pub type aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_1::Owned = T
-pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_1::clone_into(&self, target: &mut T)
-pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_1::to_owned(&self) -> T
-impl<T> core::any::Any for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_1 where T: 'static + ?core::marker::Sized
-pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_1::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_1 where T: ?core::marker::Sized
-pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_1::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_1 where T: ?core::marker::Sized
-pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_1::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_1 where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_1::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_1
-pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_1::from(t: T) -> T
 #[repr(C)] pub struct aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_2
 pub aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_2::addr: aya_obj::generated::__u64
 pub aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_2::cookie: aya_obj::generated::__u64
@@ -6371,28 +3221,6 @@ impl core::marker::Unpin for aya_obj::generated::bpf_link_info__bindgen_ty_1__bi
 impl core::marker::UnsafeUnpin for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_2
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_2
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_2
-impl<T, U> core::convert::Into<U> for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_2 where U: core::convert::From<T>
-pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_2::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_2 where U: core::convert::Into<T>
-pub type aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_2::Error = core::convert::Infallible
-pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_2::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_2 where U: core::convert::TryFrom<T>
-pub type aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_2::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_2::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_2 where T: core::clone::Clone
-pub type aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_2::Owned = T
-pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_2::clone_into(&self, target: &mut T)
-pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_2::to_owned(&self) -> T
-impl<T> core::any::Any for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_2 where T: 'static + ?core::marker::Sized
-pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_2::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_2 where T: ?core::marker::Sized
-pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_2::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_2 where T: ?core::marker::Sized
-pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_2::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_2 where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_2::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_2
-pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_2::from(t: T) -> T
 #[repr(C)] pub struct aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_3
 pub aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_3::_bitfield_1: aya_obj::generated::__BindgenBitfieldUnit<[u8; 4]>
 pub aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_3::_bitfield_align_1: [u8; 0]
@@ -6413,28 +3241,6 @@ impl core::marker::Unpin for aya_obj::generated::bpf_link_info__bindgen_ty_1__bi
 impl core::marker::UnsafeUnpin for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_3
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_3
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_3
-impl<T, U> core::convert::Into<U> for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_3 where U: core::convert::From<T>
-pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_3::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_3 where U: core::convert::Into<T>
-pub type aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_3::Error = core::convert::Infallible
-pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_3::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_3 where U: core::convert::TryFrom<T>
-pub type aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_3::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_3::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_3 where T: core::clone::Clone
-pub type aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_3::Owned = T
-pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_3::clone_into(&self, target: &mut T)
-pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_3::to_owned(&self) -> T
-impl<T> core::any::Any for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_3 where T: 'static + ?core::marker::Sized
-pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_3::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_3 where T: ?core::marker::Sized
-pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_3::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_3 where T: ?core::marker::Sized
-pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_3::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_3 where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_3::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_3
-pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_3::from(t: T) -> T
 #[repr(C)] pub struct aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_4
 pub aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_4::_bitfield_1: aya_obj::generated::__BindgenBitfieldUnit<[u8; 4]>
 pub aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_4::_bitfield_align_1: [u8; 0]
@@ -6455,28 +3261,6 @@ impl core::marker::Unpin for aya_obj::generated::bpf_link_info__bindgen_ty_1__bi
 impl core::marker::UnsafeUnpin for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_4
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_4
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_4
-impl<T, U> core::convert::Into<U> for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_4 where U: core::convert::From<T>
-pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_4::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_4 where U: core::convert::Into<T>
-pub type aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_4::Error = core::convert::Infallible
-pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_4::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_4 where U: core::convert::TryFrom<T>
-pub type aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_4::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_4::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_4 where T: core::clone::Clone
-pub type aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_4::Owned = T
-pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_4::clone_into(&self, target: &mut T)
-pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_4::to_owned(&self) -> T
-impl<T> core::any::Any for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_4 where T: 'static + ?core::marker::Sized
-pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_4::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_4 where T: ?core::marker::Sized
-pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_4::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_4 where T: ?core::marker::Sized
-pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_4::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_4 where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_4::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_4
-pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_11__bindgen_ty_1__bindgen_ty_4::from(t: T) -> T
 #[repr(C)] pub struct aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_12
 pub aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_12::attach_type: aya_obj::generated::__u32
 pub aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_12::ifindex: aya_obj::generated::__u32
@@ -6492,28 +3276,6 @@ impl core::marker::Unpin for aya_obj::generated::bpf_link_info__bindgen_ty_1__bi
 impl core::marker::UnsafeUnpin for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_12
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_12
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_12
-impl<T, U> core::convert::Into<U> for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_12 where U: core::convert::From<T>
-pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_12::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_12 where U: core::convert::Into<T>
-pub type aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_12::Error = core::convert::Infallible
-pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_12::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_12 where U: core::convert::TryFrom<T>
-pub type aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_12::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_12::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_12 where T: core::clone::Clone
-pub type aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_12::Owned = T
-pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_12::clone_into(&self, target: &mut T)
-pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_12::to_owned(&self) -> T
-impl<T> core::any::Any for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_12 where T: 'static + ?core::marker::Sized
-pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_12::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_12 where T: ?core::marker::Sized
-pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_12::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_12 where T: ?core::marker::Sized
-pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_12::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_12 where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_12::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_12
-pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_12::from(t: T) -> T
 #[repr(C)] pub struct aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_13
 pub aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_13::attach_type: aya_obj::generated::__u32
 pub aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_13::ifindex: aya_obj::generated::__u32
@@ -6529,28 +3291,6 @@ impl core::marker::Unpin for aya_obj::generated::bpf_link_info__bindgen_ty_1__bi
 impl core::marker::UnsafeUnpin for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_13
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_13
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_13
-impl<T, U> core::convert::Into<U> for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_13 where U: core::convert::From<T>
-pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_13::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_13 where U: core::convert::Into<T>
-pub type aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_13::Error = core::convert::Infallible
-pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_13::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_13 where U: core::convert::TryFrom<T>
-pub type aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_13::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_13::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_13 where T: core::clone::Clone
-pub type aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_13::Owned = T
-pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_13::clone_into(&self, target: &mut T)
-pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_13::to_owned(&self) -> T
-impl<T> core::any::Any for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_13 where T: 'static + ?core::marker::Sized
-pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_13::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_13 where T: ?core::marker::Sized
-pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_13::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_13 where T: ?core::marker::Sized
-pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_13::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_13 where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_13::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_13
-pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_13::from(t: T) -> T
 #[repr(C)] pub struct aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_2
 pub aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_2::attach_type: aya_obj::generated::__u32
 pub aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_2::target_btf_id: aya_obj::generated::__u32
@@ -6567,28 +3307,6 @@ impl core::marker::Unpin for aya_obj::generated::bpf_link_info__bindgen_ty_1__bi
 impl core::marker::UnsafeUnpin for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_2
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_2
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_2
-impl<T, U> core::convert::Into<U> for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_2 where U: core::convert::From<T>
-pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_2::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_2 where U: core::convert::Into<T>
-pub type aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_2::Error = core::convert::Infallible
-pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_2::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_2 where U: core::convert::TryFrom<T>
-pub type aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_2::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_2::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_2 where T: core::clone::Clone
-pub type aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_2::Owned = T
-pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_2::clone_into(&self, target: &mut T)
-pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_2::to_owned(&self) -> T
-impl<T> core::any::Any for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_2 where T: 'static + ?core::marker::Sized
-pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_2::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_2 where T: ?core::marker::Sized
-pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_2::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_2 where T: ?core::marker::Sized
-pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_2::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_2 where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_2::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_2
-pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_2::from(t: T) -> T
 #[repr(C)] pub struct aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_3
 pub aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_3::attach_type: aya_obj::generated::__u32
 pub aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_3::cgroup_id: aya_obj::generated::__u64
@@ -6604,28 +3322,6 @@ impl core::marker::Unpin for aya_obj::generated::bpf_link_info__bindgen_ty_1__bi
 impl core::marker::UnsafeUnpin for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_3
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_3
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_3
-impl<T, U> core::convert::Into<U> for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_3 where U: core::convert::From<T>
-pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_3::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_3 where U: core::convert::Into<T>
-pub type aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_3::Error = core::convert::Infallible
-pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_3::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_3 where U: core::convert::TryFrom<T>
-pub type aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_3::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_3::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_3 where T: core::clone::Clone
-pub type aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_3::Owned = T
-pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_3::clone_into(&self, target: &mut T)
-pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_3::to_owned(&self) -> T
-impl<T> core::any::Any for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_3 where T: 'static + ?core::marker::Sized
-pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_3::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_3 where T: ?core::marker::Sized
-pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_3::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_3 where T: ?core::marker::Sized
-pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_3::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_3 where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_3::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_3
-pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_3::from(t: T) -> T
 #[repr(C)] pub struct aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4
 pub aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4::__bindgen_anon_1: aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_1
 pub aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4::__bindgen_anon_2: aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2
@@ -6641,28 +3337,6 @@ impl core::marker::Unpin for aya_obj::generated::bpf_link_info__bindgen_ty_1__bi
 impl core::marker::UnsafeUnpin for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4
-impl<T, U> core::convert::Into<U> for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4 where U: core::convert::From<T>
-pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4 where U: core::convert::Into<T>
-pub type aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4::Error = core::convert::Infallible
-pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4 where U: core::convert::TryFrom<T>
-pub type aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4 where T: core::clone::Clone
-pub type aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4::Owned = T
-pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4::clone_into(&self, target: &mut T)
-pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4::to_owned(&self) -> T
-impl<T> core::any::Any for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4 where T: 'static + ?core::marker::Sized
-pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4 where T: ?core::marker::Sized
-pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4 where T: ?core::marker::Sized
-pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4 where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4
-pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4::from(t: T) -> T
 #[repr(C)] pub struct aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_1__bindgen_ty_1
 pub aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_1__bindgen_ty_1::map_id: aya_obj::generated::__u32
 impl core::clone::Clone for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_1__bindgen_ty_1
@@ -6677,28 +3351,6 @@ impl core::marker::Unpin for aya_obj::generated::bpf_link_info__bindgen_ty_1__bi
 impl core::marker::UnsafeUnpin for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_1__bindgen_ty_1
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_1__bindgen_ty_1
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_1__bindgen_ty_1
-impl<T, U> core::convert::Into<U> for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_1__bindgen_ty_1 where U: core::convert::From<T>
-pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_1__bindgen_ty_1::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_1__bindgen_ty_1 where U: core::convert::Into<T>
-pub type aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_1__bindgen_ty_1::Error = core::convert::Infallible
-pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_1__bindgen_ty_1::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_1__bindgen_ty_1 where U: core::convert::TryFrom<T>
-pub type aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_1__bindgen_ty_1::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_1__bindgen_ty_1::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_1__bindgen_ty_1 where T: core::clone::Clone
-pub type aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_1__bindgen_ty_1::Owned = T
-pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_1__bindgen_ty_1::clone_into(&self, target: &mut T)
-pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_1__bindgen_ty_1::to_owned(&self) -> T
-impl<T> core::any::Any for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_1__bindgen_ty_1 where T: 'static + ?core::marker::Sized
-pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_1__bindgen_ty_1::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_1__bindgen_ty_1 where T: ?core::marker::Sized
-pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_1__bindgen_ty_1::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_1__bindgen_ty_1 where T: ?core::marker::Sized
-pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_1__bindgen_ty_1::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_1__bindgen_ty_1 where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_1__bindgen_ty_1::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_1__bindgen_ty_1
-pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_1__bindgen_ty_1::from(t: T) -> T
 #[repr(C)] pub struct aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2__bindgen_ty_1
 pub aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2__bindgen_ty_1::cgroup_id: aya_obj::generated::__u64
 pub aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2__bindgen_ty_1::order: aya_obj::generated::__u32
@@ -6714,28 +3366,6 @@ impl core::marker::Unpin for aya_obj::generated::bpf_link_info__bindgen_ty_1__bi
 impl core::marker::UnsafeUnpin for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2__bindgen_ty_1
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2__bindgen_ty_1
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2__bindgen_ty_1
-impl<T, U> core::convert::Into<U> for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2__bindgen_ty_1 where U: core::convert::From<T>
-pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2__bindgen_ty_1::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2__bindgen_ty_1 where U: core::convert::Into<T>
-pub type aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2__bindgen_ty_1::Error = core::convert::Infallible
-pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2__bindgen_ty_1::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2__bindgen_ty_1 where U: core::convert::TryFrom<T>
-pub type aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2__bindgen_ty_1::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2__bindgen_ty_1::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2__bindgen_ty_1 where T: core::clone::Clone
-pub type aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2__bindgen_ty_1::Owned = T
-pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2__bindgen_ty_1::clone_into(&self, target: &mut T)
-pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2__bindgen_ty_1::to_owned(&self) -> T
-impl<T> core::any::Any for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2__bindgen_ty_1 where T: 'static + ?core::marker::Sized
-pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2__bindgen_ty_1::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2__bindgen_ty_1 where T: ?core::marker::Sized
-pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2__bindgen_ty_1::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2__bindgen_ty_1 where T: ?core::marker::Sized
-pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2__bindgen_ty_1::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2__bindgen_ty_1 where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2__bindgen_ty_1::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2__bindgen_ty_1
-pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2__bindgen_ty_1::from(t: T) -> T
 #[repr(C)] pub struct aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2__bindgen_ty_2
 pub aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2__bindgen_ty_2::pid: aya_obj::generated::__u32
 pub aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2__bindgen_ty_2::tid: aya_obj::generated::__u32
@@ -6751,28 +3381,6 @@ impl core::marker::Unpin for aya_obj::generated::bpf_link_info__bindgen_ty_1__bi
 impl core::marker::UnsafeUnpin for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2__bindgen_ty_2
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2__bindgen_ty_2
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2__bindgen_ty_2
-impl<T, U> core::convert::Into<U> for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2__bindgen_ty_2 where U: core::convert::From<T>
-pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2__bindgen_ty_2::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2__bindgen_ty_2 where U: core::convert::Into<T>
-pub type aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2__bindgen_ty_2::Error = core::convert::Infallible
-pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2__bindgen_ty_2::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2__bindgen_ty_2 where U: core::convert::TryFrom<T>
-pub type aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2__bindgen_ty_2::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2__bindgen_ty_2::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2__bindgen_ty_2 where T: core::clone::Clone
-pub type aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2__bindgen_ty_2::Owned = T
-pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2__bindgen_ty_2::clone_into(&self, target: &mut T)
-pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2__bindgen_ty_2::to_owned(&self) -> T
-impl<T> core::any::Any for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2__bindgen_ty_2 where T: 'static + ?core::marker::Sized
-pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2__bindgen_ty_2::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2__bindgen_ty_2 where T: ?core::marker::Sized
-pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2__bindgen_ty_2::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2__bindgen_ty_2 where T: ?core::marker::Sized
-pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2__bindgen_ty_2::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2__bindgen_ty_2 where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2__bindgen_ty_2::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2__bindgen_ty_2
-pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_4__bindgen_ty_2__bindgen_ty_2::from(t: T) -> T
 #[repr(C)] pub struct aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_5
 pub aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_5::attach_type: aya_obj::generated::__u32
 pub aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_5::netns_ino: aya_obj::generated::__u32
@@ -6788,28 +3396,6 @@ impl core::marker::Unpin for aya_obj::generated::bpf_link_info__bindgen_ty_1__bi
 impl core::marker::UnsafeUnpin for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_5
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_5
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_5
-impl<T, U> core::convert::Into<U> for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_5 where U: core::convert::From<T>
-pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_5::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_5 where U: core::convert::Into<T>
-pub type aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_5::Error = core::convert::Infallible
-pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_5::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_5 where U: core::convert::TryFrom<T>
-pub type aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_5::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_5::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_5 where T: core::clone::Clone
-pub type aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_5::Owned = T
-pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_5::clone_into(&self, target: &mut T)
-pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_5::to_owned(&self) -> T
-impl<T> core::any::Any for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_5 where T: 'static + ?core::marker::Sized
-pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_5::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_5 where T: ?core::marker::Sized
-pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_5::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_5 where T: ?core::marker::Sized
-pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_5::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_5 where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_5::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_5
-pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_5::from(t: T) -> T
 #[repr(C)] pub struct aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_6
 pub aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_6::ifindex: aya_obj::generated::__u32
 impl core::clone::Clone for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_6
@@ -6824,28 +3410,6 @@ impl core::marker::Unpin for aya_obj::generated::bpf_link_info__bindgen_ty_1__bi
 impl core::marker::UnsafeUnpin for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_6
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_6
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_6
-impl<T, U> core::convert::Into<U> for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_6 where U: core::convert::From<T>
-pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_6::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_6 where U: core::convert::Into<T>
-pub type aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_6::Error = core::convert::Infallible
-pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_6::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_6 where U: core::convert::TryFrom<T>
-pub type aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_6::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_6::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_6 where T: core::clone::Clone
-pub type aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_6::Owned = T
-pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_6::clone_into(&self, target: &mut T)
-pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_6::to_owned(&self) -> T
-impl<T> core::any::Any for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_6 where T: 'static + ?core::marker::Sized
-pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_6::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_6 where T: ?core::marker::Sized
-pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_6::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_6 where T: ?core::marker::Sized
-pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_6::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_6 where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_6::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_6
-pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_6::from(t: T) -> T
 #[repr(C)] pub struct aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_7
 pub aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_7::map_id: aya_obj::generated::__u32
 impl core::clone::Clone for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_7
@@ -6860,28 +3424,6 @@ impl core::marker::Unpin for aya_obj::generated::bpf_link_info__bindgen_ty_1__bi
 impl core::marker::UnsafeUnpin for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_7
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_7
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_7
-impl<T, U> core::convert::Into<U> for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_7 where U: core::convert::From<T>
-pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_7::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_7 where U: core::convert::Into<T>
-pub type aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_7::Error = core::convert::Infallible
-pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_7::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_7 where U: core::convert::TryFrom<T>
-pub type aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_7::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_7::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_7 where T: core::clone::Clone
-pub type aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_7::Owned = T
-pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_7::clone_into(&self, target: &mut T)
-pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_7::to_owned(&self) -> T
-impl<T> core::any::Any for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_7 where T: 'static + ?core::marker::Sized
-pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_7::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_7 where T: ?core::marker::Sized
-pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_7::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_7 where T: ?core::marker::Sized
-pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_7::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_7 where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_7::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_7
-pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_7::from(t: T) -> T
 #[repr(C)] pub struct aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_8
 pub aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_8::flags: aya_obj::generated::__u32
 pub aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_8::hooknum: aya_obj::generated::__u32
@@ -6899,28 +3441,6 @@ impl core::marker::Unpin for aya_obj::generated::bpf_link_info__bindgen_ty_1__bi
 impl core::marker::UnsafeUnpin for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_8
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_8
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_8
-impl<T, U> core::convert::Into<U> for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_8 where U: core::convert::From<T>
-pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_8::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_8 where U: core::convert::Into<T>
-pub type aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_8::Error = core::convert::Infallible
-pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_8::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_8 where U: core::convert::TryFrom<T>
-pub type aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_8::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_8::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_8 where T: core::clone::Clone
-pub type aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_8::Owned = T
-pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_8::clone_into(&self, target: &mut T)
-pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_8::to_owned(&self) -> T
-impl<T> core::any::Any for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_8 where T: 'static + ?core::marker::Sized
-pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_8::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_8 where T: ?core::marker::Sized
-pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_8::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_8 where T: ?core::marker::Sized
-pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_8::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_8 where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_8::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_8
-pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_8::from(t: T) -> T
 #[repr(C)] pub struct aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_9
 pub aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_9::addrs: aya_obj::generated::__u64
 pub aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_9::cookies: aya_obj::generated::__u64
@@ -6939,28 +3459,6 @@ impl core::marker::Unpin for aya_obj::generated::bpf_link_info__bindgen_ty_1__bi
 impl core::marker::UnsafeUnpin for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_9
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_9
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_9
-impl<T, U> core::convert::Into<U> for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_9 where U: core::convert::From<T>
-pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_9::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_9 where U: core::convert::Into<T>
-pub type aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_9::Error = core::convert::Infallible
-pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_9::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_9 where U: core::convert::TryFrom<T>
-pub type aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_9::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_9::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_9 where T: core::clone::Clone
-pub type aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_9::Owned = T
-pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_9::clone_into(&self, target: &mut T)
-pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_9::to_owned(&self) -> T
-impl<T> core::any::Any for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_9 where T: 'static + ?core::marker::Sized
-pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_9::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_9 where T: ?core::marker::Sized
-pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_9::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_9 where T: ?core::marker::Sized
-pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_9::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_9 where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_9::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_9
-pub fn aya_obj::generated::bpf_link_info__bindgen_ty_1__bindgen_ty_9::from(t: T) -> T
 #[repr(C)] pub struct aya_obj::generated::bpf_lpm_trie_key
 pub aya_obj::generated::bpf_lpm_trie_key::data: aya_obj::generated::__IncompleteArrayField<aya_obj::generated::__u8>
 pub aya_obj::generated::bpf_lpm_trie_key::prefixlen: aya_obj::generated::__u32
@@ -6973,22 +3471,6 @@ impl core::marker::Unpin for aya_obj::generated::bpf_lpm_trie_key
 impl core::marker::UnsafeUnpin for aya_obj::generated::bpf_lpm_trie_key
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::generated::bpf_lpm_trie_key
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::generated::bpf_lpm_trie_key
-impl<T, U> core::convert::Into<U> for aya_obj::generated::bpf_lpm_trie_key where U: core::convert::From<T>
-pub fn aya_obj::generated::bpf_lpm_trie_key::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_obj::generated::bpf_lpm_trie_key where U: core::convert::Into<T>
-pub type aya_obj::generated::bpf_lpm_trie_key::Error = core::convert::Infallible
-pub fn aya_obj::generated::bpf_lpm_trie_key::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_obj::generated::bpf_lpm_trie_key where U: core::convert::TryFrom<T>
-pub type aya_obj::generated::bpf_lpm_trie_key::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_obj::generated::bpf_lpm_trie_key::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_obj::generated::bpf_lpm_trie_key where T: 'static + ?core::marker::Sized
-pub fn aya_obj::generated::bpf_lpm_trie_key::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_obj::generated::bpf_lpm_trie_key where T: ?core::marker::Sized
-pub fn aya_obj::generated::bpf_lpm_trie_key::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::bpf_lpm_trie_key where T: ?core::marker::Sized
-pub fn aya_obj::generated::bpf_lpm_trie_key::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya_obj::generated::bpf_lpm_trie_key
-pub fn aya_obj::generated::bpf_lpm_trie_key::from(t: T) -> T
 #[repr(C)] pub struct aya_obj::generated::bpf_map_info
 pub aya_obj::generated::bpf_map_info::btf_id: aya_obj::generated::__u32
 pub aya_obj::generated::bpf_map_info::btf_key_type_id: aya_obj::generated::__u32
@@ -7018,28 +3500,6 @@ impl core::marker::Unpin for aya_obj::generated::bpf_map_info
 impl core::marker::UnsafeUnpin for aya_obj::generated::bpf_map_info
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::generated::bpf_map_info
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::generated::bpf_map_info
-impl<T, U> core::convert::Into<U> for aya_obj::generated::bpf_map_info where U: core::convert::From<T>
-pub fn aya_obj::generated::bpf_map_info::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_obj::generated::bpf_map_info where U: core::convert::Into<T>
-pub type aya_obj::generated::bpf_map_info::Error = core::convert::Infallible
-pub fn aya_obj::generated::bpf_map_info::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_obj::generated::bpf_map_info where U: core::convert::TryFrom<T>
-pub type aya_obj::generated::bpf_map_info::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_obj::generated::bpf_map_info::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya_obj::generated::bpf_map_info where T: core::clone::Clone
-pub type aya_obj::generated::bpf_map_info::Owned = T
-pub fn aya_obj::generated::bpf_map_info::clone_into(&self, target: &mut T)
-pub fn aya_obj::generated::bpf_map_info::to_owned(&self) -> T
-impl<T> core::any::Any for aya_obj::generated::bpf_map_info where T: 'static + ?core::marker::Sized
-pub fn aya_obj::generated::bpf_map_info::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_obj::generated::bpf_map_info where T: ?core::marker::Sized
-pub fn aya_obj::generated::bpf_map_info::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::bpf_map_info where T: ?core::marker::Sized
-pub fn aya_obj::generated::bpf_map_info::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_map_info where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::bpf_map_info::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_obj::generated::bpf_map_info
-pub fn aya_obj::generated::bpf_map_info::from(t: T) -> T
 #[repr(C)] pub struct aya_obj::generated::bpf_prog_info
 pub aya_obj::generated::bpf_prog_info::_bitfield_1: aya_obj::generated::__BindgenBitfieldUnit<[u8; 4]>
 pub aya_obj::generated::bpf_prog_info::_bitfield_align_1: [u8; 0]
@@ -7098,28 +3558,6 @@ impl core::marker::Unpin for aya_obj::generated::bpf_prog_info
 impl core::marker::UnsafeUnpin for aya_obj::generated::bpf_prog_info
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::generated::bpf_prog_info
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::generated::bpf_prog_info
-impl<T, U> core::convert::Into<U> for aya_obj::generated::bpf_prog_info where U: core::convert::From<T>
-pub fn aya_obj::generated::bpf_prog_info::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_obj::generated::bpf_prog_info where U: core::convert::Into<T>
-pub type aya_obj::generated::bpf_prog_info::Error = core::convert::Infallible
-pub fn aya_obj::generated::bpf_prog_info::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_obj::generated::bpf_prog_info where U: core::convert::TryFrom<T>
-pub type aya_obj::generated::bpf_prog_info::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_obj::generated::bpf_prog_info::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya_obj::generated::bpf_prog_info where T: core::clone::Clone
-pub type aya_obj::generated::bpf_prog_info::Owned = T
-pub fn aya_obj::generated::bpf_prog_info::clone_into(&self, target: &mut T)
-pub fn aya_obj::generated::bpf_prog_info::to_owned(&self) -> T
-impl<T> core::any::Any for aya_obj::generated::bpf_prog_info where T: 'static + ?core::marker::Sized
-pub fn aya_obj::generated::bpf_prog_info::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_obj::generated::bpf_prog_info where T: ?core::marker::Sized
-pub fn aya_obj::generated::bpf_prog_info::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::bpf_prog_info where T: ?core::marker::Sized
-pub fn aya_obj::generated::bpf_prog_info::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::bpf_prog_info where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::bpf_prog_info::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_obj::generated::bpf_prog_info
-pub fn aya_obj::generated::bpf_prog_info::from(t: T) -> T
 #[repr(C)] pub struct aya_obj::generated::btf_array
 pub aya_obj::generated::btf_array::index_type: aya_obj::generated::__u32
 pub aya_obj::generated::btf_array::nelems: aya_obj::generated::__u32
@@ -7136,28 +3574,6 @@ impl core::marker::Unpin for aya_obj::generated::btf_array
 impl core::marker::UnsafeUnpin for aya_obj::generated::btf_array
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::generated::btf_array
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::generated::btf_array
-impl<T, U> core::convert::Into<U> for aya_obj::generated::btf_array where U: core::convert::From<T>
-pub fn aya_obj::generated::btf_array::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_obj::generated::btf_array where U: core::convert::Into<T>
-pub type aya_obj::generated::btf_array::Error = core::convert::Infallible
-pub fn aya_obj::generated::btf_array::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_obj::generated::btf_array where U: core::convert::TryFrom<T>
-pub type aya_obj::generated::btf_array::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_obj::generated::btf_array::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya_obj::generated::btf_array where T: core::clone::Clone
-pub type aya_obj::generated::btf_array::Owned = T
-pub fn aya_obj::generated::btf_array::clone_into(&self, target: &mut T)
-pub fn aya_obj::generated::btf_array::to_owned(&self) -> T
-impl<T> core::any::Any for aya_obj::generated::btf_array where T: 'static + ?core::marker::Sized
-pub fn aya_obj::generated::btf_array::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_obj::generated::btf_array where T: ?core::marker::Sized
-pub fn aya_obj::generated::btf_array::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::btf_array where T: ?core::marker::Sized
-pub fn aya_obj::generated::btf_array::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::btf_array where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::btf_array::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_obj::generated::btf_array
-pub fn aya_obj::generated::btf_array::from(t: T) -> T
 #[repr(C)] pub struct aya_obj::generated::btf_decl_tag
 pub aya_obj::generated::btf_decl_tag::component_idx: aya_obj::generated::__s32
 impl core::clone::Clone for aya_obj::generated::btf_decl_tag
@@ -7172,28 +3588,6 @@ impl core::marker::Unpin for aya_obj::generated::btf_decl_tag
 impl core::marker::UnsafeUnpin for aya_obj::generated::btf_decl_tag
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::generated::btf_decl_tag
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::generated::btf_decl_tag
-impl<T, U> core::convert::Into<U> for aya_obj::generated::btf_decl_tag where U: core::convert::From<T>
-pub fn aya_obj::generated::btf_decl_tag::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_obj::generated::btf_decl_tag where U: core::convert::Into<T>
-pub type aya_obj::generated::btf_decl_tag::Error = core::convert::Infallible
-pub fn aya_obj::generated::btf_decl_tag::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_obj::generated::btf_decl_tag where U: core::convert::TryFrom<T>
-pub type aya_obj::generated::btf_decl_tag::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_obj::generated::btf_decl_tag::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya_obj::generated::btf_decl_tag where T: core::clone::Clone
-pub type aya_obj::generated::btf_decl_tag::Owned = T
-pub fn aya_obj::generated::btf_decl_tag::clone_into(&self, target: &mut T)
-pub fn aya_obj::generated::btf_decl_tag::to_owned(&self) -> T
-impl<T> core::any::Any for aya_obj::generated::btf_decl_tag where T: 'static + ?core::marker::Sized
-pub fn aya_obj::generated::btf_decl_tag::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_obj::generated::btf_decl_tag where T: ?core::marker::Sized
-pub fn aya_obj::generated::btf_decl_tag::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::btf_decl_tag where T: ?core::marker::Sized
-pub fn aya_obj::generated::btf_decl_tag::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::btf_decl_tag where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::btf_decl_tag::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_obj::generated::btf_decl_tag
-pub fn aya_obj::generated::btf_decl_tag::from(t: T) -> T
 #[repr(C)] pub struct aya_obj::generated::btf_enum
 pub aya_obj::generated::btf_enum::name_off: aya_obj::generated::__u32
 pub aya_obj::generated::btf_enum::val: aya_obj::generated::__s32
@@ -7209,28 +3603,6 @@ impl core::marker::Unpin for aya_obj::generated::btf_enum
 impl core::marker::UnsafeUnpin for aya_obj::generated::btf_enum
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::generated::btf_enum
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::generated::btf_enum
-impl<T, U> core::convert::Into<U> for aya_obj::generated::btf_enum where U: core::convert::From<T>
-pub fn aya_obj::generated::btf_enum::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_obj::generated::btf_enum where U: core::convert::Into<T>
-pub type aya_obj::generated::btf_enum::Error = core::convert::Infallible
-pub fn aya_obj::generated::btf_enum::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_obj::generated::btf_enum where U: core::convert::TryFrom<T>
-pub type aya_obj::generated::btf_enum::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_obj::generated::btf_enum::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya_obj::generated::btf_enum where T: core::clone::Clone
-pub type aya_obj::generated::btf_enum::Owned = T
-pub fn aya_obj::generated::btf_enum::clone_into(&self, target: &mut T)
-pub fn aya_obj::generated::btf_enum::to_owned(&self) -> T
-impl<T> core::any::Any for aya_obj::generated::btf_enum where T: 'static + ?core::marker::Sized
-pub fn aya_obj::generated::btf_enum::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_obj::generated::btf_enum where T: ?core::marker::Sized
-pub fn aya_obj::generated::btf_enum::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::btf_enum where T: ?core::marker::Sized
-pub fn aya_obj::generated::btf_enum::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::btf_enum where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::btf_enum::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_obj::generated::btf_enum
-pub fn aya_obj::generated::btf_enum::from(t: T) -> T
 #[repr(C)] pub struct aya_obj::generated::btf_ext_header
 pub aya_obj::generated::btf_ext_header::core_relo_len: core::ffi::primitives::c_uint
 pub aya_obj::generated::btf_ext_header::core_relo_off: core::ffi::primitives::c_uint
@@ -7254,28 +3626,6 @@ impl core::marker::Unpin for aya_obj::generated::btf_ext_header
 impl core::marker::UnsafeUnpin for aya_obj::generated::btf_ext_header
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::generated::btf_ext_header
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::generated::btf_ext_header
-impl<T, U> core::convert::Into<U> for aya_obj::generated::btf_ext_header where U: core::convert::From<T>
-pub fn aya_obj::generated::btf_ext_header::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_obj::generated::btf_ext_header where U: core::convert::Into<T>
-pub type aya_obj::generated::btf_ext_header::Error = core::convert::Infallible
-pub fn aya_obj::generated::btf_ext_header::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_obj::generated::btf_ext_header where U: core::convert::TryFrom<T>
-pub type aya_obj::generated::btf_ext_header::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_obj::generated::btf_ext_header::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya_obj::generated::btf_ext_header where T: core::clone::Clone
-pub type aya_obj::generated::btf_ext_header::Owned = T
-pub fn aya_obj::generated::btf_ext_header::clone_into(&self, target: &mut T)
-pub fn aya_obj::generated::btf_ext_header::to_owned(&self) -> T
-impl<T> core::any::Any for aya_obj::generated::btf_ext_header where T: 'static + ?core::marker::Sized
-pub fn aya_obj::generated::btf_ext_header::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_obj::generated::btf_ext_header where T: ?core::marker::Sized
-pub fn aya_obj::generated::btf_ext_header::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::btf_ext_header where T: ?core::marker::Sized
-pub fn aya_obj::generated::btf_ext_header::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::btf_ext_header where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::btf_ext_header::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_obj::generated::btf_ext_header
-pub fn aya_obj::generated::btf_ext_header::from(t: T) -> T
 #[repr(C)] pub struct aya_obj::generated::btf_header
 pub aya_obj::generated::btf_header::flags: aya_obj::generated::__u8
 pub aya_obj::generated::btf_header::hdr_len: aya_obj::generated::__u32
@@ -7297,28 +3647,6 @@ impl core::marker::Unpin for aya_obj::generated::btf_header
 impl core::marker::UnsafeUnpin for aya_obj::generated::btf_header
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::generated::btf_header
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::generated::btf_header
-impl<T, U> core::convert::Into<U> for aya_obj::generated::btf_header where U: core::convert::From<T>
-pub fn aya_obj::generated::btf_header::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_obj::generated::btf_header where U: core::convert::Into<T>
-pub type aya_obj::generated::btf_header::Error = core::convert::Infallible
-pub fn aya_obj::generated::btf_header::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_obj::generated::btf_header where U: core::convert::TryFrom<T>
-pub type aya_obj::generated::btf_header::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_obj::generated::btf_header::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya_obj::generated::btf_header where T: core::clone::Clone
-pub type aya_obj::generated::btf_header::Owned = T
-pub fn aya_obj::generated::btf_header::clone_into(&self, target: &mut T)
-pub fn aya_obj::generated::btf_header::to_owned(&self) -> T
-impl<T> core::any::Any for aya_obj::generated::btf_header where T: 'static + ?core::marker::Sized
-pub fn aya_obj::generated::btf_header::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_obj::generated::btf_header where T: ?core::marker::Sized
-pub fn aya_obj::generated::btf_header::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::btf_header where T: ?core::marker::Sized
-pub fn aya_obj::generated::btf_header::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::btf_header where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::btf_header::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_obj::generated::btf_header
-pub fn aya_obj::generated::btf_header::from(t: T) -> T
 #[repr(C)] pub struct aya_obj::generated::btf_member
 pub aya_obj::generated::btf_member::name_off: aya_obj::generated::__u32
 pub aya_obj::generated::btf_member::offset: aya_obj::generated::__u32
@@ -7335,28 +3663,6 @@ impl core::marker::Unpin for aya_obj::generated::btf_member
 impl core::marker::UnsafeUnpin for aya_obj::generated::btf_member
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::generated::btf_member
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::generated::btf_member
-impl<T, U> core::convert::Into<U> for aya_obj::generated::btf_member where U: core::convert::From<T>
-pub fn aya_obj::generated::btf_member::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_obj::generated::btf_member where U: core::convert::Into<T>
-pub type aya_obj::generated::btf_member::Error = core::convert::Infallible
-pub fn aya_obj::generated::btf_member::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_obj::generated::btf_member where U: core::convert::TryFrom<T>
-pub type aya_obj::generated::btf_member::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_obj::generated::btf_member::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya_obj::generated::btf_member where T: core::clone::Clone
-pub type aya_obj::generated::btf_member::Owned = T
-pub fn aya_obj::generated::btf_member::clone_into(&self, target: &mut T)
-pub fn aya_obj::generated::btf_member::to_owned(&self) -> T
-impl<T> core::any::Any for aya_obj::generated::btf_member where T: 'static + ?core::marker::Sized
-pub fn aya_obj::generated::btf_member::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_obj::generated::btf_member where T: ?core::marker::Sized
-pub fn aya_obj::generated::btf_member::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::btf_member where T: ?core::marker::Sized
-pub fn aya_obj::generated::btf_member::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::btf_member where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::btf_member::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_obj::generated::btf_member
-pub fn aya_obj::generated::btf_member::from(t: T) -> T
 #[repr(C)] pub struct aya_obj::generated::btf_param
 pub aya_obj::generated::btf_param::name_off: aya_obj::generated::__u32
 pub aya_obj::generated::btf_param::type_: aya_obj::generated::__u32
@@ -7372,28 +3678,6 @@ impl core::marker::Unpin for aya_obj::generated::btf_param
 impl core::marker::UnsafeUnpin for aya_obj::generated::btf_param
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::generated::btf_param
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::generated::btf_param
-impl<T, U> core::convert::Into<U> for aya_obj::generated::btf_param where U: core::convert::From<T>
-pub fn aya_obj::generated::btf_param::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_obj::generated::btf_param where U: core::convert::Into<T>
-pub type aya_obj::generated::btf_param::Error = core::convert::Infallible
-pub fn aya_obj::generated::btf_param::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_obj::generated::btf_param where U: core::convert::TryFrom<T>
-pub type aya_obj::generated::btf_param::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_obj::generated::btf_param::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya_obj::generated::btf_param where T: core::clone::Clone
-pub type aya_obj::generated::btf_param::Owned = T
-pub fn aya_obj::generated::btf_param::clone_into(&self, target: &mut T)
-pub fn aya_obj::generated::btf_param::to_owned(&self) -> T
-impl<T> core::any::Any for aya_obj::generated::btf_param where T: 'static + ?core::marker::Sized
-pub fn aya_obj::generated::btf_param::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_obj::generated::btf_param where T: ?core::marker::Sized
-pub fn aya_obj::generated::btf_param::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::btf_param where T: ?core::marker::Sized
-pub fn aya_obj::generated::btf_param::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::btf_param where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::btf_param::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_obj::generated::btf_param
-pub fn aya_obj::generated::btf_param::from(t: T) -> T
 #[repr(C)] pub struct aya_obj::generated::btf_type
 pub aya_obj::generated::btf_type::__bindgen_anon_1: aya_obj::generated::btf_type__bindgen_ty_1
 pub aya_obj::generated::btf_type::info: aya_obj::generated::__u32
@@ -7408,28 +3692,6 @@ impl core::marker::Unpin for aya_obj::generated::btf_type
 impl core::marker::UnsafeUnpin for aya_obj::generated::btf_type
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::generated::btf_type
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::generated::btf_type
-impl<T, U> core::convert::Into<U> for aya_obj::generated::btf_type where U: core::convert::From<T>
-pub fn aya_obj::generated::btf_type::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_obj::generated::btf_type where U: core::convert::Into<T>
-pub type aya_obj::generated::btf_type::Error = core::convert::Infallible
-pub fn aya_obj::generated::btf_type::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_obj::generated::btf_type where U: core::convert::TryFrom<T>
-pub type aya_obj::generated::btf_type::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_obj::generated::btf_type::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya_obj::generated::btf_type where T: core::clone::Clone
-pub type aya_obj::generated::btf_type::Owned = T
-pub fn aya_obj::generated::btf_type::clone_into(&self, target: &mut T)
-pub fn aya_obj::generated::btf_type::to_owned(&self) -> T
-impl<T> core::any::Any for aya_obj::generated::btf_type where T: 'static + ?core::marker::Sized
-pub fn aya_obj::generated::btf_type::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_obj::generated::btf_type where T: ?core::marker::Sized
-pub fn aya_obj::generated::btf_type::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::btf_type where T: ?core::marker::Sized
-pub fn aya_obj::generated::btf_type::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::btf_type where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::btf_type::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_obj::generated::btf_type
-pub fn aya_obj::generated::btf_type::from(t: T) -> T
 #[repr(C)] pub struct aya_obj::generated::btf_var
 pub aya_obj::generated::btf_var::linkage: aya_obj::generated::__u32
 impl core::clone::Clone for aya_obj::generated::btf_var
@@ -7444,28 +3706,6 @@ impl core::marker::Unpin for aya_obj::generated::btf_var
 impl core::marker::UnsafeUnpin for aya_obj::generated::btf_var
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::generated::btf_var
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::generated::btf_var
-impl<T, U> core::convert::Into<U> for aya_obj::generated::btf_var where U: core::convert::From<T>
-pub fn aya_obj::generated::btf_var::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_obj::generated::btf_var where U: core::convert::Into<T>
-pub type aya_obj::generated::btf_var::Error = core::convert::Infallible
-pub fn aya_obj::generated::btf_var::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_obj::generated::btf_var where U: core::convert::TryFrom<T>
-pub type aya_obj::generated::btf_var::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_obj::generated::btf_var::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya_obj::generated::btf_var where T: core::clone::Clone
-pub type aya_obj::generated::btf_var::Owned = T
-pub fn aya_obj::generated::btf_var::clone_into(&self, target: &mut T)
-pub fn aya_obj::generated::btf_var::to_owned(&self) -> T
-impl<T> core::any::Any for aya_obj::generated::btf_var where T: 'static + ?core::marker::Sized
-pub fn aya_obj::generated::btf_var::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_obj::generated::btf_var where T: ?core::marker::Sized
-pub fn aya_obj::generated::btf_var::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::btf_var where T: ?core::marker::Sized
-pub fn aya_obj::generated::btf_var::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::btf_var where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::btf_var::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_obj::generated::btf_var
-pub fn aya_obj::generated::btf_var::from(t: T) -> T
 #[repr(C)] pub struct aya_obj::generated::btf_var_secinfo
 pub aya_obj::generated::btf_var_secinfo::offset: aya_obj::generated::__u32
 pub aya_obj::generated::btf_var_secinfo::size: aya_obj::generated::__u32
@@ -7482,28 +3722,6 @@ impl core::marker::Unpin for aya_obj::generated::btf_var_secinfo
 impl core::marker::UnsafeUnpin for aya_obj::generated::btf_var_secinfo
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::generated::btf_var_secinfo
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::generated::btf_var_secinfo
-impl<T, U> core::convert::Into<U> for aya_obj::generated::btf_var_secinfo where U: core::convert::From<T>
-pub fn aya_obj::generated::btf_var_secinfo::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_obj::generated::btf_var_secinfo where U: core::convert::Into<T>
-pub type aya_obj::generated::btf_var_secinfo::Error = core::convert::Infallible
-pub fn aya_obj::generated::btf_var_secinfo::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_obj::generated::btf_var_secinfo where U: core::convert::TryFrom<T>
-pub type aya_obj::generated::btf_var_secinfo::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_obj::generated::btf_var_secinfo::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya_obj::generated::btf_var_secinfo where T: core::clone::Clone
-pub type aya_obj::generated::btf_var_secinfo::Owned = T
-pub fn aya_obj::generated::btf_var_secinfo::clone_into(&self, target: &mut T)
-pub fn aya_obj::generated::btf_var_secinfo::to_owned(&self) -> T
-impl<T> core::any::Any for aya_obj::generated::btf_var_secinfo where T: 'static + ?core::marker::Sized
-pub fn aya_obj::generated::btf_var_secinfo::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_obj::generated::btf_var_secinfo where T: ?core::marker::Sized
-pub fn aya_obj::generated::btf_var_secinfo::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::btf_var_secinfo where T: ?core::marker::Sized
-pub fn aya_obj::generated::btf_var_secinfo::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::btf_var_secinfo where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::btf_var_secinfo::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_obj::generated::btf_var_secinfo
-pub fn aya_obj::generated::btf_var_secinfo::from(t: T) -> T
 #[repr(C)] pub struct aya_obj::generated::ifinfomsg
 pub aya_obj::generated::ifinfomsg::__ifi_pad: core::ffi::primitives::c_uchar
 pub aya_obj::generated::ifinfomsg::ifi_change: core::ffi::primitives::c_uint
@@ -7523,28 +3741,6 @@ impl core::marker::Unpin for aya_obj::generated::ifinfomsg
 impl core::marker::UnsafeUnpin for aya_obj::generated::ifinfomsg
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::generated::ifinfomsg
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::generated::ifinfomsg
-impl<T, U> core::convert::Into<U> for aya_obj::generated::ifinfomsg where U: core::convert::From<T>
-pub fn aya_obj::generated::ifinfomsg::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_obj::generated::ifinfomsg where U: core::convert::Into<T>
-pub type aya_obj::generated::ifinfomsg::Error = core::convert::Infallible
-pub fn aya_obj::generated::ifinfomsg::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_obj::generated::ifinfomsg where U: core::convert::TryFrom<T>
-pub type aya_obj::generated::ifinfomsg::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_obj::generated::ifinfomsg::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya_obj::generated::ifinfomsg where T: core::clone::Clone
-pub type aya_obj::generated::ifinfomsg::Owned = T
-pub fn aya_obj::generated::ifinfomsg::clone_into(&self, target: &mut T)
-pub fn aya_obj::generated::ifinfomsg::to_owned(&self) -> T
-impl<T> core::any::Any for aya_obj::generated::ifinfomsg where T: 'static + ?core::marker::Sized
-pub fn aya_obj::generated::ifinfomsg::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_obj::generated::ifinfomsg where T: ?core::marker::Sized
-pub fn aya_obj::generated::ifinfomsg::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::ifinfomsg where T: ?core::marker::Sized
-pub fn aya_obj::generated::ifinfomsg::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::ifinfomsg where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::ifinfomsg::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_obj::generated::ifinfomsg
-pub fn aya_obj::generated::ifinfomsg::from(t: T) -> T
 #[repr(C)] pub struct aya_obj::generated::perf_event_attr
 pub aya_obj::generated::perf_event_attr::__bindgen_anon_1: aya_obj::generated::perf_event_attr__bindgen_ty_1
 pub aya_obj::generated::perf_event_attr::__bindgen_anon_2: aya_obj::generated::perf_event_attr__bindgen_ty_2
@@ -7734,28 +3930,6 @@ impl core::marker::Unpin for aya_obj::generated::perf_event_attr
 impl core::marker::UnsafeUnpin for aya_obj::generated::perf_event_attr
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::generated::perf_event_attr
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::generated::perf_event_attr
-impl<T, U> core::convert::Into<U> for aya_obj::generated::perf_event_attr where U: core::convert::From<T>
-pub fn aya_obj::generated::perf_event_attr::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_obj::generated::perf_event_attr where U: core::convert::Into<T>
-pub type aya_obj::generated::perf_event_attr::Error = core::convert::Infallible
-pub fn aya_obj::generated::perf_event_attr::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_obj::generated::perf_event_attr where U: core::convert::TryFrom<T>
-pub type aya_obj::generated::perf_event_attr::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_obj::generated::perf_event_attr::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya_obj::generated::perf_event_attr where T: core::clone::Clone
-pub type aya_obj::generated::perf_event_attr::Owned = T
-pub fn aya_obj::generated::perf_event_attr::clone_into(&self, target: &mut T)
-pub fn aya_obj::generated::perf_event_attr::to_owned(&self) -> T
-impl<T> core::any::Any for aya_obj::generated::perf_event_attr where T: 'static + ?core::marker::Sized
-pub fn aya_obj::generated::perf_event_attr::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_obj::generated::perf_event_attr where T: ?core::marker::Sized
-pub fn aya_obj::generated::perf_event_attr::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::perf_event_attr where T: ?core::marker::Sized
-pub fn aya_obj::generated::perf_event_attr::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::perf_event_attr where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::perf_event_attr::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_obj::generated::perf_event_attr
-pub fn aya_obj::generated::perf_event_attr::from(t: T) -> T
 #[repr(C)] pub struct aya_obj::generated::perf_event_header
 pub aya_obj::generated::perf_event_header::misc: aya_obj::generated::__u16
 pub aya_obj::generated::perf_event_header::size: aya_obj::generated::__u16
@@ -7772,28 +3946,6 @@ impl core::marker::Unpin for aya_obj::generated::perf_event_header
 impl core::marker::UnsafeUnpin for aya_obj::generated::perf_event_header
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::generated::perf_event_header
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::generated::perf_event_header
-impl<T, U> core::convert::Into<U> for aya_obj::generated::perf_event_header where U: core::convert::From<T>
-pub fn aya_obj::generated::perf_event_header::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_obj::generated::perf_event_header where U: core::convert::Into<T>
-pub type aya_obj::generated::perf_event_header::Error = core::convert::Infallible
-pub fn aya_obj::generated::perf_event_header::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_obj::generated::perf_event_header where U: core::convert::TryFrom<T>
-pub type aya_obj::generated::perf_event_header::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_obj::generated::perf_event_header::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya_obj::generated::perf_event_header where T: core::clone::Clone
-pub type aya_obj::generated::perf_event_header::Owned = T
-pub fn aya_obj::generated::perf_event_header::clone_into(&self, target: &mut T)
-pub fn aya_obj::generated::perf_event_header::to_owned(&self) -> T
-impl<T> core::any::Any for aya_obj::generated::perf_event_header where T: 'static + ?core::marker::Sized
-pub fn aya_obj::generated::perf_event_header::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_obj::generated::perf_event_header where T: ?core::marker::Sized
-pub fn aya_obj::generated::perf_event_header::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::perf_event_header where T: ?core::marker::Sized
-pub fn aya_obj::generated::perf_event_header::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::perf_event_header where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::perf_event_header::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_obj::generated::perf_event_header
-pub fn aya_obj::generated::perf_event_header::from(t: T) -> T
 #[repr(C)] pub struct aya_obj::generated::perf_event_mmap_page
 pub aya_obj::generated::perf_event_mmap_page::__bindgen_anon_1: aya_obj::generated::perf_event_mmap_page__bindgen_ty_1
 pub aya_obj::generated::perf_event_mmap_page::__reserved: [aya_obj::generated::__u8; 928]
@@ -7831,28 +3983,6 @@ impl core::marker::Unpin for aya_obj::generated::perf_event_mmap_page
 impl core::marker::UnsafeUnpin for aya_obj::generated::perf_event_mmap_page
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::generated::perf_event_mmap_page
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::generated::perf_event_mmap_page
-impl<T, U> core::convert::Into<U> for aya_obj::generated::perf_event_mmap_page where U: core::convert::From<T>
-pub fn aya_obj::generated::perf_event_mmap_page::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_obj::generated::perf_event_mmap_page where U: core::convert::Into<T>
-pub type aya_obj::generated::perf_event_mmap_page::Error = core::convert::Infallible
-pub fn aya_obj::generated::perf_event_mmap_page::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_obj::generated::perf_event_mmap_page where U: core::convert::TryFrom<T>
-pub type aya_obj::generated::perf_event_mmap_page::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_obj::generated::perf_event_mmap_page::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya_obj::generated::perf_event_mmap_page where T: core::clone::Clone
-pub type aya_obj::generated::perf_event_mmap_page::Owned = T
-pub fn aya_obj::generated::perf_event_mmap_page::clone_into(&self, target: &mut T)
-pub fn aya_obj::generated::perf_event_mmap_page::to_owned(&self) -> T
-impl<T> core::any::Any for aya_obj::generated::perf_event_mmap_page where T: 'static + ?core::marker::Sized
-pub fn aya_obj::generated::perf_event_mmap_page::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_obj::generated::perf_event_mmap_page where T: ?core::marker::Sized
-pub fn aya_obj::generated::perf_event_mmap_page::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::perf_event_mmap_page where T: ?core::marker::Sized
-pub fn aya_obj::generated::perf_event_mmap_page::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::perf_event_mmap_page where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::perf_event_mmap_page::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_obj::generated::perf_event_mmap_page
-pub fn aya_obj::generated::perf_event_mmap_page::from(t: T) -> T
 #[repr(C)] pub struct aya_obj::generated::perf_event_mmap_page__bindgen_ty_1__bindgen_ty_1
 pub aya_obj::generated::perf_event_mmap_page__bindgen_ty_1__bindgen_ty_1::_bitfield_1: aya_obj::generated::__BindgenBitfieldUnit<[u8; 8]>
 pub aya_obj::generated::perf_event_mmap_page__bindgen_ty_1__bindgen_ty_1::_bitfield_align_1: [u64; 0]
@@ -7898,28 +4028,6 @@ impl core::marker::Unpin for aya_obj::generated::perf_event_mmap_page__bindgen_t
 impl core::marker::UnsafeUnpin for aya_obj::generated::perf_event_mmap_page__bindgen_ty_1__bindgen_ty_1
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::generated::perf_event_mmap_page__bindgen_ty_1__bindgen_ty_1
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::generated::perf_event_mmap_page__bindgen_ty_1__bindgen_ty_1
-impl<T, U> core::convert::Into<U> for aya_obj::generated::perf_event_mmap_page__bindgen_ty_1__bindgen_ty_1 where U: core::convert::From<T>
-pub fn aya_obj::generated::perf_event_mmap_page__bindgen_ty_1__bindgen_ty_1::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_obj::generated::perf_event_mmap_page__bindgen_ty_1__bindgen_ty_1 where U: core::convert::Into<T>
-pub type aya_obj::generated::perf_event_mmap_page__bindgen_ty_1__bindgen_ty_1::Error = core::convert::Infallible
-pub fn aya_obj::generated::perf_event_mmap_page__bindgen_ty_1__bindgen_ty_1::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_obj::generated::perf_event_mmap_page__bindgen_ty_1__bindgen_ty_1 where U: core::convert::TryFrom<T>
-pub type aya_obj::generated::perf_event_mmap_page__bindgen_ty_1__bindgen_ty_1::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_obj::generated::perf_event_mmap_page__bindgen_ty_1__bindgen_ty_1::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya_obj::generated::perf_event_mmap_page__bindgen_ty_1__bindgen_ty_1 where T: core::clone::Clone
-pub type aya_obj::generated::perf_event_mmap_page__bindgen_ty_1__bindgen_ty_1::Owned = T
-pub fn aya_obj::generated::perf_event_mmap_page__bindgen_ty_1__bindgen_ty_1::clone_into(&self, target: &mut T)
-pub fn aya_obj::generated::perf_event_mmap_page__bindgen_ty_1__bindgen_ty_1::to_owned(&self) -> T
-impl<T> core::any::Any for aya_obj::generated::perf_event_mmap_page__bindgen_ty_1__bindgen_ty_1 where T: 'static + ?core::marker::Sized
-pub fn aya_obj::generated::perf_event_mmap_page__bindgen_ty_1__bindgen_ty_1::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_obj::generated::perf_event_mmap_page__bindgen_ty_1__bindgen_ty_1 where T: ?core::marker::Sized
-pub fn aya_obj::generated::perf_event_mmap_page__bindgen_ty_1__bindgen_ty_1::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::perf_event_mmap_page__bindgen_ty_1__bindgen_ty_1 where T: ?core::marker::Sized
-pub fn aya_obj::generated::perf_event_mmap_page__bindgen_ty_1__bindgen_ty_1::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::perf_event_mmap_page__bindgen_ty_1__bindgen_ty_1 where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::perf_event_mmap_page__bindgen_ty_1__bindgen_ty_1::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_obj::generated::perf_event_mmap_page__bindgen_ty_1__bindgen_ty_1
-pub fn aya_obj::generated::perf_event_mmap_page__bindgen_ty_1__bindgen_ty_1::from(t: T) -> T
 #[repr(C)] pub struct aya_obj::generated::tcmsg
 pub aya_obj::generated::tcmsg::tcm__pad1: core::ffi::primitives::c_uchar
 pub aya_obj::generated::tcmsg::tcm__pad2: core::ffi::primitives::c_ushort
@@ -7940,28 +4048,6 @@ impl core::marker::Unpin for aya_obj::generated::tcmsg
 impl core::marker::UnsafeUnpin for aya_obj::generated::tcmsg
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::generated::tcmsg
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::generated::tcmsg
-impl<T, U> core::convert::Into<U> for aya_obj::generated::tcmsg where U: core::convert::From<T>
-pub fn aya_obj::generated::tcmsg::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_obj::generated::tcmsg where U: core::convert::Into<T>
-pub type aya_obj::generated::tcmsg::Error = core::convert::Infallible
-pub fn aya_obj::generated::tcmsg::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_obj::generated::tcmsg where U: core::convert::TryFrom<T>
-pub type aya_obj::generated::tcmsg::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_obj::generated::tcmsg::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya_obj::generated::tcmsg where T: core::clone::Clone
-pub type aya_obj::generated::tcmsg::Owned = T
-pub fn aya_obj::generated::tcmsg::clone_into(&self, target: &mut T)
-pub fn aya_obj::generated::tcmsg::to_owned(&self) -> T
-impl<T> core::any::Any for aya_obj::generated::tcmsg where T: 'static + ?core::marker::Sized
-pub fn aya_obj::generated::tcmsg::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_obj::generated::tcmsg where T: ?core::marker::Sized
-pub fn aya_obj::generated::tcmsg::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_obj::generated::tcmsg where T: ?core::marker::Sized
-pub fn aya_obj::generated::tcmsg::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::generated::tcmsg where T: core::clone::Clone
-pub unsafe fn aya_obj::generated::tcmsg::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_obj::generated::tcmsg
-pub fn aya_obj::generated::tcmsg::from(t: T) -> T
 pub const aya_obj::generated::BPF_ABS: u32
 pub const aya_obj::generated::BPF_ADD: u32
 pub const aya_obj::generated::BPF_ADJ_ROOM_ENCAP_L2_MASK: aya_obj::generated::_bindgen_ty_18
@@ -8410,28 +4496,6 @@ impl core::marker::Unpin for aya_obj::maps::Map
 impl core::marker::UnsafeUnpin for aya_obj::maps::Map
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::maps::Map
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::maps::Map
-impl<T, U> core::convert::Into<U> for aya_obj::maps::Map where U: core::convert::From<T>
-pub fn aya_obj::maps::Map::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_obj::maps::Map where U: core::convert::Into<T>
-pub type aya_obj::maps::Map::Error = core::convert::Infallible
-pub fn aya_obj::maps::Map::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_obj::maps::Map where U: core::convert::TryFrom<T>
-pub type aya_obj::maps::Map::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_obj::maps::Map::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya_obj::maps::Map where T: core::clone::Clone
-pub type aya_obj::maps::Map::Owned = T
-pub fn aya_obj::maps::Map::clone_into(&self, target: &mut T)
-pub fn aya_obj::maps::Map::to_owned(&self) -> T
-impl<T> core::any::Any for aya_obj::maps::Map where T: 'static + ?core::marker::Sized
-pub fn aya_obj::maps::Map::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_obj::maps::Map where T: ?core::marker::Sized
-pub fn aya_obj::maps::Map::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_obj::maps::Map where T: ?core::marker::Sized
-pub fn aya_obj::maps::Map::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::maps::Map where T: core::clone::Clone
-pub unsafe fn aya_obj::maps::Map::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_obj::maps::Map
-pub fn aya_obj::maps::Map::from(t: T) -> T
 pub enum aya_obj::maps::PinningError
 pub aya_obj::maps::PinningError::Unsupported
 pub aya_obj::maps::PinningError::Unsupported::pinning_type: u32
@@ -8447,24 +4511,6 @@ impl core::marker::Unpin for aya_obj::maps::PinningError
 impl core::marker::UnsafeUnpin for aya_obj::maps::PinningError
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::maps::PinningError
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::maps::PinningError
-impl<T, U> core::convert::Into<U> for aya_obj::maps::PinningError where U: core::convert::From<T>
-pub fn aya_obj::maps::PinningError::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_obj::maps::PinningError where U: core::convert::Into<T>
-pub type aya_obj::maps::PinningError::Error = core::convert::Infallible
-pub fn aya_obj::maps::PinningError::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_obj::maps::PinningError where U: core::convert::TryFrom<T>
-pub type aya_obj::maps::PinningError::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_obj::maps::PinningError::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::string::ToString for aya_obj::maps::PinningError where T: core::fmt::Display + ?core::marker::Sized
-pub fn aya_obj::maps::PinningError::to_string(&self) -> alloc::string::String
-impl<T> core::any::Any for aya_obj::maps::PinningError where T: 'static + ?core::marker::Sized
-pub fn aya_obj::maps::PinningError::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_obj::maps::PinningError where T: ?core::marker::Sized
-pub fn aya_obj::maps::PinningError::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_obj::maps::PinningError where T: ?core::marker::Sized
-pub fn aya_obj::maps::PinningError::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya_obj::maps::PinningError
-pub fn aya_obj::maps::PinningError::from(t: T) -> T
 #[repr(u32)] pub enum aya_obj::maps::PinningType
 pub aya_obj::maps::PinningType::ByName = 1
 pub aya_obj::maps::PinningType::None = 0
@@ -8489,28 +4535,6 @@ impl core::marker::Unpin for aya_obj::maps::PinningType
 impl core::marker::UnsafeUnpin for aya_obj::maps::PinningType
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::maps::PinningType
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::maps::PinningType
-impl<T, U> core::convert::Into<U> for aya_obj::maps::PinningType where U: core::convert::From<T>
-pub fn aya_obj::maps::PinningType::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_obj::maps::PinningType where U: core::convert::Into<T>
-pub type aya_obj::maps::PinningType::Error = core::convert::Infallible
-pub fn aya_obj::maps::PinningType::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_obj::maps::PinningType where U: core::convert::TryFrom<T>
-pub type aya_obj::maps::PinningType::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_obj::maps::PinningType::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya_obj::maps::PinningType where T: core::clone::Clone
-pub type aya_obj::maps::PinningType::Owned = T
-pub fn aya_obj::maps::PinningType::clone_into(&self, target: &mut T)
-pub fn aya_obj::maps::PinningType::to_owned(&self) -> T
-impl<T> core::any::Any for aya_obj::maps::PinningType where T: 'static + ?core::marker::Sized
-pub fn aya_obj::maps::PinningType::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_obj::maps::PinningType where T: ?core::marker::Sized
-pub fn aya_obj::maps::PinningType::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_obj::maps::PinningType where T: ?core::marker::Sized
-pub fn aya_obj::maps::PinningType::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::maps::PinningType where T: core::clone::Clone
-pub unsafe fn aya_obj::maps::PinningType::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_obj::maps::PinningType
-pub fn aya_obj::maps::PinningType::from(t: T) -> T
 pub struct aya_obj::maps::BtfMap
 pub aya_obj::maps::BtfMap::def: aya_obj::maps::BtfMapDef
 impl core::clone::Clone for aya_obj::maps::BtfMap
@@ -8524,28 +4548,6 @@ impl core::marker::Unpin for aya_obj::maps::BtfMap
 impl core::marker::UnsafeUnpin for aya_obj::maps::BtfMap
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::maps::BtfMap
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::maps::BtfMap
-impl<T, U> core::convert::Into<U> for aya_obj::maps::BtfMap where U: core::convert::From<T>
-pub fn aya_obj::maps::BtfMap::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_obj::maps::BtfMap where U: core::convert::Into<T>
-pub type aya_obj::maps::BtfMap::Error = core::convert::Infallible
-pub fn aya_obj::maps::BtfMap::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_obj::maps::BtfMap where U: core::convert::TryFrom<T>
-pub type aya_obj::maps::BtfMap::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_obj::maps::BtfMap::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya_obj::maps::BtfMap where T: core::clone::Clone
-pub type aya_obj::maps::BtfMap::Owned = T
-pub fn aya_obj::maps::BtfMap::clone_into(&self, target: &mut T)
-pub fn aya_obj::maps::BtfMap::to_owned(&self) -> T
-impl<T> core::any::Any for aya_obj::maps::BtfMap where T: 'static + ?core::marker::Sized
-pub fn aya_obj::maps::BtfMap::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_obj::maps::BtfMap where T: ?core::marker::Sized
-pub fn aya_obj::maps::BtfMap::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_obj::maps::BtfMap where T: ?core::marker::Sized
-pub fn aya_obj::maps::BtfMap::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::maps::BtfMap where T: core::clone::Clone
-pub unsafe fn aya_obj::maps::BtfMap::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_obj::maps::BtfMap
-pub fn aya_obj::maps::BtfMap::from(t: T) -> T
 pub struct aya_obj::maps::BtfMapDef
 pub aya_obj::maps::BtfMapDef::btf_key_type_id: u32
 pub aya_obj::maps::BtfMapDef::btf_value_type_id: u32
@@ -8567,28 +4569,6 @@ impl core::marker::Unpin for aya_obj::maps::BtfMapDef
 impl core::marker::UnsafeUnpin for aya_obj::maps::BtfMapDef
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::maps::BtfMapDef
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::maps::BtfMapDef
-impl<T, U> core::convert::Into<U> for aya_obj::maps::BtfMapDef where U: core::convert::From<T>
-pub fn aya_obj::maps::BtfMapDef::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_obj::maps::BtfMapDef where U: core::convert::Into<T>
-pub type aya_obj::maps::BtfMapDef::Error = core::convert::Infallible
-pub fn aya_obj::maps::BtfMapDef::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_obj::maps::BtfMapDef where U: core::convert::TryFrom<T>
-pub type aya_obj::maps::BtfMapDef::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_obj::maps::BtfMapDef::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya_obj::maps::BtfMapDef where T: core::clone::Clone
-pub type aya_obj::maps::BtfMapDef::Owned = T
-pub fn aya_obj::maps::BtfMapDef::clone_into(&self, target: &mut T)
-pub fn aya_obj::maps::BtfMapDef::to_owned(&self) -> T
-impl<T> core::any::Any for aya_obj::maps::BtfMapDef where T: 'static + ?core::marker::Sized
-pub fn aya_obj::maps::BtfMapDef::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_obj::maps::BtfMapDef where T: ?core::marker::Sized
-pub fn aya_obj::maps::BtfMapDef::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_obj::maps::BtfMapDef where T: ?core::marker::Sized
-pub fn aya_obj::maps::BtfMapDef::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::maps::BtfMapDef where T: core::clone::Clone
-pub unsafe fn aya_obj::maps::BtfMapDef::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_obj::maps::BtfMapDef
-pub fn aya_obj::maps::BtfMapDef::from(t: T) -> T
 pub struct aya_obj::maps::LegacyMap
 pub aya_obj::maps::LegacyMap::data: alloc::vec::Vec<u8>
 pub aya_obj::maps::LegacyMap::def: aya_obj::maps::bpf_map_def
@@ -8606,28 +4586,6 @@ impl core::marker::Unpin for aya_obj::maps::LegacyMap
 impl core::marker::UnsafeUnpin for aya_obj::maps::LegacyMap
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::maps::LegacyMap
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::maps::LegacyMap
-impl<T, U> core::convert::Into<U> for aya_obj::maps::LegacyMap where U: core::convert::From<T>
-pub fn aya_obj::maps::LegacyMap::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_obj::maps::LegacyMap where U: core::convert::Into<T>
-pub type aya_obj::maps::LegacyMap::Error = core::convert::Infallible
-pub fn aya_obj::maps::LegacyMap::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_obj::maps::LegacyMap where U: core::convert::TryFrom<T>
-pub type aya_obj::maps::LegacyMap::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_obj::maps::LegacyMap::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya_obj::maps::LegacyMap where T: core::clone::Clone
-pub type aya_obj::maps::LegacyMap::Owned = T
-pub fn aya_obj::maps::LegacyMap::clone_into(&self, target: &mut T)
-pub fn aya_obj::maps::LegacyMap::to_owned(&self) -> T
-impl<T> core::any::Any for aya_obj::maps::LegacyMap where T: 'static + ?core::marker::Sized
-pub fn aya_obj::maps::LegacyMap::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_obj::maps::LegacyMap where T: ?core::marker::Sized
-pub fn aya_obj::maps::LegacyMap::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_obj::maps::LegacyMap where T: ?core::marker::Sized
-pub fn aya_obj::maps::LegacyMap::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::maps::LegacyMap where T: core::clone::Clone
-pub unsafe fn aya_obj::maps::LegacyMap::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_obj::maps::LegacyMap
-pub fn aya_obj::maps::LegacyMap::from(t: T) -> T
 #[repr(C)] pub struct aya_obj::maps::bpf_map_def
 pub aya_obj::maps::bpf_map_def::id: u32
 pub aya_obj::maps::bpf_map_def::key_size: u32
@@ -8654,28 +4612,6 @@ impl core::marker::Unpin for aya_obj::maps::bpf_map_def
 impl core::marker::UnsafeUnpin for aya_obj::maps::bpf_map_def
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::maps::bpf_map_def
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::maps::bpf_map_def
-impl<T, U> core::convert::Into<U> for aya_obj::maps::bpf_map_def where U: core::convert::From<T>
-pub fn aya_obj::maps::bpf_map_def::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_obj::maps::bpf_map_def where U: core::convert::Into<T>
-pub type aya_obj::maps::bpf_map_def::Error = core::convert::Infallible
-pub fn aya_obj::maps::bpf_map_def::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_obj::maps::bpf_map_def where U: core::convert::TryFrom<T>
-pub type aya_obj::maps::bpf_map_def::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_obj::maps::bpf_map_def::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya_obj::maps::bpf_map_def where T: core::clone::Clone
-pub type aya_obj::maps::bpf_map_def::Owned = T
-pub fn aya_obj::maps::bpf_map_def::clone_into(&self, target: &mut T)
-pub fn aya_obj::maps::bpf_map_def::to_owned(&self) -> T
-impl<T> core::any::Any for aya_obj::maps::bpf_map_def where T: 'static + ?core::marker::Sized
-pub fn aya_obj::maps::bpf_map_def::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_obj::maps::bpf_map_def where T: ?core::marker::Sized
-pub fn aya_obj::maps::bpf_map_def::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_obj::maps::bpf_map_def where T: ?core::marker::Sized
-pub fn aya_obj::maps::bpf_map_def::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::maps::bpf_map_def where T: core::clone::Clone
-pub unsafe fn aya_obj::maps::bpf_map_def::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_obj::maps::bpf_map_def
-pub fn aya_obj::maps::bpf_map_def::from(t: T) -> T
 pub mod aya_obj::obj
 pub enum aya_obj::obj::EbpfSectionKind
 pub aya_obj::obj::EbpfSectionKind::Bss
@@ -8706,28 +4642,6 @@ impl core::marker::Unpin for aya_obj::EbpfSectionKind
 impl core::marker::UnsafeUnpin for aya_obj::EbpfSectionKind
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::EbpfSectionKind
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::EbpfSectionKind
-impl<T, U> core::convert::Into<U> for aya_obj::EbpfSectionKind where U: core::convert::From<T>
-pub fn aya_obj::EbpfSectionKind::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_obj::EbpfSectionKind where U: core::convert::Into<T>
-pub type aya_obj::EbpfSectionKind::Error = core::convert::Infallible
-pub fn aya_obj::EbpfSectionKind::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_obj::EbpfSectionKind where U: core::convert::TryFrom<T>
-pub type aya_obj::EbpfSectionKind::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_obj::EbpfSectionKind::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya_obj::EbpfSectionKind where T: core::clone::Clone
-pub type aya_obj::EbpfSectionKind::Owned = T
-pub fn aya_obj::EbpfSectionKind::clone_into(&self, target: &mut T)
-pub fn aya_obj::EbpfSectionKind::to_owned(&self) -> T
-impl<T> core::any::Any for aya_obj::EbpfSectionKind where T: 'static + ?core::marker::Sized
-pub fn aya_obj::EbpfSectionKind::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_obj::EbpfSectionKind where T: ?core::marker::Sized
-pub fn aya_obj::EbpfSectionKind::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_obj::EbpfSectionKind where T: ?core::marker::Sized
-pub fn aya_obj::EbpfSectionKind::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::EbpfSectionKind where T: core::clone::Clone
-pub unsafe fn aya_obj::EbpfSectionKind::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_obj::EbpfSectionKind
-pub fn aya_obj::EbpfSectionKind::from(t: T) -> T
 pub enum aya_obj::obj::ParseError
 pub aya_obj::obj::ParseError::BtfError(aya_obj::btf::BtfError)
 pub aya_obj::obj::ParseError::ElfError(object::read::Error)
@@ -8783,24 +4697,6 @@ impl core::marker::Unpin for aya_obj::ParseError
 impl core::marker::UnsafeUnpin for aya_obj::ParseError
 impl !core::panic::unwind_safe::RefUnwindSafe for aya_obj::ParseError
 impl !core::panic::unwind_safe::UnwindSafe for aya_obj::ParseError
-impl<T, U> core::convert::Into<U> for aya_obj::ParseError where U: core::convert::From<T>
-pub fn aya_obj::ParseError::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_obj::ParseError where U: core::convert::Into<T>
-pub type aya_obj::ParseError::Error = core::convert::Infallible
-pub fn aya_obj::ParseError::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_obj::ParseError where U: core::convert::TryFrom<T>
-pub type aya_obj::ParseError::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_obj::ParseError::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::string::ToString for aya_obj::ParseError where T: core::fmt::Display + ?core::marker::Sized
-pub fn aya_obj::ParseError::to_string(&self) -> alloc::string::String
-impl<T> core::any::Any for aya_obj::ParseError where T: 'static + ?core::marker::Sized
-pub fn aya_obj::ParseError::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_obj::ParseError where T: ?core::marker::Sized
-pub fn aya_obj::ParseError::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_obj::ParseError where T: ?core::marker::Sized
-pub fn aya_obj::ParseError::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya_obj::ParseError
-pub fn aya_obj::ParseError::from(t: T) -> T
 pub enum aya_obj::obj::ProgramSection
 pub aya_obj::obj::ProgramSection::BtfTracePoint
 pub aya_obj::obj::ProgramSection::CgroupDevice
@@ -8858,28 +4754,6 @@ impl core::marker::Unpin for aya_obj::ProgramSection
 impl core::marker::UnsafeUnpin for aya_obj::ProgramSection
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::ProgramSection
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::ProgramSection
-impl<T, U> core::convert::Into<U> for aya_obj::ProgramSection where U: core::convert::From<T>
-pub fn aya_obj::ProgramSection::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_obj::ProgramSection where U: core::convert::Into<T>
-pub type aya_obj::ProgramSection::Error = core::convert::Infallible
-pub fn aya_obj::ProgramSection::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_obj::ProgramSection where U: core::convert::TryFrom<T>
-pub type aya_obj::ProgramSection::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_obj::ProgramSection::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya_obj::ProgramSection where T: core::clone::Clone
-pub type aya_obj::ProgramSection::Owned = T
-pub fn aya_obj::ProgramSection::clone_into(&self, target: &mut T)
-pub fn aya_obj::ProgramSection::to_owned(&self) -> T
-impl<T> core::any::Any for aya_obj::ProgramSection where T: 'static + ?core::marker::Sized
-pub fn aya_obj::ProgramSection::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_obj::ProgramSection where T: ?core::marker::Sized
-pub fn aya_obj::ProgramSection::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_obj::ProgramSection where T: ?core::marker::Sized
-pub fn aya_obj::ProgramSection::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::ProgramSection where T: core::clone::Clone
-pub unsafe fn aya_obj::ProgramSection::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_obj::ProgramSection
-pub fn aya_obj::ProgramSection::from(t: T) -> T
 pub struct aya_obj::obj::Features
 impl aya_obj::Features
 pub const fn aya_obj::Features::bpf_cookie(&self) -> bool
@@ -8901,22 +4775,6 @@ impl core::marker::Unpin for aya_obj::Features
 impl core::marker::UnsafeUnpin for aya_obj::Features
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::Features
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::Features
-impl<T, U> core::convert::Into<U> for aya_obj::Features where U: core::convert::From<T>
-pub fn aya_obj::Features::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_obj::Features where U: core::convert::Into<T>
-pub type aya_obj::Features::Error = core::convert::Infallible
-pub fn aya_obj::Features::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_obj::Features where U: core::convert::TryFrom<T>
-pub type aya_obj::Features::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_obj::Features::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_obj::Features where T: 'static + ?core::marker::Sized
-pub fn aya_obj::Features::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_obj::Features where T: ?core::marker::Sized
-pub fn aya_obj::Features::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_obj::Features where T: ?core::marker::Sized
-pub fn aya_obj::Features::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya_obj::Features
-pub fn aya_obj::Features::from(t: T) -> T
 pub struct aya_obj::obj::Function
 pub aya_obj::obj::Function::address: u64
 pub aya_obj::obj::Function::func_info: aya_obj::btf::FuncSecInfo
@@ -8938,28 +4796,6 @@ impl core::marker::Unpin for aya_obj::Function
 impl core::marker::UnsafeUnpin for aya_obj::Function
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::Function
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::Function
-impl<T, U> core::convert::Into<U> for aya_obj::Function where U: core::convert::From<T>
-pub fn aya_obj::Function::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_obj::Function where U: core::convert::Into<T>
-pub type aya_obj::Function::Error = core::convert::Infallible
-pub fn aya_obj::Function::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_obj::Function where U: core::convert::TryFrom<T>
-pub type aya_obj::Function::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_obj::Function::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya_obj::Function where T: core::clone::Clone
-pub type aya_obj::Function::Owned = T
-pub fn aya_obj::Function::clone_into(&self, target: &mut T)
-pub fn aya_obj::Function::to_owned(&self) -> T
-impl<T> core::any::Any for aya_obj::Function where T: 'static + ?core::marker::Sized
-pub fn aya_obj::Function::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_obj::Function where T: ?core::marker::Sized
-pub fn aya_obj::Function::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_obj::Function where T: ?core::marker::Sized
-pub fn aya_obj::Function::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::Function where T: core::clone::Clone
-pub unsafe fn aya_obj::Function::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_obj::Function
-pub fn aya_obj::Function::from(t: T) -> T
 pub struct aya_obj::obj::InvalidTypeBinding<T>
 pub aya_obj::obj::InvalidTypeBinding::value: T
 impl<T> core::marker::Freeze for aya_obj::InvalidTypeBinding<T> where T: core::marker::Freeze
@@ -8969,22 +4805,6 @@ impl<T> core::marker::Unpin for aya_obj::InvalidTypeBinding<T> where T: core::ma
 impl<T> core::marker::UnsafeUnpin for aya_obj::InvalidTypeBinding<T> where T: core::marker::UnsafeUnpin
 impl<T> core::panic::unwind_safe::RefUnwindSafe for aya_obj::InvalidTypeBinding<T> where T: core::panic::unwind_safe::RefUnwindSafe
 impl<T> core::panic::unwind_safe::UnwindSafe for aya_obj::InvalidTypeBinding<T> where T: core::panic::unwind_safe::UnwindSafe
-impl<T, U> core::convert::Into<U> for aya_obj::InvalidTypeBinding<T> where U: core::convert::From<T>
-pub fn aya_obj::InvalidTypeBinding<T>::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_obj::InvalidTypeBinding<T> where U: core::convert::Into<T>
-pub type aya_obj::InvalidTypeBinding<T>::Error = core::convert::Infallible
-pub fn aya_obj::InvalidTypeBinding<T>::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_obj::InvalidTypeBinding<T> where U: core::convert::TryFrom<T>
-pub type aya_obj::InvalidTypeBinding<T>::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_obj::InvalidTypeBinding<T>::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_obj::InvalidTypeBinding<T> where T: 'static + ?core::marker::Sized
-pub fn aya_obj::InvalidTypeBinding<T>::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_obj::InvalidTypeBinding<T> where T: ?core::marker::Sized
-pub fn aya_obj::InvalidTypeBinding<T>::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_obj::InvalidTypeBinding<T> where T: ?core::marker::Sized
-pub fn aya_obj::InvalidTypeBinding<T>::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya_obj::InvalidTypeBinding<T>
-pub fn aya_obj::InvalidTypeBinding<T>::from(t: T) -> T
 pub struct aya_obj::obj::Object
 pub aya_obj::obj::Object::btf: core::option::Option<aya_obj::btf::Btf>
 pub aya_obj::obj::Object::btf_ext: core::option::Option<aya_obj::btf::BtfExt>
@@ -9017,28 +4837,6 @@ impl core::marker::Unpin for aya_obj::Object
 impl core::marker::UnsafeUnpin for aya_obj::Object
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::Object
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::Object
-impl<T, U> core::convert::Into<U> for aya_obj::Object where U: core::convert::From<T>
-pub fn aya_obj::Object::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_obj::Object where U: core::convert::Into<T>
-pub type aya_obj::Object::Error = core::convert::Infallible
-pub fn aya_obj::Object::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_obj::Object where U: core::convert::TryFrom<T>
-pub type aya_obj::Object::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_obj::Object::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya_obj::Object where T: core::clone::Clone
-pub type aya_obj::Object::Owned = T
-pub fn aya_obj::Object::clone_into(&self, target: &mut T)
-pub fn aya_obj::Object::to_owned(&self) -> T
-impl<T> core::any::Any for aya_obj::Object where T: 'static + ?core::marker::Sized
-pub fn aya_obj::Object::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_obj::Object where T: ?core::marker::Sized
-pub fn aya_obj::Object::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_obj::Object where T: ?core::marker::Sized
-pub fn aya_obj::Object::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::Object where T: core::clone::Clone
-pub unsafe fn aya_obj::Object::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_obj::Object
-pub fn aya_obj::Object::from(t: T) -> T
 pub struct aya_obj::obj::Program
 pub aya_obj::obj::Program::address: u64
 pub aya_obj::obj::Program::kernel_version: core::option::Option<u32>
@@ -9058,28 +4856,6 @@ impl core::marker::Unpin for aya_obj::Program
 impl core::marker::UnsafeUnpin for aya_obj::Program
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::Program
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::Program
-impl<T, U> core::convert::Into<U> for aya_obj::Program where U: core::convert::From<T>
-pub fn aya_obj::Program::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_obj::Program where U: core::convert::Into<T>
-pub type aya_obj::Program::Error = core::convert::Infallible
-pub fn aya_obj::Program::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_obj::Program where U: core::convert::TryFrom<T>
-pub type aya_obj::Program::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_obj::Program::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya_obj::Program where T: core::clone::Clone
-pub type aya_obj::Program::Owned = T
-pub fn aya_obj::Program::clone_into(&self, target: &mut T)
-pub fn aya_obj::Program::to_owned(&self) -> T
-impl<T> core::any::Any for aya_obj::Program where T: 'static + ?core::marker::Sized
-pub fn aya_obj::Program::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_obj::Program where T: ?core::marker::Sized
-pub fn aya_obj::Program::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_obj::Program where T: ?core::marker::Sized
-pub fn aya_obj::Program::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::Program where T: core::clone::Clone
-pub unsafe fn aya_obj::Program::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_obj::Program
-pub fn aya_obj::Program::from(t: T) -> T
 pub fn aya_obj::obj::copy_instructions(data: &[u8]) -> core::result::Result<alloc::vec::Vec<aya_obj::generated::bpf_insn>, aya_obj::ParseError>
 pub const fn aya_obj::obj::parse_map_info(info: aya_obj::generated::bpf_map_info, pinned: aya_obj::maps::PinningType) -> aya_obj::maps::Map
 pub mod aya_obj::programs
@@ -9101,28 +4877,6 @@ impl core::marker::Unpin for aya_obj::programs::cgroup_skb::CgroupSkbAttachType
 impl core::marker::UnsafeUnpin for aya_obj::programs::cgroup_skb::CgroupSkbAttachType
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::programs::cgroup_skb::CgroupSkbAttachType
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::programs::cgroup_skb::CgroupSkbAttachType
-impl<T, U> core::convert::Into<U> for aya_obj::programs::cgroup_skb::CgroupSkbAttachType where U: core::convert::From<T>
-pub fn aya_obj::programs::cgroup_skb::CgroupSkbAttachType::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_obj::programs::cgroup_skb::CgroupSkbAttachType where U: core::convert::Into<T>
-pub type aya_obj::programs::cgroup_skb::CgroupSkbAttachType::Error = core::convert::Infallible
-pub fn aya_obj::programs::cgroup_skb::CgroupSkbAttachType::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_obj::programs::cgroup_skb::CgroupSkbAttachType where U: core::convert::TryFrom<T>
-pub type aya_obj::programs::cgroup_skb::CgroupSkbAttachType::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_obj::programs::cgroup_skb::CgroupSkbAttachType::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya_obj::programs::cgroup_skb::CgroupSkbAttachType where T: core::clone::Clone
-pub type aya_obj::programs::cgroup_skb::CgroupSkbAttachType::Owned = T
-pub fn aya_obj::programs::cgroup_skb::CgroupSkbAttachType::clone_into(&self, target: &mut T)
-pub fn aya_obj::programs::cgroup_skb::CgroupSkbAttachType::to_owned(&self) -> T
-impl<T> core::any::Any for aya_obj::programs::cgroup_skb::CgroupSkbAttachType where T: 'static + ?core::marker::Sized
-pub fn aya_obj::programs::cgroup_skb::CgroupSkbAttachType::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_obj::programs::cgroup_skb::CgroupSkbAttachType where T: ?core::marker::Sized
-pub fn aya_obj::programs::cgroup_skb::CgroupSkbAttachType::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_obj::programs::cgroup_skb::CgroupSkbAttachType where T: ?core::marker::Sized
-pub fn aya_obj::programs::cgroup_skb::CgroupSkbAttachType::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::programs::cgroup_skb::CgroupSkbAttachType where T: core::clone::Clone
-pub unsafe fn aya_obj::programs::cgroup_skb::CgroupSkbAttachType::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_obj::programs::cgroup_skb::CgroupSkbAttachType
-pub fn aya_obj::programs::cgroup_skb::CgroupSkbAttachType::from(t: T) -> T
 pub mod aya_obj::programs::cgroup_sock
 pub enum aya_obj::programs::cgroup_sock::CgroupSockAttachType
 pub aya_obj::programs::cgroup_sock::CgroupSockAttachType::PostBind4
@@ -9145,28 +4899,6 @@ impl core::marker::Unpin for aya_obj::programs::cgroup_sock::CgroupSockAttachTyp
 impl core::marker::UnsafeUnpin for aya_obj::programs::cgroup_sock::CgroupSockAttachType
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::programs::cgroup_sock::CgroupSockAttachType
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::programs::cgroup_sock::CgroupSockAttachType
-impl<T, U> core::convert::Into<U> for aya_obj::programs::cgroup_sock::CgroupSockAttachType where U: core::convert::From<T>
-pub fn aya_obj::programs::cgroup_sock::CgroupSockAttachType::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_obj::programs::cgroup_sock::CgroupSockAttachType where U: core::convert::Into<T>
-pub type aya_obj::programs::cgroup_sock::CgroupSockAttachType::Error = core::convert::Infallible
-pub fn aya_obj::programs::cgroup_sock::CgroupSockAttachType::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_obj::programs::cgroup_sock::CgroupSockAttachType where U: core::convert::TryFrom<T>
-pub type aya_obj::programs::cgroup_sock::CgroupSockAttachType::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_obj::programs::cgroup_sock::CgroupSockAttachType::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya_obj::programs::cgroup_sock::CgroupSockAttachType where T: core::clone::Clone
-pub type aya_obj::programs::cgroup_sock::CgroupSockAttachType::Owned = T
-pub fn aya_obj::programs::cgroup_sock::CgroupSockAttachType::clone_into(&self, target: &mut T)
-pub fn aya_obj::programs::cgroup_sock::CgroupSockAttachType::to_owned(&self) -> T
-impl<T> core::any::Any for aya_obj::programs::cgroup_sock::CgroupSockAttachType where T: 'static + ?core::marker::Sized
-pub fn aya_obj::programs::cgroup_sock::CgroupSockAttachType::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_obj::programs::cgroup_sock::CgroupSockAttachType where T: ?core::marker::Sized
-pub fn aya_obj::programs::cgroup_sock::CgroupSockAttachType::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_obj::programs::cgroup_sock::CgroupSockAttachType where T: ?core::marker::Sized
-pub fn aya_obj::programs::cgroup_sock::CgroupSockAttachType::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::programs::cgroup_sock::CgroupSockAttachType where T: core::clone::Clone
-pub unsafe fn aya_obj::programs::cgroup_sock::CgroupSockAttachType::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_obj::programs::cgroup_sock::CgroupSockAttachType
-pub fn aya_obj::programs::cgroup_sock::CgroupSockAttachType::from(t: T) -> T
 pub mod aya_obj::programs::cgroup_sock_addr
 pub enum aya_obj::programs::cgroup_sock_addr::CgroupSockAddrAttachType
 pub aya_obj::programs::cgroup_sock_addr::CgroupSockAddrAttachType::Bind4
@@ -9195,28 +4927,6 @@ impl core::marker::Unpin for aya_obj::programs::cgroup_sock_addr::CgroupSockAddr
 impl core::marker::UnsafeUnpin for aya_obj::programs::cgroup_sock_addr::CgroupSockAddrAttachType
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::programs::cgroup_sock_addr::CgroupSockAddrAttachType
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::programs::cgroup_sock_addr::CgroupSockAddrAttachType
-impl<T, U> core::convert::Into<U> for aya_obj::programs::cgroup_sock_addr::CgroupSockAddrAttachType where U: core::convert::From<T>
-pub fn aya_obj::programs::cgroup_sock_addr::CgroupSockAddrAttachType::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_obj::programs::cgroup_sock_addr::CgroupSockAddrAttachType where U: core::convert::Into<T>
-pub type aya_obj::programs::cgroup_sock_addr::CgroupSockAddrAttachType::Error = core::convert::Infallible
-pub fn aya_obj::programs::cgroup_sock_addr::CgroupSockAddrAttachType::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_obj::programs::cgroup_sock_addr::CgroupSockAddrAttachType where U: core::convert::TryFrom<T>
-pub type aya_obj::programs::cgroup_sock_addr::CgroupSockAddrAttachType::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_obj::programs::cgroup_sock_addr::CgroupSockAddrAttachType::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya_obj::programs::cgroup_sock_addr::CgroupSockAddrAttachType where T: core::clone::Clone
-pub type aya_obj::programs::cgroup_sock_addr::CgroupSockAddrAttachType::Owned = T
-pub fn aya_obj::programs::cgroup_sock_addr::CgroupSockAddrAttachType::clone_into(&self, target: &mut T)
-pub fn aya_obj::programs::cgroup_sock_addr::CgroupSockAddrAttachType::to_owned(&self) -> T
-impl<T> core::any::Any for aya_obj::programs::cgroup_sock_addr::CgroupSockAddrAttachType where T: 'static + ?core::marker::Sized
-pub fn aya_obj::programs::cgroup_sock_addr::CgroupSockAddrAttachType::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_obj::programs::cgroup_sock_addr::CgroupSockAddrAttachType where T: ?core::marker::Sized
-pub fn aya_obj::programs::cgroup_sock_addr::CgroupSockAddrAttachType::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_obj::programs::cgroup_sock_addr::CgroupSockAddrAttachType where T: ?core::marker::Sized
-pub fn aya_obj::programs::cgroup_sock_addr::CgroupSockAddrAttachType::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::programs::cgroup_sock_addr::CgroupSockAddrAttachType where T: core::clone::Clone
-pub unsafe fn aya_obj::programs::cgroup_sock_addr::CgroupSockAddrAttachType::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_obj::programs::cgroup_sock_addr::CgroupSockAddrAttachType
-pub fn aya_obj::programs::cgroup_sock_addr::CgroupSockAddrAttachType::from(t: T) -> T
 pub mod aya_obj::programs::cgroup_sockopt
 pub enum aya_obj::programs::cgroup_sockopt::CgroupSockoptAttachType
 pub aya_obj::programs::cgroup_sockopt::CgroupSockoptAttachType::Get
@@ -9235,28 +4945,6 @@ impl core::marker::Unpin for aya_obj::programs::cgroup_sockopt::CgroupSockoptAtt
 impl core::marker::UnsafeUnpin for aya_obj::programs::cgroup_sockopt::CgroupSockoptAttachType
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::programs::cgroup_sockopt::CgroupSockoptAttachType
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::programs::cgroup_sockopt::CgroupSockoptAttachType
-impl<T, U> core::convert::Into<U> for aya_obj::programs::cgroup_sockopt::CgroupSockoptAttachType where U: core::convert::From<T>
-pub fn aya_obj::programs::cgroup_sockopt::CgroupSockoptAttachType::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_obj::programs::cgroup_sockopt::CgroupSockoptAttachType where U: core::convert::Into<T>
-pub type aya_obj::programs::cgroup_sockopt::CgroupSockoptAttachType::Error = core::convert::Infallible
-pub fn aya_obj::programs::cgroup_sockopt::CgroupSockoptAttachType::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_obj::programs::cgroup_sockopt::CgroupSockoptAttachType where U: core::convert::TryFrom<T>
-pub type aya_obj::programs::cgroup_sockopt::CgroupSockoptAttachType::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_obj::programs::cgroup_sockopt::CgroupSockoptAttachType::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya_obj::programs::cgroup_sockopt::CgroupSockoptAttachType where T: core::clone::Clone
-pub type aya_obj::programs::cgroup_sockopt::CgroupSockoptAttachType::Owned = T
-pub fn aya_obj::programs::cgroup_sockopt::CgroupSockoptAttachType::clone_into(&self, target: &mut T)
-pub fn aya_obj::programs::cgroup_sockopt::CgroupSockoptAttachType::to_owned(&self) -> T
-impl<T> core::any::Any for aya_obj::programs::cgroup_sockopt::CgroupSockoptAttachType where T: 'static + ?core::marker::Sized
-pub fn aya_obj::programs::cgroup_sockopt::CgroupSockoptAttachType::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_obj::programs::cgroup_sockopt::CgroupSockoptAttachType where T: ?core::marker::Sized
-pub fn aya_obj::programs::cgroup_sockopt::CgroupSockoptAttachType::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_obj::programs::cgroup_sockopt::CgroupSockoptAttachType where T: ?core::marker::Sized
-pub fn aya_obj::programs::cgroup_sockopt::CgroupSockoptAttachType::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::programs::cgroup_sockopt::CgroupSockoptAttachType where T: core::clone::Clone
-pub unsafe fn aya_obj::programs::cgroup_sockopt::CgroupSockoptAttachType::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_obj::programs::cgroup_sockopt::CgroupSockoptAttachType
-pub fn aya_obj::programs::cgroup_sockopt::CgroupSockoptAttachType::from(t: T) -> T
 pub mod aya_obj::programs::sk_skb
 pub enum aya_obj::programs::sk_skb::SkSkbKind
 pub aya_obj::programs::sk_skb::SkSkbKind::StreamParser
@@ -9275,28 +4963,6 @@ impl core::marker::Unpin for aya_obj::programs::sk_skb::SkSkbKind
 impl core::marker::UnsafeUnpin for aya_obj::programs::sk_skb::SkSkbKind
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::programs::sk_skb::SkSkbKind
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::programs::sk_skb::SkSkbKind
-impl<T, U> core::convert::Into<U> for aya_obj::programs::sk_skb::SkSkbKind where U: core::convert::From<T>
-pub fn aya_obj::programs::sk_skb::SkSkbKind::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_obj::programs::sk_skb::SkSkbKind where U: core::convert::Into<T>
-pub type aya_obj::programs::sk_skb::SkSkbKind::Error = core::convert::Infallible
-pub fn aya_obj::programs::sk_skb::SkSkbKind::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_obj::programs::sk_skb::SkSkbKind where U: core::convert::TryFrom<T>
-pub type aya_obj::programs::sk_skb::SkSkbKind::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_obj::programs::sk_skb::SkSkbKind::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya_obj::programs::sk_skb::SkSkbKind where T: core::clone::Clone
-pub type aya_obj::programs::sk_skb::SkSkbKind::Owned = T
-pub fn aya_obj::programs::sk_skb::SkSkbKind::clone_into(&self, target: &mut T)
-pub fn aya_obj::programs::sk_skb::SkSkbKind::to_owned(&self) -> T
-impl<T> core::any::Any for aya_obj::programs::sk_skb::SkSkbKind where T: 'static + ?core::marker::Sized
-pub fn aya_obj::programs::sk_skb::SkSkbKind::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_obj::programs::sk_skb::SkSkbKind where T: ?core::marker::Sized
-pub fn aya_obj::programs::sk_skb::SkSkbKind::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_obj::programs::sk_skb::SkSkbKind where T: ?core::marker::Sized
-pub fn aya_obj::programs::sk_skb::SkSkbKind::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::programs::sk_skb::SkSkbKind where T: core::clone::Clone
-pub unsafe fn aya_obj::programs::sk_skb::SkSkbKind::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_obj::programs::sk_skb::SkSkbKind
-pub fn aya_obj::programs::sk_skb::SkSkbKind::from(t: T) -> T
 pub mod aya_obj::programs::xdp
 pub enum aya_obj::programs::xdp::XdpAttachType
 pub aya_obj::programs::xdp::XdpAttachType::CpuMap
@@ -9316,28 +4982,6 @@ impl core::marker::Unpin for aya_obj::programs::xdp::XdpAttachType
 impl core::marker::UnsafeUnpin for aya_obj::programs::xdp::XdpAttachType
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::programs::xdp::XdpAttachType
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::programs::xdp::XdpAttachType
-impl<T, U> core::convert::Into<U> for aya_obj::programs::xdp::XdpAttachType where U: core::convert::From<T>
-pub fn aya_obj::programs::xdp::XdpAttachType::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_obj::programs::xdp::XdpAttachType where U: core::convert::Into<T>
-pub type aya_obj::programs::xdp::XdpAttachType::Error = core::convert::Infallible
-pub fn aya_obj::programs::xdp::XdpAttachType::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_obj::programs::xdp::XdpAttachType where U: core::convert::TryFrom<T>
-pub type aya_obj::programs::xdp::XdpAttachType::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_obj::programs::xdp::XdpAttachType::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya_obj::programs::xdp::XdpAttachType where T: core::clone::Clone
-pub type aya_obj::programs::xdp::XdpAttachType::Owned = T
-pub fn aya_obj::programs::xdp::XdpAttachType::clone_into(&self, target: &mut T)
-pub fn aya_obj::programs::xdp::XdpAttachType::to_owned(&self) -> T
-impl<T> core::any::Any for aya_obj::programs::xdp::XdpAttachType where T: 'static + ?core::marker::Sized
-pub fn aya_obj::programs::xdp::XdpAttachType::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_obj::programs::xdp::XdpAttachType where T: ?core::marker::Sized
-pub fn aya_obj::programs::xdp::XdpAttachType::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_obj::programs::xdp::XdpAttachType where T: ?core::marker::Sized
-pub fn aya_obj::programs::xdp::XdpAttachType::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::programs::xdp::XdpAttachType where T: core::clone::Clone
-pub unsafe fn aya_obj::programs::xdp::XdpAttachType::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_obj::programs::xdp::XdpAttachType
-pub fn aya_obj::programs::xdp::XdpAttachType::from(t: T) -> T
 pub enum aya_obj::programs::CgroupSkbAttachType
 pub aya_obj::programs::CgroupSkbAttachType::Egress
 pub aya_obj::programs::CgroupSkbAttachType::Ingress
@@ -9355,28 +4999,6 @@ impl core::marker::Unpin for aya_obj::programs::cgroup_skb::CgroupSkbAttachType
 impl core::marker::UnsafeUnpin for aya_obj::programs::cgroup_skb::CgroupSkbAttachType
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::programs::cgroup_skb::CgroupSkbAttachType
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::programs::cgroup_skb::CgroupSkbAttachType
-impl<T, U> core::convert::Into<U> for aya_obj::programs::cgroup_skb::CgroupSkbAttachType where U: core::convert::From<T>
-pub fn aya_obj::programs::cgroup_skb::CgroupSkbAttachType::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_obj::programs::cgroup_skb::CgroupSkbAttachType where U: core::convert::Into<T>
-pub type aya_obj::programs::cgroup_skb::CgroupSkbAttachType::Error = core::convert::Infallible
-pub fn aya_obj::programs::cgroup_skb::CgroupSkbAttachType::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_obj::programs::cgroup_skb::CgroupSkbAttachType where U: core::convert::TryFrom<T>
-pub type aya_obj::programs::cgroup_skb::CgroupSkbAttachType::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_obj::programs::cgroup_skb::CgroupSkbAttachType::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya_obj::programs::cgroup_skb::CgroupSkbAttachType where T: core::clone::Clone
-pub type aya_obj::programs::cgroup_skb::CgroupSkbAttachType::Owned = T
-pub fn aya_obj::programs::cgroup_skb::CgroupSkbAttachType::clone_into(&self, target: &mut T)
-pub fn aya_obj::programs::cgroup_skb::CgroupSkbAttachType::to_owned(&self) -> T
-impl<T> core::any::Any for aya_obj::programs::cgroup_skb::CgroupSkbAttachType where T: 'static + ?core::marker::Sized
-pub fn aya_obj::programs::cgroup_skb::CgroupSkbAttachType::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_obj::programs::cgroup_skb::CgroupSkbAttachType where T: ?core::marker::Sized
-pub fn aya_obj::programs::cgroup_skb::CgroupSkbAttachType::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_obj::programs::cgroup_skb::CgroupSkbAttachType where T: ?core::marker::Sized
-pub fn aya_obj::programs::cgroup_skb::CgroupSkbAttachType::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::programs::cgroup_skb::CgroupSkbAttachType where T: core::clone::Clone
-pub unsafe fn aya_obj::programs::cgroup_skb::CgroupSkbAttachType::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_obj::programs::cgroup_skb::CgroupSkbAttachType
-pub fn aya_obj::programs::cgroup_skb::CgroupSkbAttachType::from(t: T) -> T
 pub enum aya_obj::programs::CgroupSockAddrAttachType
 pub aya_obj::programs::CgroupSockAddrAttachType::Bind4
 pub aya_obj::programs::CgroupSockAddrAttachType::Bind6
@@ -9404,28 +5026,6 @@ impl core::marker::Unpin for aya_obj::programs::cgroup_sock_addr::CgroupSockAddr
 impl core::marker::UnsafeUnpin for aya_obj::programs::cgroup_sock_addr::CgroupSockAddrAttachType
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::programs::cgroup_sock_addr::CgroupSockAddrAttachType
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::programs::cgroup_sock_addr::CgroupSockAddrAttachType
-impl<T, U> core::convert::Into<U> for aya_obj::programs::cgroup_sock_addr::CgroupSockAddrAttachType where U: core::convert::From<T>
-pub fn aya_obj::programs::cgroup_sock_addr::CgroupSockAddrAttachType::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_obj::programs::cgroup_sock_addr::CgroupSockAddrAttachType where U: core::convert::Into<T>
-pub type aya_obj::programs::cgroup_sock_addr::CgroupSockAddrAttachType::Error = core::convert::Infallible
-pub fn aya_obj::programs::cgroup_sock_addr::CgroupSockAddrAttachType::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_obj::programs::cgroup_sock_addr::CgroupSockAddrAttachType where U: core::convert::TryFrom<T>
-pub type aya_obj::programs::cgroup_sock_addr::CgroupSockAddrAttachType::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_obj::programs::cgroup_sock_addr::CgroupSockAddrAttachType::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya_obj::programs::cgroup_sock_addr::CgroupSockAddrAttachType where T: core::clone::Clone
-pub type aya_obj::programs::cgroup_sock_addr::CgroupSockAddrAttachType::Owned = T
-pub fn aya_obj::programs::cgroup_sock_addr::CgroupSockAddrAttachType::clone_into(&self, target: &mut T)
-pub fn aya_obj::programs::cgroup_sock_addr::CgroupSockAddrAttachType::to_owned(&self) -> T
-impl<T> core::any::Any for aya_obj::programs::cgroup_sock_addr::CgroupSockAddrAttachType where T: 'static + ?core::marker::Sized
-pub fn aya_obj::programs::cgroup_sock_addr::CgroupSockAddrAttachType::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_obj::programs::cgroup_sock_addr::CgroupSockAddrAttachType where T: ?core::marker::Sized
-pub fn aya_obj::programs::cgroup_sock_addr::CgroupSockAddrAttachType::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_obj::programs::cgroup_sock_addr::CgroupSockAddrAttachType where T: ?core::marker::Sized
-pub fn aya_obj::programs::cgroup_sock_addr::CgroupSockAddrAttachType::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::programs::cgroup_sock_addr::CgroupSockAddrAttachType where T: core::clone::Clone
-pub unsafe fn aya_obj::programs::cgroup_sock_addr::CgroupSockAddrAttachType::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_obj::programs::cgroup_sock_addr::CgroupSockAddrAttachType
-pub fn aya_obj::programs::cgroup_sock_addr::CgroupSockAddrAttachType::from(t: T) -> T
 pub enum aya_obj::programs::CgroupSockAttachType
 pub aya_obj::programs::CgroupSockAttachType::PostBind4
 pub aya_obj::programs::CgroupSockAttachType::PostBind6
@@ -9447,28 +5047,6 @@ impl core::marker::Unpin for aya_obj::programs::cgroup_sock::CgroupSockAttachTyp
 impl core::marker::UnsafeUnpin for aya_obj::programs::cgroup_sock::CgroupSockAttachType
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::programs::cgroup_sock::CgroupSockAttachType
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::programs::cgroup_sock::CgroupSockAttachType
-impl<T, U> core::convert::Into<U> for aya_obj::programs::cgroup_sock::CgroupSockAttachType where U: core::convert::From<T>
-pub fn aya_obj::programs::cgroup_sock::CgroupSockAttachType::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_obj::programs::cgroup_sock::CgroupSockAttachType where U: core::convert::Into<T>
-pub type aya_obj::programs::cgroup_sock::CgroupSockAttachType::Error = core::convert::Infallible
-pub fn aya_obj::programs::cgroup_sock::CgroupSockAttachType::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_obj::programs::cgroup_sock::CgroupSockAttachType where U: core::convert::TryFrom<T>
-pub type aya_obj::programs::cgroup_sock::CgroupSockAttachType::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_obj::programs::cgroup_sock::CgroupSockAttachType::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya_obj::programs::cgroup_sock::CgroupSockAttachType where T: core::clone::Clone
-pub type aya_obj::programs::cgroup_sock::CgroupSockAttachType::Owned = T
-pub fn aya_obj::programs::cgroup_sock::CgroupSockAttachType::clone_into(&self, target: &mut T)
-pub fn aya_obj::programs::cgroup_sock::CgroupSockAttachType::to_owned(&self) -> T
-impl<T> core::any::Any for aya_obj::programs::cgroup_sock::CgroupSockAttachType where T: 'static + ?core::marker::Sized
-pub fn aya_obj::programs::cgroup_sock::CgroupSockAttachType::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_obj::programs::cgroup_sock::CgroupSockAttachType where T: ?core::marker::Sized
-pub fn aya_obj::programs::cgroup_sock::CgroupSockAttachType::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_obj::programs::cgroup_sock::CgroupSockAttachType where T: ?core::marker::Sized
-pub fn aya_obj::programs::cgroup_sock::CgroupSockAttachType::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::programs::cgroup_sock::CgroupSockAttachType where T: core::clone::Clone
-pub unsafe fn aya_obj::programs::cgroup_sock::CgroupSockAttachType::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_obj::programs::cgroup_sock::CgroupSockAttachType
-pub fn aya_obj::programs::cgroup_sock::CgroupSockAttachType::from(t: T) -> T
 pub enum aya_obj::programs::CgroupSockoptAttachType
 pub aya_obj::programs::CgroupSockoptAttachType::Get
 pub aya_obj::programs::CgroupSockoptAttachType::Set
@@ -9486,28 +5064,6 @@ impl core::marker::Unpin for aya_obj::programs::cgroup_sockopt::CgroupSockoptAtt
 impl core::marker::UnsafeUnpin for aya_obj::programs::cgroup_sockopt::CgroupSockoptAttachType
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::programs::cgroup_sockopt::CgroupSockoptAttachType
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::programs::cgroup_sockopt::CgroupSockoptAttachType
-impl<T, U> core::convert::Into<U> for aya_obj::programs::cgroup_sockopt::CgroupSockoptAttachType where U: core::convert::From<T>
-pub fn aya_obj::programs::cgroup_sockopt::CgroupSockoptAttachType::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_obj::programs::cgroup_sockopt::CgroupSockoptAttachType where U: core::convert::Into<T>
-pub type aya_obj::programs::cgroup_sockopt::CgroupSockoptAttachType::Error = core::convert::Infallible
-pub fn aya_obj::programs::cgroup_sockopt::CgroupSockoptAttachType::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_obj::programs::cgroup_sockopt::CgroupSockoptAttachType where U: core::convert::TryFrom<T>
-pub type aya_obj::programs::cgroup_sockopt::CgroupSockoptAttachType::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_obj::programs::cgroup_sockopt::CgroupSockoptAttachType::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya_obj::programs::cgroup_sockopt::CgroupSockoptAttachType where T: core::clone::Clone
-pub type aya_obj::programs::cgroup_sockopt::CgroupSockoptAttachType::Owned = T
-pub fn aya_obj::programs::cgroup_sockopt::CgroupSockoptAttachType::clone_into(&self, target: &mut T)
-pub fn aya_obj::programs::cgroup_sockopt::CgroupSockoptAttachType::to_owned(&self) -> T
-impl<T> core::any::Any for aya_obj::programs::cgroup_sockopt::CgroupSockoptAttachType where T: 'static + ?core::marker::Sized
-pub fn aya_obj::programs::cgroup_sockopt::CgroupSockoptAttachType::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_obj::programs::cgroup_sockopt::CgroupSockoptAttachType where T: ?core::marker::Sized
-pub fn aya_obj::programs::cgroup_sockopt::CgroupSockoptAttachType::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_obj::programs::cgroup_sockopt::CgroupSockoptAttachType where T: ?core::marker::Sized
-pub fn aya_obj::programs::cgroup_sockopt::CgroupSockoptAttachType::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::programs::cgroup_sockopt::CgroupSockoptAttachType where T: core::clone::Clone
-pub unsafe fn aya_obj::programs::cgroup_sockopt::CgroupSockoptAttachType::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_obj::programs::cgroup_sockopt::CgroupSockoptAttachType
-pub fn aya_obj::programs::cgroup_sockopt::CgroupSockoptAttachType::from(t: T) -> T
 pub enum aya_obj::programs::SkSkbKind
 pub aya_obj::programs::SkSkbKind::StreamParser
 pub aya_obj::programs::SkSkbKind::StreamVerdict
@@ -9525,28 +5081,6 @@ impl core::marker::Unpin for aya_obj::programs::sk_skb::SkSkbKind
 impl core::marker::UnsafeUnpin for aya_obj::programs::sk_skb::SkSkbKind
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::programs::sk_skb::SkSkbKind
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::programs::sk_skb::SkSkbKind
-impl<T, U> core::convert::Into<U> for aya_obj::programs::sk_skb::SkSkbKind where U: core::convert::From<T>
-pub fn aya_obj::programs::sk_skb::SkSkbKind::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_obj::programs::sk_skb::SkSkbKind where U: core::convert::Into<T>
-pub type aya_obj::programs::sk_skb::SkSkbKind::Error = core::convert::Infallible
-pub fn aya_obj::programs::sk_skb::SkSkbKind::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_obj::programs::sk_skb::SkSkbKind where U: core::convert::TryFrom<T>
-pub type aya_obj::programs::sk_skb::SkSkbKind::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_obj::programs::sk_skb::SkSkbKind::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya_obj::programs::sk_skb::SkSkbKind where T: core::clone::Clone
-pub type aya_obj::programs::sk_skb::SkSkbKind::Owned = T
-pub fn aya_obj::programs::sk_skb::SkSkbKind::clone_into(&self, target: &mut T)
-pub fn aya_obj::programs::sk_skb::SkSkbKind::to_owned(&self) -> T
-impl<T> core::any::Any for aya_obj::programs::sk_skb::SkSkbKind where T: 'static + ?core::marker::Sized
-pub fn aya_obj::programs::sk_skb::SkSkbKind::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_obj::programs::sk_skb::SkSkbKind where T: ?core::marker::Sized
-pub fn aya_obj::programs::sk_skb::SkSkbKind::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_obj::programs::sk_skb::SkSkbKind where T: ?core::marker::Sized
-pub fn aya_obj::programs::sk_skb::SkSkbKind::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::programs::sk_skb::SkSkbKind where T: core::clone::Clone
-pub unsafe fn aya_obj::programs::sk_skb::SkSkbKind::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_obj::programs::sk_skb::SkSkbKind
-pub fn aya_obj::programs::sk_skb::SkSkbKind::from(t: T) -> T
 pub enum aya_obj::programs::XdpAttachType
 pub aya_obj::programs::XdpAttachType::CpuMap
 pub aya_obj::programs::XdpAttachType::DevMap
@@ -9565,28 +5099,6 @@ impl core::marker::Unpin for aya_obj::programs::xdp::XdpAttachType
 impl core::marker::UnsafeUnpin for aya_obj::programs::xdp::XdpAttachType
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::programs::xdp::XdpAttachType
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::programs::xdp::XdpAttachType
-impl<T, U> core::convert::Into<U> for aya_obj::programs::xdp::XdpAttachType where U: core::convert::From<T>
-pub fn aya_obj::programs::xdp::XdpAttachType::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_obj::programs::xdp::XdpAttachType where U: core::convert::Into<T>
-pub type aya_obj::programs::xdp::XdpAttachType::Error = core::convert::Infallible
-pub fn aya_obj::programs::xdp::XdpAttachType::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_obj::programs::xdp::XdpAttachType where U: core::convert::TryFrom<T>
-pub type aya_obj::programs::xdp::XdpAttachType::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_obj::programs::xdp::XdpAttachType::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya_obj::programs::xdp::XdpAttachType where T: core::clone::Clone
-pub type aya_obj::programs::xdp::XdpAttachType::Owned = T
-pub fn aya_obj::programs::xdp::XdpAttachType::clone_into(&self, target: &mut T)
-pub fn aya_obj::programs::xdp::XdpAttachType::to_owned(&self) -> T
-impl<T> core::any::Any for aya_obj::programs::xdp::XdpAttachType where T: 'static + ?core::marker::Sized
-pub fn aya_obj::programs::xdp::XdpAttachType::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_obj::programs::xdp::XdpAttachType where T: ?core::marker::Sized
-pub fn aya_obj::programs::xdp::XdpAttachType::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_obj::programs::xdp::XdpAttachType where T: ?core::marker::Sized
-pub fn aya_obj::programs::xdp::XdpAttachType::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::programs::xdp::XdpAttachType where T: core::clone::Clone
-pub unsafe fn aya_obj::programs::xdp::XdpAttachType::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_obj::programs::xdp::XdpAttachType
-pub fn aya_obj::programs::xdp::XdpAttachType::from(t: T) -> T
 pub mod aya_obj::relocation
 pub enum aya_obj::relocation::RelocationError
 pub aya_obj::relocation::RelocationError::InvalidRelocationOffset
@@ -9616,24 +5128,6 @@ impl core::marker::Unpin for aya_obj::relocation::RelocationError
 impl core::marker::UnsafeUnpin for aya_obj::relocation::RelocationError
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::relocation::RelocationError
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::relocation::RelocationError
-impl<T, U> core::convert::Into<U> for aya_obj::relocation::RelocationError where U: core::convert::From<T>
-pub fn aya_obj::relocation::RelocationError::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_obj::relocation::RelocationError where U: core::convert::Into<T>
-pub type aya_obj::relocation::RelocationError::Error = core::convert::Infallible
-pub fn aya_obj::relocation::RelocationError::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_obj::relocation::RelocationError where U: core::convert::TryFrom<T>
-pub type aya_obj::relocation::RelocationError::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_obj::relocation::RelocationError::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::string::ToString for aya_obj::relocation::RelocationError where T: core::fmt::Display + ?core::marker::Sized
-pub fn aya_obj::relocation::RelocationError::to_string(&self) -> alloc::string::String
-impl<T> core::any::Any for aya_obj::relocation::RelocationError where T: 'static + ?core::marker::Sized
-pub fn aya_obj::relocation::RelocationError::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_obj::relocation::RelocationError where T: ?core::marker::Sized
-pub fn aya_obj::relocation::RelocationError::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_obj::relocation::RelocationError where T: ?core::marker::Sized
-pub fn aya_obj::relocation::RelocationError::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya_obj::relocation::RelocationError
-pub fn aya_obj::relocation::RelocationError::from(t: T) -> T
 pub struct aya_obj::relocation::EbpfRelocationError
 impl core::error::Error for aya_obj::relocation::EbpfRelocationError
 pub fn aya_obj::relocation::EbpfRelocationError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
@@ -9648,24 +5142,6 @@ impl core::marker::Unpin for aya_obj::relocation::EbpfRelocationError
 impl core::marker::UnsafeUnpin for aya_obj::relocation::EbpfRelocationError
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::relocation::EbpfRelocationError
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::relocation::EbpfRelocationError
-impl<T, U> core::convert::Into<U> for aya_obj::relocation::EbpfRelocationError where U: core::convert::From<T>
-pub fn aya_obj::relocation::EbpfRelocationError::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_obj::relocation::EbpfRelocationError where U: core::convert::Into<T>
-pub type aya_obj::relocation::EbpfRelocationError::Error = core::convert::Infallible
-pub fn aya_obj::relocation::EbpfRelocationError::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_obj::relocation::EbpfRelocationError where U: core::convert::TryFrom<T>
-pub type aya_obj::relocation::EbpfRelocationError::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_obj::relocation::EbpfRelocationError::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::string::ToString for aya_obj::relocation::EbpfRelocationError where T: core::fmt::Display + ?core::marker::Sized
-pub fn aya_obj::relocation::EbpfRelocationError::to_string(&self) -> alloc::string::String
-impl<T> core::any::Any for aya_obj::relocation::EbpfRelocationError where T: 'static + ?core::marker::Sized
-pub fn aya_obj::relocation::EbpfRelocationError::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_obj::relocation::EbpfRelocationError where T: ?core::marker::Sized
-pub fn aya_obj::relocation::EbpfRelocationError::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_obj::relocation::EbpfRelocationError where T: ?core::marker::Sized
-pub fn aya_obj::relocation::EbpfRelocationError::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya_obj::relocation::EbpfRelocationError
-pub fn aya_obj::relocation::EbpfRelocationError::from(t: T) -> T
 pub enum aya_obj::EbpfSectionKind
 pub aya_obj::EbpfSectionKind::Bss
 pub aya_obj::EbpfSectionKind::Btf
@@ -9695,28 +5171,6 @@ impl core::marker::Unpin for aya_obj::EbpfSectionKind
 impl core::marker::UnsafeUnpin for aya_obj::EbpfSectionKind
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::EbpfSectionKind
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::EbpfSectionKind
-impl<T, U> core::convert::Into<U> for aya_obj::EbpfSectionKind where U: core::convert::From<T>
-pub fn aya_obj::EbpfSectionKind::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_obj::EbpfSectionKind where U: core::convert::Into<T>
-pub type aya_obj::EbpfSectionKind::Error = core::convert::Infallible
-pub fn aya_obj::EbpfSectionKind::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_obj::EbpfSectionKind where U: core::convert::TryFrom<T>
-pub type aya_obj::EbpfSectionKind::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_obj::EbpfSectionKind::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya_obj::EbpfSectionKind where T: core::clone::Clone
-pub type aya_obj::EbpfSectionKind::Owned = T
-pub fn aya_obj::EbpfSectionKind::clone_into(&self, target: &mut T)
-pub fn aya_obj::EbpfSectionKind::to_owned(&self) -> T
-impl<T> core::any::Any for aya_obj::EbpfSectionKind where T: 'static + ?core::marker::Sized
-pub fn aya_obj::EbpfSectionKind::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_obj::EbpfSectionKind where T: ?core::marker::Sized
-pub fn aya_obj::EbpfSectionKind::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_obj::EbpfSectionKind where T: ?core::marker::Sized
-pub fn aya_obj::EbpfSectionKind::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::EbpfSectionKind where T: core::clone::Clone
-pub unsafe fn aya_obj::EbpfSectionKind::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_obj::EbpfSectionKind
-pub fn aya_obj::EbpfSectionKind::from(t: T) -> T
 pub enum aya_obj::Map
 pub aya_obj::Map::Btf(aya_obj::maps::BtfMap)
 pub aya_obj::Map::Legacy(aya_obj::maps::LegacyMap)
@@ -9746,28 +5200,6 @@ impl core::marker::Unpin for aya_obj::maps::Map
 impl core::marker::UnsafeUnpin for aya_obj::maps::Map
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::maps::Map
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::maps::Map
-impl<T, U> core::convert::Into<U> for aya_obj::maps::Map where U: core::convert::From<T>
-pub fn aya_obj::maps::Map::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_obj::maps::Map where U: core::convert::Into<T>
-pub type aya_obj::maps::Map::Error = core::convert::Infallible
-pub fn aya_obj::maps::Map::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_obj::maps::Map where U: core::convert::TryFrom<T>
-pub type aya_obj::maps::Map::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_obj::maps::Map::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya_obj::maps::Map where T: core::clone::Clone
-pub type aya_obj::maps::Map::Owned = T
-pub fn aya_obj::maps::Map::clone_into(&self, target: &mut T)
-pub fn aya_obj::maps::Map::to_owned(&self) -> T
-impl<T> core::any::Any for aya_obj::maps::Map where T: 'static + ?core::marker::Sized
-pub fn aya_obj::maps::Map::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_obj::maps::Map where T: ?core::marker::Sized
-pub fn aya_obj::maps::Map::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_obj::maps::Map where T: ?core::marker::Sized
-pub fn aya_obj::maps::Map::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::maps::Map where T: core::clone::Clone
-pub unsafe fn aya_obj::maps::Map::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_obj::maps::Map
-pub fn aya_obj::maps::Map::from(t: T) -> T
 pub enum aya_obj::ParseError
 pub aya_obj::ParseError::BtfError(aya_obj::btf::BtfError)
 pub aya_obj::ParseError::ElfError(object::read::Error)
@@ -9823,24 +5255,6 @@ impl core::marker::Unpin for aya_obj::ParseError
 impl core::marker::UnsafeUnpin for aya_obj::ParseError
 impl !core::panic::unwind_safe::RefUnwindSafe for aya_obj::ParseError
 impl !core::panic::unwind_safe::UnwindSafe for aya_obj::ParseError
-impl<T, U> core::convert::Into<U> for aya_obj::ParseError where U: core::convert::From<T>
-pub fn aya_obj::ParseError::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_obj::ParseError where U: core::convert::Into<T>
-pub type aya_obj::ParseError::Error = core::convert::Infallible
-pub fn aya_obj::ParseError::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_obj::ParseError where U: core::convert::TryFrom<T>
-pub type aya_obj::ParseError::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_obj::ParseError::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::string::ToString for aya_obj::ParseError where T: core::fmt::Display + ?core::marker::Sized
-pub fn aya_obj::ParseError::to_string(&self) -> alloc::string::String
-impl<T> core::any::Any for aya_obj::ParseError where T: 'static + ?core::marker::Sized
-pub fn aya_obj::ParseError::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_obj::ParseError where T: ?core::marker::Sized
-pub fn aya_obj::ParseError::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_obj::ParseError where T: ?core::marker::Sized
-pub fn aya_obj::ParseError::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya_obj::ParseError
-pub fn aya_obj::ParseError::from(t: T) -> T
 pub enum aya_obj::ProgramSection
 pub aya_obj::ProgramSection::BtfTracePoint
 pub aya_obj::ProgramSection::CgroupDevice
@@ -9898,28 +5312,6 @@ impl core::marker::Unpin for aya_obj::ProgramSection
 impl core::marker::UnsafeUnpin for aya_obj::ProgramSection
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::ProgramSection
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::ProgramSection
-impl<T, U> core::convert::Into<U> for aya_obj::ProgramSection where U: core::convert::From<T>
-pub fn aya_obj::ProgramSection::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_obj::ProgramSection where U: core::convert::Into<T>
-pub type aya_obj::ProgramSection::Error = core::convert::Infallible
-pub fn aya_obj::ProgramSection::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_obj::ProgramSection where U: core::convert::TryFrom<T>
-pub type aya_obj::ProgramSection::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_obj::ProgramSection::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya_obj::ProgramSection where T: core::clone::Clone
-pub type aya_obj::ProgramSection::Owned = T
-pub fn aya_obj::ProgramSection::clone_into(&self, target: &mut T)
-pub fn aya_obj::ProgramSection::to_owned(&self) -> T
-impl<T> core::any::Any for aya_obj::ProgramSection where T: 'static + ?core::marker::Sized
-pub fn aya_obj::ProgramSection::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_obj::ProgramSection where T: ?core::marker::Sized
-pub fn aya_obj::ProgramSection::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_obj::ProgramSection where T: ?core::marker::Sized
-pub fn aya_obj::ProgramSection::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::ProgramSection where T: core::clone::Clone
-pub unsafe fn aya_obj::ProgramSection::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_obj::ProgramSection
-pub fn aya_obj::ProgramSection::from(t: T) -> T
 pub struct aya_obj::Features
 impl aya_obj::Features
 pub const fn aya_obj::Features::bpf_cookie(&self) -> bool
@@ -9941,22 +5333,6 @@ impl core::marker::Unpin for aya_obj::Features
 impl core::marker::UnsafeUnpin for aya_obj::Features
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::Features
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::Features
-impl<T, U> core::convert::Into<U> for aya_obj::Features where U: core::convert::From<T>
-pub fn aya_obj::Features::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_obj::Features where U: core::convert::Into<T>
-pub type aya_obj::Features::Error = core::convert::Infallible
-pub fn aya_obj::Features::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_obj::Features where U: core::convert::TryFrom<T>
-pub type aya_obj::Features::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_obj::Features::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_obj::Features where T: 'static + ?core::marker::Sized
-pub fn aya_obj::Features::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_obj::Features where T: ?core::marker::Sized
-pub fn aya_obj::Features::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_obj::Features where T: ?core::marker::Sized
-pub fn aya_obj::Features::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya_obj::Features
-pub fn aya_obj::Features::from(t: T) -> T
 pub struct aya_obj::Function
 pub aya_obj::Function::address: u64
 pub aya_obj::Function::func_info: aya_obj::btf::FuncSecInfo
@@ -9978,28 +5354,6 @@ impl core::marker::Unpin for aya_obj::Function
 impl core::marker::UnsafeUnpin for aya_obj::Function
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::Function
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::Function
-impl<T, U> core::convert::Into<U> for aya_obj::Function where U: core::convert::From<T>
-pub fn aya_obj::Function::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_obj::Function where U: core::convert::Into<T>
-pub type aya_obj::Function::Error = core::convert::Infallible
-pub fn aya_obj::Function::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_obj::Function where U: core::convert::TryFrom<T>
-pub type aya_obj::Function::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_obj::Function::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya_obj::Function where T: core::clone::Clone
-pub type aya_obj::Function::Owned = T
-pub fn aya_obj::Function::clone_into(&self, target: &mut T)
-pub fn aya_obj::Function::to_owned(&self) -> T
-impl<T> core::any::Any for aya_obj::Function where T: 'static + ?core::marker::Sized
-pub fn aya_obj::Function::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_obj::Function where T: ?core::marker::Sized
-pub fn aya_obj::Function::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_obj::Function where T: ?core::marker::Sized
-pub fn aya_obj::Function::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::Function where T: core::clone::Clone
-pub unsafe fn aya_obj::Function::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_obj::Function
-pub fn aya_obj::Function::from(t: T) -> T
 pub struct aya_obj::InvalidTypeBinding<T>
 pub aya_obj::InvalidTypeBinding::value: T
 impl<T> core::marker::Freeze for aya_obj::InvalidTypeBinding<T> where T: core::marker::Freeze
@@ -10009,22 +5363,6 @@ impl<T> core::marker::Unpin for aya_obj::InvalidTypeBinding<T> where T: core::ma
 impl<T> core::marker::UnsafeUnpin for aya_obj::InvalidTypeBinding<T> where T: core::marker::UnsafeUnpin
 impl<T> core::panic::unwind_safe::RefUnwindSafe for aya_obj::InvalidTypeBinding<T> where T: core::panic::unwind_safe::RefUnwindSafe
 impl<T> core::panic::unwind_safe::UnwindSafe for aya_obj::InvalidTypeBinding<T> where T: core::panic::unwind_safe::UnwindSafe
-impl<T, U> core::convert::Into<U> for aya_obj::InvalidTypeBinding<T> where U: core::convert::From<T>
-pub fn aya_obj::InvalidTypeBinding<T>::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_obj::InvalidTypeBinding<T> where U: core::convert::Into<T>
-pub type aya_obj::InvalidTypeBinding<T>::Error = core::convert::Infallible
-pub fn aya_obj::InvalidTypeBinding<T>::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_obj::InvalidTypeBinding<T> where U: core::convert::TryFrom<T>
-pub type aya_obj::InvalidTypeBinding<T>::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_obj::InvalidTypeBinding<T>::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya_obj::InvalidTypeBinding<T> where T: 'static + ?core::marker::Sized
-pub fn aya_obj::InvalidTypeBinding<T>::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_obj::InvalidTypeBinding<T> where T: ?core::marker::Sized
-pub fn aya_obj::InvalidTypeBinding<T>::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_obj::InvalidTypeBinding<T> where T: ?core::marker::Sized
-pub fn aya_obj::InvalidTypeBinding<T>::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya_obj::InvalidTypeBinding<T>
-pub fn aya_obj::InvalidTypeBinding<T>::from(t: T) -> T
 pub struct aya_obj::Object
 pub aya_obj::Object::btf: core::option::Option<aya_obj::btf::Btf>
 pub aya_obj::Object::btf_ext: core::option::Option<aya_obj::btf::BtfExt>
@@ -10057,28 +5395,6 @@ impl core::marker::Unpin for aya_obj::Object
 impl core::marker::UnsafeUnpin for aya_obj::Object
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::Object
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::Object
-impl<T, U> core::convert::Into<U> for aya_obj::Object where U: core::convert::From<T>
-pub fn aya_obj::Object::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_obj::Object where U: core::convert::Into<T>
-pub type aya_obj::Object::Error = core::convert::Infallible
-pub fn aya_obj::Object::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_obj::Object where U: core::convert::TryFrom<T>
-pub type aya_obj::Object::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_obj::Object::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya_obj::Object where T: core::clone::Clone
-pub type aya_obj::Object::Owned = T
-pub fn aya_obj::Object::clone_into(&self, target: &mut T)
-pub fn aya_obj::Object::to_owned(&self) -> T
-impl<T> core::any::Any for aya_obj::Object where T: 'static + ?core::marker::Sized
-pub fn aya_obj::Object::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_obj::Object where T: ?core::marker::Sized
-pub fn aya_obj::Object::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_obj::Object where T: ?core::marker::Sized
-pub fn aya_obj::Object::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::Object where T: core::clone::Clone
-pub unsafe fn aya_obj::Object::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_obj::Object
-pub fn aya_obj::Object::from(t: T) -> T
 pub struct aya_obj::Program
 pub aya_obj::Program::address: u64
 pub aya_obj::Program::kernel_version: core::option::Option<u32>
@@ -10098,28 +5414,6 @@ impl core::marker::Unpin for aya_obj::Program
 impl core::marker::UnsafeUnpin for aya_obj::Program
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::Program
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::Program
-impl<T, U> core::convert::Into<U> for aya_obj::Program where U: core::convert::From<T>
-pub fn aya_obj::Program::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_obj::Program where U: core::convert::Into<T>
-pub type aya_obj::Program::Error = core::convert::Infallible
-pub fn aya_obj::Program::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_obj::Program where U: core::convert::TryFrom<T>
-pub type aya_obj::Program::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_obj::Program::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya_obj::Program where T: core::clone::Clone
-pub type aya_obj::Program::Owned = T
-pub fn aya_obj::Program::clone_into(&self, target: &mut T)
-pub fn aya_obj::Program::to_owned(&self) -> T
-impl<T> core::any::Any for aya_obj::Program where T: 'static + ?core::marker::Sized
-pub fn aya_obj::Program::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_obj::Program where T: ?core::marker::Sized
-pub fn aya_obj::Program::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_obj::Program where T: ?core::marker::Sized
-pub fn aya_obj::Program::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya_obj::Program where T: core::clone::Clone
-pub unsafe fn aya_obj::Program::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya_obj::Program
-pub fn aya_obj::Program::from(t: T) -> T
 pub struct aya_obj::VerifierLog(_)
 impl aya_obj::VerifierLog
 pub const fn aya_obj::VerifierLog::new(log: alloc::string::String) -> Self
@@ -10134,23 +5428,5 @@ impl core::marker::Unpin for aya_obj::VerifierLog
 impl core::marker::UnsafeUnpin for aya_obj::VerifierLog
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::VerifierLog
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::VerifierLog
-impl<T, U> core::convert::Into<U> for aya_obj::VerifierLog where U: core::convert::From<T>
-pub fn aya_obj::VerifierLog::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya_obj::VerifierLog where U: core::convert::Into<T>
-pub type aya_obj::VerifierLog::Error = core::convert::Infallible
-pub fn aya_obj::VerifierLog::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya_obj::VerifierLog where U: core::convert::TryFrom<T>
-pub type aya_obj::VerifierLog::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya_obj::VerifierLog::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::string::ToString for aya_obj::VerifierLog where T: core::fmt::Display + ?core::marker::Sized
-pub fn aya_obj::VerifierLog::to_string(&self) -> alloc::string::String
-impl<T> core::any::Any for aya_obj::VerifierLog where T: 'static + ?core::marker::Sized
-pub fn aya_obj::VerifierLog::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya_obj::VerifierLog where T: ?core::marker::Sized
-pub fn aya_obj::VerifierLog::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya_obj::VerifierLog where T: ?core::marker::Sized
-pub fn aya_obj::VerifierLog::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya_obj::VerifierLog
-pub fn aya_obj::VerifierLog::from(t: T) -> T
 pub fn aya_obj::copy_instructions(data: &[u8]) -> core::result::Result<alloc::vec::Vec<aya_obj::generated::bpf_insn>, aya_obj::ParseError>
 pub const fn aya_obj::parse_map_info(info: aya_obj::generated::bpf_map_info, pinned: aya_obj::maps::PinningType) -> aya_obj::maps::Map

--- a/xtask/public-api/aya.txt
+++ b/xtask/public-api/aya.txt
@@ -34,22 +34,6 @@ impl<T, V> core::marker::Unpin for aya::maps::array::Array<T, V> where T: core::
 impl<T, V> core::marker::UnsafeUnpin for aya::maps::array::Array<T, V> where T: core::marker::UnsafeUnpin
 impl<T, V> core::panic::unwind_safe::RefUnwindSafe for aya::maps::array::Array<T, V> where T: core::panic::unwind_safe::RefUnwindSafe, V: core::panic::unwind_safe::RefUnwindSafe
 impl<T, V> core::panic::unwind_safe::UnwindSafe for aya::maps::array::Array<T, V> where T: core::panic::unwind_safe::UnwindSafe, V: core::panic::unwind_safe::UnwindSafe
-impl<T, U> core::convert::Into<U> for aya::maps::array::Array<T, V> where U: core::convert::From<T>
-pub fn aya::maps::array::Array<T, V>::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::maps::array::Array<T, V> where U: core::convert::Into<T>
-pub type aya::maps::array::Array<T, V>::Error = core::convert::Infallible
-pub fn aya::maps::array::Array<T, V>::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::maps::array::Array<T, V> where U: core::convert::TryFrom<T>
-pub type aya::maps::array::Array<T, V>::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::maps::array::Array<T, V>::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya::maps::array::Array<T, V> where T: 'static + ?core::marker::Sized
-pub fn aya::maps::array::Array<T, V>::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::maps::array::Array<T, V> where T: ?core::marker::Sized
-pub fn aya::maps::array::Array<T, V>::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::maps::array::Array<T, V> where T: ?core::marker::Sized
-pub fn aya::maps::array::Array<T, V>::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya::maps::array::Array<T, V>
-pub fn aya::maps::array::Array<T, V>::from(t: T) -> T
 pub struct aya::maps::array::PerCpuArray<T, V: aya::Pod>
 impl<T: core::borrow::Borrow<aya::maps::MapData>, V: aya::Pod> aya::maps::PerCpuArray<T, V>
 pub fn aya::maps::PerCpuArray<T, V>::get(&self, index: &u32, flags: u64) -> core::result::Result<aya::maps::PerCpuValues<V>, aya::maps::MapError>
@@ -78,22 +62,6 @@ impl<T, V> core::marker::Unpin for aya::maps::PerCpuArray<T, V> where T: core::m
 impl<T, V> core::marker::UnsafeUnpin for aya::maps::PerCpuArray<T, V> where T: core::marker::UnsafeUnpin
 impl<T, V> core::panic::unwind_safe::RefUnwindSafe for aya::maps::PerCpuArray<T, V> where T: core::panic::unwind_safe::RefUnwindSafe, V: core::panic::unwind_safe::RefUnwindSafe
 impl<T, V> core::panic::unwind_safe::UnwindSafe for aya::maps::PerCpuArray<T, V> where T: core::panic::unwind_safe::UnwindSafe, V: core::panic::unwind_safe::UnwindSafe
-impl<T, U> core::convert::Into<U> for aya::maps::PerCpuArray<T, V> where U: core::convert::From<T>
-pub fn aya::maps::PerCpuArray<T, V>::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::maps::PerCpuArray<T, V> where U: core::convert::Into<T>
-pub type aya::maps::PerCpuArray<T, V>::Error = core::convert::Infallible
-pub fn aya::maps::PerCpuArray<T, V>::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::maps::PerCpuArray<T, V> where U: core::convert::TryFrom<T>
-pub type aya::maps::PerCpuArray<T, V>::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::maps::PerCpuArray<T, V>::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya::maps::PerCpuArray<T, V> where T: 'static + ?core::marker::Sized
-pub fn aya::maps::PerCpuArray<T, V>::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::maps::PerCpuArray<T, V> where T: ?core::marker::Sized
-pub fn aya::maps::PerCpuArray<T, V>::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::maps::PerCpuArray<T, V> where T: ?core::marker::Sized
-pub fn aya::maps::PerCpuArray<T, V>::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya::maps::PerCpuArray<T, V>
-pub fn aya::maps::PerCpuArray<T, V>::from(t: T) -> T
 pub struct aya::maps::array::ProgramArray<T>
 impl<T: core::borrow::Borrow<aya::maps::MapData>> aya::maps::ProgramArray<T>
 pub fn aya::maps::ProgramArray<T>::indices(&self) -> aya::maps::MapKeys<'_, u32>
@@ -118,22 +86,6 @@ impl<T> core::marker::Unpin for aya::maps::ProgramArray<T> where T: core::marker
 impl<T> core::marker::UnsafeUnpin for aya::maps::ProgramArray<T> where T: core::marker::UnsafeUnpin
 impl<T> core::panic::unwind_safe::RefUnwindSafe for aya::maps::ProgramArray<T> where T: core::panic::unwind_safe::RefUnwindSafe
 impl<T> core::panic::unwind_safe::UnwindSafe for aya::maps::ProgramArray<T> where T: core::panic::unwind_safe::UnwindSafe
-impl<T, U> core::convert::Into<U> for aya::maps::ProgramArray<T> where U: core::convert::From<T>
-pub fn aya::maps::ProgramArray<T>::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::maps::ProgramArray<T> where U: core::convert::Into<T>
-pub type aya::maps::ProgramArray<T>::Error = core::convert::Infallible
-pub fn aya::maps::ProgramArray<T>::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::maps::ProgramArray<T> where U: core::convert::TryFrom<T>
-pub type aya::maps::ProgramArray<T>::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::maps::ProgramArray<T>::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya::maps::ProgramArray<T> where T: 'static + ?core::marker::Sized
-pub fn aya::maps::ProgramArray<T>::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::maps::ProgramArray<T> where T: ?core::marker::Sized
-pub fn aya::maps::ProgramArray<T>::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::maps::ProgramArray<T> where T: ?core::marker::Sized
-pub fn aya::maps::ProgramArray<T>::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya::maps::ProgramArray<T>
-pub fn aya::maps::ProgramArray<T>::from(t: T) -> T
 pub mod aya::maps::bloom_filter
 pub struct aya::maps::bloom_filter::BloomFilter<T, V: aya::Pod>
 impl<T: core::borrow::Borrow<aya::maps::MapData>, V: aya::Pod> aya::maps::bloom_filter::BloomFilter<T, V>
@@ -160,22 +112,6 @@ impl<T, V> core::marker::Unpin for aya::maps::bloom_filter::BloomFilter<T, V> wh
 impl<T, V> core::marker::UnsafeUnpin for aya::maps::bloom_filter::BloomFilter<T, V> where T: core::marker::UnsafeUnpin
 impl<T, V> core::panic::unwind_safe::RefUnwindSafe for aya::maps::bloom_filter::BloomFilter<T, V> where T: core::panic::unwind_safe::RefUnwindSafe, V: core::panic::unwind_safe::RefUnwindSafe
 impl<T, V> core::panic::unwind_safe::UnwindSafe for aya::maps::bloom_filter::BloomFilter<T, V> where T: core::panic::unwind_safe::UnwindSafe, V: core::panic::unwind_safe::UnwindSafe
-impl<T, U> core::convert::Into<U> for aya::maps::bloom_filter::BloomFilter<T, V> where U: core::convert::From<T>
-pub fn aya::maps::bloom_filter::BloomFilter<T, V>::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::maps::bloom_filter::BloomFilter<T, V> where U: core::convert::Into<T>
-pub type aya::maps::bloom_filter::BloomFilter<T, V>::Error = core::convert::Infallible
-pub fn aya::maps::bloom_filter::BloomFilter<T, V>::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::maps::bloom_filter::BloomFilter<T, V> where U: core::convert::TryFrom<T>
-pub type aya::maps::bloom_filter::BloomFilter<T, V>::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::maps::bloom_filter::BloomFilter<T, V>::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya::maps::bloom_filter::BloomFilter<T, V> where T: 'static + ?core::marker::Sized
-pub fn aya::maps::bloom_filter::BloomFilter<T, V>::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::maps::bloom_filter::BloomFilter<T, V> where T: ?core::marker::Sized
-pub fn aya::maps::bloom_filter::BloomFilter<T, V>::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::maps::bloom_filter::BloomFilter<T, V> where T: ?core::marker::Sized
-pub fn aya::maps::bloom_filter::BloomFilter<T, V>::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya::maps::bloom_filter::BloomFilter<T, V>
-pub fn aya::maps::bloom_filter::BloomFilter<T, V>::from(t: T) -> T
 pub mod aya::maps::hash_map
 pub struct aya::maps::hash_map::HashMap<T, K, V>
 impl<T: core::borrow::Borrow<aya::maps::MapData>, K: aya::Pod, V: aya::Pod> aya::maps::hash_map::HashMap<T, K, V>
@@ -212,22 +148,6 @@ impl<T, K, V> core::marker::Unpin for aya::maps::hash_map::HashMap<T, K, V> wher
 impl<T, K, V> core::marker::UnsafeUnpin for aya::maps::hash_map::HashMap<T, K, V> where T: core::marker::UnsafeUnpin
 impl<T, K, V> core::panic::unwind_safe::RefUnwindSafe for aya::maps::hash_map::HashMap<T, K, V> where T: core::panic::unwind_safe::RefUnwindSafe, K: core::panic::unwind_safe::RefUnwindSafe, V: core::panic::unwind_safe::RefUnwindSafe
 impl<T, K, V> core::panic::unwind_safe::UnwindSafe for aya::maps::hash_map::HashMap<T, K, V> where T: core::panic::unwind_safe::UnwindSafe, K: core::panic::unwind_safe::UnwindSafe, V: core::panic::unwind_safe::UnwindSafe
-impl<T, U> core::convert::Into<U> for aya::maps::hash_map::HashMap<T, K, V> where U: core::convert::From<T>
-pub fn aya::maps::hash_map::HashMap<T, K, V>::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::maps::hash_map::HashMap<T, K, V> where U: core::convert::Into<T>
-pub type aya::maps::hash_map::HashMap<T, K, V>::Error = core::convert::Infallible
-pub fn aya::maps::hash_map::HashMap<T, K, V>::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::maps::hash_map::HashMap<T, K, V> where U: core::convert::TryFrom<T>
-pub type aya::maps::hash_map::HashMap<T, K, V>::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::maps::hash_map::HashMap<T, K, V>::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya::maps::hash_map::HashMap<T, K, V> where T: 'static + ?core::marker::Sized
-pub fn aya::maps::hash_map::HashMap<T, K, V>::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::maps::hash_map::HashMap<T, K, V> where T: ?core::marker::Sized
-pub fn aya::maps::hash_map::HashMap<T, K, V>::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::maps::hash_map::HashMap<T, K, V> where T: ?core::marker::Sized
-pub fn aya::maps::hash_map::HashMap<T, K, V>::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya::maps::hash_map::HashMap<T, K, V>
-pub fn aya::maps::hash_map::HashMap<T, K, V>::from(t: T) -> T
 pub struct aya::maps::hash_map::PerCpuHashMap<T, K: aya::Pod, V: aya::Pod>
 impl<T: core::borrow::Borrow<aya::maps::MapData>, K: aya::Pod, V: aya::Pod> aya::maps::hash_map::PerCpuHashMap<T, K, V>
 pub fn aya::maps::hash_map::PerCpuHashMap<T, K, V>::get(&self, key: &K, flags: u64) -> core::result::Result<aya::maps::PerCpuValues<V>, aya::maps::MapError>
@@ -261,22 +181,6 @@ impl<T, K, V> core::marker::Unpin for aya::maps::hash_map::PerCpuHashMap<T, K, V
 impl<T, K, V> core::marker::UnsafeUnpin for aya::maps::hash_map::PerCpuHashMap<T, K, V> where T: core::marker::UnsafeUnpin
 impl<T, K, V> core::panic::unwind_safe::RefUnwindSafe for aya::maps::hash_map::PerCpuHashMap<T, K, V> where T: core::panic::unwind_safe::RefUnwindSafe, K: core::panic::unwind_safe::RefUnwindSafe, V: core::panic::unwind_safe::RefUnwindSafe
 impl<T, K, V> core::panic::unwind_safe::UnwindSafe for aya::maps::hash_map::PerCpuHashMap<T, K, V> where T: core::panic::unwind_safe::UnwindSafe, K: core::panic::unwind_safe::UnwindSafe, V: core::panic::unwind_safe::UnwindSafe
-impl<T, U> core::convert::Into<U> for aya::maps::hash_map::PerCpuHashMap<T, K, V> where U: core::convert::From<T>
-pub fn aya::maps::hash_map::PerCpuHashMap<T, K, V>::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::maps::hash_map::PerCpuHashMap<T, K, V> where U: core::convert::Into<T>
-pub type aya::maps::hash_map::PerCpuHashMap<T, K, V>::Error = core::convert::Infallible
-pub fn aya::maps::hash_map::PerCpuHashMap<T, K, V>::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::maps::hash_map::PerCpuHashMap<T, K, V> where U: core::convert::TryFrom<T>
-pub type aya::maps::hash_map::PerCpuHashMap<T, K, V>::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::maps::hash_map::PerCpuHashMap<T, K, V>::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya::maps::hash_map::PerCpuHashMap<T, K, V> where T: 'static + ?core::marker::Sized
-pub fn aya::maps::hash_map::PerCpuHashMap<T, K, V>::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::maps::hash_map::PerCpuHashMap<T, K, V> where T: ?core::marker::Sized
-pub fn aya::maps::hash_map::PerCpuHashMap<T, K, V>::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::maps::hash_map::PerCpuHashMap<T, K, V> where T: ?core::marker::Sized
-pub fn aya::maps::hash_map::PerCpuHashMap<T, K, V>::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya::maps::hash_map::PerCpuHashMap<T, K, V>
-pub fn aya::maps::hash_map::PerCpuHashMap<T, K, V>::from(t: T) -> T
 pub mod aya::maps::lpm_trie
 #[repr(C, packed(1))] pub struct aya::maps::lpm_trie::Key<K>
 impl<K: aya::Pod> aya::maps::lpm_trie::Key<K>
@@ -297,28 +201,6 @@ impl<K> core::marker::Unpin for aya::maps::lpm_trie::Key<K> where K: core::marke
 impl<K> core::marker::UnsafeUnpin for aya::maps::lpm_trie::Key<K> where K: core::marker::UnsafeUnpin
 impl<K> core::panic::unwind_safe::RefUnwindSafe for aya::maps::lpm_trie::Key<K> where K: core::panic::unwind_safe::RefUnwindSafe
 impl<K> core::panic::unwind_safe::UnwindSafe for aya::maps::lpm_trie::Key<K> where K: core::panic::unwind_safe::UnwindSafe
-impl<T, U> core::convert::Into<U> for aya::maps::lpm_trie::Key<K> where U: core::convert::From<T>
-pub fn aya::maps::lpm_trie::Key<K>::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::maps::lpm_trie::Key<K> where U: core::convert::Into<T>
-pub type aya::maps::lpm_trie::Key<K>::Error = core::convert::Infallible
-pub fn aya::maps::lpm_trie::Key<K>::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::maps::lpm_trie::Key<K> where U: core::convert::TryFrom<T>
-pub type aya::maps::lpm_trie::Key<K>::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::maps::lpm_trie::Key<K>::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya::maps::lpm_trie::Key<K> where T: core::clone::Clone
-pub type aya::maps::lpm_trie::Key<K>::Owned = T
-pub fn aya::maps::lpm_trie::Key<K>::clone_into(&self, target: &mut T)
-pub fn aya::maps::lpm_trie::Key<K>::to_owned(&self) -> T
-impl<T> core::any::Any for aya::maps::lpm_trie::Key<K> where T: 'static + ?core::marker::Sized
-pub fn aya::maps::lpm_trie::Key<K>::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::maps::lpm_trie::Key<K> where T: ?core::marker::Sized
-pub fn aya::maps::lpm_trie::Key<K>::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::maps::lpm_trie::Key<K> where T: ?core::marker::Sized
-pub fn aya::maps::lpm_trie::Key<K>::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya::maps::lpm_trie::Key<K> where T: core::clone::Clone
-pub unsafe fn aya::maps::lpm_trie::Key<K>::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya::maps::lpm_trie::Key<K>
-pub fn aya::maps::lpm_trie::Key<K>::from(t: T) -> T
 pub struct aya::maps::lpm_trie::LpmTrie<T, K, V>
 impl<T: core::borrow::Borrow<aya::maps::MapData>, K: aya::Pod, V: aya::Pod> aya::maps::lpm_trie::LpmTrie<T, K, V>
 pub fn aya::maps::lpm_trie::LpmTrie<T, K, V>::get(&self, key: &aya::maps::lpm_trie::Key<K>, flags: u64) -> core::result::Result<V, aya::maps::MapError>
@@ -354,22 +236,6 @@ impl<T, K, V> core::marker::Unpin for aya::maps::lpm_trie::LpmTrie<T, K, V> wher
 impl<T, K, V> core::marker::UnsafeUnpin for aya::maps::lpm_trie::LpmTrie<T, K, V> where T: core::marker::UnsafeUnpin
 impl<T, K, V> core::panic::unwind_safe::RefUnwindSafe for aya::maps::lpm_trie::LpmTrie<T, K, V> where T: core::panic::unwind_safe::RefUnwindSafe, K: core::panic::unwind_safe::RefUnwindSafe, V: core::panic::unwind_safe::RefUnwindSafe
 impl<T, K, V> core::panic::unwind_safe::UnwindSafe for aya::maps::lpm_trie::LpmTrie<T, K, V> where T: core::panic::unwind_safe::UnwindSafe, K: core::panic::unwind_safe::UnwindSafe, V: core::panic::unwind_safe::UnwindSafe
-impl<T, U> core::convert::Into<U> for aya::maps::lpm_trie::LpmTrie<T, K, V> where U: core::convert::From<T>
-pub fn aya::maps::lpm_trie::LpmTrie<T, K, V>::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::maps::lpm_trie::LpmTrie<T, K, V> where U: core::convert::Into<T>
-pub type aya::maps::lpm_trie::LpmTrie<T, K, V>::Error = core::convert::Infallible
-pub fn aya::maps::lpm_trie::LpmTrie<T, K, V>::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::maps::lpm_trie::LpmTrie<T, K, V> where U: core::convert::TryFrom<T>
-pub type aya::maps::lpm_trie::LpmTrie<T, K, V>::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::maps::lpm_trie::LpmTrie<T, K, V>::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya::maps::lpm_trie::LpmTrie<T, K, V> where T: 'static + ?core::marker::Sized
-pub fn aya::maps::lpm_trie::LpmTrie<T, K, V>::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::maps::lpm_trie::LpmTrie<T, K, V> where T: ?core::marker::Sized
-pub fn aya::maps::lpm_trie::LpmTrie<T, K, V>::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::maps::lpm_trie::LpmTrie<T, K, V> where T: ?core::marker::Sized
-pub fn aya::maps::lpm_trie::LpmTrie<T, K, V>::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya::maps::lpm_trie::LpmTrie<T, K, V>
-pub fn aya::maps::lpm_trie::LpmTrie<T, K, V>::from(t: T) -> T
 pub mod aya::maps::perf
 pub enum aya::maps::perf::PerfBufferError
 pub aya::maps::perf::PerfBufferError::IOError(std::io::error::Error)
@@ -399,24 +265,6 @@ impl core::marker::Unpin for aya::maps::perf::PerfBufferError
 impl core::marker::UnsafeUnpin for aya::maps::perf::PerfBufferError
 impl !core::panic::unwind_safe::RefUnwindSafe for aya::maps::perf::PerfBufferError
 impl !core::panic::unwind_safe::UnwindSafe for aya::maps::perf::PerfBufferError
-impl<T, U> core::convert::Into<U> for aya::maps::perf::PerfBufferError where U: core::convert::From<T>
-pub fn aya::maps::perf::PerfBufferError::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::maps::perf::PerfBufferError where U: core::convert::Into<T>
-pub type aya::maps::perf::PerfBufferError::Error = core::convert::Infallible
-pub fn aya::maps::perf::PerfBufferError::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::maps::perf::PerfBufferError where U: core::convert::TryFrom<T>
-pub type aya::maps::perf::PerfBufferError::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::maps::perf::PerfBufferError::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::string::ToString for aya::maps::perf::PerfBufferError where T: core::fmt::Display + ?core::marker::Sized
-pub fn aya::maps::perf::PerfBufferError::to_string(&self) -> alloc::string::String
-impl<T> core::any::Any for aya::maps::perf::PerfBufferError where T: 'static + ?core::marker::Sized
-pub fn aya::maps::perf::PerfBufferError::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::maps::perf::PerfBufferError where T: ?core::marker::Sized
-pub fn aya::maps::perf::PerfBufferError::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::maps::perf::PerfBufferError where T: ?core::marker::Sized
-pub fn aya::maps::perf::PerfBufferError::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya::maps::perf::PerfBufferError
-pub fn aya::maps::perf::PerfBufferError::from(t: T) -> T
 pub struct aya::maps::perf::Events
 pub aya::maps::perf::Events::lost: usize
 pub aya::maps::perf::Events::read: usize
@@ -433,26 +281,6 @@ impl core::marker::Unpin for aya::maps::perf::Events
 impl core::marker::UnsafeUnpin for aya::maps::perf::Events
 impl core::panic::unwind_safe::RefUnwindSafe for aya::maps::perf::Events
 impl core::panic::unwind_safe::UnwindSafe for aya::maps::perf::Events
-impl<Q, K> equivalent::Equivalent<K> for aya::maps::perf::Events where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
-pub fn aya::maps::perf::Events::equivalent(&self, key: &K) -> bool
-impl<Q, K> hashbrown::Equivalent<K> for aya::maps::perf::Events where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
-pub fn aya::maps::perf::Events::equivalent(&self, key: &K) -> bool
-impl<T, U> core::convert::Into<U> for aya::maps::perf::Events where U: core::convert::From<T>
-pub fn aya::maps::perf::Events::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::maps::perf::Events where U: core::convert::Into<T>
-pub type aya::maps::perf::Events::Error = core::convert::Infallible
-pub fn aya::maps::perf::Events::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::maps::perf::Events where U: core::convert::TryFrom<T>
-pub type aya::maps::perf::Events::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::maps::perf::Events::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya::maps::perf::Events where T: 'static + ?core::marker::Sized
-pub fn aya::maps::perf::Events::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::maps::perf::Events where T: ?core::marker::Sized
-pub fn aya::maps::perf::Events::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::maps::perf::Events where T: ?core::marker::Sized
-pub fn aya::maps::perf::Events::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya::maps::perf::Events
-pub fn aya::maps::perf::Events::from(t: T) -> T
 pub struct aya::maps::perf::PerfEventArray<T>
 impl<T: core::borrow::Borrow<aya::maps::MapData>> aya::maps::perf::PerfEventArray<T>
 pub fn aya::maps::perf::PerfEventArray<T>::pin<P: core::convert::AsRef<std::path::Path>>(&self, path: P) -> core::result::Result<(), aya::pin::PinError>
@@ -474,22 +302,6 @@ impl<T> core::marker::Unpin for aya::maps::perf::PerfEventArray<T>
 impl<T> core::marker::UnsafeUnpin for aya::maps::perf::PerfEventArray<T>
 impl<T> core::panic::unwind_safe::RefUnwindSafe for aya::maps::perf::PerfEventArray<T> where T: core::panic::unwind_safe::RefUnwindSafe
 impl<T> core::panic::unwind_safe::UnwindSafe for aya::maps::perf::PerfEventArray<T> where T: core::panic::unwind_safe::RefUnwindSafe
-impl<T, U> core::convert::Into<U> for aya::maps::perf::PerfEventArray<T> where U: core::convert::From<T>
-pub fn aya::maps::perf::PerfEventArray<T>::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::maps::perf::PerfEventArray<T> where U: core::convert::Into<T>
-pub type aya::maps::perf::PerfEventArray<T>::Error = core::convert::Infallible
-pub fn aya::maps::perf::PerfEventArray<T>::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::maps::perf::PerfEventArray<T> where U: core::convert::TryFrom<T>
-pub type aya::maps::perf::PerfEventArray<T>::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::maps::perf::PerfEventArray<T>::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya::maps::perf::PerfEventArray<T> where T: 'static + ?core::marker::Sized
-pub fn aya::maps::perf::PerfEventArray<T>::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::maps::perf::PerfEventArray<T> where T: ?core::marker::Sized
-pub fn aya::maps::perf::PerfEventArray<T>::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::maps::perf::PerfEventArray<T> where T: ?core::marker::Sized
-pub fn aya::maps::perf::PerfEventArray<T>::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya::maps::perf::PerfEventArray<T>
-pub fn aya::maps::perf::PerfEventArray<T>::from(t: T) -> T
 pub struct aya::maps::perf::PerfEventArrayBuffer<T>
 impl<T: core::borrow::BorrowMut<aya::maps::MapData>> aya::maps::perf::PerfEventArrayBuffer<T>
 pub fn aya::maps::perf::PerfEventArrayBuffer<T>::read_events(&mut self, out_bufs: &mut [bytes::bytes_mut::BytesMut]) -> core::result::Result<aya::maps::perf::Events, aya::maps::perf::PerfBufferError>
@@ -505,22 +317,6 @@ impl<T> core::marker::Unpin for aya::maps::perf::PerfEventArrayBuffer<T>
 impl<T> core::marker::UnsafeUnpin for aya::maps::perf::PerfEventArrayBuffer<T>
 impl<T> core::panic::unwind_safe::RefUnwindSafe for aya::maps::perf::PerfEventArrayBuffer<T> where T: core::panic::unwind_safe::RefUnwindSafe
 impl<T> core::panic::unwind_safe::UnwindSafe for aya::maps::perf::PerfEventArrayBuffer<T> where T: core::panic::unwind_safe::RefUnwindSafe
-impl<T, U> core::convert::Into<U> for aya::maps::perf::PerfEventArrayBuffer<T> where U: core::convert::From<T>
-pub fn aya::maps::perf::PerfEventArrayBuffer<T>::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::maps::perf::PerfEventArrayBuffer<T> where U: core::convert::Into<T>
-pub type aya::maps::perf::PerfEventArrayBuffer<T>::Error = core::convert::Infallible
-pub fn aya::maps::perf::PerfEventArrayBuffer<T>::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::maps::perf::PerfEventArrayBuffer<T> where U: core::convert::TryFrom<T>
-pub type aya::maps::perf::PerfEventArrayBuffer<T>::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::maps::perf::PerfEventArrayBuffer<T>::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya::maps::perf::PerfEventArrayBuffer<T> where T: 'static + ?core::marker::Sized
-pub fn aya::maps::perf::PerfEventArrayBuffer<T>::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::maps::perf::PerfEventArrayBuffer<T> where T: ?core::marker::Sized
-pub fn aya::maps::perf::PerfEventArrayBuffer<T>::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::maps::perf::PerfEventArrayBuffer<T> where T: ?core::marker::Sized
-pub fn aya::maps::perf::PerfEventArrayBuffer<T>::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya::maps::perf::PerfEventArrayBuffer<T>
-pub fn aya::maps::perf::PerfEventArrayBuffer<T>::from(t: T) -> T
 pub mod aya::maps::queue
 pub struct aya::maps::queue::Queue<T, V: aya::Pod>
 impl<T: core::borrow::Borrow<aya::maps::MapData>, V: aya::Pod> aya::maps::queue::Queue<T, V>
@@ -546,22 +342,6 @@ impl<T, V> core::marker::Unpin for aya::maps::queue::Queue<T, V> where T: core::
 impl<T, V> core::marker::UnsafeUnpin for aya::maps::queue::Queue<T, V> where T: core::marker::UnsafeUnpin
 impl<T, V> core::panic::unwind_safe::RefUnwindSafe for aya::maps::queue::Queue<T, V> where T: core::panic::unwind_safe::RefUnwindSafe, V: core::panic::unwind_safe::RefUnwindSafe
 impl<T, V> core::panic::unwind_safe::UnwindSafe for aya::maps::queue::Queue<T, V> where T: core::panic::unwind_safe::UnwindSafe, V: core::panic::unwind_safe::UnwindSafe
-impl<T, U> core::convert::Into<U> for aya::maps::queue::Queue<T, V> where U: core::convert::From<T>
-pub fn aya::maps::queue::Queue<T, V>::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::maps::queue::Queue<T, V> where U: core::convert::Into<T>
-pub type aya::maps::queue::Queue<T, V>::Error = core::convert::Infallible
-pub fn aya::maps::queue::Queue<T, V>::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::maps::queue::Queue<T, V> where U: core::convert::TryFrom<T>
-pub type aya::maps::queue::Queue<T, V>::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::maps::queue::Queue<T, V>::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya::maps::queue::Queue<T, V> where T: 'static + ?core::marker::Sized
-pub fn aya::maps::queue::Queue<T, V>::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::maps::queue::Queue<T, V> where T: ?core::marker::Sized
-pub fn aya::maps::queue::Queue<T, V>::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::maps::queue::Queue<T, V> where T: ?core::marker::Sized
-pub fn aya::maps::queue::Queue<T, V>::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya::maps::queue::Queue<T, V>
-pub fn aya::maps::queue::Queue<T, V>::from(t: T) -> T
 pub mod aya::maps::ring_buf
 pub struct aya::maps::ring_buf::RingBuf<T>
 impl<T> aya::maps::ring_buf::RingBuf<T>
@@ -586,22 +366,6 @@ impl<T> core::marker::Unpin for aya::maps::ring_buf::RingBuf<T> where T: core::m
 impl<T> core::marker::UnsafeUnpin for aya::maps::ring_buf::RingBuf<T> where T: core::marker::UnsafeUnpin
 impl<T> core::panic::unwind_safe::RefUnwindSafe for aya::maps::ring_buf::RingBuf<T> where T: core::panic::unwind_safe::RefUnwindSafe
 impl<T> core::panic::unwind_safe::UnwindSafe for aya::maps::ring_buf::RingBuf<T> where T: core::panic::unwind_safe::UnwindSafe
-impl<T, U> core::convert::Into<U> for aya::maps::ring_buf::RingBuf<T> where U: core::convert::From<T>
-pub fn aya::maps::ring_buf::RingBuf<T>::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::maps::ring_buf::RingBuf<T> where U: core::convert::Into<T>
-pub type aya::maps::ring_buf::RingBuf<T>::Error = core::convert::Infallible
-pub fn aya::maps::ring_buf::RingBuf<T>::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::maps::ring_buf::RingBuf<T> where U: core::convert::TryFrom<T>
-pub type aya::maps::ring_buf::RingBuf<T>::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::maps::ring_buf::RingBuf<T>::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya::maps::ring_buf::RingBuf<T> where T: 'static + ?core::marker::Sized
-pub fn aya::maps::ring_buf::RingBuf<T>::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::maps::ring_buf::RingBuf<T> where T: ?core::marker::Sized
-pub fn aya::maps::ring_buf::RingBuf<T>::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::maps::ring_buf::RingBuf<T> where T: ?core::marker::Sized
-pub fn aya::maps::ring_buf::RingBuf<T>::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya::maps::ring_buf::RingBuf<T>
-pub fn aya::maps::ring_buf::RingBuf<T>::from(t: T) -> T
 pub struct aya::maps::ring_buf::RingBufItem<'a>
 impl core::fmt::Debug for aya::maps::ring_buf::RingBufItem<'_>
 pub fn aya::maps::ring_buf::RingBufItem<'_>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
@@ -617,24 +381,6 @@ impl<'a> core::marker::Unpin for aya::maps::ring_buf::RingBufItem<'a>
 impl<'a> core::marker::UnsafeUnpin for aya::maps::ring_buf::RingBufItem<'a>
 impl<'a> core::panic::unwind_safe::RefUnwindSafe for aya::maps::ring_buf::RingBufItem<'a>
 impl<'a> !core::panic::unwind_safe::UnwindSafe for aya::maps::ring_buf::RingBufItem<'a>
-impl<P, T> core::ops::deref::Receiver for aya::maps::ring_buf::RingBufItem<'a> where P: core::ops::deref::Deref<Target = T> + ?core::marker::Sized, T: ?core::marker::Sized
-pub type aya::maps::ring_buf::RingBufItem<'a>::Target = T
-impl<T, U> core::convert::Into<U> for aya::maps::ring_buf::RingBufItem<'a> where U: core::convert::From<T>
-pub fn aya::maps::ring_buf::RingBufItem<'a>::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::maps::ring_buf::RingBufItem<'a> where U: core::convert::Into<T>
-pub type aya::maps::ring_buf::RingBufItem<'a>::Error = core::convert::Infallible
-pub fn aya::maps::ring_buf::RingBufItem<'a>::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::maps::ring_buf::RingBufItem<'a> where U: core::convert::TryFrom<T>
-pub type aya::maps::ring_buf::RingBufItem<'a>::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::maps::ring_buf::RingBufItem<'a>::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya::maps::ring_buf::RingBufItem<'a> where T: 'static + ?core::marker::Sized
-pub fn aya::maps::ring_buf::RingBufItem<'a>::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::maps::ring_buf::RingBufItem<'a> where T: ?core::marker::Sized
-pub fn aya::maps::ring_buf::RingBufItem<'a>::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::maps::ring_buf::RingBufItem<'a> where T: ?core::marker::Sized
-pub fn aya::maps::ring_buf::RingBufItem<'a>::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya::maps::ring_buf::RingBufItem<'a>
-pub fn aya::maps::ring_buf::RingBufItem<'a>::from(t: T) -> T
 pub mod aya::maps::sk_storage
 pub struct aya::maps::sk_storage::SkStorage<T, V: aya::Pod>
 impl<T: core::borrow::Borrow<aya::maps::MapData>, V: aya::Pod> aya::maps::sk_storage::SkStorage<T, V>
@@ -662,22 +408,6 @@ impl<T, V> core::marker::Unpin for aya::maps::sk_storage::SkStorage<T, V> where 
 impl<T, V> core::marker::UnsafeUnpin for aya::maps::sk_storage::SkStorage<T, V> where T: core::marker::UnsafeUnpin
 impl<T, V> core::panic::unwind_safe::RefUnwindSafe for aya::maps::sk_storage::SkStorage<T, V> where T: core::panic::unwind_safe::RefUnwindSafe, V: core::panic::unwind_safe::RefUnwindSafe
 impl<T, V> core::panic::unwind_safe::UnwindSafe for aya::maps::sk_storage::SkStorage<T, V> where T: core::panic::unwind_safe::UnwindSafe, V: core::panic::unwind_safe::UnwindSafe
-impl<T, U> core::convert::Into<U> for aya::maps::sk_storage::SkStorage<T, V> where U: core::convert::From<T>
-pub fn aya::maps::sk_storage::SkStorage<T, V>::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::maps::sk_storage::SkStorage<T, V> where U: core::convert::Into<T>
-pub type aya::maps::sk_storage::SkStorage<T, V>::Error = core::convert::Infallible
-pub fn aya::maps::sk_storage::SkStorage<T, V>::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::maps::sk_storage::SkStorage<T, V> where U: core::convert::TryFrom<T>
-pub type aya::maps::sk_storage::SkStorage<T, V>::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::maps::sk_storage::SkStorage<T, V>::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya::maps::sk_storage::SkStorage<T, V> where T: 'static + ?core::marker::Sized
-pub fn aya::maps::sk_storage::SkStorage<T, V>::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::maps::sk_storage::SkStorage<T, V> where T: ?core::marker::Sized
-pub fn aya::maps::sk_storage::SkStorage<T, V>::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::maps::sk_storage::SkStorage<T, V> where T: ?core::marker::Sized
-pub fn aya::maps::sk_storage::SkStorage<T, V>::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya::maps::sk_storage::SkStorage<T, V>
-pub fn aya::maps::sk_storage::SkStorage<T, V>::from(t: T) -> T
 pub mod aya::maps::sock
 pub struct aya::maps::sock::SockHash<T, K>
 impl<T: core::borrow::Borrow<aya::maps::MapData>, K: aya::Pod> aya::maps::SockHash<T, K>
@@ -713,22 +443,6 @@ impl<T, K> core::marker::Unpin for aya::maps::SockHash<T, K> where T: core::mark
 impl<T, K> core::marker::UnsafeUnpin for aya::maps::SockHash<T, K> where T: core::marker::UnsafeUnpin
 impl<T, K> core::panic::unwind_safe::RefUnwindSafe for aya::maps::SockHash<T, K> where T: core::panic::unwind_safe::RefUnwindSafe, K: core::panic::unwind_safe::RefUnwindSafe
 impl<T, K> core::panic::unwind_safe::UnwindSafe for aya::maps::SockHash<T, K> where T: core::panic::unwind_safe::UnwindSafe, K: core::panic::unwind_safe::UnwindSafe
-impl<T, U> core::convert::Into<U> for aya::maps::SockHash<T, K> where U: core::convert::From<T>
-pub fn aya::maps::SockHash<T, K>::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::maps::SockHash<T, K> where U: core::convert::Into<T>
-pub type aya::maps::SockHash<T, K>::Error = core::convert::Infallible
-pub fn aya::maps::SockHash<T, K>::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::maps::SockHash<T, K> where U: core::convert::TryFrom<T>
-pub type aya::maps::SockHash<T, K>::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::maps::SockHash<T, K>::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya::maps::SockHash<T, K> where T: 'static + ?core::marker::Sized
-pub fn aya::maps::SockHash<T, K>::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::maps::SockHash<T, K> where T: ?core::marker::Sized
-pub fn aya::maps::SockHash<T, K>::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::maps::SockHash<T, K> where T: ?core::marker::Sized
-pub fn aya::maps::SockHash<T, K>::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya::maps::SockHash<T, K>
-pub fn aya::maps::SockHash<T, K>::from(t: T) -> T
 pub struct aya::maps::sock::SockMap<T>
 impl<T: core::borrow::Borrow<aya::maps::MapData>> aya::maps::SockMap<T>
 pub fn aya::maps::SockMap<T>::fd(&self) -> &aya::maps::sock::SockMapFd
@@ -754,22 +468,6 @@ impl<T> core::marker::Unpin for aya::maps::SockMap<T> where T: core::marker::Unp
 impl<T> core::marker::UnsafeUnpin for aya::maps::SockMap<T> where T: core::marker::UnsafeUnpin
 impl<T> core::panic::unwind_safe::RefUnwindSafe for aya::maps::SockMap<T> where T: core::panic::unwind_safe::RefUnwindSafe
 impl<T> core::panic::unwind_safe::UnwindSafe for aya::maps::SockMap<T> where T: core::panic::unwind_safe::UnwindSafe
-impl<T, U> core::convert::Into<U> for aya::maps::SockMap<T> where U: core::convert::From<T>
-pub fn aya::maps::SockMap<T>::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::maps::SockMap<T> where U: core::convert::Into<T>
-pub type aya::maps::SockMap<T>::Error = core::convert::Infallible
-pub fn aya::maps::SockMap<T>::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::maps::SockMap<T> where U: core::convert::TryFrom<T>
-pub type aya::maps::SockMap<T>::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::maps::SockMap<T>::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya::maps::SockMap<T> where T: 'static + ?core::marker::Sized
-pub fn aya::maps::SockMap<T>::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::maps::SockMap<T> where T: ?core::marker::Sized
-pub fn aya::maps::SockMap<T>::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::maps::SockMap<T> where T: ?core::marker::Sized
-pub fn aya::maps::SockMap<T>::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya::maps::SockMap<T>
-pub fn aya::maps::SockMap<T>::from(t: T) -> T
 #[repr(transparent)] pub struct aya::maps::sock::SockMapFd(_)
 impl aya::maps::sock::SockMapFd
 pub fn aya::maps::sock::SockMapFd::try_clone(&self) -> std::io::error::Result<Self>
@@ -782,22 +480,6 @@ impl core::marker::Unpin for aya::maps::sock::SockMapFd
 impl core::marker::UnsafeUnpin for aya::maps::sock::SockMapFd
 impl core::panic::unwind_safe::RefUnwindSafe for aya::maps::sock::SockMapFd
 impl core::panic::unwind_safe::UnwindSafe for aya::maps::sock::SockMapFd
-impl<T, U> core::convert::Into<U> for aya::maps::sock::SockMapFd where U: core::convert::From<T>
-pub fn aya::maps::sock::SockMapFd::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::maps::sock::SockMapFd where U: core::convert::Into<T>
-pub type aya::maps::sock::SockMapFd::Error = core::convert::Infallible
-pub fn aya::maps::sock::SockMapFd::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::maps::sock::SockMapFd where U: core::convert::TryFrom<T>
-pub type aya::maps::sock::SockMapFd::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::maps::sock::SockMapFd::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya::maps::sock::SockMapFd where T: 'static + ?core::marker::Sized
-pub fn aya::maps::sock::SockMapFd::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::maps::sock::SockMapFd where T: ?core::marker::Sized
-pub fn aya::maps::sock::SockMapFd::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::maps::sock::SockMapFd where T: ?core::marker::Sized
-pub fn aya::maps::sock::SockMapFd::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya::maps::sock::SockMapFd
-pub fn aya::maps::sock::SockMapFd::from(t: T) -> T
 pub mod aya::maps::stack
 pub struct aya::maps::stack::Stack<T, V: aya::Pod>
 impl<T: core::borrow::Borrow<aya::maps::MapData>, V: aya::Pod> aya::maps::stack::Stack<T, V>
@@ -823,22 +505,6 @@ impl<T, V> core::marker::Unpin for aya::maps::stack::Stack<T, V> where T: core::
 impl<T, V> core::marker::UnsafeUnpin for aya::maps::stack::Stack<T, V> where T: core::marker::UnsafeUnpin
 impl<T, V> core::panic::unwind_safe::RefUnwindSafe for aya::maps::stack::Stack<T, V> where T: core::panic::unwind_safe::RefUnwindSafe, V: core::panic::unwind_safe::RefUnwindSafe
 impl<T, V> core::panic::unwind_safe::UnwindSafe for aya::maps::stack::Stack<T, V> where T: core::panic::unwind_safe::UnwindSafe, V: core::panic::unwind_safe::UnwindSafe
-impl<T, U> core::convert::Into<U> for aya::maps::stack::Stack<T, V> where U: core::convert::From<T>
-pub fn aya::maps::stack::Stack<T, V>::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::maps::stack::Stack<T, V> where U: core::convert::Into<T>
-pub type aya::maps::stack::Stack<T, V>::Error = core::convert::Infallible
-pub fn aya::maps::stack::Stack<T, V>::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::maps::stack::Stack<T, V> where U: core::convert::TryFrom<T>
-pub type aya::maps::stack::Stack<T, V>::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::maps::stack::Stack<T, V>::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya::maps::stack::Stack<T, V> where T: 'static + ?core::marker::Sized
-pub fn aya::maps::stack::Stack<T, V>::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::maps::stack::Stack<T, V> where T: ?core::marker::Sized
-pub fn aya::maps::stack::Stack<T, V>::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::maps::stack::Stack<T, V> where T: ?core::marker::Sized
-pub fn aya::maps::stack::Stack<T, V>::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya::maps::stack::Stack<T, V>
-pub fn aya::maps::stack::Stack<T, V>::from(t: T) -> T
 pub mod aya::maps::stack_trace
 pub struct aya::maps::stack_trace::StackFrame
 pub aya::maps::stack_trace::StackFrame::ip: u64
@@ -849,22 +515,6 @@ impl core::marker::Unpin for aya::maps::stack_trace::StackFrame
 impl core::marker::UnsafeUnpin for aya::maps::stack_trace::StackFrame
 impl core::panic::unwind_safe::RefUnwindSafe for aya::maps::stack_trace::StackFrame
 impl core::panic::unwind_safe::UnwindSafe for aya::maps::stack_trace::StackFrame
-impl<T, U> core::convert::Into<U> for aya::maps::stack_trace::StackFrame where U: core::convert::From<T>
-pub fn aya::maps::stack_trace::StackFrame::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::maps::stack_trace::StackFrame where U: core::convert::Into<T>
-pub type aya::maps::stack_trace::StackFrame::Error = core::convert::Infallible
-pub fn aya::maps::stack_trace::StackFrame::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::maps::stack_trace::StackFrame where U: core::convert::TryFrom<T>
-pub type aya::maps::stack_trace::StackFrame::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::maps::stack_trace::StackFrame::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya::maps::stack_trace::StackFrame where T: 'static + ?core::marker::Sized
-pub fn aya::maps::stack_trace::StackFrame::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::maps::stack_trace::StackFrame where T: ?core::marker::Sized
-pub fn aya::maps::stack_trace::StackFrame::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::maps::stack_trace::StackFrame where T: ?core::marker::Sized
-pub fn aya::maps::stack_trace::StackFrame::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya::maps::stack_trace::StackFrame
-pub fn aya::maps::stack_trace::StackFrame::from(t: T) -> T
 pub struct aya::maps::stack_trace::StackTrace
 pub aya::maps::stack_trace::StackTrace::id: u32
 impl aya::maps::stack_trace::StackTrace
@@ -879,22 +529,6 @@ impl core::marker::Unpin for aya::maps::stack_trace::StackTrace
 impl core::marker::UnsafeUnpin for aya::maps::stack_trace::StackTrace
 impl core::panic::unwind_safe::RefUnwindSafe for aya::maps::stack_trace::StackTrace
 impl core::panic::unwind_safe::UnwindSafe for aya::maps::stack_trace::StackTrace
-impl<T, U> core::convert::Into<U> for aya::maps::stack_trace::StackTrace where U: core::convert::From<T>
-pub fn aya::maps::stack_trace::StackTrace::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::maps::stack_trace::StackTrace where U: core::convert::Into<T>
-pub type aya::maps::stack_trace::StackTrace::Error = core::convert::Infallible
-pub fn aya::maps::stack_trace::StackTrace::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::maps::stack_trace::StackTrace where U: core::convert::TryFrom<T>
-pub type aya::maps::stack_trace::StackTrace::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::maps::stack_trace::StackTrace::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya::maps::stack_trace::StackTrace where T: 'static + ?core::marker::Sized
-pub fn aya::maps::stack_trace::StackTrace::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::maps::stack_trace::StackTrace where T: ?core::marker::Sized
-pub fn aya::maps::stack_trace::StackTrace::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::maps::stack_trace::StackTrace where T: ?core::marker::Sized
-pub fn aya::maps::stack_trace::StackTrace::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya::maps::stack_trace::StackTrace
-pub fn aya::maps::stack_trace::StackTrace::from(t: T) -> T
 pub struct aya::maps::stack_trace::StackTraceMap<T>
 impl<T: core::borrow::Borrow<aya::maps::MapData>> aya::maps::stack_trace::StackTraceMap<T>
 pub fn aya::maps::stack_trace::StackTraceMap<T>::get(&self, stack_id: &u32, flags: u64) -> core::result::Result<aya::maps::stack_trace::StackTrace, aya::maps::MapError>
@@ -929,22 +563,6 @@ impl<T> core::marker::Unpin for aya::maps::stack_trace::StackTraceMap<T> where T
 impl<T> core::marker::UnsafeUnpin for aya::maps::stack_trace::StackTraceMap<T> where T: core::marker::UnsafeUnpin
 impl<T> core::panic::unwind_safe::RefUnwindSafe for aya::maps::stack_trace::StackTraceMap<T> where T: core::panic::unwind_safe::RefUnwindSafe
 impl<T> core::panic::unwind_safe::UnwindSafe for aya::maps::stack_trace::StackTraceMap<T> where T: core::panic::unwind_safe::UnwindSafe
-impl<T, U> core::convert::Into<U> for aya::maps::stack_trace::StackTraceMap<T> where U: core::convert::From<T>
-pub fn aya::maps::stack_trace::StackTraceMap<T>::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::maps::stack_trace::StackTraceMap<T> where U: core::convert::Into<T>
-pub type aya::maps::stack_trace::StackTraceMap<T>::Error = core::convert::Infallible
-pub fn aya::maps::stack_trace::StackTraceMap<T>::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::maps::stack_trace::StackTraceMap<T> where U: core::convert::TryFrom<T>
-pub type aya::maps::stack_trace::StackTraceMap<T>::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::maps::stack_trace::StackTraceMap<T>::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya::maps::stack_trace::StackTraceMap<T> where T: 'static + ?core::marker::Sized
-pub fn aya::maps::stack_trace::StackTraceMap<T>::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::maps::stack_trace::StackTraceMap<T> where T: ?core::marker::Sized
-pub fn aya::maps::stack_trace::StackTraceMap<T>::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::maps::stack_trace::StackTraceMap<T> where T: ?core::marker::Sized
-pub fn aya::maps::stack_trace::StackTraceMap<T>::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya::maps::stack_trace::StackTraceMap<T>
-pub fn aya::maps::stack_trace::StackTraceMap<T>::from(t: T) -> T
 pub mod aya::maps::xdp
 pub enum aya::maps::xdp::XdpMapError
 pub aya::maps::xdp::XdpMapError::ChainedProgramNotSupported
@@ -964,24 +582,6 @@ impl core::marker::Unpin for aya::maps::xdp::XdpMapError
 impl core::marker::UnsafeUnpin for aya::maps::xdp::XdpMapError
 impl !core::panic::unwind_safe::RefUnwindSafe for aya::maps::xdp::XdpMapError
 impl !core::panic::unwind_safe::UnwindSafe for aya::maps::xdp::XdpMapError
-impl<T, U> core::convert::Into<U> for aya::maps::xdp::XdpMapError where U: core::convert::From<T>
-pub fn aya::maps::xdp::XdpMapError::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::maps::xdp::XdpMapError where U: core::convert::Into<T>
-pub type aya::maps::xdp::XdpMapError::Error = core::convert::Infallible
-pub fn aya::maps::xdp::XdpMapError::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::maps::xdp::XdpMapError where U: core::convert::TryFrom<T>
-pub type aya::maps::xdp::XdpMapError::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::maps::xdp::XdpMapError::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::string::ToString for aya::maps::xdp::XdpMapError where T: core::fmt::Display + ?core::marker::Sized
-pub fn aya::maps::xdp::XdpMapError::to_string(&self) -> alloc::string::String
-impl<T> core::any::Any for aya::maps::xdp::XdpMapError where T: 'static + ?core::marker::Sized
-pub fn aya::maps::xdp::XdpMapError::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::maps::xdp::XdpMapError where T: ?core::marker::Sized
-pub fn aya::maps::xdp::XdpMapError::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::maps::xdp::XdpMapError where T: ?core::marker::Sized
-pub fn aya::maps::xdp::XdpMapError::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya::maps::xdp::XdpMapError
-pub fn aya::maps::xdp::XdpMapError::from(t: T) -> T
 pub struct aya::maps::xdp::CpuMap<T>
 impl<T: core::borrow::Borrow<aya::maps::MapData>> aya::maps::CpuMap<T>
 pub fn aya::maps::CpuMap<T>::get(&self, cpu_index: u32, flags: u64) -> core::result::Result<aya::maps::xdp::cpu_map::CpuMapValue, aya::maps::MapError>
@@ -1007,22 +607,6 @@ impl<T> core::marker::Unpin for aya::maps::CpuMap<T> where T: core::marker::Unpi
 impl<T> core::marker::UnsafeUnpin for aya::maps::CpuMap<T> where T: core::marker::UnsafeUnpin
 impl<T> core::panic::unwind_safe::RefUnwindSafe for aya::maps::CpuMap<T> where T: core::panic::unwind_safe::RefUnwindSafe
 impl<T> core::panic::unwind_safe::UnwindSafe for aya::maps::CpuMap<T> where T: core::panic::unwind_safe::UnwindSafe
-impl<T, U> core::convert::Into<U> for aya::maps::CpuMap<T> where U: core::convert::From<T>
-pub fn aya::maps::CpuMap<T>::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::maps::CpuMap<T> where U: core::convert::Into<T>
-pub type aya::maps::CpuMap<T>::Error = core::convert::Infallible
-pub fn aya::maps::CpuMap<T>::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::maps::CpuMap<T> where U: core::convert::TryFrom<T>
-pub type aya::maps::CpuMap<T>::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::maps::CpuMap<T>::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya::maps::CpuMap<T> where T: 'static + ?core::marker::Sized
-pub fn aya::maps::CpuMap<T>::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::maps::CpuMap<T> where T: ?core::marker::Sized
-pub fn aya::maps::CpuMap<T>::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::maps::CpuMap<T> where T: ?core::marker::Sized
-pub fn aya::maps::CpuMap<T>::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya::maps::CpuMap<T>
-pub fn aya::maps::CpuMap<T>::from(t: T) -> T
 pub struct aya::maps::xdp::DevMap<T>
 impl<T: core::borrow::Borrow<aya::maps::MapData>> aya::maps::DevMap<T>
 pub fn aya::maps::DevMap<T>::get(&self, index: u32, flags: u64) -> core::result::Result<aya::maps::xdp::dev_map::DevMapValue, aya::maps::MapError>
@@ -1048,22 +632,6 @@ impl<T> core::marker::Unpin for aya::maps::DevMap<T> where T: core::marker::Unpi
 impl<T> core::marker::UnsafeUnpin for aya::maps::DevMap<T> where T: core::marker::UnsafeUnpin
 impl<T> core::panic::unwind_safe::RefUnwindSafe for aya::maps::DevMap<T> where T: core::panic::unwind_safe::RefUnwindSafe
 impl<T> core::panic::unwind_safe::UnwindSafe for aya::maps::DevMap<T> where T: core::panic::unwind_safe::UnwindSafe
-impl<T, U> core::convert::Into<U> for aya::maps::DevMap<T> where U: core::convert::From<T>
-pub fn aya::maps::DevMap<T>::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::maps::DevMap<T> where U: core::convert::Into<T>
-pub type aya::maps::DevMap<T>::Error = core::convert::Infallible
-pub fn aya::maps::DevMap<T>::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::maps::DevMap<T> where U: core::convert::TryFrom<T>
-pub type aya::maps::DevMap<T>::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::maps::DevMap<T>::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya::maps::DevMap<T> where T: 'static + ?core::marker::Sized
-pub fn aya::maps::DevMap<T>::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::maps::DevMap<T> where T: ?core::marker::Sized
-pub fn aya::maps::DevMap<T>::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::maps::DevMap<T> where T: ?core::marker::Sized
-pub fn aya::maps::DevMap<T>::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya::maps::DevMap<T>
-pub fn aya::maps::DevMap<T>::from(t: T) -> T
 pub struct aya::maps::xdp::DevMapHash<T>
 impl<T: core::borrow::Borrow<aya::maps::MapData>> aya::maps::DevMapHash<T>
 pub fn aya::maps::DevMapHash<T>::get(&self, key: u32, flags: u64) -> core::result::Result<aya::maps::xdp::dev_map::DevMapValue, aya::maps::MapError>
@@ -1094,22 +662,6 @@ impl<T> core::marker::Unpin for aya::maps::DevMapHash<T> where T: core::marker::
 impl<T> core::marker::UnsafeUnpin for aya::maps::DevMapHash<T> where T: core::marker::UnsafeUnpin
 impl<T> core::panic::unwind_safe::RefUnwindSafe for aya::maps::DevMapHash<T> where T: core::panic::unwind_safe::RefUnwindSafe
 impl<T> core::panic::unwind_safe::UnwindSafe for aya::maps::DevMapHash<T> where T: core::panic::unwind_safe::UnwindSafe
-impl<T, U> core::convert::Into<U> for aya::maps::DevMapHash<T> where U: core::convert::From<T>
-pub fn aya::maps::DevMapHash<T>::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::maps::DevMapHash<T> where U: core::convert::Into<T>
-pub type aya::maps::DevMapHash<T>::Error = core::convert::Infallible
-pub fn aya::maps::DevMapHash<T>::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::maps::DevMapHash<T> where U: core::convert::TryFrom<T>
-pub type aya::maps::DevMapHash<T>::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::maps::DevMapHash<T>::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya::maps::DevMapHash<T> where T: 'static + ?core::marker::Sized
-pub fn aya::maps::DevMapHash<T>::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::maps::DevMapHash<T> where T: ?core::marker::Sized
-pub fn aya::maps::DevMapHash<T>::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::maps::DevMapHash<T> where T: ?core::marker::Sized
-pub fn aya::maps::DevMapHash<T>::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya::maps::DevMapHash<T>
-pub fn aya::maps::DevMapHash<T>::from(t: T) -> T
 pub struct aya::maps::xdp::XskMap<T>
 impl<T: core::borrow::Borrow<aya::maps::MapData>> aya::maps::XskMap<T>
 pub fn aya::maps::XskMap<T>::len(&self) -> u32
@@ -1134,22 +686,6 @@ impl<T> core::marker::Unpin for aya::maps::XskMap<T> where T: core::marker::Unpi
 impl<T> core::marker::UnsafeUnpin for aya::maps::XskMap<T> where T: core::marker::UnsafeUnpin
 impl<T> core::panic::unwind_safe::RefUnwindSafe for aya::maps::XskMap<T> where T: core::panic::unwind_safe::RefUnwindSafe
 impl<T> core::panic::unwind_safe::UnwindSafe for aya::maps::XskMap<T> where T: core::panic::unwind_safe::UnwindSafe
-impl<T, U> core::convert::Into<U> for aya::maps::XskMap<T> where U: core::convert::From<T>
-pub fn aya::maps::XskMap<T>::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::maps::XskMap<T> where U: core::convert::Into<T>
-pub type aya::maps::XskMap<T>::Error = core::convert::Infallible
-pub fn aya::maps::XskMap<T>::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::maps::XskMap<T> where U: core::convert::TryFrom<T>
-pub type aya::maps::XskMap<T>::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::maps::XskMap<T>::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya::maps::XskMap<T> where T: 'static + ?core::marker::Sized
-pub fn aya::maps::XskMap<T>::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::maps::XskMap<T> where T: ?core::marker::Sized
-pub fn aya::maps::XskMap<T>::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::maps::XskMap<T> where T: ?core::marker::Sized
-pub fn aya::maps::XskMap<T>::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya::maps::XskMap<T>
-pub fn aya::maps::XskMap<T>::from(t: T) -> T
 pub enum aya::maps::Map
 pub aya::maps::Map::Array(aya::maps::MapData)
 pub aya::maps::Map::BloomFilter(aya::maps::MapData)
@@ -1356,22 +892,6 @@ impl core::marker::Unpin for aya::maps::Map
 impl core::marker::UnsafeUnpin for aya::maps::Map
 impl core::panic::unwind_safe::RefUnwindSafe for aya::maps::Map
 impl core::panic::unwind_safe::UnwindSafe for aya::maps::Map
-impl<T, U> core::convert::Into<U> for aya::maps::Map where U: core::convert::From<T>
-pub fn aya::maps::Map::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::maps::Map where U: core::convert::Into<T>
-pub type aya::maps::Map::Error = core::convert::Infallible
-pub fn aya::maps::Map::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::maps::Map where U: core::convert::TryFrom<T>
-pub type aya::maps::Map::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::maps::Map::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya::maps::Map where T: 'static + ?core::marker::Sized
-pub fn aya::maps::Map::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::maps::Map where T: ?core::marker::Sized
-pub fn aya::maps::Map::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::maps::Map where T: ?core::marker::Sized
-pub fn aya::maps::Map::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya::maps::Map
-pub fn aya::maps::Map::from(t: T) -> T
 pub enum aya::maps::MapError
 pub aya::maps::MapError::CreateError
 pub aya::maps::MapError::CreateError::io_error: std::io::error::Error
@@ -1426,24 +946,6 @@ impl core::marker::Unpin for aya::maps::MapError
 impl core::marker::UnsafeUnpin for aya::maps::MapError
 impl !core::panic::unwind_safe::RefUnwindSafe for aya::maps::MapError
 impl !core::panic::unwind_safe::UnwindSafe for aya::maps::MapError
-impl<T, U> core::convert::Into<U> for aya::maps::MapError where U: core::convert::From<T>
-pub fn aya::maps::MapError::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::maps::MapError where U: core::convert::Into<T>
-pub type aya::maps::MapError::Error = core::convert::Infallible
-pub fn aya::maps::MapError::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::maps::MapError where U: core::convert::TryFrom<T>
-pub type aya::maps::MapError::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::maps::MapError::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::string::ToString for aya::maps::MapError where T: core::fmt::Display + ?core::marker::Sized
-pub fn aya::maps::MapError::to_string(&self) -> alloc::string::String
-impl<T> core::any::Any for aya::maps::MapError where T: 'static + ?core::marker::Sized
-pub fn aya::maps::MapError::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::maps::MapError where T: ?core::marker::Sized
-pub fn aya::maps::MapError::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::maps::MapError where T: ?core::marker::Sized
-pub fn aya::maps::MapError::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya::maps::MapError
-pub fn aya::maps::MapError::from(t: T) -> T
 #[non_exhaustive] pub enum aya::maps::MapType
 pub aya::maps::MapType::Arena = 33
 pub aya::maps::MapType::Array = 2
@@ -1497,28 +999,6 @@ impl core::marker::Unpin for aya::maps::MapType
 impl core::marker::UnsafeUnpin for aya::maps::MapType
 impl core::panic::unwind_safe::RefUnwindSafe for aya::maps::MapType
 impl core::panic::unwind_safe::UnwindSafe for aya::maps::MapType
-impl<T, U> core::convert::Into<U> for aya::maps::MapType where U: core::convert::From<T>
-pub fn aya::maps::MapType::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::maps::MapType where U: core::convert::Into<T>
-pub type aya::maps::MapType::Error = core::convert::Infallible
-pub fn aya::maps::MapType::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::maps::MapType where U: core::convert::TryFrom<T>
-pub type aya::maps::MapType::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::maps::MapType::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya::maps::MapType where T: core::clone::Clone
-pub type aya::maps::MapType::Owned = T
-pub fn aya::maps::MapType::clone_into(&self, target: &mut T)
-pub fn aya::maps::MapType::to_owned(&self) -> T
-impl<T> core::any::Any for aya::maps::MapType where T: 'static + ?core::marker::Sized
-pub fn aya::maps::MapType::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::maps::MapType where T: ?core::marker::Sized
-pub fn aya::maps::MapType::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::maps::MapType where T: ?core::marker::Sized
-pub fn aya::maps::MapType::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya::maps::MapType where T: core::clone::Clone
-pub unsafe fn aya::maps::MapType::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya::maps::MapType
-pub fn aya::maps::MapType::from(t: T) -> T
 pub struct aya::maps::Array<T, V: aya::Pod>
 impl<T: core::borrow::Borrow<aya::maps::MapData>, V: aya::Pod> aya::maps::array::Array<T, V>
 pub fn aya::maps::array::Array<T, V>::get(&self, index: &u32, flags: u64) -> core::result::Result<V, aya::maps::MapError>
@@ -1547,22 +1027,6 @@ impl<T, V> core::marker::Unpin for aya::maps::array::Array<T, V> where T: core::
 impl<T, V> core::marker::UnsafeUnpin for aya::maps::array::Array<T, V> where T: core::marker::UnsafeUnpin
 impl<T, V> core::panic::unwind_safe::RefUnwindSafe for aya::maps::array::Array<T, V> where T: core::panic::unwind_safe::RefUnwindSafe, V: core::panic::unwind_safe::RefUnwindSafe
 impl<T, V> core::panic::unwind_safe::UnwindSafe for aya::maps::array::Array<T, V> where T: core::panic::unwind_safe::UnwindSafe, V: core::panic::unwind_safe::UnwindSafe
-impl<T, U> core::convert::Into<U> for aya::maps::array::Array<T, V> where U: core::convert::From<T>
-pub fn aya::maps::array::Array<T, V>::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::maps::array::Array<T, V> where U: core::convert::Into<T>
-pub type aya::maps::array::Array<T, V>::Error = core::convert::Infallible
-pub fn aya::maps::array::Array<T, V>::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::maps::array::Array<T, V> where U: core::convert::TryFrom<T>
-pub type aya::maps::array::Array<T, V>::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::maps::array::Array<T, V>::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya::maps::array::Array<T, V> where T: 'static + ?core::marker::Sized
-pub fn aya::maps::array::Array<T, V>::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::maps::array::Array<T, V> where T: ?core::marker::Sized
-pub fn aya::maps::array::Array<T, V>::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::maps::array::Array<T, V> where T: ?core::marker::Sized
-pub fn aya::maps::array::Array<T, V>::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya::maps::array::Array<T, V>
-pub fn aya::maps::array::Array<T, V>::from(t: T) -> T
 pub struct aya::maps::BloomFilter<T, V: aya::Pod>
 impl<T: core::borrow::Borrow<aya::maps::MapData>, V: aya::Pod> aya::maps::bloom_filter::BloomFilter<T, V>
 pub fn aya::maps::bloom_filter::BloomFilter<T, V>::contains(&self, value: impl core::borrow::Borrow<V>, flags: u64) -> core::result::Result<(), aya::maps::MapError>
@@ -1588,22 +1052,6 @@ impl<T, V> core::marker::Unpin for aya::maps::bloom_filter::BloomFilter<T, V> wh
 impl<T, V> core::marker::UnsafeUnpin for aya::maps::bloom_filter::BloomFilter<T, V> where T: core::marker::UnsafeUnpin
 impl<T, V> core::panic::unwind_safe::RefUnwindSafe for aya::maps::bloom_filter::BloomFilter<T, V> where T: core::panic::unwind_safe::RefUnwindSafe, V: core::panic::unwind_safe::RefUnwindSafe
 impl<T, V> core::panic::unwind_safe::UnwindSafe for aya::maps::bloom_filter::BloomFilter<T, V> where T: core::panic::unwind_safe::UnwindSafe, V: core::panic::unwind_safe::UnwindSafe
-impl<T, U> core::convert::Into<U> for aya::maps::bloom_filter::BloomFilter<T, V> where U: core::convert::From<T>
-pub fn aya::maps::bloom_filter::BloomFilter<T, V>::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::maps::bloom_filter::BloomFilter<T, V> where U: core::convert::Into<T>
-pub type aya::maps::bloom_filter::BloomFilter<T, V>::Error = core::convert::Infallible
-pub fn aya::maps::bloom_filter::BloomFilter<T, V>::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::maps::bloom_filter::BloomFilter<T, V> where U: core::convert::TryFrom<T>
-pub type aya::maps::bloom_filter::BloomFilter<T, V>::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::maps::bloom_filter::BloomFilter<T, V>::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya::maps::bloom_filter::BloomFilter<T, V> where T: 'static + ?core::marker::Sized
-pub fn aya::maps::bloom_filter::BloomFilter<T, V>::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::maps::bloom_filter::BloomFilter<T, V> where T: ?core::marker::Sized
-pub fn aya::maps::bloom_filter::BloomFilter<T, V>::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::maps::bloom_filter::BloomFilter<T, V> where T: ?core::marker::Sized
-pub fn aya::maps::bloom_filter::BloomFilter<T, V>::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya::maps::bloom_filter::BloomFilter<T, V>
-pub fn aya::maps::bloom_filter::BloomFilter<T, V>::from(t: T) -> T
 pub struct aya::maps::CpuMap<T>
 impl<T: core::borrow::Borrow<aya::maps::MapData>> aya::maps::CpuMap<T>
 pub fn aya::maps::CpuMap<T>::get(&self, cpu_index: u32, flags: u64) -> core::result::Result<aya::maps::xdp::cpu_map::CpuMapValue, aya::maps::MapError>
@@ -1629,22 +1077,6 @@ impl<T> core::marker::Unpin for aya::maps::CpuMap<T> where T: core::marker::Unpi
 impl<T> core::marker::UnsafeUnpin for aya::maps::CpuMap<T> where T: core::marker::UnsafeUnpin
 impl<T> core::panic::unwind_safe::RefUnwindSafe for aya::maps::CpuMap<T> where T: core::panic::unwind_safe::RefUnwindSafe
 impl<T> core::panic::unwind_safe::UnwindSafe for aya::maps::CpuMap<T> where T: core::panic::unwind_safe::UnwindSafe
-impl<T, U> core::convert::Into<U> for aya::maps::CpuMap<T> where U: core::convert::From<T>
-pub fn aya::maps::CpuMap<T>::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::maps::CpuMap<T> where U: core::convert::Into<T>
-pub type aya::maps::CpuMap<T>::Error = core::convert::Infallible
-pub fn aya::maps::CpuMap<T>::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::maps::CpuMap<T> where U: core::convert::TryFrom<T>
-pub type aya::maps::CpuMap<T>::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::maps::CpuMap<T>::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya::maps::CpuMap<T> where T: 'static + ?core::marker::Sized
-pub fn aya::maps::CpuMap<T>::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::maps::CpuMap<T> where T: ?core::marker::Sized
-pub fn aya::maps::CpuMap<T>::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::maps::CpuMap<T> where T: ?core::marker::Sized
-pub fn aya::maps::CpuMap<T>::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya::maps::CpuMap<T>
-pub fn aya::maps::CpuMap<T>::from(t: T) -> T
 pub struct aya::maps::DevMap<T>
 impl<T: core::borrow::Borrow<aya::maps::MapData>> aya::maps::DevMap<T>
 pub fn aya::maps::DevMap<T>::get(&self, index: u32, flags: u64) -> core::result::Result<aya::maps::xdp::dev_map::DevMapValue, aya::maps::MapError>
@@ -1670,22 +1102,6 @@ impl<T> core::marker::Unpin for aya::maps::DevMap<T> where T: core::marker::Unpi
 impl<T> core::marker::UnsafeUnpin for aya::maps::DevMap<T> where T: core::marker::UnsafeUnpin
 impl<T> core::panic::unwind_safe::RefUnwindSafe for aya::maps::DevMap<T> where T: core::panic::unwind_safe::RefUnwindSafe
 impl<T> core::panic::unwind_safe::UnwindSafe for aya::maps::DevMap<T> where T: core::panic::unwind_safe::UnwindSafe
-impl<T, U> core::convert::Into<U> for aya::maps::DevMap<T> where U: core::convert::From<T>
-pub fn aya::maps::DevMap<T>::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::maps::DevMap<T> where U: core::convert::Into<T>
-pub type aya::maps::DevMap<T>::Error = core::convert::Infallible
-pub fn aya::maps::DevMap<T>::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::maps::DevMap<T> where U: core::convert::TryFrom<T>
-pub type aya::maps::DevMap<T>::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::maps::DevMap<T>::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya::maps::DevMap<T> where T: 'static + ?core::marker::Sized
-pub fn aya::maps::DevMap<T>::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::maps::DevMap<T> where T: ?core::marker::Sized
-pub fn aya::maps::DevMap<T>::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::maps::DevMap<T> where T: ?core::marker::Sized
-pub fn aya::maps::DevMap<T>::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya::maps::DevMap<T>
-pub fn aya::maps::DevMap<T>::from(t: T) -> T
 pub struct aya::maps::DevMapHash<T>
 impl<T: core::borrow::Borrow<aya::maps::MapData>> aya::maps::DevMapHash<T>
 pub fn aya::maps::DevMapHash<T>::get(&self, key: u32, flags: u64) -> core::result::Result<aya::maps::xdp::dev_map::DevMapValue, aya::maps::MapError>
@@ -1716,22 +1132,6 @@ impl<T> core::marker::Unpin for aya::maps::DevMapHash<T> where T: core::marker::
 impl<T> core::marker::UnsafeUnpin for aya::maps::DevMapHash<T> where T: core::marker::UnsafeUnpin
 impl<T> core::panic::unwind_safe::RefUnwindSafe for aya::maps::DevMapHash<T> where T: core::panic::unwind_safe::RefUnwindSafe
 impl<T> core::panic::unwind_safe::UnwindSafe for aya::maps::DevMapHash<T> where T: core::panic::unwind_safe::UnwindSafe
-impl<T, U> core::convert::Into<U> for aya::maps::DevMapHash<T> where U: core::convert::From<T>
-pub fn aya::maps::DevMapHash<T>::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::maps::DevMapHash<T> where U: core::convert::Into<T>
-pub type aya::maps::DevMapHash<T>::Error = core::convert::Infallible
-pub fn aya::maps::DevMapHash<T>::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::maps::DevMapHash<T> where U: core::convert::TryFrom<T>
-pub type aya::maps::DevMapHash<T>::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::maps::DevMapHash<T>::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya::maps::DevMapHash<T> where T: 'static + ?core::marker::Sized
-pub fn aya::maps::DevMapHash<T>::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::maps::DevMapHash<T> where T: ?core::marker::Sized
-pub fn aya::maps::DevMapHash<T>::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::maps::DevMapHash<T> where T: ?core::marker::Sized
-pub fn aya::maps::DevMapHash<T>::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya::maps::DevMapHash<T>
-pub fn aya::maps::DevMapHash<T>::from(t: T) -> T
 pub struct aya::maps::HashMap<T, K, V>
 impl<T: core::borrow::Borrow<aya::maps::MapData>, K: aya::Pod, V: aya::Pod> aya::maps::hash_map::HashMap<T, K, V>
 pub fn aya::maps::hash_map::HashMap<T, K, V>::get(&self, key: &K, flags: u64) -> core::result::Result<V, aya::maps::MapError>
@@ -1767,22 +1167,6 @@ impl<T, K, V> core::marker::Unpin for aya::maps::hash_map::HashMap<T, K, V> wher
 impl<T, K, V> core::marker::UnsafeUnpin for aya::maps::hash_map::HashMap<T, K, V> where T: core::marker::UnsafeUnpin
 impl<T, K, V> core::panic::unwind_safe::RefUnwindSafe for aya::maps::hash_map::HashMap<T, K, V> where T: core::panic::unwind_safe::RefUnwindSafe, K: core::panic::unwind_safe::RefUnwindSafe, V: core::panic::unwind_safe::RefUnwindSafe
 impl<T, K, V> core::panic::unwind_safe::UnwindSafe for aya::maps::hash_map::HashMap<T, K, V> where T: core::panic::unwind_safe::UnwindSafe, K: core::panic::unwind_safe::UnwindSafe, V: core::panic::unwind_safe::UnwindSafe
-impl<T, U> core::convert::Into<U> for aya::maps::hash_map::HashMap<T, K, V> where U: core::convert::From<T>
-pub fn aya::maps::hash_map::HashMap<T, K, V>::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::maps::hash_map::HashMap<T, K, V> where U: core::convert::Into<T>
-pub type aya::maps::hash_map::HashMap<T, K, V>::Error = core::convert::Infallible
-pub fn aya::maps::hash_map::HashMap<T, K, V>::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::maps::hash_map::HashMap<T, K, V> where U: core::convert::TryFrom<T>
-pub type aya::maps::hash_map::HashMap<T, K, V>::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::maps::hash_map::HashMap<T, K, V>::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya::maps::hash_map::HashMap<T, K, V> where T: 'static + ?core::marker::Sized
-pub fn aya::maps::hash_map::HashMap<T, K, V>::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::maps::hash_map::HashMap<T, K, V> where T: ?core::marker::Sized
-pub fn aya::maps::hash_map::HashMap<T, K, V>::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::maps::hash_map::HashMap<T, K, V> where T: ?core::marker::Sized
-pub fn aya::maps::hash_map::HashMap<T, K, V>::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya::maps::hash_map::HashMap<T, K, V>
-pub fn aya::maps::hash_map::HashMap<T, K, V>::from(t: T) -> T
 pub struct aya::maps::LpmTrie<T, K, V>
 impl<T: core::borrow::Borrow<aya::maps::MapData>, K: aya::Pod, V: aya::Pod> aya::maps::lpm_trie::LpmTrie<T, K, V>
 pub fn aya::maps::lpm_trie::LpmTrie<T, K, V>::get(&self, key: &aya::maps::lpm_trie::Key<K>, flags: u64) -> core::result::Result<V, aya::maps::MapError>
@@ -1818,22 +1202,6 @@ impl<T, K, V> core::marker::Unpin for aya::maps::lpm_trie::LpmTrie<T, K, V> wher
 impl<T, K, V> core::marker::UnsafeUnpin for aya::maps::lpm_trie::LpmTrie<T, K, V> where T: core::marker::UnsafeUnpin
 impl<T, K, V> core::panic::unwind_safe::RefUnwindSafe for aya::maps::lpm_trie::LpmTrie<T, K, V> where T: core::panic::unwind_safe::RefUnwindSafe, K: core::panic::unwind_safe::RefUnwindSafe, V: core::panic::unwind_safe::RefUnwindSafe
 impl<T, K, V> core::panic::unwind_safe::UnwindSafe for aya::maps::lpm_trie::LpmTrie<T, K, V> where T: core::panic::unwind_safe::UnwindSafe, K: core::panic::unwind_safe::UnwindSafe, V: core::panic::unwind_safe::UnwindSafe
-impl<T, U> core::convert::Into<U> for aya::maps::lpm_trie::LpmTrie<T, K, V> where U: core::convert::From<T>
-pub fn aya::maps::lpm_trie::LpmTrie<T, K, V>::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::maps::lpm_trie::LpmTrie<T, K, V> where U: core::convert::Into<T>
-pub type aya::maps::lpm_trie::LpmTrie<T, K, V>::Error = core::convert::Infallible
-pub fn aya::maps::lpm_trie::LpmTrie<T, K, V>::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::maps::lpm_trie::LpmTrie<T, K, V> where U: core::convert::TryFrom<T>
-pub type aya::maps::lpm_trie::LpmTrie<T, K, V>::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::maps::lpm_trie::LpmTrie<T, K, V>::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya::maps::lpm_trie::LpmTrie<T, K, V> where T: 'static + ?core::marker::Sized
-pub fn aya::maps::lpm_trie::LpmTrie<T, K, V>::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::maps::lpm_trie::LpmTrie<T, K, V> where T: ?core::marker::Sized
-pub fn aya::maps::lpm_trie::LpmTrie<T, K, V>::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::maps::lpm_trie::LpmTrie<T, K, V> where T: ?core::marker::Sized
-pub fn aya::maps::lpm_trie::LpmTrie<T, K, V>::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya::maps::lpm_trie::LpmTrie<T, K, V>
-pub fn aya::maps::lpm_trie::LpmTrie<T, K, V>::from(t: T) -> T
 pub struct aya::maps::MapData
 impl aya::maps::MapData
 pub fn aya::maps::MapData::create(obj: aya_obj::maps::Map, name: &str, btf_fd: core::option::Option<std::os::fd::owned::BorrowedFd<'_>>) -> core::result::Result<Self, aya::maps::MapError>
@@ -1852,22 +1220,6 @@ impl core::marker::Unpin for aya::maps::MapData
 impl core::marker::UnsafeUnpin for aya::maps::MapData
 impl core::panic::unwind_safe::RefUnwindSafe for aya::maps::MapData
 impl core::panic::unwind_safe::UnwindSafe for aya::maps::MapData
-impl<T, U> core::convert::Into<U> for aya::maps::MapData where U: core::convert::From<T>
-pub fn aya::maps::MapData::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::maps::MapData where U: core::convert::Into<T>
-pub type aya::maps::MapData::Error = core::convert::Infallible
-pub fn aya::maps::MapData::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::maps::MapData where U: core::convert::TryFrom<T>
-pub type aya::maps::MapData::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::maps::MapData::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya::maps::MapData where T: 'static + ?core::marker::Sized
-pub fn aya::maps::MapData::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::maps::MapData where T: ?core::marker::Sized
-pub fn aya::maps::MapData::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::maps::MapData where T: ?core::marker::Sized
-pub fn aya::maps::MapData::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya::maps::MapData
-pub fn aya::maps::MapData::from(t: T) -> T
 pub struct aya::maps::MapFd
 impl core::fmt::Debug for aya::maps::MapFd
 pub fn aya::maps::MapFd::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
@@ -1880,22 +1232,6 @@ impl core::marker::Unpin for aya::maps::MapFd
 impl core::marker::UnsafeUnpin for aya::maps::MapFd
 impl core::panic::unwind_safe::RefUnwindSafe for aya::maps::MapFd
 impl core::panic::unwind_safe::UnwindSafe for aya::maps::MapFd
-impl<T, U> core::convert::Into<U> for aya::maps::MapFd where U: core::convert::From<T>
-pub fn aya::maps::MapFd::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::maps::MapFd where U: core::convert::Into<T>
-pub type aya::maps::MapFd::Error = core::convert::Infallible
-pub fn aya::maps::MapFd::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::maps::MapFd where U: core::convert::TryFrom<T>
-pub type aya::maps::MapFd::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::maps::MapFd::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya::maps::MapFd where T: 'static + ?core::marker::Sized
-pub fn aya::maps::MapFd::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::maps::MapFd where T: ?core::marker::Sized
-pub fn aya::maps::MapFd::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::maps::MapFd where T: ?core::marker::Sized
-pub fn aya::maps::MapFd::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya::maps::MapFd
-pub fn aya::maps::MapFd::from(t: T) -> T
 pub struct aya::maps::MapInfo(_)
 impl aya::maps::MapInfo
 pub fn aya::maps::MapInfo::fd(&self) -> core::result::Result<aya::maps::MapFd, aya::maps::MapError>
@@ -1918,22 +1254,6 @@ impl core::marker::Unpin for aya::maps::MapInfo
 impl core::marker::UnsafeUnpin for aya::maps::MapInfo
 impl core::panic::unwind_safe::RefUnwindSafe for aya::maps::MapInfo
 impl core::panic::unwind_safe::UnwindSafe for aya::maps::MapInfo
-impl<T, U> core::convert::Into<U> for aya::maps::MapInfo where U: core::convert::From<T>
-pub fn aya::maps::MapInfo::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::maps::MapInfo where U: core::convert::Into<T>
-pub type aya::maps::MapInfo::Error = core::convert::Infallible
-pub fn aya::maps::MapInfo::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::maps::MapInfo where U: core::convert::TryFrom<T>
-pub type aya::maps::MapInfo::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::maps::MapInfo::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya::maps::MapInfo where T: 'static + ?core::marker::Sized
-pub fn aya::maps::MapInfo::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::maps::MapInfo where T: ?core::marker::Sized
-pub fn aya::maps::MapInfo::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::maps::MapInfo where T: ?core::marker::Sized
-pub fn aya::maps::MapInfo::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya::maps::MapInfo
-pub fn aya::maps::MapInfo::from(t: T) -> T
 pub struct aya::maps::MapIter<'coll, K: aya::Pod, V, I: aya::maps::IterableMap<K, V>>
 impl<K: aya::Pod, V, I: aya::maps::IterableMap<K, V>> core::iter::traits::iterator::Iterator for aya::maps::MapIter<'_, K, V, I>
 pub type aya::maps::MapIter<'_, K, V, I>::Item = core::result::Result<(K, V), aya::maps::MapError>
@@ -1945,26 +1265,6 @@ impl<'coll, K, V, I> core::marker::Unpin for aya::maps::MapIter<'coll, K, V, I> 
 impl<'coll, K, V, I> core::marker::UnsafeUnpin for aya::maps::MapIter<'coll, K, V, I> where K: core::marker::UnsafeUnpin
 impl<'coll, K, V, I> core::panic::unwind_safe::RefUnwindSafe for aya::maps::MapIter<'coll, K, V, I> where I: core::panic::unwind_safe::RefUnwindSafe, V: core::panic::unwind_safe::RefUnwindSafe, K: core::panic::unwind_safe::RefUnwindSafe
 impl<'coll, K, V, I> core::panic::unwind_safe::UnwindSafe for aya::maps::MapIter<'coll, K, V, I> where I: core::panic::unwind_safe::RefUnwindSafe, V: core::panic::unwind_safe::UnwindSafe, K: core::panic::unwind_safe::UnwindSafe
-impl<I> core::iter::traits::collect::IntoIterator for aya::maps::MapIter<'coll, K, V, I> where I: core::iter::traits::iterator::Iterator
-pub type aya::maps::MapIter<'coll, K, V, I>::IntoIter = I
-pub type aya::maps::MapIter<'coll, K, V, I>::Item = <I as core::iter::traits::iterator::Iterator>::Item
-pub fn aya::maps::MapIter<'coll, K, V, I>::into_iter(self) -> I
-impl<T, U> core::convert::Into<U> for aya::maps::MapIter<'coll, K, V, I> where U: core::convert::From<T>
-pub fn aya::maps::MapIter<'coll, K, V, I>::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::maps::MapIter<'coll, K, V, I> where U: core::convert::Into<T>
-pub type aya::maps::MapIter<'coll, K, V, I>::Error = core::convert::Infallible
-pub fn aya::maps::MapIter<'coll, K, V, I>::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::maps::MapIter<'coll, K, V, I> where U: core::convert::TryFrom<T>
-pub type aya::maps::MapIter<'coll, K, V, I>::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::maps::MapIter<'coll, K, V, I>::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya::maps::MapIter<'coll, K, V, I> where T: 'static + ?core::marker::Sized
-pub fn aya::maps::MapIter<'coll, K, V, I>::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::maps::MapIter<'coll, K, V, I> where T: ?core::marker::Sized
-pub fn aya::maps::MapIter<'coll, K, V, I>::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::maps::MapIter<'coll, K, V, I> where T: ?core::marker::Sized
-pub fn aya::maps::MapIter<'coll, K, V, I>::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya::maps::MapIter<'coll, K, V, I>
-pub fn aya::maps::MapIter<'coll, K, V, I>::from(t: T) -> T
 pub struct aya::maps::MapKeys<'coll, K: aya::Pod>
 impl<K: aya::Pod> core::iter::traits::iterator::Iterator for aya::maps::MapKeys<'_, K>
 pub type aya::maps::MapKeys<'_, K>::Item = core::result::Result<K, aya::maps::MapError>
@@ -1976,26 +1276,6 @@ impl<'coll, K> core::marker::Unpin for aya::maps::MapKeys<'coll, K> where K: cor
 impl<'coll, K> core::marker::UnsafeUnpin for aya::maps::MapKeys<'coll, K> where K: core::marker::UnsafeUnpin
 impl<'coll, K> core::panic::unwind_safe::RefUnwindSafe for aya::maps::MapKeys<'coll, K> where K: core::panic::unwind_safe::RefUnwindSafe
 impl<'coll, K> core::panic::unwind_safe::UnwindSafe for aya::maps::MapKeys<'coll, K> where K: core::panic::unwind_safe::UnwindSafe
-impl<I> core::iter::traits::collect::IntoIterator for aya::maps::MapKeys<'coll, K> where I: core::iter::traits::iterator::Iterator
-pub type aya::maps::MapKeys<'coll, K>::IntoIter = I
-pub type aya::maps::MapKeys<'coll, K>::Item = <I as core::iter::traits::iterator::Iterator>::Item
-pub fn aya::maps::MapKeys<'coll, K>::into_iter(self) -> I
-impl<T, U> core::convert::Into<U> for aya::maps::MapKeys<'coll, K> where U: core::convert::From<T>
-pub fn aya::maps::MapKeys<'coll, K>::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::maps::MapKeys<'coll, K> where U: core::convert::Into<T>
-pub type aya::maps::MapKeys<'coll, K>::Error = core::convert::Infallible
-pub fn aya::maps::MapKeys<'coll, K>::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::maps::MapKeys<'coll, K> where U: core::convert::TryFrom<T>
-pub type aya::maps::MapKeys<'coll, K>::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::maps::MapKeys<'coll, K>::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya::maps::MapKeys<'coll, K> where T: 'static + ?core::marker::Sized
-pub fn aya::maps::MapKeys<'coll, K>::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::maps::MapKeys<'coll, K> where T: ?core::marker::Sized
-pub fn aya::maps::MapKeys<'coll, K>::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::maps::MapKeys<'coll, K> where T: ?core::marker::Sized
-pub fn aya::maps::MapKeys<'coll, K>::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya::maps::MapKeys<'coll, K>
-pub fn aya::maps::MapKeys<'coll, K>::from(t: T) -> T
 pub struct aya::maps::PerCpuArray<T, V: aya::Pod>
 impl<T: core::borrow::Borrow<aya::maps::MapData>, V: aya::Pod> aya::maps::PerCpuArray<T, V>
 pub fn aya::maps::PerCpuArray<T, V>::get(&self, index: &u32, flags: u64) -> core::result::Result<aya::maps::PerCpuValues<V>, aya::maps::MapError>
@@ -2024,22 +1304,6 @@ impl<T, V> core::marker::Unpin for aya::maps::PerCpuArray<T, V> where T: core::m
 impl<T, V> core::marker::UnsafeUnpin for aya::maps::PerCpuArray<T, V> where T: core::marker::UnsafeUnpin
 impl<T, V> core::panic::unwind_safe::RefUnwindSafe for aya::maps::PerCpuArray<T, V> where T: core::panic::unwind_safe::RefUnwindSafe, V: core::panic::unwind_safe::RefUnwindSafe
 impl<T, V> core::panic::unwind_safe::UnwindSafe for aya::maps::PerCpuArray<T, V> where T: core::panic::unwind_safe::UnwindSafe, V: core::panic::unwind_safe::UnwindSafe
-impl<T, U> core::convert::Into<U> for aya::maps::PerCpuArray<T, V> where U: core::convert::From<T>
-pub fn aya::maps::PerCpuArray<T, V>::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::maps::PerCpuArray<T, V> where U: core::convert::Into<T>
-pub type aya::maps::PerCpuArray<T, V>::Error = core::convert::Infallible
-pub fn aya::maps::PerCpuArray<T, V>::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::maps::PerCpuArray<T, V> where U: core::convert::TryFrom<T>
-pub type aya::maps::PerCpuArray<T, V>::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::maps::PerCpuArray<T, V>::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya::maps::PerCpuArray<T, V> where T: 'static + ?core::marker::Sized
-pub fn aya::maps::PerCpuArray<T, V>::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::maps::PerCpuArray<T, V> where T: ?core::marker::Sized
-pub fn aya::maps::PerCpuArray<T, V>::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::maps::PerCpuArray<T, V> where T: ?core::marker::Sized
-pub fn aya::maps::PerCpuArray<T, V>::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya::maps::PerCpuArray<T, V>
-pub fn aya::maps::PerCpuArray<T, V>::from(t: T) -> T
 pub struct aya::maps::PerCpuHashMap<T, K: aya::Pod, V: aya::Pod>
 impl<T: core::borrow::Borrow<aya::maps::MapData>, K: aya::Pod, V: aya::Pod> aya::maps::hash_map::PerCpuHashMap<T, K, V>
 pub fn aya::maps::hash_map::PerCpuHashMap<T, K, V>::get(&self, key: &K, flags: u64) -> core::result::Result<aya::maps::PerCpuValues<V>, aya::maps::MapError>
@@ -2073,22 +1337,6 @@ impl<T, K, V> core::marker::Unpin for aya::maps::hash_map::PerCpuHashMap<T, K, V
 impl<T, K, V> core::marker::UnsafeUnpin for aya::maps::hash_map::PerCpuHashMap<T, K, V> where T: core::marker::UnsafeUnpin
 impl<T, K, V> core::panic::unwind_safe::RefUnwindSafe for aya::maps::hash_map::PerCpuHashMap<T, K, V> where T: core::panic::unwind_safe::RefUnwindSafe, K: core::panic::unwind_safe::RefUnwindSafe, V: core::panic::unwind_safe::RefUnwindSafe
 impl<T, K, V> core::panic::unwind_safe::UnwindSafe for aya::maps::hash_map::PerCpuHashMap<T, K, V> where T: core::panic::unwind_safe::UnwindSafe, K: core::panic::unwind_safe::UnwindSafe, V: core::panic::unwind_safe::UnwindSafe
-impl<T, U> core::convert::Into<U> for aya::maps::hash_map::PerCpuHashMap<T, K, V> where U: core::convert::From<T>
-pub fn aya::maps::hash_map::PerCpuHashMap<T, K, V>::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::maps::hash_map::PerCpuHashMap<T, K, V> where U: core::convert::Into<T>
-pub type aya::maps::hash_map::PerCpuHashMap<T, K, V>::Error = core::convert::Infallible
-pub fn aya::maps::hash_map::PerCpuHashMap<T, K, V>::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::maps::hash_map::PerCpuHashMap<T, K, V> where U: core::convert::TryFrom<T>
-pub type aya::maps::hash_map::PerCpuHashMap<T, K, V>::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::maps::hash_map::PerCpuHashMap<T, K, V>::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya::maps::hash_map::PerCpuHashMap<T, K, V> where T: 'static + ?core::marker::Sized
-pub fn aya::maps::hash_map::PerCpuHashMap<T, K, V>::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::maps::hash_map::PerCpuHashMap<T, K, V> where T: ?core::marker::Sized
-pub fn aya::maps::hash_map::PerCpuHashMap<T, K, V>::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::maps::hash_map::PerCpuHashMap<T, K, V> where T: ?core::marker::Sized
-pub fn aya::maps::hash_map::PerCpuHashMap<T, K, V>::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya::maps::hash_map::PerCpuHashMap<T, K, V>
-pub fn aya::maps::hash_map::PerCpuHashMap<T, K, V>::from(t: T) -> T
 pub struct aya::maps::PerCpuValues<T: aya::Pod>
 impl<T: aya::Pod> core::convert::TryFrom<alloc::vec::Vec<T>> for aya::maps::PerCpuValues<T>
 pub type aya::maps::PerCpuValues<T>::Error = std::io::error::Error
@@ -2111,24 +1359,6 @@ impl<T> core::marker::Unpin for aya::maps::PerCpuValues<T>
 impl<T> core::marker::UnsafeUnpin for aya::maps::PerCpuValues<T>
 impl<T> core::panic::unwind_safe::RefUnwindSafe for aya::maps::PerCpuValues<T> where T: core::panic::unwind_safe::RefUnwindSafe
 impl<T> core::panic::unwind_safe::UnwindSafe for aya::maps::PerCpuValues<T> where T: core::panic::unwind_safe::UnwindSafe
-impl<P, T> core::ops::deref::Receiver for aya::maps::PerCpuValues<T> where P: core::ops::deref::Deref<Target = T> + ?core::marker::Sized, T: ?core::marker::Sized
-pub type aya::maps::PerCpuValues<T>::Target = T
-impl<T, U> core::convert::Into<U> for aya::maps::PerCpuValues<T> where U: core::convert::From<T>
-pub fn aya::maps::PerCpuValues<T>::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::maps::PerCpuValues<T> where U: core::convert::Into<T>
-pub type aya::maps::PerCpuValues<T>::Error = core::convert::Infallible
-pub fn aya::maps::PerCpuValues<T>::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::maps::PerCpuValues<T> where U: core::convert::TryFrom<T>
-pub type aya::maps::PerCpuValues<T>::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::maps::PerCpuValues<T>::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya::maps::PerCpuValues<T> where T: 'static + ?core::marker::Sized
-pub fn aya::maps::PerCpuValues<T>::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::maps::PerCpuValues<T> where T: ?core::marker::Sized
-pub fn aya::maps::PerCpuValues<T>::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::maps::PerCpuValues<T> where T: ?core::marker::Sized
-pub fn aya::maps::PerCpuValues<T>::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya::maps::PerCpuValues<T>
-pub fn aya::maps::PerCpuValues<T>::from(t: T) -> T
 pub struct aya::maps::PerfEventArray<T>
 impl<T: core::borrow::Borrow<aya::maps::MapData>> aya::maps::perf::PerfEventArray<T>
 pub fn aya::maps::perf::PerfEventArray<T>::pin<P: core::convert::AsRef<std::path::Path>>(&self, path: P) -> core::result::Result<(), aya::pin::PinError>
@@ -2150,22 +1380,6 @@ impl<T> core::marker::Unpin for aya::maps::perf::PerfEventArray<T>
 impl<T> core::marker::UnsafeUnpin for aya::maps::perf::PerfEventArray<T>
 impl<T> core::panic::unwind_safe::RefUnwindSafe for aya::maps::perf::PerfEventArray<T> where T: core::panic::unwind_safe::RefUnwindSafe
 impl<T> core::panic::unwind_safe::UnwindSafe for aya::maps::perf::PerfEventArray<T> where T: core::panic::unwind_safe::RefUnwindSafe
-impl<T, U> core::convert::Into<U> for aya::maps::perf::PerfEventArray<T> where U: core::convert::From<T>
-pub fn aya::maps::perf::PerfEventArray<T>::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::maps::perf::PerfEventArray<T> where U: core::convert::Into<T>
-pub type aya::maps::perf::PerfEventArray<T>::Error = core::convert::Infallible
-pub fn aya::maps::perf::PerfEventArray<T>::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::maps::perf::PerfEventArray<T> where U: core::convert::TryFrom<T>
-pub type aya::maps::perf::PerfEventArray<T>::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::maps::perf::PerfEventArray<T>::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya::maps::perf::PerfEventArray<T> where T: 'static + ?core::marker::Sized
-pub fn aya::maps::perf::PerfEventArray<T>::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::maps::perf::PerfEventArray<T> where T: ?core::marker::Sized
-pub fn aya::maps::perf::PerfEventArray<T>::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::maps::perf::PerfEventArray<T> where T: ?core::marker::Sized
-pub fn aya::maps::perf::PerfEventArray<T>::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya::maps::perf::PerfEventArray<T>
-pub fn aya::maps::perf::PerfEventArray<T>::from(t: T) -> T
 pub struct aya::maps::ProgramArray<T>
 impl<T: core::borrow::Borrow<aya::maps::MapData>> aya::maps::ProgramArray<T>
 pub fn aya::maps::ProgramArray<T>::indices(&self) -> aya::maps::MapKeys<'_, u32>
@@ -2190,22 +1404,6 @@ impl<T> core::marker::Unpin for aya::maps::ProgramArray<T> where T: core::marker
 impl<T> core::marker::UnsafeUnpin for aya::maps::ProgramArray<T> where T: core::marker::UnsafeUnpin
 impl<T> core::panic::unwind_safe::RefUnwindSafe for aya::maps::ProgramArray<T> where T: core::panic::unwind_safe::RefUnwindSafe
 impl<T> core::panic::unwind_safe::UnwindSafe for aya::maps::ProgramArray<T> where T: core::panic::unwind_safe::UnwindSafe
-impl<T, U> core::convert::Into<U> for aya::maps::ProgramArray<T> where U: core::convert::From<T>
-pub fn aya::maps::ProgramArray<T>::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::maps::ProgramArray<T> where U: core::convert::Into<T>
-pub type aya::maps::ProgramArray<T>::Error = core::convert::Infallible
-pub fn aya::maps::ProgramArray<T>::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::maps::ProgramArray<T> where U: core::convert::TryFrom<T>
-pub type aya::maps::ProgramArray<T>::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::maps::ProgramArray<T>::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya::maps::ProgramArray<T> where T: 'static + ?core::marker::Sized
-pub fn aya::maps::ProgramArray<T>::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::maps::ProgramArray<T> where T: ?core::marker::Sized
-pub fn aya::maps::ProgramArray<T>::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::maps::ProgramArray<T> where T: ?core::marker::Sized
-pub fn aya::maps::ProgramArray<T>::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya::maps::ProgramArray<T>
-pub fn aya::maps::ProgramArray<T>::from(t: T) -> T
 pub struct aya::maps::Queue<T, V: aya::Pod>
 impl<T: core::borrow::Borrow<aya::maps::MapData>, V: aya::Pod> aya::maps::queue::Queue<T, V>
 pub fn aya::maps::queue::Queue<T, V>::capacity(&self) -> u32
@@ -2230,22 +1428,6 @@ impl<T, V> core::marker::Unpin for aya::maps::queue::Queue<T, V> where T: core::
 impl<T, V> core::marker::UnsafeUnpin for aya::maps::queue::Queue<T, V> where T: core::marker::UnsafeUnpin
 impl<T, V> core::panic::unwind_safe::RefUnwindSafe for aya::maps::queue::Queue<T, V> where T: core::panic::unwind_safe::RefUnwindSafe, V: core::panic::unwind_safe::RefUnwindSafe
 impl<T, V> core::panic::unwind_safe::UnwindSafe for aya::maps::queue::Queue<T, V> where T: core::panic::unwind_safe::UnwindSafe, V: core::panic::unwind_safe::UnwindSafe
-impl<T, U> core::convert::Into<U> for aya::maps::queue::Queue<T, V> where U: core::convert::From<T>
-pub fn aya::maps::queue::Queue<T, V>::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::maps::queue::Queue<T, V> where U: core::convert::Into<T>
-pub type aya::maps::queue::Queue<T, V>::Error = core::convert::Infallible
-pub fn aya::maps::queue::Queue<T, V>::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::maps::queue::Queue<T, V> where U: core::convert::TryFrom<T>
-pub type aya::maps::queue::Queue<T, V>::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::maps::queue::Queue<T, V>::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya::maps::queue::Queue<T, V> where T: 'static + ?core::marker::Sized
-pub fn aya::maps::queue::Queue<T, V>::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::maps::queue::Queue<T, V> where T: ?core::marker::Sized
-pub fn aya::maps::queue::Queue<T, V>::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::maps::queue::Queue<T, V> where T: ?core::marker::Sized
-pub fn aya::maps::queue::Queue<T, V>::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya::maps::queue::Queue<T, V>
-pub fn aya::maps::queue::Queue<T, V>::from(t: T) -> T
 pub struct aya::maps::RingBuf<T>
 impl<T> aya::maps::ring_buf::RingBuf<T>
 pub fn aya::maps::ring_buf::RingBuf<T>::next(&mut self) -> core::option::Option<aya::maps::ring_buf::RingBufItem<'_>>
@@ -2269,22 +1451,6 @@ impl<T> core::marker::Unpin for aya::maps::ring_buf::RingBuf<T> where T: core::m
 impl<T> core::marker::UnsafeUnpin for aya::maps::ring_buf::RingBuf<T> where T: core::marker::UnsafeUnpin
 impl<T> core::panic::unwind_safe::RefUnwindSafe for aya::maps::ring_buf::RingBuf<T> where T: core::panic::unwind_safe::RefUnwindSafe
 impl<T> core::panic::unwind_safe::UnwindSafe for aya::maps::ring_buf::RingBuf<T> where T: core::panic::unwind_safe::UnwindSafe
-impl<T, U> core::convert::Into<U> for aya::maps::ring_buf::RingBuf<T> where U: core::convert::From<T>
-pub fn aya::maps::ring_buf::RingBuf<T>::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::maps::ring_buf::RingBuf<T> where U: core::convert::Into<T>
-pub type aya::maps::ring_buf::RingBuf<T>::Error = core::convert::Infallible
-pub fn aya::maps::ring_buf::RingBuf<T>::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::maps::ring_buf::RingBuf<T> where U: core::convert::TryFrom<T>
-pub type aya::maps::ring_buf::RingBuf<T>::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::maps::ring_buf::RingBuf<T>::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya::maps::ring_buf::RingBuf<T> where T: 'static + ?core::marker::Sized
-pub fn aya::maps::ring_buf::RingBuf<T>::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::maps::ring_buf::RingBuf<T> where T: ?core::marker::Sized
-pub fn aya::maps::ring_buf::RingBuf<T>::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::maps::ring_buf::RingBuf<T> where T: ?core::marker::Sized
-pub fn aya::maps::ring_buf::RingBuf<T>::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya::maps::ring_buf::RingBuf<T>
-pub fn aya::maps::ring_buf::RingBuf<T>::from(t: T) -> T
 pub struct aya::maps::SkStorage<T, V: aya::Pod>
 impl<T: core::borrow::Borrow<aya::maps::MapData>, V: aya::Pod> aya::maps::sk_storage::SkStorage<T, V>
 pub fn aya::maps::sk_storage::SkStorage<T, V>::get(&self, socket: &impl std::os::fd::raw::AsRawFd, flags: u64) -> core::result::Result<V, aya::maps::MapError>
@@ -2311,22 +1477,6 @@ impl<T, V> core::marker::Unpin for aya::maps::sk_storage::SkStorage<T, V> where 
 impl<T, V> core::marker::UnsafeUnpin for aya::maps::sk_storage::SkStorage<T, V> where T: core::marker::UnsafeUnpin
 impl<T, V> core::panic::unwind_safe::RefUnwindSafe for aya::maps::sk_storage::SkStorage<T, V> where T: core::panic::unwind_safe::RefUnwindSafe, V: core::panic::unwind_safe::RefUnwindSafe
 impl<T, V> core::panic::unwind_safe::UnwindSafe for aya::maps::sk_storage::SkStorage<T, V> where T: core::panic::unwind_safe::UnwindSafe, V: core::panic::unwind_safe::UnwindSafe
-impl<T, U> core::convert::Into<U> for aya::maps::sk_storage::SkStorage<T, V> where U: core::convert::From<T>
-pub fn aya::maps::sk_storage::SkStorage<T, V>::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::maps::sk_storage::SkStorage<T, V> where U: core::convert::Into<T>
-pub type aya::maps::sk_storage::SkStorage<T, V>::Error = core::convert::Infallible
-pub fn aya::maps::sk_storage::SkStorage<T, V>::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::maps::sk_storage::SkStorage<T, V> where U: core::convert::TryFrom<T>
-pub type aya::maps::sk_storage::SkStorage<T, V>::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::maps::sk_storage::SkStorage<T, V>::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya::maps::sk_storage::SkStorage<T, V> where T: 'static + ?core::marker::Sized
-pub fn aya::maps::sk_storage::SkStorage<T, V>::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::maps::sk_storage::SkStorage<T, V> where T: ?core::marker::Sized
-pub fn aya::maps::sk_storage::SkStorage<T, V>::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::maps::sk_storage::SkStorage<T, V> where T: ?core::marker::Sized
-pub fn aya::maps::sk_storage::SkStorage<T, V>::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya::maps::sk_storage::SkStorage<T, V>
-pub fn aya::maps::sk_storage::SkStorage<T, V>::from(t: T) -> T
 pub struct aya::maps::SockHash<T, K>
 impl<T: core::borrow::Borrow<aya::maps::MapData>, K: aya::Pod> aya::maps::SockHash<T, K>
 pub fn aya::maps::SockHash<T, K>::fd(&self) -> &aya::maps::sock::SockMapFd
@@ -2361,22 +1511,6 @@ impl<T, K> core::marker::Unpin for aya::maps::SockHash<T, K> where T: core::mark
 impl<T, K> core::marker::UnsafeUnpin for aya::maps::SockHash<T, K> where T: core::marker::UnsafeUnpin
 impl<T, K> core::panic::unwind_safe::RefUnwindSafe for aya::maps::SockHash<T, K> where T: core::panic::unwind_safe::RefUnwindSafe, K: core::panic::unwind_safe::RefUnwindSafe
 impl<T, K> core::panic::unwind_safe::UnwindSafe for aya::maps::SockHash<T, K> where T: core::panic::unwind_safe::UnwindSafe, K: core::panic::unwind_safe::UnwindSafe
-impl<T, U> core::convert::Into<U> for aya::maps::SockHash<T, K> where U: core::convert::From<T>
-pub fn aya::maps::SockHash<T, K>::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::maps::SockHash<T, K> where U: core::convert::Into<T>
-pub type aya::maps::SockHash<T, K>::Error = core::convert::Infallible
-pub fn aya::maps::SockHash<T, K>::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::maps::SockHash<T, K> where U: core::convert::TryFrom<T>
-pub type aya::maps::SockHash<T, K>::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::maps::SockHash<T, K>::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya::maps::SockHash<T, K> where T: 'static + ?core::marker::Sized
-pub fn aya::maps::SockHash<T, K>::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::maps::SockHash<T, K> where T: ?core::marker::Sized
-pub fn aya::maps::SockHash<T, K>::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::maps::SockHash<T, K> where T: ?core::marker::Sized
-pub fn aya::maps::SockHash<T, K>::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya::maps::SockHash<T, K>
-pub fn aya::maps::SockHash<T, K>::from(t: T) -> T
 pub struct aya::maps::SockMap<T>
 impl<T: core::borrow::Borrow<aya::maps::MapData>> aya::maps::SockMap<T>
 pub fn aya::maps::SockMap<T>::fd(&self) -> &aya::maps::sock::SockMapFd
@@ -2402,22 +1536,6 @@ impl<T> core::marker::Unpin for aya::maps::SockMap<T> where T: core::marker::Unp
 impl<T> core::marker::UnsafeUnpin for aya::maps::SockMap<T> where T: core::marker::UnsafeUnpin
 impl<T> core::panic::unwind_safe::RefUnwindSafe for aya::maps::SockMap<T> where T: core::panic::unwind_safe::RefUnwindSafe
 impl<T> core::panic::unwind_safe::UnwindSafe for aya::maps::SockMap<T> where T: core::panic::unwind_safe::UnwindSafe
-impl<T, U> core::convert::Into<U> for aya::maps::SockMap<T> where U: core::convert::From<T>
-pub fn aya::maps::SockMap<T>::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::maps::SockMap<T> where U: core::convert::Into<T>
-pub type aya::maps::SockMap<T>::Error = core::convert::Infallible
-pub fn aya::maps::SockMap<T>::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::maps::SockMap<T> where U: core::convert::TryFrom<T>
-pub type aya::maps::SockMap<T>::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::maps::SockMap<T>::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya::maps::SockMap<T> where T: 'static + ?core::marker::Sized
-pub fn aya::maps::SockMap<T>::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::maps::SockMap<T> where T: ?core::marker::Sized
-pub fn aya::maps::SockMap<T>::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::maps::SockMap<T> where T: ?core::marker::Sized
-pub fn aya::maps::SockMap<T>::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya::maps::SockMap<T>
-pub fn aya::maps::SockMap<T>::from(t: T) -> T
 pub struct aya::maps::Stack<T, V: aya::Pod>
 impl<T: core::borrow::Borrow<aya::maps::MapData>, V: aya::Pod> aya::maps::stack::Stack<T, V>
 pub fn aya::maps::stack::Stack<T, V>::capacity(&self) -> u32
@@ -2442,22 +1560,6 @@ impl<T, V> core::marker::Unpin for aya::maps::stack::Stack<T, V> where T: core::
 impl<T, V> core::marker::UnsafeUnpin for aya::maps::stack::Stack<T, V> where T: core::marker::UnsafeUnpin
 impl<T, V> core::panic::unwind_safe::RefUnwindSafe for aya::maps::stack::Stack<T, V> where T: core::panic::unwind_safe::RefUnwindSafe, V: core::panic::unwind_safe::RefUnwindSafe
 impl<T, V> core::panic::unwind_safe::UnwindSafe for aya::maps::stack::Stack<T, V> where T: core::panic::unwind_safe::UnwindSafe, V: core::panic::unwind_safe::UnwindSafe
-impl<T, U> core::convert::Into<U> for aya::maps::stack::Stack<T, V> where U: core::convert::From<T>
-pub fn aya::maps::stack::Stack<T, V>::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::maps::stack::Stack<T, V> where U: core::convert::Into<T>
-pub type aya::maps::stack::Stack<T, V>::Error = core::convert::Infallible
-pub fn aya::maps::stack::Stack<T, V>::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::maps::stack::Stack<T, V> where U: core::convert::TryFrom<T>
-pub type aya::maps::stack::Stack<T, V>::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::maps::stack::Stack<T, V>::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya::maps::stack::Stack<T, V> where T: 'static + ?core::marker::Sized
-pub fn aya::maps::stack::Stack<T, V>::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::maps::stack::Stack<T, V> where T: ?core::marker::Sized
-pub fn aya::maps::stack::Stack<T, V>::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::maps::stack::Stack<T, V> where T: ?core::marker::Sized
-pub fn aya::maps::stack::Stack<T, V>::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya::maps::stack::Stack<T, V>
-pub fn aya::maps::stack::Stack<T, V>::from(t: T) -> T
 pub struct aya::maps::StackTraceMap<T>
 impl<T: core::borrow::Borrow<aya::maps::MapData>> aya::maps::stack_trace::StackTraceMap<T>
 pub fn aya::maps::stack_trace::StackTraceMap<T>::get(&self, stack_id: &u32, flags: u64) -> core::result::Result<aya::maps::stack_trace::StackTrace, aya::maps::MapError>
@@ -2492,22 +1594,6 @@ impl<T> core::marker::Unpin for aya::maps::stack_trace::StackTraceMap<T> where T
 impl<T> core::marker::UnsafeUnpin for aya::maps::stack_trace::StackTraceMap<T> where T: core::marker::UnsafeUnpin
 impl<T> core::panic::unwind_safe::RefUnwindSafe for aya::maps::stack_trace::StackTraceMap<T> where T: core::panic::unwind_safe::RefUnwindSafe
 impl<T> core::panic::unwind_safe::UnwindSafe for aya::maps::stack_trace::StackTraceMap<T> where T: core::panic::unwind_safe::UnwindSafe
-impl<T, U> core::convert::Into<U> for aya::maps::stack_trace::StackTraceMap<T> where U: core::convert::From<T>
-pub fn aya::maps::stack_trace::StackTraceMap<T>::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::maps::stack_trace::StackTraceMap<T> where U: core::convert::Into<T>
-pub type aya::maps::stack_trace::StackTraceMap<T>::Error = core::convert::Infallible
-pub fn aya::maps::stack_trace::StackTraceMap<T>::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::maps::stack_trace::StackTraceMap<T> where U: core::convert::TryFrom<T>
-pub type aya::maps::stack_trace::StackTraceMap<T>::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::maps::stack_trace::StackTraceMap<T>::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya::maps::stack_trace::StackTraceMap<T> where T: 'static + ?core::marker::Sized
-pub fn aya::maps::stack_trace::StackTraceMap<T>::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::maps::stack_trace::StackTraceMap<T> where T: ?core::marker::Sized
-pub fn aya::maps::stack_trace::StackTraceMap<T>::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::maps::stack_trace::StackTraceMap<T> where T: ?core::marker::Sized
-pub fn aya::maps::stack_trace::StackTraceMap<T>::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya::maps::stack_trace::StackTraceMap<T>
-pub fn aya::maps::stack_trace::StackTraceMap<T>::from(t: T) -> T
 pub struct aya::maps::XskMap<T>
 impl<T: core::borrow::Borrow<aya::maps::MapData>> aya::maps::XskMap<T>
 pub fn aya::maps::XskMap<T>::len(&self) -> u32
@@ -2532,22 +1618,6 @@ impl<T> core::marker::Unpin for aya::maps::XskMap<T> where T: core::marker::Unpi
 impl<T> core::marker::UnsafeUnpin for aya::maps::XskMap<T> where T: core::marker::UnsafeUnpin
 impl<T> core::panic::unwind_safe::RefUnwindSafe for aya::maps::XskMap<T> where T: core::panic::unwind_safe::RefUnwindSafe
 impl<T> core::panic::unwind_safe::UnwindSafe for aya::maps::XskMap<T> where T: core::panic::unwind_safe::UnwindSafe
-impl<T, U> core::convert::Into<U> for aya::maps::XskMap<T> where U: core::convert::From<T>
-pub fn aya::maps::XskMap<T>::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::maps::XskMap<T> where U: core::convert::Into<T>
-pub type aya::maps::XskMap<T>::Error = core::convert::Infallible
-pub fn aya::maps::XskMap<T>::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::maps::XskMap<T> where U: core::convert::TryFrom<T>
-pub type aya::maps::XskMap<T>::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::maps::XskMap<T>::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya::maps::XskMap<T> where T: 'static + ?core::marker::Sized
-pub fn aya::maps::XskMap<T>::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::maps::XskMap<T> where T: ?core::marker::Sized
-pub fn aya::maps::XskMap<T>::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::maps::XskMap<T> where T: ?core::marker::Sized
-pub fn aya::maps::XskMap<T>::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya::maps::XskMap<T>
-pub fn aya::maps::XskMap<T>::from(t: T) -> T
 pub trait aya::maps::IterableMap<K: aya::Pod, V>
 pub fn aya::maps::IterableMap::get(&self, key: &K) -> core::result::Result<V, aya::maps::MapError>
 pub fn aya::maps::IterableMap::map(&self) -> &aya::maps::MapData
@@ -2596,24 +1666,6 @@ impl core::marker::Unpin for aya::pin::PinError
 impl core::marker::UnsafeUnpin for aya::pin::PinError
 impl !core::panic::unwind_safe::RefUnwindSafe for aya::pin::PinError
 impl !core::panic::unwind_safe::UnwindSafe for aya::pin::PinError
-impl<T, U> core::convert::Into<U> for aya::pin::PinError where U: core::convert::From<T>
-pub fn aya::pin::PinError::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::pin::PinError where U: core::convert::Into<T>
-pub type aya::pin::PinError::Error = core::convert::Infallible
-pub fn aya::pin::PinError::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::pin::PinError where U: core::convert::TryFrom<T>
-pub type aya::pin::PinError::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::pin::PinError::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::string::ToString for aya::pin::PinError where T: core::fmt::Display + ?core::marker::Sized
-pub fn aya::pin::PinError::to_string(&self) -> alloc::string::String
-impl<T> core::any::Any for aya::pin::PinError where T: 'static + ?core::marker::Sized
-pub fn aya::pin::PinError::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::pin::PinError where T: ?core::marker::Sized
-pub fn aya::pin::PinError::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::pin::PinError where T: ?core::marker::Sized
-pub fn aya::pin::PinError::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya::pin::PinError
-pub fn aya::pin::PinError::from(t: T) -> T
 pub mod aya::programs
 pub use aya::programs::CgroupSkbAttachType
 pub use aya::programs::CgroupSockAddrAttachType
@@ -2660,22 +1712,6 @@ impl core::marker::Unpin for aya::programs::cgroup_device::CgroupDevice
 impl core::marker::UnsafeUnpin for aya::programs::cgroup_device::CgroupDevice
 impl core::panic::unwind_safe::RefUnwindSafe for aya::programs::cgroup_device::CgroupDevice
 impl core::panic::unwind_safe::UnwindSafe for aya::programs::cgroup_device::CgroupDevice
-impl<T, U> core::convert::Into<U> for aya::programs::cgroup_device::CgroupDevice where U: core::convert::From<T>
-pub fn aya::programs::cgroup_device::CgroupDevice::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::programs::cgroup_device::CgroupDevice where U: core::convert::Into<T>
-pub type aya::programs::cgroup_device::CgroupDevice::Error = core::convert::Infallible
-pub fn aya::programs::cgroup_device::CgroupDevice::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::programs::cgroup_device::CgroupDevice where U: core::convert::TryFrom<T>
-pub type aya::programs::cgroup_device::CgroupDevice::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::programs::cgroup_device::CgroupDevice::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya::programs::cgroup_device::CgroupDevice where T: 'static + ?core::marker::Sized
-pub fn aya::programs::cgroup_device::CgroupDevice::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::programs::cgroup_device::CgroupDevice where T: ?core::marker::Sized
-pub fn aya::programs::cgroup_device::CgroupDevice::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::programs::cgroup_device::CgroupDevice where T: ?core::marker::Sized
-pub fn aya::programs::cgroup_device::CgroupDevice::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya::programs::cgroup_device::CgroupDevice
-pub fn aya::programs::cgroup_device::CgroupDevice::from(t: T) -> T
 pub struct aya::programs::cgroup_device::CgroupDeviceLink(_)
 impl aya::programs::links::Link for aya::programs::cgroup_device::CgroupDeviceLink
 pub type aya::programs::cgroup_device::CgroupDeviceLink::Id = aya::programs::cgroup_device::CgroupDeviceLinkId
@@ -2699,26 +1735,6 @@ impl core::marker::Unpin for aya::programs::cgroup_device::CgroupDeviceLink
 impl core::marker::UnsafeUnpin for aya::programs::cgroup_device::CgroupDeviceLink
 impl core::panic::unwind_safe::RefUnwindSafe for aya::programs::cgroup_device::CgroupDeviceLink
 impl core::panic::unwind_safe::UnwindSafe for aya::programs::cgroup_device::CgroupDeviceLink
-impl<Q, K> equivalent::Equivalent<K> for aya::programs::cgroup_device::CgroupDeviceLink where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
-pub fn aya::programs::cgroup_device::CgroupDeviceLink::equivalent(&self, key: &K) -> bool
-impl<Q, K> hashbrown::Equivalent<K> for aya::programs::cgroup_device::CgroupDeviceLink where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
-pub fn aya::programs::cgroup_device::CgroupDeviceLink::equivalent(&self, key: &K) -> bool
-impl<T, U> core::convert::Into<U> for aya::programs::cgroup_device::CgroupDeviceLink where U: core::convert::From<T>
-pub fn aya::programs::cgroup_device::CgroupDeviceLink::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::programs::cgroup_device::CgroupDeviceLink where U: core::convert::Into<T>
-pub type aya::programs::cgroup_device::CgroupDeviceLink::Error = core::convert::Infallible
-pub fn aya::programs::cgroup_device::CgroupDeviceLink::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::programs::cgroup_device::CgroupDeviceLink where U: core::convert::TryFrom<T>
-pub type aya::programs::cgroup_device::CgroupDeviceLink::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::programs::cgroup_device::CgroupDeviceLink::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya::programs::cgroup_device::CgroupDeviceLink where T: 'static + ?core::marker::Sized
-pub fn aya::programs::cgroup_device::CgroupDeviceLink::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::programs::cgroup_device::CgroupDeviceLink where T: ?core::marker::Sized
-pub fn aya::programs::cgroup_device::CgroupDeviceLink::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::programs::cgroup_device::CgroupDeviceLink where T: ?core::marker::Sized
-pub fn aya::programs::cgroup_device::CgroupDeviceLink::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya::programs::cgroup_device::CgroupDeviceLink
-pub fn aya::programs::cgroup_device::CgroupDeviceLink::from(t: T) -> T
 pub struct aya::programs::cgroup_device::CgroupDeviceLinkId(_)
 impl core::cmp::Eq for aya::programs::cgroup_device::CgroupDeviceLinkId
 impl core::cmp::PartialEq for aya::programs::cgroup_device::CgroupDeviceLinkId
@@ -2737,26 +1753,6 @@ impl core::marker::Unpin for aya::programs::cgroup_device::CgroupDeviceLinkId
 impl core::marker::UnsafeUnpin for aya::programs::cgroup_device::CgroupDeviceLinkId
 impl core::panic::unwind_safe::RefUnwindSafe for aya::programs::cgroup_device::CgroupDeviceLinkId
 impl core::panic::unwind_safe::UnwindSafe for aya::programs::cgroup_device::CgroupDeviceLinkId
-impl<Q, K> equivalent::Equivalent<K> for aya::programs::cgroup_device::CgroupDeviceLinkId where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
-pub fn aya::programs::cgroup_device::CgroupDeviceLinkId::equivalent(&self, key: &K) -> bool
-impl<Q, K> hashbrown::Equivalent<K> for aya::programs::cgroup_device::CgroupDeviceLinkId where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
-pub fn aya::programs::cgroup_device::CgroupDeviceLinkId::equivalent(&self, key: &K) -> bool
-impl<T, U> core::convert::Into<U> for aya::programs::cgroup_device::CgroupDeviceLinkId where U: core::convert::From<T>
-pub fn aya::programs::cgroup_device::CgroupDeviceLinkId::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::programs::cgroup_device::CgroupDeviceLinkId where U: core::convert::Into<T>
-pub type aya::programs::cgroup_device::CgroupDeviceLinkId::Error = core::convert::Infallible
-pub fn aya::programs::cgroup_device::CgroupDeviceLinkId::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::programs::cgroup_device::CgroupDeviceLinkId where U: core::convert::TryFrom<T>
-pub type aya::programs::cgroup_device::CgroupDeviceLinkId::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::programs::cgroup_device::CgroupDeviceLinkId::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya::programs::cgroup_device::CgroupDeviceLinkId where T: 'static + ?core::marker::Sized
-pub fn aya::programs::cgroup_device::CgroupDeviceLinkId::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::programs::cgroup_device::CgroupDeviceLinkId where T: ?core::marker::Sized
-pub fn aya::programs::cgroup_device::CgroupDeviceLinkId::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::programs::cgroup_device::CgroupDeviceLinkId where T: ?core::marker::Sized
-pub fn aya::programs::cgroup_device::CgroupDeviceLinkId::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya::programs::cgroup_device::CgroupDeviceLinkId
-pub fn aya::programs::cgroup_device::CgroupDeviceLinkId::from(t: T) -> T
 pub mod aya::programs::cgroup_skb
 pub use aya::programs::cgroup_skb::CgroupSkbAttachType
 pub struct aya::programs::cgroup_skb::CgroupSkb
@@ -2797,22 +1793,6 @@ impl core::marker::Unpin for aya::programs::cgroup_skb::CgroupSkb
 impl core::marker::UnsafeUnpin for aya::programs::cgroup_skb::CgroupSkb
 impl core::panic::unwind_safe::RefUnwindSafe for aya::programs::cgroup_skb::CgroupSkb
 impl core::panic::unwind_safe::UnwindSafe for aya::programs::cgroup_skb::CgroupSkb
-impl<T, U> core::convert::Into<U> for aya::programs::cgroup_skb::CgroupSkb where U: core::convert::From<T>
-pub fn aya::programs::cgroup_skb::CgroupSkb::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::programs::cgroup_skb::CgroupSkb where U: core::convert::Into<T>
-pub type aya::programs::cgroup_skb::CgroupSkb::Error = core::convert::Infallible
-pub fn aya::programs::cgroup_skb::CgroupSkb::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::programs::cgroup_skb::CgroupSkb where U: core::convert::TryFrom<T>
-pub type aya::programs::cgroup_skb::CgroupSkb::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::programs::cgroup_skb::CgroupSkb::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya::programs::cgroup_skb::CgroupSkb where T: 'static + ?core::marker::Sized
-pub fn aya::programs::cgroup_skb::CgroupSkb::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::programs::cgroup_skb::CgroupSkb where T: ?core::marker::Sized
-pub fn aya::programs::cgroup_skb::CgroupSkb::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::programs::cgroup_skb::CgroupSkb where T: ?core::marker::Sized
-pub fn aya::programs::cgroup_skb::CgroupSkb::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya::programs::cgroup_skb::CgroupSkb
-pub fn aya::programs::cgroup_skb::CgroupSkb::from(t: T) -> T
 pub struct aya::programs::cgroup_skb::CgroupSkbLink(_)
 impl aya::programs::links::Link for aya::programs::cgroup_skb::CgroupSkbLink
 pub type aya::programs::cgroup_skb::CgroupSkbLink::Id = aya::programs::cgroup_skb::CgroupSkbLinkId
@@ -2839,26 +1819,6 @@ impl core::marker::Unpin for aya::programs::cgroup_skb::CgroupSkbLink
 impl core::marker::UnsafeUnpin for aya::programs::cgroup_skb::CgroupSkbLink
 impl core::panic::unwind_safe::RefUnwindSafe for aya::programs::cgroup_skb::CgroupSkbLink
 impl core::panic::unwind_safe::UnwindSafe for aya::programs::cgroup_skb::CgroupSkbLink
-impl<Q, K> equivalent::Equivalent<K> for aya::programs::cgroup_skb::CgroupSkbLink where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
-pub fn aya::programs::cgroup_skb::CgroupSkbLink::equivalent(&self, key: &K) -> bool
-impl<Q, K> hashbrown::Equivalent<K> for aya::programs::cgroup_skb::CgroupSkbLink where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
-pub fn aya::programs::cgroup_skb::CgroupSkbLink::equivalent(&self, key: &K) -> bool
-impl<T, U> core::convert::Into<U> for aya::programs::cgroup_skb::CgroupSkbLink where U: core::convert::From<T>
-pub fn aya::programs::cgroup_skb::CgroupSkbLink::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::programs::cgroup_skb::CgroupSkbLink where U: core::convert::Into<T>
-pub type aya::programs::cgroup_skb::CgroupSkbLink::Error = core::convert::Infallible
-pub fn aya::programs::cgroup_skb::CgroupSkbLink::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::programs::cgroup_skb::CgroupSkbLink where U: core::convert::TryFrom<T>
-pub type aya::programs::cgroup_skb::CgroupSkbLink::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::programs::cgroup_skb::CgroupSkbLink::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya::programs::cgroup_skb::CgroupSkbLink where T: 'static + ?core::marker::Sized
-pub fn aya::programs::cgroup_skb::CgroupSkbLink::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::programs::cgroup_skb::CgroupSkbLink where T: ?core::marker::Sized
-pub fn aya::programs::cgroup_skb::CgroupSkbLink::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::programs::cgroup_skb::CgroupSkbLink where T: ?core::marker::Sized
-pub fn aya::programs::cgroup_skb::CgroupSkbLink::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya::programs::cgroup_skb::CgroupSkbLink
-pub fn aya::programs::cgroup_skb::CgroupSkbLink::from(t: T) -> T
 pub struct aya::programs::cgroup_skb::CgroupSkbLinkId(_)
 impl core::cmp::Eq for aya::programs::cgroup_skb::CgroupSkbLinkId
 impl core::cmp::PartialEq for aya::programs::cgroup_skb::CgroupSkbLinkId
@@ -2877,26 +1837,6 @@ impl core::marker::Unpin for aya::programs::cgroup_skb::CgroupSkbLinkId
 impl core::marker::UnsafeUnpin for aya::programs::cgroup_skb::CgroupSkbLinkId
 impl core::panic::unwind_safe::RefUnwindSafe for aya::programs::cgroup_skb::CgroupSkbLinkId
 impl core::panic::unwind_safe::UnwindSafe for aya::programs::cgroup_skb::CgroupSkbLinkId
-impl<Q, K> equivalent::Equivalent<K> for aya::programs::cgroup_skb::CgroupSkbLinkId where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
-pub fn aya::programs::cgroup_skb::CgroupSkbLinkId::equivalent(&self, key: &K) -> bool
-impl<Q, K> hashbrown::Equivalent<K> for aya::programs::cgroup_skb::CgroupSkbLinkId where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
-pub fn aya::programs::cgroup_skb::CgroupSkbLinkId::equivalent(&self, key: &K) -> bool
-impl<T, U> core::convert::Into<U> for aya::programs::cgroup_skb::CgroupSkbLinkId where U: core::convert::From<T>
-pub fn aya::programs::cgroup_skb::CgroupSkbLinkId::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::programs::cgroup_skb::CgroupSkbLinkId where U: core::convert::Into<T>
-pub type aya::programs::cgroup_skb::CgroupSkbLinkId::Error = core::convert::Infallible
-pub fn aya::programs::cgroup_skb::CgroupSkbLinkId::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::programs::cgroup_skb::CgroupSkbLinkId where U: core::convert::TryFrom<T>
-pub type aya::programs::cgroup_skb::CgroupSkbLinkId::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::programs::cgroup_skb::CgroupSkbLinkId::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya::programs::cgroup_skb::CgroupSkbLinkId where T: 'static + ?core::marker::Sized
-pub fn aya::programs::cgroup_skb::CgroupSkbLinkId::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::programs::cgroup_skb::CgroupSkbLinkId where T: ?core::marker::Sized
-pub fn aya::programs::cgroup_skb::CgroupSkbLinkId::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::programs::cgroup_skb::CgroupSkbLinkId where T: ?core::marker::Sized
-pub fn aya::programs::cgroup_skb::CgroupSkbLinkId::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya::programs::cgroup_skb::CgroupSkbLinkId
-pub fn aya::programs::cgroup_skb::CgroupSkbLinkId::from(t: T) -> T
 pub mod aya::programs::cgroup_sock
 pub use aya::programs::cgroup_sock::CgroupSockAttachType
 pub struct aya::programs::cgroup_sock::CgroupSock
@@ -2934,22 +1874,6 @@ impl core::marker::Unpin for aya::programs::cgroup_sock::CgroupSock
 impl core::marker::UnsafeUnpin for aya::programs::cgroup_sock::CgroupSock
 impl core::panic::unwind_safe::RefUnwindSafe for aya::programs::cgroup_sock::CgroupSock
 impl core::panic::unwind_safe::UnwindSafe for aya::programs::cgroup_sock::CgroupSock
-impl<T, U> core::convert::Into<U> for aya::programs::cgroup_sock::CgroupSock where U: core::convert::From<T>
-pub fn aya::programs::cgroup_sock::CgroupSock::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::programs::cgroup_sock::CgroupSock where U: core::convert::Into<T>
-pub type aya::programs::cgroup_sock::CgroupSock::Error = core::convert::Infallible
-pub fn aya::programs::cgroup_sock::CgroupSock::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::programs::cgroup_sock::CgroupSock where U: core::convert::TryFrom<T>
-pub type aya::programs::cgroup_sock::CgroupSock::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::programs::cgroup_sock::CgroupSock::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya::programs::cgroup_sock::CgroupSock where T: 'static + ?core::marker::Sized
-pub fn aya::programs::cgroup_sock::CgroupSock::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::programs::cgroup_sock::CgroupSock where T: ?core::marker::Sized
-pub fn aya::programs::cgroup_sock::CgroupSock::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::programs::cgroup_sock::CgroupSock where T: ?core::marker::Sized
-pub fn aya::programs::cgroup_sock::CgroupSock::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya::programs::cgroup_sock::CgroupSock
-pub fn aya::programs::cgroup_sock::CgroupSock::from(t: T) -> T
 pub struct aya::programs::cgroup_sock::CgroupSockLink(_)
 impl aya::programs::links::Link for aya::programs::cgroup_sock::CgroupSockLink
 pub type aya::programs::cgroup_sock::CgroupSockLink::Id = aya::programs::cgroup_sock::CgroupSockLinkId
@@ -2976,26 +1900,6 @@ impl core::marker::Unpin for aya::programs::cgroup_sock::CgroupSockLink
 impl core::marker::UnsafeUnpin for aya::programs::cgroup_sock::CgroupSockLink
 impl core::panic::unwind_safe::RefUnwindSafe for aya::programs::cgroup_sock::CgroupSockLink
 impl core::panic::unwind_safe::UnwindSafe for aya::programs::cgroup_sock::CgroupSockLink
-impl<Q, K> equivalent::Equivalent<K> for aya::programs::cgroup_sock::CgroupSockLink where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
-pub fn aya::programs::cgroup_sock::CgroupSockLink::equivalent(&self, key: &K) -> bool
-impl<Q, K> hashbrown::Equivalent<K> for aya::programs::cgroup_sock::CgroupSockLink where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
-pub fn aya::programs::cgroup_sock::CgroupSockLink::equivalent(&self, key: &K) -> bool
-impl<T, U> core::convert::Into<U> for aya::programs::cgroup_sock::CgroupSockLink where U: core::convert::From<T>
-pub fn aya::programs::cgroup_sock::CgroupSockLink::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::programs::cgroup_sock::CgroupSockLink where U: core::convert::Into<T>
-pub type aya::programs::cgroup_sock::CgroupSockLink::Error = core::convert::Infallible
-pub fn aya::programs::cgroup_sock::CgroupSockLink::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::programs::cgroup_sock::CgroupSockLink where U: core::convert::TryFrom<T>
-pub type aya::programs::cgroup_sock::CgroupSockLink::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::programs::cgroup_sock::CgroupSockLink::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya::programs::cgroup_sock::CgroupSockLink where T: 'static + ?core::marker::Sized
-pub fn aya::programs::cgroup_sock::CgroupSockLink::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::programs::cgroup_sock::CgroupSockLink where T: ?core::marker::Sized
-pub fn aya::programs::cgroup_sock::CgroupSockLink::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::programs::cgroup_sock::CgroupSockLink where T: ?core::marker::Sized
-pub fn aya::programs::cgroup_sock::CgroupSockLink::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya::programs::cgroup_sock::CgroupSockLink
-pub fn aya::programs::cgroup_sock::CgroupSockLink::from(t: T) -> T
 pub struct aya::programs::cgroup_sock::CgroupSockLinkId(_)
 impl core::cmp::Eq for aya::programs::cgroup_sock::CgroupSockLinkId
 impl core::cmp::PartialEq for aya::programs::cgroup_sock::CgroupSockLinkId
@@ -3014,26 +1918,6 @@ impl core::marker::Unpin for aya::programs::cgroup_sock::CgroupSockLinkId
 impl core::marker::UnsafeUnpin for aya::programs::cgroup_sock::CgroupSockLinkId
 impl core::panic::unwind_safe::RefUnwindSafe for aya::programs::cgroup_sock::CgroupSockLinkId
 impl core::panic::unwind_safe::UnwindSafe for aya::programs::cgroup_sock::CgroupSockLinkId
-impl<Q, K> equivalent::Equivalent<K> for aya::programs::cgroup_sock::CgroupSockLinkId where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
-pub fn aya::programs::cgroup_sock::CgroupSockLinkId::equivalent(&self, key: &K) -> bool
-impl<Q, K> hashbrown::Equivalent<K> for aya::programs::cgroup_sock::CgroupSockLinkId where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
-pub fn aya::programs::cgroup_sock::CgroupSockLinkId::equivalent(&self, key: &K) -> bool
-impl<T, U> core::convert::Into<U> for aya::programs::cgroup_sock::CgroupSockLinkId where U: core::convert::From<T>
-pub fn aya::programs::cgroup_sock::CgroupSockLinkId::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::programs::cgroup_sock::CgroupSockLinkId where U: core::convert::Into<T>
-pub type aya::programs::cgroup_sock::CgroupSockLinkId::Error = core::convert::Infallible
-pub fn aya::programs::cgroup_sock::CgroupSockLinkId::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::programs::cgroup_sock::CgroupSockLinkId where U: core::convert::TryFrom<T>
-pub type aya::programs::cgroup_sock::CgroupSockLinkId::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::programs::cgroup_sock::CgroupSockLinkId::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya::programs::cgroup_sock::CgroupSockLinkId where T: 'static + ?core::marker::Sized
-pub fn aya::programs::cgroup_sock::CgroupSockLinkId::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::programs::cgroup_sock::CgroupSockLinkId where T: ?core::marker::Sized
-pub fn aya::programs::cgroup_sock::CgroupSockLinkId::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::programs::cgroup_sock::CgroupSockLinkId where T: ?core::marker::Sized
-pub fn aya::programs::cgroup_sock::CgroupSockLinkId::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya::programs::cgroup_sock::CgroupSockLinkId
-pub fn aya::programs::cgroup_sock::CgroupSockLinkId::from(t: T) -> T
 pub mod aya::programs::cgroup_sock_addr
 pub use aya::programs::cgroup_sock_addr::CgroupSockAddrAttachType
 pub struct aya::programs::cgroup_sock_addr::CgroupSockAddr
@@ -3071,22 +1955,6 @@ impl core::marker::Unpin for aya::programs::cgroup_sock_addr::CgroupSockAddr
 impl core::marker::UnsafeUnpin for aya::programs::cgroup_sock_addr::CgroupSockAddr
 impl core::panic::unwind_safe::RefUnwindSafe for aya::programs::cgroup_sock_addr::CgroupSockAddr
 impl core::panic::unwind_safe::UnwindSafe for aya::programs::cgroup_sock_addr::CgroupSockAddr
-impl<T, U> core::convert::Into<U> for aya::programs::cgroup_sock_addr::CgroupSockAddr where U: core::convert::From<T>
-pub fn aya::programs::cgroup_sock_addr::CgroupSockAddr::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::programs::cgroup_sock_addr::CgroupSockAddr where U: core::convert::Into<T>
-pub type aya::programs::cgroup_sock_addr::CgroupSockAddr::Error = core::convert::Infallible
-pub fn aya::programs::cgroup_sock_addr::CgroupSockAddr::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::programs::cgroup_sock_addr::CgroupSockAddr where U: core::convert::TryFrom<T>
-pub type aya::programs::cgroup_sock_addr::CgroupSockAddr::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::programs::cgroup_sock_addr::CgroupSockAddr::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya::programs::cgroup_sock_addr::CgroupSockAddr where T: 'static + ?core::marker::Sized
-pub fn aya::programs::cgroup_sock_addr::CgroupSockAddr::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::programs::cgroup_sock_addr::CgroupSockAddr where T: ?core::marker::Sized
-pub fn aya::programs::cgroup_sock_addr::CgroupSockAddr::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::programs::cgroup_sock_addr::CgroupSockAddr where T: ?core::marker::Sized
-pub fn aya::programs::cgroup_sock_addr::CgroupSockAddr::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya::programs::cgroup_sock_addr::CgroupSockAddr
-pub fn aya::programs::cgroup_sock_addr::CgroupSockAddr::from(t: T) -> T
 pub struct aya::programs::cgroup_sock_addr::CgroupSockAddrLink(_)
 impl aya::programs::links::Link for aya::programs::cgroup_sock_addr::CgroupSockAddrLink
 pub type aya::programs::cgroup_sock_addr::CgroupSockAddrLink::Id = aya::programs::cgroup_sock_addr::CgroupSockAddrLinkId
@@ -3113,26 +1981,6 @@ impl core::marker::Unpin for aya::programs::cgroup_sock_addr::CgroupSockAddrLink
 impl core::marker::UnsafeUnpin for aya::programs::cgroup_sock_addr::CgroupSockAddrLink
 impl core::panic::unwind_safe::RefUnwindSafe for aya::programs::cgroup_sock_addr::CgroupSockAddrLink
 impl core::panic::unwind_safe::UnwindSafe for aya::programs::cgroup_sock_addr::CgroupSockAddrLink
-impl<Q, K> equivalent::Equivalent<K> for aya::programs::cgroup_sock_addr::CgroupSockAddrLink where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
-pub fn aya::programs::cgroup_sock_addr::CgroupSockAddrLink::equivalent(&self, key: &K) -> bool
-impl<Q, K> hashbrown::Equivalent<K> for aya::programs::cgroup_sock_addr::CgroupSockAddrLink where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
-pub fn aya::programs::cgroup_sock_addr::CgroupSockAddrLink::equivalent(&self, key: &K) -> bool
-impl<T, U> core::convert::Into<U> for aya::programs::cgroup_sock_addr::CgroupSockAddrLink where U: core::convert::From<T>
-pub fn aya::programs::cgroup_sock_addr::CgroupSockAddrLink::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::programs::cgroup_sock_addr::CgroupSockAddrLink where U: core::convert::Into<T>
-pub type aya::programs::cgroup_sock_addr::CgroupSockAddrLink::Error = core::convert::Infallible
-pub fn aya::programs::cgroup_sock_addr::CgroupSockAddrLink::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::programs::cgroup_sock_addr::CgroupSockAddrLink where U: core::convert::TryFrom<T>
-pub type aya::programs::cgroup_sock_addr::CgroupSockAddrLink::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::programs::cgroup_sock_addr::CgroupSockAddrLink::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya::programs::cgroup_sock_addr::CgroupSockAddrLink where T: 'static + ?core::marker::Sized
-pub fn aya::programs::cgroup_sock_addr::CgroupSockAddrLink::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::programs::cgroup_sock_addr::CgroupSockAddrLink where T: ?core::marker::Sized
-pub fn aya::programs::cgroup_sock_addr::CgroupSockAddrLink::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::programs::cgroup_sock_addr::CgroupSockAddrLink where T: ?core::marker::Sized
-pub fn aya::programs::cgroup_sock_addr::CgroupSockAddrLink::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya::programs::cgroup_sock_addr::CgroupSockAddrLink
-pub fn aya::programs::cgroup_sock_addr::CgroupSockAddrLink::from(t: T) -> T
 pub struct aya::programs::cgroup_sock_addr::CgroupSockAddrLinkId(_)
 impl core::cmp::Eq for aya::programs::cgroup_sock_addr::CgroupSockAddrLinkId
 impl core::cmp::PartialEq for aya::programs::cgroup_sock_addr::CgroupSockAddrLinkId
@@ -3151,26 +1999,6 @@ impl core::marker::Unpin for aya::programs::cgroup_sock_addr::CgroupSockAddrLink
 impl core::marker::UnsafeUnpin for aya::programs::cgroup_sock_addr::CgroupSockAddrLinkId
 impl core::panic::unwind_safe::RefUnwindSafe for aya::programs::cgroup_sock_addr::CgroupSockAddrLinkId
 impl core::panic::unwind_safe::UnwindSafe for aya::programs::cgroup_sock_addr::CgroupSockAddrLinkId
-impl<Q, K> equivalent::Equivalent<K> for aya::programs::cgroup_sock_addr::CgroupSockAddrLinkId where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
-pub fn aya::programs::cgroup_sock_addr::CgroupSockAddrLinkId::equivalent(&self, key: &K) -> bool
-impl<Q, K> hashbrown::Equivalent<K> for aya::programs::cgroup_sock_addr::CgroupSockAddrLinkId where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
-pub fn aya::programs::cgroup_sock_addr::CgroupSockAddrLinkId::equivalent(&self, key: &K) -> bool
-impl<T, U> core::convert::Into<U> for aya::programs::cgroup_sock_addr::CgroupSockAddrLinkId where U: core::convert::From<T>
-pub fn aya::programs::cgroup_sock_addr::CgroupSockAddrLinkId::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::programs::cgroup_sock_addr::CgroupSockAddrLinkId where U: core::convert::Into<T>
-pub type aya::programs::cgroup_sock_addr::CgroupSockAddrLinkId::Error = core::convert::Infallible
-pub fn aya::programs::cgroup_sock_addr::CgroupSockAddrLinkId::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::programs::cgroup_sock_addr::CgroupSockAddrLinkId where U: core::convert::TryFrom<T>
-pub type aya::programs::cgroup_sock_addr::CgroupSockAddrLinkId::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::programs::cgroup_sock_addr::CgroupSockAddrLinkId::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya::programs::cgroup_sock_addr::CgroupSockAddrLinkId where T: 'static + ?core::marker::Sized
-pub fn aya::programs::cgroup_sock_addr::CgroupSockAddrLinkId::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::programs::cgroup_sock_addr::CgroupSockAddrLinkId where T: ?core::marker::Sized
-pub fn aya::programs::cgroup_sock_addr::CgroupSockAddrLinkId::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::programs::cgroup_sock_addr::CgroupSockAddrLinkId where T: ?core::marker::Sized
-pub fn aya::programs::cgroup_sock_addr::CgroupSockAddrLinkId::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya::programs::cgroup_sock_addr::CgroupSockAddrLinkId
-pub fn aya::programs::cgroup_sock_addr::CgroupSockAddrLinkId::from(t: T) -> T
 pub mod aya::programs::cgroup_sockopt
 pub use aya::programs::cgroup_sockopt::CgroupSockoptAttachType
 pub struct aya::programs::cgroup_sockopt::CgroupSockopt
@@ -3210,22 +2038,6 @@ impl core::marker::Unpin for aya::programs::cgroup_sockopt::CgroupSockopt
 impl core::marker::UnsafeUnpin for aya::programs::cgroup_sockopt::CgroupSockopt
 impl core::panic::unwind_safe::RefUnwindSafe for aya::programs::cgroup_sockopt::CgroupSockopt
 impl core::panic::unwind_safe::UnwindSafe for aya::programs::cgroup_sockopt::CgroupSockopt
-impl<T, U> core::convert::Into<U> for aya::programs::cgroup_sockopt::CgroupSockopt where U: core::convert::From<T>
-pub fn aya::programs::cgroup_sockopt::CgroupSockopt::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::programs::cgroup_sockopt::CgroupSockopt where U: core::convert::Into<T>
-pub type aya::programs::cgroup_sockopt::CgroupSockopt::Error = core::convert::Infallible
-pub fn aya::programs::cgroup_sockopt::CgroupSockopt::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::programs::cgroup_sockopt::CgroupSockopt where U: core::convert::TryFrom<T>
-pub type aya::programs::cgroup_sockopt::CgroupSockopt::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::programs::cgroup_sockopt::CgroupSockopt::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya::programs::cgroup_sockopt::CgroupSockopt where T: 'static + ?core::marker::Sized
-pub fn aya::programs::cgroup_sockopt::CgroupSockopt::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::programs::cgroup_sockopt::CgroupSockopt where T: ?core::marker::Sized
-pub fn aya::programs::cgroup_sockopt::CgroupSockopt::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::programs::cgroup_sockopt::CgroupSockopt where T: ?core::marker::Sized
-pub fn aya::programs::cgroup_sockopt::CgroupSockopt::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya::programs::cgroup_sockopt::CgroupSockopt
-pub fn aya::programs::cgroup_sockopt::CgroupSockopt::from(t: T) -> T
 pub struct aya::programs::cgroup_sockopt::CgroupSockoptLink(_)
 impl aya::programs::links::Link for aya::programs::cgroup_sockopt::CgroupSockoptLink
 pub type aya::programs::cgroup_sockopt::CgroupSockoptLink::Id = aya::programs::cgroup_sockopt::CgroupSockoptLinkId
@@ -3249,26 +2061,6 @@ impl core::marker::Unpin for aya::programs::cgroup_sockopt::CgroupSockoptLink
 impl core::marker::UnsafeUnpin for aya::programs::cgroup_sockopt::CgroupSockoptLink
 impl core::panic::unwind_safe::RefUnwindSafe for aya::programs::cgroup_sockopt::CgroupSockoptLink
 impl core::panic::unwind_safe::UnwindSafe for aya::programs::cgroup_sockopt::CgroupSockoptLink
-impl<Q, K> equivalent::Equivalent<K> for aya::programs::cgroup_sockopt::CgroupSockoptLink where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
-pub fn aya::programs::cgroup_sockopt::CgroupSockoptLink::equivalent(&self, key: &K) -> bool
-impl<Q, K> hashbrown::Equivalent<K> for aya::programs::cgroup_sockopt::CgroupSockoptLink where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
-pub fn aya::programs::cgroup_sockopt::CgroupSockoptLink::equivalent(&self, key: &K) -> bool
-impl<T, U> core::convert::Into<U> for aya::programs::cgroup_sockopt::CgroupSockoptLink where U: core::convert::From<T>
-pub fn aya::programs::cgroup_sockopt::CgroupSockoptLink::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::programs::cgroup_sockopt::CgroupSockoptLink where U: core::convert::Into<T>
-pub type aya::programs::cgroup_sockopt::CgroupSockoptLink::Error = core::convert::Infallible
-pub fn aya::programs::cgroup_sockopt::CgroupSockoptLink::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::programs::cgroup_sockopt::CgroupSockoptLink where U: core::convert::TryFrom<T>
-pub type aya::programs::cgroup_sockopt::CgroupSockoptLink::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::programs::cgroup_sockopt::CgroupSockoptLink::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya::programs::cgroup_sockopt::CgroupSockoptLink where T: 'static + ?core::marker::Sized
-pub fn aya::programs::cgroup_sockopt::CgroupSockoptLink::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::programs::cgroup_sockopt::CgroupSockoptLink where T: ?core::marker::Sized
-pub fn aya::programs::cgroup_sockopt::CgroupSockoptLink::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::programs::cgroup_sockopt::CgroupSockoptLink where T: ?core::marker::Sized
-pub fn aya::programs::cgroup_sockopt::CgroupSockoptLink::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya::programs::cgroup_sockopt::CgroupSockoptLink
-pub fn aya::programs::cgroup_sockopt::CgroupSockoptLink::from(t: T) -> T
 pub struct aya::programs::cgroup_sockopt::CgroupSockoptLinkId(_)
 impl core::cmp::Eq for aya::programs::cgroup_sockopt::CgroupSockoptLinkId
 impl core::cmp::PartialEq for aya::programs::cgroup_sockopt::CgroupSockoptLinkId
@@ -3287,26 +2079,6 @@ impl core::marker::Unpin for aya::programs::cgroup_sockopt::CgroupSockoptLinkId
 impl core::marker::UnsafeUnpin for aya::programs::cgroup_sockopt::CgroupSockoptLinkId
 impl core::panic::unwind_safe::RefUnwindSafe for aya::programs::cgroup_sockopt::CgroupSockoptLinkId
 impl core::panic::unwind_safe::UnwindSafe for aya::programs::cgroup_sockopt::CgroupSockoptLinkId
-impl<Q, K> equivalent::Equivalent<K> for aya::programs::cgroup_sockopt::CgroupSockoptLinkId where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
-pub fn aya::programs::cgroup_sockopt::CgroupSockoptLinkId::equivalent(&self, key: &K) -> bool
-impl<Q, K> hashbrown::Equivalent<K> for aya::programs::cgroup_sockopt::CgroupSockoptLinkId where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
-pub fn aya::programs::cgroup_sockopt::CgroupSockoptLinkId::equivalent(&self, key: &K) -> bool
-impl<T, U> core::convert::Into<U> for aya::programs::cgroup_sockopt::CgroupSockoptLinkId where U: core::convert::From<T>
-pub fn aya::programs::cgroup_sockopt::CgroupSockoptLinkId::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::programs::cgroup_sockopt::CgroupSockoptLinkId where U: core::convert::Into<T>
-pub type aya::programs::cgroup_sockopt::CgroupSockoptLinkId::Error = core::convert::Infallible
-pub fn aya::programs::cgroup_sockopt::CgroupSockoptLinkId::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::programs::cgroup_sockopt::CgroupSockoptLinkId where U: core::convert::TryFrom<T>
-pub type aya::programs::cgroup_sockopt::CgroupSockoptLinkId::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::programs::cgroup_sockopt::CgroupSockoptLinkId::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya::programs::cgroup_sockopt::CgroupSockoptLinkId where T: 'static + ?core::marker::Sized
-pub fn aya::programs::cgroup_sockopt::CgroupSockoptLinkId::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::programs::cgroup_sockopt::CgroupSockoptLinkId where T: ?core::marker::Sized
-pub fn aya::programs::cgroup_sockopt::CgroupSockoptLinkId::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::programs::cgroup_sockopt::CgroupSockoptLinkId where T: ?core::marker::Sized
-pub fn aya::programs::cgroup_sockopt::CgroupSockoptLinkId::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya::programs::cgroup_sockopt::CgroupSockoptLinkId
-pub fn aya::programs::cgroup_sockopt::CgroupSockoptLinkId::from(t: T) -> T
 pub mod aya::programs::cgroup_sysctl
 pub struct aya::programs::cgroup_sysctl::CgroupSysctl
 impl aya::programs::cgroup_sysctl::CgroupSysctl
@@ -3346,22 +2118,6 @@ impl core::marker::Unpin for aya::programs::cgroup_sysctl::CgroupSysctl
 impl core::marker::UnsafeUnpin for aya::programs::cgroup_sysctl::CgroupSysctl
 impl core::panic::unwind_safe::RefUnwindSafe for aya::programs::cgroup_sysctl::CgroupSysctl
 impl core::panic::unwind_safe::UnwindSafe for aya::programs::cgroup_sysctl::CgroupSysctl
-impl<T, U> core::convert::Into<U> for aya::programs::cgroup_sysctl::CgroupSysctl where U: core::convert::From<T>
-pub fn aya::programs::cgroup_sysctl::CgroupSysctl::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::programs::cgroup_sysctl::CgroupSysctl where U: core::convert::Into<T>
-pub type aya::programs::cgroup_sysctl::CgroupSysctl::Error = core::convert::Infallible
-pub fn aya::programs::cgroup_sysctl::CgroupSysctl::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::programs::cgroup_sysctl::CgroupSysctl where U: core::convert::TryFrom<T>
-pub type aya::programs::cgroup_sysctl::CgroupSysctl::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::programs::cgroup_sysctl::CgroupSysctl::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya::programs::cgroup_sysctl::CgroupSysctl where T: 'static + ?core::marker::Sized
-pub fn aya::programs::cgroup_sysctl::CgroupSysctl::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::programs::cgroup_sysctl::CgroupSysctl where T: ?core::marker::Sized
-pub fn aya::programs::cgroup_sysctl::CgroupSysctl::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::programs::cgroup_sysctl::CgroupSysctl where T: ?core::marker::Sized
-pub fn aya::programs::cgroup_sysctl::CgroupSysctl::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya::programs::cgroup_sysctl::CgroupSysctl
-pub fn aya::programs::cgroup_sysctl::CgroupSysctl::from(t: T) -> T
 pub struct aya::programs::cgroup_sysctl::CgroupSysctlLink(_)
 impl aya::programs::links::Link for aya::programs::cgroup_sysctl::CgroupSysctlLink
 pub type aya::programs::cgroup_sysctl::CgroupSysctlLink::Id = aya::programs::cgroup_sysctl::CgroupSysctlLinkId
@@ -3385,26 +2141,6 @@ impl core::marker::Unpin for aya::programs::cgroup_sysctl::CgroupSysctlLink
 impl core::marker::UnsafeUnpin for aya::programs::cgroup_sysctl::CgroupSysctlLink
 impl core::panic::unwind_safe::RefUnwindSafe for aya::programs::cgroup_sysctl::CgroupSysctlLink
 impl core::panic::unwind_safe::UnwindSafe for aya::programs::cgroup_sysctl::CgroupSysctlLink
-impl<Q, K> equivalent::Equivalent<K> for aya::programs::cgroup_sysctl::CgroupSysctlLink where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
-pub fn aya::programs::cgroup_sysctl::CgroupSysctlLink::equivalent(&self, key: &K) -> bool
-impl<Q, K> hashbrown::Equivalent<K> for aya::programs::cgroup_sysctl::CgroupSysctlLink where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
-pub fn aya::programs::cgroup_sysctl::CgroupSysctlLink::equivalent(&self, key: &K) -> bool
-impl<T, U> core::convert::Into<U> for aya::programs::cgroup_sysctl::CgroupSysctlLink where U: core::convert::From<T>
-pub fn aya::programs::cgroup_sysctl::CgroupSysctlLink::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::programs::cgroup_sysctl::CgroupSysctlLink where U: core::convert::Into<T>
-pub type aya::programs::cgroup_sysctl::CgroupSysctlLink::Error = core::convert::Infallible
-pub fn aya::programs::cgroup_sysctl::CgroupSysctlLink::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::programs::cgroup_sysctl::CgroupSysctlLink where U: core::convert::TryFrom<T>
-pub type aya::programs::cgroup_sysctl::CgroupSysctlLink::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::programs::cgroup_sysctl::CgroupSysctlLink::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya::programs::cgroup_sysctl::CgroupSysctlLink where T: 'static + ?core::marker::Sized
-pub fn aya::programs::cgroup_sysctl::CgroupSysctlLink::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::programs::cgroup_sysctl::CgroupSysctlLink where T: ?core::marker::Sized
-pub fn aya::programs::cgroup_sysctl::CgroupSysctlLink::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::programs::cgroup_sysctl::CgroupSysctlLink where T: ?core::marker::Sized
-pub fn aya::programs::cgroup_sysctl::CgroupSysctlLink::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya::programs::cgroup_sysctl::CgroupSysctlLink
-pub fn aya::programs::cgroup_sysctl::CgroupSysctlLink::from(t: T) -> T
 pub struct aya::programs::cgroup_sysctl::CgroupSysctlLinkId(_)
 impl core::cmp::Eq for aya::programs::cgroup_sysctl::CgroupSysctlLinkId
 impl core::cmp::PartialEq for aya::programs::cgroup_sysctl::CgroupSysctlLinkId
@@ -3423,26 +2159,6 @@ impl core::marker::Unpin for aya::programs::cgroup_sysctl::CgroupSysctlLinkId
 impl core::marker::UnsafeUnpin for aya::programs::cgroup_sysctl::CgroupSysctlLinkId
 impl core::panic::unwind_safe::RefUnwindSafe for aya::programs::cgroup_sysctl::CgroupSysctlLinkId
 impl core::panic::unwind_safe::UnwindSafe for aya::programs::cgroup_sysctl::CgroupSysctlLinkId
-impl<Q, K> equivalent::Equivalent<K> for aya::programs::cgroup_sysctl::CgroupSysctlLinkId where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
-pub fn aya::programs::cgroup_sysctl::CgroupSysctlLinkId::equivalent(&self, key: &K) -> bool
-impl<Q, K> hashbrown::Equivalent<K> for aya::programs::cgroup_sysctl::CgroupSysctlLinkId where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
-pub fn aya::programs::cgroup_sysctl::CgroupSysctlLinkId::equivalent(&self, key: &K) -> bool
-impl<T, U> core::convert::Into<U> for aya::programs::cgroup_sysctl::CgroupSysctlLinkId where U: core::convert::From<T>
-pub fn aya::programs::cgroup_sysctl::CgroupSysctlLinkId::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::programs::cgroup_sysctl::CgroupSysctlLinkId where U: core::convert::Into<T>
-pub type aya::programs::cgroup_sysctl::CgroupSysctlLinkId::Error = core::convert::Infallible
-pub fn aya::programs::cgroup_sysctl::CgroupSysctlLinkId::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::programs::cgroup_sysctl::CgroupSysctlLinkId where U: core::convert::TryFrom<T>
-pub type aya::programs::cgroup_sysctl::CgroupSysctlLinkId::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::programs::cgroup_sysctl::CgroupSysctlLinkId::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya::programs::cgroup_sysctl::CgroupSysctlLinkId where T: 'static + ?core::marker::Sized
-pub fn aya::programs::cgroup_sysctl::CgroupSysctlLinkId::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::programs::cgroup_sysctl::CgroupSysctlLinkId where T: ?core::marker::Sized
-pub fn aya::programs::cgroup_sysctl::CgroupSysctlLinkId::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::programs::cgroup_sysctl::CgroupSysctlLinkId where T: ?core::marker::Sized
-pub fn aya::programs::cgroup_sysctl::CgroupSysctlLinkId::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya::programs::cgroup_sysctl::CgroupSysctlLinkId
-pub fn aya::programs::cgroup_sysctl::CgroupSysctlLinkId::from(t: T) -> T
 pub mod aya::programs::extension
 pub enum aya::programs::extension::ExtensionError
 pub aya::programs::extension::ExtensionError::NoBTF
@@ -3460,24 +2176,6 @@ impl core::marker::Unpin for aya::programs::extension::ExtensionError
 impl core::marker::UnsafeUnpin for aya::programs::extension::ExtensionError
 impl core::panic::unwind_safe::RefUnwindSafe for aya::programs::extension::ExtensionError
 impl core::panic::unwind_safe::UnwindSafe for aya::programs::extension::ExtensionError
-impl<T, U> core::convert::Into<U> for aya::programs::extension::ExtensionError where U: core::convert::From<T>
-pub fn aya::programs::extension::ExtensionError::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::programs::extension::ExtensionError where U: core::convert::Into<T>
-pub type aya::programs::extension::ExtensionError::Error = core::convert::Infallible
-pub fn aya::programs::extension::ExtensionError::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::programs::extension::ExtensionError where U: core::convert::TryFrom<T>
-pub type aya::programs::extension::ExtensionError::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::programs::extension::ExtensionError::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::string::ToString for aya::programs::extension::ExtensionError where T: core::fmt::Display + ?core::marker::Sized
-pub fn aya::programs::extension::ExtensionError::to_string(&self) -> alloc::string::String
-impl<T> core::any::Any for aya::programs::extension::ExtensionError where T: 'static + ?core::marker::Sized
-pub fn aya::programs::extension::ExtensionError::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::programs::extension::ExtensionError where T: ?core::marker::Sized
-pub fn aya::programs::extension::ExtensionError::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::programs::extension::ExtensionError where T: ?core::marker::Sized
-pub fn aya::programs::extension::ExtensionError::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya::programs::extension::ExtensionError
-pub fn aya::programs::extension::ExtensionError::from(t: T) -> T
 pub struct aya::programs::extension::Extension
 impl aya::programs::extension::Extension
 pub const aya::programs::extension::Extension::PROGRAM_TYPE: aya::programs::ProgramType
@@ -3517,22 +2215,6 @@ impl core::marker::Unpin for aya::programs::extension::Extension
 impl core::marker::UnsafeUnpin for aya::programs::extension::Extension
 impl core::panic::unwind_safe::RefUnwindSafe for aya::programs::extension::Extension
 impl core::panic::unwind_safe::UnwindSafe for aya::programs::extension::Extension
-impl<T, U> core::convert::Into<U> for aya::programs::extension::Extension where U: core::convert::From<T>
-pub fn aya::programs::extension::Extension::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::programs::extension::Extension where U: core::convert::Into<T>
-pub type aya::programs::extension::Extension::Error = core::convert::Infallible
-pub fn aya::programs::extension::Extension::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::programs::extension::Extension where U: core::convert::TryFrom<T>
-pub type aya::programs::extension::Extension::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::programs::extension::Extension::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya::programs::extension::Extension where T: 'static + ?core::marker::Sized
-pub fn aya::programs::extension::Extension::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::programs::extension::Extension where T: ?core::marker::Sized
-pub fn aya::programs::extension::Extension::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::programs::extension::Extension where T: ?core::marker::Sized
-pub fn aya::programs::extension::Extension::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya::programs::extension::Extension
-pub fn aya::programs::extension::Extension::from(t: T) -> T
 pub struct aya::programs::extension::ExtensionLink(_)
 impl aya::programs::links::Link for aya::programs::extension::ExtensionLink
 pub type aya::programs::extension::ExtensionLink::Id = aya::programs::extension::ExtensionLinkId
@@ -3560,26 +2242,6 @@ impl core::marker::Unpin for aya::programs::extension::ExtensionLink
 impl core::marker::UnsafeUnpin for aya::programs::extension::ExtensionLink
 impl core::panic::unwind_safe::RefUnwindSafe for aya::programs::extension::ExtensionLink
 impl core::panic::unwind_safe::UnwindSafe for aya::programs::extension::ExtensionLink
-impl<Q, K> equivalent::Equivalent<K> for aya::programs::extension::ExtensionLink where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
-pub fn aya::programs::extension::ExtensionLink::equivalent(&self, key: &K) -> bool
-impl<Q, K> hashbrown::Equivalent<K> for aya::programs::extension::ExtensionLink where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
-pub fn aya::programs::extension::ExtensionLink::equivalent(&self, key: &K) -> bool
-impl<T, U> core::convert::Into<U> for aya::programs::extension::ExtensionLink where U: core::convert::From<T>
-pub fn aya::programs::extension::ExtensionLink::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::programs::extension::ExtensionLink where U: core::convert::Into<T>
-pub type aya::programs::extension::ExtensionLink::Error = core::convert::Infallible
-pub fn aya::programs::extension::ExtensionLink::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::programs::extension::ExtensionLink where U: core::convert::TryFrom<T>
-pub type aya::programs::extension::ExtensionLink::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::programs::extension::ExtensionLink::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya::programs::extension::ExtensionLink where T: 'static + ?core::marker::Sized
-pub fn aya::programs::extension::ExtensionLink::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::programs::extension::ExtensionLink where T: ?core::marker::Sized
-pub fn aya::programs::extension::ExtensionLink::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::programs::extension::ExtensionLink where T: ?core::marker::Sized
-pub fn aya::programs::extension::ExtensionLink::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya::programs::extension::ExtensionLink
-pub fn aya::programs::extension::ExtensionLink::from(t: T) -> T
 pub struct aya::programs::extension::ExtensionLinkId(_)
 impl core::cmp::Eq for aya::programs::extension::ExtensionLinkId
 impl core::cmp::PartialEq for aya::programs::extension::ExtensionLinkId
@@ -3598,26 +2260,6 @@ impl core::marker::Unpin for aya::programs::extension::ExtensionLinkId
 impl core::marker::UnsafeUnpin for aya::programs::extension::ExtensionLinkId
 impl core::panic::unwind_safe::RefUnwindSafe for aya::programs::extension::ExtensionLinkId
 impl core::panic::unwind_safe::UnwindSafe for aya::programs::extension::ExtensionLinkId
-impl<Q, K> equivalent::Equivalent<K> for aya::programs::extension::ExtensionLinkId where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
-pub fn aya::programs::extension::ExtensionLinkId::equivalent(&self, key: &K) -> bool
-impl<Q, K> hashbrown::Equivalent<K> for aya::programs::extension::ExtensionLinkId where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
-pub fn aya::programs::extension::ExtensionLinkId::equivalent(&self, key: &K) -> bool
-impl<T, U> core::convert::Into<U> for aya::programs::extension::ExtensionLinkId where U: core::convert::From<T>
-pub fn aya::programs::extension::ExtensionLinkId::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::programs::extension::ExtensionLinkId where U: core::convert::Into<T>
-pub type aya::programs::extension::ExtensionLinkId::Error = core::convert::Infallible
-pub fn aya::programs::extension::ExtensionLinkId::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::programs::extension::ExtensionLinkId where U: core::convert::TryFrom<T>
-pub type aya::programs::extension::ExtensionLinkId::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::programs::extension::ExtensionLinkId::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya::programs::extension::ExtensionLinkId where T: 'static + ?core::marker::Sized
-pub fn aya::programs::extension::ExtensionLinkId::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::programs::extension::ExtensionLinkId where T: ?core::marker::Sized
-pub fn aya::programs::extension::ExtensionLinkId::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::programs::extension::ExtensionLinkId where T: ?core::marker::Sized
-pub fn aya::programs::extension::ExtensionLinkId::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya::programs::extension::ExtensionLinkId
-pub fn aya::programs::extension::ExtensionLinkId::from(t: T) -> T
 pub mod aya::programs::fentry
 pub struct aya::programs::fentry::FEntry
 impl aya::programs::fentry::FEntry
@@ -3657,22 +2299,6 @@ impl core::marker::Unpin for aya::programs::fentry::FEntry
 impl core::marker::UnsafeUnpin for aya::programs::fentry::FEntry
 impl core::panic::unwind_safe::RefUnwindSafe for aya::programs::fentry::FEntry
 impl core::panic::unwind_safe::UnwindSafe for aya::programs::fentry::FEntry
-impl<T, U> core::convert::Into<U> for aya::programs::fentry::FEntry where U: core::convert::From<T>
-pub fn aya::programs::fentry::FEntry::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::programs::fentry::FEntry where U: core::convert::Into<T>
-pub type aya::programs::fentry::FEntry::Error = core::convert::Infallible
-pub fn aya::programs::fentry::FEntry::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::programs::fentry::FEntry where U: core::convert::TryFrom<T>
-pub type aya::programs::fentry::FEntry::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::programs::fentry::FEntry::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya::programs::fentry::FEntry where T: 'static + ?core::marker::Sized
-pub fn aya::programs::fentry::FEntry::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::programs::fentry::FEntry where T: ?core::marker::Sized
-pub fn aya::programs::fentry::FEntry::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::programs::fentry::FEntry where T: ?core::marker::Sized
-pub fn aya::programs::fentry::FEntry::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya::programs::fentry::FEntry
-pub fn aya::programs::fentry::FEntry::from(t: T) -> T
 pub struct aya::programs::fentry::FEntryLink(_)
 impl aya::programs::links::Link for aya::programs::fentry::FEntryLink
 pub type aya::programs::fentry::FEntryLink::Id = aya::programs::fentry::FEntryLinkId
@@ -3700,26 +2326,6 @@ impl core::marker::Unpin for aya::programs::fentry::FEntryLink
 impl core::marker::UnsafeUnpin for aya::programs::fentry::FEntryLink
 impl core::panic::unwind_safe::RefUnwindSafe for aya::programs::fentry::FEntryLink
 impl core::panic::unwind_safe::UnwindSafe for aya::programs::fentry::FEntryLink
-impl<Q, K> equivalent::Equivalent<K> for aya::programs::fentry::FEntryLink where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
-pub fn aya::programs::fentry::FEntryLink::equivalent(&self, key: &K) -> bool
-impl<Q, K> hashbrown::Equivalent<K> for aya::programs::fentry::FEntryLink where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
-pub fn aya::programs::fentry::FEntryLink::equivalent(&self, key: &K) -> bool
-impl<T, U> core::convert::Into<U> for aya::programs::fentry::FEntryLink where U: core::convert::From<T>
-pub fn aya::programs::fentry::FEntryLink::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::programs::fentry::FEntryLink where U: core::convert::Into<T>
-pub type aya::programs::fentry::FEntryLink::Error = core::convert::Infallible
-pub fn aya::programs::fentry::FEntryLink::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::programs::fentry::FEntryLink where U: core::convert::TryFrom<T>
-pub type aya::programs::fentry::FEntryLink::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::programs::fentry::FEntryLink::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya::programs::fentry::FEntryLink where T: 'static + ?core::marker::Sized
-pub fn aya::programs::fentry::FEntryLink::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::programs::fentry::FEntryLink where T: ?core::marker::Sized
-pub fn aya::programs::fentry::FEntryLink::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::programs::fentry::FEntryLink where T: ?core::marker::Sized
-pub fn aya::programs::fentry::FEntryLink::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya::programs::fentry::FEntryLink
-pub fn aya::programs::fentry::FEntryLink::from(t: T) -> T
 pub struct aya::programs::fentry::FEntryLinkId(_)
 impl core::cmp::Eq for aya::programs::fentry::FEntryLinkId
 impl core::cmp::PartialEq for aya::programs::fentry::FEntryLinkId
@@ -3738,26 +2344,6 @@ impl core::marker::Unpin for aya::programs::fentry::FEntryLinkId
 impl core::marker::UnsafeUnpin for aya::programs::fentry::FEntryLinkId
 impl core::panic::unwind_safe::RefUnwindSafe for aya::programs::fentry::FEntryLinkId
 impl core::panic::unwind_safe::UnwindSafe for aya::programs::fentry::FEntryLinkId
-impl<Q, K> equivalent::Equivalent<K> for aya::programs::fentry::FEntryLinkId where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
-pub fn aya::programs::fentry::FEntryLinkId::equivalent(&self, key: &K) -> bool
-impl<Q, K> hashbrown::Equivalent<K> for aya::programs::fentry::FEntryLinkId where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
-pub fn aya::programs::fentry::FEntryLinkId::equivalent(&self, key: &K) -> bool
-impl<T, U> core::convert::Into<U> for aya::programs::fentry::FEntryLinkId where U: core::convert::From<T>
-pub fn aya::programs::fentry::FEntryLinkId::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::programs::fentry::FEntryLinkId where U: core::convert::Into<T>
-pub type aya::programs::fentry::FEntryLinkId::Error = core::convert::Infallible
-pub fn aya::programs::fentry::FEntryLinkId::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::programs::fentry::FEntryLinkId where U: core::convert::TryFrom<T>
-pub type aya::programs::fentry::FEntryLinkId::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::programs::fentry::FEntryLinkId::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya::programs::fentry::FEntryLinkId where T: 'static + ?core::marker::Sized
-pub fn aya::programs::fentry::FEntryLinkId::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::programs::fentry::FEntryLinkId where T: ?core::marker::Sized
-pub fn aya::programs::fentry::FEntryLinkId::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::programs::fentry::FEntryLinkId where T: ?core::marker::Sized
-pub fn aya::programs::fentry::FEntryLinkId::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya::programs::fentry::FEntryLinkId
-pub fn aya::programs::fentry::FEntryLinkId::from(t: T) -> T
 pub mod aya::programs::fexit
 pub struct aya::programs::fexit::FExit
 impl aya::programs::fexit::FExit
@@ -3797,22 +2383,6 @@ impl core::marker::Unpin for aya::programs::fexit::FExit
 impl core::marker::UnsafeUnpin for aya::programs::fexit::FExit
 impl core::panic::unwind_safe::RefUnwindSafe for aya::programs::fexit::FExit
 impl core::panic::unwind_safe::UnwindSafe for aya::programs::fexit::FExit
-impl<T, U> core::convert::Into<U> for aya::programs::fexit::FExit where U: core::convert::From<T>
-pub fn aya::programs::fexit::FExit::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::programs::fexit::FExit where U: core::convert::Into<T>
-pub type aya::programs::fexit::FExit::Error = core::convert::Infallible
-pub fn aya::programs::fexit::FExit::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::programs::fexit::FExit where U: core::convert::TryFrom<T>
-pub type aya::programs::fexit::FExit::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::programs::fexit::FExit::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya::programs::fexit::FExit where T: 'static + ?core::marker::Sized
-pub fn aya::programs::fexit::FExit::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::programs::fexit::FExit where T: ?core::marker::Sized
-pub fn aya::programs::fexit::FExit::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::programs::fexit::FExit where T: ?core::marker::Sized
-pub fn aya::programs::fexit::FExit::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya::programs::fexit::FExit
-pub fn aya::programs::fexit::FExit::from(t: T) -> T
 pub struct aya::programs::fexit::FExitLink(_)
 impl aya::programs::links::Link for aya::programs::fexit::FExitLink
 pub type aya::programs::fexit::FExitLink::Id = aya::programs::fexit::FExitLinkId
@@ -3840,26 +2410,6 @@ impl core::marker::Unpin for aya::programs::fexit::FExitLink
 impl core::marker::UnsafeUnpin for aya::programs::fexit::FExitLink
 impl core::panic::unwind_safe::RefUnwindSafe for aya::programs::fexit::FExitLink
 impl core::panic::unwind_safe::UnwindSafe for aya::programs::fexit::FExitLink
-impl<Q, K> equivalent::Equivalent<K> for aya::programs::fexit::FExitLink where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
-pub fn aya::programs::fexit::FExitLink::equivalent(&self, key: &K) -> bool
-impl<Q, K> hashbrown::Equivalent<K> for aya::programs::fexit::FExitLink where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
-pub fn aya::programs::fexit::FExitLink::equivalent(&self, key: &K) -> bool
-impl<T, U> core::convert::Into<U> for aya::programs::fexit::FExitLink where U: core::convert::From<T>
-pub fn aya::programs::fexit::FExitLink::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::programs::fexit::FExitLink where U: core::convert::Into<T>
-pub type aya::programs::fexit::FExitLink::Error = core::convert::Infallible
-pub fn aya::programs::fexit::FExitLink::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::programs::fexit::FExitLink where U: core::convert::TryFrom<T>
-pub type aya::programs::fexit::FExitLink::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::programs::fexit::FExitLink::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya::programs::fexit::FExitLink where T: 'static + ?core::marker::Sized
-pub fn aya::programs::fexit::FExitLink::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::programs::fexit::FExitLink where T: ?core::marker::Sized
-pub fn aya::programs::fexit::FExitLink::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::programs::fexit::FExitLink where T: ?core::marker::Sized
-pub fn aya::programs::fexit::FExitLink::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya::programs::fexit::FExitLink
-pub fn aya::programs::fexit::FExitLink::from(t: T) -> T
 pub struct aya::programs::fexit::FExitLinkId(_)
 impl core::cmp::Eq for aya::programs::fexit::FExitLinkId
 impl core::cmp::PartialEq for aya::programs::fexit::FExitLinkId
@@ -3878,26 +2428,6 @@ impl core::marker::Unpin for aya::programs::fexit::FExitLinkId
 impl core::marker::UnsafeUnpin for aya::programs::fexit::FExitLinkId
 impl core::panic::unwind_safe::RefUnwindSafe for aya::programs::fexit::FExitLinkId
 impl core::panic::unwind_safe::UnwindSafe for aya::programs::fexit::FExitLinkId
-impl<Q, K> equivalent::Equivalent<K> for aya::programs::fexit::FExitLinkId where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
-pub fn aya::programs::fexit::FExitLinkId::equivalent(&self, key: &K) -> bool
-impl<Q, K> hashbrown::Equivalent<K> for aya::programs::fexit::FExitLinkId where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
-pub fn aya::programs::fexit::FExitLinkId::equivalent(&self, key: &K) -> bool
-impl<T, U> core::convert::Into<U> for aya::programs::fexit::FExitLinkId where U: core::convert::From<T>
-pub fn aya::programs::fexit::FExitLinkId::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::programs::fexit::FExitLinkId where U: core::convert::Into<T>
-pub type aya::programs::fexit::FExitLinkId::Error = core::convert::Infallible
-pub fn aya::programs::fexit::FExitLinkId::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::programs::fexit::FExitLinkId where U: core::convert::TryFrom<T>
-pub type aya::programs::fexit::FExitLinkId::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::programs::fexit::FExitLinkId::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya::programs::fexit::FExitLinkId where T: 'static + ?core::marker::Sized
-pub fn aya::programs::fexit::FExitLinkId::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::programs::fexit::FExitLinkId where T: ?core::marker::Sized
-pub fn aya::programs::fexit::FExitLinkId::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::programs::fexit::FExitLinkId where T: ?core::marker::Sized
-pub fn aya::programs::fexit::FExitLinkId::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya::programs::fexit::FExitLinkId
-pub fn aya::programs::fexit::FExitLinkId::from(t: T) -> T
 pub mod aya::programs::flow_dissector
 pub struct aya::programs::flow_dissector::FlowDissector
 impl aya::programs::flow_dissector::FlowDissector
@@ -3935,22 +2465,6 @@ impl core::marker::Unpin for aya::programs::flow_dissector::FlowDissector
 impl core::marker::UnsafeUnpin for aya::programs::flow_dissector::FlowDissector
 impl core::panic::unwind_safe::RefUnwindSafe for aya::programs::flow_dissector::FlowDissector
 impl core::panic::unwind_safe::UnwindSafe for aya::programs::flow_dissector::FlowDissector
-impl<T, U> core::convert::Into<U> for aya::programs::flow_dissector::FlowDissector where U: core::convert::From<T>
-pub fn aya::programs::flow_dissector::FlowDissector::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::programs::flow_dissector::FlowDissector where U: core::convert::Into<T>
-pub type aya::programs::flow_dissector::FlowDissector::Error = core::convert::Infallible
-pub fn aya::programs::flow_dissector::FlowDissector::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::programs::flow_dissector::FlowDissector where U: core::convert::TryFrom<T>
-pub type aya::programs::flow_dissector::FlowDissector::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::programs::flow_dissector::FlowDissector::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya::programs::flow_dissector::FlowDissector where T: 'static + ?core::marker::Sized
-pub fn aya::programs::flow_dissector::FlowDissector::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::programs::flow_dissector::FlowDissector where T: ?core::marker::Sized
-pub fn aya::programs::flow_dissector::FlowDissector::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::programs::flow_dissector::FlowDissector where T: ?core::marker::Sized
-pub fn aya::programs::flow_dissector::FlowDissector::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya::programs::flow_dissector::FlowDissector
-pub fn aya::programs::flow_dissector::FlowDissector::from(t: T) -> T
 pub struct aya::programs::flow_dissector::FlowDissectorLink(_)
 impl aya::programs::links::Link for aya::programs::flow_dissector::FlowDissectorLink
 pub type aya::programs::flow_dissector::FlowDissectorLink::Id = aya::programs::flow_dissector::FlowDissectorLinkId
@@ -3977,26 +2491,6 @@ impl core::marker::Unpin for aya::programs::flow_dissector::FlowDissectorLink
 impl core::marker::UnsafeUnpin for aya::programs::flow_dissector::FlowDissectorLink
 impl core::panic::unwind_safe::RefUnwindSafe for aya::programs::flow_dissector::FlowDissectorLink
 impl core::panic::unwind_safe::UnwindSafe for aya::programs::flow_dissector::FlowDissectorLink
-impl<Q, K> equivalent::Equivalent<K> for aya::programs::flow_dissector::FlowDissectorLink where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
-pub fn aya::programs::flow_dissector::FlowDissectorLink::equivalent(&self, key: &K) -> bool
-impl<Q, K> hashbrown::Equivalent<K> for aya::programs::flow_dissector::FlowDissectorLink where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
-pub fn aya::programs::flow_dissector::FlowDissectorLink::equivalent(&self, key: &K) -> bool
-impl<T, U> core::convert::Into<U> for aya::programs::flow_dissector::FlowDissectorLink where U: core::convert::From<T>
-pub fn aya::programs::flow_dissector::FlowDissectorLink::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::programs::flow_dissector::FlowDissectorLink where U: core::convert::Into<T>
-pub type aya::programs::flow_dissector::FlowDissectorLink::Error = core::convert::Infallible
-pub fn aya::programs::flow_dissector::FlowDissectorLink::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::programs::flow_dissector::FlowDissectorLink where U: core::convert::TryFrom<T>
-pub type aya::programs::flow_dissector::FlowDissectorLink::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::programs::flow_dissector::FlowDissectorLink::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya::programs::flow_dissector::FlowDissectorLink where T: 'static + ?core::marker::Sized
-pub fn aya::programs::flow_dissector::FlowDissectorLink::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::programs::flow_dissector::FlowDissectorLink where T: ?core::marker::Sized
-pub fn aya::programs::flow_dissector::FlowDissectorLink::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::programs::flow_dissector::FlowDissectorLink where T: ?core::marker::Sized
-pub fn aya::programs::flow_dissector::FlowDissectorLink::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya::programs::flow_dissector::FlowDissectorLink
-pub fn aya::programs::flow_dissector::FlowDissectorLink::from(t: T) -> T
 pub struct aya::programs::flow_dissector::FlowDissectorLinkId(_)
 impl core::cmp::Eq for aya::programs::flow_dissector::FlowDissectorLinkId
 impl core::cmp::PartialEq for aya::programs::flow_dissector::FlowDissectorLinkId
@@ -4015,26 +2509,6 @@ impl core::marker::Unpin for aya::programs::flow_dissector::FlowDissectorLinkId
 impl core::marker::UnsafeUnpin for aya::programs::flow_dissector::FlowDissectorLinkId
 impl core::panic::unwind_safe::RefUnwindSafe for aya::programs::flow_dissector::FlowDissectorLinkId
 impl core::panic::unwind_safe::UnwindSafe for aya::programs::flow_dissector::FlowDissectorLinkId
-impl<Q, K> equivalent::Equivalent<K> for aya::programs::flow_dissector::FlowDissectorLinkId where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
-pub fn aya::programs::flow_dissector::FlowDissectorLinkId::equivalent(&self, key: &K) -> bool
-impl<Q, K> hashbrown::Equivalent<K> for aya::programs::flow_dissector::FlowDissectorLinkId where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
-pub fn aya::programs::flow_dissector::FlowDissectorLinkId::equivalent(&self, key: &K) -> bool
-impl<T, U> core::convert::Into<U> for aya::programs::flow_dissector::FlowDissectorLinkId where U: core::convert::From<T>
-pub fn aya::programs::flow_dissector::FlowDissectorLinkId::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::programs::flow_dissector::FlowDissectorLinkId where U: core::convert::Into<T>
-pub type aya::programs::flow_dissector::FlowDissectorLinkId::Error = core::convert::Infallible
-pub fn aya::programs::flow_dissector::FlowDissectorLinkId::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::programs::flow_dissector::FlowDissectorLinkId where U: core::convert::TryFrom<T>
-pub type aya::programs::flow_dissector::FlowDissectorLinkId::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::programs::flow_dissector::FlowDissectorLinkId::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya::programs::flow_dissector::FlowDissectorLinkId where T: 'static + ?core::marker::Sized
-pub fn aya::programs::flow_dissector::FlowDissectorLinkId::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::programs::flow_dissector::FlowDissectorLinkId where T: ?core::marker::Sized
-pub fn aya::programs::flow_dissector::FlowDissectorLinkId::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::programs::flow_dissector::FlowDissectorLinkId where T: ?core::marker::Sized
-pub fn aya::programs::flow_dissector::FlowDissectorLinkId::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya::programs::flow_dissector::FlowDissectorLinkId
-pub fn aya::programs::flow_dissector::FlowDissectorLinkId::from(t: T) -> T
 pub mod aya::programs::iter
 pub struct aya::programs::iter::Iter
 impl aya::programs::iter::Iter
@@ -4074,22 +2548,6 @@ impl core::marker::Unpin for aya::programs::iter::Iter
 impl core::marker::UnsafeUnpin for aya::programs::iter::Iter
 impl core::panic::unwind_safe::RefUnwindSafe for aya::programs::iter::Iter
 impl core::panic::unwind_safe::UnwindSafe for aya::programs::iter::Iter
-impl<T, U> core::convert::Into<U> for aya::programs::iter::Iter where U: core::convert::From<T>
-pub fn aya::programs::iter::Iter::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::programs::iter::Iter where U: core::convert::Into<T>
-pub type aya::programs::iter::Iter::Error = core::convert::Infallible
-pub fn aya::programs::iter::Iter::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::programs::iter::Iter where U: core::convert::TryFrom<T>
-pub type aya::programs::iter::Iter::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::programs::iter::Iter::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya::programs::iter::Iter where T: 'static + ?core::marker::Sized
-pub fn aya::programs::iter::Iter::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::programs::iter::Iter where T: ?core::marker::Sized
-pub fn aya::programs::iter::Iter::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::programs::iter::Iter where T: ?core::marker::Sized
-pub fn aya::programs::iter::Iter::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya::programs::iter::Iter
-pub fn aya::programs::iter::Iter::from(t: T) -> T
 pub struct aya::programs::iter::IterFd
 impl core::fmt::Debug for aya::programs::iter::IterFd
 pub fn aya::programs::iter::IterFd::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
@@ -4102,22 +2560,6 @@ impl core::marker::Unpin for aya::programs::iter::IterFd
 impl core::marker::UnsafeUnpin for aya::programs::iter::IterFd
 impl core::panic::unwind_safe::RefUnwindSafe for aya::programs::iter::IterFd
 impl core::panic::unwind_safe::UnwindSafe for aya::programs::iter::IterFd
-impl<T, U> core::convert::Into<U> for aya::programs::iter::IterFd where U: core::convert::From<T>
-pub fn aya::programs::iter::IterFd::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::programs::iter::IterFd where U: core::convert::Into<T>
-pub type aya::programs::iter::IterFd::Error = core::convert::Infallible
-pub fn aya::programs::iter::IterFd::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::programs::iter::IterFd where U: core::convert::TryFrom<T>
-pub type aya::programs::iter::IterFd::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::programs::iter::IterFd::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya::programs::iter::IterFd where T: 'static + ?core::marker::Sized
-pub fn aya::programs::iter::IterFd::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::programs::iter::IterFd where T: ?core::marker::Sized
-pub fn aya::programs::iter::IterFd::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::programs::iter::IterFd where T: ?core::marker::Sized
-pub fn aya::programs::iter::IterFd::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya::programs::iter::IterFd
-pub fn aya::programs::iter::IterFd::from(t: T) -> T
 pub struct aya::programs::iter::IterLink(_)
 impl aya::programs::iter::IterLink
 pub fn aya::programs::iter::IterLink::into_file(self) -> core::result::Result<std::fs::File, aya::programs::links::LinkError>
@@ -4149,26 +2591,6 @@ impl core::marker::Unpin for aya::programs::iter::IterLink
 impl core::marker::UnsafeUnpin for aya::programs::iter::IterLink
 impl core::panic::unwind_safe::RefUnwindSafe for aya::programs::iter::IterLink
 impl core::panic::unwind_safe::UnwindSafe for aya::programs::iter::IterLink
-impl<Q, K> equivalent::Equivalent<K> for aya::programs::iter::IterLink where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
-pub fn aya::programs::iter::IterLink::equivalent(&self, key: &K) -> bool
-impl<Q, K> hashbrown::Equivalent<K> for aya::programs::iter::IterLink where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
-pub fn aya::programs::iter::IterLink::equivalent(&self, key: &K) -> bool
-impl<T, U> core::convert::Into<U> for aya::programs::iter::IterLink where U: core::convert::From<T>
-pub fn aya::programs::iter::IterLink::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::programs::iter::IterLink where U: core::convert::Into<T>
-pub type aya::programs::iter::IterLink::Error = core::convert::Infallible
-pub fn aya::programs::iter::IterLink::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::programs::iter::IterLink where U: core::convert::TryFrom<T>
-pub type aya::programs::iter::IterLink::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::programs::iter::IterLink::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya::programs::iter::IterLink where T: 'static + ?core::marker::Sized
-pub fn aya::programs::iter::IterLink::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::programs::iter::IterLink where T: ?core::marker::Sized
-pub fn aya::programs::iter::IterLink::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::programs::iter::IterLink where T: ?core::marker::Sized
-pub fn aya::programs::iter::IterLink::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya::programs::iter::IterLink
-pub fn aya::programs::iter::IterLink::from(t: T) -> T
 pub struct aya::programs::iter::IterLinkId(_)
 impl core::cmp::Eq for aya::programs::iter::IterLinkId
 impl core::cmp::PartialEq for aya::programs::iter::IterLinkId
@@ -4187,26 +2609,6 @@ impl core::marker::Unpin for aya::programs::iter::IterLinkId
 impl core::marker::UnsafeUnpin for aya::programs::iter::IterLinkId
 impl core::panic::unwind_safe::RefUnwindSafe for aya::programs::iter::IterLinkId
 impl core::panic::unwind_safe::UnwindSafe for aya::programs::iter::IterLinkId
-impl<Q, K> equivalent::Equivalent<K> for aya::programs::iter::IterLinkId where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
-pub fn aya::programs::iter::IterLinkId::equivalent(&self, key: &K) -> bool
-impl<Q, K> hashbrown::Equivalent<K> for aya::programs::iter::IterLinkId where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
-pub fn aya::programs::iter::IterLinkId::equivalent(&self, key: &K) -> bool
-impl<T, U> core::convert::Into<U> for aya::programs::iter::IterLinkId where U: core::convert::From<T>
-pub fn aya::programs::iter::IterLinkId::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::programs::iter::IterLinkId where U: core::convert::Into<T>
-pub type aya::programs::iter::IterLinkId::Error = core::convert::Infallible
-pub fn aya::programs::iter::IterLinkId::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::programs::iter::IterLinkId where U: core::convert::TryFrom<T>
-pub type aya::programs::iter::IterLinkId::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::programs::iter::IterLinkId::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya::programs::iter::IterLinkId where T: 'static + ?core::marker::Sized
-pub fn aya::programs::iter::IterLinkId::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::programs::iter::IterLinkId where T: ?core::marker::Sized
-pub fn aya::programs::iter::IterLinkId::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::programs::iter::IterLinkId where T: ?core::marker::Sized
-pub fn aya::programs::iter::IterLinkId::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya::programs::iter::IterLinkId
-pub fn aya::programs::iter::IterLinkId::from(t: T) -> T
 pub mod aya::programs::kprobe
 pub enum aya::programs::kprobe::KProbeError
 pub aya::programs::kprobe::KProbeError::FileError
@@ -4227,24 +2629,6 @@ impl core::marker::Unpin for aya::programs::kprobe::KProbeError
 impl core::marker::UnsafeUnpin for aya::programs::kprobe::KProbeError
 impl !core::panic::unwind_safe::RefUnwindSafe for aya::programs::kprobe::KProbeError
 impl !core::panic::unwind_safe::UnwindSafe for aya::programs::kprobe::KProbeError
-impl<T, U> core::convert::Into<U> for aya::programs::kprobe::KProbeError where U: core::convert::From<T>
-pub fn aya::programs::kprobe::KProbeError::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::programs::kprobe::KProbeError where U: core::convert::Into<T>
-pub type aya::programs::kprobe::KProbeError::Error = core::convert::Infallible
-pub fn aya::programs::kprobe::KProbeError::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::programs::kprobe::KProbeError where U: core::convert::TryFrom<T>
-pub type aya::programs::kprobe::KProbeError::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::programs::kprobe::KProbeError::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::string::ToString for aya::programs::kprobe::KProbeError where T: core::fmt::Display + ?core::marker::Sized
-pub fn aya::programs::kprobe::KProbeError::to_string(&self) -> alloc::string::String
-impl<T> core::any::Any for aya::programs::kprobe::KProbeError where T: 'static + ?core::marker::Sized
-pub fn aya::programs::kprobe::KProbeError::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::programs::kprobe::KProbeError where T: ?core::marker::Sized
-pub fn aya::programs::kprobe::KProbeError::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::programs::kprobe::KProbeError where T: ?core::marker::Sized
-pub fn aya::programs::kprobe::KProbeError::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya::programs::kprobe::KProbeError
-pub fn aya::programs::kprobe::KProbeError::from(t: T) -> T
 pub struct aya::programs::kprobe::KProbe
 impl aya::programs::kprobe::KProbe
 pub const aya::programs::kprobe::KProbe::PROGRAM_TYPE: aya::programs::ProgramType
@@ -4283,22 +2667,6 @@ impl core::marker::Unpin for aya::programs::kprobe::KProbe
 impl core::marker::UnsafeUnpin for aya::programs::kprobe::KProbe
 impl core::panic::unwind_safe::RefUnwindSafe for aya::programs::kprobe::KProbe
 impl core::panic::unwind_safe::UnwindSafe for aya::programs::kprobe::KProbe
-impl<T, U> core::convert::Into<U> for aya::programs::kprobe::KProbe where U: core::convert::From<T>
-pub fn aya::programs::kprobe::KProbe::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::programs::kprobe::KProbe where U: core::convert::Into<T>
-pub type aya::programs::kprobe::KProbe::Error = core::convert::Infallible
-pub fn aya::programs::kprobe::KProbe::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::programs::kprobe::KProbe where U: core::convert::TryFrom<T>
-pub type aya::programs::kprobe::KProbe::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::programs::kprobe::KProbe::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya::programs::kprobe::KProbe where T: 'static + ?core::marker::Sized
-pub fn aya::programs::kprobe::KProbe::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::programs::kprobe::KProbe where T: ?core::marker::Sized
-pub fn aya::programs::kprobe::KProbe::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::programs::kprobe::KProbe where T: ?core::marker::Sized
-pub fn aya::programs::kprobe::KProbe::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya::programs::kprobe::KProbe
-pub fn aya::programs::kprobe::KProbe::from(t: T) -> T
 pub struct aya::programs::kprobe::KProbeLink(_)
 impl aya::programs::links::Link for aya::programs::kprobe::KProbeLink
 pub type aya::programs::kprobe::KProbeLink::Id = aya::programs::kprobe::KProbeLinkId
@@ -4328,26 +2696,6 @@ impl core::marker::Unpin for aya::programs::kprobe::KProbeLink
 impl core::marker::UnsafeUnpin for aya::programs::kprobe::KProbeLink
 impl core::panic::unwind_safe::RefUnwindSafe for aya::programs::kprobe::KProbeLink
 impl core::panic::unwind_safe::UnwindSafe for aya::programs::kprobe::KProbeLink
-impl<Q, K> equivalent::Equivalent<K> for aya::programs::kprobe::KProbeLink where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
-pub fn aya::programs::kprobe::KProbeLink::equivalent(&self, key: &K) -> bool
-impl<Q, K> hashbrown::Equivalent<K> for aya::programs::kprobe::KProbeLink where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
-pub fn aya::programs::kprobe::KProbeLink::equivalent(&self, key: &K) -> bool
-impl<T, U> core::convert::Into<U> for aya::programs::kprobe::KProbeLink where U: core::convert::From<T>
-pub fn aya::programs::kprobe::KProbeLink::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::programs::kprobe::KProbeLink where U: core::convert::Into<T>
-pub type aya::programs::kprobe::KProbeLink::Error = core::convert::Infallible
-pub fn aya::programs::kprobe::KProbeLink::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::programs::kprobe::KProbeLink where U: core::convert::TryFrom<T>
-pub type aya::programs::kprobe::KProbeLink::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::programs::kprobe::KProbeLink::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya::programs::kprobe::KProbeLink where T: 'static + ?core::marker::Sized
-pub fn aya::programs::kprobe::KProbeLink::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::programs::kprobe::KProbeLink where T: ?core::marker::Sized
-pub fn aya::programs::kprobe::KProbeLink::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::programs::kprobe::KProbeLink where T: ?core::marker::Sized
-pub fn aya::programs::kprobe::KProbeLink::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya::programs::kprobe::KProbeLink
-pub fn aya::programs::kprobe::KProbeLink::from(t: T) -> T
 pub struct aya::programs::kprobe::KProbeLinkId(_)
 impl core::cmp::Eq for aya::programs::kprobe::KProbeLinkId
 impl core::cmp::PartialEq for aya::programs::kprobe::KProbeLinkId
@@ -4366,26 +2714,6 @@ impl core::marker::Unpin for aya::programs::kprobe::KProbeLinkId
 impl core::marker::UnsafeUnpin for aya::programs::kprobe::KProbeLinkId
 impl core::panic::unwind_safe::RefUnwindSafe for aya::programs::kprobe::KProbeLinkId
 impl core::panic::unwind_safe::UnwindSafe for aya::programs::kprobe::KProbeLinkId
-impl<Q, K> equivalent::Equivalent<K> for aya::programs::kprobe::KProbeLinkId where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
-pub fn aya::programs::kprobe::KProbeLinkId::equivalent(&self, key: &K) -> bool
-impl<Q, K> hashbrown::Equivalent<K> for aya::programs::kprobe::KProbeLinkId where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
-pub fn aya::programs::kprobe::KProbeLinkId::equivalent(&self, key: &K) -> bool
-impl<T, U> core::convert::Into<U> for aya::programs::kprobe::KProbeLinkId where U: core::convert::From<T>
-pub fn aya::programs::kprobe::KProbeLinkId::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::programs::kprobe::KProbeLinkId where U: core::convert::Into<T>
-pub type aya::programs::kprobe::KProbeLinkId::Error = core::convert::Infallible
-pub fn aya::programs::kprobe::KProbeLinkId::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::programs::kprobe::KProbeLinkId where U: core::convert::TryFrom<T>
-pub type aya::programs::kprobe::KProbeLinkId::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::programs::kprobe::KProbeLinkId::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya::programs::kprobe::KProbeLinkId where T: 'static + ?core::marker::Sized
-pub fn aya::programs::kprobe::KProbeLinkId::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::programs::kprobe::KProbeLinkId where T: ?core::marker::Sized
-pub fn aya::programs::kprobe::KProbeLinkId::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::programs::kprobe::KProbeLinkId where T: ?core::marker::Sized
-pub fn aya::programs::kprobe::KProbeLinkId::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya::programs::kprobe::KProbeLinkId
-pub fn aya::programs::kprobe::KProbeLinkId::from(t: T) -> T
 pub mod aya::programs::links
 pub enum aya::programs::links::CgroupAttachMode
 pub aya::programs::links::CgroupAttachMode::AllowMultiple
@@ -4407,28 +2735,6 @@ impl core::marker::Unpin for aya::programs::links::CgroupAttachMode
 impl core::marker::UnsafeUnpin for aya::programs::links::CgroupAttachMode
 impl core::panic::unwind_safe::RefUnwindSafe for aya::programs::links::CgroupAttachMode
 impl core::panic::unwind_safe::UnwindSafe for aya::programs::links::CgroupAttachMode
-impl<T, U> core::convert::Into<U> for aya::programs::links::CgroupAttachMode where U: core::convert::From<T>
-pub fn aya::programs::links::CgroupAttachMode::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::programs::links::CgroupAttachMode where U: core::convert::Into<T>
-pub type aya::programs::links::CgroupAttachMode::Error = core::convert::Infallible
-pub fn aya::programs::links::CgroupAttachMode::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::programs::links::CgroupAttachMode where U: core::convert::TryFrom<T>
-pub type aya::programs::links::CgroupAttachMode::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::programs::links::CgroupAttachMode::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya::programs::links::CgroupAttachMode where T: core::clone::Clone
-pub type aya::programs::links::CgroupAttachMode::Owned = T
-pub fn aya::programs::links::CgroupAttachMode::clone_into(&self, target: &mut T)
-pub fn aya::programs::links::CgroupAttachMode::to_owned(&self) -> T
-impl<T> core::any::Any for aya::programs::links::CgroupAttachMode where T: 'static + ?core::marker::Sized
-pub fn aya::programs::links::CgroupAttachMode::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::programs::links::CgroupAttachMode where T: ?core::marker::Sized
-pub fn aya::programs::links::CgroupAttachMode::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::programs::links::CgroupAttachMode where T: ?core::marker::Sized
-pub fn aya::programs::links::CgroupAttachMode::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya::programs::links::CgroupAttachMode where T: core::clone::Clone
-pub unsafe fn aya::programs::links::CgroupAttachMode::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya::programs::links::CgroupAttachMode
-pub fn aya::programs::links::CgroupAttachMode::from(t: T) -> T
 pub enum aya::programs::links::LinkError
 pub aya::programs::links::LinkError::InvalidLink
 pub aya::programs::links::LinkError::SyscallError(aya::sys::SyscallError)
@@ -4448,24 +2754,6 @@ impl core::marker::Unpin for aya::programs::links::LinkError
 impl core::marker::UnsafeUnpin for aya::programs::links::LinkError
 impl !core::panic::unwind_safe::RefUnwindSafe for aya::programs::links::LinkError
 impl !core::panic::unwind_safe::UnwindSafe for aya::programs::links::LinkError
-impl<T, U> core::convert::Into<U> for aya::programs::links::LinkError where U: core::convert::From<T>
-pub fn aya::programs::links::LinkError::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::programs::links::LinkError where U: core::convert::Into<T>
-pub type aya::programs::links::LinkError::Error = core::convert::Infallible
-pub fn aya::programs::links::LinkError::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::programs::links::LinkError where U: core::convert::TryFrom<T>
-pub type aya::programs::links::LinkError::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::programs::links::LinkError::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::string::ToString for aya::programs::links::LinkError where T: core::fmt::Display + ?core::marker::Sized
-pub fn aya::programs::links::LinkError::to_string(&self) -> alloc::string::String
-impl<T> core::any::Any for aya::programs::links::LinkError where T: 'static + ?core::marker::Sized
-pub fn aya::programs::links::LinkError::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::programs::links::LinkError where T: ?core::marker::Sized
-pub fn aya::programs::links::LinkError::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::programs::links::LinkError where T: ?core::marker::Sized
-pub fn aya::programs::links::LinkError::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya::programs::links::LinkError
-pub fn aya::programs::links::LinkError::from(t: T) -> T
 #[non_exhaustive] pub enum aya::programs::links::LinkType
 pub aya::programs::links::LinkType::Cgroup = 3
 pub aya::programs::links::LinkType::Iter = 4
@@ -4499,28 +2787,6 @@ impl core::marker::Unpin for aya::programs::links::LinkType
 impl core::marker::UnsafeUnpin for aya::programs::links::LinkType
 impl core::panic::unwind_safe::RefUnwindSafe for aya::programs::links::LinkType
 impl core::panic::unwind_safe::UnwindSafe for aya::programs::links::LinkType
-impl<T, U> core::convert::Into<U> for aya::programs::links::LinkType where U: core::convert::From<T>
-pub fn aya::programs::links::LinkType::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::programs::links::LinkType where U: core::convert::Into<T>
-pub type aya::programs::links::LinkType::Error = core::convert::Infallible
-pub fn aya::programs::links::LinkType::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::programs::links::LinkType where U: core::convert::TryFrom<T>
-pub type aya::programs::links::LinkType::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::programs::links::LinkType::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya::programs::links::LinkType where T: core::clone::Clone
-pub type aya::programs::links::LinkType::Owned = T
-pub fn aya::programs::links::LinkType::clone_into(&self, target: &mut T)
-pub fn aya::programs::links::LinkType::to_owned(&self) -> T
-impl<T> core::any::Any for aya::programs::links::LinkType where T: 'static + ?core::marker::Sized
-pub fn aya::programs::links::LinkType::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::programs::links::LinkType where T: ?core::marker::Sized
-pub fn aya::programs::links::LinkType::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::programs::links::LinkType where T: ?core::marker::Sized
-pub fn aya::programs::links::LinkType::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya::programs::links::LinkType where T: core::clone::Clone
-pub unsafe fn aya::programs::links::LinkType::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya::programs::links::LinkType
-pub fn aya::programs::links::LinkType::from(t: T) -> T
 pub struct aya::programs::links::FdLink
 impl aya::programs::links::FdLink
 pub fn aya::programs::links::FdLink::info(&self) -> core::result::Result<aya::programs::links::LinkInfo, aya::programs::links::LinkError>
@@ -4639,26 +2905,6 @@ impl core::marker::Unpin for aya::programs::links::FdLink
 impl core::marker::UnsafeUnpin for aya::programs::links::FdLink
 impl core::panic::unwind_safe::RefUnwindSafe for aya::programs::links::FdLink
 impl core::panic::unwind_safe::UnwindSafe for aya::programs::links::FdLink
-impl<Q, K> equivalent::Equivalent<K> for aya::programs::links::FdLink where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
-pub fn aya::programs::links::FdLink::equivalent(&self, key: &K) -> bool
-impl<Q, K> hashbrown::Equivalent<K> for aya::programs::links::FdLink where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
-pub fn aya::programs::links::FdLink::equivalent(&self, key: &K) -> bool
-impl<T, U> core::convert::Into<U> for aya::programs::links::FdLink where U: core::convert::From<T>
-pub fn aya::programs::links::FdLink::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::programs::links::FdLink where U: core::convert::Into<T>
-pub type aya::programs::links::FdLink::Error = core::convert::Infallible
-pub fn aya::programs::links::FdLink::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::programs::links::FdLink where U: core::convert::TryFrom<T>
-pub type aya::programs::links::FdLink::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::programs::links::FdLink::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya::programs::links::FdLink where T: 'static + ?core::marker::Sized
-pub fn aya::programs::links::FdLink::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::programs::links::FdLink where T: ?core::marker::Sized
-pub fn aya::programs::links::FdLink::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::programs::links::FdLink where T: ?core::marker::Sized
-pub fn aya::programs::links::FdLink::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya::programs::links::FdLink
-pub fn aya::programs::links::FdLink::from(t: T) -> T
 pub struct aya::programs::links::FdLinkId(_)
 impl core::cmp::Eq for aya::programs::links::FdLinkId
 impl core::cmp::PartialEq for aya::programs::links::FdLinkId
@@ -4677,26 +2923,6 @@ impl core::marker::Unpin for aya::programs::links::FdLinkId
 impl core::marker::UnsafeUnpin for aya::programs::links::FdLinkId
 impl core::panic::unwind_safe::RefUnwindSafe for aya::programs::links::FdLinkId
 impl core::panic::unwind_safe::UnwindSafe for aya::programs::links::FdLinkId
-impl<Q, K> equivalent::Equivalent<K> for aya::programs::links::FdLinkId where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
-pub fn aya::programs::links::FdLinkId::equivalent(&self, key: &K) -> bool
-impl<Q, K> hashbrown::Equivalent<K> for aya::programs::links::FdLinkId where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
-pub fn aya::programs::links::FdLinkId::equivalent(&self, key: &K) -> bool
-impl<T, U> core::convert::Into<U> for aya::programs::links::FdLinkId where U: core::convert::From<T>
-pub fn aya::programs::links::FdLinkId::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::programs::links::FdLinkId where U: core::convert::Into<T>
-pub type aya::programs::links::FdLinkId::Error = core::convert::Infallible
-pub fn aya::programs::links::FdLinkId::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::programs::links::FdLinkId where U: core::convert::TryFrom<T>
-pub type aya::programs::links::FdLinkId::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::programs::links::FdLinkId::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya::programs::links::FdLinkId where T: 'static + ?core::marker::Sized
-pub fn aya::programs::links::FdLinkId::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::programs::links::FdLinkId where T: ?core::marker::Sized
-pub fn aya::programs::links::FdLinkId::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::programs::links::FdLinkId where T: ?core::marker::Sized
-pub fn aya::programs::links::FdLinkId::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya::programs::links::FdLinkId
-pub fn aya::programs::links::FdLinkId::from(t: T) -> T
 pub struct aya::programs::links::LinkInfo(_)
 impl aya::programs::links::LinkInfo
 pub const fn aya::programs::links::LinkInfo::id(&self) -> u32
@@ -4709,22 +2935,6 @@ impl core::marker::Unpin for aya::programs::links::LinkInfo
 impl core::marker::UnsafeUnpin for aya::programs::links::LinkInfo
 impl core::panic::unwind_safe::RefUnwindSafe for aya::programs::links::LinkInfo
 impl core::panic::unwind_safe::UnwindSafe for aya::programs::links::LinkInfo
-impl<T, U> core::convert::Into<U> for aya::programs::links::LinkInfo where U: core::convert::From<T>
-pub fn aya::programs::links::LinkInfo::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::programs::links::LinkInfo where U: core::convert::Into<T>
-pub type aya::programs::links::LinkInfo::Error = core::convert::Infallible
-pub fn aya::programs::links::LinkInfo::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::programs::links::LinkInfo where U: core::convert::TryFrom<T>
-pub type aya::programs::links::LinkInfo::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::programs::links::LinkInfo::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya::programs::links::LinkInfo where T: 'static + ?core::marker::Sized
-pub fn aya::programs::links::LinkInfo::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::programs::links::LinkInfo where T: ?core::marker::Sized
-pub fn aya::programs::links::LinkInfo::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::programs::links::LinkInfo where T: ?core::marker::Sized
-pub fn aya::programs::links::LinkInfo::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya::programs::links::LinkInfo
-pub fn aya::programs::links::LinkInfo::from(t: T) -> T
 pub struct aya::programs::links::LinkOrder
 impl aya::programs::links::LinkOrder
 pub fn aya::programs::links::LinkOrder::after_link<L: aya::programs::MultiProgLink>(link: &L) -> core::result::Result<Self, aya::programs::links::LinkError>
@@ -4746,22 +2956,6 @@ impl core::marker::Unpin for aya::programs::links::LinkOrder
 impl core::marker::UnsafeUnpin for aya::programs::links::LinkOrder
 impl core::panic::unwind_safe::RefUnwindSafe for aya::programs::links::LinkOrder
 impl core::panic::unwind_safe::UnwindSafe for aya::programs::links::LinkOrder
-impl<T, U> core::convert::Into<U> for aya::programs::links::LinkOrder where U: core::convert::From<T>
-pub fn aya::programs::links::LinkOrder::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::programs::links::LinkOrder where U: core::convert::Into<T>
-pub type aya::programs::links::LinkOrder::Error = core::convert::Infallible
-pub fn aya::programs::links::LinkOrder::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::programs::links::LinkOrder where U: core::convert::TryFrom<T>
-pub type aya::programs::links::LinkOrder::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::programs::links::LinkOrder::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya::programs::links::LinkOrder where T: 'static + ?core::marker::Sized
-pub fn aya::programs::links::LinkOrder::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::programs::links::LinkOrder where T: ?core::marker::Sized
-pub fn aya::programs::links::LinkOrder::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::programs::links::LinkOrder where T: ?core::marker::Sized
-pub fn aya::programs::links::LinkOrder::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya::programs::links::LinkOrder
-pub fn aya::programs::links::LinkOrder::from(t: T) -> T
 pub struct aya::programs::links::PinnedLink
 impl aya::programs::links::PinnedLink
 pub fn aya::programs::links::PinnedLink::from_pin<P: core::convert::AsRef<std::path::Path>>(path: P) -> core::result::Result<Self, aya::programs::links::LinkError>
@@ -4777,22 +2971,6 @@ impl core::marker::Unpin for aya::programs::links::PinnedLink
 impl core::marker::UnsafeUnpin for aya::programs::links::PinnedLink
 impl core::panic::unwind_safe::RefUnwindSafe for aya::programs::links::PinnedLink
 impl core::panic::unwind_safe::UnwindSafe for aya::programs::links::PinnedLink
-impl<T, U> core::convert::Into<U> for aya::programs::links::PinnedLink where U: core::convert::From<T>
-pub fn aya::programs::links::PinnedLink::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::programs::links::PinnedLink where U: core::convert::Into<T>
-pub type aya::programs::links::PinnedLink::Error = core::convert::Infallible
-pub fn aya::programs::links::PinnedLink::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::programs::links::PinnedLink where U: core::convert::TryFrom<T>
-pub type aya::programs::links::PinnedLink::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::programs::links::PinnedLink::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya::programs::links::PinnedLink where T: 'static + ?core::marker::Sized
-pub fn aya::programs::links::PinnedLink::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::programs::links::PinnedLink where T: ?core::marker::Sized
-pub fn aya::programs::links::PinnedLink::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::programs::links::PinnedLink where T: ?core::marker::Sized
-pub fn aya::programs::links::PinnedLink::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya::programs::links::PinnedLink
-pub fn aya::programs::links::PinnedLink::from(t: T) -> T
 pub struct aya::programs::links::ProgAttachLink
 impl aya::programs::links::Link for aya::programs::links::ProgAttachLink
 pub type aya::programs::links::ProgAttachLink::Id = aya::programs::links::ProgAttachLinkId
@@ -4822,26 +3000,6 @@ impl core::marker::Unpin for aya::programs::links::ProgAttachLink
 impl core::marker::UnsafeUnpin for aya::programs::links::ProgAttachLink
 impl core::panic::unwind_safe::RefUnwindSafe for aya::programs::links::ProgAttachLink
 impl core::panic::unwind_safe::UnwindSafe for aya::programs::links::ProgAttachLink
-impl<Q, K> equivalent::Equivalent<K> for aya::programs::links::ProgAttachLink where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
-pub fn aya::programs::links::ProgAttachLink::equivalent(&self, key: &K) -> bool
-impl<Q, K> hashbrown::Equivalent<K> for aya::programs::links::ProgAttachLink where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
-pub fn aya::programs::links::ProgAttachLink::equivalent(&self, key: &K) -> bool
-impl<T, U> core::convert::Into<U> for aya::programs::links::ProgAttachLink where U: core::convert::From<T>
-pub fn aya::programs::links::ProgAttachLink::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::programs::links::ProgAttachLink where U: core::convert::Into<T>
-pub type aya::programs::links::ProgAttachLink::Error = core::convert::Infallible
-pub fn aya::programs::links::ProgAttachLink::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::programs::links::ProgAttachLink where U: core::convert::TryFrom<T>
-pub type aya::programs::links::ProgAttachLink::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::programs::links::ProgAttachLink::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya::programs::links::ProgAttachLink where T: 'static + ?core::marker::Sized
-pub fn aya::programs::links::ProgAttachLink::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::programs::links::ProgAttachLink where T: ?core::marker::Sized
-pub fn aya::programs::links::ProgAttachLink::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::programs::links::ProgAttachLink where T: ?core::marker::Sized
-pub fn aya::programs::links::ProgAttachLink::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya::programs::links::ProgAttachLink
-pub fn aya::programs::links::ProgAttachLink::from(t: T) -> T
 pub struct aya::programs::links::ProgAttachLinkId(_, _, _)
 impl core::cmp::Eq for aya::programs::links::ProgAttachLinkId
 impl core::cmp::PartialEq for aya::programs::links::ProgAttachLinkId
@@ -4860,26 +3018,6 @@ impl core::marker::Unpin for aya::programs::links::ProgAttachLinkId
 impl core::marker::UnsafeUnpin for aya::programs::links::ProgAttachLinkId
 impl core::panic::unwind_safe::RefUnwindSafe for aya::programs::links::ProgAttachLinkId
 impl core::panic::unwind_safe::UnwindSafe for aya::programs::links::ProgAttachLinkId
-impl<Q, K> equivalent::Equivalent<K> for aya::programs::links::ProgAttachLinkId where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
-pub fn aya::programs::links::ProgAttachLinkId::equivalent(&self, key: &K) -> bool
-impl<Q, K> hashbrown::Equivalent<K> for aya::programs::links::ProgAttachLinkId where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
-pub fn aya::programs::links::ProgAttachLinkId::equivalent(&self, key: &K) -> bool
-impl<T, U> core::convert::Into<U> for aya::programs::links::ProgAttachLinkId where U: core::convert::From<T>
-pub fn aya::programs::links::ProgAttachLinkId::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::programs::links::ProgAttachLinkId where U: core::convert::Into<T>
-pub type aya::programs::links::ProgAttachLinkId::Error = core::convert::Infallible
-pub fn aya::programs::links::ProgAttachLinkId::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::programs::links::ProgAttachLinkId where U: core::convert::TryFrom<T>
-pub type aya::programs::links::ProgAttachLinkId::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::programs::links::ProgAttachLinkId::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya::programs::links::ProgAttachLinkId where T: 'static + ?core::marker::Sized
-pub fn aya::programs::links::ProgAttachLinkId::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::programs::links::ProgAttachLinkId where T: ?core::marker::Sized
-pub fn aya::programs::links::ProgAttachLinkId::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::programs::links::ProgAttachLinkId where T: ?core::marker::Sized
-pub fn aya::programs::links::ProgAttachLinkId::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya::programs::links::ProgAttachLinkId
-pub fn aya::programs::links::ProgAttachLinkId::from(t: T) -> T
 pub trait aya::programs::links::Link: core::fmt::Debug + core::cmp::Eq + core::hash::Hash + 'static
 pub type aya::programs::links::Link::Id: core::fmt::Debug + core::cmp::Eq + core::hash::Hash + equivalent::Equivalent<Self>
 pub fn aya::programs::links::Link::detach(self) -> core::result::Result<(), aya::programs::ProgramError>
@@ -5024,26 +3162,6 @@ impl core::marker::Unpin for aya::programs::lirc_mode2::LircLink
 impl core::marker::UnsafeUnpin for aya::programs::lirc_mode2::LircLink
 impl core::panic::unwind_safe::RefUnwindSafe for aya::programs::lirc_mode2::LircLink
 impl core::panic::unwind_safe::UnwindSafe for aya::programs::lirc_mode2::LircLink
-impl<Q, K> equivalent::Equivalent<K> for aya::programs::lirc_mode2::LircLink where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
-pub fn aya::programs::lirc_mode2::LircLink::equivalent(&self, key: &K) -> bool
-impl<Q, K> hashbrown::Equivalent<K> for aya::programs::lirc_mode2::LircLink where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
-pub fn aya::programs::lirc_mode2::LircLink::equivalent(&self, key: &K) -> bool
-impl<T, U> core::convert::Into<U> for aya::programs::lirc_mode2::LircLink where U: core::convert::From<T>
-pub fn aya::programs::lirc_mode2::LircLink::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::programs::lirc_mode2::LircLink where U: core::convert::Into<T>
-pub type aya::programs::lirc_mode2::LircLink::Error = core::convert::Infallible
-pub fn aya::programs::lirc_mode2::LircLink::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::programs::lirc_mode2::LircLink where U: core::convert::TryFrom<T>
-pub type aya::programs::lirc_mode2::LircLink::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::programs::lirc_mode2::LircLink::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya::programs::lirc_mode2::LircLink where T: 'static + ?core::marker::Sized
-pub fn aya::programs::lirc_mode2::LircLink::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::programs::lirc_mode2::LircLink where T: ?core::marker::Sized
-pub fn aya::programs::lirc_mode2::LircLink::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::programs::lirc_mode2::LircLink where T: ?core::marker::Sized
-pub fn aya::programs::lirc_mode2::LircLink::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya::programs::lirc_mode2::LircLink
-pub fn aya::programs::lirc_mode2::LircLink::from(t: T) -> T
 pub struct aya::programs::lirc_mode2::LircLinkId(_, _)
 impl core::cmp::Eq for aya::programs::lirc_mode2::LircLinkId
 impl core::cmp::PartialEq for aya::programs::lirc_mode2::LircLinkId
@@ -5062,26 +3180,6 @@ impl core::marker::Unpin for aya::programs::lirc_mode2::LircLinkId
 impl core::marker::UnsafeUnpin for aya::programs::lirc_mode2::LircLinkId
 impl core::panic::unwind_safe::RefUnwindSafe for aya::programs::lirc_mode2::LircLinkId
 impl core::panic::unwind_safe::UnwindSafe for aya::programs::lirc_mode2::LircLinkId
-impl<Q, K> equivalent::Equivalent<K> for aya::programs::lirc_mode2::LircLinkId where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
-pub fn aya::programs::lirc_mode2::LircLinkId::equivalent(&self, key: &K) -> bool
-impl<Q, K> hashbrown::Equivalent<K> for aya::programs::lirc_mode2::LircLinkId where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
-pub fn aya::programs::lirc_mode2::LircLinkId::equivalent(&self, key: &K) -> bool
-impl<T, U> core::convert::Into<U> for aya::programs::lirc_mode2::LircLinkId where U: core::convert::From<T>
-pub fn aya::programs::lirc_mode2::LircLinkId::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::programs::lirc_mode2::LircLinkId where U: core::convert::Into<T>
-pub type aya::programs::lirc_mode2::LircLinkId::Error = core::convert::Infallible
-pub fn aya::programs::lirc_mode2::LircLinkId::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::programs::lirc_mode2::LircLinkId where U: core::convert::TryFrom<T>
-pub type aya::programs::lirc_mode2::LircLinkId::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::programs::lirc_mode2::LircLinkId::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya::programs::lirc_mode2::LircLinkId where T: 'static + ?core::marker::Sized
-pub fn aya::programs::lirc_mode2::LircLinkId::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::programs::lirc_mode2::LircLinkId where T: ?core::marker::Sized
-pub fn aya::programs::lirc_mode2::LircLinkId::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::programs::lirc_mode2::LircLinkId where T: ?core::marker::Sized
-pub fn aya::programs::lirc_mode2::LircLinkId::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya::programs::lirc_mode2::LircLinkId
-pub fn aya::programs::lirc_mode2::LircLinkId::from(t: T) -> T
 pub struct aya::programs::lirc_mode2::LircMode2
 impl aya::programs::lirc_mode2::LircMode2
 pub const aya::programs::lirc_mode2::LircMode2::PROGRAM_TYPE: aya::programs::ProgramType
@@ -5120,22 +3218,6 @@ impl core::marker::Unpin for aya::programs::lirc_mode2::LircMode2
 impl core::marker::UnsafeUnpin for aya::programs::lirc_mode2::LircMode2
 impl core::panic::unwind_safe::RefUnwindSafe for aya::programs::lirc_mode2::LircMode2
 impl core::panic::unwind_safe::UnwindSafe for aya::programs::lirc_mode2::LircMode2
-impl<T, U> core::convert::Into<U> for aya::programs::lirc_mode2::LircMode2 where U: core::convert::From<T>
-pub fn aya::programs::lirc_mode2::LircMode2::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::programs::lirc_mode2::LircMode2 where U: core::convert::Into<T>
-pub type aya::programs::lirc_mode2::LircMode2::Error = core::convert::Infallible
-pub fn aya::programs::lirc_mode2::LircMode2::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::programs::lirc_mode2::LircMode2 where U: core::convert::TryFrom<T>
-pub type aya::programs::lirc_mode2::LircMode2::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::programs::lirc_mode2::LircMode2::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya::programs::lirc_mode2::LircMode2 where T: 'static + ?core::marker::Sized
-pub fn aya::programs::lirc_mode2::LircMode2::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::programs::lirc_mode2::LircMode2 where T: ?core::marker::Sized
-pub fn aya::programs::lirc_mode2::LircMode2::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::programs::lirc_mode2::LircMode2 where T: ?core::marker::Sized
-pub fn aya::programs::lirc_mode2::LircMode2::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya::programs::lirc_mode2::LircMode2
-pub fn aya::programs::lirc_mode2::LircMode2::from(t: T) -> T
 pub mod aya::programs::lsm
 pub struct aya::programs::lsm::Lsm
 impl aya::programs::lsm::Lsm
@@ -5175,22 +3257,6 @@ impl core::marker::Unpin for aya::programs::lsm::Lsm
 impl core::marker::UnsafeUnpin for aya::programs::lsm::Lsm
 impl core::panic::unwind_safe::RefUnwindSafe for aya::programs::lsm::Lsm
 impl core::panic::unwind_safe::UnwindSafe for aya::programs::lsm::Lsm
-impl<T, U> core::convert::Into<U> for aya::programs::lsm::Lsm where U: core::convert::From<T>
-pub fn aya::programs::lsm::Lsm::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::programs::lsm::Lsm where U: core::convert::Into<T>
-pub type aya::programs::lsm::Lsm::Error = core::convert::Infallible
-pub fn aya::programs::lsm::Lsm::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::programs::lsm::Lsm where U: core::convert::TryFrom<T>
-pub type aya::programs::lsm::Lsm::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::programs::lsm::Lsm::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya::programs::lsm::Lsm where T: 'static + ?core::marker::Sized
-pub fn aya::programs::lsm::Lsm::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::programs::lsm::Lsm where T: ?core::marker::Sized
-pub fn aya::programs::lsm::Lsm::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::programs::lsm::Lsm where T: ?core::marker::Sized
-pub fn aya::programs::lsm::Lsm::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya::programs::lsm::Lsm
-pub fn aya::programs::lsm::Lsm::from(t: T) -> T
 pub struct aya::programs::lsm::LsmLink(_)
 impl aya::programs::links::Link for aya::programs::lsm::LsmLink
 pub type aya::programs::lsm::LsmLink::Id = aya::programs::lsm::LsmLinkId
@@ -5218,26 +3284,6 @@ impl core::marker::Unpin for aya::programs::lsm::LsmLink
 impl core::marker::UnsafeUnpin for aya::programs::lsm::LsmLink
 impl core::panic::unwind_safe::RefUnwindSafe for aya::programs::lsm::LsmLink
 impl core::panic::unwind_safe::UnwindSafe for aya::programs::lsm::LsmLink
-impl<Q, K> equivalent::Equivalent<K> for aya::programs::lsm::LsmLink where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
-pub fn aya::programs::lsm::LsmLink::equivalent(&self, key: &K) -> bool
-impl<Q, K> hashbrown::Equivalent<K> for aya::programs::lsm::LsmLink where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
-pub fn aya::programs::lsm::LsmLink::equivalent(&self, key: &K) -> bool
-impl<T, U> core::convert::Into<U> for aya::programs::lsm::LsmLink where U: core::convert::From<T>
-pub fn aya::programs::lsm::LsmLink::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::programs::lsm::LsmLink where U: core::convert::Into<T>
-pub type aya::programs::lsm::LsmLink::Error = core::convert::Infallible
-pub fn aya::programs::lsm::LsmLink::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::programs::lsm::LsmLink where U: core::convert::TryFrom<T>
-pub type aya::programs::lsm::LsmLink::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::programs::lsm::LsmLink::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya::programs::lsm::LsmLink where T: 'static + ?core::marker::Sized
-pub fn aya::programs::lsm::LsmLink::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::programs::lsm::LsmLink where T: ?core::marker::Sized
-pub fn aya::programs::lsm::LsmLink::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::programs::lsm::LsmLink where T: ?core::marker::Sized
-pub fn aya::programs::lsm::LsmLink::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya::programs::lsm::LsmLink
-pub fn aya::programs::lsm::LsmLink::from(t: T) -> T
 pub struct aya::programs::lsm::LsmLinkId(_)
 impl core::cmp::Eq for aya::programs::lsm::LsmLinkId
 impl core::cmp::PartialEq for aya::programs::lsm::LsmLinkId
@@ -5256,26 +3302,6 @@ impl core::marker::Unpin for aya::programs::lsm::LsmLinkId
 impl core::marker::UnsafeUnpin for aya::programs::lsm::LsmLinkId
 impl core::panic::unwind_safe::RefUnwindSafe for aya::programs::lsm::LsmLinkId
 impl core::panic::unwind_safe::UnwindSafe for aya::programs::lsm::LsmLinkId
-impl<Q, K> equivalent::Equivalent<K> for aya::programs::lsm::LsmLinkId where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
-pub fn aya::programs::lsm::LsmLinkId::equivalent(&self, key: &K) -> bool
-impl<Q, K> hashbrown::Equivalent<K> for aya::programs::lsm::LsmLinkId where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
-pub fn aya::programs::lsm::LsmLinkId::equivalent(&self, key: &K) -> bool
-impl<T, U> core::convert::Into<U> for aya::programs::lsm::LsmLinkId where U: core::convert::From<T>
-pub fn aya::programs::lsm::LsmLinkId::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::programs::lsm::LsmLinkId where U: core::convert::Into<T>
-pub type aya::programs::lsm::LsmLinkId::Error = core::convert::Infallible
-pub fn aya::programs::lsm::LsmLinkId::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::programs::lsm::LsmLinkId where U: core::convert::TryFrom<T>
-pub type aya::programs::lsm::LsmLinkId::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::programs::lsm::LsmLinkId::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya::programs::lsm::LsmLinkId where T: 'static + ?core::marker::Sized
-pub fn aya::programs::lsm::LsmLinkId::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::programs::lsm::LsmLinkId where T: ?core::marker::Sized
-pub fn aya::programs::lsm::LsmLinkId::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::programs::lsm::LsmLinkId where T: ?core::marker::Sized
-pub fn aya::programs::lsm::LsmLinkId::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya::programs::lsm::LsmLinkId
-pub fn aya::programs::lsm::LsmLinkId::from(t: T) -> T
 pub mod aya::programs::lsm_cgroup
 pub struct aya::programs::lsm_cgroup::LsmCgroup
 impl aya::programs::lsm_cgroup::LsmCgroup
@@ -5311,22 +3337,6 @@ impl core::marker::Unpin for aya::programs::lsm_cgroup::LsmCgroup
 impl core::marker::UnsafeUnpin for aya::programs::lsm_cgroup::LsmCgroup
 impl core::panic::unwind_safe::RefUnwindSafe for aya::programs::lsm_cgroup::LsmCgroup
 impl core::panic::unwind_safe::UnwindSafe for aya::programs::lsm_cgroup::LsmCgroup
-impl<T, U> core::convert::Into<U> for aya::programs::lsm_cgroup::LsmCgroup where U: core::convert::From<T>
-pub fn aya::programs::lsm_cgroup::LsmCgroup::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::programs::lsm_cgroup::LsmCgroup where U: core::convert::Into<T>
-pub type aya::programs::lsm_cgroup::LsmCgroup::Error = core::convert::Infallible
-pub fn aya::programs::lsm_cgroup::LsmCgroup::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::programs::lsm_cgroup::LsmCgroup where U: core::convert::TryFrom<T>
-pub type aya::programs::lsm_cgroup::LsmCgroup::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::programs::lsm_cgroup::LsmCgroup::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya::programs::lsm_cgroup::LsmCgroup where T: 'static + ?core::marker::Sized
-pub fn aya::programs::lsm_cgroup::LsmCgroup::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::programs::lsm_cgroup::LsmCgroup where T: ?core::marker::Sized
-pub fn aya::programs::lsm_cgroup::LsmCgroup::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::programs::lsm_cgroup::LsmCgroup where T: ?core::marker::Sized
-pub fn aya::programs::lsm_cgroup::LsmCgroup::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya::programs::lsm_cgroup::LsmCgroup
-pub fn aya::programs::lsm_cgroup::LsmCgroup::from(t: T) -> T
 pub struct aya::programs::lsm_cgroup::LsmLink(_)
 impl aya::programs::links::Link for aya::programs::lsm_cgroup::LsmLink
 pub type aya::programs::lsm_cgroup::LsmLink::Id = aya::programs::lsm_cgroup::LsmLinkId
@@ -5354,26 +3364,6 @@ impl core::marker::Unpin for aya::programs::lsm_cgroup::LsmLink
 impl core::marker::UnsafeUnpin for aya::programs::lsm_cgroup::LsmLink
 impl core::panic::unwind_safe::RefUnwindSafe for aya::programs::lsm_cgroup::LsmLink
 impl core::panic::unwind_safe::UnwindSafe for aya::programs::lsm_cgroup::LsmLink
-impl<Q, K> equivalent::Equivalent<K> for aya::programs::lsm_cgroup::LsmLink where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
-pub fn aya::programs::lsm_cgroup::LsmLink::equivalent(&self, key: &K) -> bool
-impl<Q, K> hashbrown::Equivalent<K> for aya::programs::lsm_cgroup::LsmLink where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
-pub fn aya::programs::lsm_cgroup::LsmLink::equivalent(&self, key: &K) -> bool
-impl<T, U> core::convert::Into<U> for aya::programs::lsm_cgroup::LsmLink where U: core::convert::From<T>
-pub fn aya::programs::lsm_cgroup::LsmLink::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::programs::lsm_cgroup::LsmLink where U: core::convert::Into<T>
-pub type aya::programs::lsm_cgroup::LsmLink::Error = core::convert::Infallible
-pub fn aya::programs::lsm_cgroup::LsmLink::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::programs::lsm_cgroup::LsmLink where U: core::convert::TryFrom<T>
-pub type aya::programs::lsm_cgroup::LsmLink::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::programs::lsm_cgroup::LsmLink::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya::programs::lsm_cgroup::LsmLink where T: 'static + ?core::marker::Sized
-pub fn aya::programs::lsm_cgroup::LsmLink::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::programs::lsm_cgroup::LsmLink where T: ?core::marker::Sized
-pub fn aya::programs::lsm_cgroup::LsmLink::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::programs::lsm_cgroup::LsmLink where T: ?core::marker::Sized
-pub fn aya::programs::lsm_cgroup::LsmLink::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya::programs::lsm_cgroup::LsmLink
-pub fn aya::programs::lsm_cgroup::LsmLink::from(t: T) -> T
 pub struct aya::programs::lsm_cgroup::LsmLinkId(_)
 impl core::cmp::Eq for aya::programs::lsm_cgroup::LsmLinkId
 impl core::cmp::PartialEq for aya::programs::lsm_cgroup::LsmLinkId
@@ -5392,26 +3382,6 @@ impl core::marker::Unpin for aya::programs::lsm_cgroup::LsmLinkId
 impl core::marker::UnsafeUnpin for aya::programs::lsm_cgroup::LsmLinkId
 impl core::panic::unwind_safe::RefUnwindSafe for aya::programs::lsm_cgroup::LsmLinkId
 impl core::panic::unwind_safe::UnwindSafe for aya::programs::lsm_cgroup::LsmLinkId
-impl<Q, K> equivalent::Equivalent<K> for aya::programs::lsm_cgroup::LsmLinkId where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
-pub fn aya::programs::lsm_cgroup::LsmLinkId::equivalent(&self, key: &K) -> bool
-impl<Q, K> hashbrown::Equivalent<K> for aya::programs::lsm_cgroup::LsmLinkId where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
-pub fn aya::programs::lsm_cgroup::LsmLinkId::equivalent(&self, key: &K) -> bool
-impl<T, U> core::convert::Into<U> for aya::programs::lsm_cgroup::LsmLinkId where U: core::convert::From<T>
-pub fn aya::programs::lsm_cgroup::LsmLinkId::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::programs::lsm_cgroup::LsmLinkId where U: core::convert::Into<T>
-pub type aya::programs::lsm_cgroup::LsmLinkId::Error = core::convert::Infallible
-pub fn aya::programs::lsm_cgroup::LsmLinkId::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::programs::lsm_cgroup::LsmLinkId where U: core::convert::TryFrom<T>
-pub type aya::programs::lsm_cgroup::LsmLinkId::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::programs::lsm_cgroup::LsmLinkId::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya::programs::lsm_cgroup::LsmLinkId where T: 'static + ?core::marker::Sized
-pub fn aya::programs::lsm_cgroup::LsmLinkId::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::programs::lsm_cgroup::LsmLinkId where T: ?core::marker::Sized
-pub fn aya::programs::lsm_cgroup::LsmLinkId::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::programs::lsm_cgroup::LsmLinkId where T: ?core::marker::Sized
-pub fn aya::programs::lsm_cgroup::LsmLinkId::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya::programs::lsm_cgroup::LsmLinkId
-pub fn aya::programs::lsm_cgroup::LsmLinkId::from(t: T) -> T
 pub mod aya::programs::perf_attach
 pub struct aya::programs::perf_attach::PerfLinkId(_)
 impl core::cmp::Eq for aya::programs::perf_attach::PerfLinkId
@@ -5429,26 +3399,6 @@ impl core::marker::Unpin for aya::programs::perf_attach::PerfLinkId
 impl core::marker::UnsafeUnpin for aya::programs::perf_attach::PerfLinkId
 impl core::panic::unwind_safe::RefUnwindSafe for aya::programs::perf_attach::PerfLinkId
 impl core::panic::unwind_safe::UnwindSafe for aya::programs::perf_attach::PerfLinkId
-impl<Q, K> equivalent::Equivalent<K> for aya::programs::perf_attach::PerfLinkId where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
-pub fn aya::programs::perf_attach::PerfLinkId::equivalent(&self, key: &K) -> bool
-impl<Q, K> hashbrown::Equivalent<K> for aya::programs::perf_attach::PerfLinkId where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
-pub fn aya::programs::perf_attach::PerfLinkId::equivalent(&self, key: &K) -> bool
-impl<T, U> core::convert::Into<U> for aya::programs::perf_attach::PerfLinkId where U: core::convert::From<T>
-pub fn aya::programs::perf_attach::PerfLinkId::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::programs::perf_attach::PerfLinkId where U: core::convert::Into<T>
-pub type aya::programs::perf_attach::PerfLinkId::Error = core::convert::Infallible
-pub fn aya::programs::perf_attach::PerfLinkId::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::programs::perf_attach::PerfLinkId where U: core::convert::TryFrom<T>
-pub type aya::programs::perf_attach::PerfLinkId::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::programs::perf_attach::PerfLinkId::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya::programs::perf_attach::PerfLinkId where T: 'static + ?core::marker::Sized
-pub fn aya::programs::perf_attach::PerfLinkId::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::programs::perf_attach::PerfLinkId where T: ?core::marker::Sized
-pub fn aya::programs::perf_attach::PerfLinkId::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::programs::perf_attach::PerfLinkId where T: ?core::marker::Sized
-pub fn aya::programs::perf_attach::PerfLinkId::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya::programs::perf_attach::PerfLinkId
-pub fn aya::programs::perf_attach::PerfLinkId::from(t: T) -> T
 pub mod aya::programs::perf_event
 pub enum aya::programs::perf_event::BreakpointConfig
 pub aya::programs::perf_event::BreakpointConfig::Data
@@ -5469,28 +3419,6 @@ impl core::marker::Unpin for aya::programs::perf_event::BreakpointConfig
 impl core::marker::UnsafeUnpin for aya::programs::perf_event::BreakpointConfig
 impl core::panic::unwind_safe::RefUnwindSafe for aya::programs::perf_event::BreakpointConfig
 impl core::panic::unwind_safe::UnwindSafe for aya::programs::perf_event::BreakpointConfig
-impl<T, U> core::convert::Into<U> for aya::programs::perf_event::BreakpointConfig where U: core::convert::From<T>
-pub fn aya::programs::perf_event::BreakpointConfig::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::programs::perf_event::BreakpointConfig where U: core::convert::Into<T>
-pub type aya::programs::perf_event::BreakpointConfig::Error = core::convert::Infallible
-pub fn aya::programs::perf_event::BreakpointConfig::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::programs::perf_event::BreakpointConfig where U: core::convert::TryFrom<T>
-pub type aya::programs::perf_event::BreakpointConfig::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::programs::perf_event::BreakpointConfig::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya::programs::perf_event::BreakpointConfig where T: core::clone::Clone
-pub type aya::programs::perf_event::BreakpointConfig::Owned = T
-pub fn aya::programs::perf_event::BreakpointConfig::clone_into(&self, target: &mut T)
-pub fn aya::programs::perf_event::BreakpointConfig::to_owned(&self) -> T
-impl<T> core::any::Any for aya::programs::perf_event::BreakpointConfig where T: 'static + ?core::marker::Sized
-pub fn aya::programs::perf_event::BreakpointConfig::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::programs::perf_event::BreakpointConfig where T: ?core::marker::Sized
-pub fn aya::programs::perf_event::BreakpointConfig::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::programs::perf_event::BreakpointConfig where T: ?core::marker::Sized
-pub fn aya::programs::perf_event::BreakpointConfig::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya::programs::perf_event::BreakpointConfig where T: core::clone::Clone
-pub unsafe fn aya::programs::perf_event::BreakpointConfig::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya::programs::perf_event::BreakpointConfig
-pub fn aya::programs::perf_event::BreakpointConfig::from(t: T) -> T
 #[repr(u32)] pub enum aya::programs::perf_event::HardwareEvent
 pub aya::programs::perf_event::HardwareEvent::BranchInstructions = 4
 pub aya::programs::perf_event::HardwareEvent::BranchMisses = 5
@@ -5514,28 +3442,6 @@ impl core::marker::Unpin for aya::programs::perf_event::HardwareEvent
 impl core::marker::UnsafeUnpin for aya::programs::perf_event::HardwareEvent
 impl core::panic::unwind_safe::RefUnwindSafe for aya::programs::perf_event::HardwareEvent
 impl core::panic::unwind_safe::UnwindSafe for aya::programs::perf_event::HardwareEvent
-impl<T, U> core::convert::Into<U> for aya::programs::perf_event::HardwareEvent where U: core::convert::From<T>
-pub fn aya::programs::perf_event::HardwareEvent::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::programs::perf_event::HardwareEvent where U: core::convert::Into<T>
-pub type aya::programs::perf_event::HardwareEvent::Error = core::convert::Infallible
-pub fn aya::programs::perf_event::HardwareEvent::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::programs::perf_event::HardwareEvent where U: core::convert::TryFrom<T>
-pub type aya::programs::perf_event::HardwareEvent::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::programs::perf_event::HardwareEvent::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya::programs::perf_event::HardwareEvent where T: core::clone::Clone
-pub type aya::programs::perf_event::HardwareEvent::Owned = T
-pub fn aya::programs::perf_event::HardwareEvent::clone_into(&self, target: &mut T)
-pub fn aya::programs::perf_event::HardwareEvent::to_owned(&self) -> T
-impl<T> core::any::Any for aya::programs::perf_event::HardwareEvent where T: 'static + ?core::marker::Sized
-pub fn aya::programs::perf_event::HardwareEvent::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::programs::perf_event::HardwareEvent where T: ?core::marker::Sized
-pub fn aya::programs::perf_event::HardwareEvent::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::programs::perf_event::HardwareEvent where T: ?core::marker::Sized
-pub fn aya::programs::perf_event::HardwareEvent::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya::programs::perf_event::HardwareEvent where T: core::clone::Clone
-pub unsafe fn aya::programs::perf_event::HardwareEvent::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya::programs::perf_event::HardwareEvent
-pub fn aya::programs::perf_event::HardwareEvent::from(t: T) -> T
 #[repr(u32)] pub enum aya::programs::perf_event::HwCacheEvent
 pub aya::programs::perf_event::HwCacheEvent::Bpu = 5
 pub aya::programs::perf_event::HwCacheEvent::Dtlb = 3
@@ -5556,28 +3462,6 @@ impl core::marker::Unpin for aya::programs::perf_event::HwCacheEvent
 impl core::marker::UnsafeUnpin for aya::programs::perf_event::HwCacheEvent
 impl core::panic::unwind_safe::RefUnwindSafe for aya::programs::perf_event::HwCacheEvent
 impl core::panic::unwind_safe::UnwindSafe for aya::programs::perf_event::HwCacheEvent
-impl<T, U> core::convert::Into<U> for aya::programs::perf_event::HwCacheEvent where U: core::convert::From<T>
-pub fn aya::programs::perf_event::HwCacheEvent::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::programs::perf_event::HwCacheEvent where U: core::convert::Into<T>
-pub type aya::programs::perf_event::HwCacheEvent::Error = core::convert::Infallible
-pub fn aya::programs::perf_event::HwCacheEvent::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::programs::perf_event::HwCacheEvent where U: core::convert::TryFrom<T>
-pub type aya::programs::perf_event::HwCacheEvent::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::programs::perf_event::HwCacheEvent::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya::programs::perf_event::HwCacheEvent where T: core::clone::Clone
-pub type aya::programs::perf_event::HwCacheEvent::Owned = T
-pub fn aya::programs::perf_event::HwCacheEvent::clone_into(&self, target: &mut T)
-pub fn aya::programs::perf_event::HwCacheEvent::to_owned(&self) -> T
-impl<T> core::any::Any for aya::programs::perf_event::HwCacheEvent where T: 'static + ?core::marker::Sized
-pub fn aya::programs::perf_event::HwCacheEvent::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::programs::perf_event::HwCacheEvent where T: ?core::marker::Sized
-pub fn aya::programs::perf_event::HwCacheEvent::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::programs::perf_event::HwCacheEvent where T: ?core::marker::Sized
-pub fn aya::programs::perf_event::HwCacheEvent::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya::programs::perf_event::HwCacheEvent where T: core::clone::Clone
-pub unsafe fn aya::programs::perf_event::HwCacheEvent::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya::programs::perf_event::HwCacheEvent
-pub fn aya::programs::perf_event::HwCacheEvent::from(t: T) -> T
 #[repr(u32)] pub enum aya::programs::perf_event::HwCacheOp
 pub aya::programs::perf_event::HwCacheOp::Prefetch = 2
 pub aya::programs::perf_event::HwCacheOp::Read = 0
@@ -5594,28 +3478,6 @@ impl core::marker::Unpin for aya::programs::perf_event::HwCacheOp
 impl core::marker::UnsafeUnpin for aya::programs::perf_event::HwCacheOp
 impl core::panic::unwind_safe::RefUnwindSafe for aya::programs::perf_event::HwCacheOp
 impl core::panic::unwind_safe::UnwindSafe for aya::programs::perf_event::HwCacheOp
-impl<T, U> core::convert::Into<U> for aya::programs::perf_event::HwCacheOp where U: core::convert::From<T>
-pub fn aya::programs::perf_event::HwCacheOp::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::programs::perf_event::HwCacheOp where U: core::convert::Into<T>
-pub type aya::programs::perf_event::HwCacheOp::Error = core::convert::Infallible
-pub fn aya::programs::perf_event::HwCacheOp::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::programs::perf_event::HwCacheOp where U: core::convert::TryFrom<T>
-pub type aya::programs::perf_event::HwCacheOp::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::programs::perf_event::HwCacheOp::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya::programs::perf_event::HwCacheOp where T: core::clone::Clone
-pub type aya::programs::perf_event::HwCacheOp::Owned = T
-pub fn aya::programs::perf_event::HwCacheOp::clone_into(&self, target: &mut T)
-pub fn aya::programs::perf_event::HwCacheOp::to_owned(&self) -> T
-impl<T> core::any::Any for aya::programs::perf_event::HwCacheOp where T: 'static + ?core::marker::Sized
-pub fn aya::programs::perf_event::HwCacheOp::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::programs::perf_event::HwCacheOp where T: ?core::marker::Sized
-pub fn aya::programs::perf_event::HwCacheOp::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::programs::perf_event::HwCacheOp where T: ?core::marker::Sized
-pub fn aya::programs::perf_event::HwCacheOp::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya::programs::perf_event::HwCacheOp where T: core::clone::Clone
-pub unsafe fn aya::programs::perf_event::HwCacheOp::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya::programs::perf_event::HwCacheOp
-pub fn aya::programs::perf_event::HwCacheOp::from(t: T) -> T
 #[repr(u32)] pub enum aya::programs::perf_event::HwCacheResult
 pub aya::programs::perf_event::HwCacheResult::Access = 0
 pub aya::programs::perf_event::HwCacheResult::Miss = 1
@@ -5631,28 +3493,6 @@ impl core::marker::Unpin for aya::programs::perf_event::HwCacheResult
 impl core::marker::UnsafeUnpin for aya::programs::perf_event::HwCacheResult
 impl core::panic::unwind_safe::RefUnwindSafe for aya::programs::perf_event::HwCacheResult
 impl core::panic::unwind_safe::UnwindSafe for aya::programs::perf_event::HwCacheResult
-impl<T, U> core::convert::Into<U> for aya::programs::perf_event::HwCacheResult where U: core::convert::From<T>
-pub fn aya::programs::perf_event::HwCacheResult::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::programs::perf_event::HwCacheResult where U: core::convert::Into<T>
-pub type aya::programs::perf_event::HwCacheResult::Error = core::convert::Infallible
-pub fn aya::programs::perf_event::HwCacheResult::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::programs::perf_event::HwCacheResult where U: core::convert::TryFrom<T>
-pub type aya::programs::perf_event::HwCacheResult::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::programs::perf_event::HwCacheResult::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya::programs::perf_event::HwCacheResult where T: core::clone::Clone
-pub type aya::programs::perf_event::HwCacheResult::Owned = T
-pub fn aya::programs::perf_event::HwCacheResult::clone_into(&self, target: &mut T)
-pub fn aya::programs::perf_event::HwCacheResult::to_owned(&self) -> T
-impl<T> core::any::Any for aya::programs::perf_event::HwCacheResult where T: 'static + ?core::marker::Sized
-pub fn aya::programs::perf_event::HwCacheResult::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::programs::perf_event::HwCacheResult where T: ?core::marker::Sized
-pub fn aya::programs::perf_event::HwCacheResult::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::programs::perf_event::HwCacheResult where T: ?core::marker::Sized
-pub fn aya::programs::perf_event::HwCacheResult::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya::programs::perf_event::HwCacheResult where T: core::clone::Clone
-pub unsafe fn aya::programs::perf_event::HwCacheResult::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya::programs::perf_event::HwCacheResult
-pub fn aya::programs::perf_event::HwCacheResult::from(t: T) -> T
 #[repr(u32)] pub enum aya::programs::perf_event::PerfBreakpointLength
 pub aya::programs::perf_event::PerfBreakpointLength::Len1 = 1
 pub aya::programs::perf_event::PerfBreakpointLength::Len2 = 2
@@ -5670,28 +3510,6 @@ impl core::marker::Unpin for aya::programs::perf_event::PerfBreakpointLength
 impl core::marker::UnsafeUnpin for aya::programs::perf_event::PerfBreakpointLength
 impl core::panic::unwind_safe::RefUnwindSafe for aya::programs::perf_event::PerfBreakpointLength
 impl core::panic::unwind_safe::UnwindSafe for aya::programs::perf_event::PerfBreakpointLength
-impl<T, U> core::convert::Into<U> for aya::programs::perf_event::PerfBreakpointLength where U: core::convert::From<T>
-pub fn aya::programs::perf_event::PerfBreakpointLength::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::programs::perf_event::PerfBreakpointLength where U: core::convert::Into<T>
-pub type aya::programs::perf_event::PerfBreakpointLength::Error = core::convert::Infallible
-pub fn aya::programs::perf_event::PerfBreakpointLength::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::programs::perf_event::PerfBreakpointLength where U: core::convert::TryFrom<T>
-pub type aya::programs::perf_event::PerfBreakpointLength::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::programs::perf_event::PerfBreakpointLength::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya::programs::perf_event::PerfBreakpointLength where T: core::clone::Clone
-pub type aya::programs::perf_event::PerfBreakpointLength::Owned = T
-pub fn aya::programs::perf_event::PerfBreakpointLength::clone_into(&self, target: &mut T)
-pub fn aya::programs::perf_event::PerfBreakpointLength::to_owned(&self) -> T
-impl<T> core::any::Any for aya::programs::perf_event::PerfBreakpointLength where T: 'static + ?core::marker::Sized
-pub fn aya::programs::perf_event::PerfBreakpointLength::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::programs::perf_event::PerfBreakpointLength where T: ?core::marker::Sized
-pub fn aya::programs::perf_event::PerfBreakpointLength::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::programs::perf_event::PerfBreakpointLength where T: ?core::marker::Sized
-pub fn aya::programs::perf_event::PerfBreakpointLength::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya::programs::perf_event::PerfBreakpointLength where T: core::clone::Clone
-pub unsafe fn aya::programs::perf_event::PerfBreakpointLength::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya::programs::perf_event::PerfBreakpointLength
-pub fn aya::programs::perf_event::PerfBreakpointLength::from(t: T) -> T
 #[repr(u32)] pub enum aya::programs::perf_event::PerfBreakpointType
 pub aya::programs::perf_event::PerfBreakpointType::Read = 1
 pub aya::programs::perf_event::PerfBreakpointType::ReadWrite = 3
@@ -5708,28 +3526,6 @@ impl core::marker::Unpin for aya::programs::perf_event::PerfBreakpointType
 impl core::marker::UnsafeUnpin for aya::programs::perf_event::PerfBreakpointType
 impl core::panic::unwind_safe::RefUnwindSafe for aya::programs::perf_event::PerfBreakpointType
 impl core::panic::unwind_safe::UnwindSafe for aya::programs::perf_event::PerfBreakpointType
-impl<T, U> core::convert::Into<U> for aya::programs::perf_event::PerfBreakpointType where U: core::convert::From<T>
-pub fn aya::programs::perf_event::PerfBreakpointType::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::programs::perf_event::PerfBreakpointType where U: core::convert::Into<T>
-pub type aya::programs::perf_event::PerfBreakpointType::Error = core::convert::Infallible
-pub fn aya::programs::perf_event::PerfBreakpointType::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::programs::perf_event::PerfBreakpointType where U: core::convert::TryFrom<T>
-pub type aya::programs::perf_event::PerfBreakpointType::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::programs::perf_event::PerfBreakpointType::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya::programs::perf_event::PerfBreakpointType where T: core::clone::Clone
-pub type aya::programs::perf_event::PerfBreakpointType::Owned = T
-pub fn aya::programs::perf_event::PerfBreakpointType::clone_into(&self, target: &mut T)
-pub fn aya::programs::perf_event::PerfBreakpointType::to_owned(&self) -> T
-impl<T> core::any::Any for aya::programs::perf_event::PerfBreakpointType where T: 'static + ?core::marker::Sized
-pub fn aya::programs::perf_event::PerfBreakpointType::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::programs::perf_event::PerfBreakpointType where T: ?core::marker::Sized
-pub fn aya::programs::perf_event::PerfBreakpointType::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::programs::perf_event::PerfBreakpointType where T: ?core::marker::Sized
-pub fn aya::programs::perf_event::PerfBreakpointType::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya::programs::perf_event::PerfBreakpointType where T: core::clone::Clone
-pub unsafe fn aya::programs::perf_event::PerfBreakpointType::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya::programs::perf_event::PerfBreakpointType
-pub fn aya::programs::perf_event::PerfBreakpointType::from(t: T) -> T
 pub enum aya::programs::perf_event::PerfEventConfig
 pub aya::programs::perf_event::PerfEventConfig::Breakpoint(aya::programs::perf_event::BreakpointConfig)
 pub aya::programs::perf_event::PerfEventConfig::Hardware(aya::programs::perf_event::HardwareEvent)
@@ -5757,28 +3553,6 @@ impl core::marker::Unpin for aya::programs::perf_event::PerfEventConfig
 impl core::marker::UnsafeUnpin for aya::programs::perf_event::PerfEventConfig
 impl core::panic::unwind_safe::RefUnwindSafe for aya::programs::perf_event::PerfEventConfig
 impl core::panic::unwind_safe::UnwindSafe for aya::programs::perf_event::PerfEventConfig
-impl<T, U> core::convert::Into<U> for aya::programs::perf_event::PerfEventConfig where U: core::convert::From<T>
-pub fn aya::programs::perf_event::PerfEventConfig::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::programs::perf_event::PerfEventConfig where U: core::convert::Into<T>
-pub type aya::programs::perf_event::PerfEventConfig::Error = core::convert::Infallible
-pub fn aya::programs::perf_event::PerfEventConfig::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::programs::perf_event::PerfEventConfig where U: core::convert::TryFrom<T>
-pub type aya::programs::perf_event::PerfEventConfig::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::programs::perf_event::PerfEventConfig::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya::programs::perf_event::PerfEventConfig where T: core::clone::Clone
-pub type aya::programs::perf_event::PerfEventConfig::Owned = T
-pub fn aya::programs::perf_event::PerfEventConfig::clone_into(&self, target: &mut T)
-pub fn aya::programs::perf_event::PerfEventConfig::to_owned(&self) -> T
-impl<T> core::any::Any for aya::programs::perf_event::PerfEventConfig where T: 'static + ?core::marker::Sized
-pub fn aya::programs::perf_event::PerfEventConfig::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::programs::perf_event::PerfEventConfig where T: ?core::marker::Sized
-pub fn aya::programs::perf_event::PerfEventConfig::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::programs::perf_event::PerfEventConfig where T: ?core::marker::Sized
-pub fn aya::programs::perf_event::PerfEventConfig::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya::programs::perf_event::PerfEventConfig where T: core::clone::Clone
-pub unsafe fn aya::programs::perf_event::PerfEventConfig::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya::programs::perf_event::PerfEventConfig
-pub fn aya::programs::perf_event::PerfEventConfig::from(t: T) -> T
 pub enum aya::programs::perf_event::PerfEventScope
 pub aya::programs::perf_event::PerfEventScope::AllProcessesOneCpu
 pub aya::programs::perf_event::PerfEventScope::AllProcessesOneCpu::cpu: u32
@@ -5799,28 +3573,6 @@ impl core::marker::Unpin for aya::programs::perf_event::PerfEventScope
 impl core::marker::UnsafeUnpin for aya::programs::perf_event::PerfEventScope
 impl core::panic::unwind_safe::RefUnwindSafe for aya::programs::perf_event::PerfEventScope
 impl core::panic::unwind_safe::UnwindSafe for aya::programs::perf_event::PerfEventScope
-impl<T, U> core::convert::Into<U> for aya::programs::perf_event::PerfEventScope where U: core::convert::From<T>
-pub fn aya::programs::perf_event::PerfEventScope::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::programs::perf_event::PerfEventScope where U: core::convert::Into<T>
-pub type aya::programs::perf_event::PerfEventScope::Error = core::convert::Infallible
-pub fn aya::programs::perf_event::PerfEventScope::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::programs::perf_event::PerfEventScope where U: core::convert::TryFrom<T>
-pub type aya::programs::perf_event::PerfEventScope::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::programs::perf_event::PerfEventScope::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya::programs::perf_event::PerfEventScope where T: core::clone::Clone
-pub type aya::programs::perf_event::PerfEventScope::Owned = T
-pub fn aya::programs::perf_event::PerfEventScope::clone_into(&self, target: &mut T)
-pub fn aya::programs::perf_event::PerfEventScope::to_owned(&self) -> T
-impl<T> core::any::Any for aya::programs::perf_event::PerfEventScope where T: 'static + ?core::marker::Sized
-pub fn aya::programs::perf_event::PerfEventScope::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::programs::perf_event::PerfEventScope where T: ?core::marker::Sized
-pub fn aya::programs::perf_event::PerfEventScope::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::programs::perf_event::PerfEventScope where T: ?core::marker::Sized
-pub fn aya::programs::perf_event::PerfEventScope::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya::programs::perf_event::PerfEventScope where T: core::clone::Clone
-pub unsafe fn aya::programs::perf_event::PerfEventScope::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya::programs::perf_event::PerfEventScope
-pub fn aya::programs::perf_event::PerfEventScope::from(t: T) -> T
 pub enum aya::programs::perf_event::SamplePolicy
 pub aya::programs::perf_event::SamplePolicy::Frequency(u64)
 pub aya::programs::perf_event::SamplePolicy::Period(u64)
@@ -5836,28 +3588,6 @@ impl core::marker::Unpin for aya::programs::perf_event::SamplePolicy
 impl core::marker::UnsafeUnpin for aya::programs::perf_event::SamplePolicy
 impl core::panic::unwind_safe::RefUnwindSafe for aya::programs::perf_event::SamplePolicy
 impl core::panic::unwind_safe::UnwindSafe for aya::programs::perf_event::SamplePolicy
-impl<T, U> core::convert::Into<U> for aya::programs::perf_event::SamplePolicy where U: core::convert::From<T>
-pub fn aya::programs::perf_event::SamplePolicy::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::programs::perf_event::SamplePolicy where U: core::convert::Into<T>
-pub type aya::programs::perf_event::SamplePolicy::Error = core::convert::Infallible
-pub fn aya::programs::perf_event::SamplePolicy::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::programs::perf_event::SamplePolicy where U: core::convert::TryFrom<T>
-pub type aya::programs::perf_event::SamplePolicy::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::programs::perf_event::SamplePolicy::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya::programs::perf_event::SamplePolicy where T: core::clone::Clone
-pub type aya::programs::perf_event::SamplePolicy::Owned = T
-pub fn aya::programs::perf_event::SamplePolicy::clone_into(&self, target: &mut T)
-pub fn aya::programs::perf_event::SamplePolicy::to_owned(&self) -> T
-impl<T> core::any::Any for aya::programs::perf_event::SamplePolicy where T: 'static + ?core::marker::Sized
-pub fn aya::programs::perf_event::SamplePolicy::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::programs::perf_event::SamplePolicy where T: ?core::marker::Sized
-pub fn aya::programs::perf_event::SamplePolicy::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::programs::perf_event::SamplePolicy where T: ?core::marker::Sized
-pub fn aya::programs::perf_event::SamplePolicy::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya::programs::perf_event::SamplePolicy where T: core::clone::Clone
-pub unsafe fn aya::programs::perf_event::SamplePolicy::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya::programs::perf_event::SamplePolicy
-pub fn aya::programs::perf_event::SamplePolicy::from(t: T) -> T
 #[repr(u32)] pub enum aya::programs::perf_event::SoftwareEvent
 pub aya::programs::perf_event::SoftwareEvent::AlignmentFaults = 7
 pub aya::programs::perf_event::SoftwareEvent::BpfOutput = 10
@@ -5883,28 +3613,6 @@ impl core::marker::Unpin for aya::programs::perf_event::SoftwareEvent
 impl core::marker::UnsafeUnpin for aya::programs::perf_event::SoftwareEvent
 impl core::panic::unwind_safe::RefUnwindSafe for aya::programs::perf_event::SoftwareEvent
 impl core::panic::unwind_safe::UnwindSafe for aya::programs::perf_event::SoftwareEvent
-impl<T, U> core::convert::Into<U> for aya::programs::perf_event::SoftwareEvent where U: core::convert::From<T>
-pub fn aya::programs::perf_event::SoftwareEvent::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::programs::perf_event::SoftwareEvent where U: core::convert::Into<T>
-pub type aya::programs::perf_event::SoftwareEvent::Error = core::convert::Infallible
-pub fn aya::programs::perf_event::SoftwareEvent::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::programs::perf_event::SoftwareEvent where U: core::convert::TryFrom<T>
-pub type aya::programs::perf_event::SoftwareEvent::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::programs::perf_event::SoftwareEvent::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya::programs::perf_event::SoftwareEvent where T: core::clone::Clone
-pub type aya::programs::perf_event::SoftwareEvent::Owned = T
-pub fn aya::programs::perf_event::SoftwareEvent::clone_into(&self, target: &mut T)
-pub fn aya::programs::perf_event::SoftwareEvent::to_owned(&self) -> T
-impl<T> core::any::Any for aya::programs::perf_event::SoftwareEvent where T: 'static + ?core::marker::Sized
-pub fn aya::programs::perf_event::SoftwareEvent::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::programs::perf_event::SoftwareEvent where T: ?core::marker::Sized
-pub fn aya::programs::perf_event::SoftwareEvent::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::programs::perf_event::SoftwareEvent where T: ?core::marker::Sized
-pub fn aya::programs::perf_event::SoftwareEvent::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya::programs::perf_event::SoftwareEvent where T: core::clone::Clone
-pub unsafe fn aya::programs::perf_event::SoftwareEvent::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya::programs::perf_event::SoftwareEvent
-pub fn aya::programs::perf_event::SoftwareEvent::from(t: T) -> T
 pub struct aya::programs::perf_event::PerfEvent
 impl aya::programs::perf_event::PerfEvent
 pub const aya::programs::perf_event::PerfEvent::PROGRAM_TYPE: aya::programs::ProgramType
@@ -5943,22 +3651,6 @@ impl core::marker::Unpin for aya::programs::perf_event::PerfEvent
 impl core::marker::UnsafeUnpin for aya::programs::perf_event::PerfEvent
 impl core::panic::unwind_safe::RefUnwindSafe for aya::programs::perf_event::PerfEvent
 impl core::panic::unwind_safe::UnwindSafe for aya::programs::perf_event::PerfEvent
-impl<T, U> core::convert::Into<U> for aya::programs::perf_event::PerfEvent where U: core::convert::From<T>
-pub fn aya::programs::perf_event::PerfEvent::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::programs::perf_event::PerfEvent where U: core::convert::Into<T>
-pub type aya::programs::perf_event::PerfEvent::Error = core::convert::Infallible
-pub fn aya::programs::perf_event::PerfEvent::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::programs::perf_event::PerfEvent where U: core::convert::TryFrom<T>
-pub type aya::programs::perf_event::PerfEvent::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::programs::perf_event::PerfEvent::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya::programs::perf_event::PerfEvent where T: 'static + ?core::marker::Sized
-pub fn aya::programs::perf_event::PerfEvent::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::programs::perf_event::PerfEvent where T: ?core::marker::Sized
-pub fn aya::programs::perf_event::PerfEvent::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::programs::perf_event::PerfEvent where T: ?core::marker::Sized
-pub fn aya::programs::perf_event::PerfEvent::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya::programs::perf_event::PerfEvent
-pub fn aya::programs::perf_event::PerfEvent::from(t: T) -> T
 pub struct aya::programs::perf_event::PerfEventLink(_)
 impl aya::programs::links::Link for aya::programs::perf_event::PerfEventLink
 pub type aya::programs::perf_event::PerfEventLink::Id = aya::programs::perf_event::PerfEventLinkId
@@ -5988,26 +3680,6 @@ impl core::marker::Unpin for aya::programs::perf_event::PerfEventLink
 impl core::marker::UnsafeUnpin for aya::programs::perf_event::PerfEventLink
 impl core::panic::unwind_safe::RefUnwindSafe for aya::programs::perf_event::PerfEventLink
 impl core::panic::unwind_safe::UnwindSafe for aya::programs::perf_event::PerfEventLink
-impl<Q, K> equivalent::Equivalent<K> for aya::programs::perf_event::PerfEventLink where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
-pub fn aya::programs::perf_event::PerfEventLink::equivalent(&self, key: &K) -> bool
-impl<Q, K> hashbrown::Equivalent<K> for aya::programs::perf_event::PerfEventLink where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
-pub fn aya::programs::perf_event::PerfEventLink::equivalent(&self, key: &K) -> bool
-impl<T, U> core::convert::Into<U> for aya::programs::perf_event::PerfEventLink where U: core::convert::From<T>
-pub fn aya::programs::perf_event::PerfEventLink::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::programs::perf_event::PerfEventLink where U: core::convert::Into<T>
-pub type aya::programs::perf_event::PerfEventLink::Error = core::convert::Infallible
-pub fn aya::programs::perf_event::PerfEventLink::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::programs::perf_event::PerfEventLink where U: core::convert::TryFrom<T>
-pub type aya::programs::perf_event::PerfEventLink::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::programs::perf_event::PerfEventLink::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya::programs::perf_event::PerfEventLink where T: 'static + ?core::marker::Sized
-pub fn aya::programs::perf_event::PerfEventLink::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::programs::perf_event::PerfEventLink where T: ?core::marker::Sized
-pub fn aya::programs::perf_event::PerfEventLink::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::programs::perf_event::PerfEventLink where T: ?core::marker::Sized
-pub fn aya::programs::perf_event::PerfEventLink::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya::programs::perf_event::PerfEventLink
-pub fn aya::programs::perf_event::PerfEventLink::from(t: T) -> T
 pub struct aya::programs::perf_event::PerfEventLinkId(_)
 impl core::cmp::Eq for aya::programs::perf_event::PerfEventLinkId
 impl core::cmp::PartialEq for aya::programs::perf_event::PerfEventLinkId
@@ -6026,26 +3698,6 @@ impl core::marker::Unpin for aya::programs::perf_event::PerfEventLinkId
 impl core::marker::UnsafeUnpin for aya::programs::perf_event::PerfEventLinkId
 impl core::panic::unwind_safe::RefUnwindSafe for aya::programs::perf_event::PerfEventLinkId
 impl core::panic::unwind_safe::UnwindSafe for aya::programs::perf_event::PerfEventLinkId
-impl<Q, K> equivalent::Equivalent<K> for aya::programs::perf_event::PerfEventLinkId where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
-pub fn aya::programs::perf_event::PerfEventLinkId::equivalent(&self, key: &K) -> bool
-impl<Q, K> hashbrown::Equivalent<K> for aya::programs::perf_event::PerfEventLinkId where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
-pub fn aya::programs::perf_event::PerfEventLinkId::equivalent(&self, key: &K) -> bool
-impl<T, U> core::convert::Into<U> for aya::programs::perf_event::PerfEventLinkId where U: core::convert::From<T>
-pub fn aya::programs::perf_event::PerfEventLinkId::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::programs::perf_event::PerfEventLinkId where U: core::convert::Into<T>
-pub type aya::programs::perf_event::PerfEventLinkId::Error = core::convert::Infallible
-pub fn aya::programs::perf_event::PerfEventLinkId::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::programs::perf_event::PerfEventLinkId where U: core::convert::TryFrom<T>
-pub type aya::programs::perf_event::PerfEventLinkId::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::programs::perf_event::PerfEventLinkId::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya::programs::perf_event::PerfEventLinkId where T: 'static + ?core::marker::Sized
-pub fn aya::programs::perf_event::PerfEventLinkId::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::programs::perf_event::PerfEventLinkId where T: ?core::marker::Sized
-pub fn aya::programs::perf_event::PerfEventLinkId::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::programs::perf_event::PerfEventLinkId where T: ?core::marker::Sized
-pub fn aya::programs::perf_event::PerfEventLinkId::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya::programs::perf_event::PerfEventLinkId
-pub fn aya::programs::perf_event::PerfEventLinkId::from(t: T) -> T
 pub mod aya::programs::raw_trace_point
 pub struct aya::programs::raw_trace_point::RawTracePoint
 impl aya::programs::raw_trace_point::RawTracePoint
@@ -6085,22 +3737,6 @@ impl core::marker::Unpin for aya::programs::raw_trace_point::RawTracePoint
 impl core::marker::UnsafeUnpin for aya::programs::raw_trace_point::RawTracePoint
 impl core::panic::unwind_safe::RefUnwindSafe for aya::programs::raw_trace_point::RawTracePoint
 impl core::panic::unwind_safe::UnwindSafe for aya::programs::raw_trace_point::RawTracePoint
-impl<T, U> core::convert::Into<U> for aya::programs::raw_trace_point::RawTracePoint where U: core::convert::From<T>
-pub fn aya::programs::raw_trace_point::RawTracePoint::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::programs::raw_trace_point::RawTracePoint where U: core::convert::Into<T>
-pub type aya::programs::raw_trace_point::RawTracePoint::Error = core::convert::Infallible
-pub fn aya::programs::raw_trace_point::RawTracePoint::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::programs::raw_trace_point::RawTracePoint where U: core::convert::TryFrom<T>
-pub type aya::programs::raw_trace_point::RawTracePoint::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::programs::raw_trace_point::RawTracePoint::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya::programs::raw_trace_point::RawTracePoint where T: 'static + ?core::marker::Sized
-pub fn aya::programs::raw_trace_point::RawTracePoint::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::programs::raw_trace_point::RawTracePoint where T: ?core::marker::Sized
-pub fn aya::programs::raw_trace_point::RawTracePoint::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::programs::raw_trace_point::RawTracePoint where T: ?core::marker::Sized
-pub fn aya::programs::raw_trace_point::RawTracePoint::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya::programs::raw_trace_point::RawTracePoint
-pub fn aya::programs::raw_trace_point::RawTracePoint::from(t: T) -> T
 pub struct aya::programs::raw_trace_point::RawTracePointLink(_)
 impl aya::programs::links::Link for aya::programs::raw_trace_point::RawTracePointLink
 pub type aya::programs::raw_trace_point::RawTracePointLink::Id = aya::programs::raw_trace_point::RawTracePointLinkId
@@ -6128,26 +3764,6 @@ impl core::marker::Unpin for aya::programs::raw_trace_point::RawTracePointLink
 impl core::marker::UnsafeUnpin for aya::programs::raw_trace_point::RawTracePointLink
 impl core::panic::unwind_safe::RefUnwindSafe for aya::programs::raw_trace_point::RawTracePointLink
 impl core::panic::unwind_safe::UnwindSafe for aya::programs::raw_trace_point::RawTracePointLink
-impl<Q, K> equivalent::Equivalent<K> for aya::programs::raw_trace_point::RawTracePointLink where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
-pub fn aya::programs::raw_trace_point::RawTracePointLink::equivalent(&self, key: &K) -> bool
-impl<Q, K> hashbrown::Equivalent<K> for aya::programs::raw_trace_point::RawTracePointLink where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
-pub fn aya::programs::raw_trace_point::RawTracePointLink::equivalent(&self, key: &K) -> bool
-impl<T, U> core::convert::Into<U> for aya::programs::raw_trace_point::RawTracePointLink where U: core::convert::From<T>
-pub fn aya::programs::raw_trace_point::RawTracePointLink::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::programs::raw_trace_point::RawTracePointLink where U: core::convert::Into<T>
-pub type aya::programs::raw_trace_point::RawTracePointLink::Error = core::convert::Infallible
-pub fn aya::programs::raw_trace_point::RawTracePointLink::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::programs::raw_trace_point::RawTracePointLink where U: core::convert::TryFrom<T>
-pub type aya::programs::raw_trace_point::RawTracePointLink::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::programs::raw_trace_point::RawTracePointLink::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya::programs::raw_trace_point::RawTracePointLink where T: 'static + ?core::marker::Sized
-pub fn aya::programs::raw_trace_point::RawTracePointLink::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::programs::raw_trace_point::RawTracePointLink where T: ?core::marker::Sized
-pub fn aya::programs::raw_trace_point::RawTracePointLink::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::programs::raw_trace_point::RawTracePointLink where T: ?core::marker::Sized
-pub fn aya::programs::raw_trace_point::RawTracePointLink::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya::programs::raw_trace_point::RawTracePointLink
-pub fn aya::programs::raw_trace_point::RawTracePointLink::from(t: T) -> T
 pub struct aya::programs::raw_trace_point::RawTracePointLinkId(_)
 impl core::cmp::Eq for aya::programs::raw_trace_point::RawTracePointLinkId
 impl core::cmp::PartialEq for aya::programs::raw_trace_point::RawTracePointLinkId
@@ -6166,26 +3782,6 @@ impl core::marker::Unpin for aya::programs::raw_trace_point::RawTracePointLinkId
 impl core::marker::UnsafeUnpin for aya::programs::raw_trace_point::RawTracePointLinkId
 impl core::panic::unwind_safe::RefUnwindSafe for aya::programs::raw_trace_point::RawTracePointLinkId
 impl core::panic::unwind_safe::UnwindSafe for aya::programs::raw_trace_point::RawTracePointLinkId
-impl<Q, K> equivalent::Equivalent<K> for aya::programs::raw_trace_point::RawTracePointLinkId where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
-pub fn aya::programs::raw_trace_point::RawTracePointLinkId::equivalent(&self, key: &K) -> bool
-impl<Q, K> hashbrown::Equivalent<K> for aya::programs::raw_trace_point::RawTracePointLinkId where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
-pub fn aya::programs::raw_trace_point::RawTracePointLinkId::equivalent(&self, key: &K) -> bool
-impl<T, U> core::convert::Into<U> for aya::programs::raw_trace_point::RawTracePointLinkId where U: core::convert::From<T>
-pub fn aya::programs::raw_trace_point::RawTracePointLinkId::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::programs::raw_trace_point::RawTracePointLinkId where U: core::convert::Into<T>
-pub type aya::programs::raw_trace_point::RawTracePointLinkId::Error = core::convert::Infallible
-pub fn aya::programs::raw_trace_point::RawTracePointLinkId::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::programs::raw_trace_point::RawTracePointLinkId where U: core::convert::TryFrom<T>
-pub type aya::programs::raw_trace_point::RawTracePointLinkId::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::programs::raw_trace_point::RawTracePointLinkId::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya::programs::raw_trace_point::RawTracePointLinkId where T: 'static + ?core::marker::Sized
-pub fn aya::programs::raw_trace_point::RawTracePointLinkId::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::programs::raw_trace_point::RawTracePointLinkId where T: ?core::marker::Sized
-pub fn aya::programs::raw_trace_point::RawTracePointLinkId::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::programs::raw_trace_point::RawTracePointLinkId where T: ?core::marker::Sized
-pub fn aya::programs::raw_trace_point::RawTracePointLinkId::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya::programs::raw_trace_point::RawTracePointLinkId
-pub fn aya::programs::raw_trace_point::RawTracePointLinkId::from(t: T) -> T
 pub mod aya::programs::sk_lookup
 pub struct aya::programs::sk_lookup::SkLookup
 impl aya::programs::sk_lookup::SkLookup
@@ -6225,22 +3821,6 @@ impl core::marker::Unpin for aya::programs::sk_lookup::SkLookup
 impl core::marker::UnsafeUnpin for aya::programs::sk_lookup::SkLookup
 impl core::panic::unwind_safe::RefUnwindSafe for aya::programs::sk_lookup::SkLookup
 impl core::panic::unwind_safe::UnwindSafe for aya::programs::sk_lookup::SkLookup
-impl<T, U> core::convert::Into<U> for aya::programs::sk_lookup::SkLookup where U: core::convert::From<T>
-pub fn aya::programs::sk_lookup::SkLookup::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::programs::sk_lookup::SkLookup where U: core::convert::Into<T>
-pub type aya::programs::sk_lookup::SkLookup::Error = core::convert::Infallible
-pub fn aya::programs::sk_lookup::SkLookup::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::programs::sk_lookup::SkLookup where U: core::convert::TryFrom<T>
-pub type aya::programs::sk_lookup::SkLookup::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::programs::sk_lookup::SkLookup::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya::programs::sk_lookup::SkLookup where T: 'static + ?core::marker::Sized
-pub fn aya::programs::sk_lookup::SkLookup::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::programs::sk_lookup::SkLookup where T: ?core::marker::Sized
-pub fn aya::programs::sk_lookup::SkLookup::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::programs::sk_lookup::SkLookup where T: ?core::marker::Sized
-pub fn aya::programs::sk_lookup::SkLookup::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya::programs::sk_lookup::SkLookup
-pub fn aya::programs::sk_lookup::SkLookup::from(t: T) -> T
 pub struct aya::programs::sk_lookup::SkLookupLink(_)
 impl aya::programs::links::Link for aya::programs::sk_lookup::SkLookupLink
 pub type aya::programs::sk_lookup::SkLookupLink::Id = aya::programs::sk_lookup::SkLookupLinkId
@@ -6268,26 +3848,6 @@ impl core::marker::Unpin for aya::programs::sk_lookup::SkLookupLink
 impl core::marker::UnsafeUnpin for aya::programs::sk_lookup::SkLookupLink
 impl core::panic::unwind_safe::RefUnwindSafe for aya::programs::sk_lookup::SkLookupLink
 impl core::panic::unwind_safe::UnwindSafe for aya::programs::sk_lookup::SkLookupLink
-impl<Q, K> equivalent::Equivalent<K> for aya::programs::sk_lookup::SkLookupLink where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
-pub fn aya::programs::sk_lookup::SkLookupLink::equivalent(&self, key: &K) -> bool
-impl<Q, K> hashbrown::Equivalent<K> for aya::programs::sk_lookup::SkLookupLink where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
-pub fn aya::programs::sk_lookup::SkLookupLink::equivalent(&self, key: &K) -> bool
-impl<T, U> core::convert::Into<U> for aya::programs::sk_lookup::SkLookupLink where U: core::convert::From<T>
-pub fn aya::programs::sk_lookup::SkLookupLink::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::programs::sk_lookup::SkLookupLink where U: core::convert::Into<T>
-pub type aya::programs::sk_lookup::SkLookupLink::Error = core::convert::Infallible
-pub fn aya::programs::sk_lookup::SkLookupLink::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::programs::sk_lookup::SkLookupLink where U: core::convert::TryFrom<T>
-pub type aya::programs::sk_lookup::SkLookupLink::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::programs::sk_lookup::SkLookupLink::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya::programs::sk_lookup::SkLookupLink where T: 'static + ?core::marker::Sized
-pub fn aya::programs::sk_lookup::SkLookupLink::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::programs::sk_lookup::SkLookupLink where T: ?core::marker::Sized
-pub fn aya::programs::sk_lookup::SkLookupLink::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::programs::sk_lookup::SkLookupLink where T: ?core::marker::Sized
-pub fn aya::programs::sk_lookup::SkLookupLink::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya::programs::sk_lookup::SkLookupLink
-pub fn aya::programs::sk_lookup::SkLookupLink::from(t: T) -> T
 pub struct aya::programs::sk_lookup::SkLookupLinkId(_)
 impl core::cmp::Eq for aya::programs::sk_lookup::SkLookupLinkId
 impl core::cmp::PartialEq for aya::programs::sk_lookup::SkLookupLinkId
@@ -6306,26 +3866,6 @@ impl core::marker::Unpin for aya::programs::sk_lookup::SkLookupLinkId
 impl core::marker::UnsafeUnpin for aya::programs::sk_lookup::SkLookupLinkId
 impl core::panic::unwind_safe::RefUnwindSafe for aya::programs::sk_lookup::SkLookupLinkId
 impl core::panic::unwind_safe::UnwindSafe for aya::programs::sk_lookup::SkLookupLinkId
-impl<Q, K> equivalent::Equivalent<K> for aya::programs::sk_lookup::SkLookupLinkId where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
-pub fn aya::programs::sk_lookup::SkLookupLinkId::equivalent(&self, key: &K) -> bool
-impl<Q, K> hashbrown::Equivalent<K> for aya::programs::sk_lookup::SkLookupLinkId where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
-pub fn aya::programs::sk_lookup::SkLookupLinkId::equivalent(&self, key: &K) -> bool
-impl<T, U> core::convert::Into<U> for aya::programs::sk_lookup::SkLookupLinkId where U: core::convert::From<T>
-pub fn aya::programs::sk_lookup::SkLookupLinkId::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::programs::sk_lookup::SkLookupLinkId where U: core::convert::Into<T>
-pub type aya::programs::sk_lookup::SkLookupLinkId::Error = core::convert::Infallible
-pub fn aya::programs::sk_lookup::SkLookupLinkId::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::programs::sk_lookup::SkLookupLinkId where U: core::convert::TryFrom<T>
-pub type aya::programs::sk_lookup::SkLookupLinkId::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::programs::sk_lookup::SkLookupLinkId::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya::programs::sk_lookup::SkLookupLinkId where T: 'static + ?core::marker::Sized
-pub fn aya::programs::sk_lookup::SkLookupLinkId::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::programs::sk_lookup::SkLookupLinkId where T: ?core::marker::Sized
-pub fn aya::programs::sk_lookup::SkLookupLinkId::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::programs::sk_lookup::SkLookupLinkId where T: ?core::marker::Sized
-pub fn aya::programs::sk_lookup::SkLookupLinkId::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya::programs::sk_lookup::SkLookupLinkId
-pub fn aya::programs::sk_lookup::SkLookupLinkId::from(t: T) -> T
 pub mod aya::programs::sk_msg
 pub struct aya::programs::sk_msg::SkMsg
 impl aya::programs::sk_msg::SkMsg
@@ -6365,22 +3905,6 @@ impl core::marker::Unpin for aya::programs::sk_msg::SkMsg
 impl core::marker::UnsafeUnpin for aya::programs::sk_msg::SkMsg
 impl core::panic::unwind_safe::RefUnwindSafe for aya::programs::sk_msg::SkMsg
 impl core::panic::unwind_safe::UnwindSafe for aya::programs::sk_msg::SkMsg
-impl<T, U> core::convert::Into<U> for aya::programs::sk_msg::SkMsg where U: core::convert::From<T>
-pub fn aya::programs::sk_msg::SkMsg::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::programs::sk_msg::SkMsg where U: core::convert::Into<T>
-pub type aya::programs::sk_msg::SkMsg::Error = core::convert::Infallible
-pub fn aya::programs::sk_msg::SkMsg::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::programs::sk_msg::SkMsg where U: core::convert::TryFrom<T>
-pub type aya::programs::sk_msg::SkMsg::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::programs::sk_msg::SkMsg::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya::programs::sk_msg::SkMsg where T: 'static + ?core::marker::Sized
-pub fn aya::programs::sk_msg::SkMsg::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::programs::sk_msg::SkMsg where T: ?core::marker::Sized
-pub fn aya::programs::sk_msg::SkMsg::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::programs::sk_msg::SkMsg where T: ?core::marker::Sized
-pub fn aya::programs::sk_msg::SkMsg::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya::programs::sk_msg::SkMsg
-pub fn aya::programs::sk_msg::SkMsg::from(t: T) -> T
 pub struct aya::programs::sk_msg::SkMsgLink(_)
 impl aya::programs::links::Link for aya::programs::sk_msg::SkMsgLink
 pub type aya::programs::sk_msg::SkMsgLink::Id = aya::programs::sk_msg::SkMsgLinkId
@@ -6408,26 +3932,6 @@ impl core::marker::Unpin for aya::programs::sk_msg::SkMsgLink
 impl core::marker::UnsafeUnpin for aya::programs::sk_msg::SkMsgLink
 impl core::panic::unwind_safe::RefUnwindSafe for aya::programs::sk_msg::SkMsgLink
 impl core::panic::unwind_safe::UnwindSafe for aya::programs::sk_msg::SkMsgLink
-impl<Q, K> equivalent::Equivalent<K> for aya::programs::sk_msg::SkMsgLink where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
-pub fn aya::programs::sk_msg::SkMsgLink::equivalent(&self, key: &K) -> bool
-impl<Q, K> hashbrown::Equivalent<K> for aya::programs::sk_msg::SkMsgLink where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
-pub fn aya::programs::sk_msg::SkMsgLink::equivalent(&self, key: &K) -> bool
-impl<T, U> core::convert::Into<U> for aya::programs::sk_msg::SkMsgLink where U: core::convert::From<T>
-pub fn aya::programs::sk_msg::SkMsgLink::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::programs::sk_msg::SkMsgLink where U: core::convert::Into<T>
-pub type aya::programs::sk_msg::SkMsgLink::Error = core::convert::Infallible
-pub fn aya::programs::sk_msg::SkMsgLink::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::programs::sk_msg::SkMsgLink where U: core::convert::TryFrom<T>
-pub type aya::programs::sk_msg::SkMsgLink::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::programs::sk_msg::SkMsgLink::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya::programs::sk_msg::SkMsgLink where T: 'static + ?core::marker::Sized
-pub fn aya::programs::sk_msg::SkMsgLink::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::programs::sk_msg::SkMsgLink where T: ?core::marker::Sized
-pub fn aya::programs::sk_msg::SkMsgLink::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::programs::sk_msg::SkMsgLink where T: ?core::marker::Sized
-pub fn aya::programs::sk_msg::SkMsgLink::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya::programs::sk_msg::SkMsgLink
-pub fn aya::programs::sk_msg::SkMsgLink::from(t: T) -> T
 pub struct aya::programs::sk_msg::SkMsgLinkId(_)
 impl core::cmp::Eq for aya::programs::sk_msg::SkMsgLinkId
 impl core::cmp::PartialEq for aya::programs::sk_msg::SkMsgLinkId
@@ -6446,26 +3950,6 @@ impl core::marker::Unpin for aya::programs::sk_msg::SkMsgLinkId
 impl core::marker::UnsafeUnpin for aya::programs::sk_msg::SkMsgLinkId
 impl core::panic::unwind_safe::RefUnwindSafe for aya::programs::sk_msg::SkMsgLinkId
 impl core::panic::unwind_safe::UnwindSafe for aya::programs::sk_msg::SkMsgLinkId
-impl<Q, K> equivalent::Equivalent<K> for aya::programs::sk_msg::SkMsgLinkId where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
-pub fn aya::programs::sk_msg::SkMsgLinkId::equivalent(&self, key: &K) -> bool
-impl<Q, K> hashbrown::Equivalent<K> for aya::programs::sk_msg::SkMsgLinkId where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
-pub fn aya::programs::sk_msg::SkMsgLinkId::equivalent(&self, key: &K) -> bool
-impl<T, U> core::convert::Into<U> for aya::programs::sk_msg::SkMsgLinkId where U: core::convert::From<T>
-pub fn aya::programs::sk_msg::SkMsgLinkId::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::programs::sk_msg::SkMsgLinkId where U: core::convert::Into<T>
-pub type aya::programs::sk_msg::SkMsgLinkId::Error = core::convert::Infallible
-pub fn aya::programs::sk_msg::SkMsgLinkId::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::programs::sk_msg::SkMsgLinkId where U: core::convert::TryFrom<T>
-pub type aya::programs::sk_msg::SkMsgLinkId::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::programs::sk_msg::SkMsgLinkId::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya::programs::sk_msg::SkMsgLinkId where T: 'static + ?core::marker::Sized
-pub fn aya::programs::sk_msg::SkMsgLinkId::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::programs::sk_msg::SkMsgLinkId where T: ?core::marker::Sized
-pub fn aya::programs::sk_msg::SkMsgLinkId::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::programs::sk_msg::SkMsgLinkId where T: ?core::marker::Sized
-pub fn aya::programs::sk_msg::SkMsgLinkId::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya::programs::sk_msg::SkMsgLinkId
-pub fn aya::programs::sk_msg::SkMsgLinkId::from(t: T) -> T
 pub mod aya::programs::sk_skb
 pub use aya::programs::sk_skb::SkSkbKind
 pub struct aya::programs::sk_skb::SkSkb
@@ -6505,22 +3989,6 @@ impl core::marker::Unpin for aya::programs::sk_skb::SkSkb
 impl core::marker::UnsafeUnpin for aya::programs::sk_skb::SkSkb
 impl core::panic::unwind_safe::RefUnwindSafe for aya::programs::sk_skb::SkSkb
 impl core::panic::unwind_safe::UnwindSafe for aya::programs::sk_skb::SkSkb
-impl<T, U> core::convert::Into<U> for aya::programs::sk_skb::SkSkb where U: core::convert::From<T>
-pub fn aya::programs::sk_skb::SkSkb::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::programs::sk_skb::SkSkb where U: core::convert::Into<T>
-pub type aya::programs::sk_skb::SkSkb::Error = core::convert::Infallible
-pub fn aya::programs::sk_skb::SkSkb::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::programs::sk_skb::SkSkb where U: core::convert::TryFrom<T>
-pub type aya::programs::sk_skb::SkSkb::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::programs::sk_skb::SkSkb::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya::programs::sk_skb::SkSkb where T: 'static + ?core::marker::Sized
-pub fn aya::programs::sk_skb::SkSkb::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::programs::sk_skb::SkSkb where T: ?core::marker::Sized
-pub fn aya::programs::sk_skb::SkSkb::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::programs::sk_skb::SkSkb where T: ?core::marker::Sized
-pub fn aya::programs::sk_skb::SkSkb::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya::programs::sk_skb::SkSkb
-pub fn aya::programs::sk_skb::SkSkb::from(t: T) -> T
 pub struct aya::programs::sk_skb::SkSkbLink(_)
 impl aya::programs::links::Link for aya::programs::sk_skb::SkSkbLink
 pub type aya::programs::sk_skb::SkSkbLink::Id = aya::programs::sk_skb::SkSkbLinkId
@@ -6548,26 +4016,6 @@ impl core::marker::Unpin for aya::programs::sk_skb::SkSkbLink
 impl core::marker::UnsafeUnpin for aya::programs::sk_skb::SkSkbLink
 impl core::panic::unwind_safe::RefUnwindSafe for aya::programs::sk_skb::SkSkbLink
 impl core::panic::unwind_safe::UnwindSafe for aya::programs::sk_skb::SkSkbLink
-impl<Q, K> equivalent::Equivalent<K> for aya::programs::sk_skb::SkSkbLink where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
-pub fn aya::programs::sk_skb::SkSkbLink::equivalent(&self, key: &K) -> bool
-impl<Q, K> hashbrown::Equivalent<K> for aya::programs::sk_skb::SkSkbLink where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
-pub fn aya::programs::sk_skb::SkSkbLink::equivalent(&self, key: &K) -> bool
-impl<T, U> core::convert::Into<U> for aya::programs::sk_skb::SkSkbLink where U: core::convert::From<T>
-pub fn aya::programs::sk_skb::SkSkbLink::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::programs::sk_skb::SkSkbLink where U: core::convert::Into<T>
-pub type aya::programs::sk_skb::SkSkbLink::Error = core::convert::Infallible
-pub fn aya::programs::sk_skb::SkSkbLink::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::programs::sk_skb::SkSkbLink where U: core::convert::TryFrom<T>
-pub type aya::programs::sk_skb::SkSkbLink::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::programs::sk_skb::SkSkbLink::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya::programs::sk_skb::SkSkbLink where T: 'static + ?core::marker::Sized
-pub fn aya::programs::sk_skb::SkSkbLink::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::programs::sk_skb::SkSkbLink where T: ?core::marker::Sized
-pub fn aya::programs::sk_skb::SkSkbLink::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::programs::sk_skb::SkSkbLink where T: ?core::marker::Sized
-pub fn aya::programs::sk_skb::SkSkbLink::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya::programs::sk_skb::SkSkbLink
-pub fn aya::programs::sk_skb::SkSkbLink::from(t: T) -> T
 pub struct aya::programs::sk_skb::SkSkbLinkId(_)
 impl core::cmp::Eq for aya::programs::sk_skb::SkSkbLinkId
 impl core::cmp::PartialEq for aya::programs::sk_skb::SkSkbLinkId
@@ -6586,26 +4034,6 @@ impl core::marker::Unpin for aya::programs::sk_skb::SkSkbLinkId
 impl core::marker::UnsafeUnpin for aya::programs::sk_skb::SkSkbLinkId
 impl core::panic::unwind_safe::RefUnwindSafe for aya::programs::sk_skb::SkSkbLinkId
 impl core::panic::unwind_safe::UnwindSafe for aya::programs::sk_skb::SkSkbLinkId
-impl<Q, K> equivalent::Equivalent<K> for aya::programs::sk_skb::SkSkbLinkId where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
-pub fn aya::programs::sk_skb::SkSkbLinkId::equivalent(&self, key: &K) -> bool
-impl<Q, K> hashbrown::Equivalent<K> for aya::programs::sk_skb::SkSkbLinkId where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
-pub fn aya::programs::sk_skb::SkSkbLinkId::equivalent(&self, key: &K) -> bool
-impl<T, U> core::convert::Into<U> for aya::programs::sk_skb::SkSkbLinkId where U: core::convert::From<T>
-pub fn aya::programs::sk_skb::SkSkbLinkId::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::programs::sk_skb::SkSkbLinkId where U: core::convert::Into<T>
-pub type aya::programs::sk_skb::SkSkbLinkId::Error = core::convert::Infallible
-pub fn aya::programs::sk_skb::SkSkbLinkId::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::programs::sk_skb::SkSkbLinkId where U: core::convert::TryFrom<T>
-pub type aya::programs::sk_skb::SkSkbLinkId::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::programs::sk_skb::SkSkbLinkId::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya::programs::sk_skb::SkSkbLinkId where T: 'static + ?core::marker::Sized
-pub fn aya::programs::sk_skb::SkSkbLinkId::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::programs::sk_skb::SkSkbLinkId where T: ?core::marker::Sized
-pub fn aya::programs::sk_skb::SkSkbLinkId::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::programs::sk_skb::SkSkbLinkId where T: ?core::marker::Sized
-pub fn aya::programs::sk_skb::SkSkbLinkId::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya::programs::sk_skb::SkSkbLinkId
-pub fn aya::programs::sk_skb::SkSkbLinkId::from(t: T) -> T
 pub mod aya::programs::sock_ops
 pub struct aya::programs::sock_ops::SockOps
 impl aya::programs::sock_ops::SockOps
@@ -6645,22 +4073,6 @@ impl core::marker::Unpin for aya::programs::sock_ops::SockOps
 impl core::marker::UnsafeUnpin for aya::programs::sock_ops::SockOps
 impl core::panic::unwind_safe::RefUnwindSafe for aya::programs::sock_ops::SockOps
 impl core::panic::unwind_safe::UnwindSafe for aya::programs::sock_ops::SockOps
-impl<T, U> core::convert::Into<U> for aya::programs::sock_ops::SockOps where U: core::convert::From<T>
-pub fn aya::programs::sock_ops::SockOps::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::programs::sock_ops::SockOps where U: core::convert::Into<T>
-pub type aya::programs::sock_ops::SockOps::Error = core::convert::Infallible
-pub fn aya::programs::sock_ops::SockOps::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::programs::sock_ops::SockOps where U: core::convert::TryFrom<T>
-pub type aya::programs::sock_ops::SockOps::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::programs::sock_ops::SockOps::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya::programs::sock_ops::SockOps where T: 'static + ?core::marker::Sized
-pub fn aya::programs::sock_ops::SockOps::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::programs::sock_ops::SockOps where T: ?core::marker::Sized
-pub fn aya::programs::sock_ops::SockOps::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::programs::sock_ops::SockOps where T: ?core::marker::Sized
-pub fn aya::programs::sock_ops::SockOps::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya::programs::sock_ops::SockOps
-pub fn aya::programs::sock_ops::SockOps::from(t: T) -> T
 pub struct aya::programs::sock_ops::SockOpsLink(_)
 impl aya::programs::links::Link for aya::programs::sock_ops::SockOpsLink
 pub type aya::programs::sock_ops::SockOpsLink::Id = aya::programs::sock_ops::SockOpsLinkId
@@ -6687,26 +4099,6 @@ impl core::marker::Unpin for aya::programs::sock_ops::SockOpsLink
 impl core::marker::UnsafeUnpin for aya::programs::sock_ops::SockOpsLink
 impl core::panic::unwind_safe::RefUnwindSafe for aya::programs::sock_ops::SockOpsLink
 impl core::panic::unwind_safe::UnwindSafe for aya::programs::sock_ops::SockOpsLink
-impl<Q, K> equivalent::Equivalent<K> for aya::programs::sock_ops::SockOpsLink where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
-pub fn aya::programs::sock_ops::SockOpsLink::equivalent(&self, key: &K) -> bool
-impl<Q, K> hashbrown::Equivalent<K> for aya::programs::sock_ops::SockOpsLink where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
-pub fn aya::programs::sock_ops::SockOpsLink::equivalent(&self, key: &K) -> bool
-impl<T, U> core::convert::Into<U> for aya::programs::sock_ops::SockOpsLink where U: core::convert::From<T>
-pub fn aya::programs::sock_ops::SockOpsLink::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::programs::sock_ops::SockOpsLink where U: core::convert::Into<T>
-pub type aya::programs::sock_ops::SockOpsLink::Error = core::convert::Infallible
-pub fn aya::programs::sock_ops::SockOpsLink::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::programs::sock_ops::SockOpsLink where U: core::convert::TryFrom<T>
-pub type aya::programs::sock_ops::SockOpsLink::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::programs::sock_ops::SockOpsLink::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya::programs::sock_ops::SockOpsLink where T: 'static + ?core::marker::Sized
-pub fn aya::programs::sock_ops::SockOpsLink::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::programs::sock_ops::SockOpsLink where T: ?core::marker::Sized
-pub fn aya::programs::sock_ops::SockOpsLink::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::programs::sock_ops::SockOpsLink where T: ?core::marker::Sized
-pub fn aya::programs::sock_ops::SockOpsLink::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya::programs::sock_ops::SockOpsLink
-pub fn aya::programs::sock_ops::SockOpsLink::from(t: T) -> T
 pub struct aya::programs::sock_ops::SockOpsLinkId(_)
 impl core::cmp::Eq for aya::programs::sock_ops::SockOpsLinkId
 impl core::cmp::PartialEq for aya::programs::sock_ops::SockOpsLinkId
@@ -6725,26 +4117,6 @@ impl core::marker::Unpin for aya::programs::sock_ops::SockOpsLinkId
 impl core::marker::UnsafeUnpin for aya::programs::sock_ops::SockOpsLinkId
 impl core::panic::unwind_safe::RefUnwindSafe for aya::programs::sock_ops::SockOpsLinkId
 impl core::panic::unwind_safe::UnwindSafe for aya::programs::sock_ops::SockOpsLinkId
-impl<Q, K> equivalent::Equivalent<K> for aya::programs::sock_ops::SockOpsLinkId where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
-pub fn aya::programs::sock_ops::SockOpsLinkId::equivalent(&self, key: &K) -> bool
-impl<Q, K> hashbrown::Equivalent<K> for aya::programs::sock_ops::SockOpsLinkId where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
-pub fn aya::programs::sock_ops::SockOpsLinkId::equivalent(&self, key: &K) -> bool
-impl<T, U> core::convert::Into<U> for aya::programs::sock_ops::SockOpsLinkId where U: core::convert::From<T>
-pub fn aya::programs::sock_ops::SockOpsLinkId::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::programs::sock_ops::SockOpsLinkId where U: core::convert::Into<T>
-pub type aya::programs::sock_ops::SockOpsLinkId::Error = core::convert::Infallible
-pub fn aya::programs::sock_ops::SockOpsLinkId::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::programs::sock_ops::SockOpsLinkId where U: core::convert::TryFrom<T>
-pub type aya::programs::sock_ops::SockOpsLinkId::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::programs::sock_ops::SockOpsLinkId::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya::programs::sock_ops::SockOpsLinkId where T: 'static + ?core::marker::Sized
-pub fn aya::programs::sock_ops::SockOpsLinkId::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::programs::sock_ops::SockOpsLinkId where T: ?core::marker::Sized
-pub fn aya::programs::sock_ops::SockOpsLinkId::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::programs::sock_ops::SockOpsLinkId where T: ?core::marker::Sized
-pub fn aya::programs::sock_ops::SockOpsLinkId::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya::programs::sock_ops::SockOpsLinkId
-pub fn aya::programs::sock_ops::SockOpsLinkId::from(t: T) -> T
 pub mod aya::programs::socket_filter
 pub enum aya::programs::socket_filter::SocketFilterError
 pub aya::programs::socket_filter::SocketFilterError::SoAttachEbpfError
@@ -6764,24 +4136,6 @@ impl core::marker::Unpin for aya::programs::socket_filter::SocketFilterError
 impl core::marker::UnsafeUnpin for aya::programs::socket_filter::SocketFilterError
 impl !core::panic::unwind_safe::RefUnwindSafe for aya::programs::socket_filter::SocketFilterError
 impl !core::panic::unwind_safe::UnwindSafe for aya::programs::socket_filter::SocketFilterError
-impl<T, U> core::convert::Into<U> for aya::programs::socket_filter::SocketFilterError where U: core::convert::From<T>
-pub fn aya::programs::socket_filter::SocketFilterError::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::programs::socket_filter::SocketFilterError where U: core::convert::Into<T>
-pub type aya::programs::socket_filter::SocketFilterError::Error = core::convert::Infallible
-pub fn aya::programs::socket_filter::SocketFilterError::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::programs::socket_filter::SocketFilterError where U: core::convert::TryFrom<T>
-pub type aya::programs::socket_filter::SocketFilterError::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::programs::socket_filter::SocketFilterError::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::string::ToString for aya::programs::socket_filter::SocketFilterError where T: core::fmt::Display + ?core::marker::Sized
-pub fn aya::programs::socket_filter::SocketFilterError::to_string(&self) -> alloc::string::String
-impl<T> core::any::Any for aya::programs::socket_filter::SocketFilterError where T: 'static + ?core::marker::Sized
-pub fn aya::programs::socket_filter::SocketFilterError::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::programs::socket_filter::SocketFilterError where T: ?core::marker::Sized
-pub fn aya::programs::socket_filter::SocketFilterError::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::programs::socket_filter::SocketFilterError where T: ?core::marker::Sized
-pub fn aya::programs::socket_filter::SocketFilterError::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya::programs::socket_filter::SocketFilterError
-pub fn aya::programs::socket_filter::SocketFilterError::from(t: T) -> T
 pub struct aya::programs::socket_filter::SocketFilter
 impl aya::programs::socket_filter::SocketFilter
 pub const aya::programs::socket_filter::SocketFilter::PROGRAM_TYPE: aya::programs::ProgramType
@@ -6817,22 +4171,6 @@ impl core::marker::Unpin for aya::programs::socket_filter::SocketFilter
 impl core::marker::UnsafeUnpin for aya::programs::socket_filter::SocketFilter
 impl core::panic::unwind_safe::RefUnwindSafe for aya::programs::socket_filter::SocketFilter
 impl core::panic::unwind_safe::UnwindSafe for aya::programs::socket_filter::SocketFilter
-impl<T, U> core::convert::Into<U> for aya::programs::socket_filter::SocketFilter where U: core::convert::From<T>
-pub fn aya::programs::socket_filter::SocketFilter::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::programs::socket_filter::SocketFilter where U: core::convert::Into<T>
-pub type aya::programs::socket_filter::SocketFilter::Error = core::convert::Infallible
-pub fn aya::programs::socket_filter::SocketFilter::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::programs::socket_filter::SocketFilter where U: core::convert::TryFrom<T>
-pub type aya::programs::socket_filter::SocketFilter::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::programs::socket_filter::SocketFilter::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya::programs::socket_filter::SocketFilter where T: 'static + ?core::marker::Sized
-pub fn aya::programs::socket_filter::SocketFilter::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::programs::socket_filter::SocketFilter where T: ?core::marker::Sized
-pub fn aya::programs::socket_filter::SocketFilter::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::programs::socket_filter::SocketFilter where T: ?core::marker::Sized
-pub fn aya::programs::socket_filter::SocketFilter::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya::programs::socket_filter::SocketFilter
-pub fn aya::programs::socket_filter::SocketFilter::from(t: T) -> T
 pub struct aya::programs::socket_filter::SocketFilterLink
 impl aya::programs::links::Link for aya::programs::socket_filter::SocketFilterLink
 pub type aya::programs::socket_filter::SocketFilterLink::Id = aya::programs::socket_filter::SocketFilterLinkId
@@ -6854,26 +4192,6 @@ impl core::marker::Unpin for aya::programs::socket_filter::SocketFilterLink
 impl core::marker::UnsafeUnpin for aya::programs::socket_filter::SocketFilterLink
 impl core::panic::unwind_safe::RefUnwindSafe for aya::programs::socket_filter::SocketFilterLink
 impl core::panic::unwind_safe::UnwindSafe for aya::programs::socket_filter::SocketFilterLink
-impl<Q, K> equivalent::Equivalent<K> for aya::programs::socket_filter::SocketFilterLink where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
-pub fn aya::programs::socket_filter::SocketFilterLink::equivalent(&self, key: &K) -> bool
-impl<Q, K> hashbrown::Equivalent<K> for aya::programs::socket_filter::SocketFilterLink where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
-pub fn aya::programs::socket_filter::SocketFilterLink::equivalent(&self, key: &K) -> bool
-impl<T, U> core::convert::Into<U> for aya::programs::socket_filter::SocketFilterLink where U: core::convert::From<T>
-pub fn aya::programs::socket_filter::SocketFilterLink::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::programs::socket_filter::SocketFilterLink where U: core::convert::Into<T>
-pub type aya::programs::socket_filter::SocketFilterLink::Error = core::convert::Infallible
-pub fn aya::programs::socket_filter::SocketFilterLink::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::programs::socket_filter::SocketFilterLink where U: core::convert::TryFrom<T>
-pub type aya::programs::socket_filter::SocketFilterLink::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::programs::socket_filter::SocketFilterLink::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya::programs::socket_filter::SocketFilterLink where T: 'static + ?core::marker::Sized
-pub fn aya::programs::socket_filter::SocketFilterLink::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::programs::socket_filter::SocketFilterLink where T: ?core::marker::Sized
-pub fn aya::programs::socket_filter::SocketFilterLink::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::programs::socket_filter::SocketFilterLink where T: ?core::marker::Sized
-pub fn aya::programs::socket_filter::SocketFilterLink::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya::programs::socket_filter::SocketFilterLink
-pub fn aya::programs::socket_filter::SocketFilterLink::from(t: T) -> T
 pub struct aya::programs::socket_filter::SocketFilterLinkId(_, _)
 impl core::cmp::Eq for aya::programs::socket_filter::SocketFilterLinkId
 impl core::cmp::PartialEq for aya::programs::socket_filter::SocketFilterLinkId
@@ -6892,26 +4210,6 @@ impl core::marker::Unpin for aya::programs::socket_filter::SocketFilterLinkId
 impl core::marker::UnsafeUnpin for aya::programs::socket_filter::SocketFilterLinkId
 impl core::panic::unwind_safe::RefUnwindSafe for aya::programs::socket_filter::SocketFilterLinkId
 impl core::panic::unwind_safe::UnwindSafe for aya::programs::socket_filter::SocketFilterLinkId
-impl<Q, K> equivalent::Equivalent<K> for aya::programs::socket_filter::SocketFilterLinkId where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
-pub fn aya::programs::socket_filter::SocketFilterLinkId::equivalent(&self, key: &K) -> bool
-impl<Q, K> hashbrown::Equivalent<K> for aya::programs::socket_filter::SocketFilterLinkId where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
-pub fn aya::programs::socket_filter::SocketFilterLinkId::equivalent(&self, key: &K) -> bool
-impl<T, U> core::convert::Into<U> for aya::programs::socket_filter::SocketFilterLinkId where U: core::convert::From<T>
-pub fn aya::programs::socket_filter::SocketFilterLinkId::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::programs::socket_filter::SocketFilterLinkId where U: core::convert::Into<T>
-pub type aya::programs::socket_filter::SocketFilterLinkId::Error = core::convert::Infallible
-pub fn aya::programs::socket_filter::SocketFilterLinkId::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::programs::socket_filter::SocketFilterLinkId where U: core::convert::TryFrom<T>
-pub type aya::programs::socket_filter::SocketFilterLinkId::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::programs::socket_filter::SocketFilterLinkId::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya::programs::socket_filter::SocketFilterLinkId where T: 'static + ?core::marker::Sized
-pub fn aya::programs::socket_filter::SocketFilterLinkId::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::programs::socket_filter::SocketFilterLinkId where T: ?core::marker::Sized
-pub fn aya::programs::socket_filter::SocketFilterLinkId::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::programs::socket_filter::SocketFilterLinkId where T: ?core::marker::Sized
-pub fn aya::programs::socket_filter::SocketFilterLinkId::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya::programs::socket_filter::SocketFilterLinkId
-pub fn aya::programs::socket_filter::SocketFilterLinkId::from(t: T) -> T
 pub mod aya::programs::tc
 pub enum aya::programs::tc::TcAttachOptions
 pub aya::programs::tc::TcAttachOptions::Netlink(aya::programs::tc::NlOptions)
@@ -6925,22 +4223,6 @@ impl core::marker::Unpin for aya::programs::tc::TcAttachOptions
 impl core::marker::UnsafeUnpin for aya::programs::tc::TcAttachOptions
 impl core::panic::unwind_safe::RefUnwindSafe for aya::programs::tc::TcAttachOptions
 impl core::panic::unwind_safe::UnwindSafe for aya::programs::tc::TcAttachOptions
-impl<T, U> core::convert::Into<U> for aya::programs::tc::TcAttachOptions where U: core::convert::From<T>
-pub fn aya::programs::tc::TcAttachOptions::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::programs::tc::TcAttachOptions where U: core::convert::Into<T>
-pub type aya::programs::tc::TcAttachOptions::Error = core::convert::Infallible
-pub fn aya::programs::tc::TcAttachOptions::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::programs::tc::TcAttachOptions where U: core::convert::TryFrom<T>
-pub type aya::programs::tc::TcAttachOptions::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::programs::tc::TcAttachOptions::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya::programs::tc::TcAttachOptions where T: 'static + ?core::marker::Sized
-pub fn aya::programs::tc::TcAttachOptions::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::programs::tc::TcAttachOptions where T: ?core::marker::Sized
-pub fn aya::programs::tc::TcAttachOptions::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::programs::tc::TcAttachOptions where T: ?core::marker::Sized
-pub fn aya::programs::tc::TcAttachOptions::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya::programs::tc::TcAttachOptions
-pub fn aya::programs::tc::TcAttachOptions::from(t: T) -> T
 pub enum aya::programs::tc::TcAttachType
 pub aya::programs::tc::TcAttachType::Custom(u32)
 pub aya::programs::tc::TcAttachType::Egress
@@ -6963,32 +4245,6 @@ impl core::marker::Unpin for aya::programs::tc::TcAttachType
 impl core::marker::UnsafeUnpin for aya::programs::tc::TcAttachType
 impl core::panic::unwind_safe::RefUnwindSafe for aya::programs::tc::TcAttachType
 impl core::panic::unwind_safe::UnwindSafe for aya::programs::tc::TcAttachType
-impl<Q, K> equivalent::Equivalent<K> for aya::programs::tc::TcAttachType where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
-pub fn aya::programs::tc::TcAttachType::equivalent(&self, key: &K) -> bool
-impl<Q, K> hashbrown::Equivalent<K> for aya::programs::tc::TcAttachType where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
-pub fn aya::programs::tc::TcAttachType::equivalent(&self, key: &K) -> bool
-impl<T, U> core::convert::Into<U> for aya::programs::tc::TcAttachType where U: core::convert::From<T>
-pub fn aya::programs::tc::TcAttachType::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::programs::tc::TcAttachType where U: core::convert::Into<T>
-pub type aya::programs::tc::TcAttachType::Error = core::convert::Infallible
-pub fn aya::programs::tc::TcAttachType::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::programs::tc::TcAttachType where U: core::convert::TryFrom<T>
-pub type aya::programs::tc::TcAttachType::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::programs::tc::TcAttachType::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya::programs::tc::TcAttachType where T: core::clone::Clone
-pub type aya::programs::tc::TcAttachType::Owned = T
-pub fn aya::programs::tc::TcAttachType::clone_into(&self, target: &mut T)
-pub fn aya::programs::tc::TcAttachType::to_owned(&self) -> T
-impl<T> core::any::Any for aya::programs::tc::TcAttachType where T: 'static + ?core::marker::Sized
-pub fn aya::programs::tc::TcAttachType::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::programs::tc::TcAttachType where T: ?core::marker::Sized
-pub fn aya::programs::tc::TcAttachType::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::programs::tc::TcAttachType where T: ?core::marker::Sized
-pub fn aya::programs::tc::TcAttachType::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya::programs::tc::TcAttachType where T: core::clone::Clone
-pub unsafe fn aya::programs::tc::TcAttachType::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya::programs::tc::TcAttachType
-pub fn aya::programs::tc::TcAttachType::from(t: T) -> T
 pub enum aya::programs::tc::TcError
 pub aya::programs::tc::TcError::AlreadyAttached
 pub aya::programs::tc::TcError::InvalidLinkOperation
@@ -7015,24 +4271,6 @@ impl core::marker::Unpin for aya::programs::tc::TcError
 impl core::marker::UnsafeUnpin for aya::programs::tc::TcError
 impl !core::panic::unwind_safe::RefUnwindSafe for aya::programs::tc::TcError
 impl !core::panic::unwind_safe::UnwindSafe for aya::programs::tc::TcError
-impl<T, U> core::convert::Into<U> for aya::programs::tc::TcError where U: core::convert::From<T>
-pub fn aya::programs::tc::TcError::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::programs::tc::TcError where U: core::convert::Into<T>
-pub type aya::programs::tc::TcError::Error = core::convert::Infallible
-pub fn aya::programs::tc::TcError::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::programs::tc::TcError where U: core::convert::TryFrom<T>
-pub type aya::programs::tc::TcError::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::programs::tc::TcError::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::string::ToString for aya::programs::tc::TcError where T: core::fmt::Display + ?core::marker::Sized
-pub fn aya::programs::tc::TcError::to_string(&self) -> alloc::string::String
-impl<T> core::any::Any for aya::programs::tc::TcError where T: 'static + ?core::marker::Sized
-pub fn aya::programs::tc::TcError::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::programs::tc::TcError where T: ?core::marker::Sized
-pub fn aya::programs::tc::TcError::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::programs::tc::TcError where T: ?core::marker::Sized
-pub fn aya::programs::tc::TcError::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya::programs::tc::TcError
-pub fn aya::programs::tc::TcError::from(t: T) -> T
 pub struct aya::programs::tc::NlOptions
 pub aya::programs::tc::NlOptions::handle: u32
 pub aya::programs::tc::NlOptions::priority: u16
@@ -7053,26 +4291,6 @@ impl core::marker::Unpin for aya::programs::tc::NlOptions
 impl core::marker::UnsafeUnpin for aya::programs::tc::NlOptions
 impl core::panic::unwind_safe::RefUnwindSafe for aya::programs::tc::NlOptions
 impl core::panic::unwind_safe::UnwindSafe for aya::programs::tc::NlOptions
-impl<Q, K> equivalent::Equivalent<K> for aya::programs::tc::NlOptions where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
-pub fn aya::programs::tc::NlOptions::equivalent(&self, key: &K) -> bool
-impl<Q, K> hashbrown::Equivalent<K> for aya::programs::tc::NlOptions where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
-pub fn aya::programs::tc::NlOptions::equivalent(&self, key: &K) -> bool
-impl<T, U> core::convert::Into<U> for aya::programs::tc::NlOptions where U: core::convert::From<T>
-pub fn aya::programs::tc::NlOptions::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::programs::tc::NlOptions where U: core::convert::Into<T>
-pub type aya::programs::tc::NlOptions::Error = core::convert::Infallible
-pub fn aya::programs::tc::NlOptions::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::programs::tc::NlOptions where U: core::convert::TryFrom<T>
-pub type aya::programs::tc::NlOptions::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::programs::tc::NlOptions::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya::programs::tc::NlOptions where T: 'static + ?core::marker::Sized
-pub fn aya::programs::tc::NlOptions::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::programs::tc::NlOptions where T: ?core::marker::Sized
-pub fn aya::programs::tc::NlOptions::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::programs::tc::NlOptions where T: ?core::marker::Sized
-pub fn aya::programs::tc::NlOptions::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya::programs::tc::NlOptions
-pub fn aya::programs::tc::NlOptions::from(t: T) -> T
 pub struct aya::programs::tc::SchedClassifier
 impl aya::programs::tc::SchedClassifier
 pub const aya::programs::tc::SchedClassifier::PROGRAM_TYPE: aya::programs::ProgramType
@@ -7115,22 +4333,6 @@ impl core::marker::Unpin for aya::programs::tc::SchedClassifier
 impl core::marker::UnsafeUnpin for aya::programs::tc::SchedClassifier
 impl core::panic::unwind_safe::RefUnwindSafe for aya::programs::tc::SchedClassifier
 impl core::panic::unwind_safe::UnwindSafe for aya::programs::tc::SchedClassifier
-impl<T, U> core::convert::Into<U> for aya::programs::tc::SchedClassifier where U: core::convert::From<T>
-pub fn aya::programs::tc::SchedClassifier::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::programs::tc::SchedClassifier where U: core::convert::Into<T>
-pub type aya::programs::tc::SchedClassifier::Error = core::convert::Infallible
-pub fn aya::programs::tc::SchedClassifier::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::programs::tc::SchedClassifier where U: core::convert::TryFrom<T>
-pub type aya::programs::tc::SchedClassifier::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::programs::tc::SchedClassifier::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya::programs::tc::SchedClassifier where T: 'static + ?core::marker::Sized
-pub fn aya::programs::tc::SchedClassifier::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::programs::tc::SchedClassifier where T: ?core::marker::Sized
-pub fn aya::programs::tc::SchedClassifier::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::programs::tc::SchedClassifier where T: ?core::marker::Sized
-pub fn aya::programs::tc::SchedClassifier::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya::programs::tc::SchedClassifier
-pub fn aya::programs::tc::SchedClassifier::from(t: T) -> T
 pub struct aya::programs::tc::SchedClassifierLink(_)
 impl aya::programs::tc::SchedClassifierLink
 pub fn aya::programs::tc::SchedClassifierLink::attach_type(&self) -> core::result::Result<aya::programs::tc::TcAttachType, aya::programs::ProgramError>
@@ -7170,26 +4372,6 @@ impl core::marker::Unpin for aya::programs::tc::SchedClassifierLink
 impl core::marker::UnsafeUnpin for aya::programs::tc::SchedClassifierLink
 impl core::panic::unwind_safe::RefUnwindSafe for aya::programs::tc::SchedClassifierLink
 impl core::panic::unwind_safe::UnwindSafe for aya::programs::tc::SchedClassifierLink
-impl<Q, K> equivalent::Equivalent<K> for aya::programs::tc::SchedClassifierLink where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
-pub fn aya::programs::tc::SchedClassifierLink::equivalent(&self, key: &K) -> bool
-impl<Q, K> hashbrown::Equivalent<K> for aya::programs::tc::SchedClassifierLink where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
-pub fn aya::programs::tc::SchedClassifierLink::equivalent(&self, key: &K) -> bool
-impl<T, U> core::convert::Into<U> for aya::programs::tc::SchedClassifierLink where U: core::convert::From<T>
-pub fn aya::programs::tc::SchedClassifierLink::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::programs::tc::SchedClassifierLink where U: core::convert::Into<T>
-pub type aya::programs::tc::SchedClassifierLink::Error = core::convert::Infallible
-pub fn aya::programs::tc::SchedClassifierLink::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::programs::tc::SchedClassifierLink where U: core::convert::TryFrom<T>
-pub type aya::programs::tc::SchedClassifierLink::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::programs::tc::SchedClassifierLink::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya::programs::tc::SchedClassifierLink where T: 'static + ?core::marker::Sized
-pub fn aya::programs::tc::SchedClassifierLink::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::programs::tc::SchedClassifierLink where T: ?core::marker::Sized
-pub fn aya::programs::tc::SchedClassifierLink::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::programs::tc::SchedClassifierLink where T: ?core::marker::Sized
-pub fn aya::programs::tc::SchedClassifierLink::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya::programs::tc::SchedClassifierLink
-pub fn aya::programs::tc::SchedClassifierLink::from(t: T) -> T
 pub struct aya::programs::tc::SchedClassifierLinkId(_)
 impl core::cmp::Eq for aya::programs::tc::SchedClassifierLinkId
 impl core::cmp::PartialEq for aya::programs::tc::SchedClassifierLinkId
@@ -7208,26 +4390,6 @@ impl core::marker::Unpin for aya::programs::tc::SchedClassifierLinkId
 impl core::marker::UnsafeUnpin for aya::programs::tc::SchedClassifierLinkId
 impl core::panic::unwind_safe::RefUnwindSafe for aya::programs::tc::SchedClassifierLinkId
 impl core::panic::unwind_safe::UnwindSafe for aya::programs::tc::SchedClassifierLinkId
-impl<Q, K> equivalent::Equivalent<K> for aya::programs::tc::SchedClassifierLinkId where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
-pub fn aya::programs::tc::SchedClassifierLinkId::equivalent(&self, key: &K) -> bool
-impl<Q, K> hashbrown::Equivalent<K> for aya::programs::tc::SchedClassifierLinkId where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
-pub fn aya::programs::tc::SchedClassifierLinkId::equivalent(&self, key: &K) -> bool
-impl<T, U> core::convert::Into<U> for aya::programs::tc::SchedClassifierLinkId where U: core::convert::From<T>
-pub fn aya::programs::tc::SchedClassifierLinkId::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::programs::tc::SchedClassifierLinkId where U: core::convert::Into<T>
-pub type aya::programs::tc::SchedClassifierLinkId::Error = core::convert::Infallible
-pub fn aya::programs::tc::SchedClassifierLinkId::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::programs::tc::SchedClassifierLinkId where U: core::convert::TryFrom<T>
-pub type aya::programs::tc::SchedClassifierLinkId::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::programs::tc::SchedClassifierLinkId::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya::programs::tc::SchedClassifierLinkId where T: 'static + ?core::marker::Sized
-pub fn aya::programs::tc::SchedClassifierLinkId::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::programs::tc::SchedClassifierLinkId where T: ?core::marker::Sized
-pub fn aya::programs::tc::SchedClassifierLinkId::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::programs::tc::SchedClassifierLinkId where T: ?core::marker::Sized
-pub fn aya::programs::tc::SchedClassifierLinkId::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya::programs::tc::SchedClassifierLinkId
-pub fn aya::programs::tc::SchedClassifierLinkId::from(t: T) -> T
 pub fn aya::programs::tc::qdisc_add_clsact(if_name: &str) -> core::result::Result<(), aya::programs::tc::TcError>
 pub fn aya::programs::tc::qdisc_detach_program(if_name: &str, attach_type: aya::programs::tc::TcAttachType, name: &str) -> core::result::Result<(), aya::programs::tc::TcError>
 pub mod aya::programs::tp_btf
@@ -7269,22 +4431,6 @@ impl core::marker::Unpin for aya::programs::tp_btf::BtfTracePoint
 impl core::marker::UnsafeUnpin for aya::programs::tp_btf::BtfTracePoint
 impl core::panic::unwind_safe::RefUnwindSafe for aya::programs::tp_btf::BtfTracePoint
 impl core::panic::unwind_safe::UnwindSafe for aya::programs::tp_btf::BtfTracePoint
-impl<T, U> core::convert::Into<U> for aya::programs::tp_btf::BtfTracePoint where U: core::convert::From<T>
-pub fn aya::programs::tp_btf::BtfTracePoint::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::programs::tp_btf::BtfTracePoint where U: core::convert::Into<T>
-pub type aya::programs::tp_btf::BtfTracePoint::Error = core::convert::Infallible
-pub fn aya::programs::tp_btf::BtfTracePoint::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::programs::tp_btf::BtfTracePoint where U: core::convert::TryFrom<T>
-pub type aya::programs::tp_btf::BtfTracePoint::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::programs::tp_btf::BtfTracePoint::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya::programs::tp_btf::BtfTracePoint where T: 'static + ?core::marker::Sized
-pub fn aya::programs::tp_btf::BtfTracePoint::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::programs::tp_btf::BtfTracePoint where T: ?core::marker::Sized
-pub fn aya::programs::tp_btf::BtfTracePoint::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::programs::tp_btf::BtfTracePoint where T: ?core::marker::Sized
-pub fn aya::programs::tp_btf::BtfTracePoint::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya::programs::tp_btf::BtfTracePoint
-pub fn aya::programs::tp_btf::BtfTracePoint::from(t: T) -> T
 pub struct aya::programs::tp_btf::BtfTracePointLink(_)
 impl aya::programs::links::Link for aya::programs::tp_btf::BtfTracePointLink
 pub type aya::programs::tp_btf::BtfTracePointLink::Id = aya::programs::tp_btf::BtfTracePointLinkId
@@ -7312,26 +4458,6 @@ impl core::marker::Unpin for aya::programs::tp_btf::BtfTracePointLink
 impl core::marker::UnsafeUnpin for aya::programs::tp_btf::BtfTracePointLink
 impl core::panic::unwind_safe::RefUnwindSafe for aya::programs::tp_btf::BtfTracePointLink
 impl core::panic::unwind_safe::UnwindSafe for aya::programs::tp_btf::BtfTracePointLink
-impl<Q, K> equivalent::Equivalent<K> for aya::programs::tp_btf::BtfTracePointLink where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
-pub fn aya::programs::tp_btf::BtfTracePointLink::equivalent(&self, key: &K) -> bool
-impl<Q, K> hashbrown::Equivalent<K> for aya::programs::tp_btf::BtfTracePointLink where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
-pub fn aya::programs::tp_btf::BtfTracePointLink::equivalent(&self, key: &K) -> bool
-impl<T, U> core::convert::Into<U> for aya::programs::tp_btf::BtfTracePointLink where U: core::convert::From<T>
-pub fn aya::programs::tp_btf::BtfTracePointLink::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::programs::tp_btf::BtfTracePointLink where U: core::convert::Into<T>
-pub type aya::programs::tp_btf::BtfTracePointLink::Error = core::convert::Infallible
-pub fn aya::programs::tp_btf::BtfTracePointLink::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::programs::tp_btf::BtfTracePointLink where U: core::convert::TryFrom<T>
-pub type aya::programs::tp_btf::BtfTracePointLink::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::programs::tp_btf::BtfTracePointLink::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya::programs::tp_btf::BtfTracePointLink where T: 'static + ?core::marker::Sized
-pub fn aya::programs::tp_btf::BtfTracePointLink::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::programs::tp_btf::BtfTracePointLink where T: ?core::marker::Sized
-pub fn aya::programs::tp_btf::BtfTracePointLink::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::programs::tp_btf::BtfTracePointLink where T: ?core::marker::Sized
-pub fn aya::programs::tp_btf::BtfTracePointLink::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya::programs::tp_btf::BtfTracePointLink
-pub fn aya::programs::tp_btf::BtfTracePointLink::from(t: T) -> T
 pub struct aya::programs::tp_btf::BtfTracePointLinkId(_)
 impl core::cmp::Eq for aya::programs::tp_btf::BtfTracePointLinkId
 impl core::cmp::PartialEq for aya::programs::tp_btf::BtfTracePointLinkId
@@ -7350,26 +4476,6 @@ impl core::marker::Unpin for aya::programs::tp_btf::BtfTracePointLinkId
 impl core::marker::UnsafeUnpin for aya::programs::tp_btf::BtfTracePointLinkId
 impl core::panic::unwind_safe::RefUnwindSafe for aya::programs::tp_btf::BtfTracePointLinkId
 impl core::panic::unwind_safe::UnwindSafe for aya::programs::tp_btf::BtfTracePointLinkId
-impl<Q, K> equivalent::Equivalent<K> for aya::programs::tp_btf::BtfTracePointLinkId where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
-pub fn aya::programs::tp_btf::BtfTracePointLinkId::equivalent(&self, key: &K) -> bool
-impl<Q, K> hashbrown::Equivalent<K> for aya::programs::tp_btf::BtfTracePointLinkId where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
-pub fn aya::programs::tp_btf::BtfTracePointLinkId::equivalent(&self, key: &K) -> bool
-impl<T, U> core::convert::Into<U> for aya::programs::tp_btf::BtfTracePointLinkId where U: core::convert::From<T>
-pub fn aya::programs::tp_btf::BtfTracePointLinkId::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::programs::tp_btf::BtfTracePointLinkId where U: core::convert::Into<T>
-pub type aya::programs::tp_btf::BtfTracePointLinkId::Error = core::convert::Infallible
-pub fn aya::programs::tp_btf::BtfTracePointLinkId::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::programs::tp_btf::BtfTracePointLinkId where U: core::convert::TryFrom<T>
-pub type aya::programs::tp_btf::BtfTracePointLinkId::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::programs::tp_btf::BtfTracePointLinkId::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya::programs::tp_btf::BtfTracePointLinkId where T: 'static + ?core::marker::Sized
-pub fn aya::programs::tp_btf::BtfTracePointLinkId::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::programs::tp_btf::BtfTracePointLinkId where T: ?core::marker::Sized
-pub fn aya::programs::tp_btf::BtfTracePointLinkId::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::programs::tp_btf::BtfTracePointLinkId where T: ?core::marker::Sized
-pub fn aya::programs::tp_btf::BtfTracePointLinkId::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya::programs::tp_btf::BtfTracePointLinkId
-pub fn aya::programs::tp_btf::BtfTracePointLinkId::from(t: T) -> T
 pub mod aya::programs::trace_point
 pub enum aya::programs::trace_point::TracePointError
 pub aya::programs::trace_point::TracePointError::FileError
@@ -7390,24 +4496,6 @@ impl core::marker::Unpin for aya::programs::trace_point::TracePointError
 impl core::marker::UnsafeUnpin for aya::programs::trace_point::TracePointError
 impl !core::panic::unwind_safe::RefUnwindSafe for aya::programs::trace_point::TracePointError
 impl !core::panic::unwind_safe::UnwindSafe for aya::programs::trace_point::TracePointError
-impl<T, U> core::convert::Into<U> for aya::programs::trace_point::TracePointError where U: core::convert::From<T>
-pub fn aya::programs::trace_point::TracePointError::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::programs::trace_point::TracePointError where U: core::convert::Into<T>
-pub type aya::programs::trace_point::TracePointError::Error = core::convert::Infallible
-pub fn aya::programs::trace_point::TracePointError::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::programs::trace_point::TracePointError where U: core::convert::TryFrom<T>
-pub type aya::programs::trace_point::TracePointError::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::programs::trace_point::TracePointError::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::string::ToString for aya::programs::trace_point::TracePointError where T: core::fmt::Display + ?core::marker::Sized
-pub fn aya::programs::trace_point::TracePointError::to_string(&self) -> alloc::string::String
-impl<T> core::any::Any for aya::programs::trace_point::TracePointError where T: 'static + ?core::marker::Sized
-pub fn aya::programs::trace_point::TracePointError::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::programs::trace_point::TracePointError where T: ?core::marker::Sized
-pub fn aya::programs::trace_point::TracePointError::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::programs::trace_point::TracePointError where T: ?core::marker::Sized
-pub fn aya::programs::trace_point::TracePointError::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya::programs::trace_point::TracePointError
-pub fn aya::programs::trace_point::TracePointError::from(t: T) -> T
 pub struct aya::programs::trace_point::TracePoint
 impl aya::programs::trace_point::TracePoint
 pub const aya::programs::trace_point::TracePoint::PROGRAM_TYPE: aya::programs::ProgramType
@@ -7446,22 +4534,6 @@ impl core::marker::Unpin for aya::programs::trace_point::TracePoint
 impl core::marker::UnsafeUnpin for aya::programs::trace_point::TracePoint
 impl core::panic::unwind_safe::RefUnwindSafe for aya::programs::trace_point::TracePoint
 impl core::panic::unwind_safe::UnwindSafe for aya::programs::trace_point::TracePoint
-impl<T, U> core::convert::Into<U> for aya::programs::trace_point::TracePoint where U: core::convert::From<T>
-pub fn aya::programs::trace_point::TracePoint::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::programs::trace_point::TracePoint where U: core::convert::Into<T>
-pub type aya::programs::trace_point::TracePoint::Error = core::convert::Infallible
-pub fn aya::programs::trace_point::TracePoint::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::programs::trace_point::TracePoint where U: core::convert::TryFrom<T>
-pub type aya::programs::trace_point::TracePoint::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::programs::trace_point::TracePoint::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya::programs::trace_point::TracePoint where T: 'static + ?core::marker::Sized
-pub fn aya::programs::trace_point::TracePoint::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::programs::trace_point::TracePoint where T: ?core::marker::Sized
-pub fn aya::programs::trace_point::TracePoint::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::programs::trace_point::TracePoint where T: ?core::marker::Sized
-pub fn aya::programs::trace_point::TracePoint::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya::programs::trace_point::TracePoint
-pub fn aya::programs::trace_point::TracePoint::from(t: T) -> T
 pub struct aya::programs::trace_point::TracePointLink(_)
 impl aya::programs::links::Link for aya::programs::trace_point::TracePointLink
 pub type aya::programs::trace_point::TracePointLink::Id = aya::programs::trace_point::TracePointLinkId
@@ -7491,26 +4563,6 @@ impl core::marker::Unpin for aya::programs::trace_point::TracePointLink
 impl core::marker::UnsafeUnpin for aya::programs::trace_point::TracePointLink
 impl core::panic::unwind_safe::RefUnwindSafe for aya::programs::trace_point::TracePointLink
 impl core::panic::unwind_safe::UnwindSafe for aya::programs::trace_point::TracePointLink
-impl<Q, K> equivalent::Equivalent<K> for aya::programs::trace_point::TracePointLink where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
-pub fn aya::programs::trace_point::TracePointLink::equivalent(&self, key: &K) -> bool
-impl<Q, K> hashbrown::Equivalent<K> for aya::programs::trace_point::TracePointLink where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
-pub fn aya::programs::trace_point::TracePointLink::equivalent(&self, key: &K) -> bool
-impl<T, U> core::convert::Into<U> for aya::programs::trace_point::TracePointLink where U: core::convert::From<T>
-pub fn aya::programs::trace_point::TracePointLink::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::programs::trace_point::TracePointLink where U: core::convert::Into<T>
-pub type aya::programs::trace_point::TracePointLink::Error = core::convert::Infallible
-pub fn aya::programs::trace_point::TracePointLink::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::programs::trace_point::TracePointLink where U: core::convert::TryFrom<T>
-pub type aya::programs::trace_point::TracePointLink::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::programs::trace_point::TracePointLink::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya::programs::trace_point::TracePointLink where T: 'static + ?core::marker::Sized
-pub fn aya::programs::trace_point::TracePointLink::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::programs::trace_point::TracePointLink where T: ?core::marker::Sized
-pub fn aya::programs::trace_point::TracePointLink::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::programs::trace_point::TracePointLink where T: ?core::marker::Sized
-pub fn aya::programs::trace_point::TracePointLink::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya::programs::trace_point::TracePointLink
-pub fn aya::programs::trace_point::TracePointLink::from(t: T) -> T
 pub struct aya::programs::trace_point::TracePointLinkId(_)
 impl core::cmp::Eq for aya::programs::trace_point::TracePointLinkId
 impl core::cmp::PartialEq for aya::programs::trace_point::TracePointLinkId
@@ -7529,26 +4581,6 @@ impl core::marker::Unpin for aya::programs::trace_point::TracePointLinkId
 impl core::marker::UnsafeUnpin for aya::programs::trace_point::TracePointLinkId
 impl core::panic::unwind_safe::RefUnwindSafe for aya::programs::trace_point::TracePointLinkId
 impl core::panic::unwind_safe::UnwindSafe for aya::programs::trace_point::TracePointLinkId
-impl<Q, K> equivalent::Equivalent<K> for aya::programs::trace_point::TracePointLinkId where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
-pub fn aya::programs::trace_point::TracePointLinkId::equivalent(&self, key: &K) -> bool
-impl<Q, K> hashbrown::Equivalent<K> for aya::programs::trace_point::TracePointLinkId where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
-pub fn aya::programs::trace_point::TracePointLinkId::equivalent(&self, key: &K) -> bool
-impl<T, U> core::convert::Into<U> for aya::programs::trace_point::TracePointLinkId where U: core::convert::From<T>
-pub fn aya::programs::trace_point::TracePointLinkId::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::programs::trace_point::TracePointLinkId where U: core::convert::Into<T>
-pub type aya::programs::trace_point::TracePointLinkId::Error = core::convert::Infallible
-pub fn aya::programs::trace_point::TracePointLinkId::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::programs::trace_point::TracePointLinkId where U: core::convert::TryFrom<T>
-pub type aya::programs::trace_point::TracePointLinkId::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::programs::trace_point::TracePointLinkId::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya::programs::trace_point::TracePointLinkId where T: 'static + ?core::marker::Sized
-pub fn aya::programs::trace_point::TracePointLinkId::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::programs::trace_point::TracePointLinkId where T: ?core::marker::Sized
-pub fn aya::programs::trace_point::TracePointLinkId::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::programs::trace_point::TracePointLinkId where T: ?core::marker::Sized
-pub fn aya::programs::trace_point::TracePointLinkId::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya::programs::trace_point::TracePointLinkId
-pub fn aya::programs::trace_point::TracePointLinkId::from(t: T) -> T
 pub mod aya::programs::uprobe
 pub enum aya::programs::uprobe::ProcMapError
 pub aya::programs::uprobe::ProcMapError::ParseLine
@@ -7569,24 +4601,6 @@ impl core::marker::Unpin for aya::programs::uprobe::ProcMapError
 impl core::marker::UnsafeUnpin for aya::programs::uprobe::ProcMapError
 impl !core::panic::unwind_safe::RefUnwindSafe for aya::programs::uprobe::ProcMapError
 impl !core::panic::unwind_safe::UnwindSafe for aya::programs::uprobe::ProcMapError
-impl<T, U> core::convert::Into<U> for aya::programs::uprobe::ProcMapError where U: core::convert::From<T>
-pub fn aya::programs::uprobe::ProcMapError::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::programs::uprobe::ProcMapError where U: core::convert::Into<T>
-pub type aya::programs::uprobe::ProcMapError::Error = core::convert::Infallible
-pub fn aya::programs::uprobe::ProcMapError::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::programs::uprobe::ProcMapError where U: core::convert::TryFrom<T>
-pub type aya::programs::uprobe::ProcMapError::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::programs::uprobe::ProcMapError::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::string::ToString for aya::programs::uprobe::ProcMapError where T: core::fmt::Display + ?core::marker::Sized
-pub fn aya::programs::uprobe::ProcMapError::to_string(&self) -> alloc::string::String
-impl<T> core::any::Any for aya::programs::uprobe::ProcMapError where T: 'static + ?core::marker::Sized
-pub fn aya::programs::uprobe::ProcMapError::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::programs::uprobe::ProcMapError where T: ?core::marker::Sized
-pub fn aya::programs::uprobe::ProcMapError::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::programs::uprobe::ProcMapError where T: ?core::marker::Sized
-pub fn aya::programs::uprobe::ProcMapError::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya::programs::uprobe::ProcMapError
-pub fn aya::programs::uprobe::ProcMapError::from(t: T) -> T
 pub enum aya::programs::uprobe::UProbeAttachLocation<'a>
 pub aya::programs::uprobe::UProbeAttachLocation::AbsoluteOffset(u64)
 pub aya::programs::uprobe::UProbeAttachLocation::Symbol(&'a str)
@@ -7602,22 +4616,6 @@ impl<'a> core::marker::Unpin for aya::programs::uprobe::UProbeAttachLocation<'a>
 impl<'a> core::marker::UnsafeUnpin for aya::programs::uprobe::UProbeAttachLocation<'a>
 impl<'a> core::panic::unwind_safe::RefUnwindSafe for aya::programs::uprobe::UProbeAttachLocation<'a>
 impl<'a> core::panic::unwind_safe::UnwindSafe for aya::programs::uprobe::UProbeAttachLocation<'a>
-impl<T, U> core::convert::Into<U> for aya::programs::uprobe::UProbeAttachLocation<'a> where U: core::convert::From<T>
-pub fn aya::programs::uprobe::UProbeAttachLocation<'a>::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::programs::uprobe::UProbeAttachLocation<'a> where U: core::convert::Into<T>
-pub type aya::programs::uprobe::UProbeAttachLocation<'a>::Error = core::convert::Infallible
-pub fn aya::programs::uprobe::UProbeAttachLocation<'a>::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::programs::uprobe::UProbeAttachLocation<'a> where U: core::convert::TryFrom<T>
-pub type aya::programs::uprobe::UProbeAttachLocation<'a>::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::programs::uprobe::UProbeAttachLocation<'a>::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya::programs::uprobe::UProbeAttachLocation<'a> where T: 'static + ?core::marker::Sized
-pub fn aya::programs::uprobe::UProbeAttachLocation<'a>::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::programs::uprobe::UProbeAttachLocation<'a> where T: ?core::marker::Sized
-pub fn aya::programs::uprobe::UProbeAttachLocation<'a>::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::programs::uprobe::UProbeAttachLocation<'a> where T: ?core::marker::Sized
-pub fn aya::programs::uprobe::UProbeAttachLocation<'a>::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya::programs::uprobe::UProbeAttachLocation<'a>
-pub fn aya::programs::uprobe::UProbeAttachLocation<'a>::from(t: T) -> T
 pub enum aya::programs::uprobe::UProbeError
 pub aya::programs::uprobe::UProbeError::FileError
 pub aya::programs::uprobe::UProbeError::FileError::filename: std::path::PathBuf
@@ -7647,24 +4645,6 @@ impl core::marker::Unpin for aya::programs::uprobe::UProbeError
 impl core::marker::UnsafeUnpin for aya::programs::uprobe::UProbeError
 impl !core::panic::unwind_safe::RefUnwindSafe for aya::programs::uprobe::UProbeError
 impl !core::panic::unwind_safe::UnwindSafe for aya::programs::uprobe::UProbeError
-impl<T, U> core::convert::Into<U> for aya::programs::uprobe::UProbeError where U: core::convert::From<T>
-pub fn aya::programs::uprobe::UProbeError::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::programs::uprobe::UProbeError where U: core::convert::Into<T>
-pub type aya::programs::uprobe::UProbeError::Error = core::convert::Infallible
-pub fn aya::programs::uprobe::UProbeError::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::programs::uprobe::UProbeError where U: core::convert::TryFrom<T>
-pub type aya::programs::uprobe::UProbeError::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::programs::uprobe::UProbeError::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::string::ToString for aya::programs::uprobe::UProbeError where T: core::fmt::Display + ?core::marker::Sized
-pub fn aya::programs::uprobe::UProbeError::to_string(&self) -> alloc::string::String
-impl<T> core::any::Any for aya::programs::uprobe::UProbeError where T: 'static + ?core::marker::Sized
-pub fn aya::programs::uprobe::UProbeError::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::programs::uprobe::UProbeError where T: ?core::marker::Sized
-pub fn aya::programs::uprobe::UProbeError::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::programs::uprobe::UProbeError where T: ?core::marker::Sized
-pub fn aya::programs::uprobe::UProbeError::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya::programs::uprobe::UProbeError
-pub fn aya::programs::uprobe::UProbeError::from(t: T) -> T
 pub struct aya::programs::uprobe::UProbe
 impl aya::programs::uprobe::UProbe
 pub const aya::programs::uprobe::UProbe::PROGRAM_TYPE: aya::programs::ProgramType
@@ -7703,22 +4683,6 @@ impl core::marker::Unpin for aya::programs::uprobe::UProbe
 impl core::marker::UnsafeUnpin for aya::programs::uprobe::UProbe
 impl core::panic::unwind_safe::RefUnwindSafe for aya::programs::uprobe::UProbe
 impl core::panic::unwind_safe::UnwindSafe for aya::programs::uprobe::UProbe
-impl<T, U> core::convert::Into<U> for aya::programs::uprobe::UProbe where U: core::convert::From<T>
-pub fn aya::programs::uprobe::UProbe::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::programs::uprobe::UProbe where U: core::convert::Into<T>
-pub type aya::programs::uprobe::UProbe::Error = core::convert::Infallible
-pub fn aya::programs::uprobe::UProbe::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::programs::uprobe::UProbe where U: core::convert::TryFrom<T>
-pub type aya::programs::uprobe::UProbe::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::programs::uprobe::UProbe::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya::programs::uprobe::UProbe where T: 'static + ?core::marker::Sized
-pub fn aya::programs::uprobe::UProbe::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::programs::uprobe::UProbe where T: ?core::marker::Sized
-pub fn aya::programs::uprobe::UProbe::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::programs::uprobe::UProbe where T: ?core::marker::Sized
-pub fn aya::programs::uprobe::UProbe::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya::programs::uprobe::UProbe
-pub fn aya::programs::uprobe::UProbe::from(t: T) -> T
 pub struct aya::programs::uprobe::UProbeAttachPoint<'a>
 pub aya::programs::uprobe::UProbeAttachPoint::cookie: core::option::Option<u64>
 pub aya::programs::uprobe::UProbeAttachPoint::location: aya::programs::uprobe::UProbeAttachLocation<'a>
@@ -7731,22 +4695,6 @@ impl<'a> core::marker::Unpin for aya::programs::uprobe::UProbeAttachPoint<'a>
 impl<'a> core::marker::UnsafeUnpin for aya::programs::uprobe::UProbeAttachPoint<'a>
 impl<'a> core::panic::unwind_safe::RefUnwindSafe for aya::programs::uprobe::UProbeAttachPoint<'a>
 impl<'a> core::panic::unwind_safe::UnwindSafe for aya::programs::uprobe::UProbeAttachPoint<'a>
-impl<T, U> core::convert::Into<U> for aya::programs::uprobe::UProbeAttachPoint<'a> where U: core::convert::From<T>
-pub fn aya::programs::uprobe::UProbeAttachPoint<'a>::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::programs::uprobe::UProbeAttachPoint<'a> where U: core::convert::Into<T>
-pub type aya::programs::uprobe::UProbeAttachPoint<'a>::Error = core::convert::Infallible
-pub fn aya::programs::uprobe::UProbeAttachPoint<'a>::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::programs::uprobe::UProbeAttachPoint<'a> where U: core::convert::TryFrom<T>
-pub type aya::programs::uprobe::UProbeAttachPoint<'a>::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::programs::uprobe::UProbeAttachPoint<'a>::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya::programs::uprobe::UProbeAttachPoint<'a> where T: 'static + ?core::marker::Sized
-pub fn aya::programs::uprobe::UProbeAttachPoint<'a>::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::programs::uprobe::UProbeAttachPoint<'a> where T: ?core::marker::Sized
-pub fn aya::programs::uprobe::UProbeAttachPoint<'a>::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::programs::uprobe::UProbeAttachPoint<'a> where T: ?core::marker::Sized
-pub fn aya::programs::uprobe::UProbeAttachPoint<'a>::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya::programs::uprobe::UProbeAttachPoint<'a>
-pub fn aya::programs::uprobe::UProbeAttachPoint<'a>::from(t: T) -> T
 pub struct aya::programs::uprobe::UProbeLink(_)
 impl aya::programs::links::Link for aya::programs::uprobe::UProbeLink
 pub type aya::programs::uprobe::UProbeLink::Id = aya::programs::uprobe::UProbeLinkId
@@ -7776,26 +4724,6 @@ impl core::marker::Unpin for aya::programs::uprobe::UProbeLink
 impl core::marker::UnsafeUnpin for aya::programs::uprobe::UProbeLink
 impl core::panic::unwind_safe::RefUnwindSafe for aya::programs::uprobe::UProbeLink
 impl core::panic::unwind_safe::UnwindSafe for aya::programs::uprobe::UProbeLink
-impl<Q, K> equivalent::Equivalent<K> for aya::programs::uprobe::UProbeLink where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
-pub fn aya::programs::uprobe::UProbeLink::equivalent(&self, key: &K) -> bool
-impl<Q, K> hashbrown::Equivalent<K> for aya::programs::uprobe::UProbeLink where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
-pub fn aya::programs::uprobe::UProbeLink::equivalent(&self, key: &K) -> bool
-impl<T, U> core::convert::Into<U> for aya::programs::uprobe::UProbeLink where U: core::convert::From<T>
-pub fn aya::programs::uprobe::UProbeLink::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::programs::uprobe::UProbeLink where U: core::convert::Into<T>
-pub type aya::programs::uprobe::UProbeLink::Error = core::convert::Infallible
-pub fn aya::programs::uprobe::UProbeLink::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::programs::uprobe::UProbeLink where U: core::convert::TryFrom<T>
-pub type aya::programs::uprobe::UProbeLink::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::programs::uprobe::UProbeLink::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya::programs::uprobe::UProbeLink where T: 'static + ?core::marker::Sized
-pub fn aya::programs::uprobe::UProbeLink::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::programs::uprobe::UProbeLink where T: ?core::marker::Sized
-pub fn aya::programs::uprobe::UProbeLink::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::programs::uprobe::UProbeLink where T: ?core::marker::Sized
-pub fn aya::programs::uprobe::UProbeLink::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya::programs::uprobe::UProbeLink
-pub fn aya::programs::uprobe::UProbeLink::from(t: T) -> T
 pub struct aya::programs::uprobe::UProbeLinkId(_)
 impl core::cmp::Eq for aya::programs::uprobe::UProbeLinkId
 impl core::cmp::PartialEq for aya::programs::uprobe::UProbeLinkId
@@ -7814,26 +4742,6 @@ impl core::marker::Unpin for aya::programs::uprobe::UProbeLinkId
 impl core::marker::UnsafeUnpin for aya::programs::uprobe::UProbeLinkId
 impl core::panic::unwind_safe::RefUnwindSafe for aya::programs::uprobe::UProbeLinkId
 impl core::panic::unwind_safe::UnwindSafe for aya::programs::uprobe::UProbeLinkId
-impl<Q, K> equivalent::Equivalent<K> for aya::programs::uprobe::UProbeLinkId where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
-pub fn aya::programs::uprobe::UProbeLinkId::equivalent(&self, key: &K) -> bool
-impl<Q, K> hashbrown::Equivalent<K> for aya::programs::uprobe::UProbeLinkId where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
-pub fn aya::programs::uprobe::UProbeLinkId::equivalent(&self, key: &K) -> bool
-impl<T, U> core::convert::Into<U> for aya::programs::uprobe::UProbeLinkId where U: core::convert::From<T>
-pub fn aya::programs::uprobe::UProbeLinkId::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::programs::uprobe::UProbeLinkId where U: core::convert::Into<T>
-pub type aya::programs::uprobe::UProbeLinkId::Error = core::convert::Infallible
-pub fn aya::programs::uprobe::UProbeLinkId::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::programs::uprobe::UProbeLinkId where U: core::convert::TryFrom<T>
-pub type aya::programs::uprobe::UProbeLinkId::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::programs::uprobe::UProbeLinkId::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya::programs::uprobe::UProbeLinkId where T: 'static + ?core::marker::Sized
-pub fn aya::programs::uprobe::UProbeLinkId::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::programs::uprobe::UProbeLinkId where T: ?core::marker::Sized
-pub fn aya::programs::uprobe::UProbeLinkId::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::programs::uprobe::UProbeLinkId where T: ?core::marker::Sized
-pub fn aya::programs::uprobe::UProbeLinkId::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya::programs::uprobe::UProbeLinkId
-pub fn aya::programs::uprobe::UProbeLinkId::from(t: T) -> T
 pub mod aya::programs::xdp
 pub enum aya::programs::xdp::XdpError
 pub aya::programs::xdp::XdpError::NetlinkError(aya::sys::netlink::NetlinkError)
@@ -7852,24 +4760,6 @@ impl core::marker::Unpin for aya::programs::xdp::XdpError
 impl core::marker::UnsafeUnpin for aya::programs::xdp::XdpError
 impl !core::panic::unwind_safe::RefUnwindSafe for aya::programs::xdp::XdpError
 impl !core::panic::unwind_safe::UnwindSafe for aya::programs::xdp::XdpError
-impl<T, U> core::convert::Into<U> for aya::programs::xdp::XdpError where U: core::convert::From<T>
-pub fn aya::programs::xdp::XdpError::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::programs::xdp::XdpError where U: core::convert::Into<T>
-pub type aya::programs::xdp::XdpError::Error = core::convert::Infallible
-pub fn aya::programs::xdp::XdpError::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::programs::xdp::XdpError where U: core::convert::TryFrom<T>
-pub type aya::programs::xdp::XdpError::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::programs::xdp::XdpError::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::string::ToString for aya::programs::xdp::XdpError where T: core::fmt::Display + ?core::marker::Sized
-pub fn aya::programs::xdp::XdpError::to_string(&self) -> alloc::string::String
-impl<T> core::any::Any for aya::programs::xdp::XdpError where T: 'static + ?core::marker::Sized
-pub fn aya::programs::xdp::XdpError::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::programs::xdp::XdpError where T: ?core::marker::Sized
-pub fn aya::programs::xdp::XdpError::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::programs::xdp::XdpError where T: ?core::marker::Sized
-pub fn aya::programs::xdp::XdpError::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya::programs::xdp::XdpError
-pub fn aya::programs::xdp::XdpError::from(t: T) -> T
 pub struct aya::programs::xdp::Xdp
 impl aya::programs::xdp::Xdp
 pub const aya::programs::xdp::Xdp::PROGRAM_TYPE: aya::programs::ProgramType
@@ -7909,22 +4799,6 @@ impl core::marker::Unpin for aya::programs::xdp::Xdp
 impl core::marker::UnsafeUnpin for aya::programs::xdp::Xdp
 impl core::panic::unwind_safe::RefUnwindSafe for aya::programs::xdp::Xdp
 impl core::panic::unwind_safe::UnwindSafe for aya::programs::xdp::Xdp
-impl<T, U> core::convert::Into<U> for aya::programs::xdp::Xdp where U: core::convert::From<T>
-pub fn aya::programs::xdp::Xdp::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::programs::xdp::Xdp where U: core::convert::Into<T>
-pub type aya::programs::xdp::Xdp::Error = core::convert::Infallible
-pub fn aya::programs::xdp::Xdp::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::programs::xdp::Xdp where U: core::convert::TryFrom<T>
-pub type aya::programs::xdp::Xdp::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::programs::xdp::Xdp::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya::programs::xdp::Xdp where T: 'static + ?core::marker::Sized
-pub fn aya::programs::xdp::Xdp::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::programs::xdp::Xdp where T: ?core::marker::Sized
-pub fn aya::programs::xdp::Xdp::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::programs::xdp::Xdp where T: ?core::marker::Sized
-pub fn aya::programs::xdp::Xdp::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya::programs::xdp::Xdp
-pub fn aya::programs::xdp::Xdp::from(t: T) -> T
 pub struct aya::programs::xdp::XdpFlags(_)
 impl aya::programs::xdp::XdpFlags
 pub const aya::programs::xdp::XdpFlags::DRV_MODE: Self
@@ -8017,28 +4891,6 @@ impl core::marker::Unpin for aya::programs::xdp::XdpFlags
 impl core::marker::UnsafeUnpin for aya::programs::xdp::XdpFlags
 impl core::panic::unwind_safe::RefUnwindSafe for aya::programs::xdp::XdpFlags
 impl core::panic::unwind_safe::UnwindSafe for aya::programs::xdp::XdpFlags
-impl<T, U> core::convert::Into<U> for aya::programs::xdp::XdpFlags where U: core::convert::From<T>
-pub fn aya::programs::xdp::XdpFlags::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::programs::xdp::XdpFlags where U: core::convert::Into<T>
-pub type aya::programs::xdp::XdpFlags::Error = core::convert::Infallible
-pub fn aya::programs::xdp::XdpFlags::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::programs::xdp::XdpFlags where U: core::convert::TryFrom<T>
-pub type aya::programs::xdp::XdpFlags::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::programs::xdp::XdpFlags::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya::programs::xdp::XdpFlags where T: core::clone::Clone
-pub type aya::programs::xdp::XdpFlags::Owned = T
-pub fn aya::programs::xdp::XdpFlags::clone_into(&self, target: &mut T)
-pub fn aya::programs::xdp::XdpFlags::to_owned(&self) -> T
-impl<T> core::any::Any for aya::programs::xdp::XdpFlags where T: 'static + ?core::marker::Sized
-pub fn aya::programs::xdp::XdpFlags::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::programs::xdp::XdpFlags where T: ?core::marker::Sized
-pub fn aya::programs::xdp::XdpFlags::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::programs::xdp::XdpFlags where T: ?core::marker::Sized
-pub fn aya::programs::xdp::XdpFlags::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya::programs::xdp::XdpFlags where T: core::clone::Clone
-pub unsafe fn aya::programs::xdp::XdpFlags::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya::programs::xdp::XdpFlags
-pub fn aya::programs::xdp::XdpFlags::from(t: T) -> T
 pub struct aya::programs::xdp::XdpLink(_)
 impl aya::programs::links::Link for aya::programs::xdp::XdpLink
 pub type aya::programs::xdp::XdpLink::Id = aya::programs::xdp::XdpLinkId
@@ -8068,26 +4920,6 @@ impl core::marker::Unpin for aya::programs::xdp::XdpLink
 impl core::marker::UnsafeUnpin for aya::programs::xdp::XdpLink
 impl core::panic::unwind_safe::RefUnwindSafe for aya::programs::xdp::XdpLink
 impl core::panic::unwind_safe::UnwindSafe for aya::programs::xdp::XdpLink
-impl<Q, K> equivalent::Equivalent<K> for aya::programs::xdp::XdpLink where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
-pub fn aya::programs::xdp::XdpLink::equivalent(&self, key: &K) -> bool
-impl<Q, K> hashbrown::Equivalent<K> for aya::programs::xdp::XdpLink where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
-pub fn aya::programs::xdp::XdpLink::equivalent(&self, key: &K) -> bool
-impl<T, U> core::convert::Into<U> for aya::programs::xdp::XdpLink where U: core::convert::From<T>
-pub fn aya::programs::xdp::XdpLink::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::programs::xdp::XdpLink where U: core::convert::Into<T>
-pub type aya::programs::xdp::XdpLink::Error = core::convert::Infallible
-pub fn aya::programs::xdp::XdpLink::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::programs::xdp::XdpLink where U: core::convert::TryFrom<T>
-pub type aya::programs::xdp::XdpLink::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::programs::xdp::XdpLink::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya::programs::xdp::XdpLink where T: 'static + ?core::marker::Sized
-pub fn aya::programs::xdp::XdpLink::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::programs::xdp::XdpLink where T: ?core::marker::Sized
-pub fn aya::programs::xdp::XdpLink::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::programs::xdp::XdpLink where T: ?core::marker::Sized
-pub fn aya::programs::xdp::XdpLink::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya::programs::xdp::XdpLink
-pub fn aya::programs::xdp::XdpLink::from(t: T) -> T
 pub struct aya::programs::xdp::XdpLinkId(_)
 impl core::cmp::Eq for aya::programs::xdp::XdpLinkId
 impl core::cmp::PartialEq for aya::programs::xdp::XdpLinkId
@@ -8106,26 +4938,6 @@ impl core::marker::Unpin for aya::programs::xdp::XdpLinkId
 impl core::marker::UnsafeUnpin for aya::programs::xdp::XdpLinkId
 impl core::panic::unwind_safe::RefUnwindSafe for aya::programs::xdp::XdpLinkId
 impl core::panic::unwind_safe::UnwindSafe for aya::programs::xdp::XdpLinkId
-impl<Q, K> equivalent::Equivalent<K> for aya::programs::xdp::XdpLinkId where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
-pub fn aya::programs::xdp::XdpLinkId::equivalent(&self, key: &K) -> bool
-impl<Q, K> hashbrown::Equivalent<K> for aya::programs::xdp::XdpLinkId where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
-pub fn aya::programs::xdp::XdpLinkId::equivalent(&self, key: &K) -> bool
-impl<T, U> core::convert::Into<U> for aya::programs::xdp::XdpLinkId where U: core::convert::From<T>
-pub fn aya::programs::xdp::XdpLinkId::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::programs::xdp::XdpLinkId where U: core::convert::Into<T>
-pub type aya::programs::xdp::XdpLinkId::Error = core::convert::Infallible
-pub fn aya::programs::xdp::XdpLinkId::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::programs::xdp::XdpLinkId where U: core::convert::TryFrom<T>
-pub type aya::programs::xdp::XdpLinkId::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::programs::xdp::XdpLinkId::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya::programs::xdp::XdpLinkId where T: 'static + ?core::marker::Sized
-pub fn aya::programs::xdp::XdpLinkId::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::programs::xdp::XdpLinkId where T: ?core::marker::Sized
-pub fn aya::programs::xdp::XdpLinkId::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::programs::xdp::XdpLinkId where T: ?core::marker::Sized
-pub fn aya::programs::xdp::XdpLinkId::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya::programs::xdp::XdpLinkId
-pub fn aya::programs::xdp::XdpLinkId::from(t: T) -> T
 pub enum aya::programs::CgroupAttachMode
 pub aya::programs::CgroupAttachMode::AllowMultiple
 pub aya::programs::CgroupAttachMode::AllowOverride
@@ -8146,28 +4958,6 @@ impl core::marker::Unpin for aya::programs::links::CgroupAttachMode
 impl core::marker::UnsafeUnpin for aya::programs::links::CgroupAttachMode
 impl core::panic::unwind_safe::RefUnwindSafe for aya::programs::links::CgroupAttachMode
 impl core::panic::unwind_safe::UnwindSafe for aya::programs::links::CgroupAttachMode
-impl<T, U> core::convert::Into<U> for aya::programs::links::CgroupAttachMode where U: core::convert::From<T>
-pub fn aya::programs::links::CgroupAttachMode::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::programs::links::CgroupAttachMode where U: core::convert::Into<T>
-pub type aya::programs::links::CgroupAttachMode::Error = core::convert::Infallible
-pub fn aya::programs::links::CgroupAttachMode::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::programs::links::CgroupAttachMode where U: core::convert::TryFrom<T>
-pub type aya::programs::links::CgroupAttachMode::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::programs::links::CgroupAttachMode::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya::programs::links::CgroupAttachMode where T: core::clone::Clone
-pub type aya::programs::links::CgroupAttachMode::Owned = T
-pub fn aya::programs::links::CgroupAttachMode::clone_into(&self, target: &mut T)
-pub fn aya::programs::links::CgroupAttachMode::to_owned(&self) -> T
-impl<T> core::any::Any for aya::programs::links::CgroupAttachMode where T: 'static + ?core::marker::Sized
-pub fn aya::programs::links::CgroupAttachMode::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::programs::links::CgroupAttachMode where T: ?core::marker::Sized
-pub fn aya::programs::links::CgroupAttachMode::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::programs::links::CgroupAttachMode where T: ?core::marker::Sized
-pub fn aya::programs::links::CgroupAttachMode::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya::programs::links::CgroupAttachMode where T: core::clone::Clone
-pub unsafe fn aya::programs::links::CgroupAttachMode::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya::programs::links::CgroupAttachMode
-pub fn aya::programs::links::CgroupAttachMode::from(t: T) -> T
 pub enum aya::programs::ExtensionError
 pub aya::programs::ExtensionError::NoBTF
 impl core::convert::From<aya::programs::extension::ExtensionError> for aya::programs::ProgramError
@@ -8184,24 +4974,6 @@ impl core::marker::Unpin for aya::programs::extension::ExtensionError
 impl core::marker::UnsafeUnpin for aya::programs::extension::ExtensionError
 impl core::panic::unwind_safe::RefUnwindSafe for aya::programs::extension::ExtensionError
 impl core::panic::unwind_safe::UnwindSafe for aya::programs::extension::ExtensionError
-impl<T, U> core::convert::Into<U> for aya::programs::extension::ExtensionError where U: core::convert::From<T>
-pub fn aya::programs::extension::ExtensionError::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::programs::extension::ExtensionError where U: core::convert::Into<T>
-pub type aya::programs::extension::ExtensionError::Error = core::convert::Infallible
-pub fn aya::programs::extension::ExtensionError::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::programs::extension::ExtensionError where U: core::convert::TryFrom<T>
-pub type aya::programs::extension::ExtensionError::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::programs::extension::ExtensionError::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::string::ToString for aya::programs::extension::ExtensionError where T: core::fmt::Display + ?core::marker::Sized
-pub fn aya::programs::extension::ExtensionError::to_string(&self) -> alloc::string::String
-impl<T> core::any::Any for aya::programs::extension::ExtensionError where T: 'static + ?core::marker::Sized
-pub fn aya::programs::extension::ExtensionError::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::programs::extension::ExtensionError where T: ?core::marker::Sized
-pub fn aya::programs::extension::ExtensionError::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::programs::extension::ExtensionError where T: ?core::marker::Sized
-pub fn aya::programs::extension::ExtensionError::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya::programs::extension::ExtensionError
-pub fn aya::programs::extension::ExtensionError::from(t: T) -> T
 pub enum aya::programs::KProbeError
 pub aya::programs::KProbeError::FileError
 pub aya::programs::KProbeError::FileError::filename: std::path::PathBuf
@@ -8221,24 +4993,6 @@ impl core::marker::Unpin for aya::programs::kprobe::KProbeError
 impl core::marker::UnsafeUnpin for aya::programs::kprobe::KProbeError
 impl !core::panic::unwind_safe::RefUnwindSafe for aya::programs::kprobe::KProbeError
 impl !core::panic::unwind_safe::UnwindSafe for aya::programs::kprobe::KProbeError
-impl<T, U> core::convert::Into<U> for aya::programs::kprobe::KProbeError where U: core::convert::From<T>
-pub fn aya::programs::kprobe::KProbeError::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::programs::kprobe::KProbeError where U: core::convert::Into<T>
-pub type aya::programs::kprobe::KProbeError::Error = core::convert::Infallible
-pub fn aya::programs::kprobe::KProbeError::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::programs::kprobe::KProbeError where U: core::convert::TryFrom<T>
-pub type aya::programs::kprobe::KProbeError::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::programs::kprobe::KProbeError::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::string::ToString for aya::programs::kprobe::KProbeError where T: core::fmt::Display + ?core::marker::Sized
-pub fn aya::programs::kprobe::KProbeError::to_string(&self) -> alloc::string::String
-impl<T> core::any::Any for aya::programs::kprobe::KProbeError where T: 'static + ?core::marker::Sized
-pub fn aya::programs::kprobe::KProbeError::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::programs::kprobe::KProbeError where T: ?core::marker::Sized
-pub fn aya::programs::kprobe::KProbeError::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::programs::kprobe::KProbeError where T: ?core::marker::Sized
-pub fn aya::programs::kprobe::KProbeError::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya::programs::kprobe::KProbeError
-pub fn aya::programs::kprobe::KProbeError::from(t: T) -> T
 pub enum aya::programs::LsmAttachType
 pub aya::programs::LsmAttachType::Cgroup
 pub aya::programs::LsmAttachType::Mac
@@ -8258,32 +5012,6 @@ impl core::marker::Unpin for aya::programs::LsmAttachType
 impl core::marker::UnsafeUnpin for aya::programs::LsmAttachType
 impl core::panic::unwind_safe::RefUnwindSafe for aya::programs::LsmAttachType
 impl core::panic::unwind_safe::UnwindSafe for aya::programs::LsmAttachType
-impl<Q, K> equivalent::Equivalent<K> for aya::programs::LsmAttachType where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
-pub fn aya::programs::LsmAttachType::equivalent(&self, key: &K) -> bool
-impl<Q, K> hashbrown::Equivalent<K> for aya::programs::LsmAttachType where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
-pub fn aya::programs::LsmAttachType::equivalent(&self, key: &K) -> bool
-impl<T, U> core::convert::Into<U> for aya::programs::LsmAttachType where U: core::convert::From<T>
-pub fn aya::programs::LsmAttachType::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::programs::LsmAttachType where U: core::convert::Into<T>
-pub type aya::programs::LsmAttachType::Error = core::convert::Infallible
-pub fn aya::programs::LsmAttachType::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::programs::LsmAttachType where U: core::convert::TryFrom<T>
-pub type aya::programs::LsmAttachType::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::programs::LsmAttachType::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya::programs::LsmAttachType where T: core::clone::Clone
-pub type aya::programs::LsmAttachType::Owned = T
-pub fn aya::programs::LsmAttachType::clone_into(&self, target: &mut T)
-pub fn aya::programs::LsmAttachType::to_owned(&self) -> T
-impl<T> core::any::Any for aya::programs::LsmAttachType where T: 'static + ?core::marker::Sized
-pub fn aya::programs::LsmAttachType::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::programs::LsmAttachType where T: ?core::marker::Sized
-pub fn aya::programs::LsmAttachType::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::programs::LsmAttachType where T: ?core::marker::Sized
-pub fn aya::programs::LsmAttachType::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya::programs::LsmAttachType where T: core::clone::Clone
-pub unsafe fn aya::programs::LsmAttachType::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya::programs::LsmAttachType
-pub fn aya::programs::LsmAttachType::from(t: T) -> T
 pub enum aya::programs::ProbeKind
 pub aya::programs::ProbeKind::Entry
 pub aya::programs::ProbeKind::Return
@@ -8299,28 +5027,6 @@ impl core::marker::Unpin for aya::programs::ProbeKind
 impl core::marker::UnsafeUnpin for aya::programs::ProbeKind
 impl core::panic::unwind_safe::RefUnwindSafe for aya::programs::ProbeKind
 impl core::panic::unwind_safe::UnwindSafe for aya::programs::ProbeKind
-impl<T, U> core::convert::Into<U> for aya::programs::ProbeKind where U: core::convert::From<T>
-pub fn aya::programs::ProbeKind::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::programs::ProbeKind where U: core::convert::Into<T>
-pub type aya::programs::ProbeKind::Error = core::convert::Infallible
-pub fn aya::programs::ProbeKind::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::programs::ProbeKind where U: core::convert::TryFrom<T>
-pub type aya::programs::ProbeKind::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::programs::ProbeKind::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya::programs::ProbeKind where T: core::clone::Clone
-pub type aya::programs::ProbeKind::Owned = T
-pub fn aya::programs::ProbeKind::clone_into(&self, target: &mut T)
-pub fn aya::programs::ProbeKind::to_owned(&self) -> T
-impl<T> core::any::Any for aya::programs::ProbeKind where T: 'static + ?core::marker::Sized
-pub fn aya::programs::ProbeKind::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::programs::ProbeKind where T: ?core::marker::Sized
-pub fn aya::programs::ProbeKind::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::programs::ProbeKind where T: ?core::marker::Sized
-pub fn aya::programs::ProbeKind::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya::programs::ProbeKind where T: core::clone::Clone
-pub unsafe fn aya::programs::ProbeKind::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya::programs::ProbeKind
-pub fn aya::programs::ProbeKind::from(t: T) -> T
 pub enum aya::programs::Program
 pub aya::programs::Program::BtfTracePoint(aya::programs::tp_btf::BtfTracePoint)
 pub aya::programs::Program::CgroupDevice(aya::programs::cgroup_device::CgroupDevice)
@@ -8526,22 +5232,6 @@ impl core::marker::Unpin for aya::programs::Program
 impl core::marker::UnsafeUnpin for aya::programs::Program
 impl core::panic::unwind_safe::RefUnwindSafe for aya::programs::Program
 impl core::panic::unwind_safe::UnwindSafe for aya::programs::Program
-impl<T, U> core::convert::Into<U> for aya::programs::Program where U: core::convert::From<T>
-pub fn aya::programs::Program::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::programs::Program where U: core::convert::Into<T>
-pub type aya::programs::Program::Error = core::convert::Infallible
-pub fn aya::programs::Program::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::programs::Program where U: core::convert::TryFrom<T>
-pub type aya::programs::Program::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::programs::Program::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya::programs::Program where T: 'static + ?core::marker::Sized
-pub fn aya::programs::Program::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::programs::Program where T: ?core::marker::Sized
-pub fn aya::programs::Program::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::programs::Program where T: ?core::marker::Sized
-pub fn aya::programs::Program::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya::programs::Program
-pub fn aya::programs::Program::from(t: T) -> T
 pub enum aya::programs::ProgramError
 pub aya::programs::ProgramError::AlreadyAttached
 pub aya::programs::ProgramError::AlreadyLoaded
@@ -8605,24 +5295,6 @@ impl core::marker::Unpin for aya::programs::ProgramError
 impl core::marker::UnsafeUnpin for aya::programs::ProgramError
 impl !core::panic::unwind_safe::RefUnwindSafe for aya::programs::ProgramError
 impl !core::panic::unwind_safe::UnwindSafe for aya::programs::ProgramError
-impl<T, U> core::convert::Into<U> for aya::programs::ProgramError where U: core::convert::From<T>
-pub fn aya::programs::ProgramError::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::programs::ProgramError where U: core::convert::Into<T>
-pub type aya::programs::ProgramError::Error = core::convert::Infallible
-pub fn aya::programs::ProgramError::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::programs::ProgramError where U: core::convert::TryFrom<T>
-pub type aya::programs::ProgramError::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::programs::ProgramError::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::string::ToString for aya::programs::ProgramError where T: core::fmt::Display + ?core::marker::Sized
-pub fn aya::programs::ProgramError::to_string(&self) -> alloc::string::String
-impl<T> core::any::Any for aya::programs::ProgramError where T: 'static + ?core::marker::Sized
-pub fn aya::programs::ProgramError::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::programs::ProgramError where T: ?core::marker::Sized
-pub fn aya::programs::ProgramError::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::programs::ProgramError where T: ?core::marker::Sized
-pub fn aya::programs::ProgramError::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya::programs::ProgramError
-pub fn aya::programs::ProgramError::from(t: T) -> T
 #[non_exhaustive] pub enum aya::programs::ProgramType
 pub aya::programs::ProgramType::CgroupDevice
 pub aya::programs::ProgramType::CgroupSkb
@@ -8674,28 +5346,6 @@ impl core::marker::Unpin for aya::programs::ProgramType
 impl core::marker::UnsafeUnpin for aya::programs::ProgramType
 impl core::panic::unwind_safe::RefUnwindSafe for aya::programs::ProgramType
 impl core::panic::unwind_safe::UnwindSafe for aya::programs::ProgramType
-impl<T, U> core::convert::Into<U> for aya::programs::ProgramType where U: core::convert::From<T>
-pub fn aya::programs::ProgramType::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::programs::ProgramType where U: core::convert::Into<T>
-pub type aya::programs::ProgramType::Error = core::convert::Infallible
-pub fn aya::programs::ProgramType::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::programs::ProgramType where U: core::convert::TryFrom<T>
-pub type aya::programs::ProgramType::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::programs::ProgramType::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya::programs::ProgramType where T: core::clone::Clone
-pub type aya::programs::ProgramType::Owned = T
-pub fn aya::programs::ProgramType::clone_into(&self, target: &mut T)
-pub fn aya::programs::ProgramType::to_owned(&self) -> T
-impl<T> core::any::Any for aya::programs::ProgramType where T: 'static + ?core::marker::Sized
-pub fn aya::programs::ProgramType::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::programs::ProgramType where T: ?core::marker::Sized
-pub fn aya::programs::ProgramType::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::programs::ProgramType where T: ?core::marker::Sized
-pub fn aya::programs::ProgramType::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya::programs::ProgramType where T: core::clone::Clone
-pub unsafe fn aya::programs::ProgramType::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya::programs::ProgramType
-pub fn aya::programs::ProgramType::from(t: T) -> T
 pub enum aya::programs::SocketFilterError
 pub aya::programs::SocketFilterError::SoAttachEbpfError
 pub aya::programs::SocketFilterError::SoAttachEbpfError::io_error: std::io::error::Error
@@ -8714,24 +5364,6 @@ impl core::marker::Unpin for aya::programs::socket_filter::SocketFilterError
 impl core::marker::UnsafeUnpin for aya::programs::socket_filter::SocketFilterError
 impl !core::panic::unwind_safe::RefUnwindSafe for aya::programs::socket_filter::SocketFilterError
 impl !core::panic::unwind_safe::UnwindSafe for aya::programs::socket_filter::SocketFilterError
-impl<T, U> core::convert::Into<U> for aya::programs::socket_filter::SocketFilterError where U: core::convert::From<T>
-pub fn aya::programs::socket_filter::SocketFilterError::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::programs::socket_filter::SocketFilterError where U: core::convert::Into<T>
-pub type aya::programs::socket_filter::SocketFilterError::Error = core::convert::Infallible
-pub fn aya::programs::socket_filter::SocketFilterError::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::programs::socket_filter::SocketFilterError where U: core::convert::TryFrom<T>
-pub type aya::programs::socket_filter::SocketFilterError::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::programs::socket_filter::SocketFilterError::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::string::ToString for aya::programs::socket_filter::SocketFilterError where T: core::fmt::Display + ?core::marker::Sized
-pub fn aya::programs::socket_filter::SocketFilterError::to_string(&self) -> alloc::string::String
-impl<T> core::any::Any for aya::programs::socket_filter::SocketFilterError where T: 'static + ?core::marker::Sized
-pub fn aya::programs::socket_filter::SocketFilterError::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::programs::socket_filter::SocketFilterError where T: ?core::marker::Sized
-pub fn aya::programs::socket_filter::SocketFilterError::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::programs::socket_filter::SocketFilterError where T: ?core::marker::Sized
-pub fn aya::programs::socket_filter::SocketFilterError::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya::programs::socket_filter::SocketFilterError
-pub fn aya::programs::socket_filter::SocketFilterError::from(t: T) -> T
 pub enum aya::programs::TcAttachType
 pub aya::programs::TcAttachType::Custom(u32)
 pub aya::programs::TcAttachType::Egress
@@ -8754,32 +5386,6 @@ impl core::marker::Unpin for aya::programs::tc::TcAttachType
 impl core::marker::UnsafeUnpin for aya::programs::tc::TcAttachType
 impl core::panic::unwind_safe::RefUnwindSafe for aya::programs::tc::TcAttachType
 impl core::panic::unwind_safe::UnwindSafe for aya::programs::tc::TcAttachType
-impl<Q, K> equivalent::Equivalent<K> for aya::programs::tc::TcAttachType where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
-pub fn aya::programs::tc::TcAttachType::equivalent(&self, key: &K) -> bool
-impl<Q, K> hashbrown::Equivalent<K> for aya::programs::tc::TcAttachType where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
-pub fn aya::programs::tc::TcAttachType::equivalent(&self, key: &K) -> bool
-impl<T, U> core::convert::Into<U> for aya::programs::tc::TcAttachType where U: core::convert::From<T>
-pub fn aya::programs::tc::TcAttachType::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::programs::tc::TcAttachType where U: core::convert::Into<T>
-pub type aya::programs::tc::TcAttachType::Error = core::convert::Infallible
-pub fn aya::programs::tc::TcAttachType::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::programs::tc::TcAttachType where U: core::convert::TryFrom<T>
-pub type aya::programs::tc::TcAttachType::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::programs::tc::TcAttachType::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya::programs::tc::TcAttachType where T: core::clone::Clone
-pub type aya::programs::tc::TcAttachType::Owned = T
-pub fn aya::programs::tc::TcAttachType::clone_into(&self, target: &mut T)
-pub fn aya::programs::tc::TcAttachType::to_owned(&self) -> T
-impl<T> core::any::Any for aya::programs::tc::TcAttachType where T: 'static + ?core::marker::Sized
-pub fn aya::programs::tc::TcAttachType::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::programs::tc::TcAttachType where T: ?core::marker::Sized
-pub fn aya::programs::tc::TcAttachType::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::programs::tc::TcAttachType where T: ?core::marker::Sized
-pub fn aya::programs::tc::TcAttachType::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya::programs::tc::TcAttachType where T: core::clone::Clone
-pub unsafe fn aya::programs::tc::TcAttachType::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya::programs::tc::TcAttachType
-pub fn aya::programs::tc::TcAttachType::from(t: T) -> T
 pub enum aya::programs::TcError
 pub aya::programs::TcError::AlreadyAttached
 pub aya::programs::TcError::InvalidLinkOperation
@@ -8806,24 +5412,6 @@ impl core::marker::Unpin for aya::programs::tc::TcError
 impl core::marker::UnsafeUnpin for aya::programs::tc::TcError
 impl !core::panic::unwind_safe::RefUnwindSafe for aya::programs::tc::TcError
 impl !core::panic::unwind_safe::UnwindSafe for aya::programs::tc::TcError
-impl<T, U> core::convert::Into<U> for aya::programs::tc::TcError where U: core::convert::From<T>
-pub fn aya::programs::tc::TcError::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::programs::tc::TcError where U: core::convert::Into<T>
-pub type aya::programs::tc::TcError::Error = core::convert::Infallible
-pub fn aya::programs::tc::TcError::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::programs::tc::TcError where U: core::convert::TryFrom<T>
-pub type aya::programs::tc::TcError::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::programs::tc::TcError::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::string::ToString for aya::programs::tc::TcError where T: core::fmt::Display + ?core::marker::Sized
-pub fn aya::programs::tc::TcError::to_string(&self) -> alloc::string::String
-impl<T> core::any::Any for aya::programs::tc::TcError where T: 'static + ?core::marker::Sized
-pub fn aya::programs::tc::TcError::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::programs::tc::TcError where T: ?core::marker::Sized
-pub fn aya::programs::tc::TcError::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::programs::tc::TcError where T: ?core::marker::Sized
-pub fn aya::programs::tc::TcError::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya::programs::tc::TcError
-pub fn aya::programs::tc::TcError::from(t: T) -> T
 pub enum aya::programs::TracePointError
 pub aya::programs::TracePointError::FileError
 pub aya::programs::TracePointError::FileError::filename: std::path::PathBuf
@@ -8843,24 +5431,6 @@ impl core::marker::Unpin for aya::programs::trace_point::TracePointError
 impl core::marker::UnsafeUnpin for aya::programs::trace_point::TracePointError
 impl !core::panic::unwind_safe::RefUnwindSafe for aya::programs::trace_point::TracePointError
 impl !core::panic::unwind_safe::UnwindSafe for aya::programs::trace_point::TracePointError
-impl<T, U> core::convert::Into<U> for aya::programs::trace_point::TracePointError where U: core::convert::From<T>
-pub fn aya::programs::trace_point::TracePointError::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::programs::trace_point::TracePointError where U: core::convert::Into<T>
-pub type aya::programs::trace_point::TracePointError::Error = core::convert::Infallible
-pub fn aya::programs::trace_point::TracePointError::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::programs::trace_point::TracePointError where U: core::convert::TryFrom<T>
-pub type aya::programs::trace_point::TracePointError::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::programs::trace_point::TracePointError::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::string::ToString for aya::programs::trace_point::TracePointError where T: core::fmt::Display + ?core::marker::Sized
-pub fn aya::programs::trace_point::TracePointError::to_string(&self) -> alloc::string::String
-impl<T> core::any::Any for aya::programs::trace_point::TracePointError where T: 'static + ?core::marker::Sized
-pub fn aya::programs::trace_point::TracePointError::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::programs::trace_point::TracePointError where T: ?core::marker::Sized
-pub fn aya::programs::trace_point::TracePointError::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::programs::trace_point::TracePointError where T: ?core::marker::Sized
-pub fn aya::programs::trace_point::TracePointError::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya::programs::trace_point::TracePointError
-pub fn aya::programs::trace_point::TracePointError::from(t: T) -> T
 pub enum aya::programs::UProbeError
 pub aya::programs::UProbeError::FileError
 pub aya::programs::UProbeError::FileError::filename: std::path::PathBuf
@@ -8890,24 +5460,6 @@ impl core::marker::Unpin for aya::programs::uprobe::UProbeError
 impl core::marker::UnsafeUnpin for aya::programs::uprobe::UProbeError
 impl !core::panic::unwind_safe::RefUnwindSafe for aya::programs::uprobe::UProbeError
 impl !core::panic::unwind_safe::UnwindSafe for aya::programs::uprobe::UProbeError
-impl<T, U> core::convert::Into<U> for aya::programs::uprobe::UProbeError where U: core::convert::From<T>
-pub fn aya::programs::uprobe::UProbeError::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::programs::uprobe::UProbeError where U: core::convert::Into<T>
-pub type aya::programs::uprobe::UProbeError::Error = core::convert::Infallible
-pub fn aya::programs::uprobe::UProbeError::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::programs::uprobe::UProbeError where U: core::convert::TryFrom<T>
-pub type aya::programs::uprobe::UProbeError::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::programs::uprobe::UProbeError::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::string::ToString for aya::programs::uprobe::UProbeError where T: core::fmt::Display + ?core::marker::Sized
-pub fn aya::programs::uprobe::UProbeError::to_string(&self) -> alloc::string::String
-impl<T> core::any::Any for aya::programs::uprobe::UProbeError where T: 'static + ?core::marker::Sized
-pub fn aya::programs::uprobe::UProbeError::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::programs::uprobe::UProbeError where T: ?core::marker::Sized
-pub fn aya::programs::uprobe::UProbeError::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::programs::uprobe::UProbeError where T: ?core::marker::Sized
-pub fn aya::programs::uprobe::UProbeError::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya::programs::uprobe::UProbeError
-pub fn aya::programs::uprobe::UProbeError::from(t: T) -> T
 pub enum aya::programs::XdpError
 pub aya::programs::XdpError::NetlinkError(aya::sys::netlink::NetlinkError)
 impl core::convert::From<aya::programs::xdp::XdpError> for aya::programs::ProgramError
@@ -8925,24 +5477,6 @@ impl core::marker::Unpin for aya::programs::xdp::XdpError
 impl core::marker::UnsafeUnpin for aya::programs::xdp::XdpError
 impl !core::panic::unwind_safe::RefUnwindSafe for aya::programs::xdp::XdpError
 impl !core::panic::unwind_safe::UnwindSafe for aya::programs::xdp::XdpError
-impl<T, U> core::convert::Into<U> for aya::programs::xdp::XdpError where U: core::convert::From<T>
-pub fn aya::programs::xdp::XdpError::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::programs::xdp::XdpError where U: core::convert::Into<T>
-pub type aya::programs::xdp::XdpError::Error = core::convert::Infallible
-pub fn aya::programs::xdp::XdpError::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::programs::xdp::XdpError where U: core::convert::TryFrom<T>
-pub type aya::programs::xdp::XdpError::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::programs::xdp::XdpError::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::string::ToString for aya::programs::xdp::XdpError where T: core::fmt::Display + ?core::marker::Sized
-pub fn aya::programs::xdp::XdpError::to_string(&self) -> alloc::string::String
-impl<T> core::any::Any for aya::programs::xdp::XdpError where T: 'static + ?core::marker::Sized
-pub fn aya::programs::xdp::XdpError::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::programs::xdp::XdpError where T: ?core::marker::Sized
-pub fn aya::programs::xdp::XdpError::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::programs::xdp::XdpError where T: ?core::marker::Sized
-pub fn aya::programs::xdp::XdpError::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya::programs::xdp::XdpError
-pub fn aya::programs::xdp::XdpError::from(t: T) -> T
 pub struct aya::programs::BtfTracePoint
 impl aya::programs::tp_btf::BtfTracePoint
 pub const aya::programs::tp_btf::BtfTracePoint::PROGRAM_TYPE: aya::programs::ProgramType
@@ -8981,22 +5515,6 @@ impl core::marker::Unpin for aya::programs::tp_btf::BtfTracePoint
 impl core::marker::UnsafeUnpin for aya::programs::tp_btf::BtfTracePoint
 impl core::panic::unwind_safe::RefUnwindSafe for aya::programs::tp_btf::BtfTracePoint
 impl core::panic::unwind_safe::UnwindSafe for aya::programs::tp_btf::BtfTracePoint
-impl<T, U> core::convert::Into<U> for aya::programs::tp_btf::BtfTracePoint where U: core::convert::From<T>
-pub fn aya::programs::tp_btf::BtfTracePoint::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::programs::tp_btf::BtfTracePoint where U: core::convert::Into<T>
-pub type aya::programs::tp_btf::BtfTracePoint::Error = core::convert::Infallible
-pub fn aya::programs::tp_btf::BtfTracePoint::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::programs::tp_btf::BtfTracePoint where U: core::convert::TryFrom<T>
-pub type aya::programs::tp_btf::BtfTracePoint::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::programs::tp_btf::BtfTracePoint::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya::programs::tp_btf::BtfTracePoint where T: 'static + ?core::marker::Sized
-pub fn aya::programs::tp_btf::BtfTracePoint::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::programs::tp_btf::BtfTracePoint where T: ?core::marker::Sized
-pub fn aya::programs::tp_btf::BtfTracePoint::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::programs::tp_btf::BtfTracePoint where T: ?core::marker::Sized
-pub fn aya::programs::tp_btf::BtfTracePoint::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya::programs::tp_btf::BtfTracePoint
-pub fn aya::programs::tp_btf::BtfTracePoint::from(t: T) -> T
 pub struct aya::programs::CgroupDevice
 impl aya::programs::cgroup_device::CgroupDevice
 pub const aya::programs::cgroup_device::CgroupDevice::PROGRAM_TYPE: aya::programs::ProgramType
@@ -9036,22 +5554,6 @@ impl core::marker::Unpin for aya::programs::cgroup_device::CgroupDevice
 impl core::marker::UnsafeUnpin for aya::programs::cgroup_device::CgroupDevice
 impl core::panic::unwind_safe::RefUnwindSafe for aya::programs::cgroup_device::CgroupDevice
 impl core::panic::unwind_safe::UnwindSafe for aya::programs::cgroup_device::CgroupDevice
-impl<T, U> core::convert::Into<U> for aya::programs::cgroup_device::CgroupDevice where U: core::convert::From<T>
-pub fn aya::programs::cgroup_device::CgroupDevice::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::programs::cgroup_device::CgroupDevice where U: core::convert::Into<T>
-pub type aya::programs::cgroup_device::CgroupDevice::Error = core::convert::Infallible
-pub fn aya::programs::cgroup_device::CgroupDevice::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::programs::cgroup_device::CgroupDevice where U: core::convert::TryFrom<T>
-pub type aya::programs::cgroup_device::CgroupDevice::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::programs::cgroup_device::CgroupDevice::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya::programs::cgroup_device::CgroupDevice where T: 'static + ?core::marker::Sized
-pub fn aya::programs::cgroup_device::CgroupDevice::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::programs::cgroup_device::CgroupDevice where T: ?core::marker::Sized
-pub fn aya::programs::cgroup_device::CgroupDevice::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::programs::cgroup_device::CgroupDevice where T: ?core::marker::Sized
-pub fn aya::programs::cgroup_device::CgroupDevice::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya::programs::cgroup_device::CgroupDevice
-pub fn aya::programs::cgroup_device::CgroupDevice::from(t: T) -> T
 pub struct aya::programs::CgroupSkb
 impl aya::programs::cgroup_skb::CgroupSkb
 pub const aya::programs::cgroup_skb::CgroupSkb::PROGRAM_TYPE: aya::programs::ProgramType
@@ -9090,22 +5592,6 @@ impl core::marker::Unpin for aya::programs::cgroup_skb::CgroupSkb
 impl core::marker::UnsafeUnpin for aya::programs::cgroup_skb::CgroupSkb
 impl core::panic::unwind_safe::RefUnwindSafe for aya::programs::cgroup_skb::CgroupSkb
 impl core::panic::unwind_safe::UnwindSafe for aya::programs::cgroup_skb::CgroupSkb
-impl<T, U> core::convert::Into<U> for aya::programs::cgroup_skb::CgroupSkb where U: core::convert::From<T>
-pub fn aya::programs::cgroup_skb::CgroupSkb::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::programs::cgroup_skb::CgroupSkb where U: core::convert::Into<T>
-pub type aya::programs::cgroup_skb::CgroupSkb::Error = core::convert::Infallible
-pub fn aya::programs::cgroup_skb::CgroupSkb::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::programs::cgroup_skb::CgroupSkb where U: core::convert::TryFrom<T>
-pub type aya::programs::cgroup_skb::CgroupSkb::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::programs::cgroup_skb::CgroupSkb::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya::programs::cgroup_skb::CgroupSkb where T: 'static + ?core::marker::Sized
-pub fn aya::programs::cgroup_skb::CgroupSkb::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::programs::cgroup_skb::CgroupSkb where T: ?core::marker::Sized
-pub fn aya::programs::cgroup_skb::CgroupSkb::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::programs::cgroup_skb::CgroupSkb where T: ?core::marker::Sized
-pub fn aya::programs::cgroup_skb::CgroupSkb::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya::programs::cgroup_skb::CgroupSkb
-pub fn aya::programs::cgroup_skb::CgroupSkb::from(t: T) -> T
 pub struct aya::programs::CgroupSock
 impl aya::programs::cgroup_sock::CgroupSock
 pub const aya::programs::cgroup_sock::CgroupSock::PROGRAM_TYPE: aya::programs::ProgramType
@@ -9141,22 +5627,6 @@ impl core::marker::Unpin for aya::programs::cgroup_sock::CgroupSock
 impl core::marker::UnsafeUnpin for aya::programs::cgroup_sock::CgroupSock
 impl core::panic::unwind_safe::RefUnwindSafe for aya::programs::cgroup_sock::CgroupSock
 impl core::panic::unwind_safe::UnwindSafe for aya::programs::cgroup_sock::CgroupSock
-impl<T, U> core::convert::Into<U> for aya::programs::cgroup_sock::CgroupSock where U: core::convert::From<T>
-pub fn aya::programs::cgroup_sock::CgroupSock::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::programs::cgroup_sock::CgroupSock where U: core::convert::Into<T>
-pub type aya::programs::cgroup_sock::CgroupSock::Error = core::convert::Infallible
-pub fn aya::programs::cgroup_sock::CgroupSock::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::programs::cgroup_sock::CgroupSock where U: core::convert::TryFrom<T>
-pub type aya::programs::cgroup_sock::CgroupSock::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::programs::cgroup_sock::CgroupSock::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya::programs::cgroup_sock::CgroupSock where T: 'static + ?core::marker::Sized
-pub fn aya::programs::cgroup_sock::CgroupSock::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::programs::cgroup_sock::CgroupSock where T: ?core::marker::Sized
-pub fn aya::programs::cgroup_sock::CgroupSock::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::programs::cgroup_sock::CgroupSock where T: ?core::marker::Sized
-pub fn aya::programs::cgroup_sock::CgroupSock::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya::programs::cgroup_sock::CgroupSock
-pub fn aya::programs::cgroup_sock::CgroupSock::from(t: T) -> T
 pub struct aya::programs::CgroupSockAddr
 impl aya::programs::cgroup_sock_addr::CgroupSockAddr
 pub const aya::programs::cgroup_sock_addr::CgroupSockAddr::PROGRAM_TYPE: aya::programs::ProgramType
@@ -9192,22 +5662,6 @@ impl core::marker::Unpin for aya::programs::cgroup_sock_addr::CgroupSockAddr
 impl core::marker::UnsafeUnpin for aya::programs::cgroup_sock_addr::CgroupSockAddr
 impl core::panic::unwind_safe::RefUnwindSafe for aya::programs::cgroup_sock_addr::CgroupSockAddr
 impl core::panic::unwind_safe::UnwindSafe for aya::programs::cgroup_sock_addr::CgroupSockAddr
-impl<T, U> core::convert::Into<U> for aya::programs::cgroup_sock_addr::CgroupSockAddr where U: core::convert::From<T>
-pub fn aya::programs::cgroup_sock_addr::CgroupSockAddr::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::programs::cgroup_sock_addr::CgroupSockAddr where U: core::convert::Into<T>
-pub type aya::programs::cgroup_sock_addr::CgroupSockAddr::Error = core::convert::Infallible
-pub fn aya::programs::cgroup_sock_addr::CgroupSockAddr::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::programs::cgroup_sock_addr::CgroupSockAddr where U: core::convert::TryFrom<T>
-pub type aya::programs::cgroup_sock_addr::CgroupSockAddr::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::programs::cgroup_sock_addr::CgroupSockAddr::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya::programs::cgroup_sock_addr::CgroupSockAddr where T: 'static + ?core::marker::Sized
-pub fn aya::programs::cgroup_sock_addr::CgroupSockAddr::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::programs::cgroup_sock_addr::CgroupSockAddr where T: ?core::marker::Sized
-pub fn aya::programs::cgroup_sock_addr::CgroupSockAddr::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::programs::cgroup_sock_addr::CgroupSockAddr where T: ?core::marker::Sized
-pub fn aya::programs::cgroup_sock_addr::CgroupSockAddr::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya::programs::cgroup_sock_addr::CgroupSockAddr
-pub fn aya::programs::cgroup_sock_addr::CgroupSockAddr::from(t: T) -> T
 pub struct aya::programs::CgroupSockopt
 impl aya::programs::cgroup_sockopt::CgroupSockopt
 pub const aya::programs::cgroup_sockopt::CgroupSockopt::PROGRAM_TYPE: aya::programs::ProgramType
@@ -9245,22 +5699,6 @@ impl core::marker::Unpin for aya::programs::cgroup_sockopt::CgroupSockopt
 impl core::marker::UnsafeUnpin for aya::programs::cgroup_sockopt::CgroupSockopt
 impl core::panic::unwind_safe::RefUnwindSafe for aya::programs::cgroup_sockopt::CgroupSockopt
 impl core::panic::unwind_safe::UnwindSafe for aya::programs::cgroup_sockopt::CgroupSockopt
-impl<T, U> core::convert::Into<U> for aya::programs::cgroup_sockopt::CgroupSockopt where U: core::convert::From<T>
-pub fn aya::programs::cgroup_sockopt::CgroupSockopt::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::programs::cgroup_sockopt::CgroupSockopt where U: core::convert::Into<T>
-pub type aya::programs::cgroup_sockopt::CgroupSockopt::Error = core::convert::Infallible
-pub fn aya::programs::cgroup_sockopt::CgroupSockopt::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::programs::cgroup_sockopt::CgroupSockopt where U: core::convert::TryFrom<T>
-pub type aya::programs::cgroup_sockopt::CgroupSockopt::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::programs::cgroup_sockopt::CgroupSockopt::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya::programs::cgroup_sockopt::CgroupSockopt where T: 'static + ?core::marker::Sized
-pub fn aya::programs::cgroup_sockopt::CgroupSockopt::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::programs::cgroup_sockopt::CgroupSockopt where T: ?core::marker::Sized
-pub fn aya::programs::cgroup_sockopt::CgroupSockopt::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::programs::cgroup_sockopt::CgroupSockopt where T: ?core::marker::Sized
-pub fn aya::programs::cgroup_sockopt::CgroupSockopt::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya::programs::cgroup_sockopt::CgroupSockopt
-pub fn aya::programs::cgroup_sockopt::CgroupSockopt::from(t: T) -> T
 pub struct aya::programs::CgroupSysctl
 impl aya::programs::cgroup_sysctl::CgroupSysctl
 pub const aya::programs::cgroup_sysctl::CgroupSysctl::PROGRAM_TYPE: aya::programs::ProgramType
@@ -9299,22 +5737,6 @@ impl core::marker::Unpin for aya::programs::cgroup_sysctl::CgroupSysctl
 impl core::marker::UnsafeUnpin for aya::programs::cgroup_sysctl::CgroupSysctl
 impl core::panic::unwind_safe::RefUnwindSafe for aya::programs::cgroup_sysctl::CgroupSysctl
 impl core::panic::unwind_safe::UnwindSafe for aya::programs::cgroup_sysctl::CgroupSysctl
-impl<T, U> core::convert::Into<U> for aya::programs::cgroup_sysctl::CgroupSysctl where U: core::convert::From<T>
-pub fn aya::programs::cgroup_sysctl::CgroupSysctl::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::programs::cgroup_sysctl::CgroupSysctl where U: core::convert::Into<T>
-pub type aya::programs::cgroup_sysctl::CgroupSysctl::Error = core::convert::Infallible
-pub fn aya::programs::cgroup_sysctl::CgroupSysctl::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::programs::cgroup_sysctl::CgroupSysctl where U: core::convert::TryFrom<T>
-pub type aya::programs::cgroup_sysctl::CgroupSysctl::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::programs::cgroup_sysctl::CgroupSysctl::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya::programs::cgroup_sysctl::CgroupSysctl where T: 'static + ?core::marker::Sized
-pub fn aya::programs::cgroup_sysctl::CgroupSysctl::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::programs::cgroup_sysctl::CgroupSysctl where T: ?core::marker::Sized
-pub fn aya::programs::cgroup_sysctl::CgroupSysctl::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::programs::cgroup_sysctl::CgroupSysctl where T: ?core::marker::Sized
-pub fn aya::programs::cgroup_sysctl::CgroupSysctl::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya::programs::cgroup_sysctl::CgroupSysctl
-pub fn aya::programs::cgroup_sysctl::CgroupSysctl::from(t: T) -> T
 pub struct aya::programs::Extension
 impl aya::programs::extension::Extension
 pub const aya::programs::extension::Extension::PROGRAM_TYPE: aya::programs::ProgramType
@@ -9354,22 +5776,6 @@ impl core::marker::Unpin for aya::programs::extension::Extension
 impl core::marker::UnsafeUnpin for aya::programs::extension::Extension
 impl core::panic::unwind_safe::RefUnwindSafe for aya::programs::extension::Extension
 impl core::panic::unwind_safe::UnwindSafe for aya::programs::extension::Extension
-impl<T, U> core::convert::Into<U> for aya::programs::extension::Extension where U: core::convert::From<T>
-pub fn aya::programs::extension::Extension::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::programs::extension::Extension where U: core::convert::Into<T>
-pub type aya::programs::extension::Extension::Error = core::convert::Infallible
-pub fn aya::programs::extension::Extension::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::programs::extension::Extension where U: core::convert::TryFrom<T>
-pub type aya::programs::extension::Extension::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::programs::extension::Extension::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya::programs::extension::Extension where T: 'static + ?core::marker::Sized
-pub fn aya::programs::extension::Extension::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::programs::extension::Extension where T: ?core::marker::Sized
-pub fn aya::programs::extension::Extension::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::programs::extension::Extension where T: ?core::marker::Sized
-pub fn aya::programs::extension::Extension::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya::programs::extension::Extension
-pub fn aya::programs::extension::Extension::from(t: T) -> T
 pub struct aya::programs::FEntry
 impl aya::programs::fentry::FEntry
 pub const aya::programs::fentry::FEntry::PROGRAM_TYPE: aya::programs::ProgramType
@@ -9408,22 +5814,6 @@ impl core::marker::Unpin for aya::programs::fentry::FEntry
 impl core::marker::UnsafeUnpin for aya::programs::fentry::FEntry
 impl core::panic::unwind_safe::RefUnwindSafe for aya::programs::fentry::FEntry
 impl core::panic::unwind_safe::UnwindSafe for aya::programs::fentry::FEntry
-impl<T, U> core::convert::Into<U> for aya::programs::fentry::FEntry where U: core::convert::From<T>
-pub fn aya::programs::fentry::FEntry::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::programs::fentry::FEntry where U: core::convert::Into<T>
-pub type aya::programs::fentry::FEntry::Error = core::convert::Infallible
-pub fn aya::programs::fentry::FEntry::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::programs::fentry::FEntry where U: core::convert::TryFrom<T>
-pub type aya::programs::fentry::FEntry::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::programs::fentry::FEntry::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya::programs::fentry::FEntry where T: 'static + ?core::marker::Sized
-pub fn aya::programs::fentry::FEntry::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::programs::fentry::FEntry where T: ?core::marker::Sized
-pub fn aya::programs::fentry::FEntry::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::programs::fentry::FEntry where T: ?core::marker::Sized
-pub fn aya::programs::fentry::FEntry::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya::programs::fentry::FEntry
-pub fn aya::programs::fentry::FEntry::from(t: T) -> T
 pub struct aya::programs::FExit
 impl aya::programs::fexit::FExit
 pub const aya::programs::fexit::FExit::PROGRAM_TYPE: aya::programs::ProgramType
@@ -9462,22 +5852,6 @@ impl core::marker::Unpin for aya::programs::fexit::FExit
 impl core::marker::UnsafeUnpin for aya::programs::fexit::FExit
 impl core::panic::unwind_safe::RefUnwindSafe for aya::programs::fexit::FExit
 impl core::panic::unwind_safe::UnwindSafe for aya::programs::fexit::FExit
-impl<T, U> core::convert::Into<U> for aya::programs::fexit::FExit where U: core::convert::From<T>
-pub fn aya::programs::fexit::FExit::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::programs::fexit::FExit where U: core::convert::Into<T>
-pub type aya::programs::fexit::FExit::Error = core::convert::Infallible
-pub fn aya::programs::fexit::FExit::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::programs::fexit::FExit where U: core::convert::TryFrom<T>
-pub type aya::programs::fexit::FExit::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::programs::fexit::FExit::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya::programs::fexit::FExit where T: 'static + ?core::marker::Sized
-pub fn aya::programs::fexit::FExit::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::programs::fexit::FExit where T: ?core::marker::Sized
-pub fn aya::programs::fexit::FExit::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::programs::fexit::FExit where T: ?core::marker::Sized
-pub fn aya::programs::fexit::FExit::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya::programs::fexit::FExit
-pub fn aya::programs::fexit::FExit::from(t: T) -> T
 pub struct aya::programs::FlowDissector
 impl aya::programs::flow_dissector::FlowDissector
 pub const aya::programs::flow_dissector::FlowDissector::PROGRAM_TYPE: aya::programs::ProgramType
@@ -9514,22 +5888,6 @@ impl core::marker::Unpin for aya::programs::flow_dissector::FlowDissector
 impl core::marker::UnsafeUnpin for aya::programs::flow_dissector::FlowDissector
 impl core::panic::unwind_safe::RefUnwindSafe for aya::programs::flow_dissector::FlowDissector
 impl core::panic::unwind_safe::UnwindSafe for aya::programs::flow_dissector::FlowDissector
-impl<T, U> core::convert::Into<U> for aya::programs::flow_dissector::FlowDissector where U: core::convert::From<T>
-pub fn aya::programs::flow_dissector::FlowDissector::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::programs::flow_dissector::FlowDissector where U: core::convert::Into<T>
-pub type aya::programs::flow_dissector::FlowDissector::Error = core::convert::Infallible
-pub fn aya::programs::flow_dissector::FlowDissector::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::programs::flow_dissector::FlowDissector where U: core::convert::TryFrom<T>
-pub type aya::programs::flow_dissector::FlowDissector::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::programs::flow_dissector::FlowDissector::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya::programs::flow_dissector::FlowDissector where T: 'static + ?core::marker::Sized
-pub fn aya::programs::flow_dissector::FlowDissector::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::programs::flow_dissector::FlowDissector where T: ?core::marker::Sized
-pub fn aya::programs::flow_dissector::FlowDissector::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::programs::flow_dissector::FlowDissector where T: ?core::marker::Sized
-pub fn aya::programs::flow_dissector::FlowDissector::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya::programs::flow_dissector::FlowDissector
-pub fn aya::programs::flow_dissector::FlowDissector::from(t: T) -> T
 pub struct aya::programs::Iter
 impl aya::programs::iter::Iter
 pub const aya::programs::iter::Iter::PROGRAM_TYPE: aya::programs::ProgramType
@@ -9568,22 +5926,6 @@ impl core::marker::Unpin for aya::programs::iter::Iter
 impl core::marker::UnsafeUnpin for aya::programs::iter::Iter
 impl core::panic::unwind_safe::RefUnwindSafe for aya::programs::iter::Iter
 impl core::panic::unwind_safe::UnwindSafe for aya::programs::iter::Iter
-impl<T, U> core::convert::Into<U> for aya::programs::iter::Iter where U: core::convert::From<T>
-pub fn aya::programs::iter::Iter::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::programs::iter::Iter where U: core::convert::Into<T>
-pub type aya::programs::iter::Iter::Error = core::convert::Infallible
-pub fn aya::programs::iter::Iter::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::programs::iter::Iter where U: core::convert::TryFrom<T>
-pub type aya::programs::iter::Iter::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::programs::iter::Iter::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya::programs::iter::Iter where T: 'static + ?core::marker::Sized
-pub fn aya::programs::iter::Iter::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::programs::iter::Iter where T: ?core::marker::Sized
-pub fn aya::programs::iter::Iter::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::programs::iter::Iter where T: ?core::marker::Sized
-pub fn aya::programs::iter::Iter::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya::programs::iter::Iter
-pub fn aya::programs::iter::Iter::from(t: T) -> T
 pub struct aya::programs::KProbe
 impl aya::programs::kprobe::KProbe
 pub const aya::programs::kprobe::KProbe::PROGRAM_TYPE: aya::programs::ProgramType
@@ -9622,22 +5964,6 @@ impl core::marker::Unpin for aya::programs::kprobe::KProbe
 impl core::marker::UnsafeUnpin for aya::programs::kprobe::KProbe
 impl core::panic::unwind_safe::RefUnwindSafe for aya::programs::kprobe::KProbe
 impl core::panic::unwind_safe::UnwindSafe for aya::programs::kprobe::KProbe
-impl<T, U> core::convert::Into<U> for aya::programs::kprobe::KProbe where U: core::convert::From<T>
-pub fn aya::programs::kprobe::KProbe::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::programs::kprobe::KProbe where U: core::convert::Into<T>
-pub type aya::programs::kprobe::KProbe::Error = core::convert::Infallible
-pub fn aya::programs::kprobe::KProbe::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::programs::kprobe::KProbe where U: core::convert::TryFrom<T>
-pub type aya::programs::kprobe::KProbe::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::programs::kprobe::KProbe::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya::programs::kprobe::KProbe where T: 'static + ?core::marker::Sized
-pub fn aya::programs::kprobe::KProbe::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::programs::kprobe::KProbe where T: ?core::marker::Sized
-pub fn aya::programs::kprobe::KProbe::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::programs::kprobe::KProbe where T: ?core::marker::Sized
-pub fn aya::programs::kprobe::KProbe::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya::programs::kprobe::KProbe
-pub fn aya::programs::kprobe::KProbe::from(t: T) -> T
 pub struct aya::programs::LinkOrder
 impl aya::programs::links::LinkOrder
 pub fn aya::programs::links::LinkOrder::after_link<L: aya::programs::MultiProgLink>(link: &L) -> core::result::Result<Self, aya::programs::links::LinkError>
@@ -9659,22 +5985,6 @@ impl core::marker::Unpin for aya::programs::links::LinkOrder
 impl core::marker::UnsafeUnpin for aya::programs::links::LinkOrder
 impl core::panic::unwind_safe::RefUnwindSafe for aya::programs::links::LinkOrder
 impl core::panic::unwind_safe::UnwindSafe for aya::programs::links::LinkOrder
-impl<T, U> core::convert::Into<U> for aya::programs::links::LinkOrder where U: core::convert::From<T>
-pub fn aya::programs::links::LinkOrder::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::programs::links::LinkOrder where U: core::convert::Into<T>
-pub type aya::programs::links::LinkOrder::Error = core::convert::Infallible
-pub fn aya::programs::links::LinkOrder::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::programs::links::LinkOrder where U: core::convert::TryFrom<T>
-pub type aya::programs::links::LinkOrder::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::programs::links::LinkOrder::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya::programs::links::LinkOrder where T: 'static + ?core::marker::Sized
-pub fn aya::programs::links::LinkOrder::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::programs::links::LinkOrder where T: ?core::marker::Sized
-pub fn aya::programs::links::LinkOrder::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::programs::links::LinkOrder where T: ?core::marker::Sized
-pub fn aya::programs::links::LinkOrder::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya::programs::links::LinkOrder
-pub fn aya::programs::links::LinkOrder::from(t: T) -> T
 pub struct aya::programs::LircMode2
 impl aya::programs::lirc_mode2::LircMode2
 pub const aya::programs::lirc_mode2::LircMode2::PROGRAM_TYPE: aya::programs::ProgramType
@@ -9713,22 +6023,6 @@ impl core::marker::Unpin for aya::programs::lirc_mode2::LircMode2
 impl core::marker::UnsafeUnpin for aya::programs::lirc_mode2::LircMode2
 impl core::panic::unwind_safe::RefUnwindSafe for aya::programs::lirc_mode2::LircMode2
 impl core::panic::unwind_safe::UnwindSafe for aya::programs::lirc_mode2::LircMode2
-impl<T, U> core::convert::Into<U> for aya::programs::lirc_mode2::LircMode2 where U: core::convert::From<T>
-pub fn aya::programs::lirc_mode2::LircMode2::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::programs::lirc_mode2::LircMode2 where U: core::convert::Into<T>
-pub type aya::programs::lirc_mode2::LircMode2::Error = core::convert::Infallible
-pub fn aya::programs::lirc_mode2::LircMode2::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::programs::lirc_mode2::LircMode2 where U: core::convert::TryFrom<T>
-pub type aya::programs::lirc_mode2::LircMode2::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::programs::lirc_mode2::LircMode2::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya::programs::lirc_mode2::LircMode2 where T: 'static + ?core::marker::Sized
-pub fn aya::programs::lirc_mode2::LircMode2::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::programs::lirc_mode2::LircMode2 where T: ?core::marker::Sized
-pub fn aya::programs::lirc_mode2::LircMode2::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::programs::lirc_mode2::LircMode2 where T: ?core::marker::Sized
-pub fn aya::programs::lirc_mode2::LircMode2::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya::programs::lirc_mode2::LircMode2
-pub fn aya::programs::lirc_mode2::LircMode2::from(t: T) -> T
 pub struct aya::programs::Lsm
 impl aya::programs::lsm::Lsm
 pub const aya::programs::lsm::Lsm::PROGRAM_TYPE: aya::programs::ProgramType
@@ -9767,22 +6061,6 @@ impl core::marker::Unpin for aya::programs::lsm::Lsm
 impl core::marker::UnsafeUnpin for aya::programs::lsm::Lsm
 impl core::panic::unwind_safe::RefUnwindSafe for aya::programs::lsm::Lsm
 impl core::panic::unwind_safe::UnwindSafe for aya::programs::lsm::Lsm
-impl<T, U> core::convert::Into<U> for aya::programs::lsm::Lsm where U: core::convert::From<T>
-pub fn aya::programs::lsm::Lsm::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::programs::lsm::Lsm where U: core::convert::Into<T>
-pub type aya::programs::lsm::Lsm::Error = core::convert::Infallible
-pub fn aya::programs::lsm::Lsm::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::programs::lsm::Lsm where U: core::convert::TryFrom<T>
-pub type aya::programs::lsm::Lsm::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::programs::lsm::Lsm::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya::programs::lsm::Lsm where T: 'static + ?core::marker::Sized
-pub fn aya::programs::lsm::Lsm::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::programs::lsm::Lsm where T: ?core::marker::Sized
-pub fn aya::programs::lsm::Lsm::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::programs::lsm::Lsm where T: ?core::marker::Sized
-pub fn aya::programs::lsm::Lsm::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya::programs::lsm::Lsm
-pub fn aya::programs::lsm::Lsm::from(t: T) -> T
 pub struct aya::programs::LsmCgroup
 impl aya::programs::lsm_cgroup::LsmCgroup
 pub fn aya::programs::lsm_cgroup::LsmCgroup::attach<T: std::os::fd::owned::AsFd>(&mut self, cgroup: T) -> core::result::Result<aya::programs::lsm_cgroup::LsmLinkId, aya::programs::ProgramError>
@@ -9817,22 +6095,6 @@ impl core::marker::Unpin for aya::programs::lsm_cgroup::LsmCgroup
 impl core::marker::UnsafeUnpin for aya::programs::lsm_cgroup::LsmCgroup
 impl core::panic::unwind_safe::RefUnwindSafe for aya::programs::lsm_cgroup::LsmCgroup
 impl core::panic::unwind_safe::UnwindSafe for aya::programs::lsm_cgroup::LsmCgroup
-impl<T, U> core::convert::Into<U> for aya::programs::lsm_cgroup::LsmCgroup where U: core::convert::From<T>
-pub fn aya::programs::lsm_cgroup::LsmCgroup::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::programs::lsm_cgroup::LsmCgroup where U: core::convert::Into<T>
-pub type aya::programs::lsm_cgroup::LsmCgroup::Error = core::convert::Infallible
-pub fn aya::programs::lsm_cgroup::LsmCgroup::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::programs::lsm_cgroup::LsmCgroup where U: core::convert::TryFrom<T>
-pub type aya::programs::lsm_cgroup::LsmCgroup::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::programs::lsm_cgroup::LsmCgroup::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya::programs::lsm_cgroup::LsmCgroup where T: 'static + ?core::marker::Sized
-pub fn aya::programs::lsm_cgroup::LsmCgroup::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::programs::lsm_cgroup::LsmCgroup where T: ?core::marker::Sized
-pub fn aya::programs::lsm_cgroup::LsmCgroup::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::programs::lsm_cgroup::LsmCgroup where T: ?core::marker::Sized
-pub fn aya::programs::lsm_cgroup::LsmCgroup::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya::programs::lsm_cgroup::LsmCgroup
-pub fn aya::programs::lsm_cgroup::LsmCgroup::from(t: T) -> T
 pub struct aya::programs::PerfEvent
 impl aya::programs::perf_event::PerfEvent
 pub const aya::programs::perf_event::PerfEvent::PROGRAM_TYPE: aya::programs::ProgramType
@@ -9871,22 +6133,6 @@ impl core::marker::Unpin for aya::programs::perf_event::PerfEvent
 impl core::marker::UnsafeUnpin for aya::programs::perf_event::PerfEvent
 impl core::panic::unwind_safe::RefUnwindSafe for aya::programs::perf_event::PerfEvent
 impl core::panic::unwind_safe::UnwindSafe for aya::programs::perf_event::PerfEvent
-impl<T, U> core::convert::Into<U> for aya::programs::perf_event::PerfEvent where U: core::convert::From<T>
-pub fn aya::programs::perf_event::PerfEvent::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::programs::perf_event::PerfEvent where U: core::convert::Into<T>
-pub type aya::programs::perf_event::PerfEvent::Error = core::convert::Infallible
-pub fn aya::programs::perf_event::PerfEvent::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::programs::perf_event::PerfEvent where U: core::convert::TryFrom<T>
-pub type aya::programs::perf_event::PerfEvent::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::programs::perf_event::PerfEvent::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya::programs::perf_event::PerfEvent where T: 'static + ?core::marker::Sized
-pub fn aya::programs::perf_event::PerfEvent::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::programs::perf_event::PerfEvent where T: ?core::marker::Sized
-pub fn aya::programs::perf_event::PerfEvent::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::programs::perf_event::PerfEvent where T: ?core::marker::Sized
-pub fn aya::programs::perf_event::PerfEvent::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya::programs::perf_event::PerfEvent
-pub fn aya::programs::perf_event::PerfEvent::from(t: T) -> T
 pub struct aya::programs::ProgramFd(_)
 impl aya::programs::ProgramFd
 pub fn aya::programs::ProgramFd::try_clone(&self) -> std::io::error::Result<Self>
@@ -9901,22 +6147,6 @@ impl core::marker::Unpin for aya::programs::ProgramFd
 impl core::marker::UnsafeUnpin for aya::programs::ProgramFd
 impl core::panic::unwind_safe::RefUnwindSafe for aya::programs::ProgramFd
 impl core::panic::unwind_safe::UnwindSafe for aya::programs::ProgramFd
-impl<T, U> core::convert::Into<U> for aya::programs::ProgramFd where U: core::convert::From<T>
-pub fn aya::programs::ProgramFd::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::programs::ProgramFd where U: core::convert::Into<T>
-pub type aya::programs::ProgramFd::Error = core::convert::Infallible
-pub fn aya::programs::ProgramFd::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::programs::ProgramFd where U: core::convert::TryFrom<T>
-pub type aya::programs::ProgramFd::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::programs::ProgramFd::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya::programs::ProgramFd where T: 'static + ?core::marker::Sized
-pub fn aya::programs::ProgramFd::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::programs::ProgramFd where T: ?core::marker::Sized
-pub fn aya::programs::ProgramFd::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::programs::ProgramFd where T: ?core::marker::Sized
-pub fn aya::programs::ProgramFd::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya::programs::ProgramFd
-pub fn aya::programs::ProgramFd::from(t: T) -> T
 pub struct aya::programs::ProgramId(_)
 impl aya::programs::ProgramId
 pub unsafe const fn aya::programs::ProgramId::new(id: u32) -> Self
@@ -9927,22 +6157,6 @@ impl core::marker::Unpin for aya::programs::ProgramId
 impl core::marker::UnsafeUnpin for aya::programs::ProgramId
 impl core::panic::unwind_safe::RefUnwindSafe for aya::programs::ProgramId
 impl core::panic::unwind_safe::UnwindSafe for aya::programs::ProgramId
-impl<T, U> core::convert::Into<U> for aya::programs::ProgramId where U: core::convert::From<T>
-pub fn aya::programs::ProgramId::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::programs::ProgramId where U: core::convert::Into<T>
-pub type aya::programs::ProgramId::Error = core::convert::Infallible
-pub fn aya::programs::ProgramId::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::programs::ProgramId where U: core::convert::TryFrom<T>
-pub type aya::programs::ProgramId::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::programs::ProgramId::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya::programs::ProgramId where T: 'static + ?core::marker::Sized
-pub fn aya::programs::ProgramId::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::programs::ProgramId where T: ?core::marker::Sized
-pub fn aya::programs::ProgramId::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::programs::ProgramId where T: ?core::marker::Sized
-pub fn aya::programs::ProgramId::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya::programs::ProgramId
-pub fn aya::programs::ProgramId::from(t: T) -> T
 pub struct aya::programs::ProgramInfo(_)
 impl aya::programs::ProgramInfo
 pub fn aya::programs::ProgramInfo::btf_id(&self) -> core::option::Option<u32>
@@ -9972,22 +6186,6 @@ impl core::marker::Unpin for aya::programs::ProgramInfo
 impl core::marker::UnsafeUnpin for aya::programs::ProgramInfo
 impl core::panic::unwind_safe::RefUnwindSafe for aya::programs::ProgramInfo
 impl core::panic::unwind_safe::UnwindSafe for aya::programs::ProgramInfo
-impl<T, U> core::convert::Into<U> for aya::programs::ProgramInfo where U: core::convert::From<T>
-pub fn aya::programs::ProgramInfo::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::programs::ProgramInfo where U: core::convert::Into<T>
-pub type aya::programs::ProgramInfo::Error = core::convert::Infallible
-pub fn aya::programs::ProgramInfo::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::programs::ProgramInfo where U: core::convert::TryFrom<T>
-pub type aya::programs::ProgramInfo::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::programs::ProgramInfo::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya::programs::ProgramInfo where T: 'static + ?core::marker::Sized
-pub fn aya::programs::ProgramInfo::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::programs::ProgramInfo where T: ?core::marker::Sized
-pub fn aya::programs::ProgramInfo::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::programs::ProgramInfo where T: ?core::marker::Sized
-pub fn aya::programs::ProgramInfo::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya::programs::ProgramInfo
-pub fn aya::programs::ProgramInfo::from(t: T) -> T
 pub struct aya::programs::RawTracePoint
 impl aya::programs::raw_trace_point::RawTracePoint
 pub const aya::programs::raw_trace_point::RawTracePoint::PROGRAM_TYPE: aya::programs::ProgramType
@@ -10026,22 +6224,6 @@ impl core::marker::Unpin for aya::programs::raw_trace_point::RawTracePoint
 impl core::marker::UnsafeUnpin for aya::programs::raw_trace_point::RawTracePoint
 impl core::panic::unwind_safe::RefUnwindSafe for aya::programs::raw_trace_point::RawTracePoint
 impl core::panic::unwind_safe::UnwindSafe for aya::programs::raw_trace_point::RawTracePoint
-impl<T, U> core::convert::Into<U> for aya::programs::raw_trace_point::RawTracePoint where U: core::convert::From<T>
-pub fn aya::programs::raw_trace_point::RawTracePoint::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::programs::raw_trace_point::RawTracePoint where U: core::convert::Into<T>
-pub type aya::programs::raw_trace_point::RawTracePoint::Error = core::convert::Infallible
-pub fn aya::programs::raw_trace_point::RawTracePoint::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::programs::raw_trace_point::RawTracePoint where U: core::convert::TryFrom<T>
-pub type aya::programs::raw_trace_point::RawTracePoint::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::programs::raw_trace_point::RawTracePoint::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya::programs::raw_trace_point::RawTracePoint where T: 'static + ?core::marker::Sized
-pub fn aya::programs::raw_trace_point::RawTracePoint::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::programs::raw_trace_point::RawTracePoint where T: ?core::marker::Sized
-pub fn aya::programs::raw_trace_point::RawTracePoint::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::programs::raw_trace_point::RawTracePoint where T: ?core::marker::Sized
-pub fn aya::programs::raw_trace_point::RawTracePoint::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya::programs::raw_trace_point::RawTracePoint
-pub fn aya::programs::raw_trace_point::RawTracePoint::from(t: T) -> T
 pub struct aya::programs::SchedClassifier
 impl aya::programs::tc::SchedClassifier
 pub const aya::programs::tc::SchedClassifier::PROGRAM_TYPE: aya::programs::ProgramType
@@ -10084,22 +6266,6 @@ impl core::marker::Unpin for aya::programs::tc::SchedClassifier
 impl core::marker::UnsafeUnpin for aya::programs::tc::SchedClassifier
 impl core::panic::unwind_safe::RefUnwindSafe for aya::programs::tc::SchedClassifier
 impl core::panic::unwind_safe::UnwindSafe for aya::programs::tc::SchedClassifier
-impl<T, U> core::convert::Into<U> for aya::programs::tc::SchedClassifier where U: core::convert::From<T>
-pub fn aya::programs::tc::SchedClassifier::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::programs::tc::SchedClassifier where U: core::convert::Into<T>
-pub type aya::programs::tc::SchedClassifier::Error = core::convert::Infallible
-pub fn aya::programs::tc::SchedClassifier::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::programs::tc::SchedClassifier where U: core::convert::TryFrom<T>
-pub type aya::programs::tc::SchedClassifier::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::programs::tc::SchedClassifier::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya::programs::tc::SchedClassifier where T: 'static + ?core::marker::Sized
-pub fn aya::programs::tc::SchedClassifier::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::programs::tc::SchedClassifier where T: ?core::marker::Sized
-pub fn aya::programs::tc::SchedClassifier::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::programs::tc::SchedClassifier where T: ?core::marker::Sized
-pub fn aya::programs::tc::SchedClassifier::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya::programs::tc::SchedClassifier
-pub fn aya::programs::tc::SchedClassifier::from(t: T) -> T
 pub struct aya::programs::SkLookup
 impl aya::programs::sk_lookup::SkLookup
 pub const aya::programs::sk_lookup::SkLookup::PROGRAM_TYPE: aya::programs::ProgramType
@@ -10138,22 +6304,6 @@ impl core::marker::Unpin for aya::programs::sk_lookup::SkLookup
 impl core::marker::UnsafeUnpin for aya::programs::sk_lookup::SkLookup
 impl core::panic::unwind_safe::RefUnwindSafe for aya::programs::sk_lookup::SkLookup
 impl core::panic::unwind_safe::UnwindSafe for aya::programs::sk_lookup::SkLookup
-impl<T, U> core::convert::Into<U> for aya::programs::sk_lookup::SkLookup where U: core::convert::From<T>
-pub fn aya::programs::sk_lookup::SkLookup::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::programs::sk_lookup::SkLookup where U: core::convert::Into<T>
-pub type aya::programs::sk_lookup::SkLookup::Error = core::convert::Infallible
-pub fn aya::programs::sk_lookup::SkLookup::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::programs::sk_lookup::SkLookup where U: core::convert::TryFrom<T>
-pub type aya::programs::sk_lookup::SkLookup::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::programs::sk_lookup::SkLookup::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya::programs::sk_lookup::SkLookup where T: 'static + ?core::marker::Sized
-pub fn aya::programs::sk_lookup::SkLookup::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::programs::sk_lookup::SkLookup where T: ?core::marker::Sized
-pub fn aya::programs::sk_lookup::SkLookup::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::programs::sk_lookup::SkLookup where T: ?core::marker::Sized
-pub fn aya::programs::sk_lookup::SkLookup::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya::programs::sk_lookup::SkLookup
-pub fn aya::programs::sk_lookup::SkLookup::from(t: T) -> T
 pub struct aya::programs::SkMsg
 impl aya::programs::sk_msg::SkMsg
 pub const aya::programs::sk_msg::SkMsg::PROGRAM_TYPE: aya::programs::ProgramType
@@ -10192,22 +6342,6 @@ impl core::marker::Unpin for aya::programs::sk_msg::SkMsg
 impl core::marker::UnsafeUnpin for aya::programs::sk_msg::SkMsg
 impl core::panic::unwind_safe::RefUnwindSafe for aya::programs::sk_msg::SkMsg
 impl core::panic::unwind_safe::UnwindSafe for aya::programs::sk_msg::SkMsg
-impl<T, U> core::convert::Into<U> for aya::programs::sk_msg::SkMsg where U: core::convert::From<T>
-pub fn aya::programs::sk_msg::SkMsg::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::programs::sk_msg::SkMsg where U: core::convert::Into<T>
-pub type aya::programs::sk_msg::SkMsg::Error = core::convert::Infallible
-pub fn aya::programs::sk_msg::SkMsg::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::programs::sk_msg::SkMsg where U: core::convert::TryFrom<T>
-pub type aya::programs::sk_msg::SkMsg::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::programs::sk_msg::SkMsg::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya::programs::sk_msg::SkMsg where T: 'static + ?core::marker::Sized
-pub fn aya::programs::sk_msg::SkMsg::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::programs::sk_msg::SkMsg where T: ?core::marker::Sized
-pub fn aya::programs::sk_msg::SkMsg::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::programs::sk_msg::SkMsg where T: ?core::marker::Sized
-pub fn aya::programs::sk_msg::SkMsg::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya::programs::sk_msg::SkMsg
-pub fn aya::programs::sk_msg::SkMsg::from(t: T) -> T
 pub struct aya::programs::SkSkb
 impl aya::programs::sk_skb::SkSkb
 pub const aya::programs::sk_skb::SkSkb::PROGRAM_TYPE: aya::programs::ProgramType
@@ -10245,22 +6379,6 @@ impl core::marker::Unpin for aya::programs::sk_skb::SkSkb
 impl core::marker::UnsafeUnpin for aya::programs::sk_skb::SkSkb
 impl core::panic::unwind_safe::RefUnwindSafe for aya::programs::sk_skb::SkSkb
 impl core::panic::unwind_safe::UnwindSafe for aya::programs::sk_skb::SkSkb
-impl<T, U> core::convert::Into<U> for aya::programs::sk_skb::SkSkb where U: core::convert::From<T>
-pub fn aya::programs::sk_skb::SkSkb::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::programs::sk_skb::SkSkb where U: core::convert::Into<T>
-pub type aya::programs::sk_skb::SkSkb::Error = core::convert::Infallible
-pub fn aya::programs::sk_skb::SkSkb::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::programs::sk_skb::SkSkb where U: core::convert::TryFrom<T>
-pub type aya::programs::sk_skb::SkSkb::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::programs::sk_skb::SkSkb::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya::programs::sk_skb::SkSkb where T: 'static + ?core::marker::Sized
-pub fn aya::programs::sk_skb::SkSkb::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::programs::sk_skb::SkSkb where T: ?core::marker::Sized
-pub fn aya::programs::sk_skb::SkSkb::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::programs::sk_skb::SkSkb where T: ?core::marker::Sized
-pub fn aya::programs::sk_skb::SkSkb::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya::programs::sk_skb::SkSkb
-pub fn aya::programs::sk_skb::SkSkb::from(t: T) -> T
 pub struct aya::programs::SockOps
 impl aya::programs::sock_ops::SockOps
 pub const aya::programs::sock_ops::SockOps::PROGRAM_TYPE: aya::programs::ProgramType
@@ -10299,22 +6417,6 @@ impl core::marker::Unpin for aya::programs::sock_ops::SockOps
 impl core::marker::UnsafeUnpin for aya::programs::sock_ops::SockOps
 impl core::panic::unwind_safe::RefUnwindSafe for aya::programs::sock_ops::SockOps
 impl core::panic::unwind_safe::UnwindSafe for aya::programs::sock_ops::SockOps
-impl<T, U> core::convert::Into<U> for aya::programs::sock_ops::SockOps where U: core::convert::From<T>
-pub fn aya::programs::sock_ops::SockOps::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::programs::sock_ops::SockOps where U: core::convert::Into<T>
-pub type aya::programs::sock_ops::SockOps::Error = core::convert::Infallible
-pub fn aya::programs::sock_ops::SockOps::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::programs::sock_ops::SockOps where U: core::convert::TryFrom<T>
-pub type aya::programs::sock_ops::SockOps::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::programs::sock_ops::SockOps::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya::programs::sock_ops::SockOps where T: 'static + ?core::marker::Sized
-pub fn aya::programs::sock_ops::SockOps::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::programs::sock_ops::SockOps where T: ?core::marker::Sized
-pub fn aya::programs::sock_ops::SockOps::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::programs::sock_ops::SockOps where T: ?core::marker::Sized
-pub fn aya::programs::sock_ops::SockOps::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya::programs::sock_ops::SockOps
-pub fn aya::programs::sock_ops::SockOps::from(t: T) -> T
 pub struct aya::programs::SocketFilter
 impl aya::programs::socket_filter::SocketFilter
 pub const aya::programs::socket_filter::SocketFilter::PROGRAM_TYPE: aya::programs::ProgramType
@@ -10350,22 +6452,6 @@ impl core::marker::Unpin for aya::programs::socket_filter::SocketFilter
 impl core::marker::UnsafeUnpin for aya::programs::socket_filter::SocketFilter
 impl core::panic::unwind_safe::RefUnwindSafe for aya::programs::socket_filter::SocketFilter
 impl core::panic::unwind_safe::UnwindSafe for aya::programs::socket_filter::SocketFilter
-impl<T, U> core::convert::Into<U> for aya::programs::socket_filter::SocketFilter where U: core::convert::From<T>
-pub fn aya::programs::socket_filter::SocketFilter::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::programs::socket_filter::SocketFilter where U: core::convert::Into<T>
-pub type aya::programs::socket_filter::SocketFilter::Error = core::convert::Infallible
-pub fn aya::programs::socket_filter::SocketFilter::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::programs::socket_filter::SocketFilter where U: core::convert::TryFrom<T>
-pub type aya::programs::socket_filter::SocketFilter::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::programs::socket_filter::SocketFilter::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya::programs::socket_filter::SocketFilter where T: 'static + ?core::marker::Sized
-pub fn aya::programs::socket_filter::SocketFilter::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::programs::socket_filter::SocketFilter where T: ?core::marker::Sized
-pub fn aya::programs::socket_filter::SocketFilter::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::programs::socket_filter::SocketFilter where T: ?core::marker::Sized
-pub fn aya::programs::socket_filter::SocketFilter::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya::programs::socket_filter::SocketFilter
-pub fn aya::programs::socket_filter::SocketFilter::from(t: T) -> T
 pub struct aya::programs::TracePoint
 impl aya::programs::trace_point::TracePoint
 pub const aya::programs::trace_point::TracePoint::PROGRAM_TYPE: aya::programs::ProgramType
@@ -10404,22 +6490,6 @@ impl core::marker::Unpin for aya::programs::trace_point::TracePoint
 impl core::marker::UnsafeUnpin for aya::programs::trace_point::TracePoint
 impl core::panic::unwind_safe::RefUnwindSafe for aya::programs::trace_point::TracePoint
 impl core::panic::unwind_safe::UnwindSafe for aya::programs::trace_point::TracePoint
-impl<T, U> core::convert::Into<U> for aya::programs::trace_point::TracePoint where U: core::convert::From<T>
-pub fn aya::programs::trace_point::TracePoint::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::programs::trace_point::TracePoint where U: core::convert::Into<T>
-pub type aya::programs::trace_point::TracePoint::Error = core::convert::Infallible
-pub fn aya::programs::trace_point::TracePoint::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::programs::trace_point::TracePoint where U: core::convert::TryFrom<T>
-pub type aya::programs::trace_point::TracePoint::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::programs::trace_point::TracePoint::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya::programs::trace_point::TracePoint where T: 'static + ?core::marker::Sized
-pub fn aya::programs::trace_point::TracePoint::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::programs::trace_point::TracePoint where T: ?core::marker::Sized
-pub fn aya::programs::trace_point::TracePoint::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::programs::trace_point::TracePoint where T: ?core::marker::Sized
-pub fn aya::programs::trace_point::TracePoint::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya::programs::trace_point::TracePoint
-pub fn aya::programs::trace_point::TracePoint::from(t: T) -> T
 pub struct aya::programs::UProbe
 impl aya::programs::uprobe::UProbe
 pub const aya::programs::uprobe::UProbe::PROGRAM_TYPE: aya::programs::ProgramType
@@ -10458,22 +6528,6 @@ impl core::marker::Unpin for aya::programs::uprobe::UProbe
 impl core::marker::UnsafeUnpin for aya::programs::uprobe::UProbe
 impl core::panic::unwind_safe::RefUnwindSafe for aya::programs::uprobe::UProbe
 impl core::panic::unwind_safe::UnwindSafe for aya::programs::uprobe::UProbe
-impl<T, U> core::convert::Into<U> for aya::programs::uprobe::UProbe where U: core::convert::From<T>
-pub fn aya::programs::uprobe::UProbe::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::programs::uprobe::UProbe where U: core::convert::Into<T>
-pub type aya::programs::uprobe::UProbe::Error = core::convert::Infallible
-pub fn aya::programs::uprobe::UProbe::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::programs::uprobe::UProbe where U: core::convert::TryFrom<T>
-pub type aya::programs::uprobe::UProbe::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::programs::uprobe::UProbe::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya::programs::uprobe::UProbe where T: 'static + ?core::marker::Sized
-pub fn aya::programs::uprobe::UProbe::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::programs::uprobe::UProbe where T: ?core::marker::Sized
-pub fn aya::programs::uprobe::UProbe::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::programs::uprobe::UProbe where T: ?core::marker::Sized
-pub fn aya::programs::uprobe::UProbe::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya::programs::uprobe::UProbe
-pub fn aya::programs::uprobe::UProbe::from(t: T) -> T
 pub struct aya::programs::Xdp
 impl aya::programs::xdp::Xdp
 pub const aya::programs::xdp::Xdp::PROGRAM_TYPE: aya::programs::ProgramType
@@ -10513,22 +6567,6 @@ impl core::marker::Unpin for aya::programs::xdp::Xdp
 impl core::marker::UnsafeUnpin for aya::programs::xdp::Xdp
 impl core::panic::unwind_safe::RefUnwindSafe for aya::programs::xdp::Xdp
 impl core::panic::unwind_safe::UnwindSafe for aya::programs::xdp::Xdp
-impl<T, U> core::convert::Into<U> for aya::programs::xdp::Xdp where U: core::convert::From<T>
-pub fn aya::programs::xdp::Xdp::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::programs::xdp::Xdp where U: core::convert::Into<T>
-pub type aya::programs::xdp::Xdp::Error = core::convert::Infallible
-pub fn aya::programs::xdp::Xdp::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::programs::xdp::Xdp where U: core::convert::TryFrom<T>
-pub type aya::programs::xdp::Xdp::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::programs::xdp::Xdp::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya::programs::xdp::Xdp where T: 'static + ?core::marker::Sized
-pub fn aya::programs::xdp::Xdp::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::programs::xdp::Xdp where T: ?core::marker::Sized
-pub fn aya::programs::xdp::Xdp::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::programs::xdp::Xdp where T: ?core::marker::Sized
-pub fn aya::programs::xdp::Xdp::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya::programs::xdp::Xdp
-pub fn aya::programs::xdp::Xdp::from(t: T) -> T
 pub struct aya::programs::XdpFlags(_)
 impl aya::programs::xdp::XdpFlags
 pub const aya::programs::xdp::XdpFlags::DRV_MODE: Self
@@ -10621,28 +6659,6 @@ impl core::marker::Unpin for aya::programs::xdp::XdpFlags
 impl core::marker::UnsafeUnpin for aya::programs::xdp::XdpFlags
 impl core::panic::unwind_safe::RefUnwindSafe for aya::programs::xdp::XdpFlags
 impl core::panic::unwind_safe::UnwindSafe for aya::programs::xdp::XdpFlags
-impl<T, U> core::convert::Into<U> for aya::programs::xdp::XdpFlags where U: core::convert::From<T>
-pub fn aya::programs::xdp::XdpFlags::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::programs::xdp::XdpFlags where U: core::convert::Into<T>
-pub type aya::programs::xdp::XdpFlags::Error = core::convert::Infallible
-pub fn aya::programs::xdp::XdpFlags::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::programs::xdp::XdpFlags where U: core::convert::TryFrom<T>
-pub type aya::programs::xdp::XdpFlags::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::programs::xdp::XdpFlags::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya::programs::xdp::XdpFlags where T: core::clone::Clone
-pub type aya::programs::xdp::XdpFlags::Owned = T
-pub fn aya::programs::xdp::XdpFlags::clone_into(&self, target: &mut T)
-pub fn aya::programs::xdp::XdpFlags::to_owned(&self) -> T
-impl<T> core::any::Any for aya::programs::xdp::XdpFlags where T: 'static + ?core::marker::Sized
-pub fn aya::programs::xdp::XdpFlags::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::programs::xdp::XdpFlags where T: ?core::marker::Sized
-pub fn aya::programs::xdp::XdpFlags::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::programs::xdp::XdpFlags where T: ?core::marker::Sized
-pub fn aya::programs::xdp::XdpFlags::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya::programs::xdp::XdpFlags where T: core::clone::Clone
-pub unsafe fn aya::programs::xdp::XdpFlags::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya::programs::xdp::XdpFlags
-pub fn aya::programs::xdp::XdpFlags::from(t: T) -> T
 pub trait aya::programs::Link: core::fmt::Debug + core::cmp::Eq + core::hash::Hash + 'static
 pub type aya::programs::Link::Id: core::fmt::Debug + core::cmp::Eq + core::hash::Hash + equivalent::Equivalent<Self>
 pub fn aya::programs::Link::detach(self) -> core::result::Result<(), aya::programs::ProgramError>
@@ -10790,28 +6806,6 @@ impl core::marker::Unpin for aya::sys::Stats
 impl core::marker::UnsafeUnpin for aya::sys::Stats
 impl core::panic::unwind_safe::RefUnwindSafe for aya::sys::Stats
 impl core::panic::unwind_safe::UnwindSafe for aya::sys::Stats
-impl<T, U> core::convert::Into<U> for aya::sys::Stats where U: core::convert::From<T>
-pub fn aya::sys::Stats::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::sys::Stats where U: core::convert::Into<T>
-pub type aya::sys::Stats::Error = core::convert::Infallible
-pub fn aya::sys::Stats::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::sys::Stats where U: core::convert::TryFrom<T>
-pub type aya::sys::Stats::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::sys::Stats::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya::sys::Stats where T: core::clone::Clone
-pub type aya::sys::Stats::Owned = T
-pub fn aya::sys::Stats::clone_into(&self, target: &mut T)
-pub fn aya::sys::Stats::to_owned(&self) -> T
-impl<T> core::any::Any for aya::sys::Stats where T: 'static + ?core::marker::Sized
-pub fn aya::sys::Stats::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::sys::Stats where T: ?core::marker::Sized
-pub fn aya::sys::Stats::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::sys::Stats where T: ?core::marker::Sized
-pub fn aya::sys::Stats::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya::sys::Stats where T: core::clone::Clone
-pub unsafe fn aya::sys::Stats::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya::sys::Stats
-pub fn aya::sys::Stats::from(t: T) -> T
 pub struct aya::sys::SyscallError
 pub aya::sys::SyscallError::call: &'static str
 pub aya::sys::SyscallError::io_error: std::io::error::Error
@@ -10836,24 +6830,6 @@ impl core::marker::Unpin for aya::sys::SyscallError
 impl core::marker::UnsafeUnpin for aya::sys::SyscallError
 impl !core::panic::unwind_safe::RefUnwindSafe for aya::sys::SyscallError
 impl !core::panic::unwind_safe::UnwindSafe for aya::sys::SyscallError
-impl<T, U> core::convert::Into<U> for aya::sys::SyscallError where U: core::convert::From<T>
-pub fn aya::sys::SyscallError::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::sys::SyscallError where U: core::convert::Into<T>
-pub type aya::sys::SyscallError::Error = core::convert::Infallible
-pub fn aya::sys::SyscallError::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::sys::SyscallError where U: core::convert::TryFrom<T>
-pub type aya::sys::SyscallError::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::sys::SyscallError::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::string::ToString for aya::sys::SyscallError where T: core::fmt::Display + ?core::marker::Sized
-pub fn aya::sys::SyscallError::to_string(&self) -> alloc::string::String
-impl<T> core::any::Any for aya::sys::SyscallError where T: 'static + ?core::marker::Sized
-pub fn aya::sys::SyscallError::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::sys::SyscallError where T: ?core::marker::Sized
-pub fn aya::sys::SyscallError::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::sys::SyscallError where T: ?core::marker::Sized
-pub fn aya::sys::SyscallError::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya::sys::SyscallError
-pub fn aya::sys::SyscallError::from(t: T) -> T
 pub fn aya::sys::enable_stats(stats_type: aya::sys::Stats) -> core::result::Result<std::os::fd::owned::OwnedFd, aya::sys::SyscallError>
 pub fn aya::sys::is_map_supported(map_type: aya::maps::MapType) -> core::result::Result<bool, aya::sys::SyscallError>
 pub fn aya::sys::is_program_supported(program_type: aya::programs::ProgramType) -> core::result::Result<bool, aya::programs::ProgramError>
@@ -10883,34 +6859,6 @@ impl core::marker::Unpin for aya::util::KernelVersion
 impl core::marker::UnsafeUnpin for aya::util::KernelVersion
 impl core::panic::unwind_safe::RefUnwindSafe for aya::util::KernelVersion
 impl core::panic::unwind_safe::UnwindSafe for aya::util::KernelVersion
-impl<Q, K> equivalent::Equivalent<K> for aya::util::KernelVersion where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
-pub fn aya::util::KernelVersion::equivalent(&self, key: &K) -> bool
-impl<Q, K> hashbrown::Equivalent<K> for aya::util::KernelVersion where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
-pub fn aya::util::KernelVersion::equivalent(&self, key: &K) -> bool
-impl<T, U> core::convert::Into<U> for aya::util::KernelVersion where U: core::convert::From<T>
-pub fn aya::util::KernelVersion::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::util::KernelVersion where U: core::convert::Into<T>
-pub type aya::util::KernelVersion::Error = core::convert::Infallible
-pub fn aya::util::KernelVersion::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::util::KernelVersion where U: core::convert::TryFrom<T>
-pub type aya::util::KernelVersion::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::util::KernelVersion::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya::util::KernelVersion where T: core::clone::Clone
-pub type aya::util::KernelVersion::Owned = T
-pub fn aya::util::KernelVersion::clone_into(&self, target: &mut T)
-pub fn aya::util::KernelVersion::to_owned(&self) -> T
-impl<T> alloc::string::ToString for aya::util::KernelVersion where T: core::fmt::Display + ?core::marker::Sized
-pub fn aya::util::KernelVersion::to_string(&self) -> alloc::string::String
-impl<T> core::any::Any for aya::util::KernelVersion where T: 'static + ?core::marker::Sized
-pub fn aya::util::KernelVersion::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::util::KernelVersion where T: ?core::marker::Sized
-pub fn aya::util::KernelVersion::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::util::KernelVersion where T: ?core::marker::Sized
-pub fn aya::util::KernelVersion::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya::util::KernelVersion where T: core::clone::Clone
-pub unsafe fn aya::util::KernelVersion::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya::util::KernelVersion
-pub fn aya::util::KernelVersion::from(t: T) -> T
 pub fn aya::util::kernel_symbols() -> core::result::Result<alloc::collections::btree::map::BTreeMap<u64, alloc::string::String>, std::io::error::Error>
 pub fn aya::util::nr_cpus() -> core::result::Result<usize, (&'static str, std::io::error::Error)>
 pub fn aya::util::online_cpus() -> core::result::Result<alloc::vec::Vec<u32>, (&'static str, std::io::error::Error)>
@@ -10954,24 +6902,6 @@ impl core::marker::Unpin for aya::EbpfError
 impl core::marker::UnsafeUnpin for aya::EbpfError
 impl !core::panic::unwind_safe::RefUnwindSafe for aya::EbpfError
 impl !core::panic::unwind_safe::UnwindSafe for aya::EbpfError
-impl<T, U> core::convert::Into<U> for aya::EbpfError where U: core::convert::From<T>
-pub fn aya::EbpfError::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::EbpfError where U: core::convert::Into<T>
-pub type aya::EbpfError::Error = core::convert::Infallible
-pub fn aya::EbpfError::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::EbpfError where U: core::convert::TryFrom<T>
-pub type aya::EbpfError::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::EbpfError::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::string::ToString for aya::EbpfError where T: core::fmt::Display + ?core::marker::Sized
-pub fn aya::EbpfError::to_string(&self) -> alloc::string::String
-impl<T> core::any::Any for aya::EbpfError where T: 'static + ?core::marker::Sized
-pub fn aya::EbpfError::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::EbpfError where T: ?core::marker::Sized
-pub fn aya::EbpfError::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::EbpfError where T: ?core::marker::Sized
-pub fn aya::EbpfError::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya::EbpfError
-pub fn aya::EbpfError::from(t: T) -> T
 pub struct aya::Ebpf
 impl aya::Ebpf
 pub fn aya::Ebpf::load(data: &[u8]) -> core::result::Result<Self, aya::EbpfError>
@@ -10995,22 +6925,6 @@ impl core::marker::Unpin for aya::Ebpf
 impl core::marker::UnsafeUnpin for aya::Ebpf
 impl core::panic::unwind_safe::RefUnwindSafe for aya::Ebpf
 impl core::panic::unwind_safe::UnwindSafe for aya::Ebpf
-impl<T, U> core::convert::Into<U> for aya::Ebpf where U: core::convert::From<T>
-pub fn aya::Ebpf::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::Ebpf where U: core::convert::Into<T>
-pub type aya::Ebpf::Error = core::convert::Infallible
-pub fn aya::Ebpf::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::Ebpf where U: core::convert::TryFrom<T>
-pub type aya::Ebpf::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::Ebpf::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya::Ebpf where T: 'static + ?core::marker::Sized
-pub fn aya::Ebpf::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::Ebpf where T: ?core::marker::Sized
-pub fn aya::Ebpf::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::Ebpf where T: ?core::marker::Sized
-pub fn aya::Ebpf::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya::Ebpf
-pub fn aya::Ebpf::from(t: T) -> T
 pub struct aya::EbpfLoader<'a>
 impl<'a> aya::EbpfLoader<'a>
 pub const fn aya::EbpfLoader<'a>::allow_unsupported_maps(&mut self) -> &mut Self
@@ -11037,22 +6951,6 @@ impl<'a> core::marker::Unpin for aya::EbpfLoader<'a>
 impl<'a> core::marker::UnsafeUnpin for aya::EbpfLoader<'a>
 impl<'a> core::panic::unwind_safe::RefUnwindSafe for aya::EbpfLoader<'a>
 impl<'a> core::panic::unwind_safe::UnwindSafe for aya::EbpfLoader<'a>
-impl<T, U> core::convert::Into<U> for aya::EbpfLoader<'a> where U: core::convert::From<T>
-pub fn aya::EbpfLoader<'a>::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::EbpfLoader<'a> where U: core::convert::Into<T>
-pub type aya::EbpfLoader<'a>::Error = core::convert::Infallible
-pub fn aya::EbpfLoader<'a>::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::EbpfLoader<'a> where U: core::convert::TryFrom<T>
-pub type aya::EbpfLoader<'a>::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::EbpfLoader<'a>::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya::EbpfLoader<'a> where T: 'static + ?core::marker::Sized
-pub fn aya::EbpfLoader<'a>::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::EbpfLoader<'a> where T: ?core::marker::Sized
-pub fn aya::EbpfLoader<'a>::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::EbpfLoader<'a> where T: ?core::marker::Sized
-pub fn aya::EbpfLoader<'a>::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya::EbpfLoader<'a>
-pub fn aya::EbpfLoader<'a>::from(t: T) -> T
 pub struct aya::GlobalData<'a>
 impl<'a, T: aya::Pod> core::convert::From<&'a T> for aya::GlobalData<'a>
 pub fn aya::GlobalData<'a>::from(v: &'a T) -> Self
@@ -11065,22 +6963,6 @@ impl<'a> core::marker::Unpin for aya::GlobalData<'a>
 impl<'a> core::marker::UnsafeUnpin for aya::GlobalData<'a>
 impl<'a> core::panic::unwind_safe::RefUnwindSafe for aya::GlobalData<'a>
 impl<'a> core::panic::unwind_safe::UnwindSafe for aya::GlobalData<'a>
-impl<T, U> core::convert::Into<U> for aya::GlobalData<'a> where U: core::convert::From<T>
-pub fn aya::GlobalData<'a>::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::GlobalData<'a> where U: core::convert::Into<T>
-pub type aya::GlobalData<'a>::Error = core::convert::Infallible
-pub fn aya::GlobalData<'a>::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::GlobalData<'a> where U: core::convert::TryFrom<T>
-pub type aya::GlobalData<'a>::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::GlobalData<'a>::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for aya::GlobalData<'a> where T: 'static + ?core::marker::Sized
-pub fn aya::GlobalData<'a>::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::GlobalData<'a> where T: ?core::marker::Sized
-pub fn aya::GlobalData<'a>::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::GlobalData<'a> where T: ?core::marker::Sized
-pub fn aya::GlobalData<'a>::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for aya::GlobalData<'a>
-pub fn aya::GlobalData<'a>::from(t: T) -> T
 pub struct aya::VerifierLogLevel(_)
 impl aya::VerifierLogLevel
 pub const aya::VerifierLogLevel::DEBUG: Self
@@ -11172,28 +7054,6 @@ impl core::marker::Unpin for aya::VerifierLogLevel
 impl core::marker::UnsafeUnpin for aya::VerifierLogLevel
 impl core::panic::unwind_safe::RefUnwindSafe for aya::VerifierLogLevel
 impl core::panic::unwind_safe::UnwindSafe for aya::VerifierLogLevel
-impl<T, U> core::convert::Into<U> for aya::VerifierLogLevel where U: core::convert::From<T>
-pub fn aya::VerifierLogLevel::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for aya::VerifierLogLevel where U: core::convert::Into<T>
-pub type aya::VerifierLogLevel::Error = core::convert::Infallible
-pub fn aya::VerifierLogLevel::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for aya::VerifierLogLevel where U: core::convert::TryFrom<T>
-pub type aya::VerifierLogLevel::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn aya::VerifierLogLevel::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for aya::VerifierLogLevel where T: core::clone::Clone
-pub type aya::VerifierLogLevel::Owned = T
-pub fn aya::VerifierLogLevel::clone_into(&self, target: &mut T)
-pub fn aya::VerifierLogLevel::to_owned(&self) -> T
-impl<T> core::any::Any for aya::VerifierLogLevel where T: 'static + ?core::marker::Sized
-pub fn aya::VerifierLogLevel::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for aya::VerifierLogLevel where T: ?core::marker::Sized
-pub fn aya::VerifierLogLevel::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for aya::VerifierLogLevel where T: ?core::marker::Sized
-pub fn aya::VerifierLogLevel::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for aya::VerifierLogLevel where T: core::clone::Clone
-pub unsafe fn aya::VerifierLogLevel::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for aya::VerifierLogLevel
-pub fn aya::VerifierLogLevel::from(t: T) -> T
 pub unsafe trait aya::Pod: core::marker::Copy + 'static
 impl aya::Pod for aya_obj::generated::linux_bindings_x86_64::bpf_cpumap_val
 impl aya::Pod for aya_obj::generated::linux_bindings_x86_64::bpf_devmap_val

--- a/xtask/src/public_api.rs
+++ b/xtask/src/public_api.rs
@@ -122,6 +122,7 @@ fn check_package_api(
     })?;
 
     let public_api = public_api::Builder::from_rustdoc_json(&rustdoc_json)
+        .omit_blanket_impls(true)
         .build()
         .with_context(|| {
             format!(


### PR DESCRIPTION
### Context

While working on PR #1499 and #1417, I hit a [CI failure on the public-api check](https://github.com/aya-rs/aya/actions/runs/24302798438/job/70958997032?pr=1499) that I couldn't reproduce locally — even after matching the exact same nightly version as CI (`rustc 1.97.0-nightly (2026-04-11)`).

After some investigation, I traced the root cause to `Cargo.lock`: since it's gitignored (correctly, for a library), CI resolves dependencies from scratch and may pick up different transitive dependency versions than my local environment. In this case, a different `hashbrown` version introduced different `Equivalent` blanket impls, causing the diff.

This got me thinking about whether we can avoid this class of failure entirely. I also found #1185 where the friction of maintaining public-api snapshots was discussed.

### Approach

Blanket impls (`From<T>`, `Into`, etc. and third-party ones like `hashbrown::Equivalent`) **should not be part of Aya's API contract**, correct me if I understand it wrongly.

This PR adds `.omit_blanket_impls(true)` to the `public-api` builder to filter them out.

### Impact & Trade-off

1. Open PRs that include `xtask/public-api/*.txt` files will need to rebase and re-bless.
2. Aya currently has **no public blanket impls** of its own, but If Aya introduces a public blanket impl in the future, it would be filtered out and not caught by the public-api check.


<!-- markdownlint-disable first-line-heading -->

<!--
    Thank you for your contribution to Aya! 🎉

    For Work In Progress Pull Requests, please use the Draft PR feature.

    Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Aya Contributing Guide: https://github.com/aya-rs/aya/blob/main/CONTRIBUTING.md
     - 📖 Read the Aya Code of Conduct: https://github.com/aya-rs/aya/blob/main/CODE_OF_CONDUCT.md
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages: https://cbea.ms/git-commit/
     - 📗 Update any related documentation.

-->

<!---
      Summarize the changes you're making here. Detailed information belongs in
      the Git commit messages. If your pull request contains just one commit,
      it's best to use its message as a summary. Otherwise, if there are multiple
      atomic commits, write a summary for the entire PR. Feel free to flag
      anything you think needs a reviewer's attention.
-->

<!--
      If your changes address an issue, link it with the *Fixes* tag so
      the issue gets closed when the PR is merged, for example:

      Fixes: #1234

      If you are only referencing an issue without fully addressing it, feel
      free to link it anywhere in the summary.
-->

### Added/updated tests?

_We strongly encourage you to add a test for your changes._

- [ ] Yes
- [x] No, and this is why:  this change only include public-api
- [ ] I need help with writing tests

### Checklist

- [x] Rust code has been formatted with `cargo +nightly fmt`.
- [x] All clippy lints have been fixed.
      You can find failing lints with `cargo xtask clippy`.
- [x] Unit tests are passing locally with `cargo test`.
- [x] The [Integration tests] are passing locally.
- [x] I have blessed any API changes with `cargo xtask public-api --bless`.

[Integration tests]: https://github.com/aya-rs/aya/blob/main/test/README.md

### (Optional) What GIF best describes this PR or how it makes you feel?

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aya-rs/aya/1529)
<!-- Reviewable:end -->
