### PR TITLE
aya: add support for netkit attachments

### DIFF
--- a/aya/src/programs/links.rs
+++ b/aya/src/programs/links.rs
@@ -648,12 +648,17 @@ bitflags::bitflags! {
 ///
 /// ```no_run
 /// # let mut bpf = aya::Ebpf::load(&[])?;
-/// use aya::programs::{tc, SchedClassifier, TcAttachType, tc::TcAttachOptions, LinkOrder};
+/// use aya::programs::{LinkOrder, SchedClassifier, SchedClassifierAttachment, TcxAttachType};
 ///
 /// let prog: &mut SchedClassifier = bpf.program_mut("redirect_ingress").unwrap().try_into()?;
 /// prog.load()?;
-/// let options = TcAttachOptions::TcxOrder(LinkOrder::first());
-/// prog.attach_with_options("eth0", TcAttachType::Ingress, options)?;
+/// prog.attach(
+///     "eth0",
+///     SchedClassifierAttachment::Tcx {
+///         attach_type: TcxAttachType::Ingress,
+///         link_order: LinkOrder::first(),
+///     },
+/// )?;
 ///
 /// # Ok::<(), aya::EbpfError>(())
 /// ```

--- a/aya/src/programs/links.rs
+++ b/aya/src/programs/links.rs
@@ -656,12 +656,17 @@ bitflags::bitflags! {
 ///
 /// ```no_run
 /// # let mut bpf = aya::Ebpf::load(&[])?;
-/// use aya::programs::{tc, SchedClassifier, TcAttachType, tc::TcAttachOptions, LinkOrder};
+/// use aya::programs::{LinkOrder, SchedClassifier, SchedClassifierAttachment, TcxAttachType};
 ///
 /// let prog: &mut SchedClassifier = bpf.program_mut("redirect_ingress").unwrap().try_into()?;
 /// prog.load()?;
-/// let options = TcAttachOptions::TcxOrder(LinkOrder::first());
-/// prog.attach_with_options("eth0", TcAttachType::Ingress, options)?;
+/// prog.attach(
+///     "eth0",
+///     SchedClassifierAttachment::Tcx {
+///         attach_type: TcxAttachType::Ingress,
+///         link_order: LinkOrder::first(),
+///     },
+/// )?;
 ///
 /// # Ok::<(), aya::EbpfError>(())
 /// ```

--- a/aya/src/programs/mod.rs
+++ b/aya/src/programs/mod.rs
@@ -133,7 +133,10 @@ pub use crate::programs::{
     sk_skb::{SkSkb, SkSkbKind},
     sock_ops::SockOps,
     socket_filter::{ReusePortSocketFilter, SocketFilter, SocketFilterError},
-    tc::{SchedClassifier, TcAttachType, TcError, TcHandle},
+    tc::{
+        NetkitAttachType, SchedClassifier, SchedClassifierAttachment, TcAttachType, TcError,
+        TcHandle, TcxAttachType,
+    },
     tp_btf::BtfTracePoint,
     trace_point::{TracePoint, TracePointError},
     uprobe::{UProbe, UProbeError},

--- a/aya/src/programs/mod.rs
+++ b/aya/src/programs/mod.rs
@@ -122,7 +122,10 @@ pub use crate::programs::{
     sk_skb::{SkSkb, SkSkbKind},
     sock_ops::SockOps,
     socket_filter::{ReusePortSocketFilter, SocketFilter, SocketFilterError},
-    tc::{SchedClassifier, TcAttachType, TcError, TcHandle},
+    tc::{
+        NetkitAttachType, SchedClassifier, SchedClassifierAttachment, TcAttachType, TcError,
+        TcHandle, TcxAttachType,
+    },
     tp_btf::BtfTracePoint,
     trace_point::{TracePoint, TracePointError},
     uprobe::{UProbe, UProbeError},

--- a/aya/src/programs/tc.rs
+++ b/aya/src/programs/tc.rs
@@ -3,7 +3,7 @@ use std::{ffi::CString, io, os::fd::AsFd as _, path::Path};
 
 use aya_obj::generated::{
     TC_H_CLSACT, TC_H_MIN_EGRESS, TC_H_MIN_INGRESS,
-    bpf_attach_type::{self, BPF_TCX_EGRESS, BPF_TCX_INGRESS},
+    bpf_attach_type::{self, BPF_NETKIT_PEER, BPF_NETKIT_PRIMARY, BPF_TCX_EGRESS, BPF_TCX_INGRESS},
     bpf_link_type,
     bpf_prog_type::BPF_PROG_TYPE_SCHED_CLS,
 };
@@ -14,18 +14,42 @@ use crate::{
     VerifierLogLevel,
     programs::{
         Link, LinkError, LinkOrder, ProgramData, ProgramError, ProgramType, define_link_wrapper,
-        id_as_key, impl_try_from_fdlink, impl_try_into_fdlink, load_program_without_attach_type,
-        query,
+        id_as_key, impl_try_into_fdlink, load_program_without_attach_type, query,
     },
     sys::{
         BpfLinkCreateArgs, LinkTarget, NetlinkError, NetlinkSocket, ProgQueryTarget, SyscallError,
         bpf_link_create, bpf_link_update, bpf_prog_get_fd_by_id, netlink_find_filter_with_name,
         netlink_qdisc_add_clsact, netlink_qdisc_attach, netlink_qdisc_detach,
     },
-    util::{KernelVersion, ifindex_from_ifname, tc_handler_make},
+    util::{ifindex_from_ifname, tc_handler_make},
 };
 
-/// Traffic control attach type.
+/// Attachment configuration for [`SchedClassifier`] programs.
+pub enum SchedClassifierAttachment {
+    /// Attach as a legacy TC filter using netlink.
+    Tc {
+        /// The legacy TC hook to attach to.
+        attach_type: TcAttachType,
+        /// Netlink attach options.
+        options: NlOptions,
+    },
+    /// Attach to TCX using the eBPF link interface.
+    Tcx {
+        /// The TCX hook to attach to.
+        attach_type: TcxAttachType,
+        /// Multi-prog link ordering.
+        link_order: LinkOrder,
+    },
+    /// Attach to a Netkit device using the eBPF link interface.
+    Netkit {
+        /// The Netkit hook to attach to.
+        attach_type: NetkitAttachType,
+        /// Multi-prog link ordering.
+        link_order: LinkOrder,
+    },
+}
+
+/// Traffic control attach type using netlink.
 #[derive(Debug, Clone, Copy, Hash, Eq, PartialEq)]
 pub enum TcAttachType {
     /// Attach to ingress.
@@ -34,6 +58,45 @@ pub enum TcAttachType {
     Egress,
     /// Attach to custom parent.
     Custom(u32),
+}
+
+/// Traffic control attach type using eBPF link interface.
+/// Requires kernels >= 6.6.0.
+#[derive(Debug, Clone, Copy, Hash, Eq, PartialEq)]
+pub enum TcxAttachType {
+    /// Attach to ingress.
+    Ingress,
+    /// Attach to egress.
+    Egress,
+}
+
+impl TcxAttachType {
+    pub(crate) const fn bpf_attach_type(self) -> bpf_attach_type {
+        match self {
+            Self::Ingress => BPF_TCX_INGRESS,
+            Self::Egress => BPF_TCX_EGRESS,
+        }
+    }
+}
+
+/// Netkit attach type using eBPF link interface.
+/// Requires kernels >= 6.7.0.
+/// Can only be attached to netkit devices.
+#[derive(Debug, Clone, Copy, Hash, Eq, PartialEq)]
+pub enum NetkitAttachType {
+    /// Attach to primary.
+    Primary,
+    /// Attach to peer.
+    Peer,
+}
+
+impl NetkitAttachType {
+    pub(crate) const fn bpf_attach_type(self) -> bpf_attach_type {
+        match self {
+            Self::Primary => BPF_NETKIT_PRIMARY,
+            Self::Peer => BPF_NETKIT_PEER,
+        }
+    }
 }
 
 /// A network traffic control classifier.
@@ -47,7 +110,13 @@ pub enum TcAttachType {
 ///
 /// # Minimum kernel version
 ///
-/// The minimum kernel version required to use this feature is 4.1.
+/// Legacy TC attachments require kernel 4.1 or later. TCX attachments require
+/// kernel 6.6 or later. Netkit attachments require kernel 6.7 or later and a
+/// netkit device.
+///
+/// # Legacy TC attachment
+///
+/// Legacy TC attachments use netlink and require the `clsact` qdisc.
 ///
 /// ```no_run
 /// # #[derive(Debug, thiserror::Error)]
@@ -64,15 +133,100 @@ pub enum TcAttachType {
 /// #     Ebpf(#[from] aya::EbpfError)
 /// # }
 /// # let mut bpf = aya::Ebpf::load(&[])?;
-/// use aya::programs::{tc, SchedClassifier, TcAttachType};
+/// use aya::programs::{tc::{self, NlOptions}, SchedClassifier, SchedClassifierAttachment, TcAttachType};
 ///
 /// // the clsact qdisc needs to be added before SchedClassifier programs can be
-/// // attached
+/// // attached with legacy TC
 /// tc::qdisc_add_clsact("eth0")?;
 ///
 /// let prog: &mut SchedClassifier = bpf.program_mut("redirect_ingress").unwrap().try_into()?;
 /// prog.load()?;
-/// prog.attach("eth0", TcAttachType::Ingress)?;
+/// prog.attach(
+///     "eth0",
+///     SchedClassifierAttachment::Tc {
+///         attach_type: TcAttachType::Ingress,
+///         options: NlOptions::default(),
+///     },
+/// )?;
+///
+/// # Ok::<(), Error>(())
+/// ```
+///
+/// # TCX attachment
+///
+/// TCX attachments use eBPF links and support multi-prog ordering.
+///
+/// ```no_run
+/// # #[derive(Debug, thiserror::Error)]
+/// # enum Error {
+/// #     #[error(transparent)]
+/// #     IO(#[from] std::io::Error),
+/// #     #[error(transparent)]
+/// #     Map(#[from] aya::maps::MapError),
+/// #     #[error(transparent)]
+/// #     Program(#[from] aya::programs::ProgramError),
+/// #     #[error(transparent)]
+/// #     Tc(#[from] aya::programs::tc::TcError),
+/// #     #[error(transparent)]
+/// #     Ebpf(#[from] aya::EbpfError)
+/// # }
+/// # let mut bpf = aya::Ebpf::load(&[])?;
+/// use aya::programs::{LinkOrder, SchedClassifier, SchedClassifierAttachment, TcxAttachType};
+///
+/// let prog: &mut SchedClassifier = bpf.program_mut("redirect_ingress").unwrap().try_into()?;
+/// prog.load()?;
+/// prog.attach(
+///     "eth0",
+///     SchedClassifierAttachment::Tcx {
+///         attach_type: TcxAttachType::Ingress,
+///         link_order: LinkOrder::default(),
+///     },
+/// )?;
+///
+/// # Ok::<(), Error>(())
+/// ```
+///
+/// # Netkit attachment
+///
+/// Netkit attachments use eBPF links and support multi-prog ordering. The
+/// interface must be a netkit device.
+///
+/// ```no_run
+/// # #[derive(Debug, thiserror::Error)]
+/// # enum Error {
+/// #     #[error(transparent)]
+/// #     IO(#[from] std::io::Error),
+/// #     #[error(transparent)]
+/// #     Map(#[from] aya::maps::MapError),
+/// #     #[error(transparent)]
+/// #     Program(#[from] aya::programs::ProgramError),
+/// #     #[error(transparent)]
+/// #     Tc(#[from] aya::programs::tc::TcError),
+/// #     #[error(transparent)]
+/// #     Ebpf(#[from] aya::EbpfError)
+/// # }
+/// # let mut bpf = aya::Ebpf::load(&[])?;
+/// use aya::programs::{LinkOrder, NetkitAttachType, SchedClassifier, SchedClassifierAttachment};
+///
+/// let primary_prog: &mut SchedClassifier = bpf.program_mut("primary").unwrap().try_into()?;
+/// primary_prog.load()?;
+/// primary_prog.attach(
+///     "nk0",
+///     SchedClassifierAttachment::Netkit {
+///         attach_type: NetkitAttachType::Primary,
+///         link_order: LinkOrder::default(),
+///     },
+/// )?;
+/// let peer_prog: &mut SchedClassifier = bpf.program_mut("peer").unwrap().try_into()?;
+/// peer_prog.load()?;
+/// // Peer attachment still occurs on the primary interface
+/// peer_prog.attach(
+///     "nk0",
+///     SchedClassifierAttachment::Netkit {
+///         attach_type: NetkitAttachType::Peer,
+///         link_order: LinkOrder::default(),
+///     },
+/// )?;
 ///
 /// # Ok::<(), Error>(())
 /// ```
@@ -97,13 +251,8 @@ pub enum TcError {
     /// the clsact qdisc is already attached.
     #[error("the clsact qdisc is already attached")]
     AlreadyAttached,
-    /// tcx links can only be attached to ingress or egress, custom attachment is not supported.
-    #[error(
-        "tcx links can only be attached to ingress or egress, custom attachment: {0} is not supported"
-    )]
-    InvalidTcxAttach(u32),
-    /// operation not supported for programs loaded via tcx.
-    #[error("operation not supported for programs loaded via tcx")]
+    /// operation not supported for programs loaded via tcx or netkit.
+    #[error("operation not supported for fd-backed TC links")]
     InvalidLinkOperation,
 }
 
@@ -115,28 +264,6 @@ impl TcAttachType {
             Self::Egress => tc_handler_make(TC_H_CLSACT, TC_H_MIN_EGRESS),
         }
     }
-
-    pub(crate) const fn tcx_attach_type(self) -> Result<bpf_attach_type, TcError> {
-        match self {
-            Self::Ingress => Ok(BPF_TCX_INGRESS),
-            Self::Egress => Ok(BPF_TCX_EGRESS),
-            Self::Custom(tcx_attach_type) => Err(TcError::InvalidTcxAttach(tcx_attach_type)),
-        }
-    }
-}
-
-/// Options for a [`SchedClassifier`] attach operation.
-///
-/// The options vary based on what is supported by the current kernel. Kernels
-/// older than 6.6.0 must utilize netlink for attachments, while newer kernels
-/// can utilize the modern TCX eBPF link type which supports the kernel's
-/// multi-prog API.
-#[derive(Debug)]
-pub enum TcAttachOptions {
-    /// Netlink attach options.
-    Netlink(NlOptions),
-    /// Tcx attach options.
-    TcxOrder(LinkOrder),
 }
 
 /// A TC filter handle in `major:minor` form.
@@ -217,11 +344,7 @@ impl SchedClassifier {
 
     /// Attaches the program to the given `interface`.
     ///
-    /// On kernels >= 6.6.0, it will attempt to use the TCX interface and attach as
-    /// the last TCX program. On older kernels, it will fallback to using the
-    /// legacy netlink interface.
-    ///
-    /// For finer grained control over link ordering use [`SchedClassifier::attach_with_options`].
+    /// TCX requires kernels >= 6.6.0 and netkit requires kernels >= 6.7.0.
     ///
     /// The returned value can be used to detach, see [`SchedClassifier::detach`].
     ///
@@ -235,84 +358,33 @@ impl SchedClassifier {
     pub fn attach(
         &mut self,
         interface: &str,
-        attach_type: TcAttachType,
-    ) -> Result<SchedClassifierLinkId, ProgramError> {
-        if !matches!(attach_type, TcAttachType::Custom(_)) && KernelVersion::at_least(6, 6, 0) {
-            self.attach_with_options(
-                interface,
-                attach_type,
-                TcAttachOptions::TcxOrder(LinkOrder::default()),
-            )
-        } else {
-            self.attach_with_options(
-                interface,
-                attach_type,
-                TcAttachOptions::Netlink(NlOptions::default()),
-            )
-        }
-    }
-
-    /// Attaches the program to the given `interface` with options defined in [`TcAttachOptions`].
-    ///
-    /// The returned value can be used to detach, see [`SchedClassifier::detach`].
-    ///
-    /// # Link Pinning (TCX mode, kernel >= 6.6)
-    ///
-    /// Links can be pinned to bpffs for atomic replacement across process restarts.
-    ///
-    /// ```no_run
-    /// # use std::{io, path::Path};
-    ///
-    /// # use aya::{
-    /// #     programs::{
-    /// #         LinkOrder, SchedClassifier, TcAttachType,
-    /// #         links::{FdLink, LinkError, PinnedLink},
-    /// #         tc::TcAttachOptions,
-    /// #     },
-    /// #     sys::SyscallError,
-    /// # };
-    ///
-    /// # let mut bpf = aya::Ebpf::load(&[])?;
-    /// # let prog: &mut SchedClassifier = bpf.program_mut("prog").unwrap().try_into()?;
-    /// # prog.load()?;
-    /// let pin_path = "/sys/fs/bpf/my_link";
-    ///
-    /// let link_id = match PinnedLink::from_pin(pin_path) {
-    ///     Ok(old) => {
-    ///         let link = FdLink::from(old).try_into()?;
-    ///         prog.attach_to_link(link)?
-    ///     }
-    ///     Err(LinkError::SyscallError(SyscallError { io_error, .. }))
-    ///         if io_error.kind() == io::ErrorKind::NotFound =>
-    ///     {
-    ///         prog.attach_with_options(
-    ///             "eth0",
-    ///             TcAttachType::Ingress,
-    ///             TcAttachOptions::TcxOrder(LinkOrder::default()),
-    ///         )?
-    ///     }
-    ///     Err(e) => return Err(e.into()),
-    /// };
-    ///
-    /// let link = prog.take_link(link_id)?;
-    /// let fd_link: FdLink = link.try_into()?;
-    /// fd_link.pin(pin_path)?;
-    /// # Ok::<(), Box<dyn std::error::Error>>(())
-    /// ```
-    ///
-    /// # Errors
-    ///
-    /// [`TcError::NetlinkError`] is returned if attaching fails. A common cause
-    /// of failure is not having added the `clsact` qdisc to the given
-    /// interface, see [`qdisc_add_clsact`].
-    pub fn attach_with_options(
-        &mut self,
-        interface: &str,
-        attach_type: TcAttachType,
-        options: TcAttachOptions,
+        attachment: SchedClassifierAttachment,
     ) -> Result<SchedClassifierLinkId, ProgramError> {
         let if_index = ifindex_from_ifname(interface).map_err(TcError::IoError)?;
-        self.do_attach(if_index, attach_type, options, true)
+        match attachment {
+            SchedClassifierAttachment::Tc {
+                attach_type,
+                options,
+            } => self.do_netlink_attach(if_index, attach_type, options, true),
+            SchedClassifierAttachment::Tcx {
+                attach_type,
+                link_order,
+            } => self.do_bpf_link_attach(
+                if_index,
+                attach_type.bpf_attach_type(),
+                &link_order,
+                Some(BpfLinkCreateArgs::Tcx(&link_order.link_ref)),
+            ),
+            SchedClassifierAttachment::Netkit {
+                attach_type,
+                link_order,
+            } => self.do_bpf_link_attach(
+                if_index,
+                attach_type.bpf_attach_type(),
+                &link_order,
+                Some(BpfLinkCreateArgs::Netkit(&link_order.link_ref)),
+            ),
+        }
     }
 
     /// Atomically replaces the program referenced by the provided link.
@@ -346,78 +418,84 @@ impl SchedClassifier {
                 priority,
                 handle,
                 classid,
-            }) => self.do_attach(
+            }) => self.do_netlink_attach(
                 if_index,
                 attach_type,
-                TcAttachOptions::Netlink(NlOptions {
+                NlOptions {
                     priority,
                     handle,
                     classid,
-                }),
+                },
                 false,
             ),
         }
     }
 
-    fn do_attach(
+    fn do_bpf_link_attach(
+        &mut self,
+        if_index: u32,
+        attach_type: bpf_attach_type,
+        link_order: &LinkOrder,
+        bpf_link_create_args: Option<BpfLinkCreateArgs<'_>>,
+    ) -> Result<SchedClassifierLinkId, ProgramError> {
+        let prog_fd = self.fd()?;
+        let prog_fd = prog_fd.as_fd();
+
+        let link_fd = bpf_link_create(
+            prog_fd,
+            LinkTarget::IfIndex(if_index),
+            attach_type,
+            link_order.flags.bits(),
+            bpf_link_create_args,
+        )
+        .map_err(|io_error| SyscallError {
+            call: "bpf_mprog_attach",
+            io_error,
+        })?;
+
+        self.data
+            .links
+            .insert(SchedClassifierLink::new(TcLinkInner::Fd(FdLink::new(
+                link_fd,
+            ))))
+    }
+
+    fn do_netlink_attach(
         &mut self,
         if_index: u32,
         attach_type: TcAttachType,
-        options: TcAttachOptions,
+        options: NlOptions,
         create: bool,
     ) -> Result<SchedClassifierLinkId, ProgramError> {
         let prog_fd = self.fd()?;
         let prog_fd = prog_fd.as_fd();
 
-        match options {
-            TcAttachOptions::Netlink(options) => {
-                let name = self.data.name.as_deref().unwrap_or_default();
-                // TODO: avoid this unwrap by adding a new error variant.
-                let name = CString::new(name).unwrap();
-                let (priority, handle) = unsafe {
-                    netlink_qdisc_attach(
-                        if_index as i32,
-                        &attach_type,
-                        prog_fd,
-                        &name,
-                        options.priority,
-                        options.handle,
-                        options.classid,
-                        create,
-                    )
-                }
-                .map_err(TcError::NetlinkError)?;
-
-                self.data
-                    .links
-                    .insert(SchedClassifierLink::new(TcLinkInner::NlLink(NlLink {
-                        if_index,
-                        attach_type,
-                        priority,
-                        handle,
-                        classid: options.classid,
-                    })))
-            }
-            TcAttachOptions::TcxOrder(options) => {
-                let link_fd = bpf_link_create(
-                    prog_fd,
-                    LinkTarget::IfIndex(if_index),
-                    attach_type.tcx_attach_type()?,
-                    options.flags.bits(),
-                    Some(BpfLinkCreateArgs::Tcx(&options.link_ref)),
-                )
-                .map_err(|io_error| SyscallError {
-                    call: "bpf_mprog_attach",
-                    io_error,
-                })?;
-
-                self.data
-                    .links
-                    .insert(SchedClassifierLink::new(TcLinkInner::Fd(FdLink::new(
-                        link_fd,
-                    ))))
-            }
+        let name = self.data.name.as_deref().unwrap_or_default();
+        // TODO: avoid this unwrap by adding a new error variant.
+        let name = CString::new(name).unwrap();
+        let (priority, handle) = unsafe {
+            netlink_qdisc_attach(
+                if_index as i32,
+                &attach_type,
+                prog_fd,
+                &name,
+                options.priority,
+                options.handle,
+                options.classid,
+                create,
+            )
         }
+        .map_err(TcError::NetlinkError)?;
+
+        self.data
+            .links
+            .insert(SchedClassifierLink::new(TcLinkInner::NlLink(NlLink {
+                if_index,
+                attach_type,
+                priority,
+                handle,
+                classid: options.classid,
+            })))
     }
 
     /// Creates a program from a pinned entry on a bpffs.
@@ -436,24 +514,52 @@ impl SchedClassifier {
     /// # Example
     ///
     /// ```no_run
-    /// # use aya::programs::tc::{TcAttachType, SchedClassifier};
+    /// # use aya::programs::tc::{TcxAttachType, SchedClassifier};
     /// # #[derive(Debug, thiserror::Error)]
     /// # enum Error {
     /// #     #[error(transparent)]
     /// #     Program(#[from] aya::programs::ProgramError),
     /// # }
-    /// let (revision, programs) = SchedClassifier::query_tcx("eth0", TcAttachType::Ingress)?;
+    /// let (revision, programs) = SchedClassifier::query_tcx("eth0", TcxAttachType::Ingress)?;
     /// # Ok::<(), Error>(())
     /// ```
     pub fn query_tcx(
         interface: &str,
-        attach_type: TcAttachType,
+        attach_type: TcxAttachType,
+    ) -> Result<(u64, Vec<ProgramInfo>), ProgramError> {
+        Self::query_bpf_links(interface, attach_type.bpf_attach_type())
+    }
+
+    /// Queries a given interface for attached Netkit programs.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// # use aya::programs::tc::{NetkitAttachType, SchedClassifier};
+    /// # #[derive(Debug, thiserror::Error)]
+    /// # enum Error {
+    /// #     #[error(transparent)]
+    /// #     Program(#[from] aya::programs::ProgramError),
+    /// # }
+    /// let (revision, programs) = SchedClassifier::query_netkit("nk0", NetkitAttachType::Primary)?;
+    /// # Ok::<(), Error>(())
+    /// ```
+    pub fn query_netkit(
+        interface: &str,
+        attach_type: NetkitAttachType,
+    ) -> Result<(u64, Vec<ProgramInfo>), ProgramError> {
+        Self::query_bpf_links(interface, attach_type.bpf_attach_type())
+    }
+
+    fn query_bpf_links(
+        interface: &str,
+        attach_type: bpf_attach_type,
     ) -> Result<(u64, Vec<ProgramInfo>), ProgramError> {
         let if_index = ifindex_from_ifname(interface).map_err(TcError::IoError)?;
 
         let (revision, prog_ids) = query(
             ProgQueryTarget::IfIndex(if_index),
-            attach_type.tcx_attach_type()?,
+            attach_type,
             0,
             &mut None,
         )?;
@@ -551,11 +657,24 @@ impl<'a> TryFrom<&'a SchedClassifierLink> for &'a FdLink {
 }
 
 impl_try_into_fdlink!(SchedClassifierLink, TcLinkInner);
-impl_try_from_fdlink!(
-    SchedClassifierLink,
-    TcLinkInner,
-    bpf_link_type::BPF_LINK_TYPE_TCX
-);
+
+impl TryFrom<FdLink> for SchedClassifierLink {
+    type Error = LinkError;
+
+    fn try_from(fd_link: FdLink) -> Result<Self, Self::Error> {
+        let info = crate::sys::bpf_link_get_info_by_fd(fd_link.fd.as_fd())?;
+
+        match info.type_ {
+            link_type
+                if link_type == bpf_link_type::BPF_LINK_TYPE_TCX as u32
+                    || link_type == bpf_link_type::BPF_LINK_TYPE_NETKIT as u32 =>
+            {
+                Ok(Self::new(TcLinkInner::Fd(fd_link)))
+            }
+            _ => Err(LinkError::InvalidLink),
+        }
+    }
+}
 
 define_link_wrapper!(
     SchedClassifierLink,
@@ -653,7 +772,7 @@ impl SchedClassifierLink {
     }
 }
 
-/// Add the `clasct` qdisc to the given interface.
+/// Add the `clsact` qdisc to the given interface.
 ///
 /// The `clsact` qdisc must be added to an interface before [`SchedClassifier`]
 /// programs can be attached.

--- a/aya/src/programs/tc.rs
+++ b/aya/src/programs/tc.rs
@@ -3,7 +3,7 @@ use std::{ffi::CString, io, os::fd::AsFd as _, path::Path};
 
 use aya_obj::generated::{
     TC_H_CLSACT, TC_H_MIN_EGRESS, TC_H_MIN_INGRESS,
-    bpf_attach_type::{self, BPF_TCX_EGRESS, BPF_TCX_INGRESS},
+    bpf_attach_type::{self, BPF_NETKIT_PEER, BPF_NETKIT_PRIMARY, BPF_TCX_EGRESS, BPF_TCX_INGRESS},
     bpf_link_type,
     bpf_prog_type::BPF_PROG_TYPE_SCHED_CLS,
 };
@@ -14,18 +14,42 @@ use crate::{
     VerifierLogLevel,
     programs::{
         Link, LinkError, LinkOrder, ProgramData, ProgramError, ProgramType, define_link_wrapper,
-        id_as_key, impl_try_from_fdlink, impl_try_into_fdlink, load_program_without_attach_type,
-        query,
+        id_as_key, impl_try_into_fdlink, load_program_without_attach_type, query,
     },
     sys::{
         BpfLinkCreateArgs, LinkTarget, NetlinkError, NetlinkSocket, ProgQueryTarget, SyscallError,
         bpf_link_create, bpf_link_update, bpf_prog_get_fd_by_id, netlink_find_filter_with_name,
         netlink_qdisc_add_clsact, netlink_qdisc_attach, netlink_qdisc_detach,
     },
-    util::{KernelVersion, ifindex_from_ifname, tc_handler_make},
+    util::{ifindex_from_ifname, tc_handler_make},
 };
 
-/// Traffic control attach type.
+/// Attachment configuration for [`SchedClassifier`] programs.
+pub enum SchedClassifierAttachment {
+    /// Attach as a legacy TC filter using netlink.
+    Tc {
+        /// The legacy TC hook to attach to.
+        attach_type: TcAttachType,
+        /// Netlink attach options.
+        options: NlOptions,
+    },
+    /// Attach to TCX using the eBPF link interface.
+    Tcx {
+        /// The TCX hook to attach to.
+        attach_type: TcxAttachType,
+        /// Multi-prog link ordering.
+        link_order: LinkOrder,
+    },
+    /// Attach to a Netkit device using the eBPF link interface.
+    Netkit {
+        /// The Netkit hook to attach to.
+        attach_type: NetkitAttachType,
+        /// Multi-prog link ordering.
+        link_order: LinkOrder,
+    },
+}
+
+/// Traffic control attach type using netlink.
 #[derive(Debug, Clone, Copy, Hash, Eq, PartialEq)]
 pub enum TcAttachType {
     /// Attach to ingress.
@@ -34,6 +58,45 @@ pub enum TcAttachType {
     Egress,
     /// Attach to custom parent.
     Custom(u32),
+}
+
+/// Traffic control attach type using eBPF link interface.
+/// Requires kernels >= 6.6.0.
+#[derive(Debug, Clone, Copy, Hash, Eq, PartialEq)]
+pub enum TcxAttachType {
+    /// Attach to ingress.
+    Ingress,
+    /// Attach to egress.
+    Egress,
+}
+
+impl TcxAttachType {
+    pub(crate) const fn bpf_attach_type(self) -> bpf_attach_type {
+        match self {
+            Self::Ingress => BPF_TCX_INGRESS,
+            Self::Egress => BPF_TCX_EGRESS,
+        }
+    }
+}
+
+/// Netkit attach type using eBPF link interface.
+/// Requires kernels >= 6.7.0.
+/// Can only be attached to netkit devices.
+#[derive(Debug, Clone, Copy, Hash, Eq, PartialEq)]
+pub enum NetkitAttachType {
+    /// Attach to primary.
+    Primary,
+    /// Attach to peer.
+    Peer,
+}
+
+impl NetkitAttachType {
+    pub(crate) const fn bpf_attach_type(self) -> bpf_attach_type {
+        match self {
+            Self::Primary => BPF_NETKIT_PRIMARY,
+            Self::Peer => BPF_NETKIT_PEER,
+        }
+    }
 }
 
 /// A network traffic control classifier.
@@ -47,7 +110,13 @@ pub enum TcAttachType {
 ///
 /// # Minimum kernel version
 ///
-/// The minimum kernel version required to use this feature is 4.1.
+/// Legacy TC attachments require kernel 4.1 or later. TCX attachments require
+/// kernel 6.6 or later. Netkit attachments require kernel 6.7 or later and a
+/// netkit device.
+///
+/// # Legacy TC attachment
+///
+/// Legacy TC attachments use netlink and require the `clsact` qdisc.
 ///
 /// ```no_run
 /// # #[derive(Debug, thiserror::Error)]
@@ -64,15 +133,100 @@ pub enum TcAttachType {
 /// #     Ebpf(#[from] aya::EbpfError)
 /// # }
 /// # let mut bpf = aya::Ebpf::load(&[])?;
-/// use aya::programs::{tc, SchedClassifier, TcAttachType};
+/// use aya::programs::{tc::{self, NlOptions}, SchedClassifier, SchedClassifierAttachment, TcAttachType};
 ///
 /// // the clsact qdisc needs to be added before SchedClassifier programs can be
-/// // attached
+/// // attached with legacy TC
 /// tc::qdisc_add_clsact("eth0")?;
 ///
 /// let prog: &mut SchedClassifier = bpf.program_mut("redirect_ingress").unwrap().try_into()?;
 /// prog.load()?;
-/// prog.attach("eth0", TcAttachType::Ingress)?;
+/// prog.attach(
+///     "eth0",
+///     SchedClassifierAttachment::Tc {
+///         attach_type: TcAttachType::Ingress,
+///         options: NlOptions::default(),
+///     },
+/// )?;
+///
+/// # Ok::<(), Error>(())
+/// ```
+///
+/// # TCX attachment
+///
+/// TCX attachments use eBPF links and support multi-prog ordering.
+///
+/// ```no_run
+/// # #[derive(Debug, thiserror::Error)]
+/// # enum Error {
+/// #     #[error(transparent)]
+/// #     IO(#[from] std::io::Error),
+/// #     #[error(transparent)]
+/// #     Map(#[from] aya::maps::MapError),
+/// #     #[error(transparent)]
+/// #     Program(#[from] aya::programs::ProgramError),
+/// #     #[error(transparent)]
+/// #     Tc(#[from] aya::programs::tc::TcError),
+/// #     #[error(transparent)]
+/// #     Ebpf(#[from] aya::EbpfError)
+/// # }
+/// # let mut bpf = aya::Ebpf::load(&[])?;
+/// use aya::programs::{LinkOrder, SchedClassifier, SchedClassifierAttachment, TcxAttachType};
+///
+/// let prog: &mut SchedClassifier = bpf.program_mut("redirect_ingress").unwrap().try_into()?;
+/// prog.load()?;
+/// prog.attach(
+///     "eth0",
+///     SchedClassifierAttachment::Tcx {
+///         attach_type: TcxAttachType::Ingress,
+///         link_order: LinkOrder::default(),
+///     },
+/// )?;
+///
+/// # Ok::<(), Error>(())
+/// ```
+///
+/// # Netkit attachment
+///
+/// Netkit attachments use eBPF links and support multi-prog ordering. The
+/// interface must be a netkit device.
+///
+/// ```no_run
+/// # #[derive(Debug, thiserror::Error)]
+/// # enum Error {
+/// #     #[error(transparent)]
+/// #     IO(#[from] std::io::Error),
+/// #     #[error(transparent)]
+/// #     Map(#[from] aya::maps::MapError),
+/// #     #[error(transparent)]
+/// #     Program(#[from] aya::programs::ProgramError),
+/// #     #[error(transparent)]
+/// #     Tc(#[from] aya::programs::tc::TcError),
+/// #     #[error(transparent)]
+/// #     Ebpf(#[from] aya::EbpfError)
+/// # }
+/// # let mut bpf = aya::Ebpf::load(&[])?;
+/// use aya::programs::{LinkOrder, NetkitAttachType, SchedClassifier, SchedClassifierAttachment};
+///
+/// let primary_prog: &mut SchedClassifier = bpf.program_mut("primary").unwrap().try_into()?;
+/// primary_prog.load()?;
+/// primary_prog.attach(
+///     "nk0",
+///     SchedClassifierAttachment::Netkit {
+///         attach_type: NetkitAttachType::Primary,
+///         link_order: LinkOrder::default(),
+///     },
+/// )?;
+/// let peer_prog: &mut SchedClassifier = bpf.program_mut("peer").unwrap().try_into()?;
+/// peer_prog.load()?;
+/// // Peer attachment still occurs on the primary interface
+/// peer_prog.attach(
+///     "nk0",
+///     SchedClassifierAttachment::Netkit {
+///         attach_type: NetkitAttachType::Peer,
+///         link_order: LinkOrder::default(),
+///     },
+/// )?;
 ///
 /// # Ok::<(), Error>(())
 /// ```
@@ -97,13 +251,8 @@ pub enum TcError {
     /// the clsact qdisc is already attached.
     #[error("the clsact qdisc is already attached")]
     AlreadyAttached,
-    /// tcx links can only be attached to ingress or egress, custom attachment is not supported.
-    #[error(
-        "tcx links can only be attached to ingress or egress, custom attachment: {0} is not supported"
-    )]
-    InvalidTcxAttach(u32),
-    /// operation not supported for programs loaded via tcx.
-    #[error("operation not supported for programs loaded via tcx")]
+    /// operation not supported for programs loaded via tcx or netkit.
+    #[error("operation not supported for fd-backed TC links")]
     InvalidLinkOperation,
 }
 
@@ -115,28 +264,6 @@ impl TcAttachType {
             Self::Egress => tc_handler_make(TC_H_CLSACT, TC_H_MIN_EGRESS),
         }
     }
-
-    pub(crate) const fn tcx_attach_type(self) -> Result<bpf_attach_type, TcError> {
-        match self {
-            Self::Ingress => Ok(BPF_TCX_INGRESS),
-            Self::Egress => Ok(BPF_TCX_EGRESS),
-            Self::Custom(tcx_attach_type) => Err(TcError::InvalidTcxAttach(tcx_attach_type)),
-        }
-    }
-}
-
-/// Options for a [`SchedClassifier`] attach operation.
-///
-/// The options vary based on what is supported by the current kernel. Kernels
-/// older than 6.6.0 must utilize netlink for attachments, while newer kernels
-/// can utilize the modern TCX eBPF link type which supports the kernel's
-/// multi-prog API.
-#[derive(Debug)]
-pub enum TcAttachOptions {
-    /// Netlink attach options.
-    Netlink(NlOptions),
-    /// Tcx attach options.
-    TcxOrder(LinkOrder),
 }
 
 /// A TC filter handle in `major:minor` form.
@@ -217,11 +344,7 @@ impl SchedClassifier {
 
     /// Attaches the program to the given `interface`.
     ///
-    /// On kernels >= 6.6.0, it will attempt to use the TCX interface and attach as
-    /// the last TCX program. On older kernels, it will fallback to using the
-    /// legacy netlink interface.
-    ///
-    /// For finer grained control over link ordering use [`SchedClassifier::attach_with_options`].
+    /// TCX requires kernels >= 6.6.0 and netkit requires kernels >= 6.7.0.
     ///
     /// The returned value can be used to detach, see [`SchedClassifier::detach`].
     ///
@@ -235,84 +358,33 @@ impl SchedClassifier {
     pub fn attach(
         &mut self,
         interface: &str,
-        attach_type: TcAttachType,
-    ) -> Result<SchedClassifierLinkId, ProgramError> {
-        if !matches!(attach_type, TcAttachType::Custom(_)) && KernelVersion::at_least(6, 6, 0) {
-            self.attach_with_options(
-                interface,
-                attach_type,
-                TcAttachOptions::TcxOrder(LinkOrder::default()),
-            )
-        } else {
-            self.attach_with_options(
-                interface,
-                attach_type,
-                TcAttachOptions::Netlink(NlOptions::default()),
-            )
-        }
-    }
-
-    /// Attaches the program to the given `interface` with options defined in [`TcAttachOptions`].
-    ///
-    /// The returned value can be used to detach, see [`SchedClassifier::detach`].
-    ///
-    /// # Link Pinning (TCX mode, kernel >= 6.6)
-    ///
-    /// Links can be pinned to bpffs for atomic replacement across process restarts.
-    ///
-    /// ```no_run
-    /// # use std::{io, path::Path};
-    ///
-    /// # use aya::{
-    /// #     programs::{
-    /// #         LinkOrder, SchedClassifier, TcAttachType,
-    /// #         links::{FdLink, LinkError, PinnedLink},
-    /// #         tc::TcAttachOptions,
-    /// #     },
-    /// #     sys::SyscallError,
-    /// # };
-    ///
-    /// # let mut bpf = aya::Ebpf::load(&[])?;
-    /// # let prog: &mut SchedClassifier = bpf.program_mut("prog").unwrap().try_into()?;
-    /// # prog.load()?;
-    /// let pin_path = "/sys/fs/bpf/my_link";
-    ///
-    /// let link_id = match PinnedLink::from_pin(pin_path) {
-    ///     Ok(old) => {
-    ///         let link = FdLink::from(old).try_into()?;
-    ///         prog.attach_to_link(link)?
-    ///     }
-    ///     Err(LinkError::SyscallError(SyscallError { io_error, .. }))
-    ///         if io_error.kind() == io::ErrorKind::NotFound =>
-    ///     {
-    ///         prog.attach_with_options(
-    ///             "eth0",
-    ///             TcAttachType::Ingress,
-    ///             TcAttachOptions::TcxOrder(LinkOrder::default()),
-    ///         )?
-    ///     }
-    ///     Err(e) => return Err(e.into()),
-    /// };
-    ///
-    /// let link = prog.take_link(link_id)?;
-    /// let fd_link: FdLink = link.try_into()?;
-    /// fd_link.pin(pin_path)?;
-    /// # Ok::<(), Box<dyn std::error::Error>>(())
-    /// ```
-    ///
-    /// # Errors
-    ///
-    /// [`TcError::NetlinkError`] is returned if attaching fails. A common cause
-    /// of failure is not having added the `clsact` qdisc to the given
-    /// interface, see [`qdisc_add_clsact`].
-    pub fn attach_with_options(
-        &mut self,
-        interface: &str,
-        attach_type: TcAttachType,
-        options: TcAttachOptions,
+        attachment: SchedClassifierAttachment,
     ) -> Result<SchedClassifierLinkId, ProgramError> {
         let if_index = ifindex_from_ifname(interface).map_err(TcError::IoError)?;
-        self.do_attach(if_index, attach_type, options, true)
+        match attachment {
+            SchedClassifierAttachment::Tc {
+                attach_type,
+                options,
+            } => self.do_netlink_attach(if_index, attach_type, options, true),
+            SchedClassifierAttachment::Tcx {
+                attach_type,
+                link_order,
+            } => self.do_bpf_link_attach(
+                if_index,
+                attach_type.bpf_attach_type(),
+                &link_order,
+                Some(BpfLinkCreateArgs::Tcx(&link_order.link_ref)),
+            ),
+            SchedClassifierAttachment::Netkit {
+                attach_type,
+                link_order,
+            } => self.do_bpf_link_attach(
+                if_index,
+                attach_type.bpf_attach_type(),
+                &link_order,
+                Some(BpfLinkCreateArgs::Netkit(&link_order.link_ref)),
+            ),
+        }
     }
 
     /// Atomically replaces the program referenced by the provided link.
@@ -346,78 +418,84 @@ impl SchedClassifier {
                 priority,
                 handle,
                 classid,
-            }) => self.do_attach(
+            }) => self.do_netlink_attach(
                 if_index,
                 attach_type,
-                TcAttachOptions::Netlink(NlOptions {
+                NlOptions {
                     priority,
                     handle,
                     classid,
-                }),
+                },
                 false,
             ),
         }
     }
 
-    fn do_attach(
+    fn do_bpf_link_attach(
+        &mut self,
+        if_index: u32,
+        attach_type: bpf_attach_type,
+        link_order: &LinkOrder,
+        bpf_link_create_args: Option<BpfLinkCreateArgs<'_>>,
+    ) -> Result<SchedClassifierLinkId, ProgramError> {
+        let prog_fd = self.fd()?;
+        let prog_fd = prog_fd.as_fd();
+
+        let link_fd = bpf_link_create(
+            prog_fd,
+            LinkTarget::IfIndex(if_index),
+            attach_type,
+            link_order.flags.bits(),
+            bpf_link_create_args,
+        )
+        .map_err(|io_error| SyscallError {
+            call: "bpf_mprog_attach",
+            io_error,
+        })?;
+
+        self.data
+            .links
+            .insert(SchedClassifierLink::new(TcLinkInner::Fd(FdLink::new(
+                link_fd,
+            ))))
+    }
+
+    fn do_netlink_attach(
         &mut self,
         if_index: u32,
         attach_type: TcAttachType,
-        options: TcAttachOptions,
+        options: NlOptions,
         create: bool,
     ) -> Result<SchedClassifierLinkId, ProgramError> {
         let prog_fd = self.fd()?;
         let prog_fd = prog_fd.as_fd();
 
-        match options {
-            TcAttachOptions::Netlink(options) => {
-                let name = self.data.name.as_deref().unwrap_or_default();
-                // TODO: avoid this unwrap by adding a new error variant.
-                let name = CString::new(name).unwrap();
-                let (priority, handle) = unsafe {
-                    netlink_qdisc_attach(
-                        if_index as i32,
-                        &attach_type,
-                        prog_fd,
-                        &name,
-                        options.priority,
-                        options.handle,
-                        options.classid,
-                        create,
-                    )
-                }
-                .map_err(TcError::NetlinkError)?;
-
-                self.data
-                    .links
-                    .insert(SchedClassifierLink::new(TcLinkInner::NlLink(NlLink {
-                        if_index,
-                        attach_type,
-                        priority,
-                        handle,
-                        classid: options.classid,
-                    })))
-            }
-            TcAttachOptions::TcxOrder(options) => {
-                let link_fd = bpf_link_create(
-                    prog_fd,
-                    LinkTarget::IfIndex(if_index),
-                    attach_type.tcx_attach_type()?,
-                    options.flags.bits(),
-                    Some(BpfLinkCreateArgs::Tcx(&options.link_ref)),
-                )
-                .map_err(|io_error| SyscallError {
-                    call: "bpf_mprog_attach",
-                    io_error,
-                })?;
-
-                self.data
-                    .links
-                    .insert(SchedClassifierLink::new(TcLinkInner::Fd(FdLink::new(
-                        link_fd,
-                    ))))
-            }
+        let name = self.data.name.as_deref().unwrap_or_default();
+        // TODO: avoid this unwrap by adding a new error variant.
+        let name = CString::new(name).unwrap();
+        let (priority, handle) = unsafe {
+            netlink_qdisc_attach(
+                if_index as i32,
+                &attach_type,
+                prog_fd,
+                &name,
+                options.priority,
+                options.handle,
+                options.classid,
+                create,
+            )
         }
+        .map_err(TcError::NetlinkError)?;
+
+        self.data
+            .links
+            .insert(SchedClassifierLink::new(TcLinkInner::NlLink(NlLink {
+                if_index,
+                attach_type,
+                priority,
+                handle,
+                classid: options.classid,
+            })))
     }
 
     /// Creates a program from a pinned entry on a bpffs.
@@ -436,24 +514,52 @@ impl SchedClassifier {
     /// # Example
     ///
     /// ```no_run
-    /// # use aya::programs::tc::{TcAttachType, SchedClassifier};
+    /// # use aya::programs::tc::{TcxAttachType, SchedClassifier};
     /// # #[derive(Debug, thiserror::Error)]
     /// # enum Error {
     /// #     #[error(transparent)]
     /// #     Program(#[from] aya::programs::ProgramError),
     /// # }
-    /// let (revision, programs) = SchedClassifier::query_tcx("eth0", TcAttachType::Ingress)?;
+    /// let (revision, programs) = SchedClassifier::query_tcx("eth0", TcxAttachType::Ingress)?;
     /// # Ok::<(), Error>(())
     /// ```
     pub fn query_tcx(
         interface: &str,
-        attach_type: TcAttachType,
+        attach_type: TcxAttachType,
+    ) -> Result<(u64, Vec<ProgramInfo>), ProgramError> {
+        Self::query_bpf_links(interface, attach_type.bpf_attach_type())
+    }
+
+    /// Queries a given interface for attached Netkit programs.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// # use aya::programs::tc::{NetkitAttachType, SchedClassifier};
+    /// # #[derive(Debug, thiserror::Error)]
+    /// # enum Error {
+    /// #     #[error(transparent)]
+    /// #     Program(#[from] aya::programs::ProgramError),
+    /// # }
+    /// let (revision, programs) = SchedClassifier::query_netkit("nk0", NetkitAttachType::Primary)?;
+    /// # Ok::<(), Error>(())
+    /// ```
+    pub fn query_netkit(
+        interface: &str,
+        attach_type: NetkitAttachType,
+    ) -> Result<(u64, Vec<ProgramInfo>), ProgramError> {
+        Self::query_bpf_links(interface, attach_type.bpf_attach_type())
+    }
+
+    fn query_bpf_links(
+        interface: &str,
+        attach_type: bpf_attach_type,
     ) -> Result<(u64, Vec<ProgramInfo>), ProgramError> {
         let if_index = ifindex_from_ifname(interface).map_err(TcError::IoError)?;
 
         let (revision, prog_ids) = query(
             ProgQueryTarget::IfIndex(if_index),
-            attach_type.tcx_attach_type()?,
+            attach_type,
             0,
             &mut None,
         )?;
@@ -553,11 +659,24 @@ impl<'a> TryFrom<&'a SchedClassifierLink> for &'a FdLink {
 }
 
 impl_try_into_fdlink!(SchedClassifierLink, TcLinkInner);
-impl_try_from_fdlink!(
-    SchedClassifierLink,
-    TcLinkInner,
-    bpf_link_type::BPF_LINK_TYPE_TCX
-);
+
+impl TryFrom<FdLink> for SchedClassifierLink {
+    type Error = LinkError;
+
+    fn try_from(fd_link: FdLink) -> Result<Self, Self::Error> {
+        let info = crate::sys::bpf_link_get_info_by_fd(fd_link.fd.as_fd())?;
+
+        match info.type_ {
+            link_type
+                if link_type == bpf_link_type::BPF_LINK_TYPE_TCX as u32
+                    || link_type == bpf_link_type::BPF_LINK_TYPE_NETKIT as u32 =>
+            {
+                Ok(Self::new(TcLinkInner::Fd(fd_link)))
+            }
+            _ => Err(LinkError::InvalidLink),
+        }
+    }
+}
 
 define_link_wrapper!(
     SchedClassifierLink,
@@ -655,7 +774,7 @@ impl SchedClassifierLink {
     }
 }
 
-/// Add the `clasct` qdisc to the given interface.
+/// Add the `clsact` qdisc to the given interface.
 ///
 /// The `clsact` qdisc must be added to an interface before [`SchedClassifier`]
 /// programs can be attached.

--- a/aya/src/sys/bpf.rs
+++ b/aya/src/sys/bpf.rs
@@ -430,6 +430,8 @@ pub(crate) enum BpfLinkCreateArgs<'a> {
     PerfEvent { bpf_cookie: u64 },
     // since kernel 6.6
     Tcx(&'a LinkRef),
+    // since kernel 6.7
+    Netkit(&'a LinkRef),
 }
 
 // since kernel 5.7
@@ -482,6 +484,25 @@ pub(crate) fn bpf_link_create(
                             .link_create
                             .__bindgen_anon_3
                             .tcx
+                            .__bindgen_anon_1
+                            .relative_id,
+                    );
+                },
+            },
+            BpfLinkCreateArgs::Netkit(link_ref) => match link_ref {
+                LinkRef::Fd(fd) => {
+                    attr.link_create
+                        .__bindgen_anon_3
+                        .netkit
+                        .__bindgen_anon_1
+                        .relative_fd = fd.to_owned() as u32;
+                }
+                LinkRef::Id(id) => unsafe {
+                    id.clone_into(
+                        &mut attr
+                            .link_create
+                            .__bindgen_anon_3
+                            .netkit
                             .__bindgen_anon_1
                             .relative_id,
                     );

--- a/aya/src/sys/bpf.rs
+++ b/aya/src/sys/bpf.rs
@@ -442,6 +442,8 @@ pub(crate) enum BpfLinkCreateArgs<'a> {
         pid: u32,
         flags: u32,
     },
+    // since kernel 6.7
+    Netkit(&'a LinkRef),
 }
 
 // since kernel 5.7
@@ -520,6 +522,25 @@ pub(crate) fn bpf_link_create(
                     .map(|slice| slice.as_ptr() as u64)
                     .unwrap_or_default();
             }
+            BpfLinkCreateArgs::Netkit(link_ref) => match link_ref {
+                LinkRef::Fd(fd) => {
+                    attr.link_create
+                        .__bindgen_anon_3
+                        .netkit
+                        .__bindgen_anon_1
+                        .relative_fd = fd.to_owned() as u32;
+                }
+                LinkRef::Id(id) => unsafe {
+                    id.clone_into(
+                        &mut attr
+                            .link_create
+                            .__bindgen_anon_3
+                            .netkit
+                            .__bindgen_anon_1
+                            .relative_id,
+                    );
+                },
+            },
         }
     }
 

--- a/aya/src/sys/netlink.rs
+++ b/aya/src/sys/netlink.rs
@@ -424,6 +424,73 @@ pub(crate) fn netlink_find_filter_with_name(
     }))
 }
 
+// IFLA_NETKIT_PEER_INFO from the Linux UAPI.
+// https://github.com/torvalds/linux/blob/999cb275/include/uapi/linux/if_link.h#L1295-L1303
+#[cfg(any(test, feature = "test-helpers"))]
+const IFLA_NETKIT_PEER_INFO: u16 = 1;
+
+#[cfg(any(test, feature = "test-helpers"))]
+fn netkit_request(primary: &CStr, peer: &CStr) -> io::Result<Request<128>> {
+    use libc::{IFLA_IFNAME, IFLA_INFO_DATA, IFLA_INFO_KIND, IFLA_LINKINFO, IFNAMSIZ, RTM_NEWLINK};
+
+    for name in [primary, peer] {
+        if name.to_bytes().is_empty() || name.to_bytes_with_nul().len() > IFNAMSIZ {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "invalid interface name length",
+            ));
+        }
+    }
+
+    // Safety: Request and its ifinfomsg are POD.
+    let mut req = unsafe { mem::zeroed::<Request<128>>() };
+    let header_len = size_of::<nlmsghdr>() + size_of::<ifinfomsg>();
+    req.header = nlmsghdr {
+        nlmsg_len: header_len as u32,
+        nlmsg_flags: (NLM_F_REQUEST | NLM_F_ACK | NLM_F_CREATE | NLM_F_EXCL) as u16,
+        nlmsg_type: RTM_NEWLINK,
+        nlmsg_pid: 0,
+        nlmsg_seq: 1,
+    };
+    req.if_info.ifi_family = AF_UNSPEC as u8;
+
+    // The peer payload starts with an ifinfomsg, followed by link attributes.
+    // https://github.com/torvalds/linux/blob/35613731/drivers/net/netkit.c#L333-L338
+    let mut peer_buf = [0; 64];
+    let (rest, peer_header_len) = write_bytes(
+        &mut peer_buf,
+        &bytes_of(&req)[size_of::<nlmsghdr>()..header_len],
+    )?;
+    let (_, peer_name_len) = write_attr_bytes(rest, IFLA_IFNAME, peer.to_bytes_with_nul())?;
+
+    let mut data_buf = [0; 64];
+    let (_, data_len) = write_attr_bytes(
+        &mut data_buf,
+        IFLA_NETKIT_PEER_INFO,
+        &peer_buf[..peer_header_len + peer_name_len],
+    )?;
+
+    let (rest, name_len) =
+        write_attr_bytes(&mut req.attrs, IFLA_IFNAME, primary.to_bytes_with_nul())?;
+    let mut info = NestedAttrs::new(rest, IFLA_LINKINFO);
+    info.write_attr_bytes(IFLA_INFO_KIND, c"netkit".to_bytes_with_nul())?;
+    info.write_attr_bytes(IFLA_INFO_DATA | NLA_F_NESTED as u16, &data_buf[..data_len])?;
+    let info_len = info.finish()?;
+    req.header.nlmsg_len += (name_len + info_len) as u32;
+    Ok(req)
+}
+
+#[cfg(feature = "test-helpers")]
+pub(crate) fn netlink_create_netkit(primary: &CStr, peer: &CStr) -> Result<(), NetlinkError> {
+    let req = netkit_request(primary, peer).map_err(NetlinkErrorInternal::from)?;
+    let sock = NetlinkSocket::open()?;
+    sock.send(&bytes_of(&req)[..req.header.nlmsg_len as usize])?;
+    for msg in sock.recv() {
+        msg?;
+    }
+    Ok(())
+}
+
 #[doc(hidden)]
 pub unsafe fn netlink_set_link_up(if_index: i32) -> Result<(), NetlinkError> {
     let sock = NetlinkSocket::open()?;
@@ -454,13 +521,13 @@ pub unsafe fn netlink_set_link_up(if_index: i32) -> Result<(), NetlinkError> {
 
 #[derive(Copy, Clone)]
 #[repr(C)]
-struct Request {
+struct Request<const N: usize = 64> {
     header: nlmsghdr,
     if_info: ifinfomsg,
-    attrs: [u8; 64],
+    attrs: [u8; N],
 }
 
-unsafe impl Pod for Request {}
+unsafe impl<const N: usize> Pod for Request<N> {}
 
 #[derive(Copy, Clone)]
 #[repr(C)]
@@ -852,6 +919,67 @@ mod tests {
     use rstest::rstest;
 
     use super::*;
+
+    #[test]
+    fn netkit_request_encodes_peer() {
+        use libc::{IFLA_IFNAME, IFLA_INFO_DATA, IFLA_INFO_KIND, IFLA_LINKINFO, RTM_NEWLINK};
+
+        // Exercise the maximum interface name length and nested peer payload.
+        let primary = c"primary12345678";
+        let peer = c"peer12345678901";
+        let req = netkit_request(primary, peer).unwrap();
+        assert_eq!(req.header.nlmsg_type, RTM_NEWLINK);
+        assert_eq!(
+            req.header.nlmsg_flags,
+            (NLM_F_REQUEST | NLM_F_ACK | NLM_F_CREATE | NLM_F_EXCL) as u16
+        );
+        let len = req.header.nlmsg_len as usize - size_of::<nlmsghdr>() - size_of::<ifinfomsg>();
+        let attrs = NlAttrsIterator::new(&req.attrs[..len])
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap();
+        assert_eq!(attrs.len(), 2);
+        assert_eq!(attrs[0].header.nla_type, IFLA_IFNAME);
+        assert_eq!(attrs[0].data, primary.to_bytes_with_nul());
+        assert_eq!(
+            attrs[1].header.nla_type,
+            IFLA_LINKINFO | NLA_F_NESTED as u16
+        );
+        let info = NlAttrsIterator::new(attrs[1].data)
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap();
+        assert_eq!(info.len(), 2);
+        assert_eq!(info[0].header.nla_type, IFLA_INFO_KIND);
+        assert_eq!(info[0].data, c"netkit".to_bytes_with_nul());
+        assert_eq!(
+            info[1].header.nla_type,
+            IFLA_INFO_DATA | NLA_F_NESTED as u16
+        );
+        let data = NlAttrsIterator::new(info[1].data)
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap();
+        assert_eq!(data.len(), 1);
+        assert_eq!(data[0].header.nla_type, IFLA_NETKIT_PEER_INFO);
+        let (header, attrs) = data[0].data.split_at(size_of::<ifinfomsg>());
+        assert_eq!(header, &[0; size_of::<ifinfomsg>()]);
+        let peer_attrs = NlAttrsIterator::new(attrs)
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap();
+        assert_eq!(peer_attrs.len(), 1);
+        assert_eq!(peer_attrs[0].header.nla_type, IFLA_IFNAME);
+        assert_eq!(peer_attrs[0].data, peer.to_bytes_with_nul());
+    }
+
+    #[test]
+    fn netkit_request_rejects_invalid_name_lengths() {
+        for name in [c"", c"1234567890123456"] {
+            for (primary, peer) in [(name, c"peer"), (c"primary", name)] {
+                assert_eq!(
+                    netkit_request(primary, peer).err().unwrap().kind(),
+                    io::ErrorKind::InvalidInput
+                );
+            }
+        }
+    }
 
     #[test]
     fn test_nested_attrs() {

--- a/aya/src/test_helpers.rs
+++ b/aya/src/test_helpers.rs
@@ -2,6 +2,7 @@
 
 use std::{
     borrow::Cow,
+    ffi::CString,
     fs,
     io::{self, BufRead as _, BufReader, Write as _},
     marker::PhantomData,
@@ -13,7 +14,10 @@ use std::{
 
 use libc::if_nametoindex;
 
-use crate::{netlink_set_link_up, sys::NetlinkError};
+use crate::{
+    netlink_set_link_up,
+    sys::{NetlinkError, netlink_create_netkit},
+};
 
 /// The cgroup-relative name of the file to which a PID is written to assign
 /// that process to the cgroup.
@@ -477,6 +481,33 @@ impl Drop for NetNsGuard {
             }
         }
     }
+}
+
+fn ifindex(if_name: &str) -> io::Result<u32> {
+    let if_name =
+        CString::new(if_name).map_err(|err| io::Error::new(io::ErrorKind::InvalidInput, err))?;
+    let idx = unsafe { if_nametoindex(if_name.as_ptr()) };
+    if idx == 0 {
+        Err(io::Error::last_os_error())
+    } else {
+        Ok(idx)
+    }
+}
+
+/// Creates a Netkit pair using netlink and brings both interfaces up.
+pub fn create_netkit_link(primary: &str, peer: &str) -> io::Result<()> {
+    let primary_name =
+        CString::new(primary).map_err(|err| io::Error::new(io::ErrorKind::InvalidInput, err))?;
+    let peer_name =
+        CString::new(peer).map_err(|err| io::Error::new(io::ErrorKind::InvalidInput, err))?;
+    netlink_create_netkit(&primary_name, &peer_name).map_err(io::Error::other)?;
+
+    for if_name in [primary, peer] {
+        let idx = ifindex(if_name)?;
+        unsafe { netlink_set_link_up(idx as i32) }.map_err(io::Error::other)?;
+    }
+
+    Ok(())
 }
 
 /// Asserts a condition based on the running kernel version.

--- a/test/integration-test/src/tests.rs
+++ b/test/integration-test/src/tests.rs
@@ -46,6 +46,7 @@ mod lpm_trie;
 mod lsm;
 mod map_pin;
 mod maps_disjoint;
+mod netkit;
 mod per_cpu_array;
 mod perf_event_array;
 mod perf_event_bp;

--- a/test/integration-test/src/tests.rs
+++ b/test/integration-test/src/tests.rs
@@ -47,6 +47,7 @@ mod lpm_trie;
 mod lsm;
 mod map_pin;
 mod maps_disjoint;
+mod netkit;
 mod per_cpu_array;
 mod perf_event_array;
 mod perf_event_bp;

--- a/test/integration-test/src/tests/load.rs
+++ b/test/integration-test/src/tests/load.rs
@@ -8,8 +8,9 @@ use aya::{
     maps::{Array, RingBuf},
     pin::PinError,
     programs::{
-        FlowDissector, KProbe, LinkOrder, ProbeKind, Program, ProgramError, SchedClassifier,
-        SchedClassifierAttachment, TcxAttachType, TracePoint, UProbe, Xdp, XdpMode,
+        FlowDissector, KProbe, LinkOrder, NetkitAttachType, ProbeKind, Program, ProgramError,
+        SchedClassifier, SchedClassifierAttachment, TcxAttachType, TracePoint, UProbe, Xdp,
+        XdpMode,
         flow_dissector::{FlowDissectorLink, FlowDissectorLinkId},
         kprobe::{KProbeLink, KProbeLinkId},
         links::{FdLink, LinkError, PinnedLink},
@@ -22,6 +23,8 @@ use aya::{
 };
 use aya_obj::programs::XdpAttachType;
 use rstest::rstest;
+
+use crate::utils::NetNsGuard;
 
 const MAX_RETRIES: usize = 100;
 pub(crate) const RETRY_DURATION: Duration = Duration::from_millis(10);
@@ -485,6 +488,62 @@ fn pin_tcx_link() {
     assert_loaded(program_name);
 
     // Clean up: remove the stale pin file and drop the bpf instance (which drops the program and link)
+    remove_file(pin_path).unwrap();
+    drop(bpf);
+    assert_unloaded(program_name);
+}
+
+#[test_log::test]
+fn pin_netkit_link() {
+    let kernel_version = KernelVersion::current().unwrap();
+    if kernel_version < KernelVersion::new(6, 7, 0) {
+        eprintln!("skipping pin_netkit_link test on kernel {kernel_version:?}");
+        return;
+    }
+
+    use crate::utils::create_netkit_link;
+    let _netns = NetNsGuard::new();
+    if let Err(err) = create_netkit_link("nk-aya-0", "nk-aya-1") {
+        eprintln!("skipping pin_netkit_link test: {err}");
+        return;
+    }
+
+    let program_name = "tcx_next";
+    let pin_path = "/sys/fs/bpf/aya-netkit-test-nk0";
+    let mut bpf = Ebpf::load(crate::TCX).unwrap();
+    let prog: &mut SchedClassifier = bpf.program_mut(program_name).unwrap().try_into().unwrap();
+    prog.load().unwrap();
+
+    let link_id = prog
+        .attach(
+            "nk0",
+            SchedClassifierAttachment::Netkit {
+                attach_type: NetkitAttachType::Primary,
+                link_order: LinkOrder::default(),
+            },
+        )
+        .unwrap();
+    let link = prog.take_link(link_id).unwrap();
+    assert_loaded(program_name);
+
+    let fd_link: FdLink = link.try_into().unwrap();
+    fd_link.pin(pin_path).unwrap();
+
+    // Because of the pin, the program is still attached.
+    prog.unload().unwrap();
+    assert_loaded(program_name);
+
+    // Load a new program and atomically replace the old one using attach_to_link.
+    let mut bpf = Ebpf::load(crate::TCX).unwrap();
+    let prog: &mut SchedClassifier = bpf.program_mut(program_name).unwrap().try_into().unwrap();
+    prog.load().unwrap();
+
+    let old_link = PinnedLink::from_pin(pin_path).unwrap();
+    let link = FdLink::from(old_link).try_into().unwrap();
+    let _link_id = prog.attach_to_link(link).unwrap();
+
+    assert_loaded(program_name);
+
     remove_file(pin_path).unwrap();
     drop(bpf);
     assert_unloaded(program_name);

--- a/test/integration-test/src/tests/load.rs
+++ b/test/integration-test/src/tests/load.rs
@@ -9,12 +9,11 @@ use aya::{
     pin::PinError,
     programs::{
         FlowDissector, KProbe, LinkOrder, ProbeKind, Program, ProgramError, SchedClassifier,
-        TcAttachType, TracePoint, UProbe, Xdp, XdpMode,
+        SchedClassifierAttachment, TcxAttachType, TracePoint, UProbe, Xdp, XdpMode,
         flow_dissector::{FlowDissectorLink, FlowDissectorLinkId},
         kprobe::{KProbeLink, KProbeLinkId},
         links::{FdLink, LinkError, PinnedLink},
         loaded_links, loaded_programs,
-        tc::TcAttachOptions,
         trace_point::{TracePointLink, TracePointLinkId},
         uprobe::{UProbeLink, UProbeLinkId, UProbeScope},
         xdp::{XdpLink, XdpLinkId},
@@ -457,10 +456,12 @@ fn pin_tcx_link() {
     prog.load().unwrap();
 
     let link_id = prog
-        .attach_with_options(
+        .attach(
             "lo",
-            TcAttachType::Ingress,
-            TcAttachOptions::TcxOrder(LinkOrder::default()),
+            SchedClassifierAttachment::Tcx {
+                attach_type: TcxAttachType::Ingress,
+                link_order: LinkOrder::default(),
+            },
         )
         .unwrap();
     let link = prog.take_link(link_id).unwrap();

--- a/test/integration-test/src/tests/load.rs
+++ b/test/integration-test/src/tests/load.rs
@@ -9,12 +9,11 @@ use aya::{
     pin::PinError,
     programs::{
         FlowDissector, KProbe, LinkOrder, ProbeKind, Program, ProgramError, SchedClassifier,
-        TcAttachType, TracePoint, UProbe, Xdp, XdpMode,
+        SchedClassifierAttachment, TcxAttachType, TracePoint, UProbe, Xdp, XdpMode,
         flow_dissector::{FlowDissectorLink, FlowDissectorLinkId},
         kprobe::{KProbeLink, KProbeLinkId},
         links::{FdLink, LinkError, PinnedLink},
         loaded_links, loaded_programs,
-        tc::TcAttachOptions,
         trace_point::{TracePointLink, TracePointLinkId},
         uprobe::{UProbeLink, UProbeLinkId, UProbeScope},
         xdp::{XdpLink, XdpLinkId},
@@ -456,10 +455,12 @@ fn pin_tcx_link() {
     prog.load().unwrap();
 
     let link_id = prog
-        .attach_with_options(
+        .attach(
             "lo",
-            TcAttachType::Ingress,
-            TcAttachOptions::TcxOrder(LinkOrder::default()),
+            SchedClassifierAttachment::Tcx {
+                attach_type: TcxAttachType::Ingress,
+                link_order: LinkOrder::default(),
+            },
         )
         .unwrap();
     let link = prog.take_link(link_id).unwrap();

--- a/test/integration-test/src/tests/load.rs
+++ b/test/integration-test/src/tests/load.rs
@@ -8,8 +8,9 @@ use aya::{
     maps::{Array, RingBuf},
     pin::PinError,
     programs::{
-        FlowDissector, KProbe, LinkOrder, ProbeKind, Program, ProgramError, SchedClassifier,
-        SchedClassifierAttachment, TcxAttachType, TracePoint, UProbe, Xdp, XdpMode,
+        FlowDissector, KProbe, LinkOrder, NetkitAttachType, ProbeKind, Program, ProgramError,
+        SchedClassifier, SchedClassifierAttachment, TcxAttachType, TracePoint, UProbe, Xdp,
+        XdpMode,
         flow_dissector::{FlowDissectorLink, FlowDissectorLinkId},
         kprobe::{KProbeLink, KProbeLinkId},
         links::{FdLink, LinkError, PinnedLink},
@@ -19,6 +20,7 @@ use aya::{
         xdp::{XdpLink, XdpLinkId},
     },
     sys::is_perf_link_supported,
+    test_helpers::NetNsGuard,
     util::KernelVersion,
 };
 use aya_obj::programs::XdpAttachType;
@@ -446,7 +448,6 @@ fn pin_tcx_link() {
         return;
     }
 
-    use aya::test_helpers::NetNsGuard;
     let _netns = NetNsGuard::new().unwrap();
 
     let program_name = "tcx_next";
@@ -486,6 +487,65 @@ fn pin_tcx_link() {
     assert_loaded(program_name);
 
     // Clean up: remove the stale pin file and drop the bpf instance (which drops the program and link)
+    remove_file(pin_path).unwrap();
+    drop(bpf);
+    assert_unloaded(program_name);
+}
+
+#[test_log::test]
+fn pin_netkit_link() {
+    let kernel_version = KernelVersion::current().unwrap();
+    if kernel_version < KernelVersion::new(6, 7, 0) {
+        eprintln!("skipping pin_netkit_link test on kernel {kernel_version:?}");
+        return;
+    }
+
+    let primary = "nk-aya-0";
+    let peer = "nk-aya-1";
+
+    use aya::test_helpers::create_netkit_link;
+    let _netns = NetNsGuard::new().unwrap();
+    if let Err(err) = create_netkit_link(primary, peer) {
+        eprintln!("skipping pin_netkit_link test: {err}");
+        return;
+    }
+
+    let program_name = "tcx_next";
+    let pin_path = "/sys/fs/bpf/aya-netkit-test-nk0";
+    let mut bpf = Ebpf::load(crate::TCX).unwrap();
+    let prog: &mut SchedClassifier = bpf.program_mut(program_name).unwrap().try_into().unwrap();
+    prog.load().unwrap();
+
+    let link_id = prog
+        .attach(
+            primary,
+            SchedClassifierAttachment::Netkit {
+                attach_type: NetkitAttachType::Primary,
+                link_order: LinkOrder::default(),
+            },
+        )
+        .unwrap();
+    let link = prog.take_link(link_id).unwrap();
+    assert_loaded(program_name);
+
+    let fd_link: FdLink = link.try_into().unwrap();
+    fd_link.pin(pin_path).unwrap();
+
+    // Because of the pin, the program is still attached.
+    prog.unload().unwrap();
+    assert_loaded(program_name);
+
+    // Load a new program and atomically replace the old one using attach_to_link.
+    let mut bpf = Ebpf::load(crate::TCX).unwrap();
+    let prog: &mut SchedClassifier = bpf.program_mut(program_name).unwrap().try_into().unwrap();
+    prog.load().unwrap();
+
+    let old_link = PinnedLink::from_pin(pin_path).unwrap();
+    let link = FdLink::from(old_link).try_into().unwrap();
+    let _link_id = prog.attach_to_link(link).unwrap();
+
+    assert_loaded(program_name);
+
     remove_file(pin_path).unwrap();
     drop(bpf);
     assert_unloaded(program_name);

--- a/test/integration-test/src/tests/netkit.rs
+++ b/test/integration-test/src/tests/netkit.rs
@@ -1,0 +1,108 @@
+use aya::{
+    Ebpf,
+    programs::{
+        LinkOrder, NetkitAttachType, ProgramId, SchedClassifier, tc::SchedClassifierAttachment,
+    },
+    util::KernelVersion,
+};
+
+use crate::utils::{NetNsGuard, create_netkit_link};
+
+#[test_log::test]
+fn netkit() {
+    let kernel_version = KernelVersion::current().unwrap();
+    if kernel_version < KernelVersion::new(6, 7, 0) {
+        eprintln!("skipping netkit_attach test on kernel {kernel_version:?}");
+        return;
+    }
+    let primary = "nk-aya-0";
+    let peer = "nk-aya-1";
+
+    let _netns = NetNsGuard::new();
+    if let Err(err) = create_netkit_link(primary, peer) {
+        eprintln!("skipping netkit_attach test: {err}");
+        return;
+    }
+
+    macro_rules! attach_program_with_link_order_inner {
+        ($program_name:ident, $link_order:expr) => {
+            let mut ebpf = Ebpf::load(crate::TCX).unwrap();
+            let $program_name: &mut SchedClassifier =
+                ebpf.program_mut("tcx_next").unwrap().try_into().unwrap();
+            $program_name.load().unwrap();
+        };
+    }
+    macro_rules! attach_program_with_link_order {
+        ($program_name:ident, $link_order:expr) => {
+            attach_program_with_link_order_inner!($program_name, $link_order);
+            $program_name
+                .attach(
+                    primary,
+                    SchedClassifierAttachment::Netkit {
+                        attach_type: NetkitAttachType::Primary,
+                        link_order: $link_order,
+                    },
+                )
+                .unwrap();
+        };
+        ($program_name:ident, $link_id_name:ident, $link_order:expr) => {
+            attach_program_with_link_order_inner!($program_name, $link_order);
+            let $link_id_name = $program_name
+                .attach(
+                    primary,
+                    SchedClassifierAttachment::Netkit {
+                        attach_type: NetkitAttachType::Primary,
+                        link_order: $link_order,
+                    },
+                )
+                .unwrap();
+        };
+    }
+
+    attach_program_with_link_order!(default, LinkOrder::default());
+    attach_program_with_link_order!(first, LinkOrder::first());
+    attach_program_with_link_order!(last, last_link_id, LinkOrder::last());
+
+    let last_link = last.take_link(last_link_id).unwrap();
+
+    attach_program_with_link_order!(before_last, LinkOrder::before_link(&last_link).unwrap());
+    attach_program_with_link_order!(after_last, LinkOrder::after_link(&last_link).unwrap());
+
+    attach_program_with_link_order!(before_default, LinkOrder::before_program(default).unwrap());
+    attach_program_with_link_order!(after_default, LinkOrder::after_program(default).unwrap());
+
+    attach_program_with_link_order!(
+        before_first,
+        LinkOrder::before_program_id(unsafe { ProgramId::new(first.info().unwrap().id()) })
+    );
+    attach_program_with_link_order!(
+        after_first,
+        LinkOrder::after_program_id(unsafe { ProgramId::new(first.info().unwrap().id()) })
+    );
+
+    let expected_order = [
+        before_first,
+        first,
+        after_first,
+        before_default,
+        default,
+        after_default,
+        before_last,
+        last,
+        after_last,
+    ]
+    .iter()
+    .map(|program| program.info().unwrap().id())
+    .collect::<Vec<_>>();
+
+    let (revision, got_order) =
+        SchedClassifier::query_netkit(primary, NetkitAttachType::Primary).unwrap();
+    assert_eq!(revision, (expected_order.len() + 1) as u64);
+    assert_eq!(
+        got_order
+            .iter()
+            .map(aya::programs::ProgramInfo::id)
+            .collect::<Vec<_>>(),
+        expected_order
+    );
+}

--- a/test/integration-test/src/tests/netkit.rs
+++ b/test/integration-test/src/tests/netkit.rs
@@ -1,31 +1,28 @@
 use aya::{
     Ebpf,
     programs::{
-        LinkOrder, ProgramId, SchedClassifier, TcxAttachType, tc::SchedClassifierAttachment,
+        LinkOrder, NetkitAttachType, ProgramId, SchedClassifier, tc::SchedClassifierAttachment,
     },
-    test_helpers::NetNsGuard,
+    test_helpers::{NetNsGuard, create_netkit_link},
     util::KernelVersion,
 };
 
 #[test_log::test]
-fn tcx() {
+fn netkit() {
     let kernel_version = KernelVersion::current().unwrap();
-    if kernel_version < KernelVersion::new(6, 6, 0) {
-        eprintln!("skipping tcx_attach test on kernel {kernel_version:?}");
+    if kernel_version < KernelVersion::new(6, 7, 0) {
+        eprintln!("skipping netkit_attach test on kernel {kernel_version:?}");
+        return;
+    }
+    let primary = "nk-aya-0";
+    let peer = "nk-aya-1";
+
+    let _netns = NetNsGuard::new().unwrap();
+    if let Err(err) = create_netkit_link(primary, peer) {
+        eprintln!("skipping netkit_attach test: {err}");
         return;
     }
 
-    let _netns = NetNsGuard::new().unwrap();
-
-    // We need a dedicated `Ebpf` instance for each program that we load
-    // since TCX does not allow the same program ID to be attached multiple
-    // times to the same interface/direction.
-    //
-    // Variables declared within this macro are within a closure scope to avoid
-    // variable name conflicts.
-    //
-    // Yields a tuple of the `Ebpf` which must remain in scope for the duration
-    // of the test, and the link ID of the attached program.
     macro_rules! attach_program_with_link_order_inner {
         ($program_name:ident, $link_order:expr) => {
             let mut ebpf = Ebpf::load(crate::TCX).unwrap();
@@ -39,9 +36,9 @@ fn tcx() {
             attach_program_with_link_order_inner!($program_name, $link_order);
             $program_name
                 .attach(
-                    "lo",
-                    SchedClassifierAttachment::Tcx {
-                        attach_type: TcxAttachType::Ingress,
+                    primary,
+                    SchedClassifierAttachment::Netkit {
+                        attach_type: NetkitAttachType::Primary,
                         link_order: $link_order,
                     },
                 )
@@ -51,9 +48,9 @@ fn tcx() {
             attach_program_with_link_order_inner!($program_name, $link_order);
             let $link_id_name = $program_name
                 .attach(
-                    "lo",
-                    SchedClassifierAttachment::Tcx {
-                        attach_type: TcxAttachType::Ingress,
+                    primary,
+                    SchedClassifierAttachment::Netkit {
+                        attach_type: NetkitAttachType::Primary,
                         link_order: $link_order,
                     },
                 )
@@ -97,7 +94,8 @@ fn tcx() {
     .map(|program| program.info().unwrap().id())
     .collect::<Vec<_>>();
 
-    let (revision, got_order) = SchedClassifier::query_tcx("lo", TcxAttachType::Ingress).unwrap();
+    let (revision, got_order) =
+        SchedClassifier::query_netkit(primary, NetkitAttachType::Primary).unwrap();
     assert_eq!(revision, (expected_order.len() + 1) as u64);
     assert_eq!(
         got_order

--- a/test/integration-test/src/tests/tc_netlink.rs
+++ b/test/integration-test/src/tests/tc_netlink.rs
@@ -2,7 +2,7 @@ use aya::{
     Ebpf,
     programs::{
         SchedClassifier, TcAttachType,
-        tc::{NlOptions, TcAttachOptions, TcHandle, qdisc_add_clsact},
+        tc::{NlOptions, SchedClassifierAttachment, TcHandle, qdisc_add_clsact},
     },
     test_helpers::NetNsGuard,
     util::KernelVersion,
@@ -55,13 +55,15 @@ fn netlink_attach_to_link_preserves_classid() {
     let classid = TcHandle::new(1, 1);
 
     let link_id = prog
-        .attach_with_options(
+        .attach(
             "lo",
-            TcAttachType::Ingress,
-            TcAttachOptions::Netlink(NlOptions {
-                classid: Some(classid),
-                ..Default::default()
-            }),
+            SchedClassifierAttachment::Tc {
+                attach_type: TcAttachType::Ingress,
+                options: NlOptions {
+                    classid: Some(classid),
+                    ..Default::default()
+                },
+            },
         )
         .unwrap();
 
@@ -90,10 +92,12 @@ fn netlink_attach_auto_assigns_handle() {
     prog.load().unwrap();
 
     let link_id = prog
-        .attach_with_options(
+        .attach(
             "lo",
-            TcAttachType::Ingress,
-            TcAttachOptions::Netlink(NlOptions::default()),
+            SchedClassifierAttachment::Tc {
+                attach_type: TcAttachType::Ingress,
+                options: NlOptions::default(),
+            },
         )
         .unwrap();
 
@@ -119,13 +123,15 @@ fn netlink_attach_preserves_explicit_handle() {
     let handle = TcHandle::new(1, 0xfffe);
 
     let link_id = prog
-        .attach_with_options(
+        .attach(
             "lo",
-            TcAttachType::Ingress,
-            TcAttachOptions::Netlink(NlOptions {
-                handle,
-                ..Default::default()
-            }),
+            SchedClassifierAttachment::Tc {
+                attach_type: TcAttachType::Ingress,
+                options: NlOptions {
+                    handle,
+                    ..Default::default()
+                },
+            },
         )
         .unwrap();
 

--- a/test/integration-test/src/tests/tcx.rs
+++ b/test/integration-test/src/tests/tcx.rs
@@ -1,6 +1,9 @@
 use aya::{
     Ebpf,
-    programs::{LinkOrder, ProgramId, SchedClassifier, TcAttachType, tc::TcAttachOptions},
+    programs::{
+        LinkOrder, ProgramId, SchedClassifier, TcAttachType, TcxAttachType,
+        tc::{SchedClassifierAttachment, TcAttachOptions},
+    },
     test_helpers::NetNsGuard,
     util::KernelVersion,
 };
@@ -36,20 +39,24 @@ fn tcx() {
         ($program_name:ident, $link_order:expr) => {
             attach_program_with_link_order_inner!($program_name, $link_order);
             $program_name
-                .attach_with_options(
+                .attach(
                     "lo",
-                    TcAttachType::Ingress,
-                    TcAttachOptions::TcxOrder($link_order),
+                    SchedClassifierAttachment::Tcx {
+                        attach_type: TcxAttachType::Ingress,
+                        link_order: $link_order,
+                    },
                 )
                 .unwrap();
         };
         ($program_name:ident, $link_id_name:ident, $link_order:expr) => {
             attach_program_with_link_order_inner!($program_name, $link_order);
             let $link_id_name = $program_name
-                .attach_with_options(
+                .attach(
                     "lo",
-                    TcAttachType::Ingress,
-                    TcAttachOptions::TcxOrder($link_order),
+                    SchedClassifierAttachment::Tcx {
+                        attach_type: TcxAttachType::Ingress,
+                        link_order: $link_order,
+                    },
                 )
                 .unwrap();
         };
@@ -91,7 +98,7 @@ fn tcx() {
     .map(|program| program.info().unwrap().id())
     .collect::<Vec<_>>();
 
-    let (revision, got_order) = SchedClassifier::query_tcx("lo", TcAttachType::Ingress).unwrap();
+    let (revision, got_order) = SchedClassifier::query_tcx("lo", TcxAttachType::Ingress).unwrap();
     assert_eq!(revision, (expected_order.len() + 1) as u64);
     assert_eq!(
         got_order

--- a/xtask/public-api/aya.txt
+++ b/xtask/public-api/aya.txt
@@ -4855,18 +4855,44 @@ impl core::marker::UnsafeUnpin for aya::programs::socket_filter::SocketFilter
 impl core::panic::unwind_safe::RefUnwindSafe for aya::programs::socket_filter::SocketFilter
 impl core::panic::unwind_safe::UnwindSafe for aya::programs::socket_filter::SocketFilter
 pub mod aya::programs::tc
-pub enum aya::programs::tc::TcAttachOptions
-pub aya::programs::tc::TcAttachOptions::Netlink(aya::programs::tc::NlOptions)
-pub aya::programs::tc::TcAttachOptions::TcxOrder(aya::programs::links::LinkOrder)
-impl core::fmt::Debug for aya::programs::tc::TcAttachOptions
-pub fn aya::programs::tc::TcAttachOptions::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl core::marker::Freeze for aya::programs::tc::TcAttachOptions
-impl core::marker::Send for aya::programs::tc::TcAttachOptions
-impl core::marker::Sync for aya::programs::tc::TcAttachOptions
-impl core::marker::Unpin for aya::programs::tc::TcAttachOptions
-impl core::marker::UnsafeUnpin for aya::programs::tc::TcAttachOptions
-impl core::panic::unwind_safe::RefUnwindSafe for aya::programs::tc::TcAttachOptions
-impl core::panic::unwind_safe::UnwindSafe for aya::programs::tc::TcAttachOptions
+pub enum aya::programs::tc::NetkitAttachType
+pub aya::programs::tc::NetkitAttachType::Peer
+pub aya::programs::tc::NetkitAttachType::Primary
+impl core::clone::Clone for aya::programs::tc::NetkitAttachType
+pub fn aya::programs::tc::NetkitAttachType::clone(&self) -> aya::programs::tc::NetkitAttachType
+impl core::cmp::Eq for aya::programs::tc::NetkitAttachType
+impl core::cmp::PartialEq for aya::programs::tc::NetkitAttachType
+pub fn aya::programs::tc::NetkitAttachType::eq(&self, &aya::programs::tc::NetkitAttachType) -> bool
+impl core::fmt::Debug for aya::programs::tc::NetkitAttachType
+pub fn aya::programs::tc::NetkitAttachType::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::hash::Hash for aya::programs::tc::NetkitAttachType
+pub fn aya::programs::tc::NetkitAttachType::hash<__H: core::hash::Hasher>(&self, &mut __H)
+impl core::marker::Copy for aya::programs::tc::NetkitAttachType
+impl core::marker::StructuralPartialEq for aya::programs::tc::NetkitAttachType
+impl core::marker::Freeze for aya::programs::tc::NetkitAttachType
+impl core::marker::Send for aya::programs::tc::NetkitAttachType
+impl core::marker::Sync for aya::programs::tc::NetkitAttachType
+impl core::marker::Unpin for aya::programs::tc::NetkitAttachType
+impl core::marker::UnsafeUnpin for aya::programs::tc::NetkitAttachType
+impl core::panic::unwind_safe::RefUnwindSafe for aya::programs::tc::NetkitAttachType
+impl core::panic::unwind_safe::UnwindSafe for aya::programs::tc::NetkitAttachType
+pub enum aya::programs::tc::SchedClassifierAttachment
+pub aya::programs::tc::SchedClassifierAttachment::Netkit
+pub aya::programs::tc::SchedClassifierAttachment::Netkit::attach_type: aya::programs::tc::NetkitAttachType
+pub aya::programs::tc::SchedClassifierAttachment::Netkit::link_order: aya::programs::links::LinkOrder
+pub aya::programs::tc::SchedClassifierAttachment::Tc
+pub aya::programs::tc::SchedClassifierAttachment::Tc::attach_type: aya::programs::tc::TcAttachType
+pub aya::programs::tc::SchedClassifierAttachment::Tc::options: aya::programs::tc::NlOptions
+pub aya::programs::tc::SchedClassifierAttachment::Tcx
+pub aya::programs::tc::SchedClassifierAttachment::Tcx::attach_type: aya::programs::tc::TcxAttachType
+pub aya::programs::tc::SchedClassifierAttachment::Tcx::link_order: aya::programs::links::LinkOrder
+impl core::marker::Freeze for aya::programs::tc::SchedClassifierAttachment
+impl core::marker::Send for aya::programs::tc::SchedClassifierAttachment
+impl core::marker::Sync for aya::programs::tc::SchedClassifierAttachment
+impl core::marker::Unpin for aya::programs::tc::SchedClassifierAttachment
+impl core::marker::UnsafeUnpin for aya::programs::tc::SchedClassifierAttachment
+impl core::panic::unwind_safe::RefUnwindSafe for aya::programs::tc::SchedClassifierAttachment
+impl core::panic::unwind_safe::UnwindSafe for aya::programs::tc::SchedClassifierAttachment
 pub enum aya::programs::tc::TcAttachType
 pub aya::programs::tc::TcAttachType::Custom(u32)
 pub aya::programs::tc::TcAttachType::Egress
@@ -4892,7 +4918,6 @@ impl core::panic::unwind_safe::UnwindSafe for aya::programs::tc::TcAttachType
 pub enum aya::programs::tc::TcError
 pub aya::programs::tc::TcError::AlreadyAttached
 pub aya::programs::tc::TcError::InvalidLinkOperation
-pub aya::programs::tc::TcError::InvalidTcxAttach(u32)
 pub aya::programs::tc::TcError::IoError(std::io::error::Error)
 pub aya::programs::tc::TcError::NetlinkError(aya::sys::NetlinkError)
 pub aya::programs::tc::TcError::NulError(alloc::ffi::c_str::NulError)
@@ -4917,6 +4942,27 @@ impl core::marker::Unpin for aya::programs::tc::TcError
 impl core::marker::UnsafeUnpin for aya::programs::tc::TcError
 impl !core::panic::unwind_safe::RefUnwindSafe for aya::programs::tc::TcError
 impl !core::panic::unwind_safe::UnwindSafe for aya::programs::tc::TcError
+pub enum aya::programs::tc::TcxAttachType
+pub aya::programs::tc::TcxAttachType::Egress
+pub aya::programs::tc::TcxAttachType::Ingress
+impl core::clone::Clone for aya::programs::tc::TcxAttachType
+pub fn aya::programs::tc::TcxAttachType::clone(&self) -> aya::programs::tc::TcxAttachType
+impl core::cmp::Eq for aya::programs::tc::TcxAttachType
+impl core::cmp::PartialEq for aya::programs::tc::TcxAttachType
+pub fn aya::programs::tc::TcxAttachType::eq(&self, &aya::programs::tc::TcxAttachType) -> bool
+impl core::fmt::Debug for aya::programs::tc::TcxAttachType
+pub fn aya::programs::tc::TcxAttachType::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::hash::Hash for aya::programs::tc::TcxAttachType
+pub fn aya::programs::tc::TcxAttachType::hash<__H: core::hash::Hasher>(&self, &mut __H)
+impl core::marker::Copy for aya::programs::tc::TcxAttachType
+impl core::marker::StructuralPartialEq for aya::programs::tc::TcxAttachType
+impl core::marker::Freeze for aya::programs::tc::TcxAttachType
+impl core::marker::Send for aya::programs::tc::TcxAttachType
+impl core::marker::Sync for aya::programs::tc::TcxAttachType
+impl core::marker::Unpin for aya::programs::tc::TcxAttachType
+impl core::marker::UnsafeUnpin for aya::programs::tc::TcxAttachType
+impl core::panic::unwind_safe::RefUnwindSafe for aya::programs::tc::TcxAttachType
+impl core::panic::unwind_safe::UnwindSafe for aya::programs::tc::TcxAttachType
 pub struct aya::programs::tc::NlOptions
 pub aya::programs::tc::NlOptions::classid: core::option::Option<aya::programs::tc::TcHandle>
 pub aya::programs::tc::NlOptions::handle: aya::programs::tc::TcHandle
@@ -4941,12 +4987,12 @@ impl core::panic::unwind_safe::UnwindSafe for aya::programs::tc::NlOptions
 pub struct aya::programs::tc::SchedClassifier
 impl aya::programs::tc::SchedClassifier
 pub const aya::programs::tc::SchedClassifier::PROGRAM_TYPE: aya::programs::ProgramType
-pub fn aya::programs::tc::SchedClassifier::attach(&mut self, &str, aya::programs::tc::TcAttachType) -> core::result::Result<aya::programs::tc::SchedClassifierLinkId, aya::programs::ProgramError>
+pub fn aya::programs::tc::SchedClassifier::attach(&mut self, &str, aya::programs::tc::SchedClassifierAttachment) -> core::result::Result<aya::programs::tc::SchedClassifierLinkId, aya::programs::ProgramError>
 pub fn aya::programs::tc::SchedClassifier::attach_to_link(&mut self, aya::programs::tc::SchedClassifierLink) -> core::result::Result<aya::programs::tc::SchedClassifierLinkId, aya::programs::ProgramError>
-pub fn aya::programs::tc::SchedClassifier::attach_with_options(&mut self, &str, aya::programs::tc::TcAttachType, aya::programs::tc::TcAttachOptions) -> core::result::Result<aya::programs::tc::SchedClassifierLinkId, aya::programs::ProgramError>
 pub fn aya::programs::tc::SchedClassifier::from_pin<P: core::convert::AsRef<std::path::Path>>(P) -> core::result::Result<Self, aya::programs::ProgramError>
 pub fn aya::programs::tc::SchedClassifier::load(&mut self) -> core::result::Result<(), aya::programs::ProgramError>
-pub fn aya::programs::tc::SchedClassifier::query_tcx(&str, aya::programs::tc::TcAttachType) -> core::result::Result<(u64, alloc::vec::Vec<aya::programs::ProgramInfo>), aya::programs::ProgramError>
+pub fn aya::programs::tc::SchedClassifier::query_netkit(&str, aya::programs::tc::NetkitAttachType) -> core::result::Result<(u64, alloc::vec::Vec<aya::programs::ProgramInfo>), aya::programs::ProgramError>
+pub fn aya::programs::tc::SchedClassifier::query_tcx(&str, aya::programs::tc::TcxAttachType) -> core::result::Result<(u64, alloc::vec::Vec<aya::programs::ProgramInfo>), aya::programs::ProgramError>
 impl aya::programs::tc::SchedClassifier
 pub fn aya::programs::tc::SchedClassifier::detach(&mut self, aya::programs::tc::SchedClassifierLinkId) -> core::result::Result<(), aya::programs::ProgramError>
 pub fn aya::programs::tc::SchedClassifier::take_link(&mut self, aya::programs::tc::SchedClassifierLinkId) -> core::result::Result<aya::programs::tc::SchedClassifierLink, aya::programs::ProgramError>
@@ -5671,6 +5717,27 @@ impl core::marker::Unpin for aya::programs::LsmAttachType
 impl core::marker::UnsafeUnpin for aya::programs::LsmAttachType
 impl core::panic::unwind_safe::RefUnwindSafe for aya::programs::LsmAttachType
 impl core::panic::unwind_safe::UnwindSafe for aya::programs::LsmAttachType
+pub enum aya::programs::NetkitAttachType
+pub aya::programs::NetkitAttachType::Peer
+pub aya::programs::NetkitAttachType::Primary
+impl core::clone::Clone for aya::programs::tc::NetkitAttachType
+pub fn aya::programs::tc::NetkitAttachType::clone(&self) -> aya::programs::tc::NetkitAttachType
+impl core::cmp::Eq for aya::programs::tc::NetkitAttachType
+impl core::cmp::PartialEq for aya::programs::tc::NetkitAttachType
+pub fn aya::programs::tc::NetkitAttachType::eq(&self, &aya::programs::tc::NetkitAttachType) -> bool
+impl core::fmt::Debug for aya::programs::tc::NetkitAttachType
+pub fn aya::programs::tc::NetkitAttachType::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::hash::Hash for aya::programs::tc::NetkitAttachType
+pub fn aya::programs::tc::NetkitAttachType::hash<__H: core::hash::Hasher>(&self, &mut __H)
+impl core::marker::Copy for aya::programs::tc::NetkitAttachType
+impl core::marker::StructuralPartialEq for aya::programs::tc::NetkitAttachType
+impl core::marker::Freeze for aya::programs::tc::NetkitAttachType
+impl core::marker::Send for aya::programs::tc::NetkitAttachType
+impl core::marker::Sync for aya::programs::tc::NetkitAttachType
+impl core::marker::Unpin for aya::programs::tc::NetkitAttachType
+impl core::marker::UnsafeUnpin for aya::programs::tc::NetkitAttachType
+impl core::panic::unwind_safe::RefUnwindSafe for aya::programs::tc::NetkitAttachType
+impl core::panic::unwind_safe::UnwindSafe for aya::programs::tc::NetkitAttachType
 pub enum aya::programs::ProbeKind
 pub aya::programs::ProbeKind::Entry
 pub aya::programs::ProbeKind::Return
@@ -6024,6 +6091,23 @@ impl core::marker::Unpin for aya::programs::ProgramType
 impl core::marker::UnsafeUnpin for aya::programs::ProgramType
 impl core::panic::unwind_safe::RefUnwindSafe for aya::programs::ProgramType
 impl core::panic::unwind_safe::UnwindSafe for aya::programs::ProgramType
+pub enum aya::programs::SchedClassifierAttachment
+pub aya::programs::SchedClassifierAttachment::Netkit
+pub aya::programs::SchedClassifierAttachment::Netkit::attach_type: aya::programs::tc::NetkitAttachType
+pub aya::programs::SchedClassifierAttachment::Netkit::link_order: aya::programs::links::LinkOrder
+pub aya::programs::SchedClassifierAttachment::Tc
+pub aya::programs::SchedClassifierAttachment::Tc::attach_type: aya::programs::tc::TcAttachType
+pub aya::programs::SchedClassifierAttachment::Tc::options: aya::programs::tc::NlOptions
+pub aya::programs::SchedClassifierAttachment::Tcx
+pub aya::programs::SchedClassifierAttachment::Tcx::attach_type: aya::programs::tc::TcxAttachType
+pub aya::programs::SchedClassifierAttachment::Tcx::link_order: aya::programs::links::LinkOrder
+impl core::marker::Freeze for aya::programs::tc::SchedClassifierAttachment
+impl core::marker::Send for aya::programs::tc::SchedClassifierAttachment
+impl core::marker::Sync for aya::programs::tc::SchedClassifierAttachment
+impl core::marker::Unpin for aya::programs::tc::SchedClassifierAttachment
+impl core::marker::UnsafeUnpin for aya::programs::tc::SchedClassifierAttachment
+impl core::panic::unwind_safe::RefUnwindSafe for aya::programs::tc::SchedClassifierAttachment
+impl core::panic::unwind_safe::UnwindSafe for aya::programs::tc::SchedClassifierAttachment
 pub enum aya::programs::SkReuseportError
 pub aya::programs::SkReuseportError::SetsockoptError
 pub aya::programs::SkReuseportError::SetsockoptError::io_error: std::io::error::Error
@@ -6087,7 +6171,6 @@ impl core::panic::unwind_safe::UnwindSafe for aya::programs::tc::TcAttachType
 pub enum aya::programs::TcError
 pub aya::programs::TcError::AlreadyAttached
 pub aya::programs::TcError::InvalidLinkOperation
-pub aya::programs::TcError::InvalidTcxAttach(u32)
 pub aya::programs::TcError::IoError(std::io::error::Error)
 pub aya::programs::TcError::NetlinkError(aya::sys::NetlinkError)
 pub aya::programs::TcError::NulError(alloc::ffi::c_str::NulError)
@@ -6112,6 +6195,27 @@ impl core::marker::Unpin for aya::programs::tc::TcError
 impl core::marker::UnsafeUnpin for aya::programs::tc::TcError
 impl !core::panic::unwind_safe::RefUnwindSafe for aya::programs::tc::TcError
 impl !core::panic::unwind_safe::UnwindSafe for aya::programs::tc::TcError
+pub enum aya::programs::TcxAttachType
+pub aya::programs::TcxAttachType::Egress
+pub aya::programs::TcxAttachType::Ingress
+impl core::clone::Clone for aya::programs::tc::TcxAttachType
+pub fn aya::programs::tc::TcxAttachType::clone(&self) -> aya::programs::tc::TcxAttachType
+impl core::cmp::Eq for aya::programs::tc::TcxAttachType
+impl core::cmp::PartialEq for aya::programs::tc::TcxAttachType
+pub fn aya::programs::tc::TcxAttachType::eq(&self, &aya::programs::tc::TcxAttachType) -> bool
+impl core::fmt::Debug for aya::programs::tc::TcxAttachType
+pub fn aya::programs::tc::TcxAttachType::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::hash::Hash for aya::programs::tc::TcxAttachType
+pub fn aya::programs::tc::TcxAttachType::hash<__H: core::hash::Hasher>(&self, &mut __H)
+impl core::marker::Copy for aya::programs::tc::TcxAttachType
+impl core::marker::StructuralPartialEq for aya::programs::tc::TcxAttachType
+impl core::marker::Freeze for aya::programs::tc::TcxAttachType
+impl core::marker::Send for aya::programs::tc::TcxAttachType
+impl core::marker::Sync for aya::programs::tc::TcxAttachType
+impl core::marker::Unpin for aya::programs::tc::TcxAttachType
+impl core::marker::UnsafeUnpin for aya::programs::tc::TcxAttachType
+impl core::panic::unwind_safe::RefUnwindSafe for aya::programs::tc::TcxAttachType
+impl core::panic::unwind_safe::UnwindSafe for aya::programs::tc::TcxAttachType
 pub enum aya::programs::TracePointError
 pub aya::programs::TracePointError::FileError
 pub aya::programs::TracePointError::FileError::filename: std::path::PathBuf
@@ -7036,12 +7140,12 @@ impl core::panic::unwind_safe::UnwindSafe for aya::programs::socket_filter::Reus
 pub struct aya::programs::SchedClassifier
 impl aya::programs::tc::SchedClassifier
 pub const aya::programs::tc::SchedClassifier::PROGRAM_TYPE: aya::programs::ProgramType
-pub fn aya::programs::tc::SchedClassifier::attach(&mut self, &str, aya::programs::tc::TcAttachType) -> core::result::Result<aya::programs::tc::SchedClassifierLinkId, aya::programs::ProgramError>
+pub fn aya::programs::tc::SchedClassifier::attach(&mut self, &str, aya::programs::tc::SchedClassifierAttachment) -> core::result::Result<aya::programs::tc::SchedClassifierLinkId, aya::programs::ProgramError>
 pub fn aya::programs::tc::SchedClassifier::attach_to_link(&mut self, aya::programs::tc::SchedClassifierLink) -> core::result::Result<aya::programs::tc::SchedClassifierLinkId, aya::programs::ProgramError>
-pub fn aya::programs::tc::SchedClassifier::attach_with_options(&mut self, &str, aya::programs::tc::TcAttachType, aya::programs::tc::TcAttachOptions) -> core::result::Result<aya::programs::tc::SchedClassifierLinkId, aya::programs::ProgramError>
 pub fn aya::programs::tc::SchedClassifier::from_pin<P: core::convert::AsRef<std::path::Path>>(P) -> core::result::Result<Self, aya::programs::ProgramError>
 pub fn aya::programs::tc::SchedClassifier::load(&mut self) -> core::result::Result<(), aya::programs::ProgramError>
-pub fn aya::programs::tc::SchedClassifier::query_tcx(&str, aya::programs::tc::TcAttachType) -> core::result::Result<(u64, alloc::vec::Vec<aya::programs::ProgramInfo>), aya::programs::ProgramError>
+pub fn aya::programs::tc::SchedClassifier::query_netkit(&str, aya::programs::tc::NetkitAttachType) -> core::result::Result<(u64, alloc::vec::Vec<aya::programs::ProgramInfo>), aya::programs::ProgramError>
+pub fn aya::programs::tc::SchedClassifier::query_tcx(&str, aya::programs::tc::TcxAttachType) -> core::result::Result<(u64, alloc::vec::Vec<aya::programs::ProgramInfo>), aya::programs::ProgramError>
 impl aya::programs::tc::SchedClassifier
 pub fn aya::programs::tc::SchedClassifier::detach(&mut self, aya::programs::tc::SchedClassifierLinkId) -> core::result::Result<(), aya::programs::ProgramError>
 pub fn aya::programs::tc::SchedClassifier::take_link(&mut self, aya::programs::tc::SchedClassifierLinkId) -> core::result::Result<aya::programs::tc::SchedClassifierLink, aya::programs::ProgramError>

--- a/xtask/public-api/aya.txt
+++ b/xtask/public-api/aya.txt
@@ -8039,6 +8039,7 @@ impl core::marker::Unpin for aya::test_helpers::NetNsGuard
 impl core::marker::UnsafeUnpin for aya::test_helpers::NetNsGuard
 impl core::panic::unwind_safe::RefUnwindSafe for aya::test_helpers::NetNsGuard
 impl core::panic::unwind_safe::UnwindSafe for aya::test_helpers::NetNsGuard
+pub fn aya::test_helpers::create_netkit_link(&str, &str) -> core::io::error::Result<()>
 pub type aya::test_helpers::AyaTestResult<T> = core::result::Result<T, aya::test_helpers::AyaTestError>
 pub mod aya::util
 pub struct aya::util::KernelVersion

--- a/xtask/public-api/aya.txt
+++ b/xtask/public-api/aya.txt
@@ -4907,18 +4907,44 @@ impl core::marker::UnsafeUnpin for aya::programs::socket_filter::SocketFilter
 impl core::panic::unwind_safe::RefUnwindSafe for aya::programs::socket_filter::SocketFilter
 impl core::panic::unwind_safe::UnwindSafe for aya::programs::socket_filter::SocketFilter
 pub mod aya::programs::tc
-pub enum aya::programs::tc::TcAttachOptions
-pub aya::programs::tc::TcAttachOptions::Netlink(aya::programs::tc::NlOptions)
-pub aya::programs::tc::TcAttachOptions::TcxOrder(aya::programs::links::LinkOrder)
-impl core::fmt::Debug for aya::programs::tc::TcAttachOptions
-pub fn aya::programs::tc::TcAttachOptions::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl core::marker::Freeze for aya::programs::tc::TcAttachOptions
-impl core::marker::Send for aya::programs::tc::TcAttachOptions
-impl core::marker::Sync for aya::programs::tc::TcAttachOptions
-impl core::marker::Unpin for aya::programs::tc::TcAttachOptions
-impl core::marker::UnsafeUnpin for aya::programs::tc::TcAttachOptions
-impl core::panic::unwind_safe::RefUnwindSafe for aya::programs::tc::TcAttachOptions
-impl core::panic::unwind_safe::UnwindSafe for aya::programs::tc::TcAttachOptions
+pub enum aya::programs::tc::NetkitAttachType
+pub aya::programs::tc::NetkitAttachType::Peer
+pub aya::programs::tc::NetkitAttachType::Primary
+impl core::clone::Clone for aya::programs::tc::NetkitAttachType
+pub fn aya::programs::tc::NetkitAttachType::clone(&self) -> aya::programs::tc::NetkitAttachType
+impl core::cmp::Eq for aya::programs::tc::NetkitAttachType
+impl core::cmp::PartialEq for aya::programs::tc::NetkitAttachType
+pub fn aya::programs::tc::NetkitAttachType::eq(&self, &aya::programs::tc::NetkitAttachType) -> bool
+impl core::fmt::Debug for aya::programs::tc::NetkitAttachType
+pub fn aya::programs::tc::NetkitAttachType::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::hash::Hash for aya::programs::tc::NetkitAttachType
+pub fn aya::programs::tc::NetkitAttachType::hash<__H: core::hash::Hasher>(&self, &mut __H)
+impl core::marker::Copy for aya::programs::tc::NetkitAttachType
+impl core::marker::StructuralPartialEq for aya::programs::tc::NetkitAttachType
+impl core::marker::Freeze for aya::programs::tc::NetkitAttachType
+impl core::marker::Send for aya::programs::tc::NetkitAttachType
+impl core::marker::Sync for aya::programs::tc::NetkitAttachType
+impl core::marker::Unpin for aya::programs::tc::NetkitAttachType
+impl core::marker::UnsafeUnpin for aya::programs::tc::NetkitAttachType
+impl core::panic::unwind_safe::RefUnwindSafe for aya::programs::tc::NetkitAttachType
+impl core::panic::unwind_safe::UnwindSafe for aya::programs::tc::NetkitAttachType
+pub enum aya::programs::tc::SchedClassifierAttachment
+pub aya::programs::tc::SchedClassifierAttachment::Netkit
+pub aya::programs::tc::SchedClassifierAttachment::Netkit::attach_type: aya::programs::tc::NetkitAttachType
+pub aya::programs::tc::SchedClassifierAttachment::Netkit::link_order: aya::programs::links::LinkOrder
+pub aya::programs::tc::SchedClassifierAttachment::Tc
+pub aya::programs::tc::SchedClassifierAttachment::Tc::attach_type: aya::programs::tc::TcAttachType
+pub aya::programs::tc::SchedClassifierAttachment::Tc::options: aya::programs::tc::NlOptions
+pub aya::programs::tc::SchedClassifierAttachment::Tcx
+pub aya::programs::tc::SchedClassifierAttachment::Tcx::attach_type: aya::programs::tc::TcxAttachType
+pub aya::programs::tc::SchedClassifierAttachment::Tcx::link_order: aya::programs::links::LinkOrder
+impl core::marker::Freeze for aya::programs::tc::SchedClassifierAttachment
+impl core::marker::Send for aya::programs::tc::SchedClassifierAttachment
+impl core::marker::Sync for aya::programs::tc::SchedClassifierAttachment
+impl core::marker::Unpin for aya::programs::tc::SchedClassifierAttachment
+impl core::marker::UnsafeUnpin for aya::programs::tc::SchedClassifierAttachment
+impl core::panic::unwind_safe::RefUnwindSafe for aya::programs::tc::SchedClassifierAttachment
+impl core::panic::unwind_safe::UnwindSafe for aya::programs::tc::SchedClassifierAttachment
 pub enum aya::programs::tc::TcAttachType
 pub aya::programs::tc::TcAttachType::Custom(u32)
 pub aya::programs::tc::TcAttachType::Egress
@@ -4944,7 +4970,6 @@ impl core::panic::unwind_safe::UnwindSafe for aya::programs::tc::TcAttachType
 pub enum aya::programs::tc::TcError
 pub aya::programs::tc::TcError::AlreadyAttached
 pub aya::programs::tc::TcError::InvalidLinkOperation
-pub aya::programs::tc::TcError::InvalidTcxAttach(u32)
 pub aya::programs::tc::TcError::IoError(core::io::error::Error)
 pub aya::programs::tc::TcError::NetlinkError(aya::sys::NetlinkError)
 pub aya::programs::tc::TcError::NulError(alloc::ffi::c_str::NulError)
@@ -4969,6 +4994,27 @@ impl core::marker::Unpin for aya::programs::tc::TcError
 impl core::marker::UnsafeUnpin for aya::programs::tc::TcError
 impl !core::panic::unwind_safe::RefUnwindSafe for aya::programs::tc::TcError
 impl !core::panic::unwind_safe::UnwindSafe for aya::programs::tc::TcError
+pub enum aya::programs::tc::TcxAttachType
+pub aya::programs::tc::TcxAttachType::Egress
+pub aya::programs::tc::TcxAttachType::Ingress
+impl core::clone::Clone for aya::programs::tc::TcxAttachType
+pub fn aya::programs::tc::TcxAttachType::clone(&self) -> aya::programs::tc::TcxAttachType
+impl core::cmp::Eq for aya::programs::tc::TcxAttachType
+impl core::cmp::PartialEq for aya::programs::tc::TcxAttachType
+pub fn aya::programs::tc::TcxAttachType::eq(&self, &aya::programs::tc::TcxAttachType) -> bool
+impl core::fmt::Debug for aya::programs::tc::TcxAttachType
+pub fn aya::programs::tc::TcxAttachType::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::hash::Hash for aya::programs::tc::TcxAttachType
+pub fn aya::programs::tc::TcxAttachType::hash<__H: core::hash::Hasher>(&self, &mut __H)
+impl core::marker::Copy for aya::programs::tc::TcxAttachType
+impl core::marker::StructuralPartialEq for aya::programs::tc::TcxAttachType
+impl core::marker::Freeze for aya::programs::tc::TcxAttachType
+impl core::marker::Send for aya::programs::tc::TcxAttachType
+impl core::marker::Sync for aya::programs::tc::TcxAttachType
+impl core::marker::Unpin for aya::programs::tc::TcxAttachType
+impl core::marker::UnsafeUnpin for aya::programs::tc::TcxAttachType
+impl core::panic::unwind_safe::RefUnwindSafe for aya::programs::tc::TcxAttachType
+impl core::panic::unwind_safe::UnwindSafe for aya::programs::tc::TcxAttachType
 pub struct aya::programs::tc::NlOptions
 pub aya::programs::tc::NlOptions::classid: core::option::Option<aya::programs::tc::TcHandle>
 pub aya::programs::tc::NlOptions::handle: aya::programs::tc::TcHandle
@@ -4993,12 +5039,12 @@ impl core::panic::unwind_safe::UnwindSafe for aya::programs::tc::NlOptions
 pub struct aya::programs::tc::SchedClassifier
 impl aya::programs::tc::SchedClassifier
 pub const aya::programs::tc::SchedClassifier::PROGRAM_TYPE: aya::programs::ProgramType
-pub fn aya::programs::tc::SchedClassifier::attach(&mut self, &str, aya::programs::tc::TcAttachType) -> core::result::Result<aya::programs::tc::SchedClassifierLinkId, aya::programs::ProgramError>
+pub fn aya::programs::tc::SchedClassifier::attach(&mut self, &str, aya::programs::tc::SchedClassifierAttachment) -> core::result::Result<aya::programs::tc::SchedClassifierLinkId, aya::programs::ProgramError>
 pub fn aya::programs::tc::SchedClassifier::attach_to_link(&mut self, aya::programs::tc::SchedClassifierLink) -> core::result::Result<aya::programs::tc::SchedClassifierLinkId, aya::programs::ProgramError>
-pub fn aya::programs::tc::SchedClassifier::attach_with_options(&mut self, &str, aya::programs::tc::TcAttachType, aya::programs::tc::TcAttachOptions) -> core::result::Result<aya::programs::tc::SchedClassifierLinkId, aya::programs::ProgramError>
 pub fn aya::programs::tc::SchedClassifier::from_pin<P: core::convert::AsRef<std::path::Path>>(P) -> core::result::Result<Self, aya::programs::ProgramError>
 pub fn aya::programs::tc::SchedClassifier::load(&mut self) -> core::result::Result<(), aya::programs::ProgramError>
-pub fn aya::programs::tc::SchedClassifier::query_tcx(&str, aya::programs::tc::TcAttachType) -> core::result::Result<(u64, alloc::vec::Vec<aya::programs::ProgramInfo>), aya::programs::ProgramError>
+pub fn aya::programs::tc::SchedClassifier::query_netkit(&str, aya::programs::tc::NetkitAttachType) -> core::result::Result<(u64, alloc::vec::Vec<aya::programs::ProgramInfo>), aya::programs::ProgramError>
+pub fn aya::programs::tc::SchedClassifier::query_tcx(&str, aya::programs::tc::TcxAttachType) -> core::result::Result<(u64, alloc::vec::Vec<aya::programs::ProgramInfo>), aya::programs::ProgramError>
 impl aya::programs::tc::SchedClassifier
 pub fn aya::programs::tc::SchedClassifier::detach(&mut self, aya::programs::tc::SchedClassifierLinkId) -> core::result::Result<(), aya::programs::ProgramError>
 pub fn aya::programs::tc::SchedClassifier::take_link(&mut self, aya::programs::tc::SchedClassifierLinkId) -> core::result::Result<aya::programs::tc::SchedClassifierLink, aya::programs::ProgramError>
@@ -5752,6 +5798,27 @@ impl core::marker::Unpin for aya::programs::LsmAttachType
 impl core::marker::UnsafeUnpin for aya::programs::LsmAttachType
 impl core::panic::unwind_safe::RefUnwindSafe for aya::programs::LsmAttachType
 impl core::panic::unwind_safe::UnwindSafe for aya::programs::LsmAttachType
+pub enum aya::programs::NetkitAttachType
+pub aya::programs::NetkitAttachType::Peer
+pub aya::programs::NetkitAttachType::Primary
+impl core::clone::Clone for aya::programs::tc::NetkitAttachType
+pub fn aya::programs::tc::NetkitAttachType::clone(&self) -> aya::programs::tc::NetkitAttachType
+impl core::cmp::Eq for aya::programs::tc::NetkitAttachType
+impl core::cmp::PartialEq for aya::programs::tc::NetkitAttachType
+pub fn aya::programs::tc::NetkitAttachType::eq(&self, &aya::programs::tc::NetkitAttachType) -> bool
+impl core::fmt::Debug for aya::programs::tc::NetkitAttachType
+pub fn aya::programs::tc::NetkitAttachType::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::hash::Hash for aya::programs::tc::NetkitAttachType
+pub fn aya::programs::tc::NetkitAttachType::hash<__H: core::hash::Hasher>(&self, &mut __H)
+impl core::marker::Copy for aya::programs::tc::NetkitAttachType
+impl core::marker::StructuralPartialEq for aya::programs::tc::NetkitAttachType
+impl core::marker::Freeze for aya::programs::tc::NetkitAttachType
+impl core::marker::Send for aya::programs::tc::NetkitAttachType
+impl core::marker::Sync for aya::programs::tc::NetkitAttachType
+impl core::marker::Unpin for aya::programs::tc::NetkitAttachType
+impl core::marker::UnsafeUnpin for aya::programs::tc::NetkitAttachType
+impl core::panic::unwind_safe::RefUnwindSafe for aya::programs::tc::NetkitAttachType
+impl core::panic::unwind_safe::UnwindSafe for aya::programs::tc::NetkitAttachType
 pub enum aya::programs::ProbeKind
 pub aya::programs::ProbeKind::Entry
 pub aya::programs::ProbeKind::Return
@@ -6107,6 +6174,23 @@ impl core::marker::Unpin for aya::programs::ProgramType
 impl core::marker::UnsafeUnpin for aya::programs::ProgramType
 impl core::panic::unwind_safe::RefUnwindSafe for aya::programs::ProgramType
 impl core::panic::unwind_safe::UnwindSafe for aya::programs::ProgramType
+pub enum aya::programs::SchedClassifierAttachment
+pub aya::programs::SchedClassifierAttachment::Netkit
+pub aya::programs::SchedClassifierAttachment::Netkit::attach_type: aya::programs::tc::NetkitAttachType
+pub aya::programs::SchedClassifierAttachment::Netkit::link_order: aya::programs::links::LinkOrder
+pub aya::programs::SchedClassifierAttachment::Tc
+pub aya::programs::SchedClassifierAttachment::Tc::attach_type: aya::programs::tc::TcAttachType
+pub aya::programs::SchedClassifierAttachment::Tc::options: aya::programs::tc::NlOptions
+pub aya::programs::SchedClassifierAttachment::Tcx
+pub aya::programs::SchedClassifierAttachment::Tcx::attach_type: aya::programs::tc::TcxAttachType
+pub aya::programs::SchedClassifierAttachment::Tcx::link_order: aya::programs::links::LinkOrder
+impl core::marker::Freeze for aya::programs::tc::SchedClassifierAttachment
+impl core::marker::Send for aya::programs::tc::SchedClassifierAttachment
+impl core::marker::Sync for aya::programs::tc::SchedClassifierAttachment
+impl core::marker::Unpin for aya::programs::tc::SchedClassifierAttachment
+impl core::marker::UnsafeUnpin for aya::programs::tc::SchedClassifierAttachment
+impl core::panic::unwind_safe::RefUnwindSafe for aya::programs::tc::SchedClassifierAttachment
+impl core::panic::unwind_safe::UnwindSafe for aya::programs::tc::SchedClassifierAttachment
 pub enum aya::programs::SkReuseportError
 pub aya::programs::SkReuseportError::SetsockoptError
 pub aya::programs::SkReuseportError::SetsockoptError::io_error: core::io::error::Error
@@ -6170,7 +6254,6 @@ impl core::panic::unwind_safe::UnwindSafe for aya::programs::tc::TcAttachType
 pub enum aya::programs::TcError
 pub aya::programs::TcError::AlreadyAttached
 pub aya::programs::TcError::InvalidLinkOperation
-pub aya::programs::TcError::InvalidTcxAttach(u32)
 pub aya::programs::TcError::IoError(core::io::error::Error)
 pub aya::programs::TcError::NetlinkError(aya::sys::NetlinkError)
 pub aya::programs::TcError::NulError(alloc::ffi::c_str::NulError)
@@ -6195,6 +6278,27 @@ impl core::marker::Unpin for aya::programs::tc::TcError
 impl core::marker::UnsafeUnpin for aya::programs::tc::TcError
 impl !core::panic::unwind_safe::RefUnwindSafe for aya::programs::tc::TcError
 impl !core::panic::unwind_safe::UnwindSafe for aya::programs::tc::TcError
+pub enum aya::programs::TcxAttachType
+pub aya::programs::TcxAttachType::Egress
+pub aya::programs::TcxAttachType::Ingress
+impl core::clone::Clone for aya::programs::tc::TcxAttachType
+pub fn aya::programs::tc::TcxAttachType::clone(&self) -> aya::programs::tc::TcxAttachType
+impl core::cmp::Eq for aya::programs::tc::TcxAttachType
+impl core::cmp::PartialEq for aya::programs::tc::TcxAttachType
+pub fn aya::programs::tc::TcxAttachType::eq(&self, &aya::programs::tc::TcxAttachType) -> bool
+impl core::fmt::Debug for aya::programs::tc::TcxAttachType
+pub fn aya::programs::tc::TcxAttachType::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::hash::Hash for aya::programs::tc::TcxAttachType
+pub fn aya::programs::tc::TcxAttachType::hash<__H: core::hash::Hasher>(&self, &mut __H)
+impl core::marker::Copy for aya::programs::tc::TcxAttachType
+impl core::marker::StructuralPartialEq for aya::programs::tc::TcxAttachType
+impl core::marker::Freeze for aya::programs::tc::TcxAttachType
+impl core::marker::Send for aya::programs::tc::TcxAttachType
+impl core::marker::Sync for aya::programs::tc::TcxAttachType
+impl core::marker::Unpin for aya::programs::tc::TcxAttachType
+impl core::marker::UnsafeUnpin for aya::programs::tc::TcxAttachType
+impl core::panic::unwind_safe::RefUnwindSafe for aya::programs::tc::TcxAttachType
+impl core::panic::unwind_safe::UnwindSafe for aya::programs::tc::TcxAttachType
 pub enum aya::programs::TracePointError
 pub aya::programs::TracePointError::FileError
 pub aya::programs::TracePointError::FileError::filename: std::path::PathBuf
@@ -7129,12 +7233,12 @@ impl core::panic::unwind_safe::UnwindSafe for aya::programs::socket_filter::Reus
 pub struct aya::programs::SchedClassifier
 impl aya::programs::tc::SchedClassifier
 pub const aya::programs::tc::SchedClassifier::PROGRAM_TYPE: aya::programs::ProgramType
-pub fn aya::programs::tc::SchedClassifier::attach(&mut self, &str, aya::programs::tc::TcAttachType) -> core::result::Result<aya::programs::tc::SchedClassifierLinkId, aya::programs::ProgramError>
+pub fn aya::programs::tc::SchedClassifier::attach(&mut self, &str, aya::programs::tc::SchedClassifierAttachment) -> core::result::Result<aya::programs::tc::SchedClassifierLinkId, aya::programs::ProgramError>
 pub fn aya::programs::tc::SchedClassifier::attach_to_link(&mut self, aya::programs::tc::SchedClassifierLink) -> core::result::Result<aya::programs::tc::SchedClassifierLinkId, aya::programs::ProgramError>
-pub fn aya::programs::tc::SchedClassifier::attach_with_options(&mut self, &str, aya::programs::tc::TcAttachType, aya::programs::tc::TcAttachOptions) -> core::result::Result<aya::programs::tc::SchedClassifierLinkId, aya::programs::ProgramError>
 pub fn aya::programs::tc::SchedClassifier::from_pin<P: core::convert::AsRef<std::path::Path>>(P) -> core::result::Result<Self, aya::programs::ProgramError>
 pub fn aya::programs::tc::SchedClassifier::load(&mut self) -> core::result::Result<(), aya::programs::ProgramError>
-pub fn aya::programs::tc::SchedClassifier::query_tcx(&str, aya::programs::tc::TcAttachType) -> core::result::Result<(u64, alloc::vec::Vec<aya::programs::ProgramInfo>), aya::programs::ProgramError>
+pub fn aya::programs::tc::SchedClassifier::query_netkit(&str, aya::programs::tc::NetkitAttachType) -> core::result::Result<(u64, alloc::vec::Vec<aya::programs::ProgramInfo>), aya::programs::ProgramError>
+pub fn aya::programs::tc::SchedClassifier::query_tcx(&str, aya::programs::tc::TcxAttachType) -> core::result::Result<(u64, alloc::vec::Vec<aya::programs::ProgramInfo>), aya::programs::ProgramError>
 impl aya::programs::tc::SchedClassifier
 pub fn aya::programs::tc::SchedClassifier::detach(&mut self, aya::programs::tc::SchedClassifierLinkId) -> core::result::Result<(), aya::programs::ProgramError>
 pub fn aya::programs::tc::SchedClassifier::take_link(&mut self, aya::programs::tc::SchedClassifierLinkId) -> core::result::Result<aya::programs::tc::SchedClassifierLink, aya::programs::ProgramError>


### PR DESCRIPTION
<!-- markdownlint-disable first-line-heading -->

Adds support for netkit primary and peer attachments. This refactors the
attachments from one that covers tc and tcx and hiding the attachment
type from the user to making the user explicitly choose which attachment
they are using.

<!--
    Thank you for your contribution to Aya! 🎉

    For Work In Progress Pull Requests, please use the Draft PR feature.

    Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Aya Contributing Guide: https://github.com/aya-rs/aya/blob/main/CONTRIBUTING.md
     - 📖 Read the Aya Code of Conduct: https://github.com/aya-rs/aya/blob/main/CODE_OF_CONDUCT.md
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages: https://cbea.ms/git-commit/
     - 📗 Update any related documentation.

-->

<!---
      Summarize the changes you're making here. Detailed information belongs in
      the Git commit messages. If your pull request contains just one commit,
      it's best to use its message as a summary. Otherwise, if there are multiple
      atomic commits, write a summary for the entire PR. Feel free to flag
      anything you think needs a reviewer's attention.
-->

<!--
      If your changes address an issue, link it with the *Fixes* tag so
      the issue gets closed when the PR is merged, for example:

      Fixes: #1234

      If you are only referencing an issue without fully addressing it, feel
      free to link it anywhere in the summary.
-->

### Added/updated tests?

_We strongly encourage you to add a test for your changes._

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

### Checklist

- [x] Rust code has been formatted with `cargo +nightly fmt`.
- [x] All clippy lints have been fixed.
      You can find failing lints with `cargo xtask clippy`.
- [x] Unit tests are passing locally with `cargo test`.
- [x] The [Integration tests] are passing locally.
- [x] I have blessed any API changes with `cargo xtask public-api --bless`.

[Integration tests]: https://github.com/aya-rs/aya/blob/main/test/README.md

### (Optional) What GIF best describes this PR or how it makes you feel?

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aya-rs/aya/1553)
<!-- Reviewable:end -->
