### PR TITLE
aya-ebpf: add BTF map definition for sockmap and sockhash

### DIFF
--- a/ebpf/aya-ebpf/src/btf_maps/mod.rs
+++ b/ebpf/aya-ebpf/src/btf_maps/mod.rs
@@ -8,6 +8,8 @@ pub mod program_array;
 pub mod reuseport_sock_array;
 pub mod ring_buf;
 pub mod sk_storage;
+pub mod sock_hash;
+pub mod sock_map;
 pub mod stack_trace;
 
 pub use array::Array;
@@ -20,6 +22,8 @@ pub use program_array::ProgramArray;
 pub use reuseport_sock_array::ReusePortSockArray;
 pub use ring_buf::RingBuf;
 pub use sk_storage::SkStorage;
+pub use sock_hash::SockHash;
+pub use sock_map::SockMap;
 pub use stack_trace::StackTrace;
 
 /// Defines a BTF-compatible map struct with flat `#[repr(C)]` layout.

--- a/ebpf/aya-ebpf/src/btf_maps/sock_hash.rs
+++ b/ebpf/aya-ebpf/src/btf_maps/sock_hash.rs
@@ -1,0 +1,145 @@
+use core::{
+    borrow::{Borrow, BorrowMut},
+    ptr,
+};
+
+use crate::{
+    ENOENT, EbpfContext as _,
+    bindings::bpf_sock_ops,
+    btf_maps::btf_map_def,
+    cty::c_long,
+    helpers::{
+        bpf_msg_redirect_hash, bpf_sk_assign, bpf_sk_redirect_hash, bpf_sk_release,
+        bpf_sock_hash_update,
+    },
+    lookup,
+    programs::{SkBuffContext, SkLookupContext, SkMsgContext},
+};
+
+btf_map_def!(
+    /// A BTF-compatible BPF sockhash.
+    ///
+    /// `SockHash` stores sockets keyed by an arbitrary `K`. Sockets can be
+    /// inserted from `SOCK_OPS` programs via [`SockHash::update`] or from
+    /// userspace, and consumed by `SK_SKB`, `SK_MSG`, or `SK_LOOKUP`
+    /// programs to redirect or assign packets.
+    ///
+    /// # Minimum kernel version
+    ///
+    /// The minimum kernel version required to use this feature is 4.18.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use aya_ebpf::{btf_maps::SockHash, macros::btf_map};
+    ///
+    /// #[btf_map]
+    /// static SOCKS: SockHash<u32, 128> = SockHash::new();
+    /// ```
+    pub struct SockHash<K; const MAX_ENTRIES: usize, const FLAGS: usize = 0>,
+    map_type: BPF_MAP_TYPE_SOCKHASH,
+    max_entries: MAX_ENTRIES,
+    map_flags: FLAGS,
+    key_type: K,
+    value_type: u32,
+);
+
+impl<K, const MAX_ENTRIES: usize, const FLAGS: usize> SockHash<K, MAX_ENTRIES, FLAGS> {
+    // Enforces kernel constraints (kernel/net/core/sock_map.c sock_hash_alloc):
+    // key_size must be > 0 and <= MAX_BPF_STACK (512). `const _: ()` is
+    // forbidden in a generic impl, and a named associated const is lazy
+    // without a reference, hence `let () = Self::_CHECK` in every method.
+    const _CHECK: () = {
+        assert!(size_of::<K>() > 0, "SockHash key must be non-zero sized.");
+        assert!(
+            size_of::<K>() <= 512,
+            "SockHash key must be at most 512 bytes (MAX_BPF_STACK).",
+        );
+        assert!(
+            MAX_ENTRIES > 0,
+            "SockHash max_entries must be greater than zero.",
+        );
+    };
+
+    /// Inserts the socket from `sk_ops` into the map under `key`.
+    pub fn update(
+        &self,
+        mut key: impl BorrowMut<K>,
+        mut sk_ops: impl BorrowMut<bpf_sock_ops>,
+        flags: u64,
+    ) -> Result<(), i32> {
+        let () = Self::_CHECK;
+        let ret = unsafe {
+            bpf_sock_hash_update(
+                ptr::from_mut(sk_ops.borrow_mut()),
+                self.as_ptr().cast(),
+                ptr::from_mut(key.borrow_mut()).cast(),
+                flags,
+            )
+        };
+        (ret == 0).then_some(()).ok_or(ret as i32)
+    }
+
+    /// Redirects the message in `ctx` to the socket at `key`.
+    pub fn redirect_msg(
+        &self,
+        ctx: impl Borrow<SkMsgContext>,
+        mut key: impl BorrowMut<K>,
+        flags: u64,
+    ) -> c_long {
+        let () = Self::_CHECK;
+        unsafe {
+            bpf_msg_redirect_hash(
+                ctx.borrow().msg,
+                self.as_ptr().cast(),
+                ptr::from_mut(key.borrow_mut()).cast(),
+                flags,
+            )
+        }
+    }
+
+    /// Redirects the socket buffer in `ctx` to the socket at `key`.
+    pub fn redirect_skb(
+        &self,
+        ctx: impl Borrow<SkBuffContext>,
+        mut key: impl BorrowMut<K>,
+        flags: u64,
+    ) -> c_long {
+        let () = Self::_CHECK;
+        unsafe {
+            bpf_sk_redirect_hash(
+                ctx.borrow().skb.skb,
+                self.as_ptr().cast(),
+                ptr::from_mut(key.borrow_mut()).cast(),
+                flags,
+            )
+        }
+    }
+
+    /// Assigns the socket at `key` as the result of the `SK_LOOKUP` `ctx`.
+    ///
+    /// # Minimum kernel version
+    ///
+    /// The minimum kernel version required to use this method is
+    /// [5.9](https://github.com/torvalds/linux/commit/e9ddbb7707ff5891616240026062b8c1e29864ca),
+    /// when `bpf_sk_assign` was extended to `SK_LOOKUP` programs.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Err(-ENOENT)` if `key` is not present in the map. Otherwise
+    /// propagates the [`bpf_sk_assign`] errno.
+    ///
+    /// [`bpf_sk_assign`]: https://docs.ebpf.io/linux/helper-function/bpf_sk_assign/
+    pub fn redirect_sk_lookup(
+        &self,
+        ctx: impl Borrow<SkLookupContext>,
+        key: impl Borrow<K>,
+        flags: u64,
+    ) -> Result<(), i32> {
+        let () = Self::_CHECK;
+        let sk = lookup(self.as_ptr(), key.borrow()).ok_or(-ENOENT)?;
+        let ret = unsafe { bpf_sk_assign(ctx.borrow().as_ptr().cast(), sk.as_ptr(), flags) };
+        let _: c_long = unsafe { bpf_sk_release(sk.as_ptr()) };
+        (ret == 0).then_some(()).ok_or(ret as i32)
+    }
+}

--- a/ebpf/aya-ebpf/src/btf_maps/sock_map.rs
+++ b/ebpf/aya-ebpf/src/btf_maps/sock_map.rs
@@ -1,0 +1,121 @@
+use crate::{
+    ENOENT, EbpfContext as _,
+    bindings::bpf_sock_ops,
+    btf_maps::btf_map_def,
+    cty::c_long,
+    helpers::{
+        bpf_msg_redirect_map, bpf_sk_assign, bpf_sk_redirect_map, bpf_sk_release,
+        bpf_sock_map_update,
+    },
+    lookup,
+    programs::{SkBuffContext, SkLookupContext, SkMsgContext},
+};
+
+btf_map_def!(
+    /// A BTF-compatible BPF sockmap.
+    ///
+    /// `SockMap` stores sockets keyed by a `u32` index. Sockets can be
+    /// inserted from `SOCK_OPS` programs via [`SockMap::update`] or from
+    /// userspace, and consumed by `SK_SKB`, `SK_MSG`, or `SK_LOOKUP`
+    /// programs to redirect or assign packets.
+    ///
+    /// # Minimum kernel version
+    ///
+    /// The minimum kernel version required to use this feature is 4.14.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use aya_ebpf::{btf_maps::SockMap, macros::btf_map};
+    ///
+    /// #[btf_map]
+    /// static SOCKS: SockMap<128> = SockMap::new();
+    /// ```
+    pub struct SockMap<; const MAX_ENTRIES: usize, const FLAGS: usize = 0>,
+    map_type: BPF_MAP_TYPE_SOCKMAP,
+    max_entries: MAX_ENTRIES,
+    map_flags: FLAGS,
+    key_type: u32,
+    value_type: u32,
+);
+
+impl<const MAX_ENTRIES: usize, const FLAGS: usize> SockMap<MAX_ENTRIES, FLAGS> {
+    // Enforces kernel constraints (kernel/net/core/sock_map.c sock_map_alloc):
+    // max_entries must be > 0. `const _: ()` is forbidden in a generic impl,
+    // and a named associated const is lazy without a reference, hence
+    // `let () = Self::_CHECK` in every method.
+    const _CHECK: () = {
+        assert!(
+            MAX_ENTRIES > 0,
+            "SockMap max_entries must be greater than zero.",
+        );
+    };
+
+    /// Inserts the socket from `sk_ops` into the map at `index`.
+    ///
+    /// Wraps `bpf_sock_map_update`. Intended for `SOCK_OPS` programs.
+    ///
+    /// # Safety
+    ///
+    /// `sk_ops` must be a valid pointer to a `bpf_sock_ops` structure,
+    /// typically the `ops` field of a [`SockOpsContext`]. The kernel
+    /// guarantees its validity within the program's execution context.
+    ///
+    /// [`SockOpsContext`]: crate::programs::SockOpsContext
+    pub unsafe fn update(
+        &self,
+        mut index: u32,
+        sk_ops: *mut bpf_sock_ops,
+        flags: u64,
+    ) -> Result<(), i32> {
+        let () = Self::_CHECK;
+        let ret = unsafe {
+            bpf_sock_map_update(
+                sk_ops,
+                self.as_ptr().cast(),
+                core::ptr::from_mut(&mut index).cast(),
+                flags,
+            )
+        };
+        if ret == 0 { Ok(()) } else { Err(ret as i32) }
+    }
+
+    /// Redirects the message in `ctx` to the socket at `index`.
+    pub fn redirect_msg(&self, ctx: &SkMsgContext, index: u32, flags: u64) -> c_long {
+        let () = Self::_CHECK;
+        unsafe { bpf_msg_redirect_map(ctx.as_ptr().cast(), self.as_ptr().cast(), index, flags) }
+    }
+
+    /// Redirects the socket buffer in `ctx` to the socket at `index`.
+    pub fn redirect_skb(&self, ctx: &SkBuffContext, index: u32, flags: u64) -> c_long {
+        let () = Self::_CHECK;
+        unsafe { bpf_sk_redirect_map(ctx.as_ptr().cast(), self.as_ptr().cast(), index, flags) }
+    }
+
+    /// Assigns the socket at `index` as the result of the `SK_LOOKUP` `ctx`.
+    ///
+    /// # Minimum kernel version
+    ///
+    /// The minimum kernel version required to use this method is
+    /// [5.9](https://github.com/torvalds/linux/commit/e9ddbb7707ff5891616240026062b8c1e29864ca),
+    /// when `bpf_sk_assign` was extended to `SK_LOOKUP` programs.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Err(-ENOENT)` if `index` is not present in the map. Otherwise
+    /// propagates the [`bpf_sk_assign`] errno.
+    ///
+    /// [`bpf_sk_assign`]: https://docs.ebpf.io/linux/helper-function/bpf_sk_assign/
+    pub fn redirect_sk_lookup(
+        &self,
+        ctx: &SkLookupContext,
+        index: u32,
+        flags: u64,
+    ) -> Result<(), i32> {
+        let () = Self::_CHECK;
+        let sk = lookup(self.as_ptr(), &index).ok_or(-ENOENT)?;
+        let ret = unsafe { bpf_sk_assign(ctx.as_ptr().cast(), sk.as_ptr(), flags) };
+        let _: c_long = unsafe { bpf_sk_release(sk.as_ptr()) };
+        if ret == 0 { Ok(()) } else { Err(ret as i32) }
+    }
+}

--- a/ebpf/aya-ebpf/src/lib.rs
+++ b/ebpf/aya-ebpf/src/lib.rs
@@ -195,6 +195,9 @@ fn lookup<K, V>(def: *mut c_void, key: &K) -> Option<NonNull<V>> {
     NonNull::new(unsafe { bpf_map_lookup_elem(def, key.cast()) }.cast())
 }
 
+/// `ENOENT` errno value, returned (negated) when [`lookup`] misses.
+pub(crate) const ENOENT: i32 = 2;
+
 /// A read-only global value that may be initialized by the loader.
 ///
 /// Prefer using this to a plain `static` variable to avoid compiler optimizations eliding reads.

--- a/ebpf/aya-ebpf/src/maps/sock_hash.rs
+++ b/ebpf/aya-ebpf/src/maps/sock_hash.rs
@@ -5,7 +5,7 @@ use core::{
 };
 
 use crate::{
-    EbpfContext as _,
+    ENOENT, EbpfContext as _,
     bindings::{bpf_map_type::BPF_MAP_TYPE_SOCKHASH, bpf_sock_ops},
     cty::c_long,
     helpers::{
@@ -80,13 +80,10 @@ impl<K> SockHash<K> {
         ctx: impl Borrow<SkLookupContext>,
         key: impl Borrow<K>,
         flags: u64,
-    ) -> Result<(), u32> {
-        let sk = lookup(self.def.as_ptr(), key.borrow()).ok_or(1u32)?;
+    ) -> Result<(), i32> {
+        let sk = lookup(self.def.as_ptr(), key.borrow()).ok_or(-ENOENT)?;
         let ret = unsafe { bpf_sk_assign(ctx.borrow().as_ptr().cast(), sk.as_ptr(), flags) };
         let _: c_long = unsafe { bpf_sk_release(sk.as_ptr()) };
-        match ret {
-            0 => Ok(()),
-            _ret => Err(1),
-        }
+        (ret == 0).then_some(()).ok_or(ret as i32)
     }
 }

--- a/ebpf/aya-ebpf/src/maps/sock_map.rs
+++ b/ebpf/aya-ebpf/src/maps/sock_map.rs
@@ -1,5 +1,5 @@
 use crate::{
-    EbpfContext as _,
+    ENOENT, EbpfContext as _,
     bindings::{bpf_map_type::BPF_MAP_TYPE_SOCKMAP, bpf_sock_ops},
     cty::c_long,
     helpers::{
@@ -52,13 +52,10 @@ impl SockMap {
         ctx: &SkLookupContext,
         index: u32,
         flags: u64,
-    ) -> Result<(), u32> {
-        let sk = lookup(self.def.as_ptr(), &index).ok_or(1u32)?;
+    ) -> Result<(), i32> {
+        let sk = lookup(self.def.as_ptr(), &index).ok_or(-ENOENT)?;
         let ret = unsafe { bpf_sk_assign(ctx.as_ptr().cast(), sk.as_ptr(), flags) };
         let _: c_long = unsafe { bpf_sk_release(sk.as_ptr()) };
-        match ret {
-            0 => Ok(()),
-            _ret => Err(1),
-        }
+        if ret == 0 { Ok(()) } else { Err(ret as i32) }
     }
 }

--- a/test/integration-ebpf/Cargo.toml
+++ b/test/integration-ebpf/Cargo.toml
@@ -105,6 +105,14 @@ name = "sk_storage"
 path = "src/sk_storage.rs"
 
 [[bin]]
+name = "sock_hash"
+path = "src/sock_hash.rs"
+
+[[bin]]
+name = "sock_map"
+path = "src/sock_map.rs"
+
+[[bin]]
 name = "simple_prog"
 path = "src/simple_prog.rs"
 

--- a/test/integration-ebpf/src/sock_hash.rs
+++ b/test/integration-ebpf/src/sock_hash.rs
@@ -1,0 +1,40 @@
+#![no_std]
+#![no_main]
+#![expect(unused_crate_dependencies, reason = "used in other bins")]
+
+use aya_ebpf::{
+    bindings::sk_action::{SK_DROP, SK_PASS},
+    btf_maps::{Array, SockHash as BtfSockHash},
+    macros::{btf_map, map, sk_lookup},
+    maps::SockHash as LegacySockHash,
+    programs::SkLookupContext,
+};
+#[cfg(not(test))]
+extern crate ebpf_panic;
+
+#[map(name = "SOCKETS_LEGACY")]
+static SOCKETS_LEGACY: LegacySockHash<u32> = LegacySockHash::with_max_entries(1, 0);
+
+#[btf_map(name = "SOCKETS_BTF")]
+static SOCKETS_BTF: BtfSockHash<u32, 1> = BtfSockHash::new();
+
+#[btf_map(name = "LAST_ERRNO")]
+static LAST_ERRNO: Array<i32, 1> = Array::new();
+
+macro_rules! define_sk_lookup {
+    ($map:ident, $prog:ident) => {
+        #[sk_lookup]
+        fn $prog(ctx: SkLookupContext) -> u32 {
+            match $map.redirect_sk_lookup(&ctx, 0u32, 0) {
+                Ok(()) => SK_PASS,
+                Err(errno) => match LAST_ERRNO.set(0, errno, 0) {
+                    // Single-slot ARRAY set is infallible at runtime.
+                    Ok(()) | Err(_) => SK_DROP,
+                },
+            }
+        }
+    };
+}
+
+define_sk_lookup!(SOCKETS_LEGACY, sk_lookup_legacy);
+define_sk_lookup!(SOCKETS_BTF, sk_lookup_btf);

--- a/test/integration-ebpf/src/sock_map.rs
+++ b/test/integration-ebpf/src/sock_map.rs
@@ -1,0 +1,40 @@
+#![no_std]
+#![no_main]
+#![expect(unused_crate_dependencies, reason = "used in other bins")]
+
+use aya_ebpf::{
+    bindings::sk_action::{SK_DROP, SK_PASS},
+    btf_maps::{Array, SockMap as BtfSockMap},
+    macros::{btf_map, map, sk_lookup},
+    maps::SockMap as LegacySockMap,
+    programs::SkLookupContext,
+};
+#[cfg(not(test))]
+extern crate ebpf_panic;
+
+#[map(name = "SOCKETS_LEGACY")]
+static SOCKETS_LEGACY: LegacySockMap = LegacySockMap::with_max_entries(1, 0);
+
+#[btf_map(name = "SOCKETS_BTF")]
+static SOCKETS_BTF: BtfSockMap<1> = BtfSockMap::new();
+
+#[btf_map(name = "LAST_ERRNO")]
+static LAST_ERRNO: Array<i32, 1> = Array::new();
+
+macro_rules! define_sk_lookup {
+    ($map:ident, $prog:ident) => {
+        #[sk_lookup]
+        fn $prog(ctx: SkLookupContext) -> u32 {
+            match $map.redirect_sk_lookup(&ctx, 0, 0) {
+                Ok(()) => SK_PASS,
+                Err(errno) => match LAST_ERRNO.set(0, errno, 0) {
+                    // Single-slot ARRAY set is infallible at runtime.
+                    Ok(()) | Err(_) => SK_DROP,
+                },
+            }
+        }
+    };
+}
+
+define_sk_lookup!(SOCKETS_LEGACY, sk_lookup_legacy);
+define_sk_lookup!(SOCKETS_BTF, sk_lookup_btf);

--- a/test/integration-test/src/lib.rs
+++ b/test/integration-test/src/lib.rs
@@ -62,6 +62,8 @@ bpf_file!(
     SIMPLE_PROG => "simple_prog",
     SK_REUSEPORT => "sk_reuseport",
     SK_STORAGE => "sk_storage",
+    SOCK_HASH => "sock_hash",
+    SOCK_MAP => "sock_map",
     STRNCMP => "strncmp",
     TCX => "tcx",
     TEST => "test",

--- a/test/integration-test/src/tests.rs
+++ b/test/integration-test/src/tests.rs
@@ -34,6 +34,7 @@ mod raw_tracepoint;
 mod rbpf;
 mod relocations;
 mod ring_buf;
+mod sk_lookup;
 mod sk_reuseport;
 mod sk_storage;
 mod smoke;

--- a/test/integration-test/src/tests/sk_lookup.rs
+++ b/test/integration-test/src/tests/sk_lookup.rs
@@ -1,0 +1,153 @@
+use std::{
+    io::ErrorKind,
+    net::{Ipv4Addr, TcpListener, TcpStream},
+    os::fd::AsRawFd as _,
+    time::Duration,
+};
+
+use aya::{
+    Ebpf, EbpfLoader,
+    maps::{Array, MapType, SockHash, SockMap},
+    programs::{ProgramType, SkLookup},
+    sys::{is_map_supported, is_program_supported},
+};
+use libc::ENOENT;
+use test_case::test_case;
+
+use crate::utils::NetNsGuard;
+
+const CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
+const MISS_TIMEOUT: Duration = Duration::from_millis(200);
+
+#[derive(Clone, Copy, Debug)]
+enum MapKind {
+    Hash,
+    Map,
+}
+
+impl MapKind {
+    const fn map_type(self) -> MapType {
+        match self {
+            Self::Hash => MapType::SockHash,
+            Self::Map => MapType::SockMap,
+        }
+    }
+
+    fn insert_canary(self, bpf: &mut Ebpf, name: &str, canary: &TcpListener) {
+        match self {
+            Self::Hash => {
+                let mut m: SockHash<_, u32> = bpf
+                    .map_mut(name)
+                    .unwrap_or_else(|| panic!("missing map {name}"))
+                    .try_into()
+                    .unwrap_or_else(|err| panic!("map {name} is not a SockHash: {err}"));
+                m.insert(0u32, canary.as_raw_fd(), 0)
+                    .expect("insert canary");
+            }
+            Self::Map => {
+                let mut m: SockMap<_> = bpf
+                    .map_mut(name)
+                    .unwrap_or_else(|| panic!("missing map {name}"))
+                    .try_into()
+                    .unwrap_or_else(|err| panic!("map {name} is not a SockMap: {err}"));
+                m.set(0, canary, 0).expect("insert canary");
+            }
+        }
+    }
+}
+
+#[test_case(crate::SOCK_HASH, MapKind::Hash, "SOCKETS_LEGACY", "sk_lookup_legacy" ; "sock_hash legacy")]
+#[test_case(crate::SOCK_HASH, MapKind::Hash, "SOCKETS_BTF", "sk_lookup_btf" ; "sock_hash btf")]
+#[test_case(crate::SOCK_MAP, MapKind::Map, "SOCKETS_LEGACY", "sk_lookup_legacy" ; "sock_map legacy")]
+#[test_case(crate::SOCK_MAP, MapKind::Map, "SOCKETS_BTF", "sk_lookup_btf" ; "sock_map btf")]
+#[test_log::test]
+fn redirect_sk_lookup(bpf_bytes: &[u8], kind: MapKind, map_name: &str, prog_name: &str) {
+    if !is_map_supported(kind.map_type()).unwrap() {
+        eprintln!("skipping test - {:?} not supported", kind.map_type());
+        return;
+    }
+    if !is_program_supported(ProgramType::SkLookup).unwrap() {
+        eprintln!("skipping test - sk_lookup not supported");
+        return;
+    }
+
+    let netns = NetNsGuard::new();
+
+    let canary = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).expect("bind canary listener");
+
+    // Reserve and immediately release a port so the kernel's normal lookup
+    // misses; SK_LOOKUP must then redirect the SYN to canary.
+    let probe_addr = {
+        let probe = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).expect("bind probe listener");
+        probe.local_addr().expect("probe local_addr")
+    };
+
+    let mut bpf = EbpfLoader::new().load(bpf_bytes).expect("load bpf program");
+
+    kind.insert_canary(&mut bpf, map_name, &canary);
+
+    let prog: &mut SkLookup = bpf
+        .program_mut(prog_name)
+        .unwrap_or_else(|| panic!("missing program {prog_name}"))
+        .try_into()
+        .unwrap_or_else(|err| panic!("program {prog_name} is not an SkLookup: {err}"));
+    prog.load()
+        .unwrap_or_else(|err| panic!("load {prog_name}: {err}"));
+    prog.attach(&netns)
+        .unwrap_or_else(|err| panic!("attach {prog_name}: {err}"));
+
+    let stream =
+        TcpStream::connect_timeout(&probe_addr, CONNECT_TIMEOUT).expect("connect to probe address");
+
+    canary.accept().expect("canary accept failed");
+
+    drop(stream);
+}
+
+#[test_case(crate::SOCK_HASH, MapKind::Hash, "sk_lookup_legacy" ; "sock_hash legacy")]
+#[test_case(crate::SOCK_HASH, MapKind::Hash, "sk_lookup_btf" ; "sock_hash btf")]
+#[test_case(crate::SOCK_MAP, MapKind::Map, "sk_lookup_legacy" ; "sock_map legacy")]
+#[test_case(crate::SOCK_MAP, MapKind::Map, "sk_lookup_btf" ; "sock_map btf")]
+#[test_log::test]
+fn redirect_sk_lookup_miss_propagates_enoent(bpf_bytes: &[u8], kind: MapKind, prog_name: &str) {
+    if !is_map_supported(kind.map_type()).unwrap() {
+        eprintln!("skipping test - {:?} not supported", kind.map_type());
+        return;
+    }
+    if !is_program_supported(ProgramType::SkLookup).unwrap() {
+        eprintln!("skipping test - sk_lookup not supported");
+        return;
+    }
+
+    let netns = NetNsGuard::new();
+
+    // Empty map: `redirect_sk_lookup` must return `Err(-ENOENT)` and the BPF
+    // program records it in LAST_ERRNO before returning SK_DROP.
+    let probe_addr = {
+        let probe = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).expect("bind probe listener");
+        probe.local_addr().expect("probe local_addr")
+    };
+
+    let mut bpf = EbpfLoader::new().load(bpf_bytes).expect("load bpf program");
+
+    let prog: &mut SkLookup = bpf
+        .program_mut(prog_name)
+        .unwrap_or_else(|| panic!("missing program {prog_name}"))
+        .try_into()
+        .unwrap_or_else(|err| panic!("program {prog_name} is not an SkLookup: {err}"));
+    prog.load()
+        .unwrap_or_else(|err| panic!("load {prog_name}: {err}"));
+    prog.attach(&netns)
+        .unwrap_or_else(|err| panic!("attach {prog_name}: {err}"));
+
+    let err = TcpStream::connect_timeout(&probe_addr, MISS_TIMEOUT)
+        .expect_err("connect should fail when redirect_sk_lookup misses");
+    assert_eq!(err.kind(), ErrorKind::ConnectionRefused, "got {err:?}");
+
+    let last_errno: Array<_, i32> = bpf
+        .take_map("LAST_ERRNO")
+        .expect("missing LAST_ERRNO map")
+        .try_into()
+        .expect("LAST_ERRNO is not an Array");
+    assert_eq!(last_errno.get(&0, 0).unwrap(), -ENOENT);
+}

--- a/test/integration-test/src/utils.rs
+++ b/test/integration-test/src/utils.rs
@@ -6,6 +6,7 @@ use std::{
     ffi::CString,
     fs,
     io::{self, Write as _},
+    os::fd::{AsFd, BorrowedFd},
     path::Path,
     process,
     sync::atomic::{AtomicU64, Ordering},
@@ -138,20 +139,22 @@ impl Drop for ChildCgroup<'_> {
 pub(crate) struct NetNsGuard {
     name: String,
     old_ns: fs::File,
+    new_ns: fs::File,
 }
 
 impl NetNsGuard {
     const PERSIST_DIR: &str = "/var/run/netns/";
+    const THREAD_NETNS: &str = "/proc/thread-self/ns/net";
 
     #[expect(
         clippy::print_stdout,
         reason = "integration tests print namespace transitions for diagnostics"
     )]
     pub(crate) fn new() -> Self {
-        let current_thread_netns_path = format!("/proc/self/task/{}/ns/net", nix::unistd::gettid());
-        let old_ns = fs::File::open(&current_thread_netns_path).unwrap_or_else(|err| {
-            panic!("fs::File::open(\"{current_thread_netns_path}\"): {err:?}")
-        });
+        // `/proc/thread-self/ns/net` resolves to the calling thread's netns
+        // (`/proc/self/ns/net` would always pin to the main thread's).
+        let old_ns = fs::File::open(Self::THREAD_NETNS)
+            .unwrap_or_else(|err| panic!("fs::File::open(\"{}\"): {err:?}", Self::THREAD_NETNS));
 
         static COUNTER: AtomicU64 = AtomicU64::new(0);
         let pid = process::id();
@@ -165,8 +168,12 @@ impl NetNsGuard {
         nix::sched::unshare(nix::sched::CloneFlags::CLONE_NEWNET)
             .expect("nix::sched::unshare(CLONE_NEWNET)");
 
+        // Re-open after unshare to capture the freshly entered namespace.
+        let new_ns = fs::File::open(Self::THREAD_NETNS)
+            .unwrap_or_else(|err| panic!("fs::File::open(\"{}\"): {err:?}", Self::THREAD_NETNS));
+
         nix::mount::mount(
-            Some(current_thread_netns_path.as_str()),
+            Some(Self::THREAD_NETNS),
             &ns_path,
             Some("none"),
             nix::mount::MsFlags::MS_BIND,
@@ -176,7 +183,11 @@ impl NetNsGuard {
 
         println!("entered network namespace {name}");
 
-        let ns = Self { name, old_ns };
+        let ns = Self {
+            name,
+            old_ns,
+            new_ns,
+        };
 
         // By default, the loopback in a new netns is down. Set it up.
         let lo = CString::new("lo").unwrap();
@@ -196,6 +207,12 @@ impl NetNsGuard {
     }
 }
 
+impl AsFd for NetNsGuard {
+    fn as_fd(&self) -> BorrowedFd<'_> {
+        self.new_ns.as_fd()
+    }
+}
+
 impl Drop for NetNsGuard {
     #[expect(
         clippy::print_stderr,
@@ -206,7 +223,11 @@ impl Drop for NetNsGuard {
         reason = "debug formatting preserves error context in drop"
     )]
     fn drop(&mut self) {
-        let Self { old_ns, name } = self;
+        let Self {
+            old_ns,
+            name,
+            new_ns: _,
+        } = self;
         match (|| -> Result<()> {
             nix::sched::setns(old_ns, nix::sched::CloneFlags::CLONE_NEWNET)
                 .context("nix::sched::setns(_, CLONE_NEWNET)")?;

--- a/xtask/public-api/aya-ebpf.txt
+++ b/xtask/public-api/aya-ebpf.txt
@@ -185,6 +185,42 @@ impl<T> core::marker::Unpin for aya_ebpf::btf_maps::sk_storage::SkStorage<T>
 impl<T> core::marker::UnsafeUnpin for aya_ebpf::btf_maps::sk_storage::SkStorage<T>
 impl<T> core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::btf_maps::sk_storage::SkStorage<T> where T: core::panic::unwind_safe::RefUnwindSafe
 impl<T> core::panic::unwind_safe::UnwindSafe for aya_ebpf::btf_maps::sk_storage::SkStorage<T> where T: core::panic::unwind_safe::RefUnwindSafe
+pub mod aya_ebpf::btf_maps::sock_hash
+#[repr(C)] pub struct aya_ebpf::btf_maps::sock_hash::SockHash<K, const MAX_ENTRIES: usize, const FLAGS: usize>
+impl<K, const MAX_ENTRIES: usize, const FLAGS: usize> aya_ebpf::btf_maps::sock_hash::SockHash<K, MAX_ENTRIES, FLAGS>
+pub const fn aya_ebpf::btf_maps::sock_hash::SockHash<K, MAX_ENTRIES, FLAGS>::new() -> Self
+impl<K, const MAX_ENTRIES: usize, const FLAGS: usize> aya_ebpf::btf_maps::sock_hash::SockHash<K, MAX_ENTRIES, FLAGS>
+pub fn aya_ebpf::btf_maps::sock_hash::SockHash<K, MAX_ENTRIES, FLAGS>::redirect_msg(&self, ctx: impl core::borrow::Borrow<aya_ebpf::programs::sk_msg::SkMsgContext>, key: impl core::borrow::BorrowMut<K>, flags: u64) -> aya_ebpf_cty::od::c_long
+pub fn aya_ebpf::btf_maps::sock_hash::SockHash<K, MAX_ENTRIES, FLAGS>::redirect_sk_lookup(&self, ctx: impl core::borrow::Borrow<aya_ebpf::programs::sk_lookup::SkLookupContext>, key: impl core::borrow::Borrow<K>, flags: u64) -> core::result::Result<(), i32>
+pub fn aya_ebpf::btf_maps::sock_hash::SockHash<K, MAX_ENTRIES, FLAGS>::redirect_skb(&self, ctx: impl core::borrow::Borrow<aya_ebpf::programs::sk_buff::SkBuffContext>, key: impl core::borrow::BorrowMut<K>, flags: u64) -> aya_ebpf_cty::od::c_long
+pub fn aya_ebpf::btf_maps::sock_hash::SockHash<K, MAX_ENTRIES, FLAGS>::update(&self, key: impl core::borrow::BorrowMut<K>, sk_ops: impl core::borrow::BorrowMut<aya_ebpf_bindings::x86_64::bindings::bpf_sock_ops>, flags: u64) -> core::result::Result<(), i32>
+impl<K, const MAX_ENTRIES: usize, const FLAGS: usize> core::default::Default for aya_ebpf::btf_maps::sock_hash::SockHash<K, MAX_ENTRIES, FLAGS>
+pub fn aya_ebpf::btf_maps::sock_hash::SockHash<K, MAX_ENTRIES, FLAGS>::default() -> Self
+impl<K, const MAX_ENTRIES: usize, const FLAGS: usize> core::marker::Sync for aya_ebpf::btf_maps::sock_hash::SockHash<K, MAX_ENTRIES, FLAGS>
+impl<K, const MAX_ENTRIES: usize, const FLAGS: usize> core::marker::Freeze for aya_ebpf::btf_maps::sock_hash::SockHash<K, MAX_ENTRIES, FLAGS>
+impl<K, const MAX_ENTRIES: usize, const FLAGS: usize> !core::marker::Send for aya_ebpf::btf_maps::sock_hash::SockHash<K, MAX_ENTRIES, FLAGS>
+impl<K, const MAX_ENTRIES: usize, const FLAGS: usize> core::marker::Unpin for aya_ebpf::btf_maps::sock_hash::SockHash<K, MAX_ENTRIES, FLAGS>
+impl<K, const MAX_ENTRIES: usize, const FLAGS: usize> core::marker::UnsafeUnpin for aya_ebpf::btf_maps::sock_hash::SockHash<K, MAX_ENTRIES, FLAGS>
+impl<K, const MAX_ENTRIES: usize, const FLAGS: usize> core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::btf_maps::sock_hash::SockHash<K, MAX_ENTRIES, FLAGS> where K: core::panic::unwind_safe::RefUnwindSafe
+impl<K, const MAX_ENTRIES: usize, const FLAGS: usize> core::panic::unwind_safe::UnwindSafe for aya_ebpf::btf_maps::sock_hash::SockHash<K, MAX_ENTRIES, FLAGS> where K: core::panic::unwind_safe::RefUnwindSafe
+pub mod aya_ebpf::btf_maps::sock_map
+#[repr(C)] pub struct aya_ebpf::btf_maps::sock_map::SockMap<const MAX_ENTRIES: usize, const FLAGS: usize>
+impl<const MAX_ENTRIES: usize, const FLAGS: usize> aya_ebpf::btf_maps::sock_map::SockMap<MAX_ENTRIES, FLAGS>
+pub const fn aya_ebpf::btf_maps::sock_map::SockMap<MAX_ENTRIES, FLAGS>::new() -> Self
+impl<const MAX_ENTRIES: usize, const FLAGS: usize> aya_ebpf::btf_maps::sock_map::SockMap<MAX_ENTRIES, FLAGS>
+pub fn aya_ebpf::btf_maps::sock_map::SockMap<MAX_ENTRIES, FLAGS>::redirect_msg(&self, ctx: &aya_ebpf::programs::sk_msg::SkMsgContext, index: u32, flags: u64) -> aya_ebpf_cty::od::c_long
+pub fn aya_ebpf::btf_maps::sock_map::SockMap<MAX_ENTRIES, FLAGS>::redirect_sk_lookup(&self, ctx: &aya_ebpf::programs::sk_lookup::SkLookupContext, index: u32, flags: u64) -> core::result::Result<(), i32>
+pub fn aya_ebpf::btf_maps::sock_map::SockMap<MAX_ENTRIES, FLAGS>::redirect_skb(&self, ctx: &aya_ebpf::programs::sk_buff::SkBuffContext, index: u32, flags: u64) -> aya_ebpf_cty::od::c_long
+pub unsafe fn aya_ebpf::btf_maps::sock_map::SockMap<MAX_ENTRIES, FLAGS>::update(&self, index: u32, sk_ops: *mut aya_ebpf_bindings::x86_64::bindings::bpf_sock_ops, flags: u64) -> core::result::Result<(), i32>
+impl<const MAX_ENTRIES: usize, const FLAGS: usize> core::default::Default for aya_ebpf::btf_maps::sock_map::SockMap<MAX_ENTRIES, FLAGS>
+pub fn aya_ebpf::btf_maps::sock_map::SockMap<MAX_ENTRIES, FLAGS>::default() -> Self
+impl<const MAX_ENTRIES: usize, const FLAGS: usize> core::marker::Sync for aya_ebpf::btf_maps::sock_map::SockMap<MAX_ENTRIES, FLAGS>
+impl<const MAX_ENTRIES: usize, const FLAGS: usize> core::marker::Freeze for aya_ebpf::btf_maps::sock_map::SockMap<MAX_ENTRIES, FLAGS>
+impl<const MAX_ENTRIES: usize, const FLAGS: usize> !core::marker::Send for aya_ebpf::btf_maps::sock_map::SockMap<MAX_ENTRIES, FLAGS>
+impl<const MAX_ENTRIES: usize, const FLAGS: usize> core::marker::Unpin for aya_ebpf::btf_maps::sock_map::SockMap<MAX_ENTRIES, FLAGS>
+impl<const MAX_ENTRIES: usize, const FLAGS: usize> core::marker::UnsafeUnpin for aya_ebpf::btf_maps::sock_map::SockMap<MAX_ENTRIES, FLAGS>
+impl<const MAX_ENTRIES: usize, const FLAGS: usize> core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::btf_maps::sock_map::SockMap<MAX_ENTRIES, FLAGS>
+impl<const MAX_ENTRIES: usize, const FLAGS: usize> core::panic::unwind_safe::UnwindSafe for aya_ebpf::btf_maps::sock_map::SockMap<MAX_ENTRIES, FLAGS>
 pub mod aya_ebpf::btf_maps::stack_trace
 #[repr(C)] pub struct aya_ebpf::btf_maps::stack_trace::StackTrace<const MAX_ENTRIES: usize, const FLAGS: usize, const DEPTH: usize>
 impl<const MAX_ENTRIES: usize, const FLAGS: usize, const DEPTH: usize> aya_ebpf::btf_maps::stack_trace::StackTrace<MAX_ENTRIES, FLAGS, DEPTH>
@@ -341,6 +377,40 @@ impl<T> core::marker::Unpin for aya_ebpf::btf_maps::sk_storage::SkStorage<T>
 impl<T> core::marker::UnsafeUnpin for aya_ebpf::btf_maps::sk_storage::SkStorage<T>
 impl<T> core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::btf_maps::sk_storage::SkStorage<T> where T: core::panic::unwind_safe::RefUnwindSafe
 impl<T> core::panic::unwind_safe::UnwindSafe for aya_ebpf::btf_maps::sk_storage::SkStorage<T> where T: core::panic::unwind_safe::RefUnwindSafe
+#[repr(C)] pub struct aya_ebpf::btf_maps::SockHash<K, const MAX_ENTRIES: usize, const FLAGS: usize>
+impl<K, const MAX_ENTRIES: usize, const FLAGS: usize> aya_ebpf::btf_maps::sock_hash::SockHash<K, MAX_ENTRIES, FLAGS>
+pub const fn aya_ebpf::btf_maps::sock_hash::SockHash<K, MAX_ENTRIES, FLAGS>::new() -> Self
+impl<K, const MAX_ENTRIES: usize, const FLAGS: usize> aya_ebpf::btf_maps::sock_hash::SockHash<K, MAX_ENTRIES, FLAGS>
+pub fn aya_ebpf::btf_maps::sock_hash::SockHash<K, MAX_ENTRIES, FLAGS>::redirect_msg(&self, ctx: impl core::borrow::Borrow<aya_ebpf::programs::sk_msg::SkMsgContext>, key: impl core::borrow::BorrowMut<K>, flags: u64) -> aya_ebpf_cty::od::c_long
+pub fn aya_ebpf::btf_maps::sock_hash::SockHash<K, MAX_ENTRIES, FLAGS>::redirect_sk_lookup(&self, ctx: impl core::borrow::Borrow<aya_ebpf::programs::sk_lookup::SkLookupContext>, key: impl core::borrow::Borrow<K>, flags: u64) -> core::result::Result<(), i32>
+pub fn aya_ebpf::btf_maps::sock_hash::SockHash<K, MAX_ENTRIES, FLAGS>::redirect_skb(&self, ctx: impl core::borrow::Borrow<aya_ebpf::programs::sk_buff::SkBuffContext>, key: impl core::borrow::BorrowMut<K>, flags: u64) -> aya_ebpf_cty::od::c_long
+pub fn aya_ebpf::btf_maps::sock_hash::SockHash<K, MAX_ENTRIES, FLAGS>::update(&self, key: impl core::borrow::BorrowMut<K>, sk_ops: impl core::borrow::BorrowMut<aya_ebpf_bindings::x86_64::bindings::bpf_sock_ops>, flags: u64) -> core::result::Result<(), i32>
+impl<K, const MAX_ENTRIES: usize, const FLAGS: usize> core::default::Default for aya_ebpf::btf_maps::sock_hash::SockHash<K, MAX_ENTRIES, FLAGS>
+pub fn aya_ebpf::btf_maps::sock_hash::SockHash<K, MAX_ENTRIES, FLAGS>::default() -> Self
+impl<K, const MAX_ENTRIES: usize, const FLAGS: usize> core::marker::Sync for aya_ebpf::btf_maps::sock_hash::SockHash<K, MAX_ENTRIES, FLAGS>
+impl<K, const MAX_ENTRIES: usize, const FLAGS: usize> core::marker::Freeze for aya_ebpf::btf_maps::sock_hash::SockHash<K, MAX_ENTRIES, FLAGS>
+impl<K, const MAX_ENTRIES: usize, const FLAGS: usize> !core::marker::Send for aya_ebpf::btf_maps::sock_hash::SockHash<K, MAX_ENTRIES, FLAGS>
+impl<K, const MAX_ENTRIES: usize, const FLAGS: usize> core::marker::Unpin for aya_ebpf::btf_maps::sock_hash::SockHash<K, MAX_ENTRIES, FLAGS>
+impl<K, const MAX_ENTRIES: usize, const FLAGS: usize> core::marker::UnsafeUnpin for aya_ebpf::btf_maps::sock_hash::SockHash<K, MAX_ENTRIES, FLAGS>
+impl<K, const MAX_ENTRIES: usize, const FLAGS: usize> core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::btf_maps::sock_hash::SockHash<K, MAX_ENTRIES, FLAGS> where K: core::panic::unwind_safe::RefUnwindSafe
+impl<K, const MAX_ENTRIES: usize, const FLAGS: usize> core::panic::unwind_safe::UnwindSafe for aya_ebpf::btf_maps::sock_hash::SockHash<K, MAX_ENTRIES, FLAGS> where K: core::panic::unwind_safe::RefUnwindSafe
+#[repr(C)] pub struct aya_ebpf::btf_maps::SockMap<const MAX_ENTRIES: usize, const FLAGS: usize>
+impl<const MAX_ENTRIES: usize, const FLAGS: usize> aya_ebpf::btf_maps::sock_map::SockMap<MAX_ENTRIES, FLAGS>
+pub const fn aya_ebpf::btf_maps::sock_map::SockMap<MAX_ENTRIES, FLAGS>::new() -> Self
+impl<const MAX_ENTRIES: usize, const FLAGS: usize> aya_ebpf::btf_maps::sock_map::SockMap<MAX_ENTRIES, FLAGS>
+pub fn aya_ebpf::btf_maps::sock_map::SockMap<MAX_ENTRIES, FLAGS>::redirect_msg(&self, ctx: &aya_ebpf::programs::sk_msg::SkMsgContext, index: u32, flags: u64) -> aya_ebpf_cty::od::c_long
+pub fn aya_ebpf::btf_maps::sock_map::SockMap<MAX_ENTRIES, FLAGS>::redirect_sk_lookup(&self, ctx: &aya_ebpf::programs::sk_lookup::SkLookupContext, index: u32, flags: u64) -> core::result::Result<(), i32>
+pub fn aya_ebpf::btf_maps::sock_map::SockMap<MAX_ENTRIES, FLAGS>::redirect_skb(&self, ctx: &aya_ebpf::programs::sk_buff::SkBuffContext, index: u32, flags: u64) -> aya_ebpf_cty::od::c_long
+pub unsafe fn aya_ebpf::btf_maps::sock_map::SockMap<MAX_ENTRIES, FLAGS>::update(&self, index: u32, sk_ops: *mut aya_ebpf_bindings::x86_64::bindings::bpf_sock_ops, flags: u64) -> core::result::Result<(), i32>
+impl<const MAX_ENTRIES: usize, const FLAGS: usize> core::default::Default for aya_ebpf::btf_maps::sock_map::SockMap<MAX_ENTRIES, FLAGS>
+pub fn aya_ebpf::btf_maps::sock_map::SockMap<MAX_ENTRIES, FLAGS>::default() -> Self
+impl<const MAX_ENTRIES: usize, const FLAGS: usize> core::marker::Sync for aya_ebpf::btf_maps::sock_map::SockMap<MAX_ENTRIES, FLAGS>
+impl<const MAX_ENTRIES: usize, const FLAGS: usize> core::marker::Freeze for aya_ebpf::btf_maps::sock_map::SockMap<MAX_ENTRIES, FLAGS>
+impl<const MAX_ENTRIES: usize, const FLAGS: usize> !core::marker::Send for aya_ebpf::btf_maps::sock_map::SockMap<MAX_ENTRIES, FLAGS>
+impl<const MAX_ENTRIES: usize, const FLAGS: usize> core::marker::Unpin for aya_ebpf::btf_maps::sock_map::SockMap<MAX_ENTRIES, FLAGS>
+impl<const MAX_ENTRIES: usize, const FLAGS: usize> core::marker::UnsafeUnpin for aya_ebpf::btf_maps::sock_map::SockMap<MAX_ENTRIES, FLAGS>
+impl<const MAX_ENTRIES: usize, const FLAGS: usize> core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::btf_maps::sock_map::SockMap<MAX_ENTRIES, FLAGS>
+impl<const MAX_ENTRIES: usize, const FLAGS: usize> core::panic::unwind_safe::UnwindSafe for aya_ebpf::btf_maps::sock_map::SockMap<MAX_ENTRIES, FLAGS>
 #[repr(C)] pub struct aya_ebpf::btf_maps::StackTrace<const MAX_ENTRIES: usize, const FLAGS: usize, const DEPTH: usize>
 impl<const MAX_ENTRIES: usize, const FLAGS: usize, const DEPTH: usize> aya_ebpf::btf_maps::stack_trace::StackTrace<MAX_ENTRIES, FLAGS, DEPTH>
 pub const fn aya_ebpf::btf_maps::stack_trace::StackTrace<MAX_ENTRIES, FLAGS, DEPTH>::new() -> Self
@@ -634,7 +704,7 @@ pub mod aya_ebpf::maps::sock_hash
 impl<K> aya_ebpf::maps::sock_hash::SockHash<K>
 pub const fn aya_ebpf::maps::sock_hash::SockHash<K>::pinned(max_entries: u32, flags: u32) -> Self
 pub fn aya_ebpf::maps::sock_hash::SockHash<K>::redirect_msg(&self, ctx: impl core::borrow::Borrow<aya_ebpf::programs::sk_msg::SkMsgContext>, key: impl core::borrow::BorrowMut<K>, flags: u64) -> aya_ebpf_cty::od::c_long
-pub fn aya_ebpf::maps::sock_hash::SockHash<K>::redirect_sk_lookup(&self, ctx: impl core::borrow::Borrow<aya_ebpf::programs::sk_lookup::SkLookupContext>, key: impl core::borrow::Borrow<K>, flags: u64) -> core::result::Result<(), u32>
+pub fn aya_ebpf::maps::sock_hash::SockHash<K>::redirect_sk_lookup(&self, ctx: impl core::borrow::Borrow<aya_ebpf::programs::sk_lookup::SkLookupContext>, key: impl core::borrow::Borrow<K>, flags: u64) -> core::result::Result<(), i32>
 pub fn aya_ebpf::maps::sock_hash::SockHash<K>::redirect_skb(&self, ctx: impl core::borrow::Borrow<aya_ebpf::programs::sk_buff::SkBuffContext>, key: impl core::borrow::BorrowMut<K>, flags: u64) -> aya_ebpf_cty::od::c_long
 pub fn aya_ebpf::maps::sock_hash::SockHash<K>::update(&self, key: impl core::borrow::BorrowMut<K>, sk_ops: impl core::borrow::BorrowMut<aya_ebpf_bindings::x86_64::bindings::bpf_sock_ops>, flags: u64) -> core::result::Result<(), i32>
 pub const fn aya_ebpf::maps::sock_hash::SockHash<K>::with_max_entries(max_entries: u32, flags: u32) -> Self
@@ -650,7 +720,7 @@ pub mod aya_ebpf::maps::sock_map
 impl aya_ebpf::maps::sock_map::SockMap
 pub const fn aya_ebpf::maps::sock_map::SockMap::pinned(max_entries: u32, flags: u32) -> Self
 pub unsafe fn aya_ebpf::maps::sock_map::SockMap::redirect_msg(&self, ctx: &aya_ebpf::programs::sk_msg::SkMsgContext, index: u32, flags: u64) -> aya_ebpf_cty::od::c_long
-pub fn aya_ebpf::maps::sock_map::SockMap::redirect_sk_lookup(&self, ctx: &aya_ebpf::programs::sk_lookup::SkLookupContext, index: u32, flags: u64) -> core::result::Result<(), u32>
+pub fn aya_ebpf::maps::sock_map::SockMap::redirect_sk_lookup(&self, ctx: &aya_ebpf::programs::sk_lookup::SkLookupContext, index: u32, flags: u64) -> core::result::Result<(), i32>
 pub unsafe fn aya_ebpf::maps::sock_map::SockMap::redirect_skb(&self, ctx: &aya_ebpf::programs::sk_buff::SkBuffContext, index: u32, flags: u64) -> aya_ebpf_cty::od::c_long
 pub unsafe fn aya_ebpf::maps::sock_map::SockMap::update(&self, index: u32, sk_ops: *mut aya_ebpf_bindings::x86_64::bindings::bpf_sock_ops, flags: u64) -> core::result::Result<(), i32>
 pub const fn aya_ebpf::maps::sock_map::SockMap::with_max_entries(max_entries: u32, flags: u32) -> Self
@@ -982,7 +1052,7 @@ impl core::panic::unwind_safe::UnwindSafe for aya_ebpf::maps::ring_buf::RingBuf
 impl<K> aya_ebpf::maps::sock_hash::SockHash<K>
 pub const fn aya_ebpf::maps::sock_hash::SockHash<K>::pinned(max_entries: u32, flags: u32) -> Self
 pub fn aya_ebpf::maps::sock_hash::SockHash<K>::redirect_msg(&self, ctx: impl core::borrow::Borrow<aya_ebpf::programs::sk_msg::SkMsgContext>, key: impl core::borrow::BorrowMut<K>, flags: u64) -> aya_ebpf_cty::od::c_long
-pub fn aya_ebpf::maps::sock_hash::SockHash<K>::redirect_sk_lookup(&self, ctx: impl core::borrow::Borrow<aya_ebpf::programs::sk_lookup::SkLookupContext>, key: impl core::borrow::Borrow<K>, flags: u64) -> core::result::Result<(), u32>
+pub fn aya_ebpf::maps::sock_hash::SockHash<K>::redirect_sk_lookup(&self, ctx: impl core::borrow::Borrow<aya_ebpf::programs::sk_lookup::SkLookupContext>, key: impl core::borrow::Borrow<K>, flags: u64) -> core::result::Result<(), i32>
 pub fn aya_ebpf::maps::sock_hash::SockHash<K>::redirect_skb(&self, ctx: impl core::borrow::Borrow<aya_ebpf::programs::sk_buff::SkBuffContext>, key: impl core::borrow::BorrowMut<K>, flags: u64) -> aya_ebpf_cty::od::c_long
 pub fn aya_ebpf::maps::sock_hash::SockHash<K>::update(&self, key: impl core::borrow::BorrowMut<K>, sk_ops: impl core::borrow::BorrowMut<aya_ebpf_bindings::x86_64::bindings::bpf_sock_ops>, flags: u64) -> core::result::Result<(), i32>
 pub const fn aya_ebpf::maps::sock_hash::SockHash<K>::with_max_entries(max_entries: u32, flags: u32) -> Self
@@ -997,7 +1067,7 @@ impl<K> core::panic::unwind_safe::UnwindSafe for aya_ebpf::maps::sock_hash::Sock
 impl aya_ebpf::maps::sock_map::SockMap
 pub const fn aya_ebpf::maps::sock_map::SockMap::pinned(max_entries: u32, flags: u32) -> Self
 pub unsafe fn aya_ebpf::maps::sock_map::SockMap::redirect_msg(&self, ctx: &aya_ebpf::programs::sk_msg::SkMsgContext, index: u32, flags: u64) -> aya_ebpf_cty::od::c_long
-pub fn aya_ebpf::maps::sock_map::SockMap::redirect_sk_lookup(&self, ctx: &aya_ebpf::programs::sk_lookup::SkLookupContext, index: u32, flags: u64) -> core::result::Result<(), u32>
+pub fn aya_ebpf::maps::sock_map::SockMap::redirect_sk_lookup(&self, ctx: &aya_ebpf::programs::sk_lookup::SkLookupContext, index: u32, flags: u64) -> core::result::Result<(), i32>
 pub unsafe fn aya_ebpf::maps::sock_map::SockMap::redirect_skb(&self, ctx: &aya_ebpf::programs::sk_buff::SkBuffContext, index: u32, flags: u64) -> aya_ebpf_cty::od::c_long
 pub unsafe fn aya_ebpf::maps::sock_map::SockMap::update(&self, index: u32, sk_ops: *mut aya_ebpf_bindings::x86_64::bindings::bpf_sock_ops, flags: u64) -> core::result::Result<(), i32>
 pub const fn aya_ebpf::maps::sock_map::SockMap::with_max_entries(max_entries: u32, flags: u32) -> Self


### PR DESCRIPTION
Adds `SockMap<MAX_ENTRIES, FLAGS>` and `SockHash<K, MAX_ENTRIES, FLAGS>`
to `aya_ebpf::btf_maps`, mirroring the existing legacy types in
`aya_ebpf::maps`.

Compile-time `assert!`s enforce `max_entries > 0` and, for SockHash,
a key size in `1..=512` (kernel `MAX_BPF_STACK`).

Integration tests cover `redirect_sk_lookup` on both legacy and BTF
variants.

### Added/updated tests?

- [x] Yes

### Checklist

- [x] Rust code has been formatted with `cargo +nightly fmt`.
- [x] All clippy lints have been fixed.
      You can find failing lints with `cargo xtask clippy`.
- [x] Unit tests are passing locally with `cargo test`.
- [x] The integration tests are passing locally.
- [x] I have blessed any API changes with `cargo xtask public-api --bless`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aya-rs/aya/1558)
<!-- Reviewable:end -->
