### PR TITLE
aya-ebpf: add BTF map definition for LPM trie

### DIFF
--- a/ebpf/aya-ebpf/src/btf_maps/lpm_trie.rs
+++ b/ebpf/aya-ebpf/src/btf_maps/lpm_trie.rs
@@ -1,0 +1,114 @@
+use core::borrow::Borrow;
+
+use aya_ebpf_bindings::bindings::BPF_F_NO_PREALLOC;
+
+pub use crate::maps::lpm_trie::Key;
+use crate::{btf_maps::btf_map_def, insert, lookup, remove};
+
+btf_map_def!(
+    /// A BTF-compatible BPF LPM trie map.
+    ///
+    /// An LPM trie stores values keyed by an arbitrary-length prefix and
+    /// supports longest-prefix-match lookups. A common use case is IP routing
+    /// tables.
+    ///
+    /// # Minimum kernel version
+    ///
+    /// The minimum kernel version required to use this feature is 4.11.
+    ///
+    /// # `BPF_F_NO_PREALLOC`
+    ///
+    /// The kernel rejects LPM tries that do not set `BPF_F_NO_PREALLOC`. The
+    /// default value of `FLAGS` already sets this bit. Callers that override
+    /// `FLAGS` must keep `BPF_F_NO_PREALLOC` set or the map will fail to load
+    /// with `EINVAL`.
+    ///
+    /// # Key layout
+    ///
+    /// Keys are instances of [`Key<K>`], a `#[repr(C, packed)]` struct whose
+    /// first field is a `u32` prefix length (expressed in bits) and whose
+    /// second field is the `K`-typed data to match.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use aya_ebpf::{btf_maps::{LpmTrie, lpm_trie::Key}, macros::btf_map};
+    ///
+    /// #[btf_map]
+    /// static ROUTES: LpmTrie<[u8; 4], u32, 1024> = LpmTrie::new();
+    /// ```
+    pub struct LpmTrie<K, V; const MAX_ENTRIES: usize, const FLAGS: usize = { BPF_F_NO_PREALLOC as usize }>,
+    map_type: BPF_MAP_TYPE_LPM_TRIE,
+    max_entries: MAX_ENTRIES,
+    map_flags: FLAGS,
+    key_type: Key<K>,
+    value_type: V,
+);
+
+impl<K, V, const MAX_ENTRIES: usize, const FLAGS: usize> LpmTrie<K, V, MAX_ENTRIES, FLAGS> {
+    // Enforces kernel constraints (kernel/bpf/lpm_trie.c) and value
+    // alignment on the returned reference. `const _: ()` is forbidden in
+    // a generic impl, and a named associated const is lazy without a
+    // reference, hence `let () = Self::_CHECK` in every method.
+    const _CHECK: () = {
+        assert!(
+            size_of::<Key<K>>() >= 5,
+            "LPM trie key must be at least 5 bytes (prefix_len + one data byte).",
+        );
+        assert!(
+            size_of::<Key<K>>() <= 260,
+            "LPM trie key must be at most 260 bytes (prefix_len + 256 data bytes).",
+        );
+        assert!(
+            size_of::<V>() >= 1,
+            "LPM trie value must be non-zero sized.",
+        );
+        assert!(
+            MAX_ENTRIES > 0,
+            "LPM trie max_entries must be greater than zero."
+        );
+        // The kernel stores `V` at offset `size_of::<K>()` inside the trie
+        // node data area (see `trie_lookup_elem` in kernel/bpf/lpm_trie.c,
+        // which returns `found->data + trie->data_size`). Two conditions must
+        // hold for the returned pointer to be naturally aligned for `V`:
+        //
+        // 1. The trie node's `data[]` base must be aligned to
+        //    `align_of::<V>()`. `lpm_trie_node` contains an `rcu_head` and
+        //    raw pointers, so its overall alignment is
+        //    `align_of::<*mut ()>()`, which is 8 on 64-bit Linux. Values with
+        //    stricter alignment would be under-aligned.
+        // 2. The offset `size_of::<K>()` must be a multiple of
+        //    `align_of::<V>()`.
+        assert!(
+            align_of::<V>() <= 8,
+            "LPM trie value alignment must be at most 8 bytes.",
+        );
+        assert!(
+            size_of::<K>().is_multiple_of(align_of::<V>()),
+            "LPM trie value alignment requires size_of::<K>() to be a multiple of align_of::<V>().",
+        );
+    };
+
+    /// Looks up the value for the longest prefix in the trie that matches `key`.
+    ///
+    /// Returns `None` if no prefix in the trie matches.
+    #[inline(always)]
+    pub fn get(&self, key: &Key<K>) -> Option<&V> {
+        let () = Self::_CHECK;
+        lookup(self.as_ptr(), key).map(|p| unsafe { p.as_ref() })
+    }
+
+    /// Inserts or updates the value for the exact `(prefix_len, data)` pair.
+    #[inline(always)]
+    pub fn insert(&self, key: &Key<K>, value: impl Borrow<V>, flags: u64) -> Result<(), i32> {
+        let () = Self::_CHECK;
+        insert(self.as_ptr(), key, value.borrow(), flags)
+    }
+
+    /// Removes the entry for the exact `(prefix_len, data)` pair.
+    #[inline(always)]
+    pub fn remove(&self, key: &Key<K>) -> Result<(), i32> {
+        let () = Self::_CHECK;
+        remove(self.as_ptr(), key)
+    }
+}

--- a/ebpf/aya-ebpf/src/btf_maps/mod.rs
+++ b/ebpf/aya-ebpf/src/btf_maps/mod.rs
@@ -1,10 +1,12 @@
 pub mod array;
 pub mod bloom_filter;
+pub mod lpm_trie;
 pub mod ring_buf;
 pub mod sk_storage;
 
 pub use array::Array;
 pub use bloom_filter::BloomFilter;
+pub use lpm_trie::LpmTrie;
 pub use ring_buf::RingBuf;
 pub use sk_storage::SkStorage;
 

--- a/test/integration-common/src/lib.rs
+++ b/test/integration-common/src/lib.rs
@@ -123,3 +123,20 @@ pub mod sk_storage {
     #[cfg(feature = "user")]
     unsafe impl aya::Pod for Value {}
 }
+
+pub mod lpm_trie {
+    pub const LPM_MATCH_SLOT: u32 = 0;
+    pub const NO_MATCH_SLOT: u32 = 1;
+    pub const REMOVE_SLOT: u32 = 2;
+    pub const NUM_SLOTS: u32 = 3;
+
+    #[repr(C)]
+    #[derive(Clone, Copy, Default)]
+    pub struct TestResult {
+        pub value: u32,
+        pub ran: u32,
+    }
+
+    #[cfg(feature = "user")]
+    unsafe impl aya::Pod for TestResult {}
+}

--- a/test/integration-ebpf/Cargo.toml
+++ b/test/integration-ebpf/Cargo.toml
@@ -53,6 +53,10 @@ name = "log"
 path = "src/log.rs"
 
 [[bin]]
+name = "lpm_trie"
+path = "src/lpm_trie.rs"
+
+[[bin]]
 name = "map_test"
 path = "src/map_test.rs"
 

--- a/test/integration-ebpf/src/lpm_trie.rs
+++ b/test/integration-ebpf/src/lpm_trie.rs
@@ -1,0 +1,59 @@
+#![no_std]
+#![no_main]
+#![expect(unused_crate_dependencies, reason = "used in other bins")]
+
+#[cfg(not(test))]
+extern crate ebpf_panic;
+
+use aya_ebpf::{
+    btf_maps::{Array as BtfArray, LpmTrie as BtfLpmTrie, lpm_trie::Key},
+    macros::{btf_map, map, uprobe},
+    maps::{Array as LegacyArray, LpmTrie as LegacyLpmTrie},
+    programs::ProbeContext,
+};
+use integration_common::lpm_trie::{
+    LPM_MATCH_SLOT, NO_MATCH_SLOT, NUM_SLOTS, REMOVE_SLOT, TestResult,
+};
+
+#[btf_map]
+static ROUTES: BtfLpmTrie<[u8; 4], u32, 64> = BtfLpmTrie::new();
+
+#[btf_map]
+static RESULTS: BtfArray<TestResult, { NUM_SLOTS as usize }> = BtfArray::new();
+
+#[map]
+static ROUTES_LEGACY: LegacyLpmTrie<[u8; 4], u32> =
+    LegacyLpmTrie::<[u8; 4], u32>::with_max_entries(64, 0);
+
+#[map]
+static RESULTS_LEGACY: LegacyArray<TestResult> =
+    LegacyArray::<TestResult>::with_max_entries(NUM_SLOTS, 0);
+
+macro_rules! define_lpm_trie_test {
+    ($routes_map:ident, $results_map:ident, $probe_name:ident $(,)?) => {
+        #[uprobe]
+        fn $probe_name(_ctx: ProbeContext) -> u32 {
+            let record = |slot: u32, key: &Key<[u8; 4]>| {
+                if let Some(ptr) = $results_map.get_ptr_mut(slot) {
+                    unsafe {
+                        if let Some(val) = $routes_map.get(key) {
+                            (*ptr).value = *val;
+                        }
+                        (*ptr).ran = 1;
+                    }
+                }
+            };
+
+            record(LPM_MATCH_SLOT, &Key::new(32, [192, 168, 1, 42]));
+            record(NO_MATCH_SLOT, &Key::new(32, [10, 0, 0, 1]));
+            if $routes_map.remove(&Key::new(24, [192, 168, 1, 0])).is_ok() {
+                record(REMOVE_SLOT, &Key::new(32, [192, 168, 1, 42]));
+            }
+
+            0
+        }
+    };
+}
+
+define_lpm_trie_test!(ROUTES, RESULTS, test_btf_lpm_trie);
+define_lpm_trie_test!(ROUTES_LEGACY, RESULTS_LEGACY, test_lpm_trie_legacy);

--- a/test/integration-test/src/lib.rs
+++ b/test/integration-test/src/lib.rs
@@ -46,6 +46,7 @@ bpf_file!(
     KPROBE => "kprobe",
     LINEAR_DATA_STRUCTURES => "linear_data_structures",
     LOG => "log",
+    LPM_TRIE => "lpm_trie",
     MAP_TEST => "map_test",
     MEMMOVE_TEST => "memmove_test",
     NAME_TEST => "name_test",

--- a/test/integration-test/src/tests.rs
+++ b/test/integration-test/src/tests.rs
@@ -21,6 +21,7 @@ mod kprobe;
 mod linear_data_structures;
 mod load;
 mod log;
+mod lpm_trie;
 mod lsm;
 mod map_pin;
 mod maps_disjoint;

--- a/test/integration-test/src/tests/bloom_filter.rs
+++ b/test/integration-test/src/tests/bloom_filter.rs
@@ -7,6 +7,7 @@ use aya::{
 use integration_common::bloom_filter::{
     CONTAINS_ABSENT_INDEX, CONTAINS_PRESENT_INDEX, INSERT_INDEX,
 };
+use test_case::test_case;
 
 #[unsafe(no_mangle)]
 #[inline(never)]
@@ -22,8 +23,20 @@ extern "C" fn trigger_bloom_contains(result_index: u32, value: u32) {
     core::hint::black_box(value);
 }
 
+#[test_case(
+    "RESULT_LEGACY",
+    "FILTER_LEGACY",
+    "bloom_filter_insert_legacy",
+    "bloom_filter_contains_legacy" ; "legacy"
+)]
+#[test_case(
+    "RESULT",
+    "FILTER",
+    "btf_bloom_filter_insert",
+    "btf_bloom_filter_contains" ; "btf"
+)]
 #[test_log::test]
-fn bloom_filter_basic() {
+fn bloom_filter_basic(result_map: &str, filter_map: &str, insert_prog: &str, contains_prog: &str) {
     if !is_map_supported(MapType::BloomFilter).unwrap() {
         eprintln!("skipping test - bloom filter map not supported");
         return;
@@ -33,75 +46,56 @@ fn bloom_filter_basic() {
         .load(crate::BLOOM_FILTER)
         .expect("load bloom_filter program");
 
-    for (variant, result_map, filter_map, progs_and_symbols) in [
-        (
-            "legacy",
-            "RESULT_LEGACY",
-            "FILTER_LEGACY",
-            [
-                ("bloom_filter_insert_legacy", "trigger_bloom_insert"),
-                ("bloom_filter_contains_legacy", "trigger_bloom_contains"),
-            ],
-        ),
-        (
-            "btf",
-            "RESULT",
-            "FILTER",
-            [
-                ("btf_bloom_filter_insert", "trigger_bloom_insert"),
-                ("btf_bloom_filter_contains", "trigger_bloom_contains"),
-            ],
-        ),
+    for (prog_name, symbol) in [
+        (insert_prog, "trigger_bloom_insert"),
+        (contains_prog, "trigger_bloom_contains"),
     ] {
-        for (prog_name, symbol) in progs_and_symbols {
-            let prog: &mut UProbe = bpf
-                .program_mut(prog_name)
-                .unwrap_or_else(|| panic!("missing program {prog_name}"))
-                .try_into()
-                .unwrap_or_else(|_| panic!("program {prog_name} is not a uprobe"));
-            prog.load()
-                .unwrap_or_else(|err| panic!("load {prog_name}: {err}"));
-            prog.attach(symbol, "/proc/self/exe", None)
-                .unwrap_or_else(|err| panic!("attach {prog_name}: {err}"));
-        }
-
-        let array = Array::<_, i32>::try_from(bpf.take_map(result_map).unwrap()).unwrap();
-        let mut filter =
-            BloomFilter::<_, u32>::try_from(bpf.take_map(filter_map).unwrap()).unwrap();
-        const PRESENT: u32 = 1337;
-        const ABSENT: u32 = 1337_1337;
-        const USER_PRESENT: u32 = 42_4242;
-        const USER_ABSENT: u32 = 7_777_777;
-
-        trigger_bloom_insert(INSERT_INDEX, PRESENT);
-        assert_eq!(array.get(&INSERT_INDEX, 0).unwrap(), 0);
-
-        trigger_bloom_contains(CONTAINS_PRESENT_INDEX, PRESENT);
-        assert_eq!(array.get(&CONTAINS_PRESENT_INDEX, 0).unwrap(), 0);
-
-        trigger_bloom_contains(CONTAINS_ABSENT_INDEX, ABSENT);
-        let absent_status = array.get(&CONTAINS_ABSENT_INDEX, 0).unwrap();
-        // Bloom filters can yield false positives; treat both a miss (-ENOENT) and a hit (0) as valid.
-        assert!(
-            absent_status == -libc::ENOENT || absent_status == 0,
-            "unexpected {variant} BloomFilter result for absent value: {absent_status}"
-        );
-
-        filter.contains(PRESENT, 0).unwrap();
-
-        match filter.contains(USER_ABSENT, 0) {
-            Ok(())
-            // Bloom filters can yield false positives; treat both a miss and a hit as valid.
-            | Err(MapError::ElementNotFound) => {}
-            Err(err) => panic!(
-                "unexpected {variant} BloomFilter::contains result for absent value: {err}"
-            ),
-        }
-
-        filter.insert(USER_PRESENT, 0).unwrap();
-        filter.contains(USER_PRESENT, 0).unwrap();
-
-        trigger_bloom_contains(CONTAINS_PRESENT_INDEX, USER_PRESENT);
-        assert_eq!(array.get(&CONTAINS_PRESENT_INDEX, 0).unwrap(), 0);
+        let prog: &mut UProbe = bpf
+            .program_mut(prog_name)
+            .unwrap_or_else(|| panic!("missing program {prog_name}"))
+            .try_into()
+            .unwrap_or_else(|err| panic!("program {prog_name} is not a uprobe: {err}"));
+        prog.load()
+            .unwrap_or_else(|err| panic!("load {prog_name}: {err}"));
+        prog.attach(symbol, "/proc/self/exe", None)
+            .unwrap_or_else(|err| panic!("attach {prog_name}: {err}"));
     }
+
+    let array = Array::<_, i32>::try_from(bpf.take_map(result_map).unwrap()).unwrap();
+    let mut filter = BloomFilter::<_, u32>::try_from(bpf.take_map(filter_map).unwrap()).unwrap();
+    const PRESENT: u32 = 1337;
+    const ABSENT: u32 = 1337_1337;
+    const USER_PRESENT: u32 = 42_4242;
+    const USER_ABSENT: u32 = 7_777_777;
+
+    trigger_bloom_insert(INSERT_INDEX, PRESENT);
+    assert_eq!(array.get(&INSERT_INDEX, 0).unwrap(), 0);
+
+    trigger_bloom_contains(CONTAINS_PRESENT_INDEX, PRESENT);
+    assert_eq!(array.get(&CONTAINS_PRESENT_INDEX, 0).unwrap(), 0);
+
+    trigger_bloom_contains(CONTAINS_ABSENT_INDEX, ABSENT);
+    let absent_status = array.get(&CONTAINS_ABSENT_INDEX, 0).unwrap();
+    // Bloom filters can yield false positives; treat both a miss (-ENOENT) and a hit (0) as valid.
+    assert!(
+        absent_status == -libc::ENOENT || absent_status == 0,
+        "unexpected BloomFilter result for absent value: {absent_status}"
+    );
+
+    filter.contains(PRESENT, 0).unwrap();
+
+    match filter.contains(USER_ABSENT, 0) {
+        Ok(())
+        // Bloom filters can yield false positives; treat both a miss and a hit as valid.
+        | Err(MapError::ElementNotFound) => {}
+        Err(err) => {
+            panic!("unexpected BloomFilter::contains result for absent value: {err}")
+        }
+    }
+
+    filter.insert(USER_PRESENT, 0).unwrap();
+    filter.contains(USER_PRESENT, 0).unwrap();
+
+    trigger_bloom_contains(CONTAINS_PRESENT_INDEX, USER_PRESENT);
+    assert_eq!(array.get(&CONTAINS_PRESENT_INDEX, 0).unwrap(), 0);
 }

--- a/test/integration-test/src/tests/lpm_trie.rs
+++ b/test/integration-test/src/tests/lpm_trie.rs
@@ -1,0 +1,66 @@
+use aya::{
+    Ebpf,
+    maps::{Array, LpmTrie, lpm_trie::Key},
+    programs::UProbe,
+};
+use integration_common::lpm_trie::{LPM_MATCH_SLOT, NO_MATCH_SLOT, REMOVE_SLOT, TestResult};
+use test_case::test_case;
+
+#[unsafe(no_mangle)]
+#[inline(never)]
+extern "C" fn trigger_lpm_trie() {
+    core::hint::black_box(());
+}
+
+#[test_case("test_btf_lpm_trie", "ROUTES", "RESULTS" ; "btf")]
+#[test_case("test_lpm_trie_legacy", "ROUTES_LEGACY", "RESULTS_LEGACY" ; "legacy")]
+#[test_log::test]
+fn lpm_trie_basic(prog_name: &str, routes_map: &str, results_map: &str) {
+    let mut bpf = Ebpf::load(crate::LPM_TRIE).unwrap();
+
+    {
+        let mut routes: LpmTrie<_, [u8; 4], u32> =
+            bpf.map_mut(routes_map).unwrap().try_into().unwrap();
+        routes
+            .insert(&Key::new(16, [192, 168, 0, 0]), 42u32, 0)
+            .unwrap();
+        routes
+            .insert(&Key::new(24, [192, 168, 1, 0]), 7u32, 0)
+            .unwrap();
+    }
+
+    let prog: &mut UProbe = bpf
+        .program_mut(prog_name)
+        .unwrap_or_else(|| panic!("missing program {prog_name}"))
+        .try_into()
+        .unwrap_or_else(|err| panic!("program {prog_name} is not a uprobe: {err}"));
+    prog.load()
+        .unwrap_or_else(|err| panic!("load {prog_name}: {err}"));
+    prog.attach("trigger_lpm_trie", "/proc/self/exe", None)
+        .unwrap_or_else(|err| panic!("attach {prog_name}: {err}"));
+
+    trigger_lpm_trie();
+
+    let results = Array::<_, TestResult>::try_from(bpf.map(results_map).unwrap()).unwrap();
+
+    let TestResult { ran, value } = results.get(&LPM_MATCH_SLOT, 0).unwrap();
+    assert_eq!(ran, 1, "LPM-match probe did not run");
+    assert_eq!(
+        value, 7,
+        "longest-prefix-match should return the /24 value, not the /16"
+    );
+
+    let TestResult { ran, value } = results.get(&NO_MATCH_SLOT, 0).unwrap();
+    assert_eq!(ran, 1, "no-match probe did not run");
+    assert_eq!(
+        value, 0,
+        "get() should return None for a key outside the trie"
+    );
+
+    let TestResult { ran, value } = results.get(&REMOVE_SLOT, 0).unwrap();
+    assert_eq!(ran, 1, "after-remove probe did not run");
+    assert_eq!(
+        value, 42,
+        "after removing the /24, longest-prefix-match should fall back to the /16"
+    );
+}

--- a/xtask/public-api/aya-ebpf.txt
+++ b/xtask/public-api/aya-ebpf.txt
@@ -39,6 +39,35 @@ impl<T, const MAX_ENTRIES: usize, const FLAGS: usize, const HASH_FUNCS: usize> c
 impl<T, const MAX_ENTRIES: usize, const FLAGS: usize, const HASH_FUNCS: usize> core::marker::UnsafeUnpin for aya_ebpf::btf_maps::bloom_filter::BloomFilter<T, MAX_ENTRIES, FLAGS, HASH_FUNCS>
 impl<T, const MAX_ENTRIES: usize, const FLAGS: usize, const HASH_FUNCS: usize> core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::btf_maps::bloom_filter::BloomFilter<T, MAX_ENTRIES, FLAGS, HASH_FUNCS> where T: core::panic::unwind_safe::RefUnwindSafe
 impl<T, const MAX_ENTRIES: usize, const FLAGS: usize, const HASH_FUNCS: usize> core::panic::unwind_safe::UnwindSafe for aya_ebpf::btf_maps::bloom_filter::BloomFilter<T, MAX_ENTRIES, FLAGS, HASH_FUNCS> where T: core::panic::unwind_safe::RefUnwindSafe
+pub mod aya_ebpf::btf_maps::lpm_trie
+#[repr(C, packed(1))] pub struct aya_ebpf::btf_maps::lpm_trie::Key<K>
+pub aya_ebpf::btf_maps::lpm_trie::Key::data: K
+pub aya_ebpf::btf_maps::lpm_trie::Key::prefix_len: u32
+impl<K> aya_ebpf::maps::lpm_trie::Key<K>
+pub const fn aya_ebpf::maps::lpm_trie::Key<K>::new(prefix_len: u32, data: K) -> Self
+impl<K> core::marker::Freeze for aya_ebpf::maps::lpm_trie::Key<K> where K: core::marker::Freeze
+impl<K> core::marker::Send for aya_ebpf::maps::lpm_trie::Key<K> where K: core::marker::Send
+impl<K> core::marker::Sync for aya_ebpf::maps::lpm_trie::Key<K> where K: core::marker::Sync
+impl<K> core::marker::Unpin for aya_ebpf::maps::lpm_trie::Key<K> where K: core::marker::Unpin
+impl<K> core::marker::UnsafeUnpin for aya_ebpf::maps::lpm_trie::Key<K> where K: core::marker::UnsafeUnpin
+impl<K> core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::maps::lpm_trie::Key<K> where K: core::panic::unwind_safe::RefUnwindSafe
+impl<K> core::panic::unwind_safe::UnwindSafe for aya_ebpf::maps::lpm_trie::Key<K> where K: core::panic::unwind_safe::UnwindSafe
+#[repr(C)] pub struct aya_ebpf::btf_maps::lpm_trie::LpmTrie<K, V, const MAX_ENTRIES: usize, const FLAGS: usize>
+impl<K, V, const MAX_ENTRIES: usize, const FLAGS: usize> aya_ebpf::btf_maps::lpm_trie::LpmTrie<K, V, MAX_ENTRIES, FLAGS>
+pub fn aya_ebpf::btf_maps::lpm_trie::LpmTrie<K, V, MAX_ENTRIES, FLAGS>::get(&self, key: &aya_ebpf::maps::lpm_trie::Key<K>) -> core::option::Option<&V>
+pub fn aya_ebpf::btf_maps::lpm_trie::LpmTrie<K, V, MAX_ENTRIES, FLAGS>::insert(&self, key: &aya_ebpf::maps::lpm_trie::Key<K>, value: impl core::borrow::Borrow<V>, flags: u64) -> core::result::Result<(), i32>
+pub fn aya_ebpf::btf_maps::lpm_trie::LpmTrie<K, V, MAX_ENTRIES, FLAGS>::remove(&self, key: &aya_ebpf::maps::lpm_trie::Key<K>) -> core::result::Result<(), i32>
+impl<K, V, const MAX_ENTRIES: usize, const FLAGS: usize> aya_ebpf::btf_maps::lpm_trie::LpmTrie<K, V, MAX_ENTRIES, FLAGS>
+pub const fn aya_ebpf::btf_maps::lpm_trie::LpmTrie<K, V, MAX_ENTRIES, FLAGS>::new() -> Self
+impl<K, V, const MAX_ENTRIES: usize, const FLAGS: usize> core::default::Default for aya_ebpf::btf_maps::lpm_trie::LpmTrie<K, V, MAX_ENTRIES, FLAGS>
+pub fn aya_ebpf::btf_maps::lpm_trie::LpmTrie<K, V, MAX_ENTRIES, FLAGS>::default() -> Self
+impl<K, V, const MAX_ENTRIES: usize, const FLAGS: usize> core::marker::Sync for aya_ebpf::btf_maps::lpm_trie::LpmTrie<K, V, MAX_ENTRIES, FLAGS>
+impl<K, V, const MAX_ENTRIES: usize, const FLAGS: usize> core::marker::Freeze for aya_ebpf::btf_maps::lpm_trie::LpmTrie<K, V, MAX_ENTRIES, FLAGS>
+impl<K, V, const MAX_ENTRIES: usize, const FLAGS: usize> !core::marker::Send for aya_ebpf::btf_maps::lpm_trie::LpmTrie<K, V, MAX_ENTRIES, FLAGS>
+impl<K, V, const MAX_ENTRIES: usize, const FLAGS: usize> core::marker::Unpin for aya_ebpf::btf_maps::lpm_trie::LpmTrie<K, V, MAX_ENTRIES, FLAGS>
+impl<K, V, const MAX_ENTRIES: usize, const FLAGS: usize> core::marker::UnsafeUnpin for aya_ebpf::btf_maps::lpm_trie::LpmTrie<K, V, MAX_ENTRIES, FLAGS>
+impl<K, V, const MAX_ENTRIES: usize, const FLAGS: usize> core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::btf_maps::lpm_trie::LpmTrie<K, V, MAX_ENTRIES, FLAGS> where V: core::panic::unwind_safe::RefUnwindSafe, K: core::panic::unwind_safe::RefUnwindSafe
+impl<K, V, const MAX_ENTRIES: usize, const FLAGS: usize> core::panic::unwind_safe::UnwindSafe for aya_ebpf::btf_maps::lpm_trie::LpmTrie<K, V, MAX_ENTRIES, FLAGS> where V: core::panic::unwind_safe::RefUnwindSafe, K: core::panic::unwind_safe::RefUnwindSafe
 pub mod aya_ebpf::btf_maps::ring_buf
 #[repr(C)] pub struct aya_ebpf::btf_maps::ring_buf::RingBuf<T, const MAX_ENTRIES: usize, const FLAGS: usize>
 impl<T, const MAX_ENTRIES: usize, const FLAGS: usize> aya_ebpf::btf_maps::ring_buf::RingBuf<T, MAX_ENTRIES, FLAGS>
@@ -107,6 +136,22 @@ impl<T, const MAX_ENTRIES: usize, const FLAGS: usize, const HASH_FUNCS: usize> c
 impl<T, const MAX_ENTRIES: usize, const FLAGS: usize, const HASH_FUNCS: usize> core::marker::UnsafeUnpin for aya_ebpf::btf_maps::bloom_filter::BloomFilter<T, MAX_ENTRIES, FLAGS, HASH_FUNCS>
 impl<T, const MAX_ENTRIES: usize, const FLAGS: usize, const HASH_FUNCS: usize> core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::btf_maps::bloom_filter::BloomFilter<T, MAX_ENTRIES, FLAGS, HASH_FUNCS> where T: core::panic::unwind_safe::RefUnwindSafe
 impl<T, const MAX_ENTRIES: usize, const FLAGS: usize, const HASH_FUNCS: usize> core::panic::unwind_safe::UnwindSafe for aya_ebpf::btf_maps::bloom_filter::BloomFilter<T, MAX_ENTRIES, FLAGS, HASH_FUNCS> where T: core::panic::unwind_safe::RefUnwindSafe
+#[repr(C)] pub struct aya_ebpf::btf_maps::LpmTrie<K, V, const MAX_ENTRIES: usize, const FLAGS: usize>
+impl<K, V, const MAX_ENTRIES: usize, const FLAGS: usize> aya_ebpf::btf_maps::lpm_trie::LpmTrie<K, V, MAX_ENTRIES, FLAGS>
+pub fn aya_ebpf::btf_maps::lpm_trie::LpmTrie<K, V, MAX_ENTRIES, FLAGS>::get(&self, key: &aya_ebpf::maps::lpm_trie::Key<K>) -> core::option::Option<&V>
+pub fn aya_ebpf::btf_maps::lpm_trie::LpmTrie<K, V, MAX_ENTRIES, FLAGS>::insert(&self, key: &aya_ebpf::maps::lpm_trie::Key<K>, value: impl core::borrow::Borrow<V>, flags: u64) -> core::result::Result<(), i32>
+pub fn aya_ebpf::btf_maps::lpm_trie::LpmTrie<K, V, MAX_ENTRIES, FLAGS>::remove(&self, key: &aya_ebpf::maps::lpm_trie::Key<K>) -> core::result::Result<(), i32>
+impl<K, V, const MAX_ENTRIES: usize, const FLAGS: usize> aya_ebpf::btf_maps::lpm_trie::LpmTrie<K, V, MAX_ENTRIES, FLAGS>
+pub const fn aya_ebpf::btf_maps::lpm_trie::LpmTrie<K, V, MAX_ENTRIES, FLAGS>::new() -> Self
+impl<K, V, const MAX_ENTRIES: usize, const FLAGS: usize> core::default::Default for aya_ebpf::btf_maps::lpm_trie::LpmTrie<K, V, MAX_ENTRIES, FLAGS>
+pub fn aya_ebpf::btf_maps::lpm_trie::LpmTrie<K, V, MAX_ENTRIES, FLAGS>::default() -> Self
+impl<K, V, const MAX_ENTRIES: usize, const FLAGS: usize> core::marker::Sync for aya_ebpf::btf_maps::lpm_trie::LpmTrie<K, V, MAX_ENTRIES, FLAGS>
+impl<K, V, const MAX_ENTRIES: usize, const FLAGS: usize> core::marker::Freeze for aya_ebpf::btf_maps::lpm_trie::LpmTrie<K, V, MAX_ENTRIES, FLAGS>
+impl<K, V, const MAX_ENTRIES: usize, const FLAGS: usize> !core::marker::Send for aya_ebpf::btf_maps::lpm_trie::LpmTrie<K, V, MAX_ENTRIES, FLAGS>
+impl<K, V, const MAX_ENTRIES: usize, const FLAGS: usize> core::marker::Unpin for aya_ebpf::btf_maps::lpm_trie::LpmTrie<K, V, MAX_ENTRIES, FLAGS>
+impl<K, V, const MAX_ENTRIES: usize, const FLAGS: usize> core::marker::UnsafeUnpin for aya_ebpf::btf_maps::lpm_trie::LpmTrie<K, V, MAX_ENTRIES, FLAGS>
+impl<K, V, const MAX_ENTRIES: usize, const FLAGS: usize> core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::btf_maps::lpm_trie::LpmTrie<K, V, MAX_ENTRIES, FLAGS> where V: core::panic::unwind_safe::RefUnwindSafe, K: core::panic::unwind_safe::RefUnwindSafe
+impl<K, V, const MAX_ENTRIES: usize, const FLAGS: usize> core::panic::unwind_safe::UnwindSafe for aya_ebpf::btf_maps::lpm_trie::LpmTrie<K, V, MAX_ENTRIES, FLAGS> where V: core::panic::unwind_safe::RefUnwindSafe, K: core::panic::unwind_safe::RefUnwindSafe
 #[repr(C)] pub struct aya_ebpf::btf_maps::RingBuf<T, const MAX_ENTRIES: usize, const FLAGS: usize>
 impl<T, const MAX_ENTRIES: usize, const FLAGS: usize> aya_ebpf::btf_maps::ring_buf::RingBuf<T, MAX_ENTRIES, FLAGS>
 pub const fn aya_ebpf::btf_maps::ring_buf::RingBuf<T, MAX_ENTRIES, FLAGS>::new() -> Self


### PR DESCRIPTION
BTF `.maps` support for `BPF_MAP_TYPE_LPM_TRIE`. The `Key<K>` wrapper
from `aya_ebpf::maps::lpm_trie` is reused to avoid duplication.

Compile-time assertions enforce the kernel-enforced key size (5..=260
bytes), value size, max_entries, and the alignment invariant that
prevents `get` from manufacturing a misaligned &V.

The integration test, parameterized via `test_case` over both the BTF
and legacy map definitions, exercises longest-prefix-match, the
None-return path, and the remove operation. A second commit migrates
the existing bloom filter test to the same `test_case` pattern.

### Added/updated tests?

- [x] Yes

### Checklist

- [x] Rust code has been formatted with `cargo +nightly fmt`.
- [x] All clippy lints have been fixed.
      You can find failing lints with `cargo xtask clippy`.
- [x] Unit tests are passing locally with `cargo test`.
- [x] The integration tests are passing locally.
- [x] I have blessed any API changes with `cargo xtask public-api --bless`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aya-rs/aya/1536)
<!-- Reviewable:end -->
