### PR TITLE
feat: Added bounds check for `SkBuff::load_bytes` and relevant integration test.

### DIFF
--- a/ebpf/aya-ebpf/src/programs/sk_buff.rs
+++ b/ebpf/aya-ebpf/src/programs/sk_buff.rs
@@ -7,7 +7,7 @@ use aya_ebpf_bindings::helpers::{
 };
 use aya_ebpf_cty::c_long;
 
-use crate::{EbpfContext, bindings::__sk_buff};
+use crate::{EbpfContext, bindings::__sk_buff, check_bounds_signed};
 
 pub struct SkBuff {
     pub skb: *mut __sk_buff,
@@ -85,8 +85,12 @@ impl SkBuff {
     #[inline(always)]
     pub fn load_bytes(&self, offset: usize, dst: &mut [u8]) -> Result<usize, c_long> {
         let len = usize::try_from(self.len()).map_err(|core::num::TryFromIntError { .. }| -1)?;
+        // 0 byte reads will trip the verifier. We need to ensure that the valid range of values for len is at least 1.
         let len = len.checked_sub(offset).ok_or(-1)?;
         let len = len.min(dst.len());
+        if !check_bounds_signed(len as i64, 1, dst.len() as i64) {
+            return Err(-1);
+        }
         let len_u32 = u32::try_from(len).map_err(|core::num::TryFromIntError { .. }| -1)?;
         let ret = unsafe {
             bpf_skb_load_bytes(

--- a/test/integration-ebpf/Cargo.toml
+++ b/test/integration-ebpf/Cargo.toml
@@ -135,3 +135,7 @@ path = "src/printk_test.rs"
 [[bin]]
 name = "prog_array"
 path = "src/prog_array.rs"
+
+[[bin]]
+name = "socket_filter"
+path = "src/socket_filter.rs"

--- a/test/integration-ebpf/src/socket_filter.rs
+++ b/test/integration-ebpf/src/socket_filter.rs
@@ -1,0 +1,17 @@
+#![no_std]
+#![no_main]
+#![expect(unused_crate_dependencies, reason = "used in other bins")]
+
+use aya_ebpf::{macros::socket_filter, programs::SkBuffContext};
+
+#[cfg(not(test))]
+extern crate ebpf_panic;
+
+#[socket_filter]
+fn read_one(ctx: SkBuffContext) -> i64 {
+    // Read 1 byte
+    let mut dst = [0; 2];
+    let _result: Result<_, _> = ctx.load_bytes(0, &mut dst);
+
+    0
+}

--- a/test/integration-test/src/lib.rs
+++ b/test/integration-test/src/lib.rs
@@ -67,6 +67,7 @@ bpf_file!(
     UPROBE_COOKIE => "uprobe_cookie",
     PRINTK_TEST => "printk_test",
     PROG_ARRAY => "prog_array",
+    SOCKET_FILTER => "socket_filter",
 );
 
 #[cfg(test)]

--- a/test/integration-test/src/tests.rs
+++ b/test/integration-test/src/tests.rs
@@ -35,6 +35,7 @@ mod relocations;
 mod ring_buf;
 mod sk_storage;
 mod smoke;
+mod socket_filter;
 mod strncmp;
 mod tcx;
 mod uprobe_cookie;

--- a/test/integration-test/src/tests/socket_filter.rs
+++ b/test/integration-test/src/tests/socket_filter.rs
@@ -1,0 +1,8 @@
+use aya::{Ebpf, programs::SocketFilter};
+
+#[test]
+fn socket_filter_load() {
+    let mut bpf = Ebpf::load(crate::SOCKET_FILTER).unwrap();
+    let prog: &mut SocketFilter = bpf.program_mut("read_one").unwrap().try_into().unwrap();
+    prog.load().unwrap();
+}


### PR DESCRIPTION
<!-- markdownlint-disable first-line-heading -->

<!--
    Thank you for your contribution to Aya! 🎉

    For Work In Progress Pull Requests, please use the Draft PR feature.

    Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Aya Contributing Guide: https://github.com/aya-rs/aya/blob/main/CONTRIBUTING.md
     - 📖 Read the Aya Code of Conduct: https://github.com/aya-rs/aya/blob/main/CODE_OF_CONDUCT.md
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages: https://cbea.ms/git-commit/
     - 📗 Update any related documentation.

-->

<!---
      Summarize the changes you're making here. Detailed information belongs in
      the Git commit messages. If your pull request contains just one commit,
      it's best to use its message as a summary. Otherwise, if there are multiple
      atomic commits, write a summary for the entire PR. Feel free to flag
      anything you think needs a reviewer's attention.
-->

<!--
      If your changes address an issue, link it with the *Fixes* tag so
      the issue gets closed when the PR is merged, for example:

      Fixes: #1234

      If you are only referencing an issue without fully addressing it, feel
      free to link it anywhere in the summary.
-->

This is a reboot of #1218, with some minor commit juggling (i.e. moving changes from one commit to the other to make them a little more atomic).

> […], attempting to resolve the invalid zero-sized read error found on discord and in my personal projects.
> 
> This PR contains:
> 
> The correct inclusive bounds check.
> 
> An integration test which fails before the update and succeeds after.

### Added/updated tests?

_We strongly encourage you to add a test for your changes._

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

### Checklist

- [x] Rust code has been formatted with `cargo +nightly fmt`.
- [x] All clippy lints have been fixed.
      You can find failing lints with `cargo xtask clippy`.
- [x] Unit tests are passing locally with `cargo test`.
- [ ] The [Integration tests] are passing locally.
- [ ] I have blessed any API changes with `cargo xtask public-api --bless`.

(the last two err out on my machine due to problems in the development environment, not the changes themselves)

[Integration tests]: https://github.com/aya-rs/aya/blob/main/test/README.md

Unit test failures:

- `maps::tests::test_create_perf_event_array` because `/sys/devices/system/cpu/possible` is not available in the sandbox I run tests in
- `maps::hash_map::per_cpu_hash_map::tests::test_get_not_found`: probably the same thing:

```text
assertion failed: `Err(SyscallError(SyscallError { call: "bpf_map_lookup_elem", io_error: Os { code: 2, kind: NotFound, message: "No such file or directory" } }))` does not match `Err(MapError::KeyNotFound)`
```

### (Optional) What GIF best describes this PR or how it makes you feel?

Me trying to run the tests without setting up the full development environment.
Also: me running the tests against the wrong branch.

<img width="250" height="185" alt="bonk" src="https://github.com/user-attachments/assets/f683b7c7-3d73-4ef1-b6eb-3ed77300ca2d" />

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aya-rs/aya/1539)
<!-- Reviewable:end -->
