### PR TITLE
aya: fix wrong BPF_LINK_TYPE in TryFrom<FdLink>

### DIFF
--- a/aya/src/programs/iter.rs
+++ b/aya/src/programs/iter.rs
@@ -15,9 +15,10 @@ use aya_obj::{
 use crate::{
     programs::{
         FdLink, LinkError, PerfLinkIdInner, PerfLinkInner, ProgramData, ProgramError, ProgramType,
-        define_link_wrapper, impl_try_into_fdlink, load_program_with_attach_type,
+        define_link_wrapper, impl_try_from_fdlink, impl_try_into_fdlink,
+        load_program_with_attach_type,
     },
-    sys::{LinkTarget, SyscallError, bpf_create_iter, bpf_link_create, bpf_link_get_info_by_fd},
+    sys::{LinkTarget, SyscallError, bpf_create_iter, bpf_link_create},
 };
 
 /// A BPF iterator which allows to dump data from the kernel-space into the
@@ -103,19 +104,8 @@ impl AsFd for IterFd {
     }
 }
 
-impl TryFrom<FdLink> for IterLink {
-    type Error = LinkError;
-
-    fn try_from(fd_link: FdLink) -> Result<Self, Self::Error> {
-        let info = bpf_link_get_info_by_fd(fd_link.fd.as_fd())?;
-        if info.type_ == (BPF_LINK_TYPE_ITER as u32) {
-            return Ok(Self::new(PerfLinkInner::Fd(fd_link)));
-        }
-        Err(LinkError::InvalidLink)
-    }
-}
-
 impl_try_into_fdlink!(IterLink, PerfLinkInner);
+impl_try_from_fdlink!(IterLink, PerfLinkInner, BPF_LINK_TYPE_ITER);
 
 define_link_wrapper!(IterLink, IterLinkId, PerfLinkInner, PerfLinkIdInner, Iter);
 

--- a/aya/src/programs/kprobe.rs
+++ b/aya/src/programs/kprobe.rs
@@ -3,7 +3,6 @@ use std::{
     ffi::OsStr,
     fmt::{self, Write},
     io,
-    os::fd::AsFd as _,
     path::{Path, PathBuf},
 };
 
@@ -13,12 +12,11 @@ use thiserror::Error;
 use crate::{
     VerifierLogLevel,
     programs::{
-        FdLink, LinkError, ProgramData, ProgramError, ProgramType, define_link_wrapper,
+        ProgramData, ProgramError, ProgramType, define_link_wrapper, impl_try_from_fdlink,
         impl_try_into_fdlink, load_program_without_attach_type,
         perf_attach::{PerfLinkIdInner, PerfLinkInner},
         probe::{Probe, ProbeKind, attach},
     },
-    sys::bpf_link_get_info_by_fd,
 };
 
 /// A kernel probe.
@@ -146,15 +144,8 @@ pub enum KProbeError {
 }
 
 impl_try_into_fdlink!(KProbeLink, PerfLinkInner);
-
-impl TryFrom<FdLink> for KProbeLink {
-    type Error = LinkError;
-
-    fn try_from(fd_link: FdLink) -> Result<Self, Self::Error> {
-        let info = bpf_link_get_info_by_fd(fd_link.fd.as_fd())?;
-        if info.type_ == (bpf_link_type::BPF_LINK_TYPE_KPROBE_MULTI as u32) {
-            return Ok(Self::new(PerfLinkInner::Fd(fd_link)));
-        }
-        Err(LinkError::InvalidLink)
-    }
-}
+impl_try_from_fdlink!(
+    KProbeLink,
+    PerfLinkInner,
+    bpf_link_type::BPF_LINK_TYPE_PERF_EVENT
+);

--- a/aya/src/programs/links.rs
+++ b/aya/src/programs/links.rs
@@ -583,6 +583,26 @@ macro_rules! impl_try_into_fdlink {
 
 pub(crate) use impl_try_into_fdlink;
 
+macro_rules! impl_try_from_fdlink {
+    ($wrapper:ident, $inner:ident, $link_type:expr) => {
+        impl TryFrom<$crate::programs::FdLink> for $wrapper {
+            type Error = $crate::programs::LinkError;
+
+            fn try_from(fd_link: $crate::programs::FdLink) -> Result<Self, Self::Error> {
+                use std::os::fd::AsFd as _;
+
+                let info = $crate::sys::bpf_link_get_info_by_fd(fd_link.fd.as_fd())?;
+                if info.type_ == ($link_type as u32) {
+                    return Ok(Self::new($inner::Fd(fd_link)));
+                }
+                Err($crate::programs::LinkError::InvalidLink)
+            }
+        }
+    };
+}
+
+pub(crate) use impl_try_from_fdlink;
+
 #[derive(Error, Debug)]
 /// Errors from operations on links.
 pub enum LinkError {

--- a/aya/src/programs/mod.rs
+++ b/aya/src/programs/mod.rs
@@ -132,7 +132,7 @@ use crate::{
     programs::{
         links::{
             FdLink, FdLinkId, LinkError, LinkInfo, Links, ProgAttachLink, ProgAttachLinkId,
-            define_link_wrapper, id_as_key, impl_try_into_fdlink,
+            define_link_wrapper, id_as_key, impl_try_from_fdlink, impl_try_into_fdlink,
         },
         perf_attach::{PerfLinkIdInner, PerfLinkInner, perf_attach, perf_attach_debugfs},
     },

--- a/aya/src/programs/perf_event.rs
+++ b/aya/src/programs/perf_event.rs
@@ -11,12 +11,12 @@ use aya_obj::generated::{
 
 use crate::{
     programs::{
-        FdLink, LinkError, ProgramData, ProgramError, ProgramType, impl_try_into_fdlink,
+        ProgramData, ProgramError, ProgramType, impl_try_from_fdlink, impl_try_into_fdlink,
         links::define_link_wrapper,
         load_program_without_attach_type,
         perf_attach::{PerfLinkIdInner, PerfLinkInner, perf_attach},
     },
-    sys::{SyscallError, bpf_link_get_info_by_fd, perf_event_open},
+    sys::{SyscallError, perf_event_open},
 };
 
 /// The type of perf event and their respective configuration.
@@ -476,18 +476,11 @@ impl PerfEvent {
 }
 
 impl_try_into_fdlink!(PerfEventLink, PerfLinkInner);
-
-impl TryFrom<FdLink> for PerfEventLink {
-    type Error = LinkError;
-
-    fn try_from(fd_link: FdLink) -> Result<Self, Self::Error> {
-        let info = bpf_link_get_info_by_fd(fd_link.fd.as_fd())?;
-        if info.type_ == (bpf_link_type::BPF_LINK_TYPE_PERF_EVENT as u32) {
-            return Ok(Self::new(PerfLinkInner::Fd(fd_link)));
-        }
-        Err(LinkError::InvalidLink)
-    }
-}
+impl_try_from_fdlink!(
+    PerfEventLink,
+    PerfLinkInner,
+    bpf_link_type::BPF_LINK_TYPE_PERF_EVENT
+);
 
 define_link_wrapper!(
     PerfEventLink,

--- a/aya/src/programs/tc.rs
+++ b/aya/src/programs/tc.rs
@@ -14,13 +14,13 @@ use crate::{
     VerifierLogLevel,
     programs::{
         Link, LinkError, LinkOrder, ProgramData, ProgramError, ProgramType, define_link_wrapper,
-        id_as_key, impl_try_into_fdlink, load_program_without_attach_type, query,
+        id_as_key, impl_try_from_fdlink, impl_try_into_fdlink, load_program_without_attach_type,
+        query,
     },
     sys::{
         BpfLinkCreateArgs, LinkTarget, NetlinkError, NetlinkSocket, ProgQueryTarget, SyscallError,
-        bpf_link_create, bpf_link_get_info_by_fd, bpf_link_update, bpf_prog_get_fd_by_id,
-        netlink_find_filter_with_name, netlink_qdisc_add_clsact, netlink_qdisc_attach,
-        netlink_qdisc_detach,
+        bpf_link_create, bpf_link_update, bpf_prog_get_fd_by_id, netlink_find_filter_with_name,
+        netlink_qdisc_add_clsact, netlink_qdisc_attach, netlink_qdisc_detach,
     },
     util::{KernelVersion, ifindex_from_ifname, tc_handler_make},
 };
@@ -488,18 +488,11 @@ impl<'a> TryFrom<&'a SchedClassifierLink> for &'a FdLink {
 }
 
 impl_try_into_fdlink!(SchedClassifierLink, TcLinkInner);
-
-impl TryFrom<FdLink> for SchedClassifierLink {
-    type Error = LinkError;
-
-    fn try_from(fd_link: FdLink) -> Result<Self, Self::Error> {
-        let info = bpf_link_get_info_by_fd(fd_link.fd.as_fd())?;
-        if info.type_ == (bpf_link_type::BPF_LINK_TYPE_TCX as u32) {
-            return Ok(Self::new(TcLinkInner::Fd(fd_link)));
-        }
-        Err(LinkError::InvalidLink)
-    }
-}
+impl_try_from_fdlink!(
+    SchedClassifierLink,
+    TcLinkInner,
+    bpf_link_type::BPF_LINK_TYPE_TCX
+);
 
 define_link_wrapper!(
     SchedClassifierLink,

--- a/aya/src/programs/trace_point.rs
+++ b/aya/src/programs/trace_point.rs
@@ -10,12 +10,12 @@ use thiserror::Error;
 
 use crate::{
     programs::{
-        FdLink, LinkError, ProgramData, ProgramError, ProgramType, define_link_wrapper,
+        ProgramData, ProgramError, ProgramType, define_link_wrapper, impl_try_from_fdlink,
         impl_try_into_fdlink, load_program_without_attach_type,
         perf_attach::{PerfLinkIdInner, PerfLinkInner, perf_attach},
         utils::find_tracefs_path,
     },
-    sys::{SyscallError, bpf_link_get_info_by_fd, perf_event_open_trace_point},
+    sys::{SyscallError, perf_event_open_trace_point},
 };
 
 /// The type returned when attaching a [`TracePoint`] fails.
@@ -99,18 +99,11 @@ define_link_wrapper!(
 );
 
 impl_try_into_fdlink!(TracePointLink, PerfLinkInner);
-
-impl TryFrom<FdLink> for TracePointLink {
-    type Error = LinkError;
-
-    fn try_from(fd_link: FdLink) -> Result<Self, Self::Error> {
-        let info = bpf_link_get_info_by_fd(fd_link.fd.as_fd())?;
-        if info.type_ == (bpf_link_type::BPF_LINK_TYPE_TRACING as u32) {
-            return Ok(Self::new(PerfLinkInner::Fd(fd_link)));
-        }
-        Err(LinkError::InvalidLink)
-    }
-}
+impl_try_from_fdlink!(
+    TracePointLink,
+    PerfLinkInner,
+    bpf_link_type::BPF_LINK_TYPE_PERF_EVENT
+);
 
 pub(crate) fn read_sys_fs_trace_point_id(
     tracefs: &Path,

--- a/aya/src/programs/uprobe.rs
+++ b/aya/src/programs/uprobe.rs
@@ -6,10 +6,7 @@ use std::{
     fmt::{self, Write},
     fs,
     io::{self, BufRead as _, Cursor, Read as _},
-    os::{
-        fd::AsFd as _,
-        unix::ffi::{OsStrExt as _, OsStringExt as _},
-    },
+    os::unix::ffi::{OsStrExt as _, OsStringExt as _},
     path::{Path, PathBuf},
     sync::LazyLock,
 };
@@ -21,12 +18,11 @@ use thiserror::Error;
 use crate::{
     VerifierLogLevel,
     programs::{
-        FdLink, LinkError, ProgramData, ProgramError, ProgramType, define_link_wrapper,
+        ProgramData, ProgramError, ProgramType, define_link_wrapper, impl_try_from_fdlink,
         impl_try_into_fdlink, load_program_without_attach_type,
         perf_attach::{PerfLinkIdInner, PerfLinkInner},
         probe::{OsStringExt as _, Probe, ProbeKind, attach},
     },
-    sys::bpf_link_get_info_by_fd,
     util::MMap,
 };
 
@@ -228,18 +224,11 @@ define_link_wrapper!(
 );
 
 impl_try_into_fdlink!(UProbeLink, PerfLinkInner);
-
-impl TryFrom<FdLink> for UProbeLink {
-    type Error = LinkError;
-
-    fn try_from(fd_link: FdLink) -> Result<Self, Self::Error> {
-        let info = bpf_link_get_info_by_fd(fd_link.fd.as_fd())?;
-        if info.type_ == (bpf_link_type::BPF_LINK_TYPE_TRACING as u32) {
-            return Ok(Self::new(PerfLinkInner::Fd(fd_link)));
-        }
-        Err(LinkError::InvalidLink)
-    }
-}
+impl_try_from_fdlink!(
+    UProbeLink,
+    PerfLinkInner,
+    bpf_link_type::BPF_LINK_TYPE_PERF_EVENT
+);
 
 /// The type returned when attaching an [`UProbe`] fails.
 #[derive(Debug, Error)]

--- a/aya/src/programs/xdp.rs
+++ b/aya/src/programs/xdp.rs
@@ -19,12 +19,12 @@ use thiserror::Error;
 use crate::{
     VerifierLogLevel,
     programs::{
-        FdLink, Link, LinkError, ProgramData, ProgramError, ProgramType, define_link_wrapper,
-        id_as_key, impl_try_into_fdlink, load_program_with_attach_type,
+        FdLink, Link, ProgramData, ProgramError, ProgramType, define_link_wrapper, id_as_key,
+        impl_try_from_fdlink, impl_try_into_fdlink, load_program_with_attach_type,
     },
     sys::{
-        LinkTarget, NetlinkError, SyscallError, bpf_link_create, bpf_link_get_info_by_fd,
-        bpf_link_update, netlink_set_xdp_fd,
+        LinkTarget, NetlinkError, SyscallError, bpf_link_create, bpf_link_update,
+        netlink_set_xdp_fd,
     },
     util::KernelVersion,
 };
@@ -294,18 +294,6 @@ impl Link for XdpLinkInner {
 id_as_key!(XdpLinkInner, XdpLinkIdInner);
 
 impl_try_into_fdlink!(XdpLink, XdpLinkInner);
-
-impl TryFrom<FdLink> for XdpLink {
-    type Error = LinkError;
-
-    fn try_from(fd_link: FdLink) -> Result<Self, Self::Error> {
-        // unwrap of fd_link.fd will not panic since it's only None when being dropped.
-        let info = bpf_link_get_info_by_fd(fd_link.fd.as_fd())?;
-        if info.type_ == (bpf_link_type::BPF_LINK_TYPE_XDP as u32) {
-            return Ok(Self::new(XdpLinkInner::Fd(fd_link)));
-        }
-        Err(LinkError::InvalidLink)
-    }
-}
+impl_try_from_fdlink!(XdpLink, XdpLinkInner, bpf_link_type::BPF_LINK_TYPE_XDP);
 
 define_link_wrapper!(XdpLink, XdpLinkId, XdpLinkInner, XdpLinkIdInner, Xdp);

--- a/test/integration-test/src/tests/load.rs
+++ b/test/integration-test/src/tests/load.rs
@@ -535,7 +535,7 @@ fn run_pin_program_lifecycle_test<P>(
     expect_fd_link: bool,
 ) where
     P: UnloadProgramOps + PinProgramOps,
-    P::OwnedLink: TryInto<FdLink, Error = LinkError>,
+    P::OwnedLink: TryFrom<FdLink, Error = LinkError> + TryInto<FdLink, Error = LinkError>,
     for<'a> &'a mut Program: TryInto<&'a mut P, Error = ProgramError>,
 {
     let mut prog = {
@@ -574,6 +574,10 @@ fn run_pin_program_lifecycle_test<P>(
                 // 4. Load a new version of the program, unpin link, and atomically replace old program
                 {
                     let link = PinnedLink::from_pin(link_pin).unwrap().unpin().unwrap();
+                    let link: P::OwnedLink = link
+                        .try_into()
+                        .expect("pinned link should round-trip through FdLink");
+                    let link: FdLink = link.try_into().unwrap();
                     if let Some(attach_to_link) = attach_to_link {
                         let mut bpf = Ebpf::load(bpf_image).unwrap();
                         let prog: &mut P =


### PR DESCRIPTION
### Context

UProbe, KProbe, and TracePoint all checked the wrong bpf_link_type when converting from FdLink. All three use perf_attach, which produces BPF_LINK_TYPE_PERF_EVENT links, but the checks matched BPF_LINK_TYPE_TRACING (UProbe, TracePoint) and
BPF_LINK_TYPE_KPROBE_MULTI (KProbe).

Strengthen pin_lifecycle tests to verify the FdLink to link conversion, covering this previously untested path.

Found while working on #1417.

<!-- markdownlint-disable first-line-heading -->

<!--
    Thank you for your contribution to Aya! 🎉

    For Work In Progress Pull Requests, please use the Draft PR feature.

    Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Aya Contributing Guide: https://github.com/aya-rs/aya/blob/main/CONTRIBUTING.md
     - 📖 Read the Aya Code of Conduct: https://github.com/aya-rs/aya/blob/main/CODE_OF_CONDUCT.md
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages: https://cbea.ms/git-commit/
     - 📗 Update any related documentation.

-->

<!---
      Summarize the changes you're making here. Detailed information belongs in
      the Git commit messages. If your pull request contains just one commit,
      it's best to use its message as a summary. Otherwise, if there are multiple
      atomic commits, write a summary for the entire PR. Feel free to flag
      anything you think needs a reviewer's attention.
-->

<!--
      If your changes address an issue, link it with the *Fixes* tag so
      the issue gets closed when the PR is merged, for example:

      Fixes: #1234

      If you are only referencing an issue without fully addressing it, feel
      free to link it anywhere in the summary.
-->

### Added/updated tests?

_We strongly encourage you to add a test for your changes._

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

### Checklist

- [x] Rust code has been formatted with `cargo +nightly fmt`.
- [x] All clippy lints have been fixed.
      You can find failing lints with `cargo xtask clippy`.
- [x] Unit tests are passing locally with `cargo test`.
- [x] The [Integration tests] are passing locally.
- [x] I have blessed any API changes with `cargo xtask public-api --bless`.

[Integration tests]: https://github.com/aya-rs/aya/blob/main/test/README.md

### (Optional) What GIF best describes this PR or how it makes you feel?

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aya-rs/aya/1532)
<!-- Reviewable:end -->
