### PR TITLE
aya-ebpf: add BTF map definition for program array

### DIFF
--- a/ebpf/aya-ebpf/src/btf_maps/mod.rs
+++ b/ebpf/aya-ebpf/src/btf_maps/mod.rs
@@ -21,14 +21,14 @@ pub use sk_storage::SkStorage;
 /// wrapper; the macro adds `*const` internally (this is a BTF implementation
 /// detail).
 ///
-/// Generics are limited to type parameters (with optional defaults) followed by
-/// a semicolon and const parameters (with optional defaults). Lifetimes and
-/// bounds are not supported.
+/// Generics are an optional list of type parameters (with optional defaults)
+/// optionally followed by a semicolon and const parameters (with optional
+/// defaults). Lifetimes and bounds are not supported.
 macro_rules! btf_map_def {
     (
         $(#[$attr:meta])*
         $vis:vis struct $name:ident<
-            $($ty_gen:ident $(= $ty_default:ty)?),+
+            $($ty_gen:ident $(= $ty_default:ty)?),*
             $(; $(const $const_gen:ident : $const_ty:ty $(= $const_default:tt)?),+)?
             $(,)?
         >,
@@ -45,8 +45,8 @@ macro_rules! btf_map_def {
         // Without it, Rust may reorder fields and libbpf will fail to parse the map definition.
         #[repr(C)]
         $vis struct $name<
-            $($ty_gen $(= $ty_default)?),+
-            $(, $(const $const_gen : $const_ty $(= $const_default)?),+)?
+            $($ty_gen $(= $ty_default)?,)*
+            $($(const $const_gen : $const_ty $(= $const_default)?,)+)?
         > {
             r#type: *const [i32; $crate::bindings::bpf_map_type::$map_type as usize],
             key: *const $key_ty,
@@ -59,19 +59,19 @@ macro_rules! btf_map_def {
         }
 
         unsafe impl<
-            $($ty_gen),+
-            $(, $(const $const_gen : $const_ty),+)?
+            $($ty_gen,)*
+            $($(const $const_gen : $const_ty,)+)?
         > Sync for $name<
-            $($ty_gen),+
-            $(, $($const_gen),+)?
+            $($ty_gen,)*
+            $($($const_gen,)+)?
         > {}
 
         impl<
-            $($ty_gen),+
-            $(, $(const $const_gen : $const_ty),+)?
+            $($ty_gen,)*
+            $($(const $const_gen : $const_ty,)+)?
         > Default for $name<
-            $($ty_gen),+
-            $(, $($const_gen),+)?
+            $($ty_gen,)*
+            $($($const_gen,)+)?
         > {
             fn default() -> Self {
                 Self::new()
@@ -79,11 +79,11 @@ macro_rules! btf_map_def {
         }
 
         impl<
-            $($ty_gen),+
-            $(, $(const $const_gen : $const_ty),+)?
+            $($ty_gen,)*
+            $($(const $const_gen : $const_ty,)+)?
         > $name<
-            $($ty_gen),+
-            $(, $($const_gen),+)?
+            $($ty_gen,)*
+            $($($const_gen,)+)?
         > {
             pub const fn new() -> Self {
                 Self {

--- a/ebpf/aya-ebpf/src/btf_maps/mod.rs
+++ b/ebpf/aya-ebpf/src/btf_maps/mod.rs
@@ -2,6 +2,7 @@ pub mod array;
 pub mod bloom_filter;
 pub mod lpm_trie;
 pub mod per_cpu_array;
+pub mod program_array;
 pub mod ring_buf;
 pub mod sk_storage;
 
@@ -9,6 +10,7 @@ pub use array::Array;
 pub use bloom_filter::BloomFilter;
 pub use lpm_trie::LpmTrie;
 pub use per_cpu_array::PerCpuArray;
+pub use program_array::ProgramArray;
 pub use ring_buf::RingBuf;
 pub use sk_storage::SkStorage;
 

--- a/ebpf/aya-ebpf/src/btf_maps/program_array.rs
+++ b/ebpf/aya-ebpf/src/btf_maps/program_array.rs
@@ -1,0 +1,58 @@
+use crate::{EbpfContext, btf_maps::btf_map_def, helpers::bpf_tail_call};
+
+btf_map_def!(
+    /// A BTF-compatible BPF program array map.
+    ///
+    /// This map type stores an array of program indices for tail calling.
+    /// Both keys and values are `u32`; values are file descriptors of BPF
+    /// programs to tail-call into.
+    ///
+    /// # Minimum kernel version
+    ///
+    /// The minimum kernel version required to use this feature is 4.20.
+    /// `BPF_MAP_TYPE_PROG_ARRAY` itself dates back to 4.2, but kernels
+    /// prior to 4.20 either silently dropped BTF for prog-array maps
+    /// (4.18) or rejected BTF `BPF_MAP_CREATE` with `-ENOTSUPP` (4.19).
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use aya_ebpf::{btf_maps::ProgramArray, macros::btf_map};
+    ///
+    /// #[btf_map]
+    /// static JUMP_TABLE: ProgramArray<16> = ProgramArray::new();
+    /// ```
+    pub struct ProgramArray<; const MAX_ENTRIES: usize, const FLAGS: usize = 0>,
+    map_type: BPF_MAP_TYPE_PROG_ARRAY,
+    max_entries: MAX_ENTRIES,
+    map_flags: FLAGS,
+    key_type: u32,
+    value_type: u32,
+);
+
+impl<const MAX_ENTRIES: usize, const FLAGS: usize> ProgramArray<MAX_ENTRIES, FLAGS> {
+    /// Performs a tail call into a program indexed by this map.
+    ///
+    /// # Safety
+    ///
+    /// This function is inherently unsafe, since it causes control flow to
+    /// jump into another eBPF program. This can have side effects, such as
+    /// drop methods not being called. Note that tail calling into an eBPF
+    /// program is not the same thing as a function call -- control flow
+    /// never returns to the caller.
+    ///
+    /// # Return Value
+    ///
+    /// On success, this function does not return into the original program.
+    /// On failure, control returns to the caller. The kernel's
+    /// `bpf_tail_call` helper is declared with `ret_type = RET_VOID` and
+    /// does not write `R0` on failure, so callers cannot distinguish
+    /// between the three failure modes (out-of-bounds index, empty slot,
+    /// or `MAX_TAIL_CALL_CNT` exceeded).
+    pub unsafe fn tail_call<C: EbpfContext>(&self, ctx: &C, index: u32) {
+        // SAFETY: `ctx` and `self` are valid pointers managed by aya.
+        unsafe {
+            bpf_tail_call(ctx.as_ptr(), self.as_ptr(), index);
+        }
+    }
+}

--- a/ebpf/aya-ebpf/src/maps/program_array.rs
+++ b/ebpf/aya-ebpf/src/maps/program_array.rs
@@ -1,5 +1,3 @@
-use core::hint::unreachable_unchecked;
-
 use crate::{
     EbpfContext,
     bindings::bpf_map_type::BPF_MAP_TYPE_PROG_ARRAY,
@@ -18,15 +16,13 @@ use crate::{
 /// #[map]
 /// static JUMP_TABLE: ProgramArray = ProgramArray::with_max_entries(16, 0);
 ///
-/// # unsafe fn try_test(ctx: &LsmContext) -> Result<(), i32> {
+/// # unsafe fn try_test(ctx: &LsmContext) {
 /// let index: u32 = 13;
 ///
 /// unsafe {
-///     JUMP_TABLE.tail_call(ctx, index)?;
+///     JUMP_TABLE.tail_call(ctx, index);
 /// }
-///
-/// # Err(-1)
-/// }
+/// # }
 /// ```
 #[repr(transparent)]
 pub struct ProgramArray {
@@ -36,29 +32,28 @@ pub struct ProgramArray {
 impl ProgramArray {
     map_constructors!(u32, u32, BPF_MAP_TYPE_PROG_ARRAY);
 
-    /// Perform a tail call into a program indexed by this map.
+    /// Performs a tail call into a program indexed by this map.
     ///
     /// # Safety
     ///
-    /// This function is inherently unsafe, since it causes control flow to jump into
-    /// another eBPF program. This can have side effects, such as drop methods not being
-    /// called. Note that tail calling into an eBPF program is not the same thing as
-    /// a function call -- control flow never returns to the caller.
+    /// This function is inherently unsafe, since it causes control flow to
+    /// jump into another eBPF program. This can have side effects, such as
+    /// drop methods not being called. Note that tail calling into an eBPF
+    /// program is not the same thing as a function call -- control flow
+    /// never returns to the caller.
     ///
     /// # Return Value
     ///
-    /// On success, this function **does not return** into the original program.
-    /// On failure, a negative error is returned, wrapped in `Err()`.
-    pub unsafe fn tail_call<C: EbpfContext>(
-        &self,
-        ctx: &C,
-        index: u32,
-    ) -> Result<core::convert::Infallible, i32> {
-        let res = unsafe { bpf_tail_call(ctx.as_ptr(), self.def.as_ptr().cast(), index) };
-        if res < 0 {
-            Err(res as i32)
-        } else {
-            unsafe { unreachable_unchecked() }
+    /// On success, this function does not return into the original program.
+    /// On failure, control returns to the caller. The kernel's
+    /// `bpf_tail_call` helper is declared with `ret_type = RET_VOID` and
+    /// does not write `R0` on failure, so callers cannot distinguish
+    /// between the three failure modes (out-of-bounds index, empty slot,
+    /// or `MAX_TAIL_CALL_CNT` exceeded).
+    pub unsafe fn tail_call<C: EbpfContext>(&self, ctx: &C, index: u32) {
+        // SAFETY: `ctx` and `self.def` are valid pointers managed by aya.
+        unsafe {
+            bpf_tail_call(ctx.as_ptr(), self.def.as_ptr().cast(), index);
         }
     }
 }

--- a/test/integration-common/src/lib.rs
+++ b/test/integration-common/src/lib.rs
@@ -9,6 +9,15 @@ pub mod array {
     pub const ARRAY_LEN: u32 = 4;
 }
 
+pub mod prog_array {
+    /// Slot written by the uprobe after `tail_call` falls through.
+    pub const RESULT_INDEX: u32 = 0;
+
+    /// Arbitrary non-zero sentinel written by the uprobe to prove control
+    /// returned from a failed `tail_call`.
+    pub const FAILURE_SENTINEL: u32 = 42;
+}
+
 pub mod bloom_filter {
     pub const INSERT_INDEX: u32 = 0;
     pub const CONTAINS_PRESENT_INDEX: u32 = 1;

--- a/test/integration-common/src/lib.rs
+++ b/test/integration-common/src/lib.rs
@@ -13,9 +13,15 @@ pub mod prog_array {
     /// Slot written by the uprobe after `tail_call` falls through.
     pub const RESULT_INDEX: u32 = 0;
 
+    /// Slot written by the tail-call target to prove the target ran.
+    pub const SUCCESS_INDEX: u32 = 1;
+
     /// Arbitrary non-zero sentinel written by the uprobe to prove control
     /// returned from a failed `tail_call`.
     pub const FAILURE_SENTINEL: u32 = 42;
+
+    /// Arbitrary non-zero sentinel written by the tail-call target program.
+    pub const SUCCESS_SENTINEL: u32 = 43;
 }
 
 pub mod bloom_filter {

--- a/test/integration-ebpf/Cargo.toml
+++ b/test/integration-ebpf/Cargo.toml
@@ -131,3 +131,7 @@ path = "src/perf_event_bp.rs"
 [[bin]]
 name = "printk_test"
 path = "src/printk_test.rs"
+
+[[bin]]
+name = "prog_array"
+path = "src/prog_array.rs"

--- a/test/integration-ebpf/src/prog_array.rs
+++ b/test/integration-ebpf/src/prog_array.rs
@@ -6,31 +6,61 @@
 extern crate ebpf_panic;
 
 use aya_ebpf::{
+    btf_maps::{Array as BtfArray, ProgramArray as BtfProgramArray},
     cty::c_long,
-    macros::{map, uprobe},
+    macros::{btf_map, map, uprobe},
     maps::{Array as LegacyArray, ProgramArray as LegacyProgramArray},
     programs::ProbeContext,
 };
-use integration_common::prog_array::{FAILURE_SENTINEL, RESULT_INDEX};
+use integration_common::prog_array::{
+    FAILURE_SENTINEL, RESULT_INDEX, SUCCESS_INDEX, SUCCESS_SENTINEL,
+};
 
 // An unpopulated slot guarantees `bpf_tail_call` falls through to the
 // caller; the entry probe records the sentinel from that path.
+#[btf_map]
+static ARRAY: BtfProgramArray<1, 0> = BtfProgramArray::new();
+
+#[btf_map]
+static RESULT: BtfArray<u32, 2, 0> = BtfArray::new();
+
 #[map]
 static ARRAY_LEGACY: LegacyProgramArray = LegacyProgramArray::with_max_entries(1, 0);
 
 #[map]
-static RESULT_LEGACY: LegacyArray<u32> = LegacyArray::with_max_entries(1, 0);
+static RESULT_LEGACY: LegacyArray<u32> = LegacyArray::with_max_entries(2, 0);
 
-#[uprobe]
-fn tail_call_empty_legacy(ctx: ProbeContext) -> Result<(), c_long> {
-    // A successful tail call never returns here, so this runs only on
-    // failure.
-    unsafe {
-        ARRAY_LEGACY.tail_call(&ctx, 0);
-    }
-    let ptr = RESULT_LEGACY.get_ptr_mut(RESULT_INDEX).ok_or(-1)?;
-    unsafe {
-        *ptr = FAILURE_SENTINEL;
-    }
-    Ok(())
+macro_rules! define_prog_array_tail_call_test {
+    ($array_map:ident, $result_map:ident, $entry_probe:ident, $target_probe:ident $(,)?) => {
+        #[uprobe]
+        fn $entry_probe(ctx: ProbeContext) -> Result<(), c_long> {
+            // A successful tail call never returns here, so this runs
+            // only on failure.
+            unsafe {
+                $array_map.tail_call(&ctx, 0);
+            }
+            let ptr = $result_map.get_ptr_mut(RESULT_INDEX).ok_or(-1)?;
+            unsafe {
+                *ptr = FAILURE_SENTINEL;
+            }
+            Ok(())
+        }
+
+        #[uprobe]
+        fn $target_probe(_ctx: ProbeContext) -> Result<(), c_long> {
+            let ptr = $result_map.get_ptr_mut(SUCCESS_INDEX).ok_or(-1)?;
+            unsafe {
+                *ptr = SUCCESS_SENTINEL;
+            }
+            Ok(())
+        }
+    };
 }
+
+define_prog_array_tail_call_test!(ARRAY, RESULT, tail_call_empty, tail_call_target);
+define_prog_array_tail_call_test!(
+    ARRAY_LEGACY,
+    RESULT_LEGACY,
+    tail_call_empty_legacy,
+    tail_call_target_legacy,
+);

--- a/test/integration-ebpf/src/prog_array.rs
+++ b/test/integration-ebpf/src/prog_array.rs
@@ -1,0 +1,36 @@
+#![no_std]
+#![no_main]
+#![expect(unused_crate_dependencies, reason = "used in other bins")]
+
+#[cfg(not(test))]
+extern crate ebpf_panic;
+
+use aya_ebpf::{
+    cty::c_long,
+    macros::{map, uprobe},
+    maps::{Array as LegacyArray, ProgramArray as LegacyProgramArray},
+    programs::ProbeContext,
+};
+use integration_common::prog_array::{FAILURE_SENTINEL, RESULT_INDEX};
+
+// An unpopulated slot guarantees `bpf_tail_call` falls through to the
+// caller; the entry probe records the sentinel from that path.
+#[map]
+static ARRAY_LEGACY: LegacyProgramArray = LegacyProgramArray::with_max_entries(1, 0);
+
+#[map]
+static RESULT_LEGACY: LegacyArray<u32> = LegacyArray::with_max_entries(1, 0);
+
+#[uprobe]
+fn tail_call_empty_legacy(ctx: ProbeContext) -> Result<(), c_long> {
+    // A successful tail call never returns here, so this runs only on
+    // failure.
+    unsafe {
+        ARRAY_LEGACY.tail_call(&ctx, 0);
+    }
+    let ptr = RESULT_LEGACY.get_ptr_mut(RESULT_INDEX).ok_or(-1)?;
+    unsafe {
+        *ptr = FAILURE_SENTINEL;
+    }
+    Ok(())
+}

--- a/test/integration-test/src/lib.rs
+++ b/test/integration-test/src/lib.rs
@@ -66,6 +66,7 @@ bpf_file!(
     XDP_SEC => "xdp_sec",
     UPROBE_COOKIE => "uprobe_cookie",
     PRINTK_TEST => "printk_test",
+    PROG_ARRAY => "prog_array",
 );
 
 #[cfg(test)]

--- a/test/integration-test/src/tests.rs
+++ b/test/integration-test/src/tests.rs
@@ -28,6 +28,7 @@ mod maps_disjoint;
 mod per_cpu_array;
 mod perf_event_bp;
 mod printk;
+mod prog_array;
 mod raw_tracepoint;
 mod rbpf;
 mod relocations;

--- a/test/integration-test/src/tests/prog_array.rs
+++ b/test/integration-test/src/tests/prog_array.rs
@@ -1,10 +1,12 @@
 use aya::{
     EbpfLoader,
-    maps::{Array, MapType},
+    maps::{Array, MapType, ProgramArray},
     programs::UProbe,
     sys::is_map_supported,
 };
-use integration_common::prog_array::{FAILURE_SENTINEL, RESULT_INDEX};
+use integration_common::prog_array::{
+    FAILURE_SENTINEL, RESULT_INDEX, SUCCESS_INDEX, SUCCESS_SENTINEL,
+};
 use test_case::test_case;
 
 #[unsafe(no_mangle)]
@@ -13,10 +15,21 @@ extern "C" fn trigger_tail_call_empty() {
     std::hint::black_box(());
 }
 
+#[unsafe(no_mangle)]
+#[inline(never)]
+extern "C" fn trigger_tail_call_success() {
+    std::hint::black_box(());
+}
+
 #[test_case(
     "RESULT_LEGACY",
     "tail_call_empty_legacy"
     ; "legacy"
+)]
+#[test_case(
+    "RESULT",
+    "tail_call_empty"
+    ; "btf"
 )]
 #[test_log::test]
 fn tail_call_empty(result_map: &str, entry_prog: &str) {
@@ -47,5 +60,75 @@ fn tail_call_empty(result_map: &str, entry_prog: &str) {
         result.get(&RESULT_INDEX, 0).unwrap(),
         FAILURE_SENTINEL,
         "tail_call on an empty slot must fall through and let the probe record the sentinel",
+    );
+}
+
+#[test_case(
+    "RESULT_LEGACY",
+    "ARRAY_LEGACY",
+    "tail_call_empty_legacy",
+    "tail_call_target_legacy"
+    ; "legacy"
+)]
+#[test_case(
+    "RESULT",
+    "ARRAY",
+    "tail_call_empty",
+    "tail_call_target"
+    ; "btf"
+)]
+#[test_log::test]
+fn tail_call_success(result_map: &str, array_map: &str, entry_prog: &str, target_prog: &str) {
+    if !is_map_supported(MapType::ProgramArray).unwrap() {
+        eprintln!("skipping test - program array map not supported");
+        return;
+    }
+
+    let mut bpf = EbpfLoader::new()
+        .load(crate::PROG_ARRAY)
+        .expect("load prog_array program");
+
+    {
+        let target: &mut UProbe = bpf
+            .program_mut(target_prog)
+            .unwrap_or_else(|| panic!("missing program {target_prog}"))
+            .try_into()
+            .unwrap_or_else(|err| panic!("program {target_prog} is not a uprobe: {err}"));
+        target
+            .load()
+            .unwrap_or_else(|err| panic!("load {target_prog}: {err}"));
+    }
+
+    {
+        let entry: &mut UProbe = bpf
+            .program_mut(entry_prog)
+            .unwrap_or_else(|| panic!("missing program {entry_prog}"))
+            .try_into()
+            .unwrap_or_else(|err| panic!("program {entry_prog} is not a uprobe: {err}"));
+        entry
+            .load()
+            .unwrap_or_else(|err| panic!("load {entry_prog}: {err}"));
+        entry
+            .attach("trigger_tail_call_success", "/proc/self/exe", None)
+            .unwrap_or_else(|err| panic!("attach {entry_prog}: {err}"));
+    }
+
+    let mut array: ProgramArray<_> = bpf.take_map(array_map).unwrap().try_into().unwrap();
+    let target_fd = bpf.program(target_prog).unwrap().fd().unwrap();
+    array.set(0, target_fd, 0).unwrap();
+
+    let result = Array::<_, u32>::try_from(bpf.map(result_map).unwrap()).unwrap();
+
+    trigger_tail_call_success();
+
+    assert_eq!(
+        result.get(&SUCCESS_INDEX, 0).unwrap(),
+        SUCCESS_SENTINEL,
+        "tail_call into a populated slot must jump to the target program",
+    );
+    assert_eq!(
+        result.get(&RESULT_INDEX, 0).unwrap(),
+        0,
+        "entry must not reach the failure path after a successful tail_call",
     );
 }

--- a/test/integration-test/src/tests/prog_array.rs
+++ b/test/integration-test/src/tests/prog_array.rs
@@ -1,0 +1,51 @@
+use aya::{
+    EbpfLoader,
+    maps::{Array, MapType},
+    programs::UProbe,
+    sys::is_map_supported,
+};
+use integration_common::prog_array::{FAILURE_SENTINEL, RESULT_INDEX};
+use test_case::test_case;
+
+#[unsafe(no_mangle)]
+#[inline(never)]
+extern "C" fn trigger_tail_call_empty() {
+    std::hint::black_box(());
+}
+
+#[test_case(
+    "RESULT_LEGACY",
+    "tail_call_empty_legacy"
+    ; "legacy"
+)]
+#[test_log::test]
+fn tail_call_empty(result_map: &str, entry_prog: &str) {
+    if !is_map_supported(MapType::ProgramArray).unwrap() {
+        eprintln!("skipping test - program array map not supported");
+        return;
+    }
+
+    let mut bpf = EbpfLoader::new()
+        .load(crate::PROG_ARRAY)
+        .expect("load prog_array program");
+
+    let prog: &mut UProbe = bpf
+        .program_mut(entry_prog)
+        .unwrap_or_else(|| panic!("missing program {entry_prog}"))
+        .try_into()
+        .unwrap_or_else(|err| panic!("program {entry_prog} is not a uprobe: {err}"));
+    prog.load()
+        .unwrap_or_else(|err| panic!("load {entry_prog}: {err}"));
+    prog.attach("trigger_tail_call_empty", "/proc/self/exe", None)
+        .unwrap_or_else(|err| panic!("attach {entry_prog}: {err}"));
+
+    let result = Array::<_, u32>::try_from(bpf.map(result_map).unwrap()).unwrap();
+
+    trigger_tail_call_empty();
+
+    assert_eq!(
+        result.get(&RESULT_INDEX, 0).unwrap(),
+        FAILURE_SENTINEL,
+        "tail_call on an empty slot must fall through and let the probe record the sentinel",
+    );
+}

--- a/xtask/public-api/aya-ebpf.txt
+++ b/xtask/public-api/aya-ebpf.txt
@@ -411,7 +411,7 @@ pub mod aya_ebpf::maps::program_array
 #[repr(transparent)] pub struct aya_ebpf::maps::program_array::ProgramArray
 impl aya_ebpf::maps::program_array::ProgramArray
 pub const fn aya_ebpf::maps::program_array::ProgramArray::pinned(max_entries: u32, flags: u32) -> Self
-pub unsafe fn aya_ebpf::maps::program_array::ProgramArray::tail_call<C: aya_ebpf::EbpfContext>(&self, ctx: &C, index: u32) -> core::result::Result<core::convert::Infallible, i32>
+pub unsafe fn aya_ebpf::maps::program_array::ProgramArray::tail_call<C: aya_ebpf::EbpfContext>(&self, ctx: &C, index: u32)
 pub const fn aya_ebpf::maps::program_array::ProgramArray::with_max_entries(max_entries: u32, flags: u32) -> Self
 impl !core::marker::Freeze for aya_ebpf::maps::program_array::ProgramArray
 impl core::marker::Send for aya_ebpf::maps::program_array::ProgramArray
@@ -783,7 +783,7 @@ impl core::panic::unwind_safe::UnwindSafe for aya_ebpf::maps::PerfEventByteArray
 #[repr(transparent)] pub struct aya_ebpf::maps::ProgramArray
 impl aya_ebpf::maps::program_array::ProgramArray
 pub const fn aya_ebpf::maps::program_array::ProgramArray::pinned(max_entries: u32, flags: u32) -> Self
-pub unsafe fn aya_ebpf::maps::program_array::ProgramArray::tail_call<C: aya_ebpf::EbpfContext>(&self, ctx: &C, index: u32) -> core::result::Result<core::convert::Infallible, i32>
+pub unsafe fn aya_ebpf::maps::program_array::ProgramArray::tail_call<C: aya_ebpf::EbpfContext>(&self, ctx: &C, index: u32)
 pub const fn aya_ebpf::maps::program_array::ProgramArray::with_max_entries(max_entries: u32, flags: u32) -> Self
 impl !core::marker::Freeze for aya_ebpf::maps::program_array::ProgramArray
 impl core::marker::Send for aya_ebpf::maps::program_array::ProgramArray

--- a/xtask/public-api/aya-ebpf.txt
+++ b/xtask/public-api/aya-ebpf.txt
@@ -86,6 +86,21 @@ impl<T, const MAX_ENTRIES: usize, const FLAGS: usize> core::marker::Unpin for ay
 impl<T, const MAX_ENTRIES: usize, const FLAGS: usize> core::marker::UnsafeUnpin for aya_ebpf::btf_maps::per_cpu_array::PerCpuArray<T, MAX_ENTRIES, FLAGS>
 impl<T, const MAX_ENTRIES: usize, const FLAGS: usize> core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::btf_maps::per_cpu_array::PerCpuArray<T, MAX_ENTRIES, FLAGS> where T: core::panic::unwind_safe::RefUnwindSafe
 impl<T, const MAX_ENTRIES: usize, const FLAGS: usize> core::panic::unwind_safe::UnwindSafe for aya_ebpf::btf_maps::per_cpu_array::PerCpuArray<T, MAX_ENTRIES, FLAGS> where T: core::panic::unwind_safe::RefUnwindSafe
+pub mod aya_ebpf::btf_maps::program_array
+#[repr(C)] pub struct aya_ebpf::btf_maps::program_array::ProgramArray<const MAX_ENTRIES: usize, const FLAGS: usize>
+impl<const MAX_ENTRIES: usize, const FLAGS: usize> aya_ebpf::btf_maps::program_array::ProgramArray<MAX_ENTRIES, FLAGS>
+pub const fn aya_ebpf::btf_maps::program_array::ProgramArray<MAX_ENTRIES, FLAGS>::new() -> Self
+impl<const MAX_ENTRIES: usize, const FLAGS: usize> aya_ebpf::btf_maps::program_array::ProgramArray<MAX_ENTRIES, FLAGS>
+pub unsafe fn aya_ebpf::btf_maps::program_array::ProgramArray<MAX_ENTRIES, FLAGS>::tail_call<C: aya_ebpf::EbpfContext>(&self, ctx: &C, index: u32)
+impl<const MAX_ENTRIES: usize, const FLAGS: usize> core::default::Default for aya_ebpf::btf_maps::program_array::ProgramArray<MAX_ENTRIES, FLAGS>
+pub fn aya_ebpf::btf_maps::program_array::ProgramArray<MAX_ENTRIES, FLAGS>::default() -> Self
+impl<const MAX_ENTRIES: usize, const FLAGS: usize> core::marker::Sync for aya_ebpf::btf_maps::program_array::ProgramArray<MAX_ENTRIES, FLAGS>
+impl<const MAX_ENTRIES: usize, const FLAGS: usize> core::marker::Freeze for aya_ebpf::btf_maps::program_array::ProgramArray<MAX_ENTRIES, FLAGS>
+impl<const MAX_ENTRIES: usize, const FLAGS: usize> !core::marker::Send for aya_ebpf::btf_maps::program_array::ProgramArray<MAX_ENTRIES, FLAGS>
+impl<const MAX_ENTRIES: usize, const FLAGS: usize> core::marker::Unpin for aya_ebpf::btf_maps::program_array::ProgramArray<MAX_ENTRIES, FLAGS>
+impl<const MAX_ENTRIES: usize, const FLAGS: usize> core::marker::UnsafeUnpin for aya_ebpf::btf_maps::program_array::ProgramArray<MAX_ENTRIES, FLAGS>
+impl<const MAX_ENTRIES: usize, const FLAGS: usize> core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::btf_maps::program_array::ProgramArray<MAX_ENTRIES, FLAGS>
+impl<const MAX_ENTRIES: usize, const FLAGS: usize> core::panic::unwind_safe::UnwindSafe for aya_ebpf::btf_maps::program_array::ProgramArray<MAX_ENTRIES, FLAGS>
 pub mod aya_ebpf::btf_maps::ring_buf
 #[repr(C)] pub struct aya_ebpf::btf_maps::ring_buf::RingBuf<T, const MAX_ENTRIES: usize, const FLAGS: usize>
 impl<T, const MAX_ENTRIES: usize, const FLAGS: usize> aya_ebpf::btf_maps::ring_buf::RingBuf<T, MAX_ENTRIES, FLAGS>
@@ -187,6 +202,20 @@ impl<T, const MAX_ENTRIES: usize, const FLAGS: usize> core::marker::Unpin for ay
 impl<T, const MAX_ENTRIES: usize, const FLAGS: usize> core::marker::UnsafeUnpin for aya_ebpf::btf_maps::per_cpu_array::PerCpuArray<T, MAX_ENTRIES, FLAGS>
 impl<T, const MAX_ENTRIES: usize, const FLAGS: usize> core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::btf_maps::per_cpu_array::PerCpuArray<T, MAX_ENTRIES, FLAGS> where T: core::panic::unwind_safe::RefUnwindSafe
 impl<T, const MAX_ENTRIES: usize, const FLAGS: usize> core::panic::unwind_safe::UnwindSafe for aya_ebpf::btf_maps::per_cpu_array::PerCpuArray<T, MAX_ENTRIES, FLAGS> where T: core::panic::unwind_safe::RefUnwindSafe
+#[repr(C)] pub struct aya_ebpf::btf_maps::ProgramArray<const MAX_ENTRIES: usize, const FLAGS: usize>
+impl<const MAX_ENTRIES: usize, const FLAGS: usize> aya_ebpf::btf_maps::program_array::ProgramArray<MAX_ENTRIES, FLAGS>
+pub const fn aya_ebpf::btf_maps::program_array::ProgramArray<MAX_ENTRIES, FLAGS>::new() -> Self
+impl<const MAX_ENTRIES: usize, const FLAGS: usize> aya_ebpf::btf_maps::program_array::ProgramArray<MAX_ENTRIES, FLAGS>
+pub unsafe fn aya_ebpf::btf_maps::program_array::ProgramArray<MAX_ENTRIES, FLAGS>::tail_call<C: aya_ebpf::EbpfContext>(&self, ctx: &C, index: u32)
+impl<const MAX_ENTRIES: usize, const FLAGS: usize> core::default::Default for aya_ebpf::btf_maps::program_array::ProgramArray<MAX_ENTRIES, FLAGS>
+pub fn aya_ebpf::btf_maps::program_array::ProgramArray<MAX_ENTRIES, FLAGS>::default() -> Self
+impl<const MAX_ENTRIES: usize, const FLAGS: usize> core::marker::Sync for aya_ebpf::btf_maps::program_array::ProgramArray<MAX_ENTRIES, FLAGS>
+impl<const MAX_ENTRIES: usize, const FLAGS: usize> core::marker::Freeze for aya_ebpf::btf_maps::program_array::ProgramArray<MAX_ENTRIES, FLAGS>
+impl<const MAX_ENTRIES: usize, const FLAGS: usize> !core::marker::Send for aya_ebpf::btf_maps::program_array::ProgramArray<MAX_ENTRIES, FLAGS>
+impl<const MAX_ENTRIES: usize, const FLAGS: usize> core::marker::Unpin for aya_ebpf::btf_maps::program_array::ProgramArray<MAX_ENTRIES, FLAGS>
+impl<const MAX_ENTRIES: usize, const FLAGS: usize> core::marker::UnsafeUnpin for aya_ebpf::btf_maps::program_array::ProgramArray<MAX_ENTRIES, FLAGS>
+impl<const MAX_ENTRIES: usize, const FLAGS: usize> core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::btf_maps::program_array::ProgramArray<MAX_ENTRIES, FLAGS>
+impl<const MAX_ENTRIES: usize, const FLAGS: usize> core::panic::unwind_safe::UnwindSafe for aya_ebpf::btf_maps::program_array::ProgramArray<MAX_ENTRIES, FLAGS>
 #[repr(C)] pub struct aya_ebpf::btf_maps::RingBuf<T, const MAX_ENTRIES: usize, const FLAGS: usize>
 impl<T, const MAX_ENTRIES: usize, const FLAGS: usize> aya_ebpf::btf_maps::ring_buf::RingBuf<T, MAX_ENTRIES, FLAGS>
 pub const fn aya_ebpf::btf_maps::ring_buf::RingBuf<T, MAX_ENTRIES, FLAGS>::new() -> Self


### PR DESCRIPTION
BTF `.maps` support for `BPF_MAP_TYPE_PROG_ARRAY`, matching the shape
of `btf_maps::Array`. Keys and values are `u32`, so `ProgramArray` is
the first `btf_map_def!` caller with no type parameters; a
preparatory commit loosens the macro matcher accordingly.

A second preparatory commit fixes a pre-existing soundness bug in
legacy `maps::ProgramArray::tail_call`: the kernel's `bpf_tail_call`
helper is declared `RET_VOID` and does not write `R0` on failure, so
the wrapper could reach `unreachable_unchecked()` on real failures.
Discard the helper return and always return synthetic `Err(-1)`. The
BTF variant uses the same corrected contract.

The integration test is parameterized via `test_case` over both the
BTF and legacy map definitions, covering an empty slot (failure
fall-through) and a populated slot (control jumps to the target
program).

### Added/updated tests?

- [x] Yes

### Checklist

- [x] Rust code has been formatted with `cargo +nightly fmt`.
- [x] All clippy lints have been fixed.
      You can find failing lints with `cargo xtask clippy`.
- [x] Unit tests are passing locally with `cargo test`.
- [x] The integration tests are passing locally.
- [x] I have blessed any API changes with `cargo xtask public-api --bless`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aya-rs/aya/1538)
<!-- Reviewable:end -->
