### PR TITLE
Make XDP attach mode type-safe

### DIFF
--- a/aya/src/programs/extension.rs
+++ b/aya/src/programs/extension.rs
@@ -38,12 +38,12 @@ pub enum ExtensionError {
 /// # Examples
 ///
 /// ```no_run
-/// use aya::{EbpfLoader, programs::{Xdp, XdpFlags, Extension}};
+/// use aya::{EbpfLoader, programs::{Xdp, XdpMode, Extension}};
 ///
 /// let mut bpf = EbpfLoader::new().extension("extension").load_file("app.o")?;
 /// let prog: &mut Xdp = bpf.program_mut("main").unwrap().try_into()?;
 /// prog.load()?;
-/// prog.attach("eth0", XdpFlags::default())?;
+/// prog.attach("eth0", XdpMode::default())?;
 ///
 /// let prog_fd = prog.fd().unwrap();
 /// let prog_fd = prog_fd.try_clone().unwrap();

--- a/aya/src/programs/mod.rs
+++ b/aya/src/programs/mod.rs
@@ -125,7 +125,7 @@ pub use crate::programs::{
     tp_btf::BtfTracePoint,
     trace_point::{TracePoint, TracePointError},
     uprobe::{UProbe, UProbeError},
-    xdp::{Xdp, XdpError, XdpFlags},
+    xdp::{Xdp, XdpError, XdpMode},
 };
 use crate::{
     VerifierLogLevel,

--- a/aya/src/programs/xdp.rs
+++ b/aya/src/programs/xdp.rs
@@ -9,8 +9,8 @@ use std::{
 
 use aya_obj::{
     generated::{
-        XDP_FLAGS_DRV_MODE, XDP_FLAGS_HW_MODE, XDP_FLAGS_REPLACE, XDP_FLAGS_SKB_MODE,
-        XDP_FLAGS_UPDATE_IF_NOEXIST, bpf_link_type, bpf_prog_type::BPF_PROG_TYPE_XDP,
+        XDP_FLAGS_DRV_MODE, XDP_FLAGS_HW_MODE, XDP_FLAGS_SKB_MODE, bpf_link_type,
+        bpf_prog_type::BPF_PROG_TYPE_XDP,
     },
     programs::XdpAttachType,
 };
@@ -37,20 +37,28 @@ pub enum XdpError {
     NetlinkError(#[from] NetlinkError),
 }
 
-bitflags::bitflags! {
-    /// Flags passed to [`Xdp::attach()`].
-    #[derive(Clone, Copy, Debug, Default)]
-    pub struct XdpFlags: u32 {
-        /// Skb mode.
-        const SKB_MODE = XDP_FLAGS_SKB_MODE;
-        /// Driver mode.
-        const DRV_MODE = XDP_FLAGS_DRV_MODE;
-        /// Hardware mode.
-        const HW_MODE = XDP_FLAGS_HW_MODE;
-        /// Replace a previously attached XDP program.
-        const REPLACE = XDP_FLAGS_REPLACE;
-        /// Only attach if there isn't another XDP program already attached.
-        const UPDATE_IF_NOEXIST = XDP_FLAGS_UPDATE_IF_NOEXIST;
+/// XDP attachment mode.
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq)]
+pub enum XdpMode {
+    /// Let the kernel choose the mode.
+    #[default]
+    Default,
+    /// Generic XDP, executed by the kernel network stack.
+    Skb,
+    /// Native XDP, executed by the network driver.
+    Driver,
+    /// Hardware offload, executed by the network device.
+    Hardware,
+}
+
+impl XdpMode {
+    pub(crate) const fn flags(self) -> u32 {
+        match self {
+            Self::Default => 0,
+            Self::Skb => XDP_FLAGS_SKB_MODE,
+            Self::Driver => XDP_FLAGS_DRV_MODE,
+            Self::Hardware => XDP_FLAGS_HW_MODE,
+        }
     }
 }
 
@@ -69,10 +77,10 @@ bitflags::bitflags! {
 ///
 /// ```no_run
 /// # let mut bpf = Ebpf::load_file("ebpf_programs.o")?;
-/// use aya::{Ebpf, programs::{Xdp, XdpFlags}};
+/// use aya::{Ebpf, programs::{Xdp, XdpMode}};
 ///
 /// let program: &mut Xdp = bpf.program_mut("intercept_packets").unwrap().try_into()?;
-/// program.attach("eth0", XdpFlags::default())?;
+/// program.attach("eth0", XdpMode::default())?;
 /// # Ok::<(), aya::EbpfError>(())
 /// ```
 #[derive(Debug)]
@@ -103,7 +111,7 @@ impl Xdp {
     ///
     /// When `bpf_link_create` is unavailable or rejects the request, the call
     /// transparently falls back to the legacy netlink-based attach path.
-    pub fn attach(&mut self, interface: &str, flags: XdpFlags) -> Result<XdpLinkId, ProgramError> {
+    pub fn attach(&mut self, interface: &str, mode: XdpMode) -> Result<XdpLinkId, ProgramError> {
         // TODO: avoid this unwrap by adding a new error variant.
         let c_interface = CString::new(interface).unwrap();
         let if_index = unsafe { libc::if_nametoindex(c_interface.as_ptr()) };
@@ -112,7 +120,7 @@ impl Xdp {
                 name: interface.to_string(),
             });
         }
-        self.attach_to_if_index(if_index, flags)
+        self.attach_to_if_index(if_index, mode)
     }
 
     /// Attaches the program to the given interface index.
@@ -126,16 +134,17 @@ impl Xdp {
     pub fn attach_to_if_index(
         &mut self,
         if_index: u32,
-        flags: XdpFlags,
+        mode: XdpMode,
     ) -> Result<XdpLinkId, ProgramError> {
         let Self { data, attach_type } = self;
         let prog_fd = data.fd()?;
         let prog_fd = prog_fd.as_fd();
+        let flags = mode.flags();
         let link = match bpf_link_create(
             prog_fd,
             LinkTarget::IfIndex(if_index),
             *attach_type,
-            flags.bits(),
+            flags,
             None,
         ) {
             Ok(link_fd) => XdpLinkInner::Fd(FdLink::new(link_fd)),
@@ -150,14 +159,14 @@ impl Xdp {
                 // Fall back to netlink-based attachment.
 
                 let if_index = if_index as i32;
-                unsafe { netlink_set_xdp_fd(if_index, Some(prog_fd), None, flags.bits()) }
+                unsafe { netlink_set_xdp_fd(if_index, Some(prog_fd), None, mode) }
                     .map_err(XdpError::NetlinkError)?;
 
                 let prog_fd = prog_fd.as_raw_fd();
                 XdpLinkInner::NlLink(NlLink {
                     if_index,
                     prog_fd,
-                    flags,
+                    mode,
                 })
             }
         };
@@ -198,21 +207,24 @@ impl Xdp {
                     .links
                     .insert(XdpLink::new(XdpLinkInner::Fd(FdLink::new(link_fd))))
             }
-            XdpLinkInner::NlLink(nl_link) => {
-                let if_index = nl_link.if_index;
-                let old_prog_fd = nl_link.prog_fd;
+            XdpLinkInner::NlLink(NlLink {
+                if_index,
+                prog_fd: old_prog_fd,
+                mode,
+            }) => {
                 // SAFETY: TODO(https://github.com/aya-rs/aya/issues/612): make this safe by not holding `RawFd`s.
                 let old_prog_fd = unsafe { BorrowedFd::borrow_raw(old_prog_fd) };
-                let flags = nl_link.flags;
-                let replace_flags = flags | XdpFlags::REPLACE;
                 unsafe {
-                    netlink_set_xdp_fd(
-                        if_index,
-                        Some(prog_fd),
-                        Some(old_prog_fd),
-                        replace_flags.bits(),
-                    )
-                    .map_err(XdpError::NetlinkError)?;
+                    // Preserve the atomic replacement contract for netlink
+                    // links: only replace the current XDP program if it still
+                    // matches the program fd recorded in this link. The
+                    // netlink API expresses that compare-and-replace operation
+                    // with XDP_FLAGS_REPLACE and IFLA_XDP_EXPECTED_FD, which
+                    // were added in Linux 5.7. On older kernels this request
+                    // is expected to fail in the kernel instead of degrading to
+                    // an unconditional replacement.
+                    netlink_set_xdp_fd(if_index, Some(prog_fd), Some(old_prog_fd), mode)
+                        .map_err(XdpError::NetlinkError)?;
                 }
 
                 let prog_fd = prog_fd.as_raw_fd();
@@ -221,7 +233,7 @@ impl Xdp {
                     .insert(XdpLink::new(XdpLinkInner::NlLink(NlLink {
                         if_index,
                         prog_fd,
-                        flags,
+                        mode,
                     })))
             }
         }
@@ -232,7 +244,7 @@ impl Xdp {
 pub(crate) struct NlLink {
     if_index: i32,
     prog_fd: RawFd,
-    flags: XdpFlags,
+    mode: XdpMode,
 }
 
 #[derive(Debug, Hash, Eq, PartialEq)]
@@ -242,19 +254,32 @@ impl Link for NlLink {
     type Id = NlLinkId;
 
     fn id(&self) -> Self::Id {
-        NlLinkId(self.if_index, self.prog_fd)
+        let Self {
+            if_index,
+            prog_fd,
+            mode: _,
+        } = self;
+        NlLinkId(*if_index, *prog_fd)
     }
 
     fn detach(self) -> Result<(), ProgramError> {
-        let flags = if KernelVersion::at_least(5, 7, 0) {
-            self.flags.bits() | XDP_FLAGS_REPLACE
-        } else {
-            self.flags.bits()
-        };
-        // SAFETY: TODO(https://github.com/aya-rs/aya/issues/612): make this safe by not holding `RawFd`s.
-        let prog_fd = unsafe { BorrowedFd::borrow_raw(self.prog_fd) };
+        let Self {
+            if_index,
+            prog_fd,
+            mode,
+        } = self;
+        // IFLA_XDP_EXPECTED_FD and XDP_FLAGS_REPLACE were added in Linux 5.7;
+        // see https://github.com/torvalds/linux/commit/92234c8f. Use them
+        // when available so detach only clears the program represented by this
+        // link. On older kernels, skip the expected fd so detach keeps the
+        // legacy best-effort behavior instead of failing because the kernel
+        // does not understand the replacement attributes.
+        let prog_fd = KernelVersion::at_least(5, 7, 0).then(|| {
+            // SAFETY: TODO(https://github.com/aya-rs/aya/issues/612): make this safe by not holding `RawFd`s.
+            unsafe { BorrowedFd::borrow_raw(prog_fd) }
+        });
         let _unused: Result<(), NetlinkError> =
-            unsafe { netlink_set_xdp_fd(self.if_index, None, Some(prog_fd), flags) };
+            unsafe { netlink_set_xdp_fd(if_index, None, prog_fd, mode) };
         Ok(())
     }
 }

--- a/aya/src/sys/netlink.rs
+++ b/aya/src/sys/netlink.rs
@@ -8,7 +8,8 @@ use std::{
 use aya_obj::generated::{
     IFLA_XDP_EXPECTED_FD, IFLA_XDP_FD, IFLA_XDP_FLAGS, NLMSG_ALIGNTO, TC_H_CLSACT, TC_H_INGRESS,
     TC_H_MAJ_MASK, TC_H_UNSPEC, TCA_BPF_FD, TCA_BPF_FLAG_ACT_DIRECT, TCA_BPF_FLAGS, TCA_BPF_NAME,
-    TCA_KIND, TCA_OPTIONS, XDP_FLAGS_REPLACE, ifinfomsg, nlmsgerr_attrs::NLMSGERR_ATTR_MSG, tcmsg,
+    TCA_KIND, TCA_OPTIONS, XDP_FLAGS_REPLACE, XDP_FLAGS_UPDATE_IF_NOEXIST, ifinfomsg,
+    nlmsgerr_attrs::NLMSGERR_ATTR_MSG, tcmsg,
 };
 use libc::{
     AF_NETLINK, AF_UNSPEC, ETH_P_ALL, IFF_UP, IFLA_XDP, NETLINK_CAP_ACK, NETLINK_EXT_ACK,
@@ -21,7 +22,7 @@ use thiserror::Error;
 
 use crate::{
     Pod,
-    programs::TcAttachType,
+    programs::{TcAttachType, XdpMode},
     util::{bytes_of, tc_handler_make},
 };
 
@@ -106,8 +107,8 @@ impl NetlinkError {
 pub(crate) unsafe fn netlink_set_xdp_fd(
     if_index: i32,
     fd: Option<BorrowedFd<'_>>,
-    old_fd: Option<BorrowedFd<'_>>,
-    flags: u32,
+    expected_fd: Option<BorrowedFd<'_>>,
+    mode: XdpMode,
 ) -> Result<(), NetlinkError> {
     let sock = NetlinkSocket::open()?;
 
@@ -132,18 +133,21 @@ pub(crate) unsafe fn netlink_set_xdp_fd(
         .write_attr(IFLA_XDP_FD as u16, fd.map_or(-1, |fd| fd.as_raw_fd()))
         .map_err(|e| NetlinkError(NetlinkErrorInternal::IoError(e)))?;
 
-    if flags > 0 {
+    let flags = mode.flags() | XDP_FLAGS_UPDATE_IF_NOEXIST;
+    let (flags, expected_fd) = match expected_fd {
+        None => (flags, None),
+        Some(fd) => (flags | XDP_FLAGS_REPLACE, Some(fd.as_raw_fd())),
+    };
+
+    if flags != 0 {
         attrs
             .write_attr(IFLA_XDP_FLAGS as u16, flags)
             .map_err(|e| NetlinkError(NetlinkErrorInternal::IoError(e)))?;
     }
 
-    if flags & XDP_FLAGS_REPLACE != 0 {
+    if let Some(expected_fd) = expected_fd {
         attrs
-            .write_attr(
-                IFLA_XDP_EXPECTED_FD as u16,
-                old_fd.map(|fd| fd.as_raw_fd()).unwrap(),
-            )
+            .write_attr(IFLA_XDP_EXPECTED_FD as u16, expected_fd)
             .map_err(|e| NetlinkError(NetlinkErrorInternal::IoError(e)))?;
     }
 

--- a/test/integration-test/src/tests/load.rs
+++ b/test/integration-test/src/tests/load.rs
@@ -9,7 +9,7 @@ use aya::{
     pin::PinError,
     programs::{
         FlowDissector, KProbe, LinkOrder, ProbeKind, Program, ProgramError, SchedClassifier,
-        TcAttachType, TracePoint, UProbe, Xdp, XdpFlags,
+        TcAttachType, TracePoint, UProbe, Xdp, XdpMode,
         flow_dissector::{FlowDissectorLink, FlowDissectorLinkId},
         kprobe::{KProbeLink, KProbeLinkId},
         links::{FdLink, LinkError, PinnedLink},
@@ -36,7 +36,7 @@ fn long_name() {
         .try_into()
         .unwrap();
     name_prog.load().unwrap();
-    name_prog.attach("lo", XdpFlags::default()).unwrap();
+    name_prog.attach("lo", XdpMode::default()).unwrap();
 
     // We used to be able to assert with bpftool that the program name was short.
     // It seem though that it now uses the name from the ELF symbol table instead.
@@ -281,7 +281,7 @@ fn unload_xdp() {
     type P = Xdp;
 
     let program_name = "pass";
-    let attach = |prog: &mut P| prog.attach("lo", XdpFlags::default()).unwrap();
+    let attach = |prog: &mut P| prog.attach("lo", XdpMode::default()).unwrap();
     run_unload_program_test(
         crate::TEST,
         program_name,
@@ -413,7 +413,7 @@ fn pin_link() {
     type P = Xdp;
 
     let program_name = "pass";
-    let attach = |prog: &mut P| prog.attach("lo", XdpFlags::default()).unwrap();
+    let attach = |prog: &mut P| prog.attach("lo", XdpMode::default()).unwrap();
 
     let mut bpf = Ebpf::load(crate::TEST).unwrap();
     let prog: &mut P = bpf.program_mut(program_name).unwrap().try_into().unwrap();
@@ -519,7 +519,7 @@ fn pin_lifecycle() {
     type P = Xdp;
 
     let program_name = "pass";
-    let attach = |prog: &mut P| prog.attach("lo", XdpFlags::default()).unwrap();
+    let attach = |prog: &mut P| prog.attach("lo", XdpMode::default()).unwrap();
     let program_pin = "/sys/fs/bpf/aya-xdp-test-prog";
     let link_pin = "/sys/fs/bpf/aya-xdp-test-lo";
     let from_pin = |program_pin: &str| P::from_pin(program_pin, XdpAttachType::Interface).unwrap();

--- a/test/integration-test/src/tests/smoke.rs
+++ b/test/integration-test/src/tests/smoke.rs
@@ -1,6 +1,6 @@
 use aya::{
     Ebpf, EbpfLoader,
-    programs::{Extension, TracePoint, Xdp, XdpFlags, tc},
+    programs::{Extension, TracePoint, Xdp, XdpMode, tc},
     util::KernelVersion,
 };
 
@@ -34,7 +34,7 @@ fn xdp() {
     let mut bpf = Ebpf::load(crate::PASS).unwrap();
     let dispatcher: &mut Xdp = bpf.program_mut("pass").unwrap().try_into().unwrap();
     dispatcher.load().unwrap();
-    dispatcher.attach("lo", XdpFlags::default()).unwrap();
+    dispatcher.attach("lo", XdpMode::default()).unwrap();
 }
 
 #[test_log::test]
@@ -72,7 +72,7 @@ fn extension() {
     let mut bpf = Ebpf::load(crate::MAIN).unwrap();
     let pass: &mut Xdp = bpf.program_mut("xdp_pass").unwrap().try_into().unwrap();
     pass.load().unwrap();
-    pass.attach("lo", XdpFlags::default()).unwrap();
+    pass.attach("lo", XdpMode::default()).unwrap();
 
     let mut bpf = EbpfLoader::new()
         .extension("xdp_drop")

--- a/test/integration-test/src/tests/xdp.rs
+++ b/test/integration-test/src/tests/xdp.rs
@@ -4,7 +4,7 @@ use assert_matches::assert_matches;
 use aya::{
     Ebpf,
     maps::{Array, CpuMap, XskMap},
-    programs::{ProgramError, Xdp, XdpError, XdpFlags, xdp::XdpLinkId},
+    programs::{ProgramError, Xdp, XdpError, XdpMode, xdp::XdpLinkId},
     util::KernelVersion,
 };
 use object::{Object as _, ObjectSection as _, ObjectSymbol as _, SymbolSection};
@@ -29,7 +29,7 @@ fn af_xdp() {
         .try_into()
         .unwrap();
     xdp.load().unwrap();
-    xdp.attach("lo", XdpFlags::default()).unwrap();
+    xdp.attach("lo", XdpMode::default()).unwrap();
 
     const SIZE: usize = 2 * 4096;
 
@@ -185,7 +185,7 @@ fn cpumap_chain() {
     // Load the main program
     let xdp: &mut Xdp = bpf.program_mut("redirect_cpu").unwrap().try_into().unwrap();
     xdp.load().unwrap();
-    let result = xdp.attach("lo", XdpFlags::default());
+    let result = xdp.attach("lo", XdpMode::default());
     // Generic devices did not support cpumap XDP programs until 5.15.
     //
     // See https://github.com/torvalds/linux/commit/11941f8a85362f612df61f4aaab0e41b64d2111d.

--- a/xtask/public-api/aya.txt
+++ b/xtask/public-api/aya.txt
@@ -4915,11 +4915,36 @@ impl core::marker::Unpin for aya::programs::xdp::XdpError
 impl core::marker::UnsafeUnpin for aya::programs::xdp::XdpError
 impl !core::panic::unwind_safe::RefUnwindSafe for aya::programs::xdp::XdpError
 impl !core::panic::unwind_safe::UnwindSafe for aya::programs::xdp::XdpError
+pub enum aya::programs::xdp::XdpMode
+pub aya::programs::xdp::XdpMode::Default
+pub aya::programs::xdp::XdpMode::Driver
+pub aya::programs::xdp::XdpMode::Hardware
+pub aya::programs::xdp::XdpMode::Skb
+impl core::clone::Clone for aya::programs::xdp::XdpMode
+pub fn aya::programs::xdp::XdpMode::clone(&self) -> aya::programs::xdp::XdpMode
+impl core::cmp::Eq for aya::programs::xdp::XdpMode
+impl core::cmp::PartialEq for aya::programs::xdp::XdpMode
+pub fn aya::programs::xdp::XdpMode::eq(&self, other: &aya::programs::xdp::XdpMode) -> bool
+impl core::default::Default for aya::programs::xdp::XdpMode
+pub fn aya::programs::xdp::XdpMode::default() -> aya::programs::xdp::XdpMode
+impl core::fmt::Debug for aya::programs::xdp::XdpMode
+pub fn aya::programs::xdp::XdpMode::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::hash::Hash for aya::programs::xdp::XdpMode
+pub fn aya::programs::xdp::XdpMode::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+impl core::marker::Copy for aya::programs::xdp::XdpMode
+impl core::marker::StructuralPartialEq for aya::programs::xdp::XdpMode
+impl core::marker::Freeze for aya::programs::xdp::XdpMode
+impl core::marker::Send for aya::programs::xdp::XdpMode
+impl core::marker::Sync for aya::programs::xdp::XdpMode
+impl core::marker::Unpin for aya::programs::xdp::XdpMode
+impl core::marker::UnsafeUnpin for aya::programs::xdp::XdpMode
+impl core::panic::unwind_safe::RefUnwindSafe for aya::programs::xdp::XdpMode
+impl core::panic::unwind_safe::UnwindSafe for aya::programs::xdp::XdpMode
 pub struct aya::programs::xdp::Xdp
 impl aya::programs::xdp::Xdp
 pub const aya::programs::xdp::Xdp::PROGRAM_TYPE: aya::programs::ProgramType
-pub fn aya::programs::xdp::Xdp::attach(&mut self, interface: &str, flags: aya::programs::xdp::XdpFlags) -> core::result::Result<aya::programs::xdp::XdpLinkId, aya::programs::ProgramError>
-pub fn aya::programs::xdp::Xdp::attach_to_if_index(&mut self, if_index: u32, flags: aya::programs::xdp::XdpFlags) -> core::result::Result<aya::programs::xdp::XdpLinkId, aya::programs::ProgramError>
+pub fn aya::programs::xdp::Xdp::attach(&mut self, interface: &str, mode: aya::programs::xdp::XdpMode) -> core::result::Result<aya::programs::xdp::XdpLinkId, aya::programs::ProgramError>
+pub fn aya::programs::xdp::Xdp::attach_to_if_index(&mut self, if_index: u32, mode: aya::programs::xdp::XdpMode) -> core::result::Result<aya::programs::xdp::XdpLinkId, aya::programs::ProgramError>
 pub fn aya::programs::xdp::Xdp::attach_to_link(&mut self, link: aya::programs::xdp::XdpLink) -> core::result::Result<aya::programs::xdp::XdpLinkId, aya::programs::ProgramError>
 pub fn aya::programs::xdp::Xdp::from_pin<P: core::convert::AsRef<std::path::Path>>(path: P, attach_type: aya_obj::programs::xdp::XdpAttachType) -> core::result::Result<Self, aya::programs::ProgramError>
 pub fn aya::programs::xdp::Xdp::load(&mut self) -> core::result::Result<(), aya::programs::ProgramError>
@@ -4958,98 +4983,6 @@ impl core::marker::Unpin for aya::programs::xdp::Xdp
 impl core::marker::UnsafeUnpin for aya::programs::xdp::Xdp
 impl core::panic::unwind_safe::RefUnwindSafe for aya::programs::xdp::Xdp
 impl core::panic::unwind_safe::UnwindSafe for aya::programs::xdp::Xdp
-pub struct aya::programs::xdp::XdpFlags(_)
-impl aya::programs::xdp::XdpFlags
-pub const aya::programs::xdp::XdpFlags::DRV_MODE: Self
-pub const aya::programs::xdp::XdpFlags::HW_MODE: Self
-pub const aya::programs::xdp::XdpFlags::REPLACE: Self
-pub const aya::programs::xdp::XdpFlags::SKB_MODE: Self
-pub const aya::programs::xdp::XdpFlags::UPDATE_IF_NOEXIST: Self
-impl aya::programs::xdp::XdpFlags
-pub const fn aya::programs::xdp::XdpFlags::all() -> Self
-pub const fn aya::programs::xdp::XdpFlags::bits(&self) -> u32
-pub const fn aya::programs::xdp::XdpFlags::complement(self) -> Self
-pub const fn aya::programs::xdp::XdpFlags::contains(&self, other: Self) -> bool
-pub const fn aya::programs::xdp::XdpFlags::difference(self, other: Self) -> Self
-pub const fn aya::programs::xdp::XdpFlags::empty() -> Self
-pub const fn aya::programs::xdp::XdpFlags::from_bits(bits: u32) -> core::option::Option<Self>
-pub const fn aya::programs::xdp::XdpFlags::from_bits_retain(bits: u32) -> Self
-pub const fn aya::programs::xdp::XdpFlags::from_bits_truncate(bits: u32) -> Self
-pub fn aya::programs::xdp::XdpFlags::from_name(name: &str) -> core::option::Option<Self>
-pub fn aya::programs::xdp::XdpFlags::insert(&mut self, other: Self)
-pub const fn aya::programs::xdp::XdpFlags::intersection(self, other: Self) -> Self
-pub const fn aya::programs::xdp::XdpFlags::intersects(&self, other: Self) -> bool
-pub const fn aya::programs::xdp::XdpFlags::is_all(&self) -> bool
-pub const fn aya::programs::xdp::XdpFlags::is_empty(&self) -> bool
-pub fn aya::programs::xdp::XdpFlags::remove(&mut self, other: Self)
-pub fn aya::programs::xdp::XdpFlags::set(&mut self, other: Self, value: bool)
-pub const fn aya::programs::xdp::XdpFlags::symmetric_difference(self, other: Self) -> Self
-pub fn aya::programs::xdp::XdpFlags::toggle(&mut self, other: Self)
-pub const fn aya::programs::xdp::XdpFlags::union(self, other: Self) -> Self
-impl aya::programs::xdp::XdpFlags
-pub const fn aya::programs::xdp::XdpFlags::iter(&self) -> bitflags::iter::Iter<aya::programs::xdp::XdpFlags>
-pub const fn aya::programs::xdp::XdpFlags::iter_names(&self) -> bitflags::iter::IterNames<aya::programs::xdp::XdpFlags>
-impl bitflags::traits::Flags for aya::programs::xdp::XdpFlags
-pub type aya::programs::xdp::XdpFlags::Bits = u32
-pub const aya::programs::xdp::XdpFlags::FLAGS: &'static [bitflags::traits::Flag<aya::programs::xdp::XdpFlags>]
-pub fn aya::programs::xdp::XdpFlags::bits(&self) -> u32
-pub fn aya::programs::xdp::XdpFlags::from_bits_retain(bits: u32) -> aya::programs::xdp::XdpFlags
-impl bitflags::traits::PublicFlags for aya::programs::xdp::XdpFlags
-pub type aya::programs::xdp::XdpFlags::Internal = InternalBitFlags
-pub type aya::programs::xdp::XdpFlags::Primitive = u32
-impl core::clone::Clone for aya::programs::xdp::XdpFlags
-pub fn aya::programs::xdp::XdpFlags::clone(&self) -> aya::programs::xdp::XdpFlags
-impl core::default::Default for aya::programs::xdp::XdpFlags
-pub fn aya::programs::xdp::XdpFlags::default() -> aya::programs::xdp::XdpFlags
-impl core::fmt::Binary for aya::programs::xdp::XdpFlags
-pub fn aya::programs::xdp::XdpFlags::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl core::fmt::Debug for aya::programs::xdp::XdpFlags
-pub fn aya::programs::xdp::XdpFlags::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl core::fmt::LowerHex for aya::programs::xdp::XdpFlags
-pub fn aya::programs::xdp::XdpFlags::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl core::fmt::Octal for aya::programs::xdp::XdpFlags
-pub fn aya::programs::xdp::XdpFlags::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl core::fmt::UpperHex for aya::programs::xdp::XdpFlags
-pub fn aya::programs::xdp::XdpFlags::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl core::iter::traits::collect::Extend<aya::programs::xdp::XdpFlags> for aya::programs::xdp::XdpFlags
-pub fn aya::programs::xdp::XdpFlags::extend<T: core::iter::traits::collect::IntoIterator<Item = Self>>(&mut self, iterator: T)
-impl core::iter::traits::collect::FromIterator<aya::programs::xdp::XdpFlags> for aya::programs::xdp::XdpFlags
-pub fn aya::programs::xdp::XdpFlags::from_iter<T: core::iter::traits::collect::IntoIterator<Item = Self>>(iterator: T) -> Self
-impl core::iter::traits::collect::IntoIterator for aya::programs::xdp::XdpFlags
-pub type aya::programs::xdp::XdpFlags::IntoIter = bitflags::iter::Iter<aya::programs::xdp::XdpFlags>
-pub type aya::programs::xdp::XdpFlags::Item = aya::programs::xdp::XdpFlags
-pub fn aya::programs::xdp::XdpFlags::into_iter(self) -> Self::IntoIter
-impl core::marker::Copy for aya::programs::xdp::XdpFlags
-impl core::ops::arith::Sub for aya::programs::xdp::XdpFlags
-pub type aya::programs::xdp::XdpFlags::Output = aya::programs::xdp::XdpFlags
-pub fn aya::programs::xdp::XdpFlags::sub(self, other: Self) -> Self
-impl core::ops::arith::SubAssign for aya::programs::xdp::XdpFlags
-pub fn aya::programs::xdp::XdpFlags::sub_assign(&mut self, other: Self)
-impl core::ops::bit::BitAnd for aya::programs::xdp::XdpFlags
-pub type aya::programs::xdp::XdpFlags::Output = aya::programs::xdp::XdpFlags
-pub fn aya::programs::xdp::XdpFlags::bitand(self, other: Self) -> Self
-impl core::ops::bit::BitAndAssign for aya::programs::xdp::XdpFlags
-pub fn aya::programs::xdp::XdpFlags::bitand_assign(&mut self, other: Self)
-impl core::ops::bit::BitOr for aya::programs::xdp::XdpFlags
-pub type aya::programs::xdp::XdpFlags::Output = aya::programs::xdp::XdpFlags
-pub fn aya::programs::xdp::XdpFlags::bitor(self, other: aya::programs::xdp::XdpFlags) -> Self
-impl core::ops::bit::BitOrAssign for aya::programs::xdp::XdpFlags
-pub fn aya::programs::xdp::XdpFlags::bitor_assign(&mut self, other: Self)
-impl core::ops::bit::BitXor for aya::programs::xdp::XdpFlags
-pub type aya::programs::xdp::XdpFlags::Output = aya::programs::xdp::XdpFlags
-pub fn aya::programs::xdp::XdpFlags::bitxor(self, other: Self) -> Self
-impl core::ops::bit::BitXorAssign for aya::programs::xdp::XdpFlags
-pub fn aya::programs::xdp::XdpFlags::bitxor_assign(&mut self, other: Self)
-impl core::ops::bit::Not for aya::programs::xdp::XdpFlags
-pub type aya::programs::xdp::XdpFlags::Output = aya::programs::xdp::XdpFlags
-pub fn aya::programs::xdp::XdpFlags::not(self) -> Self
-impl core::marker::Freeze for aya::programs::xdp::XdpFlags
-impl core::marker::Send for aya::programs::xdp::XdpFlags
-impl core::marker::Sync for aya::programs::xdp::XdpFlags
-impl core::marker::Unpin for aya::programs::xdp::XdpFlags
-impl core::marker::UnsafeUnpin for aya::programs::xdp::XdpFlags
-impl core::panic::unwind_safe::RefUnwindSafe for aya::programs::xdp::XdpFlags
-impl core::panic::unwind_safe::UnwindSafe for aya::programs::xdp::XdpFlags
 pub struct aya::programs::xdp::XdpLink(_)
 impl aya::programs::links::Link for aya::programs::xdp::XdpLink
 pub type aya::programs::xdp::XdpLink::Id = aya::programs::xdp::XdpLinkId
@@ -5665,6 +5598,31 @@ impl core::marker::Unpin for aya::programs::xdp::XdpError
 impl core::marker::UnsafeUnpin for aya::programs::xdp::XdpError
 impl !core::panic::unwind_safe::RefUnwindSafe for aya::programs::xdp::XdpError
 impl !core::panic::unwind_safe::UnwindSafe for aya::programs::xdp::XdpError
+pub enum aya::programs::XdpMode
+pub aya::programs::XdpMode::Default
+pub aya::programs::XdpMode::Driver
+pub aya::programs::XdpMode::Hardware
+pub aya::programs::XdpMode::Skb
+impl core::clone::Clone for aya::programs::xdp::XdpMode
+pub fn aya::programs::xdp::XdpMode::clone(&self) -> aya::programs::xdp::XdpMode
+impl core::cmp::Eq for aya::programs::xdp::XdpMode
+impl core::cmp::PartialEq for aya::programs::xdp::XdpMode
+pub fn aya::programs::xdp::XdpMode::eq(&self, other: &aya::programs::xdp::XdpMode) -> bool
+impl core::default::Default for aya::programs::xdp::XdpMode
+pub fn aya::programs::xdp::XdpMode::default() -> aya::programs::xdp::XdpMode
+impl core::fmt::Debug for aya::programs::xdp::XdpMode
+pub fn aya::programs::xdp::XdpMode::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::hash::Hash for aya::programs::xdp::XdpMode
+pub fn aya::programs::xdp::XdpMode::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+impl core::marker::Copy for aya::programs::xdp::XdpMode
+impl core::marker::StructuralPartialEq for aya::programs::xdp::XdpMode
+impl core::marker::Freeze for aya::programs::xdp::XdpMode
+impl core::marker::Send for aya::programs::xdp::XdpMode
+impl core::marker::Sync for aya::programs::xdp::XdpMode
+impl core::marker::Unpin for aya::programs::xdp::XdpMode
+impl core::marker::UnsafeUnpin for aya::programs::xdp::XdpMode
+impl core::panic::unwind_safe::RefUnwindSafe for aya::programs::xdp::XdpMode
+impl core::panic::unwind_safe::UnwindSafe for aya::programs::xdp::XdpMode
 pub struct aya::programs::BtfTracePoint
 impl aya::programs::tp_btf::BtfTracePoint
 pub const aya::programs::tp_btf::BtfTracePoint::PROGRAM_TYPE: aya::programs::ProgramType
@@ -6850,8 +6808,8 @@ impl core::panic::unwind_safe::UnwindSafe for aya::programs::uprobe::UProbe
 pub struct aya::programs::Xdp
 impl aya::programs::xdp::Xdp
 pub const aya::programs::xdp::Xdp::PROGRAM_TYPE: aya::programs::ProgramType
-pub fn aya::programs::xdp::Xdp::attach(&mut self, interface: &str, flags: aya::programs::xdp::XdpFlags) -> core::result::Result<aya::programs::xdp::XdpLinkId, aya::programs::ProgramError>
-pub fn aya::programs::xdp::Xdp::attach_to_if_index(&mut self, if_index: u32, flags: aya::programs::xdp::XdpFlags) -> core::result::Result<aya::programs::xdp::XdpLinkId, aya::programs::ProgramError>
+pub fn aya::programs::xdp::Xdp::attach(&mut self, interface: &str, mode: aya::programs::xdp::XdpMode) -> core::result::Result<aya::programs::xdp::XdpLinkId, aya::programs::ProgramError>
+pub fn aya::programs::xdp::Xdp::attach_to_if_index(&mut self, if_index: u32, mode: aya::programs::xdp::XdpMode) -> core::result::Result<aya::programs::xdp::XdpLinkId, aya::programs::ProgramError>
 pub fn aya::programs::xdp::Xdp::attach_to_link(&mut self, link: aya::programs::xdp::XdpLink) -> core::result::Result<aya::programs::xdp::XdpLinkId, aya::programs::ProgramError>
 pub fn aya::programs::xdp::Xdp::from_pin<P: core::convert::AsRef<std::path::Path>>(path: P, attach_type: aya_obj::programs::xdp::XdpAttachType) -> core::result::Result<Self, aya::programs::ProgramError>
 pub fn aya::programs::xdp::Xdp::load(&mut self) -> core::result::Result<(), aya::programs::ProgramError>
@@ -6890,98 +6848,6 @@ impl core::marker::Unpin for aya::programs::xdp::Xdp
 impl core::marker::UnsafeUnpin for aya::programs::xdp::Xdp
 impl core::panic::unwind_safe::RefUnwindSafe for aya::programs::xdp::Xdp
 impl core::panic::unwind_safe::UnwindSafe for aya::programs::xdp::Xdp
-pub struct aya::programs::XdpFlags(_)
-impl aya::programs::xdp::XdpFlags
-pub const aya::programs::xdp::XdpFlags::DRV_MODE: Self
-pub const aya::programs::xdp::XdpFlags::HW_MODE: Self
-pub const aya::programs::xdp::XdpFlags::REPLACE: Self
-pub const aya::programs::xdp::XdpFlags::SKB_MODE: Self
-pub const aya::programs::xdp::XdpFlags::UPDATE_IF_NOEXIST: Self
-impl aya::programs::xdp::XdpFlags
-pub const fn aya::programs::xdp::XdpFlags::all() -> Self
-pub const fn aya::programs::xdp::XdpFlags::bits(&self) -> u32
-pub const fn aya::programs::xdp::XdpFlags::complement(self) -> Self
-pub const fn aya::programs::xdp::XdpFlags::contains(&self, other: Self) -> bool
-pub const fn aya::programs::xdp::XdpFlags::difference(self, other: Self) -> Self
-pub const fn aya::programs::xdp::XdpFlags::empty() -> Self
-pub const fn aya::programs::xdp::XdpFlags::from_bits(bits: u32) -> core::option::Option<Self>
-pub const fn aya::programs::xdp::XdpFlags::from_bits_retain(bits: u32) -> Self
-pub const fn aya::programs::xdp::XdpFlags::from_bits_truncate(bits: u32) -> Self
-pub fn aya::programs::xdp::XdpFlags::from_name(name: &str) -> core::option::Option<Self>
-pub fn aya::programs::xdp::XdpFlags::insert(&mut self, other: Self)
-pub const fn aya::programs::xdp::XdpFlags::intersection(self, other: Self) -> Self
-pub const fn aya::programs::xdp::XdpFlags::intersects(&self, other: Self) -> bool
-pub const fn aya::programs::xdp::XdpFlags::is_all(&self) -> bool
-pub const fn aya::programs::xdp::XdpFlags::is_empty(&self) -> bool
-pub fn aya::programs::xdp::XdpFlags::remove(&mut self, other: Self)
-pub fn aya::programs::xdp::XdpFlags::set(&mut self, other: Self, value: bool)
-pub const fn aya::programs::xdp::XdpFlags::symmetric_difference(self, other: Self) -> Self
-pub fn aya::programs::xdp::XdpFlags::toggle(&mut self, other: Self)
-pub const fn aya::programs::xdp::XdpFlags::union(self, other: Self) -> Self
-impl aya::programs::xdp::XdpFlags
-pub const fn aya::programs::xdp::XdpFlags::iter(&self) -> bitflags::iter::Iter<aya::programs::xdp::XdpFlags>
-pub const fn aya::programs::xdp::XdpFlags::iter_names(&self) -> bitflags::iter::IterNames<aya::programs::xdp::XdpFlags>
-impl bitflags::traits::Flags for aya::programs::xdp::XdpFlags
-pub type aya::programs::xdp::XdpFlags::Bits = u32
-pub const aya::programs::xdp::XdpFlags::FLAGS: &'static [bitflags::traits::Flag<aya::programs::xdp::XdpFlags>]
-pub fn aya::programs::xdp::XdpFlags::bits(&self) -> u32
-pub fn aya::programs::xdp::XdpFlags::from_bits_retain(bits: u32) -> aya::programs::xdp::XdpFlags
-impl bitflags::traits::PublicFlags for aya::programs::xdp::XdpFlags
-pub type aya::programs::xdp::XdpFlags::Internal = InternalBitFlags
-pub type aya::programs::xdp::XdpFlags::Primitive = u32
-impl core::clone::Clone for aya::programs::xdp::XdpFlags
-pub fn aya::programs::xdp::XdpFlags::clone(&self) -> aya::programs::xdp::XdpFlags
-impl core::default::Default for aya::programs::xdp::XdpFlags
-pub fn aya::programs::xdp::XdpFlags::default() -> aya::programs::xdp::XdpFlags
-impl core::fmt::Binary for aya::programs::xdp::XdpFlags
-pub fn aya::programs::xdp::XdpFlags::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl core::fmt::Debug for aya::programs::xdp::XdpFlags
-pub fn aya::programs::xdp::XdpFlags::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl core::fmt::LowerHex for aya::programs::xdp::XdpFlags
-pub fn aya::programs::xdp::XdpFlags::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl core::fmt::Octal for aya::programs::xdp::XdpFlags
-pub fn aya::programs::xdp::XdpFlags::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl core::fmt::UpperHex for aya::programs::xdp::XdpFlags
-pub fn aya::programs::xdp::XdpFlags::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl core::iter::traits::collect::Extend<aya::programs::xdp::XdpFlags> for aya::programs::xdp::XdpFlags
-pub fn aya::programs::xdp::XdpFlags::extend<T: core::iter::traits::collect::IntoIterator<Item = Self>>(&mut self, iterator: T)
-impl core::iter::traits::collect::FromIterator<aya::programs::xdp::XdpFlags> for aya::programs::xdp::XdpFlags
-pub fn aya::programs::xdp::XdpFlags::from_iter<T: core::iter::traits::collect::IntoIterator<Item = Self>>(iterator: T) -> Self
-impl core::iter::traits::collect::IntoIterator for aya::programs::xdp::XdpFlags
-pub type aya::programs::xdp::XdpFlags::IntoIter = bitflags::iter::Iter<aya::programs::xdp::XdpFlags>
-pub type aya::programs::xdp::XdpFlags::Item = aya::programs::xdp::XdpFlags
-pub fn aya::programs::xdp::XdpFlags::into_iter(self) -> Self::IntoIter
-impl core::marker::Copy for aya::programs::xdp::XdpFlags
-impl core::ops::arith::Sub for aya::programs::xdp::XdpFlags
-pub type aya::programs::xdp::XdpFlags::Output = aya::programs::xdp::XdpFlags
-pub fn aya::programs::xdp::XdpFlags::sub(self, other: Self) -> Self
-impl core::ops::arith::SubAssign for aya::programs::xdp::XdpFlags
-pub fn aya::programs::xdp::XdpFlags::sub_assign(&mut self, other: Self)
-impl core::ops::bit::BitAnd for aya::programs::xdp::XdpFlags
-pub type aya::programs::xdp::XdpFlags::Output = aya::programs::xdp::XdpFlags
-pub fn aya::programs::xdp::XdpFlags::bitand(self, other: Self) -> Self
-impl core::ops::bit::BitAndAssign for aya::programs::xdp::XdpFlags
-pub fn aya::programs::xdp::XdpFlags::bitand_assign(&mut self, other: Self)
-impl core::ops::bit::BitOr for aya::programs::xdp::XdpFlags
-pub type aya::programs::xdp::XdpFlags::Output = aya::programs::xdp::XdpFlags
-pub fn aya::programs::xdp::XdpFlags::bitor(self, other: aya::programs::xdp::XdpFlags) -> Self
-impl core::ops::bit::BitOrAssign for aya::programs::xdp::XdpFlags
-pub fn aya::programs::xdp::XdpFlags::bitor_assign(&mut self, other: Self)
-impl core::ops::bit::BitXor for aya::programs::xdp::XdpFlags
-pub type aya::programs::xdp::XdpFlags::Output = aya::programs::xdp::XdpFlags
-pub fn aya::programs::xdp::XdpFlags::bitxor(self, other: Self) -> Self
-impl core::ops::bit::BitXorAssign for aya::programs::xdp::XdpFlags
-pub fn aya::programs::xdp::XdpFlags::bitxor_assign(&mut self, other: Self)
-impl core::ops::bit::Not for aya::programs::xdp::XdpFlags
-pub type aya::programs::xdp::XdpFlags::Output = aya::programs::xdp::XdpFlags
-pub fn aya::programs::xdp::XdpFlags::not(self) -> Self
-impl core::marker::Freeze for aya::programs::xdp::XdpFlags
-impl core::marker::Send for aya::programs::xdp::XdpFlags
-impl core::marker::Sync for aya::programs::xdp::XdpFlags
-impl core::marker::Unpin for aya::programs::xdp::XdpFlags
-impl core::marker::UnsafeUnpin for aya::programs::xdp::XdpFlags
-impl core::panic::unwind_safe::RefUnwindSafe for aya::programs::xdp::XdpFlags
-impl core::panic::unwind_safe::UnwindSafe for aya::programs::xdp::XdpFlags
 pub trait aya::programs::Link: core::fmt::Debug + core::cmp::Eq + core::hash::Hash + 'static
 pub type aya::programs::Link::Id: core::fmt::Debug + core::cmp::Eq + core::hash::Hash + equivalent::Equivalent<Self>
 pub fn aya::programs::Link::detach(self) -> core::result::Result<(), aya::programs::ProgramError>


### PR DESCRIPTION
Replace the public XDP flag bitset with an enum for the mutually
exclusive attach modes. Keep netlink-only replacement details internal
so callers cannot request invalid flag combinations.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aya-rs/aya/1545)
<!-- Reviewable:end -->
