### PR TITLE
aya-ebpf-macros: emit uprobe.multi sections

### DIFF
--- a/aya-ebpf-macros/Cargo.toml
+++ b/aya-ebpf-macros/Cargo.toml
@@ -24,3 +24,4 @@ syn = { workspace = true, default-features = true, features = ["full"] }
 
 [dev-dependencies]
 aya-ebpf = { path = "../ebpf/aya-ebpf", default-features = false }
+test-case = { workspace = true }

--- a/aya-ebpf-macros/src/uprobe.rs
+++ b/aya-ebpf-macros/src/uprobe.rs
@@ -29,6 +29,7 @@ pub(crate) struct UProbe {
     offset: Option<u64>,
     item: ItemFn,
     sleepable: bool,
+    multi: bool,
 }
 
 impl UProbe {
@@ -49,6 +50,7 @@ impl UProbe {
             .transpose()
             .map_err(|err| span.error(format!("failed to parse `offset` argument: {err}")))?;
         let sleepable = args.pop_bool("sleepable");
+        let multi = args.pop_bool("multi");
         args.into_error()?;
         Ok(Self {
             kind,
@@ -57,6 +59,7 @@ impl UProbe {
             offset,
             item,
             sleepable,
+            multi,
         })
     }
 
@@ -68,6 +71,7 @@ impl UProbe {
             offset,
             item,
             sleepable,
+            multi,
         } = self;
         let ItemFn {
             attrs: _,
@@ -76,6 +80,12 @@ impl UProbe {
             block: _,
         } = item;
         let mut prefix = kind.to_string();
+        // `.multi` must come before `.s` to match libbpf's SEC convention,
+        // e.g. `uprobe.multi.s` rather than `uprobe.s.multi`.
+        // https://docs.kernel.org/bpf/libbpf/program_types.html
+        if *multi {
+            prefix.push_str(".multi");
+        }
         if *sleepable {
             prefix.push_str(".s");
         }
@@ -116,14 +126,49 @@ impl UProbe {
 #[cfg(test)]
 mod tests {
     use syn::parse_quote;
+    use test_case::test_case;
 
     use super::*;
 
-    #[test]
-    fn uprobe() {
+    #[test_case(UProbeKind::UProbe, "", "uprobe"; "uprobe")]
+    #[test_case(UProbeKind::UProbe, "sleepable", "uprobe.s"; "uprobe_sleepable")]
+    #[test_case(
+        UProbeKind::UProbe,
+        r#"path = "/self/proc/exe", function = "trigger_uprobe""#,
+        "uprobe/self/proc/exe:trigger_uprobe";
+        "uprobe_with_path"
+    )]
+    #[test_case(
+        UProbeKind::UProbe,
+        r#"path = "/self/proc/exe", function = "foo", offset = "123""#,
+        "uprobe/self/proc/exe:foo+123";
+        "uprobe_with_path_and_offset"
+    )]
+    #[test_case(UProbeKind::URetProbe, "", "uretprobe"; "uretprobe")]
+    #[test_case(UProbeKind::UProbe, "multi", "uprobe.multi"; "uprobe_multi")]
+    #[test_case(
+        UProbeKind::UProbe,
+        "multi, sleepable",
+        "uprobe.multi.s";
+        "uprobe_multi_sleepable"
+    )]
+    #[test_case(
+        UProbeKind::UProbe,
+        r#"multi, path = "/self/proc/exe", function = "trigger_uprobe""#,
+        "uprobe.multi/self/proc/exe:trigger_uprobe";
+        "uprobe_multi_with_path"
+    )]
+    #[test_case(UProbeKind::URetProbe, "multi", "uretprobe.multi"; "uretprobe_multi")]
+    #[test_case(
+        UProbeKind::URetProbe,
+        "multi, sleepable",
+        "uretprobe.multi.s";
+        "uretprobe_multi_sleepable"
+    )]
+    fn uprobe(kind: UProbeKind, attrs: &str, section_name: &str) {
         let uprobe = UProbe::parse(
-            UProbeKind::UProbe,
-            parse_quote! {},
+            kind,
+            attrs.parse().unwrap(),
             parse_quote! {
                 fn foo(ctx: ProbeContext) -> u32 {
                     0
@@ -131,138 +176,19 @@ mod tests {
             },
         )
         .unwrap();
+
+        let probe_type = match kind {
+            UProbeKind::UProbe => quote! { ProbeContext },
+            UProbeKind::URetProbe => quote! { RetProbeContext },
+        };
+
         assert_eq!(
             uprobe.expand().unwrap().to_string(),
             quote! {
                 #[unsafe(no_mangle)]
-                #[unsafe(link_section = "uprobe")]
+                #[unsafe(link_section = #section_name)]
                 fn foo(ctx: *mut ::core::ffi::c_void) -> u32 {
-                    let _ = foo(::aya_ebpf::programs::ProbeContext::new(ctx));
-                    return 0;
-
-                    fn foo(ctx: ProbeContext) -> u32 {
-                        0
-                    }
-                }
-            }
-            .to_string()
-        );
-    }
-
-    #[test]
-    fn uprobe_sleepable() {
-        let uprobe = UProbe::parse(
-            UProbeKind::UProbe,
-            parse_quote! {sleepable},
-            parse_quote! {
-                fn foo(ctx: ProbeContext) -> u32 {
-                    0
-                }
-            },
-        )
-        .unwrap();
-        assert_eq!(
-            uprobe.expand().unwrap().to_string(),
-            quote! {
-                #[unsafe(no_mangle)]
-                #[unsafe(link_section = "uprobe.s")]
-                fn foo(ctx: *mut ::core::ffi::c_void) -> u32 {
-                    let _ = foo(::aya_ebpf::programs::ProbeContext::new(ctx));
-                    return 0;
-
-                    fn foo(ctx: ProbeContext) -> u32 {
-                        0
-                    }
-                }
-            }
-            .to_string()
-        );
-    }
-
-    #[test]
-    fn uprobe_with_path() {
-        let uprobe = UProbe::parse(
-            UProbeKind::UProbe,
-            parse_quote! {
-                path = "/self/proc/exe",
-                function = "trigger_uprobe"
-            },
-            parse_quote! {
-                fn foo(ctx: ProbeContext) -> u32 {
-                    0
-                }
-            },
-        )
-        .unwrap();
-        assert_eq!(
-            uprobe.expand().unwrap().to_string(),
-            quote! {
-                #[unsafe(no_mangle)]
-                #[unsafe(link_section = "uprobe/self/proc/exe:trigger_uprobe")]
-                fn foo(ctx: *mut ::core::ffi::c_void) -> u32 {
-                    let _ = foo(::aya_ebpf::programs::ProbeContext::new(ctx));
-                    return 0;
-
-                    fn foo(ctx: ProbeContext) -> u32 {
-                        0
-                    }
-                }
-            }
-            .to_string()
-        );
-    }
-
-    #[test]
-    fn test_uprobe_with_path_and_offset() {
-        let uprobe = UProbe::parse(
-            UProbeKind::UProbe,
-            parse_quote! {
-                path = "/self/proc/exe", function = "foo", offset = "123"
-            },
-            parse_quote! {
-                fn foo(ctx: ProbeContext) -> u32 {
-                    0
-                }
-            },
-        )
-        .unwrap();
-        assert_eq!(
-            uprobe.expand().unwrap().to_string(),
-            quote! {
-                #[unsafe(no_mangle)]
-                #[unsafe(link_section = "uprobe/self/proc/exe:foo+123")]
-                fn foo(ctx: *mut ::core::ffi::c_void) -> u32 {
-                    let _ = foo(::aya_ebpf::programs::ProbeContext::new(ctx));
-                    return 0;
-
-                    fn foo(ctx: ProbeContext) -> u32 {
-                        0
-                    }
-                }
-            }
-            .to_string()
-        );
-    }
-
-    #[test]
-    fn test_uretprobe() {
-        let uprobe = UProbe::parse(
-            UProbeKind::URetProbe,
-            parse_quote! {},
-            parse_quote! {
-                fn foo(ctx: ProbeContext) -> u32 {
-                    0
-                }
-            },
-        )
-        .unwrap();
-        assert_eq!(
-            uprobe.expand().unwrap().to_string(),
-            quote! {
-                #[unsafe(no_mangle)]
-                #[unsafe(link_section = "uretprobe")]
-                fn foo(ctx: *mut ::core::ffi::c_void) -> u32 {
-                    let _ = foo(::aya_ebpf::programs::RetProbeContext::new(ctx));
+                    let _ = foo(::aya_ebpf::programs::#probe_type::new(ctx));
                     return 0;
 
                     fn foo(ctx: ProbeContext) -> u32 {


### PR DESCRIPTION
Allow #[uprobe] and #[uretprobe] to take a multi argument and emit the uprobe.multi and uretprobe.multi ELF section names in object files.

Split out from #1417 for easier review.

<!-- markdownlint-disable first-line-heading -->

<!--
    Thank you for your contribution to Aya! 🎉

    For Work In Progress Pull Requests, please use the Draft PR feature.

    Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Aya Contributing Guide: https://github.com/aya-rs/aya/blob/main/CONTRIBUTING.md
     - 📖 Read the Aya Code of Conduct: https://github.com/aya-rs/aya/blob/main/CODE_OF_CONDUCT.md
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages: https://cbea.ms/git-commit/
     - 📗 Update any related documentation.

-->

<!---
      Summarize the changes you're making here. Detailed information belongs in
      the Git commit messages. If your pull request contains just one commit,
      it's best to use its message as a summary. Otherwise, if there are multiple
      atomic commits, write a summary for the entire PR. Feel free to flag
      anything you think needs a reviewer's attention.
-->

<!--
      If your changes address an issue, link it with the *Fixes* tag so
      the issue gets closed when the PR is merged, for example:

      Fixes: #1234

      If you are only referencing an issue without fully addressing it, feel
      free to link it anywhere in the summary.
-->

### Added/updated tests?

_We strongly encourage you to add a test for your changes._

- [x] Yes

### Checklist

- [x] Rust code has been formatted with `cargo +nightly fmt`.
- [x] All clippy lints have been fixed.
      You can find failing lints with `cargo xtask clippy`.
- [x] Unit tests are passing locally with `cargo test`.
- [x] The [Integration tests] are passing locally.
- [x] I have blessed any API changes with `cargo xtask public-api --bless`.

[Integration tests]: https://github.com/aya-rs/aya/blob/main/test/README.md

### (Optional) What GIF best describes this PR or how it makes you feel?

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aya-rs/aya/1548)
<!-- Reviewable:end -->
