### PR TITLE
aya-ebpf: gate bpf_get_stackid to tracing contexts via sealed trait

### DIFF
--- a/ebpf/aya-ebpf/src/btf_maps/stack_trace.rs
+++ b/ebpf/aya-ebpf/src/btf_maps/stack_trace.rs
@@ -1,14 +1,14 @@
 use aya_ebpf_bindings::bindings::{BPF_F_STACK_BUILD_ID, PERF_MAX_STACK_DEPTH};
 
-use crate::{EbpfContext, btf_maps::btf_map_def, cty::c_long, helpers::bpf_get_stackid};
+use crate::btf_maps::btf_map_def;
 
 btf_map_def!(
     /// A BTF-compatible BPF stack-trace map.
     ///
     /// Stores hashed stack traces keyed by a `u32` stack ID, where each value
     /// is a fixed-depth array of return addresses. Populate a stack trace by
-    /// calling [`StackTrace::get_stackid`] from a tracing program; read the
-    /// resulting trace from user space via
+    /// calling [`StackIdContext::get_stackid`][get-stackid] from a tracing
+    /// program; read the resulting trace from user space via
     /// `aya::maps::StackTraceMap`.
     ///
     /// # Minimum kernel version
@@ -19,10 +19,10 @@ btf_map_def!(
     ///
     /// `BPF_F_STACK_BUILD_ID` switches the kernel element layout to
     /// `struct bpf_stack_build_id` (32 bytes), which this type does not
-    /// model. Calling [`StackTrace::get_stackid`] on a monomorphisation
-    /// that sets the flag fails to compile, and loading such a map for
-    /// reading through `aya::maps::StackTraceMap` is rejected at load
-    /// time.
+    /// model. Calling [`StackIdContext::get_stackid`][get-stackid] on a
+    /// monomorphisation that sets the flag fails to compile, and loading
+    /// such a map for reading through `aya::maps::StackTraceMap` is
+    /// rejected at load time.
     ///
     /// # Example
     ///
@@ -32,6 +32,8 @@ btf_map_def!(
     /// #[btf_map]
     /// static STACK_TRACES: StackTrace<1024> = StackTrace::new();
     /// ```
+    ///
+    /// [get-stackid]: crate::programs::tracing::StackIdContext::get_stackid
     pub struct StackTrace<;
         const MAX_ENTRIES: usize,
         const FLAGS: usize = 0,
@@ -47,9 +49,9 @@ btf_map_def!(
 impl<const MAX_ENTRIES: usize, const FLAGS: usize, const DEPTH: usize>
     StackTrace<MAX_ENTRIES, FLAGS, DEPTH>
 {
-    // `const _: ()` is forbidden in a generic impl; named associated
-    // const is lazy without reference - hence `let () = Self::_CHECK`
-    // in each public method.
+    // `const _: ()` is forbidden in a generic impl; a named associated
+    // const is lazy without reference, hence `let () = Self::_CHECK` in
+    // the `StackTraceMap::as_ptr` impl below.
     const _CHECK: () = {
         assert!(DEPTH > 0, "stack trace DEPTH must be greater than zero.");
         assert!(
@@ -61,21 +63,6 @@ impl<const MAX_ENTRIES: usize, const FLAGS: usize, const DEPTH: usize>
             "BPF_F_STACK_BUILD_ID is not supported by StackTrace.",
         );
     };
-
-    /// Obtain an identifier for the current stack trace.
-    ///
-    /// # Safety
-    ///
-    /// `bpf_get_stackid` is only available to tracing program types
-    /// (kprobe, tracepoint, `perf_event`, `raw_tracepoint`). Calling
-    /// it from any other program type fails verification.
-    #[inline(always)]
-    pub unsafe fn get_stackid<C: EbpfContext>(&self, ctx: &C, flags: u64) -> Result<c_long, i32> {
-        let () = Self::_CHECK;
-        // SAFETY: `ctx` and `self` are valid pointers managed by aya.
-        let ret = unsafe { bpf_get_stackid(ctx.as_ptr(), self.as_ptr(), flags) };
-        if ret < 0 { Err(ret as i32) } else { Ok(ret) }
-    }
 }
 
 impl<const MAX_ENTRIES: usize, const FLAGS: usize, const DEPTH: usize>

--- a/ebpf/aya-ebpf/src/btf_maps/stack_trace.rs
+++ b/ebpf/aya-ebpf/src/btf_maps/stack_trace.rs
@@ -77,3 +77,12 @@ impl<const MAX_ENTRIES: usize, const FLAGS: usize, const DEPTH: usize>
         if ret < 0 { Err(ret as i32) } else { Ok(ret) }
     }
 }
+
+impl<const MAX_ENTRIES: usize, const FLAGS: usize, const DEPTH: usize>
+    crate::programs::tracing::sealed::StackTraceMap for StackTrace<MAX_ENTRIES, FLAGS, DEPTH>
+{
+    fn as_ptr(&self) -> *mut core::ffi::c_void {
+        let () = Self::_CHECK;
+        self.as_ptr()
+    }
+}

--- a/ebpf/aya-ebpf/src/maps/stack_trace.rs
+++ b/ebpf/aya-ebpf/src/maps/stack_trace.rs
@@ -1,12 +1,7 @@
-use core::borrow::Borrow;
-
 use aya_ebpf_bindings::bindings::PERF_MAX_STACK_DEPTH;
 
 use crate::{
-    EbpfContext,
     bindings::bpf_map_type::BPF_MAP_TYPE_STACK_TRACE,
-    cty::c_long,
-    helpers::bpf_get_stackid,
     maps::{MapDef, PinningType},
 };
 
@@ -21,20 +16,6 @@ impl StackTrace {
         [u64; PERF_MAX_STACK_DEPTH as usize],
         BPF_MAP_TYPE_STACK_TRACE
     );
-
-    #[expect(
-        clippy::missing_safety_doc,
-        reason = "safety requirements come from the underlying helper"
-    )]
-    pub unsafe fn get_stackid<C: EbpfContext>(
-        &self,
-        ctx: impl Borrow<C>,
-        flags: u64,
-    ) -> Result<c_long, i32> {
-        let ret =
-            unsafe { bpf_get_stackid(ctx.borrow().as_ptr(), self.def.as_ptr().cast(), flags) };
-        if ret < 0 { Err(ret as i32) } else { Ok(ret) }
-    }
 }
 
 impl crate::programs::tracing::sealed::StackTraceMap for StackTrace {

--- a/ebpf/aya-ebpf/src/maps/stack_trace.rs
+++ b/ebpf/aya-ebpf/src/maps/stack_trace.rs
@@ -36,3 +36,9 @@ impl StackTrace {
         if ret < 0 { Err(ret as i32) } else { Ok(ret) }
     }
 }
+
+impl crate::programs::tracing::sealed::StackTraceMap for StackTrace {
+    fn as_ptr(&self) -> *mut core::ffi::c_void {
+        self.def.as_ptr().cast()
+    }
+}

--- a/ebpf/aya-ebpf/src/programs/mod.rs
+++ b/ebpf/aya-ebpf/src/programs/mod.rs
@@ -19,6 +19,7 @@ pub mod sysctl;
 pub mod tc;
 pub mod tp_btf;
 pub mod tracepoint;
+pub mod tracing;
 pub mod xdp;
 
 pub use device::DeviceContext;

--- a/ebpf/aya-ebpf/src/programs/tracing.rs
+++ b/ebpf/aya-ebpf/src/programs/tracing.rs
@@ -1,0 +1,58 @@
+use crate::{EbpfContext, cty::c_long, helpers::bpf_get_stackid};
+
+pub(crate) mod sealed {
+    #[expect(unnameable_types, reason = "this is the sealed trait pattern")]
+    pub trait StackIdContext: super::EbpfContext {}
+
+    #[expect(unnameable_types, reason = "this is the sealed trait pattern")]
+    pub trait StackTraceMap {
+        fn as_ptr(&self) -> *mut core::ffi::c_void;
+    }
+}
+
+/// Contexts from which [`bpf_get_stackid`] can be called.
+///
+/// The kernel verifier restricts `bpf_get_stackid` to program types whose
+/// `get_func_proto` callback returns `&bpf_get_stackid_proto`, either via a
+/// direct `BPF_FUNC_get_stackid` arm or via the `raw_tp_prog_func_proto`
+/// fallthrough chain. This trait is sealed and implemented only for the
+/// aya context types whose underlying `BPF_PROG_TYPE_*` is in that set.
+///
+/// [`bpf_get_stackid`]: crate::helpers::bpf_get_stackid
+pub trait StackIdContext: sealed::StackIdContext {
+    /// Obtain an identifier for the current stack trace.
+    fn get_stackid<M: StackTraceMap>(&self, map: &M, flags: u64) -> Result<c_long, i32> {
+        let ret = unsafe { bpf_get_stackid(self.as_ptr(), map.as_ptr(), flags) };
+        if ret < 0 { Err(ret as i32) } else { Ok(ret) }
+    }
+}
+
+impl<T: sealed::StackIdContext> StackIdContext for T {}
+
+/// Map types that [`StackIdContext::get_stackid`] can target.
+///
+/// This trait is sealed; aya implements it for both the legacy
+/// [`crate::maps::StackTrace`] and the BTF [`crate::btf_maps::StackTrace`].
+pub trait StackTraceMap: sealed::StackTraceMap {}
+
+impl<T: sealed::StackTraceMap> StackTraceMap for T {}
+
+macro_rules! impl_stack_id_context {
+    ($($ty:ty),+ $(,)?) => {
+        $(
+            impl sealed::StackIdContext for $ty {}
+        )+
+    };
+}
+
+impl_stack_id_context!(
+    crate::programs::probe::ProbeContext,
+    crate::programs::retprobe::RetProbeContext,
+    crate::programs::tracepoint::TracePointContext,
+    crate::programs::raw_tracepoint::RawTracePointContext,
+    crate::programs::tp_btf::BtfTracePointContext,
+    crate::programs::perf_event::PerfEventContext,
+    crate::programs::fentry::FEntryContext,
+    crate::programs::fexit::FExitContext,
+    crate::programs::lsm::LsmContext,
+);

--- a/test/integration-ebpf/Cargo.toml
+++ b/test/integration-ebpf/Cargo.toml
@@ -151,3 +151,7 @@ path = "src/prog_array.rs"
 [[bin]]
 name = "stack_trace"
 path = "src/stack_trace.rs"
+
+[[bin]]
+name = "stack_trace_lsm"
+path = "src/stack_trace_lsm.rs"

--- a/test/integration-ebpf/src/stack_trace.rs
+++ b/test/integration-ebpf/src/stack_trace.rs
@@ -11,7 +11,7 @@ use aya_ebpf::{
     cty::c_long,
     macros::{btf_map, map, uprobe},
     maps::{Array as LegacyArray, StackTrace as LegacyStackTrace},
-    programs::ProbeContext,
+    programs::{ProbeContext, tracing::StackIdContext as _},
 };
 use integration_common::stack_trace::TestResult;
 
@@ -31,8 +31,7 @@ macro_rules! define_stack_trace_test {
     ($map:ident, $result:ident, $probe:ident $(,)?) => {
         #[uprobe]
         fn $probe(ctx: ProbeContext) -> Result<(), c_long> {
-            let id =
-                unsafe { $map.get_stackid::<ProbeContext>(&ctx, u64::from(BPF_F_USER_STACK))? };
+            let id = ctx.get_stackid(&$map, u64::from(BPF_F_USER_STACK))?;
             let slot = $result.get_ptr_mut(0).ok_or(-1)?;
             unsafe {
                 *slot = TestResult {

--- a/test/integration-ebpf/src/stack_trace_lsm.rs
+++ b/test/integration-ebpf/src/stack_trace_lsm.rs
@@ -1,0 +1,63 @@
+#![no_std]
+#![no_main]
+#![expect(unused_crate_dependencies, reason = "used in other bins")]
+
+#[cfg(not(test))]
+extern crate ebpf_panic;
+
+use aya_ebpf::{
+    EbpfContext as _,
+    btf_maps::{Array as BtfArray, StackTrace as BtfStackTrace},
+    macros::{btf_map, lsm, map},
+    maps::{Array as LegacyArray, StackTrace as LegacyStackTrace},
+    programs::{LsmContext, tracing::StackIdContext as _},
+};
+use integration_common::stack_trace::TestResult;
+
+#[btf_map]
+static STACKS: BtfStackTrace<1> = BtfStackTrace::new();
+
+#[btf_map]
+static RESULT: BtfArray<TestResult, 1, 0> = BtfArray::new();
+
+#[map]
+static STACKS_LEGACY: LegacyStackTrace = LegacyStackTrace::with_max_entries(1, 0);
+
+#[map]
+static RESULT_LEGACY: LegacyArray<TestResult> = LegacyArray::with_max_entries(1, 0);
+
+// Userspace writes the test's tgid to index 0 so the probe only records stacks
+// for this process, avoiding cross-process contamination on busy hosts.
+#[map]
+static TARGET_TGID: LegacyArray<u32> = LegacyArray::with_max_entries(1, 0);
+
+macro_rules! define_lsm_stack_test {
+    ($stacks:ident, $result:ident, $probe:ident $(,)?) => {
+        #[lsm(hook = "socket_bind")]
+        fn $probe(ctx: LsmContext) -> i32 {
+            // `socket_bind(sock, addr, addrlen)` has 3 arguments; the prior LSM
+            // program's return value is exposed as a synthetic last argument.
+            let retval: i32 = ctx.arg(3);
+            let target = TARGET_TGID.get(0).copied().unwrap_or(0);
+            if target == 0 || ctx.tgid() != target {
+                return retval;
+            }
+            let Ok(id) = ctx.get_stackid(&$stacks, 0) else {
+                return retval;
+            };
+            let Some(slot) = $result.get_ptr_mut(0) else {
+                return retval;
+            };
+            unsafe {
+                *slot = TestResult {
+                    stack_id: id as u32,
+                    ran: true,
+                };
+            }
+            retval
+        }
+    };
+}
+
+define_lsm_stack_test!(STACKS, RESULT, record_stackid_lsm);
+define_lsm_stack_test!(STACKS_LEGACY, RESULT_LEGACY, record_stackid_lsm_legacy);

--- a/test/integration-test/src/lib.rs
+++ b/test/integration-test/src/lib.rs
@@ -71,6 +71,7 @@ bpf_file!(
     PRINTK_TEST => "printk_test",
     PROG_ARRAY => "prog_array",
     STACK_TRACE => "stack_trace",
+    STACK_TRACE_LSM => "stack_trace_lsm",
 );
 
 #[cfg(test)]

--- a/test/integration-test/src/tests.rs
+++ b/test/integration-test/src/tests.rs
@@ -38,6 +38,7 @@ mod sk_reuseport;
 mod sk_storage;
 mod smoke;
 mod stack_trace;
+mod stack_trace_lsm;
 mod strncmp;
 mod tcx;
 mod uprobe_cookie;

--- a/test/integration-test/src/tests/stack_trace_lsm.rs
+++ b/test/integration-test/src/tests/stack_trace_lsm.rs
@@ -1,0 +1,76 @@
+use assert_matches::assert_matches;
+use aya::{
+    Btf, Ebpf,
+    maps::{Array, MapType, StackTraceMap},
+    programs::{Lsm, LsmAttachType, ProgramError, ProgramType},
+    sys::{SyscallError, is_map_supported, is_program_supported},
+};
+use integration_common::stack_trace::TestResult;
+use test_case::test_case;
+
+#[test_case("STACKS_LEGACY", "RESULT_LEGACY", "record_stackid_lsm_legacy" ; "legacy")]
+#[test_case("STACKS", "RESULT", "record_stackid_lsm" ; "btf")]
+#[test_log::test]
+fn record_stackid_lsm(stacks_map: &str, result_map: &str, prog: &str) {
+    if !is_map_supported(MapType::StackTrace).unwrap() {
+        eprintln!("skipping test - stack trace map not supported");
+        return;
+    }
+
+    let btf = Btf::from_sys_fs().unwrap();
+    let mut bpf: Ebpf = Ebpf::load(crate::STACK_TRACE_LSM).unwrap();
+    {
+        let mut target_tgid: Array<_, u32> =
+            Array::try_from(bpf.map_mut("TARGET_TGID").unwrap()).unwrap();
+        target_tgid.set(0, std::process::id(), 0).unwrap();
+    }
+    let link_id = {
+        let lsm: &mut Lsm = bpf
+            .program_mut(prog)
+            .unwrap_or_else(|| panic!("missing program {prog}"))
+            .try_into()
+            .unwrap();
+        lsm.load("socket_bind", &btf).unwrap();
+        let result = lsm.attach();
+        if !is_program_supported(ProgramType::Lsm(LsmAttachType::Mac)).unwrap() {
+            assert_matches!(result, Err(ProgramError::SyscallError(SyscallError { call, io_error })) => {
+                assert_eq!(call, "bpf_raw_tracepoint_open");
+                assert_eq!(io_error.raw_os_error(), Some(524));
+            });
+            eprintln!("skipping test - LSM programs not supported");
+            return;
+        }
+        result.unwrap()
+    };
+
+    std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+
+    // The BPF LSM module is only active on kernels booted with `lsm=bpf`.
+    // Attach succeeds either way (`is_program_supported` only requires
+    // `CONFIG_BPF_LSM=y`), but the hook only fires when the module is live.
+    if !std::fs::read_to_string("/sys/kernel/security/lsm")
+        .unwrap()
+        .contains("bpf")
+    {
+        eprintln!("skipping runtime assertions - BPF LSM not active");
+        return;
+    }
+
+    let result = Array::<_, TestResult>::try_from(bpf.map(result_map).unwrap()).unwrap();
+    let TestResult { stack_id, ran } = result.get(&0, 0).unwrap();
+    assert!(ran, "LSM probe {prog} did not run");
+
+    let stacks = StackTraceMap::try_from(bpf.map(stacks_map).unwrap()).unwrap();
+    let trace = stacks
+        .get(&stack_id, 0)
+        .expect("stack_id not found in stack trace map");
+    let frames = trace.frames();
+    assert!(
+        frames.iter().any(|f| f.ip != 0),
+        "stack trace for stack_id {stack_id} has no non-zero IP frame; got {} frames",
+        frames.len(),
+    );
+
+    let lsm: &mut Lsm = bpf.program_mut(prog).unwrap().try_into().unwrap();
+    lsm.detach(link_id).unwrap();
+}

--- a/xtask/public-api/aya-ebpf.txt
+++ b/xtask/public-api/aya-ebpf.txt
@@ -1549,6 +1549,13 @@ impl core::marker::Unpin for aya_ebpf::programs::tracepoint::TracePointContext
 impl core::marker::UnsafeUnpin for aya_ebpf::programs::tracepoint::TracePointContext
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::programs::tracepoint::TracePointContext
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf::programs::tracepoint::TracePointContext
+pub mod aya_ebpf::programs::tracing
+pub trait aya_ebpf::programs::tracing::StackIdContext: aya_ebpf::programs::tracing::sealed::StackIdContext
+pub fn aya_ebpf::programs::tracing::StackIdContext::get_stackid<M: aya_ebpf::programs::tracing::StackTraceMap>(&self, map: &M, flags: u64) -> core::result::Result<aya_ebpf_cty::od::c_long, i32>
+impl<T: aya_ebpf::programs::tracing::sealed::StackIdContext> aya_ebpf::programs::tracing::StackIdContext for T
+pub fn T::get_stackid<M: aya_ebpf::programs::tracing::StackTraceMap>(&self, map: &M, flags: u64) -> core::result::Result<aya_ebpf_cty::od::c_long, i32>
+pub trait aya_ebpf::programs::tracing::StackTraceMap: aya_ebpf::programs::tracing::sealed::StackTraceMap
+impl<T: aya_ebpf::programs::tracing::sealed::StackTraceMap> aya_ebpf::programs::tracing::StackTraceMap for T
 pub mod aya_ebpf::programs::xdp
 pub struct aya_ebpf::programs::xdp::XdpContext
 pub aya_ebpf::programs::xdp::XdpContext::ctx: *mut aya_ebpf_bindings::x86_64::bindings::xdp_md

--- a/xtask/public-api/aya-ebpf.txt
+++ b/xtask/public-api/aya-ebpf.txt
@@ -188,8 +188,6 @@ impl<T> core::panic::unwind_safe::UnwindSafe for aya_ebpf::btf_maps::sk_storage:
 pub mod aya_ebpf::btf_maps::stack_trace
 #[repr(C)] pub struct aya_ebpf::btf_maps::stack_trace::StackTrace<const MAX_ENTRIES: usize, const FLAGS: usize, const DEPTH: usize>
 impl<const MAX_ENTRIES: usize, const FLAGS: usize, const DEPTH: usize> aya_ebpf::btf_maps::stack_trace::StackTrace<MAX_ENTRIES, FLAGS, DEPTH>
-pub unsafe fn aya_ebpf::btf_maps::stack_trace::StackTrace<MAX_ENTRIES, FLAGS, DEPTH>::get_stackid<C: aya_ebpf::EbpfContext>(&self, ctx: &C, flags: u64) -> core::result::Result<aya_ebpf_cty::od::c_long, i32>
-impl<const MAX_ENTRIES: usize, const FLAGS: usize, const DEPTH: usize> aya_ebpf::btf_maps::stack_trace::StackTrace<MAX_ENTRIES, FLAGS, DEPTH>
 pub const fn aya_ebpf::btf_maps::stack_trace::StackTrace<MAX_ENTRIES, FLAGS, DEPTH>::new() -> Self
 impl<const MAX_ENTRIES: usize, const FLAGS: usize, const DEPTH: usize> core::default::Default for aya_ebpf::btf_maps::stack_trace::StackTrace<MAX_ENTRIES, FLAGS, DEPTH>
 pub fn aya_ebpf::btf_maps::stack_trace::StackTrace<MAX_ENTRIES, FLAGS, DEPTH>::default() -> Self
@@ -344,8 +342,6 @@ impl<T> core::marker::UnsafeUnpin for aya_ebpf::btf_maps::sk_storage::SkStorage<
 impl<T> core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::btf_maps::sk_storage::SkStorage<T> where T: core::panic::unwind_safe::RefUnwindSafe
 impl<T> core::panic::unwind_safe::UnwindSafe for aya_ebpf::btf_maps::sk_storage::SkStorage<T> where T: core::panic::unwind_safe::RefUnwindSafe
 #[repr(C)] pub struct aya_ebpf::btf_maps::StackTrace<const MAX_ENTRIES: usize, const FLAGS: usize, const DEPTH: usize>
-impl<const MAX_ENTRIES: usize, const FLAGS: usize, const DEPTH: usize> aya_ebpf::btf_maps::stack_trace::StackTrace<MAX_ENTRIES, FLAGS, DEPTH>
-pub unsafe fn aya_ebpf::btf_maps::stack_trace::StackTrace<MAX_ENTRIES, FLAGS, DEPTH>::get_stackid<C: aya_ebpf::EbpfContext>(&self, ctx: &C, flags: u64) -> core::result::Result<aya_ebpf_cty::od::c_long, i32>
 impl<const MAX_ENTRIES: usize, const FLAGS: usize, const DEPTH: usize> aya_ebpf::btf_maps::stack_trace::StackTrace<MAX_ENTRIES, FLAGS, DEPTH>
 pub const fn aya_ebpf::btf_maps::stack_trace::StackTrace<MAX_ENTRIES, FLAGS, DEPTH>::new() -> Self
 impl<const MAX_ENTRIES: usize, const FLAGS: usize, const DEPTH: usize> core::default::Default for aya_ebpf::btf_maps::stack_trace::StackTrace<MAX_ENTRIES, FLAGS, DEPTH>
@@ -683,7 +679,6 @@ impl<T> core::panic::unwind_safe::UnwindSafe for aya_ebpf::maps::stack::Stack<T>
 pub mod aya_ebpf::maps::stack_trace
 #[repr(transparent)] pub struct aya_ebpf::maps::stack_trace::StackTrace
 impl aya_ebpf::maps::stack_trace::StackTrace
-pub unsafe fn aya_ebpf::maps::stack_trace::StackTrace::get_stackid<C: aya_ebpf::EbpfContext>(&self, ctx: impl core::borrow::Borrow<C>, flags: u64) -> core::result::Result<aya_ebpf_cty::od::c_long, i32>
 pub const fn aya_ebpf::maps::stack_trace::StackTrace::pinned(max_entries: u32, flags: u32) -> Self
 pub const fn aya_ebpf::maps::stack_trace::StackTrace::with_max_entries(max_entries: u32, flags: u32) -> Self
 impl !core::marker::Freeze for aya_ebpf::maps::stack_trace::StackTrace
@@ -1029,7 +1024,6 @@ impl<T> !core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::maps::stack::Stac
 impl<T> core::panic::unwind_safe::UnwindSafe for aya_ebpf::maps::stack::Stack<T> where T: core::panic::unwind_safe::UnwindSafe
 #[repr(transparent)] pub struct aya_ebpf::maps::StackTrace
 impl aya_ebpf::maps::stack_trace::StackTrace
-pub unsafe fn aya_ebpf::maps::stack_trace::StackTrace::get_stackid<C: aya_ebpf::EbpfContext>(&self, ctx: impl core::borrow::Borrow<C>, flags: u64) -> core::result::Result<aya_ebpf_cty::od::c_long, i32>
 pub const fn aya_ebpf::maps::stack_trace::StackTrace::pinned(max_entries: u32, flags: u32) -> Self
 pub const fn aya_ebpf::maps::stack_trace::StackTrace::with_max_entries(max_entries: u32, flags: u32) -> Self
 impl !core::marker::Freeze for aya_ebpf::maps::stack_trace::StackTrace

--- a/xtask/src/run.rs
+++ b/xtask/src/run.rs
@@ -822,6 +822,11 @@ pub(crate) fn run(opts: Options, workspace_root: &Path) -> Result<()> {
                 //
                 // Heed the advice and boot with noapic. We don't know why this happens.
                 kernel_args.push(" noapic");
+                // Activate BPF LSM so `#[lsm]` programs actually run their hooks.
+                // Without this, `CONFIG_BPF_LSM=y` kernels still leave `bpf`
+                // out of `/sys/kernel/security/lsm` and LSM tests exercise
+                // only load/attach, missing runtime regressions.
+                kernel_args.push(" lsm=bpf");
                 qemu.args(["-no-reboot", "-nographic", "-m", "1024M", "-smp", "2"])
                     .arg("-append")
                     .arg(kernel_args)


### PR DESCRIPTION
Introduces a sealed `StackIdContext` trait that gates `bpf_get_stackid`
at compile time to the aya context types whose kernel program type
reaches the helper in v6.17 (kprobe, tracepoint, perf_event,
raw_tracepoint, tracing, lsm). Callers move from
`StackTrace::get_stackid` to `ctx.get_stackid(&map, flags)`.
Follow-up to #1542.

A preparatory commit adds the trait and crate-private map impls
without touching the existing methods, so the new API is usable on
its own.

A second commit deletes the legacy and BTF `get_stackid` methods and
migrates the integration-test macro to the context-method API.

A third commit adds `lsm=bpf` to the integration-test VM kernel
command line so `#[lsm]` programs actually run their hooks in CI.

A final commit adds `#[lsm(hook = "socket_bind")]` probes calling
`StackIdContext::get_stackid` against both the legacy and BTF
`StackTrace` maps, plus a `#[test_case]`-parametrized integration
test that validates the `bpf_lsm_func_proto` fallthrough chain. The
probes filter on the test's tgid and return the prior LSM program's
`retval` unchanged.

### Added/updated tests?

- [x] Yes

### Checklist

- [x] Rust code has been formatted with `cargo +nightly fmt`.
- [x] All clippy lints have been fixed.
      You can find failing lints with `cargo xtask clippy`.
- [x] Unit tests are passing locally with `cargo test`.
- [x] The integration tests are passing locally.
- [x] I have blessed any API changes with `cargo xtask public-api --bless`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aya-rs/aya/1549)
<!-- Reviewable:end -->
