### PR TITLE
aya-ebpf: add BTF map definition for stack trace

### DIFF
--- a/aya/src/maps/mod.rs
+++ b/aya/src/maps/mod.rs
@@ -144,6 +144,15 @@ pub enum MapError {
         expected: usize,
     },
 
+    /// Invalid value stride
+    #[error("invalid value size {size}, expected a non-zero multiple of {stride}")]
+    InvalidValueStride {
+        /// Size encountered
+        size: usize,
+        /// Required stride
+        stride: usize,
+    },
+
     /// Index is out of bounds
     #[error("the index is {index} but `max_entries` is {max_entries}")]
     OutOfBounds {
@@ -196,6 +205,15 @@ pub enum MapError {
         name: String,
         /// The map type
         map_type: bpf_map_type,
+    },
+
+    /// Unsupported map flags
+    #[error("unsupported map flags {flags:#x}: {reason}")]
+    UnsupportedMapFlags {
+        /// The map flags
+        flags: u32,
+        /// The reason
+        reason: &'static str,
     },
 }
 

--- a/aya/src/maps/stack_trace.rs
+++ b/aya/src/maps/stack_trace.rs
@@ -4,11 +4,10 @@
 
 use std::{
     borrow::{Borrow, BorrowMut},
-    fs, io,
     os::fd::AsFd as _,
-    path::Path,
-    str::FromStr,
 };
+
+use aya_obj::generated::BPF_F_STACK_BUILD_ID;
 
 use crate::{
     maps::{IterableMap, MapData, MapError, MapIter, MapKeys, hash_map},
@@ -78,24 +77,43 @@ pub struct StackTraceMap<T> {
     max_stack_depth: usize,
 }
 
+// A stack trace entry is a single `u64` instruction pointer, matching the
+// kernel layout for `BPF_MAP_TYPE_STACK_TRACE` values.
+type StackEntry = u64;
+
 impl<T: Borrow<MapData>> StackTraceMap<T> {
     pub(crate) fn new(map: T) -> Result<Self, MapError> {
         let data = map.borrow();
-        let expected = size_of::<u32>();
-        let size = data.obj.key_size() as usize;
-        if size != expected {
-            return Err(MapError::InvalidKeySize { size, expected });
+
+        let key_size = data.obj.key_size() as usize;
+        let expected_key = size_of::<u32>();
+        if key_size != expected_key {
+            return Err(MapError::InvalidKeySize {
+                size: key_size,
+                expected: expected_key,
+            });
         }
 
-        let max_stack_depth =
-            sysctl::<usize>("kernel/perf_event_max_stack").map_err(|io_error| SyscallError {
-                call: "sysctl",
-                io_error,
-            })?;
-        let size = data.obj.value_size() as usize;
-        if size > max_stack_depth * size_of::<u64>() {
-            return Err(MapError::InvalidValueSize { size, expected });
+        // BPF_F_STACK_BUILD_ID switches stack entries to
+        // `struct bpf_stack_build_id` (32 bytes), which `get` decodes as
+        // `[u64]` and would silently corrupt. Reject it.
+        let flags = data.obj.map_flags();
+        if flags & BPF_F_STACK_BUILD_ID != 0 {
+            return Err(MapError::UnsupportedMapFlags {
+                flags,
+                reason: "StackTraceMap does not support bpf_stack_build_id entries",
+            });
         }
+
+        let value_size = data.obj.value_size() as usize;
+        let expected_stride = size_of::<StackEntry>();
+        if value_size == 0 || !value_size.is_multiple_of(expected_stride) {
+            return Err(MapError::InvalidValueStride {
+                size: value_size,
+                stride: expected_stride,
+            });
+        }
+        let max_stack_depth = value_size / expected_stride;
 
         Ok(Self {
             inner: map,
@@ -112,7 +130,7 @@ impl<T: Borrow<MapData>> StackTraceMap<T> {
     pub fn get(&self, stack_id: &u32, flags: u64) -> Result<StackTrace, MapError> {
         let fd = self.inner.borrow().fd().as_fd();
 
-        let mut frames = vec![0; self.max_stack_depth];
+        let mut frames: Vec<StackEntry> = vec![0; self.max_stack_depth];
         bpf_map_lookup_elem_ptr(fd, Some(stack_id), frames.as_mut_ptr(), flags)
             .map_err(|io_error| SyscallError {
                 call: "bpf_map_lookup_elem",
@@ -191,11 +209,4 @@ impl StackTrace {
 pub struct StackFrame {
     /// The instruction pointer of this frame.
     pub ip: u64,
-}
-
-fn sysctl<T: FromStr>(key: &str) -> Result<T, io::Error> {
-    let val = fs::read_to_string(Path::new("/proc/sys").join(key))?;
-    val.trim()
-        .parse::<T>()
-        .map_err(|_err: T::Err| io::Error::new(io::ErrorKind::InvalidData, val))
 }

--- a/ebpf/aya-ebpf-bindings/include/bindings.h
+++ b/ebpf/aya-ebpf-bindings/include/bindings.h
@@ -7,6 +7,8 @@ typedef __u32 __bitwise __wsum;
 #include <bpf/bpf_helpers.h>
 #include <linux/bpf.h>
 #include <linux/bpf_perf_event.h>
+// needed for PERF_MAX_STACK_DEPTH
+#include <linux/perf_event.h>
 // needed for TC_ACT_*
 #include <linux/pkt_cls.h>
 #include <linux/ptrace.h>

--- a/ebpf/aya-ebpf-bindings/src/aarch64/bindings.rs
+++ b/ebpf/aya-ebpf-bindings/src/aarch64/bindings.rs
@@ -255,6 +255,7 @@ pub const BPF_F_TEST_XDP_LIVE_FRAMES: u32 = 2;
 pub const BPF_BUILD_ID_SIZE: u32 = 20;
 pub const BPF_OBJ_NAME_LEN: u32 = 16;
 pub const BPF_TAG_SIZE: u32 = 8;
+pub const PERF_MAX_STACK_DEPTH: u32 = 127;
 pub const TC_ACT_UNSPEC: i32 = -1;
 pub const TC_ACT_OK: u32 = 0;
 pub const TC_ACT_RECLASSIFY: u32 = 1;

--- a/ebpf/aya-ebpf-bindings/src/armv7/bindings.rs
+++ b/ebpf/aya-ebpf-bindings/src/armv7/bindings.rs
@@ -255,6 +255,7 @@ pub const BPF_F_TEST_XDP_LIVE_FRAMES: u32 = 2;
 pub const BPF_BUILD_ID_SIZE: u32 = 20;
 pub const BPF_OBJ_NAME_LEN: u32 = 16;
 pub const BPF_TAG_SIZE: u32 = 8;
+pub const PERF_MAX_STACK_DEPTH: u32 = 127;
 pub const TC_ACT_UNSPEC: i32 = -1;
 pub const TC_ACT_OK: u32 = 0;
 pub const TC_ACT_RECLASSIFY: u32 = 1;

--- a/ebpf/aya-ebpf-bindings/src/loongarch64/bindings.rs
+++ b/ebpf/aya-ebpf-bindings/src/loongarch64/bindings.rs
@@ -255,6 +255,7 @@ pub const BPF_F_TEST_XDP_LIVE_FRAMES: u32 = 2;
 pub const BPF_BUILD_ID_SIZE: u32 = 20;
 pub const BPF_OBJ_NAME_LEN: u32 = 16;
 pub const BPF_TAG_SIZE: u32 = 8;
+pub const PERF_MAX_STACK_DEPTH: u32 = 127;
 pub const TC_ACT_UNSPEC: i32 = -1;
 pub const TC_ACT_OK: u32 = 0;
 pub const TC_ACT_RECLASSIFY: u32 = 1;

--- a/ebpf/aya-ebpf-bindings/src/mips/bindings.rs
+++ b/ebpf/aya-ebpf-bindings/src/mips/bindings.rs
@@ -255,6 +255,7 @@ pub const BPF_F_TEST_XDP_LIVE_FRAMES: u32 = 2;
 pub const BPF_BUILD_ID_SIZE: u32 = 20;
 pub const BPF_OBJ_NAME_LEN: u32 = 16;
 pub const BPF_TAG_SIZE: u32 = 8;
+pub const PERF_MAX_STACK_DEPTH: u32 = 127;
 pub const TC_ACT_UNSPEC: i32 = -1;
 pub const TC_ACT_OK: u32 = 0;
 pub const TC_ACT_RECLASSIFY: u32 = 1;

--- a/ebpf/aya-ebpf-bindings/src/mips64/bindings.rs
+++ b/ebpf/aya-ebpf-bindings/src/mips64/bindings.rs
@@ -255,6 +255,7 @@ pub const BPF_F_TEST_XDP_LIVE_FRAMES: u32 = 2;
 pub const BPF_BUILD_ID_SIZE: u32 = 20;
 pub const BPF_OBJ_NAME_LEN: u32 = 16;
 pub const BPF_TAG_SIZE: u32 = 8;
+pub const PERF_MAX_STACK_DEPTH: u32 = 127;
 pub const TC_ACT_UNSPEC: i32 = -1;
 pub const TC_ACT_OK: u32 = 0;
 pub const TC_ACT_RECLASSIFY: u32 = 1;

--- a/ebpf/aya-ebpf-bindings/src/powerpc64/bindings.rs
+++ b/ebpf/aya-ebpf-bindings/src/powerpc64/bindings.rs
@@ -255,6 +255,7 @@ pub const BPF_F_TEST_XDP_LIVE_FRAMES: u32 = 2;
 pub const BPF_BUILD_ID_SIZE: u32 = 20;
 pub const BPF_OBJ_NAME_LEN: u32 = 16;
 pub const BPF_TAG_SIZE: u32 = 8;
+pub const PERF_MAX_STACK_DEPTH: u32 = 127;
 pub const TC_ACT_UNSPEC: i32 = -1;
 pub const TC_ACT_OK: u32 = 0;
 pub const TC_ACT_RECLASSIFY: u32 = 1;

--- a/ebpf/aya-ebpf-bindings/src/riscv64/bindings.rs
+++ b/ebpf/aya-ebpf-bindings/src/riscv64/bindings.rs
@@ -255,6 +255,7 @@ pub const BPF_F_TEST_XDP_LIVE_FRAMES: u32 = 2;
 pub const BPF_BUILD_ID_SIZE: u32 = 20;
 pub const BPF_OBJ_NAME_LEN: u32 = 16;
 pub const BPF_TAG_SIZE: u32 = 8;
+pub const PERF_MAX_STACK_DEPTH: u32 = 127;
 pub const TC_ACT_UNSPEC: i32 = -1;
 pub const TC_ACT_OK: u32 = 0;
 pub const TC_ACT_RECLASSIFY: u32 = 1;

--- a/ebpf/aya-ebpf-bindings/src/s390x/bindings.rs
+++ b/ebpf/aya-ebpf-bindings/src/s390x/bindings.rs
@@ -255,6 +255,7 @@ pub const BPF_F_TEST_XDP_LIVE_FRAMES: u32 = 2;
 pub const BPF_BUILD_ID_SIZE: u32 = 20;
 pub const BPF_OBJ_NAME_LEN: u32 = 16;
 pub const BPF_TAG_SIZE: u32 = 8;
+pub const PERF_MAX_STACK_DEPTH: u32 = 127;
 pub const TC_ACT_UNSPEC: i32 = -1;
 pub const TC_ACT_OK: u32 = 0;
 pub const TC_ACT_RECLASSIFY: u32 = 1;

--- a/ebpf/aya-ebpf-bindings/src/x86_64/bindings.rs
+++ b/ebpf/aya-ebpf-bindings/src/x86_64/bindings.rs
@@ -255,6 +255,7 @@ pub const BPF_F_TEST_XDP_LIVE_FRAMES: u32 = 2;
 pub const BPF_BUILD_ID_SIZE: u32 = 20;
 pub const BPF_OBJ_NAME_LEN: u32 = 16;
 pub const BPF_TAG_SIZE: u32 = 8;
+pub const PERF_MAX_STACK_DEPTH: u32 = 127;
 pub const TC_ACT_UNSPEC: i32 = -1;
 pub const TC_ACT_OK: u32 = 0;
 pub const TC_ACT_RECLASSIFY: u32 = 1;

--- a/ebpf/aya-ebpf/src/btf_maps/mod.rs
+++ b/ebpf/aya-ebpf/src/btf_maps/mod.rs
@@ -6,6 +6,7 @@ pub mod program_array;
 pub mod reuseport_sock_array;
 pub mod ring_buf;
 pub mod sk_storage;
+pub mod stack_trace;
 
 pub use array::Array;
 pub use bloom_filter::BloomFilter;
@@ -15,6 +16,7 @@ pub use program_array::ProgramArray;
 pub use reuseport_sock_array::ReusePortSockArray;
 pub use ring_buf::RingBuf;
 pub use sk_storage::SkStorage;
+pub use stack_trace::StackTrace;
 
 /// Defines a BTF-compatible map struct with flat `#[repr(C)]` layout.
 ///

--- a/ebpf/aya-ebpf/src/btf_maps/stack_trace.rs
+++ b/ebpf/aya-ebpf/src/btf_maps/stack_trace.rs
@@ -1,0 +1,79 @@
+use aya_ebpf_bindings::bindings::{BPF_F_STACK_BUILD_ID, PERF_MAX_STACK_DEPTH};
+
+use crate::{EbpfContext, btf_maps::btf_map_def, cty::c_long, helpers::bpf_get_stackid};
+
+btf_map_def!(
+    /// A BTF-compatible BPF stack-trace map.
+    ///
+    /// Stores hashed stack traces keyed by a `u32` stack ID, where each value
+    /// is a fixed-depth array of return addresses. Populate a stack trace by
+    /// calling [`StackTrace::get_stackid`] from a tracing program; read the
+    /// resulting trace from user space via
+    /// `aya::maps::StackTraceMap`.
+    ///
+    /// # Minimum kernel version
+    ///
+    /// The minimum kernel version required to use this feature is 4.6.
+    ///
+    /// # Flag restrictions
+    ///
+    /// `BPF_F_STACK_BUILD_ID` switches the kernel element layout to
+    /// `struct bpf_stack_build_id` (32 bytes), which this type does not
+    /// model. Calling [`StackTrace::get_stackid`] on a monomorphisation
+    /// that sets the flag fails to compile, and loading such a map for
+    /// reading through `aya::maps::StackTraceMap` is rejected at load
+    /// time.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use aya_ebpf::{btf_maps::StackTrace, macros::btf_map};
+    ///
+    /// #[btf_map]
+    /// static STACK_TRACES: StackTrace<1024> = StackTrace::new();
+    /// ```
+    pub struct StackTrace<;
+        const MAX_ENTRIES: usize,
+        const FLAGS: usize = 0,
+        const DEPTH: usize = { PERF_MAX_STACK_DEPTH as usize },
+    >,
+    map_type: BPF_MAP_TYPE_STACK_TRACE,
+    max_entries: MAX_ENTRIES,
+    map_flags: FLAGS,
+    key_type: u32,
+    value_type: [u64; DEPTH],
+);
+
+impl<const MAX_ENTRIES: usize, const FLAGS: usize, const DEPTH: usize>
+    StackTrace<MAX_ENTRIES, FLAGS, DEPTH>
+{
+    // `const _: ()` is forbidden in a generic impl; named associated
+    // const is lazy without reference - hence `let () = Self::_CHECK`
+    // in each public method.
+    const _CHECK: () = {
+        assert!(DEPTH > 0, "stack trace DEPTH must be greater than zero.");
+        assert!(
+            MAX_ENTRIES > 0,
+            "stack trace max_entries must be greater than zero.",
+        );
+        assert!(
+            FLAGS & BPF_F_STACK_BUILD_ID as usize == 0,
+            "BPF_F_STACK_BUILD_ID is not supported by StackTrace.",
+        );
+    };
+
+    /// Obtain an identifier for the current stack trace.
+    ///
+    /// # Safety
+    ///
+    /// `bpf_get_stackid` is only available to tracing program types
+    /// (kprobe, tracepoint, `perf_event`, `raw_tracepoint`). Calling
+    /// it from any other program type fails verification.
+    #[inline(always)]
+    pub unsafe fn get_stackid<C: EbpfContext>(&self, ctx: &C, flags: u64) -> Result<c_long, i32> {
+        let () = Self::_CHECK;
+        // SAFETY: `ctx` and `self` are valid pointers managed by aya.
+        let ret = unsafe { bpf_get_stackid(ctx.as_ptr(), self.as_ptr(), flags) };
+        if ret < 0 { Err(ret as i32) } else { Ok(ret) }
+    }
+}

--- a/ebpf/aya-ebpf/src/maps/stack_trace.rs
+++ b/ebpf/aya-ebpf/src/maps/stack_trace.rs
@@ -1,5 +1,7 @@
 use core::borrow::Borrow;
 
+use aya_ebpf_bindings::bindings::PERF_MAX_STACK_DEPTH;
+
 use crate::{
     EbpfContext,
     bindings::bpf_map_type::BPF_MAP_TYPE_STACK_TRACE,
@@ -13,10 +15,12 @@ pub struct StackTrace {
     def: MapDef,
 }
 
-const PERF_MAX_STACK_DEPTH: usize = 127;
-
 impl StackTrace {
-    map_constructors!(u32, [u64; PERF_MAX_STACK_DEPTH], BPF_MAP_TYPE_STACK_TRACE);
+    map_constructors!(
+        u32,
+        [u64; PERF_MAX_STACK_DEPTH as usize],
+        BPF_MAP_TYPE_STACK_TRACE
+    );
 
     #[expect(
         clippy::missing_safety_doc,

--- a/test/integration-common/src/lib.rs
+++ b/test/integration-common/src/lib.rs
@@ -166,3 +166,17 @@ pub mod sk_reuseport {
     pub const SELECT_SOCKET_INDEX: u32 = 0;
     pub const MIGRATE_SOCKET_INDEX: u32 = 2;
 }
+
+pub mod stack_trace {
+    #[repr(C)]
+    #[derive(Clone, Copy, Default)]
+    pub struct TestResult {
+        pub stack_id: u32,
+
+        /// Distinguishes a recorded result from a zero-initialised slot.
+        pub ran: bool,
+    }
+
+    #[cfg(feature = "user")]
+    unsafe impl aya::Pod for TestResult {}
+}

--- a/test/integration-common/src/lib.rs
+++ b/test/integration-common/src/lib.rs
@@ -152,7 +152,8 @@ pub mod lpm_trie {
     #[derive(Clone, Copy, Default)]
     pub struct TestResult {
         pub value: u32,
-        pub ran: u32,
+        /// Distinguishes a recorded result from a zero-initialised slot.
+        pub ran: bool,
     }
 
     #[cfg(feature = "user")]

--- a/test/integration-ebpf/Cargo.toml
+++ b/test/integration-ebpf/Cargo.toml
@@ -139,3 +139,7 @@ path = "src/printk_test.rs"
 [[bin]]
 name = "prog_array"
 path = "src/prog_array.rs"
+
+[[bin]]
+name = "stack_trace"
+path = "src/stack_trace.rs"

--- a/test/integration-ebpf/src/lpm_trie.rs
+++ b/test/integration-ebpf/src/lpm_trie.rs
@@ -39,7 +39,7 @@ macro_rules! define_lpm_trie_test {
                         if let Some(val) = $routes_map.get(key) {
                             (*ptr).value = *val;
                         }
-                        (*ptr).ran = 1;
+                        (*ptr).ran = true;
                     }
                 }
             };

--- a/test/integration-ebpf/src/stack_trace.rs
+++ b/test/integration-ebpf/src/stack_trace.rs
@@ -1,0 +1,49 @@
+#![no_std]
+#![no_main]
+#![expect(unused_crate_dependencies, reason = "used in other bins")]
+
+#[cfg(not(test))]
+extern crate ebpf_panic;
+
+use aya_ebpf::{
+    bindings::BPF_F_USER_STACK,
+    btf_maps::{Array as BtfArray, StackTrace as BtfStackTrace},
+    cty::c_long,
+    macros::{btf_map, map, uprobe},
+    maps::{Array as LegacyArray, StackTrace as LegacyStackTrace},
+    programs::ProbeContext,
+};
+use integration_common::stack_trace::TestResult;
+
+#[btf_map]
+static STACKS: BtfStackTrace<1> = BtfStackTrace::new();
+
+#[btf_map]
+static RESULT: BtfArray<TestResult, 1, 0> = BtfArray::new();
+
+#[map]
+static STACKS_LEGACY: LegacyStackTrace = LegacyStackTrace::with_max_entries(1, 0);
+
+#[map]
+static RESULT_LEGACY: LegacyArray<TestResult> = LegacyArray::with_max_entries(1, 0);
+
+macro_rules! define_stack_trace_test {
+    ($map:ident, $result:ident, $probe:ident $(,)?) => {
+        #[uprobe]
+        fn $probe(ctx: ProbeContext) -> Result<(), c_long> {
+            let id =
+                unsafe { $map.get_stackid::<ProbeContext>(&ctx, u64::from(BPF_F_USER_STACK))? };
+            let slot = $result.get_ptr_mut(0).ok_or(-1)?;
+            unsafe {
+                *slot = TestResult {
+                    stack_id: id as u32,
+                    ran: true,
+                };
+            }
+            Ok(())
+        }
+    };
+}
+
+define_stack_trace_test!(STACKS, RESULT, record_stackid);
+define_stack_trace_test!(STACKS_LEGACY, RESULT_LEGACY, record_stackid_legacy);

--- a/test/integration-test/src/lib.rs
+++ b/test/integration-test/src/lib.rs
@@ -68,6 +68,7 @@ bpf_file!(
     UPROBE_COOKIE => "uprobe_cookie",
     PRINTK_TEST => "printk_test",
     PROG_ARRAY => "prog_array",
+    STACK_TRACE => "stack_trace",
 );
 
 #[cfg(test)]

--- a/test/integration-test/src/tests.rs
+++ b/test/integration-test/src/tests.rs
@@ -36,6 +36,7 @@ mod ring_buf;
 mod sk_reuseport;
 mod sk_storage;
 mod smoke;
+mod stack_trace;
 mod strncmp;
 mod tcx;
 mod uprobe_cookie;

--- a/test/integration-test/src/tests/lpm_trie.rs
+++ b/test/integration-test/src/tests/lpm_trie.rs
@@ -44,21 +44,21 @@ fn lpm_trie_basic(prog_name: &str, routes_map: &str, results_map: &str) {
     let results = Array::<_, TestResult>::try_from(bpf.map(results_map).unwrap()).unwrap();
 
     let TestResult { ran, value } = results.get(&LPM_MATCH_SLOT, 0).unwrap();
-    assert_eq!(ran, 1, "LPM-match probe did not run");
+    assert!(ran, "LPM-match probe did not run");
     assert_eq!(
         value, 7,
         "longest-prefix-match should return the /24 value, not the /16"
     );
 
     let TestResult { ran, value } = results.get(&NO_MATCH_SLOT, 0).unwrap();
-    assert_eq!(ran, 1, "no-match probe did not run");
+    assert!(ran, "no-match probe did not run");
     assert_eq!(
         value, 0,
         "get() should return None for a key outside the trie"
     );
 
     let TestResult { ran, value } = results.get(&REMOVE_SLOT, 0).unwrap();
-    assert_eq!(ran, 1, "after-remove probe did not run");
+    assert!(ran, "after-remove probe did not run");
     assert_eq!(
         value, 42,
         "after removing the /24, longest-prefix-match should fall back to the /16"

--- a/test/integration-test/src/tests/stack_trace.rs
+++ b/test/integration-test/src/tests/stack_trace.rs
@@ -1,0 +1,57 @@
+use aya::{
+    EbpfLoader,
+    maps::{Array, MapType, StackTraceMap},
+    programs::UProbe,
+    sys::is_map_supported,
+};
+use integration_common::stack_trace::TestResult;
+use test_case::test_case;
+
+#[unsafe(no_mangle)]
+#[inline(never)]
+extern "C" fn trigger_record_stackid() {
+    std::hint::black_box(());
+}
+
+#[test_case("STACKS_LEGACY", "RESULT_LEGACY", "record_stackid_legacy" ; "legacy")]
+#[test_case("STACKS", "RESULT", "record_stackid" ; "btf")]
+#[test_log::test]
+fn record_stackid(stacks_map: &str, result_map: &str, prog: &str) {
+    if !is_map_supported(MapType::StackTrace).unwrap() {
+        eprintln!("skipping test - stack trace map not supported");
+        return;
+    }
+
+    let mut bpf = EbpfLoader::new()
+        .load(crate::STACK_TRACE)
+        .expect("load stack_trace program");
+
+    let uprobe: &mut UProbe = bpf
+        .program_mut(prog)
+        .unwrap_or_else(|| panic!("missing program {prog}"))
+        .try_into()
+        .unwrap_or_else(|err| panic!("program {prog} is not a uprobe: {err}"));
+    uprobe
+        .load()
+        .unwrap_or_else(|err| panic!("load {prog}: {err}"));
+    uprobe
+        .attach("trigger_record_stackid", "/proc/self/exe", None)
+        .unwrap_or_else(|err| panic!("attach {prog}: {err}"));
+
+    trigger_record_stackid();
+
+    let result = Array::<_, TestResult>::try_from(bpf.map(result_map).unwrap()).unwrap();
+    let TestResult { stack_id, ran } = result.get(&0, 0).unwrap();
+    assert!(ran, "probe {prog} did not run");
+
+    let stacks = StackTraceMap::try_from(bpf.map(stacks_map).unwrap()).unwrap();
+    let trace = stacks
+        .get(&stack_id, 0)
+        .expect("stack_id not found in stack trace map");
+    let frames = trace.frames();
+    assert!(
+        frames.iter().any(|f| f.ip != 0),
+        "stack trace for stack_id {stack_id} has no non-zero IP frame; got {} frames",
+        frames.len(),
+    );
+}

--- a/xtask/public-api/aya-ebpf-bindings.txt
+++ b/xtask/public-api/aya-ebpf-bindings.txt
@@ -3824,6 +3824,7 @@ pub const aya_ebpf_bindings::bindings::BPF_X: u32
 pub const aya_ebpf_bindings::bindings::BPF_XADD: u32
 pub const aya_ebpf_bindings::bindings::BPF_XCHG: u32
 pub const aya_ebpf_bindings::bindings::BPF_XOR: u32
+pub const aya_ebpf_bindings::bindings::PERF_MAX_STACK_DEPTH: u32
 pub const aya_ebpf_bindings::bindings::SOL_SOCKET: u32
 pub const aya_ebpf_bindings::bindings::SO_ACCEPTCONN: u32
 pub const aya_ebpf_bindings::bindings::SO_ATTACH_BPF: u32

--- a/xtask/public-api/aya-ebpf.txt
+++ b/xtask/public-api/aya-ebpf.txt
@@ -153,6 +153,21 @@ impl<T> core::marker::Unpin for aya_ebpf::btf_maps::sk_storage::SkStorage<T>
 impl<T> core::marker::UnsafeUnpin for aya_ebpf::btf_maps::sk_storage::SkStorage<T>
 impl<T> core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::btf_maps::sk_storage::SkStorage<T> where T: core::panic::unwind_safe::RefUnwindSafe
 impl<T> core::panic::unwind_safe::UnwindSafe for aya_ebpf::btf_maps::sk_storage::SkStorage<T> where T: core::panic::unwind_safe::RefUnwindSafe
+pub mod aya_ebpf::btf_maps::stack_trace
+#[repr(C)] pub struct aya_ebpf::btf_maps::stack_trace::StackTrace<const MAX_ENTRIES: usize, const FLAGS: usize, const DEPTH: usize>
+impl<const MAX_ENTRIES: usize, const FLAGS: usize, const DEPTH: usize> aya_ebpf::btf_maps::stack_trace::StackTrace<MAX_ENTRIES, FLAGS, DEPTH>
+pub unsafe fn aya_ebpf::btf_maps::stack_trace::StackTrace<MAX_ENTRIES, FLAGS, DEPTH>::get_stackid<C: aya_ebpf::EbpfContext>(&self, ctx: &C, flags: u64) -> core::result::Result<aya_ebpf_cty::od::c_long, i32>
+impl<const MAX_ENTRIES: usize, const FLAGS: usize, const DEPTH: usize> aya_ebpf::btf_maps::stack_trace::StackTrace<MAX_ENTRIES, FLAGS, DEPTH>
+pub const fn aya_ebpf::btf_maps::stack_trace::StackTrace<MAX_ENTRIES, FLAGS, DEPTH>::new() -> Self
+impl<const MAX_ENTRIES: usize, const FLAGS: usize, const DEPTH: usize> core::default::Default for aya_ebpf::btf_maps::stack_trace::StackTrace<MAX_ENTRIES, FLAGS, DEPTH>
+pub fn aya_ebpf::btf_maps::stack_trace::StackTrace<MAX_ENTRIES, FLAGS, DEPTH>::default() -> Self
+impl<const MAX_ENTRIES: usize, const FLAGS: usize, const DEPTH: usize> core::marker::Sync for aya_ebpf::btf_maps::stack_trace::StackTrace<MAX_ENTRIES, FLAGS, DEPTH>
+impl<const MAX_ENTRIES: usize, const FLAGS: usize, const DEPTH: usize> core::marker::Freeze for aya_ebpf::btf_maps::stack_trace::StackTrace<MAX_ENTRIES, FLAGS, DEPTH>
+impl<const MAX_ENTRIES: usize, const FLAGS: usize, const DEPTH: usize> !core::marker::Send for aya_ebpf::btf_maps::stack_trace::StackTrace<MAX_ENTRIES, FLAGS, DEPTH>
+impl<const MAX_ENTRIES: usize, const FLAGS: usize, const DEPTH: usize> core::marker::Unpin for aya_ebpf::btf_maps::stack_trace::StackTrace<MAX_ENTRIES, FLAGS, DEPTH>
+impl<const MAX_ENTRIES: usize, const FLAGS: usize, const DEPTH: usize> core::marker::UnsafeUnpin for aya_ebpf::btf_maps::stack_trace::StackTrace<MAX_ENTRIES, FLAGS, DEPTH>
+impl<const MAX_ENTRIES: usize, const FLAGS: usize, const DEPTH: usize> core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::btf_maps::stack_trace::StackTrace<MAX_ENTRIES, FLAGS, DEPTH>
+impl<const MAX_ENTRIES: usize, const FLAGS: usize, const DEPTH: usize> core::panic::unwind_safe::UnwindSafe for aya_ebpf::btf_maps::stack_trace::StackTrace<MAX_ENTRIES, FLAGS, DEPTH>
 #[repr(C)] pub struct aya_ebpf::btf_maps::Array<T, const MAX_ENTRIES: usize, const FLAGS: usize>
 impl<T, const MAX_ENTRIES: usize, const FLAGS: usize> aya_ebpf::btf_maps::array::Array<T, MAX_ENTRIES, FLAGS>
 pub fn aya_ebpf::btf_maps::array::Array<T, MAX_ENTRIES, FLAGS>::get(&self, index: u32) -> core::option::Option<&T>
@@ -266,6 +281,20 @@ impl<T> core::marker::Unpin for aya_ebpf::btf_maps::sk_storage::SkStorage<T>
 impl<T> core::marker::UnsafeUnpin for aya_ebpf::btf_maps::sk_storage::SkStorage<T>
 impl<T> core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::btf_maps::sk_storage::SkStorage<T> where T: core::panic::unwind_safe::RefUnwindSafe
 impl<T> core::panic::unwind_safe::UnwindSafe for aya_ebpf::btf_maps::sk_storage::SkStorage<T> where T: core::panic::unwind_safe::RefUnwindSafe
+#[repr(C)] pub struct aya_ebpf::btf_maps::StackTrace<const MAX_ENTRIES: usize, const FLAGS: usize, const DEPTH: usize>
+impl<const MAX_ENTRIES: usize, const FLAGS: usize, const DEPTH: usize> aya_ebpf::btf_maps::stack_trace::StackTrace<MAX_ENTRIES, FLAGS, DEPTH>
+pub unsafe fn aya_ebpf::btf_maps::stack_trace::StackTrace<MAX_ENTRIES, FLAGS, DEPTH>::get_stackid<C: aya_ebpf::EbpfContext>(&self, ctx: &C, flags: u64) -> core::result::Result<aya_ebpf_cty::od::c_long, i32>
+impl<const MAX_ENTRIES: usize, const FLAGS: usize, const DEPTH: usize> aya_ebpf::btf_maps::stack_trace::StackTrace<MAX_ENTRIES, FLAGS, DEPTH>
+pub const fn aya_ebpf::btf_maps::stack_trace::StackTrace<MAX_ENTRIES, FLAGS, DEPTH>::new() -> Self
+impl<const MAX_ENTRIES: usize, const FLAGS: usize, const DEPTH: usize> core::default::Default for aya_ebpf::btf_maps::stack_trace::StackTrace<MAX_ENTRIES, FLAGS, DEPTH>
+pub fn aya_ebpf::btf_maps::stack_trace::StackTrace<MAX_ENTRIES, FLAGS, DEPTH>::default() -> Self
+impl<const MAX_ENTRIES: usize, const FLAGS: usize, const DEPTH: usize> core::marker::Sync for aya_ebpf::btf_maps::stack_trace::StackTrace<MAX_ENTRIES, FLAGS, DEPTH>
+impl<const MAX_ENTRIES: usize, const FLAGS: usize, const DEPTH: usize> core::marker::Freeze for aya_ebpf::btf_maps::stack_trace::StackTrace<MAX_ENTRIES, FLAGS, DEPTH>
+impl<const MAX_ENTRIES: usize, const FLAGS: usize, const DEPTH: usize> !core::marker::Send for aya_ebpf::btf_maps::stack_trace::StackTrace<MAX_ENTRIES, FLAGS, DEPTH>
+impl<const MAX_ENTRIES: usize, const FLAGS: usize, const DEPTH: usize> core::marker::Unpin for aya_ebpf::btf_maps::stack_trace::StackTrace<MAX_ENTRIES, FLAGS, DEPTH>
+impl<const MAX_ENTRIES: usize, const FLAGS: usize, const DEPTH: usize> core::marker::UnsafeUnpin for aya_ebpf::btf_maps::stack_trace::StackTrace<MAX_ENTRIES, FLAGS, DEPTH>
+impl<const MAX_ENTRIES: usize, const FLAGS: usize, const DEPTH: usize> core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::btf_maps::stack_trace::StackTrace<MAX_ENTRIES, FLAGS, DEPTH>
+impl<const MAX_ENTRIES: usize, const FLAGS: usize, const DEPTH: usize> core::panic::unwind_safe::UnwindSafe for aya_ebpf::btf_maps::stack_trace::StackTrace<MAX_ENTRIES, FLAGS, DEPTH>
 pub type aya_ebpf::btf_maps::ReusePortSockArray<const MAX_ENTRIES: usize, const FLAGS: usize> = aya_ebpf::btf_maps::reuseport_sock_array::ReusePortSockArrayImpl<u32, MAX_ENTRIES, FLAGS>
 pub mod aya_ebpf::helpers
 pub use aya_ebpf::helpers::generated

--- a/xtask/public-api/aya.txt
+++ b/xtask/public-api/aya.txt
@@ -941,6 +941,9 @@ pub aya::maps::MapError::InvalidName::name: alloc::string::String
 pub aya::maps::MapError::InvalidValueSize
 pub aya::maps::MapError::InvalidValueSize::expected: usize
 pub aya::maps::MapError::InvalidValueSize::size: usize
+pub aya::maps::MapError::InvalidValueStride
+pub aya::maps::MapError::InvalidValueStride::size: usize
+pub aya::maps::MapError::InvalidValueStride::stride: usize
 pub aya::maps::MapError::IoError(std::io::error::Error)
 pub aya::maps::MapError::KeyNotFound
 pub aya::maps::MapError::OutOfBounds
@@ -955,6 +958,9 @@ pub aya::maps::MapError::SyscallError(aya::sys::SyscallError)
 pub aya::maps::MapError::Unsupported
 pub aya::maps::MapError::Unsupported::map_type: aya_obj::generated::linux_bindings_x86_64::bpf_map_type
 pub aya::maps::MapError::Unsupported::name: alloc::string::String
+pub aya::maps::MapError::UnsupportedMapFlags
+pub aya::maps::MapError::UnsupportedMapFlags::flags: u32
+pub aya::maps::MapError::UnsupportedMapFlags::reason: &'static str
 impl core::convert::From<aya::maps::MapError> for aya::EbpfError
 pub fn aya::EbpfError::from(source: aya::maps::MapError) -> Self
 impl core::convert::From<aya::maps::MapError> for aya::maps::xdp::XdpMapError

--- a/xtask/src/codegen/aya_ebpf_bindings.rs
+++ b/xtask/src/codegen/aya_ebpf_bindings.rs
@@ -76,7 +76,14 @@ pub(crate) fn codegen(opts: &SysrootOptions, libbpf_dir: &Path) -> Result<()> {
             "xdp_action",
             "tcx_action_base",
         ];
-        let vars = ["BPF_.*", "bpf_.*", "TC_ACT_.*", "SOL_SOCKET", "SO_.*"];
+        let vars = [
+            "BPF_.*",
+            "bpf_.*",
+            "PERF_MAX_STACK_DEPTH",
+            "TC_ACT_.*",
+            "SOL_SOCKET",
+            "SO_.*",
+        ];
 
         for x in &types {
             bindgen = bindgen.allowlist_type(x);


### PR DESCRIPTION
BTF `.maps` support for `BPF_MAP_TYPE_STACK_TRACE`. Keys are `u32`
stack IDs, values are `[u64; DEPTH]` with `DEPTH` defaulting to
`PERF_MAX_STACK_DEPTH` (127). Compile-time assertions enforce
non-zero `DEPTH`/`max_entries` and reject `BPF_F_STACK_BUILD_ID`.
A preparatory commit exposes `PERF_MAX_STACK_DEPTH` from
`aya-ebpf-bindings` so neither BTF nor legacy `StackTrace` needs
to hardcode the value.

Another preparatory commit rejects `BPF_F_STACK_BUILD_ID` in
`aya::maps::StackTraceMap`. The flag switches the kernel element
layout to `struct bpf_stack_build_id` (32 bytes), but the wrapper
unconditionally decodes values as `[u64]` and silently corrupts
reads. Adds `MapError::UnsupportedMapFlags` and
`MapError::InvalidValueStride`, and drops the now-redundant
sysctl read.

The integration test is parameterized via `test_case` over both
the BTF and legacy map definitions. Each case attaches a uprobe
that records a stack id via `get_stackid` and verifies the
resulting trace has at least one non-zero IP frame.

A final commit cleans up the lpm_trie test's `TestResult::ran`
from `u32` to `bool`.

### Added/updated tests?

- [x] Yes

### Checklist

- [x] Rust code has been formatted with `cargo +nightly fmt`.
- [x] All clippy lints have been fixed.
      You can find failing lints with `cargo xtask clippy`.
- [x] Unit tests are passing locally with `cargo test`.
- [x] The integration tests are passing locally.
- [x] I have blessed any API changes with `cargo xtask public-api --bless`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aya-rs/aya/1542)
<!-- Reviewable:end -->
