### PR TITLE
aya-obj: Remove the `no_std` support

### DIFF
--- a/aya-obj/Cargo.toml
+++ b/aya-obj/Cargo.toml
@@ -18,14 +18,10 @@ workspace = true
 
 [dependencies]
 bytes = { workspace = true }
-hashbrown = { workspace = true, features = ["default-hasher", "equivalent"] }
 log = { workspace = true }
 object = { workspace = true, features = ["elf", "read_core"] }
-thiserror = { workspace = true }
+thiserror = { workspace = true, features = ["std"] }
 
 [dev-dependencies]
 assert_matches = { workspace = true }
 rbpf = { workspace = true }
-
-[features]
-std = ["thiserror/std"]

--- a/aya-obj/src/btf/btf.rs
+++ b/aya-obj/src/btf/btf.rs
@@ -1,14 +1,8 @@
-use alloc::{
+use std::{
     borrow::{Cow, ToOwned as _},
-    format,
-    string::String,
-    vec,
-    vec::Vec,
-};
-use core::{
     cell::OnceCell,
     ffi::{CStr, FromBytesUntilNulError},
-    mem, ptr,
+    format, mem, ptr,
 };
 
 use bytes::BufMut as _;
@@ -34,7 +28,6 @@ pub(crate) const MAX_SPEC_LEN: usize = 64;
 /// The error type returned when `BTF` operations fail.
 #[derive(thiserror::Error, Debug)]
 pub enum BtfError {
-    #[cfg(feature = "std")]
     /// Error parsing file
     #[error("error parsing {path}")]
     FileError {
@@ -128,7 +121,6 @@ pub enum BtfError {
         type_id: u32,
     },
 
-    #[cfg(feature = "std")]
     /// Loading the btf failed
     #[error("the BPF_BTF_LOAD syscall returned {io_error}. Verifier output: {verifier_log}")]
     LoadError {
@@ -319,13 +311,11 @@ impl Btf {
     }
 
     /// Loads BTF metadata from `/sys/kernel/btf/vmlinux`.
-    #[cfg(feature = "std")]
     pub fn from_sys_fs() -> Result<Self, BtfError> {
         Self::parse_file("/sys/kernel/btf/vmlinux", Endianness::default())
     }
 
     /// Loads BTF metadata from the given `path`.
-    #[cfg(feature = "std")]
     pub fn parse_file<P: AsRef<std::path::Path>>(
         path: P,
         endianness: Endianness,
@@ -1878,7 +1868,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "std")]
     #[cfg_attr(miri, ignore = "`open` not available when isolation is enabled")]
     #[cfg_attr(
         target_endian = "big",

--- a/aya-obj/src/btf/info.rs
+++ b/aya-obj/src/btf/info.rs
@@ -1,5 +1,3 @@
-use alloc::{string::String, vec, vec::Vec};
-
 use bytes::BufMut as _;
 use object::Endianness;
 

--- a/aya-obj/src/btf/relocation.rs
+++ b/aya-obj/src/btf/relocation.rs
@@ -1,12 +1,12 @@
-use alloc::{
+use std::{
     borrow::{Cow, ToOwned as _},
     collections::BTreeMap,
     format,
-    string::{String, ToString as _},
-    vec,
-    vec::Vec,
+    num::ParseIntError,
+    ops::Bound::Included,
+    ptr,
+    string::ToString as _,
 };
-use core::{num::ParseIntError, ops::Bound::Included, ptr};
 
 use object::SectionIndex;
 
@@ -37,7 +37,6 @@ pub struct BtfRelocationError {
 /// Relocation failures
 #[derive(thiserror::Error, Debug)]
 enum RelocationError {
-    #[cfg(feature = "std")]
     /// I/O error
     #[error(transparent)]
     IOError(#[from] std::io::Error),

--- a/aya-obj/src/btf/types.rs
+++ b/aya-obj/src/btf/types.rs
@@ -1,8 +1,7 @@
 #![expect(clippy::unused_self, reason = "these APIs are horrible")]
 #![expect(missing_docs, reason = "TODO")]
 
-use alloc::{string::ToString as _, vec, vec::Vec};
-use core::{fmt::Display, ptr};
+use std::{fmt::Display, ptr, string::ToString as _};
 
 use object::Endianness;
 

--- a/aya-obj/src/lib.rs
+++ b/aya-obj/src/lib.rs
@@ -37,10 +37,7 @@
 //! let bytes = std::fs::read("program.o").unwrap();
 //! let mut object = Object::parse(&bytes).unwrap();
 //! // Relocate the programs
-//! #[cfg(feature = "std")]
 //! let text_sections = std::collections::HashSet::new();
-//! #[cfg(not(feature = "std"))]
-//! let text_sections = hashbrown::HashSet::new();
 //! object.relocate_calls(&text_sections).unwrap();
 //! object.relocate_maps(std::iter::empty(), &text_sections).unwrap();
 //!
@@ -59,21 +56,13 @@
 //!
 //! [rbpf]: https://github.com/qmonnet/rbpf
 
-#![no_std]
 #![doc(
     html_logo_url = "https://aya-rs.dev/assets/images/crabby.svg",
     html_favicon_url = "https://aya-rs.dev/assets/images/crabby.svg"
 )]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![deny(missing_docs)]
-#![cfg_attr(
-    any(feature = "std", test),
-    expect(unused_crate_dependencies, reason = "used in doctests")
-)]
-
-extern crate alloc;
-#[cfg(feature = "std")]
-extern crate std;
+#![cfg_attr(test, expect(unused_crate_dependencies, reason = "used in doctests"))]
 
 pub mod btf;
 #[expect(
@@ -113,11 +102,11 @@ pub use obj::*;
 /// An error returned from the verifier.
 ///
 /// Provides a [`Debug`] implementation that doesn't escape newlines.
-pub struct VerifierLog(alloc::string::String);
+pub struct VerifierLog(String);
 
 impl VerifierLog {
     /// Create a new verifier log.
-    pub const fn new(log: alloc::string::String) -> Self {
+    pub const fn new(log: String) -> Self {
         Self(log)
     }
 }

--- a/aya-obj/src/maps.rs
+++ b/aya-obj/src/maps.rs
@@ -1,7 +1,5 @@
 //! Map struct and type bindings.
 
-use alloc::vec::Vec;
-
 use crate::{EbpfSectionKind, InvalidTypeBinding, generated::bpf_map_type};
 
 impl TryFrom<u32> for bpf_map_type {

--- a/aya-obj/src/obj.rs
+++ b/aya-obj/src/obj.rs
@@ -1,18 +1,13 @@
 //! Object file loading, parsing, and relocation.
 
-use alloc::{
+use std::{
     borrow::ToOwned as _,
     collections::BTreeMap,
-    ffi::CString,
-    string::{String, ToString as _},
-    vec,
-    vec::Vec,
-};
-use core::{
-    ffi::{CStr, FromBytesWithNulError},
+    ffi::{CStr, CString, FromBytesWithNulError},
     mem, ptr,
     slice::from_raw_parts_mut,
     str::FromStr,
+    string::ToString as _,
 };
 
 use log::debug;
@@ -1164,7 +1159,7 @@ fn parse_license(data: &[u8]) -> Result<CString, ParseError> {
                 data: data.to_vec(),
             },
         })
-        .map(alloc::borrow::ToOwned::to_owned)
+        .map(ToOwned::to_owned)
 }
 
 fn parse_version(data: &[u8], endianness: Endianness) -> Result<Option<u32>, ParseError> {
@@ -1461,8 +1456,6 @@ fn get_func_and_line_info(
 
 #[cfg(test)]
 mod tests {
-    use alloc::vec;
-
     use assert_matches::assert_matches;
 
     use super::*;

--- a/aya-obj/src/relocation.rs
+++ b/aya-obj/src/relocation.rs
@@ -1,6 +1,6 @@
 //! Program relocation handling.
 
-use alloc::{borrow::ToOwned as _, collections::BTreeMap, string::String};
+use std::{borrow::ToOwned as _, collections::BTreeMap};
 
 use log::debug;
 use object::{SectionIndex, SymbolKind};
@@ -16,10 +16,7 @@ use crate::{
     util::{HashMap, HashSet},
 };
 
-#[cfg(feature = "std")]
 type RawFd = std::os::fd::RawFd;
-#[cfg(not(feature = "std"))]
-type RawFd = core::ffi::c_int;
 
 pub(crate) const INS_SIZE: usize = size_of::<bpf_insn>();
 
@@ -495,7 +492,7 @@ fn insn_is_call(ins: bpf_insn) -> bool {
 
 #[cfg(test)]
 mod test {
-    use alloc::{string::ToString as _, vec, vec::Vec};
+    use std::string::ToString as _;
 
     use super::*;
     use crate::maps::{BtfMap, LegacyMap};

--- a/aya-obj/src/util.rs
+++ b/aya-obj/src/util.rs
@@ -1,13 +1,5 @@
 use core::{ptr, slice};
-#[cfg(feature = "std")]
-pub(crate) use std::collections::HashMap;
-#[cfg(feature = "std")]
-pub(crate) use std::collections::HashSet;
-
-#[cfg(not(feature = "std"))]
-pub(crate) use hashbrown::HashMap;
-#[cfg(not(feature = "std"))]
-pub(crate) use hashbrown::HashSet;
+pub(crate) use std::collections::{HashMap, HashSet};
 
 /// Converts a <T> to a byte slice.
 pub(crate) const unsafe fn bytes_of<T>(val: &T) -> &[u8] {

--- a/aya/Cargo.toml
+++ b/aya/Cargo.toml
@@ -18,10 +18,12 @@ workspace = true
 
 [dependencies]
 assert_matches = { workspace = true }
-aya-obj = { path = "../aya-obj", version = "^0.2.2", features = ["std"] }
+aya-obj = { path = "../aya-obj", version = "^0.2.2" }
 bitflags = { workspace = true }
 bytes = { workspace = true }
-hashbrown = { workspace = true }
+# TODO(https://github.com/rust-lang/rust/issues/60896): Remove once
+# `std::collections::hash_set::Entry` is stabilized.
+hashbrown = { workspace = true, features = ["default-hasher", "equivalent"] }
 libc = { workspace = true }
 log = { workspace = true }
 object = { workspace = true, features = ["elf", "read_core", "std", "write"] }

--- a/test/integration-test/Cargo.toml
+++ b/test/integration-test/Cargo.toml
@@ -20,7 +20,7 @@ aya = { path = "../../aya", version = "^0.13.2", default-features = false }
 anyhow = { workspace = true, features = ["std"] }
 assert_matches = { workspace = true }
 aya-log = { path = "../../aya-log", version = "^0.2.2", default-features = false }
-aya-obj = { path = "../../aya-obj", version = "^0.2.2", default-features = false }
+aya-obj = { path = "../../aya-obj", version = "^0.2.2" }
 bytes = { workspace = true }
 epoll = { workspace = true }
 futures = { workspace = true, features = ["alloc"] }


### PR DESCRIPTION
The original motivation for `no_std` support in `aya-obj` was to keep it closer to `object`. In practice, though, one of `aya-obj`'s main jobs is sanitizing bytecode and BTF, and that logic relies on dynamic data structures.

Given that, keeping `no_std` support no longer reflects how the crate is actually used and only adds maintenance overhead.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aya-rs/aya/1556)
<!-- Reviewable:end -->
