### PR TITLE
aya: fix pid=0 handling in uprobe attach

### DIFF
--- a/aya/src/bpf.rs
+++ b/aya/src/bpf.rs
@@ -1099,11 +1099,11 @@ impl Ebpf {
     ///
     /// ```no_run
     /// # let mut bpf = aya::Ebpf::load(&[])?;
-    /// use aya::programs::UProbe;
+    /// use aya::programs::{uprobe::UProbeScope, UProbe};
     ///
     /// let program: &mut UProbe = bpf.program_mut("SSL_read").unwrap().try_into()?;
     /// program.load()?;
-    /// program.attach("SSL_read", "libssl", None)?;
+    /// program.attach("SSL_read", "libssl", UProbeScope::AllProcesses)?;
     /// # Ok::<(), aya::EbpfError>(())
     /// ```
     pub fn program_mut(&mut self, name: &str) -> Option<&mut Program> {

--- a/aya/src/programs/uprobe.rs
+++ b/aya/src/programs/uprobe.rs
@@ -109,7 +109,8 @@ impl UProbe {
     /// Attaches the uprobe to the function `fn_name` defined in the `target`.
     /// If the attach point specifies an offset, it is added to the address of
     /// the target function. If `pid` is not `None`, the program executes only
-    /// when the target function is executed by the given `pid`.
+    /// when the target function is executed by the given `pid`; `Some(0)`
+    /// means the calling process/thread.
     ///
     /// The `target` argument can be an absolute path to a binary or library, or
     /// a library name (eg: `"libc"`).
@@ -131,7 +132,10 @@ impl UProbe {
         pid: Option<u32>,
     ) -> Result<UProbeLinkId, ProgramError> {
         let UProbeAttachPoint { location, cookie } = point.into();
-        let proc_map = pid.map(ProcMap::new).transpose()?;
+        // /proc/0/maps does not exist; use the current pid only for ProcMap
+        // resolution and preserve pid=0 for the actual attach semantics.
+        let proc_map_pid = pid.map(|pid| if pid == 0 { std::process::id() } else { pid });
+        let proc_map = proc_map_pid.map(ProcMap::new).transpose()?;
         let path = resolve_attach_path(target.as_ref(), proc_map.as_ref())?;
         let (symbol, offset) = match location {
             UProbeAttachLocation::Symbol(s) => (Some(s), 0),

--- a/aya/src/programs/uprobe.rs
+++ b/aya/src/programs/uprobe.rs
@@ -6,6 +6,7 @@ use std::{
     fmt::{self, Write},
     fs,
     io::{self, BufRead as _, Cursor, Read as _},
+    num::NonZeroU32,
     os::unix::ffi::{OsStrExt as _, OsStringExt as _},
     path::{Path, PathBuf},
     sync::LazyLock,
@@ -88,6 +89,17 @@ impl<'a, L: Into<UProbeAttachLocation<'a>>> From<L> for UProbeAttachPoint<'a> {
     }
 }
 
+/// Specifies which processes a uprobe should fire for.
+#[derive(Debug, Clone, Copy)]
+pub enum UProbeScope {
+    /// Fire for any process that hits the attach point.
+    AllProcesses,
+    /// Fire only when the calling process/thread hits the attach point.
+    CallingProcess,
+    /// Fire only when the given process hits the attach point.
+    OneProcess(NonZeroU32),
+}
+
 impl UProbe {
     /// The type of the program according to the kernel.
     pub const PROGRAM_TYPE: ProgramType = ProgramType::KProbe;
@@ -108,9 +120,8 @@ impl UProbe {
     ///
     /// Attaches the uprobe to the function `fn_name` defined in the `target`.
     /// If the attach point specifies an offset, it is added to the address of
-    /// the target function. If `pid` is not `None`, the program executes only
-    /// when the target function is executed by the given `pid`; `Some(0)`
-    /// means the calling process/thread.
+    /// the target function. `scope` specifies which processes should trigger
+    /// the uprobe.
     ///
     /// The `target` argument can be an absolute path to a binary or library, or
     /// a library name (eg: `"libc"`).
@@ -129,12 +140,19 @@ impl UProbe {
         &mut self,
         point: Point,
         target: T,
-        pid: Option<u32>,
+        scope: UProbeScope,
     ) -> Result<UProbeLinkId, ProgramError> {
         let UProbeAttachPoint { location, cookie } = point.into();
-        // /proc/0/maps does not exist; use the current pid only for ProcMap
-        // resolution and preserve pid=0 for the actual attach semantics.
-        let proc_map_pid = pid.map(|pid| if pid == 0 { std::process::id() } else { pid });
+        let (proc_map_pid, perf_event_pid) = match scope {
+            UProbeScope::AllProcesses => (None, None),
+            // /proc/0/maps does not exist, so use the real pid for ProcMap
+            // resolution while keeping the kernel's pid=0 sentinel for attach.
+            UProbeScope::CallingProcess => (Some(std::process::id()), Some(0)),
+            UProbeScope::OneProcess(pid) => {
+                let pid = pid.get();
+                (Some(pid), Some(pid))
+            }
+        };
         let proc_map = proc_map_pid.map(ProcMap::new).transpose()?;
         let path = resolve_attach_path(target.as_ref(), proc_map.as_ref())?;
         let (symbol, offset) = match location {
@@ -155,7 +173,7 @@ impl UProbe {
 
         let Self { data, kind } = self;
         let path = path.as_os_str();
-        attach::<Self, _>(data, *kind, path, offset, pid, cookie)
+        attach::<Self, _>(data, *kind, path, offset, perf_event_pid, cookie)
     }
 
     /// Creates a program from a pinned entry on a bpffs.

--- a/test/integration-test/src/tests/array.rs
+++ b/test/integration-test/src/tests/array.rs
@@ -1,4 +1,8 @@
-use aya::{EbpfLoader, maps::Array, programs::UProbe};
+use aya::{
+    EbpfLoader,
+    maps::Array,
+    programs::{UProbe, uprobe::UProbeScope},
+};
 use integration_common::array::{ARRAY_LEN, GET_INDEX, GET_PTR_INDEX, GET_PTR_MUT_INDEX};
 use test_case::test_case;
 
@@ -68,7 +72,7 @@ fn test_array(
             .unwrap_or_else(|err| panic!("program {prog_name} is not a uprobe: {err}"));
         prog.load()
             .unwrap_or_else(|err| panic!("load {prog_name}: {err}"));
-        prog.attach(symbol, "/proc/self/exe", None)
+        prog.attach(symbol, "/proc/self/exe", UProbeScope::AllProcesses)
             .unwrap_or_else(|err| panic!("attach {prog_name}: {err}"));
     }
 

--- a/test/integration-test/src/tests/bloom_filter.rs
+++ b/test/integration-test/src/tests/bloom_filter.rs
@@ -1,7 +1,7 @@
 use aya::{
     EbpfLoader,
     maps::{Array, MapError, MapType, bloom_filter::BloomFilter},
-    programs::UProbe,
+    programs::{UProbe, uprobe::UProbeScope},
     sys::is_map_supported,
 };
 use integration_common::bloom_filter::{
@@ -57,7 +57,7 @@ fn bloom_filter_basic(result_map: &str, filter_map: &str, insert_prog: &str, con
             .unwrap_or_else(|err| panic!("program {prog_name} is not a uprobe: {err}"));
         prog.load()
             .unwrap_or_else(|err| panic!("load {prog_name}: {err}"));
-        prog.attach(symbol, "/proc/self/exe", None)
+        prog.attach(symbol, "/proc/self/exe", UProbeScope::AllProcesses)
             .unwrap_or_else(|err| panic!("attach {prog_name}: {err}"));
     }
 

--- a/test/integration-test/src/tests/bpf_probe_read.rs
+++ b/test/integration-test/src/tests/bpf_probe_read.rs
@@ -1,4 +1,8 @@
-use aya::{Ebpf, maps::Array, programs::UProbe};
+use aya::{
+    Ebpf,
+    maps::Array,
+    programs::{UProbe, uprobe::UProbeScope},
+};
 use integration_common::bpf_probe_read::{RESULT_BUF_LEN, TestResult};
 
 #[test_log::test]
@@ -99,7 +103,8 @@ fn load_and_attach_uprobe(prog_name: &str, func_name: &str, bytes: &[u8]) -> Ebp
     let prog: &mut UProbe = bpf.program_mut(prog_name).unwrap().try_into().unwrap();
     prog.load().unwrap();
 
-    prog.attach(func_name, "/proc/self/exe", None).unwrap();
+    prog.attach(func_name, "/proc/self/exe", UProbeScope::AllProcesses)
+        .unwrap();
 
     bpf
 }

--- a/test/integration-test/src/tests/btf_relocations.rs
+++ b/test/integration-test/src/tests/btf_relocations.rs
@@ -1,4 +1,8 @@
-use aya::{EbpfLoader, Endianness, maps::Array, programs::UProbe};
+use aya::{
+    EbpfLoader, Endianness,
+    maps::Array,
+    programs::{UProbe, uprobe::UProbeScope},
+};
 use aya_obj::btf::Btf;
 use test_case::test_case;
 
@@ -90,7 +94,11 @@ fn relocation_tests(
     let program: &mut UProbe = bpf.program_mut("program").unwrap().try_into().unwrap();
     program.load().unwrap();
     program
-        .attach("trigger_btf_relocations_program", "/proc/self/exe", None)
+        .attach(
+            "trigger_btf_relocations_program",
+            "/proc/self/exe",
+            UProbeScope::AllProcesses,
+        )
         .unwrap();
 
     trigger_btf_relocations_program();

--- a/test/integration-test/src/tests/info.rs
+++ b/test/integration-test/src/tests/info.rs
@@ -11,7 +11,10 @@ use std::{fs, panic, path::Path, time::SystemTime};
 use aya::{
     Ebpf,
     maps::{Array, HashMap, IterableMap as _, MapError, MapType, loaded_maps},
-    programs::{ProgramError, ProgramType, SocketFilter, TracePoint, UProbe, loaded_programs},
+    programs::{
+        ProgramError, ProgramType, SocketFilter, TracePoint, UProbe, loaded_programs,
+        uprobe::UProbeScope,
+    },
     sys::{is_map_supported, is_program_supported},
     util::KernelVersion,
 };
@@ -65,7 +68,13 @@ fn test_loaded_programs() {
     };
 
     // Ensure we can perform basic operations on the re-created program.
-    let res = p.attach("uprobe_function", "/proc/self/exe", None).unwrap();
+    let res = p
+        .attach(
+            "uprobe_function",
+            "/proc/self/exe",
+            UProbeScope::AllProcesses,
+        )
+        .unwrap();
 
     // Ensure the program can be detached.
     p.detach(res).unwrap();

--- a/test/integration-test/src/tests/linear_data_structures.rs
+++ b/test/integration-test/src/tests/linear_data_structures.rs
@@ -1,4 +1,8 @@
-use aya::{EbpfLoader, maps::Array, programs::UProbe};
+use aya::{
+    EbpfLoader,
+    maps::Array,
+    programs::{UProbe, uprobe::UProbeScope},
+};
 use integration_common::linear_data_structures::{PEEK_INDEX, POP_INDEX};
 
 enum Order {
@@ -47,7 +51,8 @@ macro_rules! define_linear_ds_host_test {
             ] {
                 let prog: &mut UProbe = bpf.program_mut(prog_name).unwrap().try_into().unwrap();
                 prog.load().unwrap();
-                prog.attach(symbol, "/proc/self/exe", None).unwrap();
+                prog.attach(symbol, "/proc/self/exe", UProbeScope::AllProcesses)
+                    .unwrap();
             }
             let array_map = bpf.map("RESULT").unwrap();
             let array = Array::<_, u64>::try_from(array_map).unwrap();

--- a/test/integration-test/src/tests/load.rs
+++ b/test/integration-test/src/tests/load.rs
@@ -369,6 +369,23 @@ fn basic_uprobe() {
 }
 
 #[test_log::test]
+fn basic_uprobe_pid_zero_is_self() {
+    type P = UProbe;
+
+    let program_name = "test_uprobe";
+    let attach = |prog: &mut P| {
+        prog.attach("uprobe_function", "/proc/self/exe", Some(0))
+            .unwrap()
+    };
+    run_unload_program_test(
+        crate::TEST,
+        program_name,
+        attach,
+        aya::features().bpf_perf_link(), // probe uses perf_attach.
+    );
+}
+
+#[test_log::test]
 fn basic_flow_dissector() {
     type P = FlowDissector;
 

--- a/test/integration-test/src/tests/load.rs
+++ b/test/integration-test/src/tests/load.rs
@@ -1,4 +1,6 @@
-use std::{convert::TryInto as _, fs::remove_file, path::Path, thread, time::Duration};
+use std::{
+    convert::TryInto as _, fs::remove_file, num::NonZeroU32, path::Path, thread, time::Duration,
+};
 
 use assert_matches::assert_matches;
 use aya::{
@@ -14,12 +16,13 @@ use aya::{
         loaded_links, loaded_programs,
         tc::TcAttachOptions,
         trace_point::{TracePointLink, TracePointLinkId},
-        uprobe::{UProbeLink, UProbeLinkId},
+        uprobe::{UProbeLink, UProbeLinkId, UProbeScope},
         xdp::{XdpLink, XdpLinkId},
     },
     util::KernelVersion,
 };
 use aya_obj::programs::XdpAttachType;
+use test_case::test_case;
 
 const MAX_RETRIES: usize = 100;
 pub(crate) const RETRY_DURATION: Duration = Duration::from_millis(10);
@@ -55,8 +58,12 @@ fn ringbuffer_btf_map() {
 
     let prog: &mut UProbe = bpf.program_mut("bpf_prog").unwrap().try_into().unwrap();
     prog.load().unwrap();
-    prog.attach("trigger_bpf_program", "/proc/self/exe", None)
-        .unwrap();
+    prog.attach(
+        "trigger_bpf_program",
+        "/proc/self/exe",
+        UProbeScope::AllProcesses,
+    )
+    .unwrap();
 
     trigger_bpf_program();
 
@@ -77,8 +84,12 @@ fn multiple_btf_maps() {
 
     let prog: &mut UProbe = bpf.program_mut("bpf_prog").unwrap().try_into().unwrap();
     prog.load().unwrap();
-    prog.attach("trigger_bpf_program", "/proc/self/exe", None)
-        .unwrap();
+    prog.attach(
+        "trigger_bpf_program",
+        "/proc/self/exe",
+        UProbeScope::AllProcesses,
+    )
+    .unwrap();
 
     trigger_bpf_program();
 
@@ -127,8 +138,12 @@ fn pin_lifecycle_multiple_btf_maps() {
 
     let prog: &mut UProbe = bpf.program_mut("bpf_prog").unwrap().try_into().unwrap();
     prog.load().unwrap();
-    prog.attach("trigger_bpf_program", "/proc/self/exe", None)
-        .unwrap();
+    prog.attach(
+        "trigger_bpf_program",
+        "/proc/self/exe",
+        UProbeScope::AllProcesses,
+    )
+    .unwrap();
 
     trigger_bpf_program();
 
@@ -276,13 +291,14 @@ fn unload_xdp() {
     );
 }
 
-fn run_unload_program_test<P>(
+fn run_unload_program_test<P, F>(
     bpf_image: &[u8],
     program_name: &str,
-    attach: fn(&mut P) -> P::LinkId,
+    attach: F,
     expect_fd_link: bool,
 ) where
     P: UnloadProgramOps,
+    F: Fn(&mut P) -> P::LinkId,
     P::OwnedLink: TryInto<FdLink, Error = LinkError>,
     for<'a> &'a mut Program: TryInto<&'a mut P, Error = ProgramError>,
 {
@@ -351,32 +367,22 @@ fn basic_tracepoint() {
     );
 }
 
+#[test_case(UProbeScope::AllProcesses; "all_processes")]
+#[test_case(UProbeScope::CallingProcess; "calling_process")]
+#[test_case(
+    UProbeScope::OneProcess(NonZeroU32::new(std::process::id()).unwrap());
+    "one_process"
+)]
 #[test_log::test]
-fn basic_uprobe() {
+fn basic_uprobe_scopes(scope: UProbeScope) {
     type P = UProbe;
 
     let program_name = "test_uprobe";
     let attach = |prog: &mut P| {
-        prog.attach("uprobe_function", "/proc/self/exe", None)
+        prog.attach("uprobe_function", "/proc/self/exe", scope)
             .unwrap()
     };
-    run_unload_program_test(
-        crate::TEST,
-        program_name,
-        attach,
-        aya::features().bpf_perf_link(), // probe uses perf_attach.
-    );
-}
 
-#[test_log::test]
-fn basic_uprobe_pid_zero_is_self() {
-    type P = UProbe;
-
-    let program_name = "test_uprobe";
-    let attach = |prog: &mut P| {
-        prog.attach("uprobe_function", "/proc/self/exe", Some(0))
-            .unwrap()
-    };
     run_unload_program_test(
         crate::TEST,
         program_name,
@@ -676,8 +682,12 @@ fn pin_lifecycle_uprobe() {
 
     let program_name = "test_uprobe";
     let attach = |prog: &mut P| {
-        prog.attach("uprobe_function", "/proc/self/exe", None)
-            .unwrap()
+        prog.attach(
+            "uprobe_function",
+            "/proc/self/exe",
+            UProbeScope::AllProcesses,
+        )
+        .unwrap()
     };
     let program_pin = "/sys/fs/bpf/aya-uprobe-test-prog";
     let link_pin = "/sys/fs/bpf/aya-uprobe-test-uprobe-function";

--- a/test/integration-test/src/tests/log.rs
+++ b/test/integration-test/src/tests/log.rs
@@ -1,6 +1,10 @@
 use std::{borrow::Cow, sync::Mutex};
 
-use aya::{Ebpf, EbpfLoader, maps::Array, programs::UProbe};
+use aya::{
+    Ebpf, EbpfLoader,
+    maps::Array,
+    programs::{UProbe, uprobe::UProbeScope},
+};
 use aya_log::EbpfLogger;
 use integration_common::log::{BUF_LEN, Buffer};
 use log::{Level, Log, Record};
@@ -69,8 +73,12 @@ fn log() {
 
     let prog: &mut UProbe = bpf.program_mut("test_log").unwrap().try_into().unwrap();
     prog.load().unwrap();
-    prog.attach("trigger_ebpf_program", "/proc/self/exe", None)
-        .unwrap();
+    prog.attach(
+        "trigger_ebpf_program",
+        "/proc/self/exe",
+        UProbeScope::AllProcesses,
+    )
+    .unwrap();
 
     // Call the function that the uprobe is attached to, so it starts logging.
     trigger_ebpf_program();
@@ -248,8 +256,12 @@ fn log_level_only_error_warn() {
 
     let prog: &mut UProbe = bpf.program_mut("test_log").unwrap().try_into().unwrap();
     prog.load().unwrap();
-    prog.attach("trigger_ebpf_program", "/proc/self/exe", None)
-        .unwrap();
+    prog.attach(
+        "trigger_ebpf_program",
+        "/proc/self/exe",
+        UProbeScope::AllProcesses,
+    )
+    .unwrap();
 
     trigger_ebpf_program();
     logger.flush();
@@ -303,8 +315,12 @@ fn log_level_prevents_verif_fail() {
         .try_into()
         .unwrap();
     prog.load().unwrap();
-    prog.attach("trigger_ebpf_program", "/proc/self/exe", None)
-        .unwrap();
+    prog.attach(
+        "trigger_ebpf_program",
+        "/proc/self/exe",
+        UProbeScope::AllProcesses,
+    )
+    .unwrap();
 
     trigger_ebpf_program();
     logger.flush();

--- a/test/integration-test/src/tests/lpm_trie.rs
+++ b/test/integration-test/src/tests/lpm_trie.rs
@@ -1,7 +1,7 @@
 use aya::{
     Ebpf,
     maps::{Array, LpmTrie, lpm_trie::Key},
-    programs::UProbe,
+    programs::{UProbe, uprobe::UProbeScope},
 };
 use integration_common::lpm_trie::{LPM_MATCH_SLOT, NO_MATCH_SLOT, REMOVE_SLOT, TestResult};
 use test_case::test_case;
@@ -36,8 +36,12 @@ fn lpm_trie_basic(prog_name: &str, routes_map: &str, results_map: &str) {
         .unwrap_or_else(|err| panic!("program {prog_name} is not a uprobe: {err}"));
     prog.load()
         .unwrap_or_else(|err| panic!("load {prog_name}: {err}"));
-    prog.attach("trigger_lpm_trie", "/proc/self/exe", None)
-        .unwrap_or_else(|err| panic!("attach {prog_name}: {err}"));
+    prog.attach(
+        "trigger_lpm_trie",
+        "/proc/self/exe",
+        UProbeScope::AllProcesses,
+    )
+    .unwrap_or_else(|err| panic!("attach {prog_name}: {err}"));
 
     trigger_lpm_trie();
 

--- a/test/integration-test/src/tests/maps_disjoint.rs
+++ b/test/integration-test/src/tests/maps_disjoint.rs
@@ -1,7 +1,7 @@
 use aya::{
     Ebpf,
     maps::{Array, HashMap},
-    programs::UProbe,
+    programs::{UProbe, uprobe::UProbeScope},
 };
 
 #[unsafe(no_mangle)]
@@ -20,8 +20,12 @@ fn test_maps_disjoint() {
         .unwrap();
 
     prog.load().unwrap();
-    prog.attach("trigger_ebpf_program_maps_disjoint", "/proc/self/exe", None)
-        .unwrap();
+    prog.attach(
+        "trigger_ebpf_program_maps_disjoint",
+        "/proc/self/exe",
+        UProbeScope::AllProcesses,
+    )
+    .unwrap();
 
     let [foo, bar, baz] = bpf.maps_disjoint_mut(["FOO", "BAR", "BAZ"]);
 

--- a/test/integration-test/src/tests/per_cpu_array.rs
+++ b/test/integration-test/src/tests/per_cpu_array.rs
@@ -1,7 +1,7 @@
 use aya::{
     EbpfLoader,
     maps::{Array, MapType, PerCpuArray, PerCpuValues},
-    programs::UProbe,
+    programs::{UProbe, uprobe::UProbeScope},
     sys::is_map_supported,
     util::nr_cpus,
 };
@@ -81,7 +81,7 @@ fn per_cpu_array_basic(
             .unwrap_or_else(|err| panic!("program {prog_name} is not a uprobe: {err}"));
         prog.load()
             .unwrap_or_else(|err| panic!("load {prog_name}: {err}"));
-        prog.attach(symbol, "/proc/self/exe", None)
+        prog.attach(symbol, "/proc/self/exe", UProbeScope::AllProcesses)
             .unwrap_or_else(|err| panic!("attach {prog_name}: {err}"));
     }
 

--- a/test/integration-test/src/tests/printk.rs
+++ b/test/integration-test/src/tests/printk.rs
@@ -15,7 +15,11 @@ use std::{
     path::Path,
 };
 
-use aya::{Ebpf, programs::UProbe, util::KernelVersion};
+use aya::{
+    Ebpf,
+    programs::{UProbe, uprobe::UProbeScope},
+    util::KernelVersion,
+};
 use integration_common::printk::{
     MARKER, TEST_CHAR, TEST_I8, TEST_I16, TEST_I32, TEST_I64, TEST_ISIZE, TEST_U8, TEST_U16,
     TEST_U32, TEST_U64, TEST_USIZE,
@@ -77,8 +81,12 @@ async fn bpf_printk(
         .try_into()
         .unwrap();
     prog.load().unwrap();
-    prog.attach("trigger_bpf_printk", "/proc/self/exe", None)
-        .unwrap();
+    prog.attach(
+        "trigger_bpf_printk",
+        "/proc/self/exe",
+        UProbeScope::AllProcesses,
+    )
+    .unwrap();
 
     let tracefs_mount = "/sys/kernel/debug/tracing";
     let tracefs_mount = Path::new(tracefs_mount);

--- a/test/integration-test/src/tests/prog_array.rs
+++ b/test/integration-test/src/tests/prog_array.rs
@@ -1,7 +1,7 @@
 use aya::{
     EbpfLoader,
     maps::{Array, MapType, ProgramArray},
-    programs::UProbe,
+    programs::{UProbe, uprobe::UProbeScope},
     sys::is_map_supported,
 };
 use integration_common::prog_array::{
@@ -49,8 +49,12 @@ fn tail_call_empty(result_map: &str, entry_prog: &str) {
         .unwrap_or_else(|err| panic!("program {entry_prog} is not a uprobe: {err}"));
     prog.load()
         .unwrap_or_else(|err| panic!("load {entry_prog}: {err}"));
-    prog.attach("trigger_tail_call_empty", "/proc/self/exe", None)
-        .unwrap_or_else(|err| panic!("attach {entry_prog}: {err}"));
+    prog.attach(
+        "trigger_tail_call_empty",
+        "/proc/self/exe",
+        UProbeScope::AllProcesses,
+    )
+    .unwrap_or_else(|err| panic!("attach {entry_prog}: {err}"));
 
     let result = Array::<_, u32>::try_from(bpf.map(result_map).unwrap()).unwrap();
 
@@ -109,7 +113,11 @@ fn tail_call_success(result_map: &str, array_map: &str, entry_prog: &str, target
             .load()
             .unwrap_or_else(|err| panic!("load {entry_prog}: {err}"));
         entry
-            .attach("trigger_tail_call_success", "/proc/self/exe", None)
+            .attach(
+                "trigger_tail_call_success",
+                "/proc/self/exe",
+                UProbeScope::AllProcesses,
+            )
             .unwrap_or_else(|err| panic!("attach {entry_prog}: {err}"));
     }
 

--- a/test/integration-test/src/tests/relocations.rs
+++ b/test/integration-test/src/tests/relocations.rs
@@ -1,6 +1,6 @@
 use aya::{
     Ebpf,
-    programs::{UProbe, Xdp},
+    programs::{UProbe, Xdp, uprobe::UProbeScope},
     util::KernelVersion,
 };
 
@@ -55,8 +55,12 @@ fn load_and_attach(name: &str, bytes: &[u8]) -> Ebpf {
     let prog: &mut UProbe = bpf.program_mut(name).unwrap().try_into().unwrap();
     prog.load().unwrap();
 
-    prog.attach("trigger_relocations_program", "/proc/self/exe", None)
-        .unwrap();
+    prog.attach(
+        "trigger_relocations_program",
+        "/proc/self/exe",
+        UProbeScope::AllProcesses,
+    )
+    .unwrap();
 
     bpf
 }

--- a/test/integration-test/src/tests/ring_buf.rs
+++ b/test/integration-test/src/tests/ring_buf.rs
@@ -14,7 +14,7 @@ use assert_matches::assert_matches;
 use aya::{
     Ebpf, EbpfLoader,
     maps::{Array, MapData, ring_buf::RingBuf},
-    programs::UProbe,
+    programs::{UProbe, uprobe::UProbeScope},
 };
 use aya_obj::generated::BPF_RINGBUF_HDR_SZ;
 use integration_common::ring_buf::Registers;
@@ -90,8 +90,12 @@ impl RingBufTest {
         let regs = Array::<_, Registers>::try_from(regs).unwrap();
         let prog: &mut UProbe = bpf.program_mut(variant.prog).unwrap().try_into().unwrap();
         prog.load().unwrap();
-        prog.attach("ring_buf_trigger_ebpf_program", "/proc/self/exe", None)
-            .unwrap();
+        prog.attach(
+            "ring_buf_trigger_ebpf_program",
+            "/proc/self/exe",
+            UProbeScope::AllProcesses,
+        )
+        .unwrap();
 
         Self {
             bpf,
@@ -199,7 +203,8 @@ fn ring_buf_mismatch_size<T>(
     let mut ring_buf = RingBuf::try_from(ring_buf).unwrap();
     let prog: &mut UProbe = bpf.program_mut(prog).unwrap().try_into().unwrap();
     prog.load().unwrap();
-    prog.attach(trigger_symbol, "/proc/self/exe", None).unwrap();
+    prog.attach(trigger_symbol, "/proc/self/exe", UProbeScope::AllProcesses)
+        .unwrap();
 
     trigger(value.into());
     {

--- a/test/integration-test/src/tests/stack_trace.rs
+++ b/test/integration-test/src/tests/stack_trace.rs
@@ -1,7 +1,7 @@
 use aya::{
     EbpfLoader,
     maps::{Array, MapType, StackTraceMap},
-    programs::UProbe,
+    programs::{UProbe, uprobe::UProbeScope},
     sys::is_map_supported,
 };
 use integration_common::stack_trace::TestResult;
@@ -35,7 +35,11 @@ fn record_stackid(stacks_map: &str, result_map: &str, prog: &str) {
         .load()
         .unwrap_or_else(|err| panic!("load {prog}: {err}"));
     uprobe
-        .attach("trigger_record_stackid", "/proc/self/exe", None)
+        .attach(
+            "trigger_record_stackid",
+            "/proc/self/exe",
+            UProbeScope::AllProcesses,
+        )
         .unwrap_or_else(|err| panic!("attach {prog}: {err}"));
 
     trigger_record_stackid();

--- a/test/integration-test/src/tests/strncmp.rs
+++ b/test/integration-test/src/tests/strncmp.rs
@@ -6,7 +6,7 @@ use std::{
 use aya::{
     Ebpf,
     maps::{Array, MapData},
-    programs::UProbe,
+    programs::{UProbe, uprobe::UProbeScope},
     util::KernelVersion,
 };
 use integration_common::strncmp::TestResult;
@@ -29,8 +29,12 @@ fn bpf_strncmp() {
             .unwrap();
         prog.load().unwrap();
 
-        prog.attach("trigger_bpf_strncmp", "/proc/self/exe", None)
-            .unwrap();
+        prog.attach(
+            "trigger_bpf_strncmp",
+            "/proc/self/exe",
+            UProbeScope::AllProcesses,
+        )
+        .unwrap();
     }
 
     let array = Array::<_, TestResult>::try_from(bpf.map("RESULT").unwrap()).unwrap();

--- a/test/integration-test/src/tests/uprobe_cookie.rs
+++ b/test/integration-test/src/tests/uprobe_cookie.rs
@@ -1,7 +1,10 @@
 use aya::{
     EbpfLoader,
     maps::ring_buf::RingBuf,
-    programs::{UProbe, uprobe::UProbeAttachPoint},
+    programs::{
+        UProbe,
+        uprobe::{UProbeAttachPoint, UProbeScope},
+    },
     util::KernelVersion,
 };
 
@@ -37,7 +40,7 @@ fn test_uprobe_cookie() {
                 cookie: Some(cookie),
             },
             "/proc/self/exe",
-            None,
+            UProbeScope::AllProcesses,
         )
         .unwrap()
     };

--- a/xtask/public-api/aya.txt
+++ b/xtask/public-api/aya.txt
@@ -4766,10 +4766,26 @@ impl core::marker::Unpin for aya::programs::uprobe::UProbeError
 impl core::marker::UnsafeUnpin for aya::programs::uprobe::UProbeError
 impl !core::panic::unwind_safe::RefUnwindSafe for aya::programs::uprobe::UProbeError
 impl !core::panic::unwind_safe::UnwindSafe for aya::programs::uprobe::UProbeError
+pub enum aya::programs::uprobe::UProbeScope
+pub aya::programs::uprobe::UProbeScope::AllProcesses
+pub aya::programs::uprobe::UProbeScope::CallingProcess
+pub aya::programs::uprobe::UProbeScope::OneProcess(core::num::nonzero::NonZeroU32)
+impl core::clone::Clone for aya::programs::uprobe::UProbeScope
+pub fn aya::programs::uprobe::UProbeScope::clone(&self) -> aya::programs::uprobe::UProbeScope
+impl core::fmt::Debug for aya::programs::uprobe::UProbeScope
+pub fn aya::programs::uprobe::UProbeScope::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Copy for aya::programs::uprobe::UProbeScope
+impl core::marker::Freeze for aya::programs::uprobe::UProbeScope
+impl core::marker::Send for aya::programs::uprobe::UProbeScope
+impl core::marker::Sync for aya::programs::uprobe::UProbeScope
+impl core::marker::Unpin for aya::programs::uprobe::UProbeScope
+impl core::marker::UnsafeUnpin for aya::programs::uprobe::UProbeScope
+impl core::panic::unwind_safe::RefUnwindSafe for aya::programs::uprobe::UProbeScope
+impl core::panic::unwind_safe::UnwindSafe for aya::programs::uprobe::UProbeScope
 pub struct aya::programs::uprobe::UProbe
 impl aya::programs::uprobe::UProbe
 pub const aya::programs::uprobe::UProbe::PROGRAM_TYPE: aya::programs::ProgramType
-pub fn aya::programs::uprobe::UProbe::attach<'a, T: core::convert::AsRef<std::path::Path>, Point: core::convert::Into<aya::programs::uprobe::UProbeAttachPoint<'a>>>(&mut self, point: Point, target: T, pid: core::option::Option<u32>) -> core::result::Result<aya::programs::uprobe::UProbeLinkId, aya::programs::ProgramError>
+pub fn aya::programs::uprobe::UProbe::attach<'a, T: core::convert::AsRef<std::path::Path>, Point: core::convert::Into<aya::programs::uprobe::UProbeAttachPoint<'a>>>(&mut self, point: Point, target: T, scope: aya::programs::uprobe::UProbeScope) -> core::result::Result<aya::programs::uprobe::UProbeLinkId, aya::programs::ProgramError>
 pub fn aya::programs::uprobe::UProbe::from_pin<P: core::convert::AsRef<std::path::Path>>(path: P, kind: aya::programs::ProbeKind) -> core::result::Result<Self, aya::programs::ProgramError>
 pub const fn aya::programs::uprobe::UProbe::kind(&self) -> aya::programs::ProbeKind
 pub fn aya::programs::uprobe::UProbe::load(&mut self) -> core::result::Result<(), aya::programs::ProgramError>
@@ -6678,7 +6694,7 @@ impl core::panic::unwind_safe::UnwindSafe for aya::programs::trace_point::TraceP
 pub struct aya::programs::UProbe
 impl aya::programs::uprobe::UProbe
 pub const aya::programs::uprobe::UProbe::PROGRAM_TYPE: aya::programs::ProgramType
-pub fn aya::programs::uprobe::UProbe::attach<'a, T: core::convert::AsRef<std::path::Path>, Point: core::convert::Into<aya::programs::uprobe::UProbeAttachPoint<'a>>>(&mut self, point: Point, target: T, pid: core::option::Option<u32>) -> core::result::Result<aya::programs::uprobe::UProbeLinkId, aya::programs::ProgramError>
+pub fn aya::programs::uprobe::UProbe::attach<'a, T: core::convert::AsRef<std::path::Path>, Point: core::convert::Into<aya::programs::uprobe::UProbeAttachPoint<'a>>>(&mut self, point: Point, target: T, scope: aya::programs::uprobe::UProbeScope) -> core::result::Result<aya::programs::uprobe::UProbeLinkId, aya::programs::ProgramError>
 pub fn aya::programs::uprobe::UProbe::from_pin<P: core::convert::AsRef<std::path::Path>>(path: P, kind: aya::programs::ProbeKind) -> core::result::Result<Self, aya::programs::ProgramError>
 pub const fn aya::programs::uprobe::UProbe::kind(&self) -> aya::programs::ProbeKind
 pub fn aya::programs::uprobe::UProbe::load(&mut self) -> core::result::Result<(), aya::programs::ProgramError>


### PR DESCRIPTION
### Summary

While working on multi-uprobe support (#1417), @alessandrod pointed out that `Some(0)` has inconsistent semantics between the single-attach (`perf_event_open`: pid=0 → current process) and multi-attach (`bpf_link_create`: pid=0 → all processes) paths.

Investigating this, I found that `Some(0)` never actually worked in aya's existing single-attach path either: `UProbe::attach` unconditionally reads `/proc/{pid}/maps` when pid is `Some`, and  `/proc/0/maps` does not exist (pid 0 is the kernel swapper process). The attach fails before even reaching the kernel.

This PR uses the real pid only for the ProcMap lookup, and keeps the original pid=0 for the actual attach call, matching libbpf's single-attach behavior which passes pid=0 directly to  `perf_event_open_probe`  ([ref](https://github.com/torvalds/linux/blob/8541d8f725/tools/lib/bpf/libbpf.c#L12845-L12847)).

And replace the pid Option in UProbe::attach with UProbeScope so the all-processes, calling-process, and explicit-pid cases are all expressed directly in the type.

This removes pid=0 as a magic value from the public API, keeps the calling-process case explicit, and uses the current pid for ProcMap resolution introduced in the previous commit. Update docs and integration tests to use the new scope-based API.

<!-- markdownlint-disable first-line-heading -->

<!--
    Thank you for your contribution to Aya! 🎉

    For Work In Progress Pull Requests, please use the Draft PR feature.

    Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Aya Contributing Guide: https://github.com/aya-rs/aya/blob/main/CONTRIBUTING.md
     - 📖 Read the Aya Code of Conduct: https://github.com/aya-rs/aya/blob/main/CODE_OF_CONDUCT.md
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages: https://cbea.ms/git-commit/
     - 📗 Update any related documentation.

-->

<!---
      Summarize the changes you're making here. Detailed information belongs in
      the Git commit messages. If your pull request contains just one commit,
      it's best to use its message as a summary. Otherwise, if there are multiple
      atomic commits, write a summary for the entire PR. Feel free to flag
      anything you think needs a reviewer's attention.
-->

<!--
      If your changes address an issue, link it with the *Fixes* tag so
      the issue gets closed when the PR is merged, for example:

      Fixes: #1234

      If you are only referencing an issue without fully addressing it, feel
      free to link it anywhere in the summary.
-->

### Added/updated tests?

_We strongly encourage you to add a test for your changes._

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

### Checklist

- [x] Rust code has been formatted with `cargo +nightly fmt`.
- [x] All clippy lints have been fixed.
      You can find failing lints with `cargo xtask clippy`.
- [x] Unit tests are passing locally with `cargo test`.
- [x] The [Integration tests] are passing locally.
- [x] I have blessed any API changes with `cargo xtask public-api --bless`.

[Integration tests]: https://github.com/aya-rs/aya/blob/main/test/README.md

### (Optional) What GIF best describes this PR or how it makes you feel?

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aya-rs/aya/1543)
<!-- Reviewable:end -->
