### PR TITLE
aya-ebpf: add BTF map definition for per-cpu array

### DIFF
--- a/ebpf/aya-ebpf/src/btf_maps/mod.rs
+++ b/ebpf/aya-ebpf/src/btf_maps/mod.rs
@@ -1,12 +1,14 @@
 pub mod array;
 pub mod bloom_filter;
 pub mod lpm_trie;
+pub mod per_cpu_array;
 pub mod ring_buf;
 pub mod sk_storage;
 
 pub use array::Array;
 pub use bloom_filter::BloomFilter;
 pub use lpm_trie::LpmTrie;
+pub use per_cpu_array::PerCpuArray;
 pub use ring_buf::RingBuf;
 pub use sk_storage::SkStorage;
 

--- a/ebpf/aya-ebpf/src/btf_maps/per_cpu_array.rs
+++ b/ebpf/aya-ebpf/src/btf_maps/per_cpu_array.rs
@@ -1,0 +1,111 @@
+use core::{borrow::Borrow, ptr::NonNull};
+
+use crate::{btf_maps::btf_map_def, insert, lookup};
+
+btf_map_def!(
+    /// A BTF-compatible BPF per-CPU array map.
+    ///
+    /// This map type stores a distinct value of type `T` per CPU, indexed by
+    /// `u32` keys. Reads and writes from eBPF programs always reference the
+    /// slot belonging to the CPU that executes the program; other CPUs' slots
+    /// are accessible only from user space.
+    ///
+    /// # Minimum kernel version
+    ///
+    /// The minimum kernel version required to use this feature is 4.18.
+    /// `BPF_MAP_TYPE_PERCPU_ARRAY` itself dates back to 4.6, but BTF-style
+    /// map declarations require BTF map-create support in `BPF_MAP_CREATE`,
+    /// which landed in 4.18.
+    ///
+    /// # Flag and size restrictions
+    ///
+    /// The kernel rejects per-CPU arrays with any of these flags set and
+    /// returns `EINVAL` at load time:
+    /// - `BPF_F_MMAPABLE` — accepted only on `BPF_MAP_TYPE_ARRAY`.
+    /// - `BPF_F_INNER_MAP` — accepted only on `BPF_MAP_TYPE_ARRAY`.
+    /// - `BPF_F_NUMA_NODE` — per-CPU maps require `NUMA_NO_NODE`.
+    /// - `BPF_F_PRESERVE_ELEMS` — accepted only on
+    ///   `BPF_MAP_TYPE_PERF_EVENT_ARRAY`.
+    ///
+    /// Each per-CPU value must also satisfy
+    /// `round_up(size_of::<T>(), 8) <= PCPU_MIN_UNIT_SIZE` (32 KiB on most
+    /// kernel builds) and `size_of::<T>() <= INT_MAX`. Violations fail with
+    /// `E2BIG` at load time.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use aya_ebpf::{btf_maps::PerCpuArray, macros::btf_map};
+    ///
+    /// #[btf_map]
+    /// static COUNTERS: PerCpuArray<u64, 8> = PerCpuArray::new();
+    /// ```
+    pub struct PerCpuArray<T; const MAX_ENTRIES: usize, const FLAGS: usize = 0>,
+    map_type: BPF_MAP_TYPE_PERCPU_ARRAY,
+    max_entries: MAX_ENTRIES,
+    map_flags: FLAGS,
+    key_type: u32,
+    value_type: T,
+);
+
+impl<T, const MAX_ENTRIES: usize, const FLAGS: usize> PerCpuArray<T, MAX_ENTRIES, FLAGS> {
+    // Enforces kernel constraints from kernel/bpf/arraymap.c and the
+    // per-CPU allocator alignment invariant. `const _: ()` is forbidden in
+    // a generic impl, and a named associated const is lazy without a
+    // reference, hence `let () = Self::_CHECK` in every method.
+    const _CHECK: () = {
+        assert!(
+            size_of::<T>() >= 1,
+            "per-CPU array value must be non-zero sized.",
+        );
+        assert!(
+            MAX_ENTRIES > 0,
+            "per-CPU array max_entries must be greater than zero.",
+        );
+        // The kernel per-CPU allocator aligns slots to 8 bytes
+        // (bpf_array_alloc_percpu -> bpf_map_alloc_percpu(..., 8, ...)).
+        // Values with stricter alignment would be under-aligned for `&T`
+        // returned by `get`.
+        assert!(
+            align_of::<T>() <= 8,
+            "per-CPU array value alignment must be at most 8 bytes.",
+        );
+    };
+
+    /// Returns a reference to the current CPU's slot at `index`, or `None`
+    /// if `index` is out of bounds.
+    #[inline(always)]
+    pub fn get(&self, index: u32) -> Option<&T> {
+        let () = Self::_CHECK;
+        unsafe { self.lookup(index).map(|p| p.as_ref()) }
+    }
+
+    /// Returns a const pointer to the current CPU's slot at `index`.
+    #[inline(always)]
+    pub fn get_ptr(&self, index: u32) -> Option<*const T> {
+        let () = Self::_CHECK;
+        unsafe { self.lookup(index).map(|p| p.as_ptr().cast_const()) }
+    }
+
+    /// Returns a mutable pointer to the current CPU's slot at `index`.
+    #[inline(always)]
+    pub fn get_ptr_mut(&self, index: u32) -> Option<*mut T> {
+        let () = Self::_CHECK;
+        unsafe { self.lookup(index).map(NonNull::as_ptr) }
+    }
+
+    #[inline(always)]
+    unsafe fn lookup(&self, index: u32) -> Option<NonNull<T>> {
+        lookup(self.as_ptr(), &index)
+    }
+
+    /// Overwrites the current CPU's slot at `index`.
+    ///
+    /// `flags` is forwarded to `bpf_map_update_elem`; `BPF_NOEXIST` is
+    /// rejected by the kernel for arrays.
+    #[inline(always)]
+    pub fn set(&self, index: u32, value: impl Borrow<T>, flags: u64) -> Result<(), i32> {
+        let () = Self::_CHECK;
+        insert(self.as_ptr(), &index, value.borrow(), flags)
+    }
+}

--- a/ebpf/aya-ebpf/src/maps/per_cpu_array.rs
+++ b/ebpf/aya-ebpf/src/maps/per_cpu_array.rs
@@ -1,8 +1,8 @@
-use core::{marker::PhantomData, ptr::NonNull};
+use core::{borrow::Borrow, marker::PhantomData, ptr::NonNull};
 
 use crate::{
     bindings::bpf_map_type::BPF_MAP_TYPE_PERCPU_ARRAY,
-    lookup,
+    insert, lookup,
     maps::{MapDef, PinningType},
 };
 
@@ -36,5 +36,11 @@ impl<T> PerCpuArray<T> {
     #[inline(always)]
     unsafe fn lookup(&self, index: u32) -> Option<NonNull<T>> {
         lookup(self.def.as_ptr(), &index)
+    }
+
+    /// Sets the value of the current CPU's slot at the given index.
+    #[inline(always)]
+    pub fn set(&self, index: u32, value: impl Borrow<T>, flags: u64) -> Result<(), i32> {
+        insert(self.def.as_ptr(), &index, value.borrow(), flags)
     }
 }

--- a/test/integration-common/src/lib.rs
+++ b/test/integration-common/src/lib.rs
@@ -4,6 +4,9 @@ pub mod array {
     pub const GET_INDEX: u32 = 0;
     pub const GET_PTR_INDEX: u32 = 1;
     pub const GET_PTR_MUT_INDEX: u32 = 2;
+    pub const NUM_SLOTS: u32 = 3;
+    /// Arbitrary number of slots exercised by the array tests.
+    pub const ARRAY_LEN: u32 = 4;
 }
 
 pub mod bloom_filter {

--- a/test/integration-ebpf/Cargo.toml
+++ b/test/integration-ebpf/Cargo.toml
@@ -73,6 +73,10 @@ name = "pass"
 path = "src/pass.rs"
 
 [[bin]]
+name = "per_cpu_array"
+path = "src/per_cpu_array.rs"
+
+[[bin]]
 name = "raw_tracepoint"
 path = "src/raw_tracepoint.rs"
 

--- a/test/integration-ebpf/src/array.rs
+++ b/test/integration-ebpf/src/array.rs
@@ -12,17 +12,19 @@ use aya_ebpf::{
     maps::Array as LegacyArray,
     programs::ProbeContext,
 };
-use integration_common::array::{GET_INDEX, GET_PTR_INDEX, GET_PTR_MUT_INDEX};
+use integration_common::array::{
+    ARRAY_LEN, GET_INDEX, GET_PTR_INDEX, GET_PTR_MUT_INDEX, NUM_SLOTS,
+};
 
 #[btf_map]
-static RESULT: Array<u32, 3 /* max_elements */, 0> = Array::new();
+static RESULT: Array<u32, { NUM_SLOTS as usize }, 0> = Array::new();
 #[btf_map]
-static ARRAY: Array<u32, 10 /* max_elements */, 0> = Array::new();
+static ARRAY: Array<u32, { ARRAY_LEN as usize }, 0> = Array::new();
 
 #[map]
-static RESULT_LEGACY: LegacyArray<u32> = LegacyArray::with_max_entries(3, 0);
+static RESULT_LEGACY: LegacyArray<u32> = LegacyArray::with_max_entries(NUM_SLOTS, 0);
 #[map]
-static ARRAY_LEGACY: LegacyArray<u32> = LegacyArray::with_max_entries(10, 0);
+static ARRAY_LEGACY: LegacyArray<u32> = LegacyArray::with_max_entries(ARRAY_LEN, 0);
 
 macro_rules! define_array_test {
     (

--- a/test/integration-ebpf/src/per_cpu_array.rs
+++ b/test/integration-ebpf/src/per_cpu_array.rs
@@ -1,0 +1,91 @@
+#![no_std]
+#![no_main]
+#![expect(unused_crate_dependencies, reason = "used in other bins")]
+
+#[cfg(not(test))]
+extern crate ebpf_panic;
+
+use aya_ebpf::{
+    btf_maps::{Array as BtfArray, PerCpuArray as BtfPerCpuArray},
+    cty::c_long,
+    macros::{btf_map, map, uprobe},
+    maps::{Array as LegacyArray, PerCpuArray as LegacyPerCpuArray},
+    programs::ProbeContext,
+};
+use integration_common::array::{GET_INDEX, GET_PTR_INDEX, GET_PTR_MUT_INDEX, NUM_SLOTS};
+
+#[btf_map]
+static RESULT: BtfArray<u32, { NUM_SLOTS as usize }, 0> = BtfArray::new();
+#[btf_map]
+static ARRAY: BtfPerCpuArray<u32, 1, 0> = BtfPerCpuArray::new();
+
+#[map]
+static RESULT_LEGACY: LegacyArray<u32> = LegacyArray::with_max_entries(NUM_SLOTS, 0);
+#[map]
+static ARRAY_LEGACY: LegacyPerCpuArray<u32> = LegacyPerCpuArray::with_max_entries(1, 0);
+
+macro_rules! define_per_cpu_array_test {
+    (
+        $result_map:ident,
+        $array_map:ident,
+        $result_set_fn:ident,
+        $get_prog:ident,
+        $get_ptr_prog:ident,
+        $get_ptr_mut_prog:ident,
+        $set_prog:ident
+        $(,)?
+    ) => {
+        #[inline(always)]
+        fn $result_set_fn(index: u32, value: u32) -> Result<(), c_long> {
+            let ptr = $result_map.get_ptr_mut(index).ok_or(-1)?;
+            let dst = unsafe { ptr.as_mut() };
+            let dst_res = dst.ok_or(-1)?;
+            *dst_res = value;
+            Ok(())
+        }
+
+        #[uprobe]
+        fn $get_prog(ctx: ProbeContext) -> Result<(), c_long> {
+            let index = ctx.arg(0).ok_or(-1)?;
+            let value = $array_map.get(index).ok_or(-1)?;
+            $result_set_fn(GET_INDEX, *value)?;
+            Ok(())
+        }
+
+        #[uprobe]
+        fn $get_ptr_prog(ctx: ProbeContext) -> Result<(), c_long> {
+            let index = ctx.arg(0).ok_or(-1)?;
+            let value = $array_map.get_ptr(index).ok_or(-1)?;
+            $result_set_fn(GET_PTR_INDEX, unsafe { *value })?;
+            Ok(())
+        }
+
+        #[uprobe]
+        fn $get_ptr_mut_prog(ctx: ProbeContext) -> Result<(), c_long> {
+            let index = ctx.arg(0).ok_or(-1)?;
+            let ptr = $array_map.get_ptr_mut(index).ok_or(-1)?;
+            let value = unsafe { *ptr };
+            $result_set_fn(GET_PTR_MUT_INDEX, value)?;
+            Ok(())
+        }
+
+        #[uprobe]
+        fn $set_prog(ctx: ProbeContext) -> Result<(), c_long> {
+            let index: u32 = ctx.arg(0).ok_or(-1)?;
+            let value: u32 = ctx.arg(1).ok_or(-1)?;
+            $array_map.set(index, value, 0).map_err(c_long::from)?;
+            Ok(())
+        }
+    };
+}
+
+define_per_cpu_array_test!(RESULT, ARRAY, result_set, get, get_ptr, get_ptr_mut, set);
+define_per_cpu_array_test!(
+    RESULT_LEGACY,
+    ARRAY_LEGACY,
+    result_set_legacy,
+    get_legacy,
+    get_ptr_legacy,
+    get_ptr_mut_legacy,
+    set_legacy,
+);

--- a/test/integration-test/src/lib.rs
+++ b/test/integration-test/src/lib.rs
@@ -51,6 +51,7 @@ bpf_file!(
     MEMMOVE_TEST => "memmove_test",
     NAME_TEST => "name_test",
     PASS => "pass",
+    PER_CPU_ARRAY => "per_cpu_array",
     PERF_EVENT_BP => "perf_event_bp",
     RAW_TRACEPOINT => "raw_tracepoint",
     REDIRECT => "redirect",

--- a/test/integration-test/src/tests.rs
+++ b/test/integration-test/src/tests.rs
@@ -25,6 +25,7 @@ mod lpm_trie;
 mod lsm;
 mod map_pin;
 mod maps_disjoint;
+mod per_cpu_array;
 mod perf_event_bp;
 mod printk;
 mod raw_tracepoint;

--- a/test/integration-test/src/tests/array.rs
+++ b/test/integration-test/src/tests/array.rs
@@ -1,5 +1,6 @@
 use aya::{EbpfLoader, maps::Array, programs::UProbe};
-use integration_common::array::{GET_INDEX, GET_PTR_INDEX, GET_PTR_MUT_INDEX};
+use integration_common::array::{ARRAY_LEN, GET_INDEX, GET_PTR_INDEX, GET_PTR_MUT_INDEX};
+use test_case::test_case;
 
 #[unsafe(no_mangle)]
 #[inline(never)]
@@ -25,64 +26,76 @@ extern "C" fn get_ptr_mut(index: u32) {
     std::hint::black_box(index);
 }
 
+#[test_case(
+    "RESULT_LEGACY",
+    "ARRAY_LEGACY",
+    "set_legacy",
+    "get_legacy",
+    "get_ptr_legacy",
+    "get_ptr_mut_legacy"
+    ; "legacy"
+)]
+#[test_case(
+    "RESULT",
+    "ARRAY",
+    "set",
+    "get",
+    "get_ptr",
+    "get_ptr_mut"
+    ; "btf"
+)]
 #[test_log::test]
-fn test_array() {
+fn test_array(
+    result_map: &str,
+    array_map: &str,
+    set_prog: &str,
+    get_prog: &str,
+    get_ptr_prog: &str,
+    get_ptr_mut_prog: &str,
+) {
     let mut ebpf = EbpfLoader::new().load(crate::ARRAY).unwrap();
-    for (result_map, array_map, progs_and_symbols) in [
-        // BTF map definitions.
-        (
-            "RESULT",
-            "ARRAY",
-            [
-                ("set", "set"),
-                ("get", "get"),
-                ("get_ptr", "get_ptr"),
-                ("get_ptr_mut", "get_ptr_mut"),
-            ],
-        ),
-        // Legacy map definitions.
-        (
-            "RESULT_LEGACY",
-            "ARRAY_LEGACY",
-            [
-                ("set_legacy", "set"),
-                ("get_legacy", "get"),
-                ("get_ptr_legacy", "get_ptr"),
-                ("get_ptr_mut_legacy", "get_ptr_mut"),
-            ],
-        ),
+
+    for (prog_name, symbol) in [
+        (set_prog, "set"),
+        (get_prog, "get"),
+        (get_ptr_prog, "get_ptr"),
+        (get_ptr_mut_prog, "get_ptr_mut"),
     ] {
-        for (prog_name, symbol) in progs_and_symbols {
-            let prog: &mut UProbe = ebpf.program_mut(prog_name).unwrap().try_into().unwrap();
-            prog.load().unwrap();
-            prog.attach(symbol, "/proc/self/exe", None).unwrap();
-        }
-        let result_array = ebpf.map(result_map).unwrap();
-        let result_array = Array::<_, u32>::try_from(result_array).unwrap();
-        let array = ebpf.map(array_map).unwrap();
-        let array = Array::<_, u32>::try_from(array).unwrap();
-        let seq = 0..9;
-        for i in seq.clone() {
-            set(i, i.pow(2));
-        }
-        for i in seq.clone() {
-            // Assert the value returned by user-space API.
-            let expected_value = i.pow(2);
-            let value = array.get(&i, 0).unwrap();
-            assert_eq!(value, expected_value);
-            // Assert the value returned by eBPF in-kernel API.
-            get(i);
-            let result = result_array.get(&GET_INDEX, 0).unwrap();
-            assert_eq!(result, expected_value);
-            get_ptr(i);
-            let result = result_array.get(&GET_PTR_INDEX, 0).unwrap();
-            assert_eq!(result, expected_value);
-        }
-        for i in seq.clone() {
-            let value = i.pow(2);
-            get_ptr_mut(i);
-            let result = result_array.get(&GET_PTR_MUT_INDEX, 0).unwrap();
-            assert_eq!(result, value);
-        }
+        let prog: &mut UProbe = ebpf
+            .program_mut(prog_name)
+            .unwrap_or_else(|| panic!("missing program {prog_name}"))
+            .try_into()
+            .unwrap_or_else(|err| panic!("program {prog_name} is not a uprobe: {err}"));
+        prog.load()
+            .unwrap_or_else(|err| panic!("load {prog_name}: {err}"));
+        prog.attach(symbol, "/proc/self/exe", None)
+            .unwrap_or_else(|err| panic!("attach {prog_name}: {err}"));
+    }
+
+    let result_array = Array::<_, u32>::try_from(ebpf.map(result_map).unwrap()).unwrap();
+    let array = Array::<_, u32>::try_from(ebpf.map(array_map).unwrap()).unwrap();
+
+    let seq = 0..ARRAY_LEN;
+    for i in seq.clone() {
+        set(i, i.pow(2));
+    }
+    for i in seq.clone() {
+        // Assert the value returned by user-space API.
+        let expected_value = i.pow(2);
+        let value = array.get(&i, 0).unwrap();
+        assert_eq!(value, expected_value);
+        // Assert the value returned by eBPF in-kernel API.
+        get(i);
+        let result = result_array.get(&GET_INDEX, 0).unwrap();
+        assert_eq!(result, expected_value);
+        get_ptr(i);
+        let result = result_array.get(&GET_PTR_INDEX, 0).unwrap();
+        assert_eq!(result, expected_value);
+    }
+    for i in seq {
+        let value = i.pow(2);
+        get_ptr_mut(i);
+        let result = result_array.get(&GET_PTR_MUT_INDEX, 0).unwrap();
+        assert_eq!(result, value);
     }
 }

--- a/test/integration-test/src/tests/per_cpu_array.rs
+++ b/test/integration-test/src/tests/per_cpu_array.rs
@@ -1,0 +1,124 @@
+use aya::{
+    EbpfLoader,
+    maps::{Array, MapType, PerCpuArray, PerCpuValues},
+    programs::UProbe,
+    sys::is_map_supported,
+    util::nr_cpus,
+};
+use integration_common::array::{GET_INDEX, GET_PTR_INDEX, GET_PTR_MUT_INDEX};
+use test_case::test_case;
+
+#[unsafe(no_mangle)]
+#[inline(never)]
+extern "C" fn trigger_get(index: u32) {
+    std::hint::black_box(index);
+}
+
+#[unsafe(no_mangle)]
+#[inline(never)]
+extern "C" fn trigger_get_ptr(index: u32) {
+    std::hint::black_box(index);
+}
+
+#[unsafe(no_mangle)]
+#[inline(never)]
+extern "C" fn trigger_get_ptr_mut(index: u32) {
+    std::hint::black_box(index);
+}
+
+#[unsafe(no_mangle)]
+#[inline(never)]
+extern "C" fn trigger_set(index: u32, value: u32) {
+    std::hint::black_box((index, value));
+}
+
+#[test_case(
+    "RESULT_LEGACY",
+    "ARRAY_LEGACY",
+    "get_legacy",
+    "get_ptr_legacy",
+    "get_ptr_mut_legacy",
+    "set_legacy"
+    ; "legacy"
+)]
+#[test_case(
+    "RESULT",
+    "ARRAY",
+    "get",
+    "get_ptr",
+    "get_ptr_mut",
+    "set"
+    ; "btf"
+)]
+#[test_log::test]
+fn per_cpu_array_basic(
+    result_map: &str,
+    array_map: &str,
+    get_prog: &str,
+    get_ptr_prog: &str,
+    get_ptr_mut_prog: &str,
+    set_prog: &str,
+) {
+    if !is_map_supported(MapType::PerCpuArray).unwrap() {
+        eprintln!("skipping test - per-cpu array map not supported");
+        return;
+    }
+
+    let mut bpf = EbpfLoader::new()
+        .load(crate::PER_CPU_ARRAY)
+        .expect("load per_cpu_array program");
+
+    for (prog_name, symbol) in [
+        (get_prog, "trigger_get"),
+        (get_ptr_prog, "trigger_get_ptr"),
+        (get_ptr_mut_prog, "trigger_get_ptr_mut"),
+        (set_prog, "trigger_set"),
+    ] {
+        let prog: &mut UProbe = bpf
+            .program_mut(prog_name)
+            .unwrap_or_else(|| panic!("missing program {prog_name}"))
+            .try_into()
+            .unwrap_or_else(|err| panic!("program {prog_name} is not a uprobe: {err}"));
+        prog.load()
+            .unwrap_or_else(|err| panic!("load {prog_name}: {err}"));
+        prog.attach(symbol, "/proc/self/exe", None)
+            .unwrap_or_else(|err| panic!("attach {prog_name}: {err}"));
+    }
+
+    let mut array: PerCpuArray<_, u32> = bpf.take_map(array_map).unwrap().try_into().unwrap();
+    let result = Array::<_, u32>::try_from(bpf.map(result_map).unwrap()).unwrap();
+
+    const INDEX: u32 = 0;
+    const VALUE: u32 = 0xCAFE;
+
+    // Write a uniform value across every CPU slot so the uprobe (which runs
+    // on an arbitrary CPU) observes a deterministic value.
+    let cpu_count = nr_cpus().unwrap();
+    let initial = PerCpuValues::try_from(vec![VALUE; cpu_count]).unwrap();
+    array.set(INDEX, initial, 0).unwrap();
+
+    trigger_get(INDEX);
+    assert_eq!(result.get(&GET_INDEX, 0).unwrap(), VALUE);
+
+    trigger_get_ptr(INDEX);
+    assert_eq!(result.get(&GET_PTR_INDEX, 0).unwrap(), VALUE);
+
+    trigger_get_ptr_mut(INDEX);
+    assert_eq!(result.get(&GET_PTR_MUT_INDEX, 0).unwrap(), VALUE);
+
+    const NEW_VALUE: u32 = 0x1234;
+    trigger_set(INDEX, NEW_VALUE);
+
+    // The probe mutates only the executing CPU's slot; every other slot
+    // must still hold the uniform value written from user space.
+    let after = array.get(&INDEX, 0).unwrap();
+    let mut new_count = 0usize;
+    for slot in after.iter() {
+        match *slot {
+            NEW_VALUE => new_count += 1,
+            VALUE => {}
+            other => panic!("unexpected per-CPU slot value: {other:#x}"),
+        }
+    }
+    assert_eq!(new_count, 1, "set() should mutate exactly one per-CPU slot");
+}

--- a/xtask/public-api/aya-ebpf.txt
+++ b/xtask/public-api/aya-ebpf.txt
@@ -68,6 +68,24 @@ impl<K, V, const MAX_ENTRIES: usize, const FLAGS: usize> core::marker::Unpin for
 impl<K, V, const MAX_ENTRIES: usize, const FLAGS: usize> core::marker::UnsafeUnpin for aya_ebpf::btf_maps::lpm_trie::LpmTrie<K, V, MAX_ENTRIES, FLAGS>
 impl<K, V, const MAX_ENTRIES: usize, const FLAGS: usize> core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::btf_maps::lpm_trie::LpmTrie<K, V, MAX_ENTRIES, FLAGS> where V: core::panic::unwind_safe::RefUnwindSafe, K: core::panic::unwind_safe::RefUnwindSafe
 impl<K, V, const MAX_ENTRIES: usize, const FLAGS: usize> core::panic::unwind_safe::UnwindSafe for aya_ebpf::btf_maps::lpm_trie::LpmTrie<K, V, MAX_ENTRIES, FLAGS> where V: core::panic::unwind_safe::RefUnwindSafe, K: core::panic::unwind_safe::RefUnwindSafe
+pub mod aya_ebpf::btf_maps::per_cpu_array
+#[repr(C)] pub struct aya_ebpf::btf_maps::per_cpu_array::PerCpuArray<T, const MAX_ENTRIES: usize, const FLAGS: usize>
+impl<T, const MAX_ENTRIES: usize, const FLAGS: usize> aya_ebpf::btf_maps::per_cpu_array::PerCpuArray<T, MAX_ENTRIES, FLAGS>
+pub fn aya_ebpf::btf_maps::per_cpu_array::PerCpuArray<T, MAX_ENTRIES, FLAGS>::get(&self, index: u32) -> core::option::Option<&T>
+pub fn aya_ebpf::btf_maps::per_cpu_array::PerCpuArray<T, MAX_ENTRIES, FLAGS>::get_ptr(&self, index: u32) -> core::option::Option<*const T>
+pub fn aya_ebpf::btf_maps::per_cpu_array::PerCpuArray<T, MAX_ENTRIES, FLAGS>::get_ptr_mut(&self, index: u32) -> core::option::Option<*mut T>
+pub fn aya_ebpf::btf_maps::per_cpu_array::PerCpuArray<T, MAX_ENTRIES, FLAGS>::set(&self, index: u32, value: impl core::borrow::Borrow<T>, flags: u64) -> core::result::Result<(), i32>
+impl<T, const MAX_ENTRIES: usize, const FLAGS: usize> aya_ebpf::btf_maps::per_cpu_array::PerCpuArray<T, MAX_ENTRIES, FLAGS>
+pub const fn aya_ebpf::btf_maps::per_cpu_array::PerCpuArray<T, MAX_ENTRIES, FLAGS>::new() -> Self
+impl<T, const MAX_ENTRIES: usize, const FLAGS: usize> core::default::Default for aya_ebpf::btf_maps::per_cpu_array::PerCpuArray<T, MAX_ENTRIES, FLAGS>
+pub fn aya_ebpf::btf_maps::per_cpu_array::PerCpuArray<T, MAX_ENTRIES, FLAGS>::default() -> Self
+impl<T, const MAX_ENTRIES: usize, const FLAGS: usize> core::marker::Sync for aya_ebpf::btf_maps::per_cpu_array::PerCpuArray<T, MAX_ENTRIES, FLAGS>
+impl<T, const MAX_ENTRIES: usize, const FLAGS: usize> core::marker::Freeze for aya_ebpf::btf_maps::per_cpu_array::PerCpuArray<T, MAX_ENTRIES, FLAGS>
+impl<T, const MAX_ENTRIES: usize, const FLAGS: usize> !core::marker::Send for aya_ebpf::btf_maps::per_cpu_array::PerCpuArray<T, MAX_ENTRIES, FLAGS>
+impl<T, const MAX_ENTRIES: usize, const FLAGS: usize> core::marker::Unpin for aya_ebpf::btf_maps::per_cpu_array::PerCpuArray<T, MAX_ENTRIES, FLAGS>
+impl<T, const MAX_ENTRIES: usize, const FLAGS: usize> core::marker::UnsafeUnpin for aya_ebpf::btf_maps::per_cpu_array::PerCpuArray<T, MAX_ENTRIES, FLAGS>
+impl<T, const MAX_ENTRIES: usize, const FLAGS: usize> core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::btf_maps::per_cpu_array::PerCpuArray<T, MAX_ENTRIES, FLAGS> where T: core::panic::unwind_safe::RefUnwindSafe
+impl<T, const MAX_ENTRIES: usize, const FLAGS: usize> core::panic::unwind_safe::UnwindSafe for aya_ebpf::btf_maps::per_cpu_array::PerCpuArray<T, MAX_ENTRIES, FLAGS> where T: core::panic::unwind_safe::RefUnwindSafe
 pub mod aya_ebpf::btf_maps::ring_buf
 #[repr(C)] pub struct aya_ebpf::btf_maps::ring_buf::RingBuf<T, const MAX_ENTRIES: usize, const FLAGS: usize>
 impl<T, const MAX_ENTRIES: usize, const FLAGS: usize> aya_ebpf::btf_maps::ring_buf::RingBuf<T, MAX_ENTRIES, FLAGS>
@@ -152,6 +170,23 @@ impl<K, V, const MAX_ENTRIES: usize, const FLAGS: usize> core::marker::Unpin for
 impl<K, V, const MAX_ENTRIES: usize, const FLAGS: usize> core::marker::UnsafeUnpin for aya_ebpf::btf_maps::lpm_trie::LpmTrie<K, V, MAX_ENTRIES, FLAGS>
 impl<K, V, const MAX_ENTRIES: usize, const FLAGS: usize> core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::btf_maps::lpm_trie::LpmTrie<K, V, MAX_ENTRIES, FLAGS> where V: core::panic::unwind_safe::RefUnwindSafe, K: core::panic::unwind_safe::RefUnwindSafe
 impl<K, V, const MAX_ENTRIES: usize, const FLAGS: usize> core::panic::unwind_safe::UnwindSafe for aya_ebpf::btf_maps::lpm_trie::LpmTrie<K, V, MAX_ENTRIES, FLAGS> where V: core::panic::unwind_safe::RefUnwindSafe, K: core::panic::unwind_safe::RefUnwindSafe
+#[repr(C)] pub struct aya_ebpf::btf_maps::PerCpuArray<T, const MAX_ENTRIES: usize, const FLAGS: usize>
+impl<T, const MAX_ENTRIES: usize, const FLAGS: usize> aya_ebpf::btf_maps::per_cpu_array::PerCpuArray<T, MAX_ENTRIES, FLAGS>
+pub fn aya_ebpf::btf_maps::per_cpu_array::PerCpuArray<T, MAX_ENTRIES, FLAGS>::get(&self, index: u32) -> core::option::Option<&T>
+pub fn aya_ebpf::btf_maps::per_cpu_array::PerCpuArray<T, MAX_ENTRIES, FLAGS>::get_ptr(&self, index: u32) -> core::option::Option<*const T>
+pub fn aya_ebpf::btf_maps::per_cpu_array::PerCpuArray<T, MAX_ENTRIES, FLAGS>::get_ptr_mut(&self, index: u32) -> core::option::Option<*mut T>
+pub fn aya_ebpf::btf_maps::per_cpu_array::PerCpuArray<T, MAX_ENTRIES, FLAGS>::set(&self, index: u32, value: impl core::borrow::Borrow<T>, flags: u64) -> core::result::Result<(), i32>
+impl<T, const MAX_ENTRIES: usize, const FLAGS: usize> aya_ebpf::btf_maps::per_cpu_array::PerCpuArray<T, MAX_ENTRIES, FLAGS>
+pub const fn aya_ebpf::btf_maps::per_cpu_array::PerCpuArray<T, MAX_ENTRIES, FLAGS>::new() -> Self
+impl<T, const MAX_ENTRIES: usize, const FLAGS: usize> core::default::Default for aya_ebpf::btf_maps::per_cpu_array::PerCpuArray<T, MAX_ENTRIES, FLAGS>
+pub fn aya_ebpf::btf_maps::per_cpu_array::PerCpuArray<T, MAX_ENTRIES, FLAGS>::default() -> Self
+impl<T, const MAX_ENTRIES: usize, const FLAGS: usize> core::marker::Sync for aya_ebpf::btf_maps::per_cpu_array::PerCpuArray<T, MAX_ENTRIES, FLAGS>
+impl<T, const MAX_ENTRIES: usize, const FLAGS: usize> core::marker::Freeze for aya_ebpf::btf_maps::per_cpu_array::PerCpuArray<T, MAX_ENTRIES, FLAGS>
+impl<T, const MAX_ENTRIES: usize, const FLAGS: usize> !core::marker::Send for aya_ebpf::btf_maps::per_cpu_array::PerCpuArray<T, MAX_ENTRIES, FLAGS>
+impl<T, const MAX_ENTRIES: usize, const FLAGS: usize> core::marker::Unpin for aya_ebpf::btf_maps::per_cpu_array::PerCpuArray<T, MAX_ENTRIES, FLAGS>
+impl<T, const MAX_ENTRIES: usize, const FLAGS: usize> core::marker::UnsafeUnpin for aya_ebpf::btf_maps::per_cpu_array::PerCpuArray<T, MAX_ENTRIES, FLAGS>
+impl<T, const MAX_ENTRIES: usize, const FLAGS: usize> core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::btf_maps::per_cpu_array::PerCpuArray<T, MAX_ENTRIES, FLAGS> where T: core::panic::unwind_safe::RefUnwindSafe
+impl<T, const MAX_ENTRIES: usize, const FLAGS: usize> core::panic::unwind_safe::UnwindSafe for aya_ebpf::btf_maps::per_cpu_array::PerCpuArray<T, MAX_ENTRIES, FLAGS> where T: core::panic::unwind_safe::RefUnwindSafe
 #[repr(C)] pub struct aya_ebpf::btf_maps::RingBuf<T, const MAX_ENTRIES: usize, const FLAGS: usize>
 impl<T, const MAX_ENTRIES: usize, const FLAGS: usize> aya_ebpf::btf_maps::ring_buf::RingBuf<T, MAX_ENTRIES, FLAGS>
 pub const fn aya_ebpf::btf_maps::ring_buf::RingBuf<T, MAX_ENTRIES, FLAGS>::new() -> Self

--- a/xtask/public-api/aya-ebpf.txt
+++ b/xtask/public-api/aya-ebpf.txt
@@ -336,6 +336,7 @@ pub fn aya_ebpf::maps::per_cpu_array::PerCpuArray<T>::get(&self, index: u32) -> 
 pub fn aya_ebpf::maps::per_cpu_array::PerCpuArray<T>::get_ptr(&self, index: u32) -> core::option::Option<*const T>
 pub fn aya_ebpf::maps::per_cpu_array::PerCpuArray<T>::get_ptr_mut(&self, index: u32) -> core::option::Option<*mut T>
 pub const fn aya_ebpf::maps::per_cpu_array::PerCpuArray<T>::pinned(max_entries: u32, flags: u32) -> Self
+pub fn aya_ebpf::maps::per_cpu_array::PerCpuArray<T>::set(&self, index: u32, value: impl core::borrow::Borrow<T>, flags: u64) -> core::result::Result<(), i32>
 pub const fn aya_ebpf::maps::per_cpu_array::PerCpuArray<T>::with_max_entries(max_entries: u32, flags: u32) -> Self
 impl<T> !core::marker::Freeze for aya_ebpf::maps::per_cpu_array::PerCpuArray<T>
 impl<T> core::marker::Send for aya_ebpf::maps::per_cpu_array::PerCpuArray<T> where T: core::marker::Send
@@ -693,6 +694,7 @@ pub fn aya_ebpf::maps::per_cpu_array::PerCpuArray<T>::get(&self, index: u32) -> 
 pub fn aya_ebpf::maps::per_cpu_array::PerCpuArray<T>::get_ptr(&self, index: u32) -> core::option::Option<*const T>
 pub fn aya_ebpf::maps::per_cpu_array::PerCpuArray<T>::get_ptr_mut(&self, index: u32) -> core::option::Option<*mut T>
 pub const fn aya_ebpf::maps::per_cpu_array::PerCpuArray<T>::pinned(max_entries: u32, flags: u32) -> Self
+pub fn aya_ebpf::maps::per_cpu_array::PerCpuArray<T>::set(&self, index: u32, value: impl core::borrow::Borrow<T>, flags: u64) -> core::result::Result<(), i32>
 pub const fn aya_ebpf::maps::per_cpu_array::PerCpuArray<T>::with_max_entries(max_entries: u32, flags: u32) -> Self
 impl<T> !core::marker::Freeze for aya_ebpf::maps::per_cpu_array::PerCpuArray<T>
 impl<T> core::marker::Send for aya_ebpf::maps::per_cpu_array::PerCpuArray<T> where T: core::marker::Send


### PR DESCRIPTION
Add `set` to legacy `maps::PerCpuArray` so that all four array siblings
(`maps::Array`, `btf_maps::Array`, `maps::PerCpuArray`,
`btf_maps::PerCpuArray`) expose the method, mirroring
`maps::Array::set`.

A second commit introduces BTF `.maps` support for
`BPF_MAP_TYPE_PERCPU_ARRAY`, matching the shape of `btf_maps::Array`.
Compile-time assertions enforce the kernel-enforced non-zero value
size, non-zero `max_entries`, and the per-CPU allocator alignment
invariant that would otherwise let `get` hand out a misaligned `&T`.
The integration test is parameterized via `test_case` over both the
BTF and legacy map definitions, exercising the read helpers against
a uniform per-CPU value written from user space, and verifies that
`set` mutates a single per-CPU slot by reading the array back from
user space.

A third commit migrates the existing array test to the same
`test_case` pattern and ties the map size to a shared
`integration_common::array::ARRAY_LEN` constant used by the test
loop bound as well.

### Added/updated tests?

- [x] Yes

### Checklist

- [x] Rust code has been formatted with `cargo +nightly fmt`.
- [x] All clippy lints have been fixed.
      You can find failing lints with `cargo xtask clippy`.
- [x] Unit tests are passing locally with `cargo test`.
- [x] The integration tests are passing locally.
- [x] I have blessed any API changes with `cargo xtask public-api --bless`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aya-rs/aya/1537)
<!-- Reviewable:end -->
