### PR TITLE
aya: add uprobe virtual address helper

### DIFF
--- a/aya/src/programs/uprobe.rs
+++ b/aya/src/programs/uprobe.rs
@@ -50,6 +50,7 @@ pub struct UProbe {
 
 /// The location in the target object file to which the uprobe is to be
 /// attached.
+#[derive(Debug)]
 pub enum UProbeAttachLocation<'a> {
     /// The location of the target function in the target object file.
     Symbol(&'a str),
@@ -69,6 +70,93 @@ impl<'a> From<&'a str> for UProbeAttachLocation<'a> {
 impl From<u64> for UProbeAttachLocation<'static> {
     fn from(offset: u64) -> Self {
         Self::AbsoluteOffset(offset)
+    }
+}
+
+/// The type returned when constructing a [`UProbeAttachLocation`] fails.
+#[derive(Debug, Error)]
+pub enum UProbeAttachLocationError {
+    /// The instruction address is not in the containing section.
+    #[error(
+        "instruction address {instruction_address:#x} is not in section: \
+        before section address {section_address:#x}"
+    )]
+    AddressNotInSection {
+        /// The instruction's virtual address.
+        instruction_address: u64,
+        /// The containing section's virtual address.
+        section_address: u64,
+    },
+
+    /// The computed file offset does not fit in [`u64`].
+    #[error(
+        "computed file offset overflows u64: \
+        {instruction_address:#x} - {section_address:#x} + {section_offset:#x}"
+    )]
+    FileOffsetOverflow {
+        /// The instruction's virtual address.
+        instruction_address: u64,
+        /// The containing section's virtual address.
+        section_address: u64,
+        /// The containing section's file offset.
+        section_offset: u64,
+    },
+}
+
+impl UProbeAttachLocation<'static> {
+    /// Returns an attach location from an ELF virtual address.
+    ///
+    /// The kernel expects uprobes and uretprobes to be attached by object file
+    /// offset. If you have already resolved the instruction to an ELF virtual
+    /// address, pass that address together with the virtual address and file
+    /// offset of the section that contains it.
+    ///
+    /// This returns [`UProbeAttachLocation::AbsoluteOffset`] using the same
+    /// address translation used for uprobe attachment:
+    ///
+    /// ```text
+    /// file_offset = instruction_address - section_address + section_offset
+    /// ```
+    ///
+    /// The arguments correspond to ELF values as follows:
+    ///
+    /// - `instruction_address`: the instruction virtual address, typically a
+    ///   symbol's `st_value`.
+    /// - `section_address`: the containing section's virtual address
+    ///   (`sh_addr`).
+    /// - `section_offset`: the containing section's file offset (`sh_offset`).
+    ///
+    /// `instruction_address` must be greater than or equal to
+    /// `section_address`. The caller must pass the `section_address` and
+    /// `section_offset` for the section containing `instruction_address`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`UProbeAttachLocationError::AddressNotInSection`] if
+    /// `instruction_address` is less than `section_address`.
+    ///
+    /// Returns [`UProbeAttachLocationError::FileOffsetOverflow`] if the
+    /// computed file offset does not fit in [`u64`].
+    pub fn from_virtual_address(
+        instruction_address: u64,
+        section_address: u64,
+        section_offset: u64,
+    ) -> Result<Self, UProbeAttachLocationError> {
+        let section_relative_offset = instruction_address.checked_sub(section_address).ok_or(
+            UProbeAttachLocationError::AddressNotInSection {
+                instruction_address,
+                section_address,
+            },
+        )?;
+        let file_offset = section_relative_offset.checked_add(section_offset).ok_or(
+            UProbeAttachLocationError::FileOffsetOverflow {
+                instruction_address,
+                section_address,
+                section_offset,
+            },
+        )?;
+
+        Ok(Self::AbsoluteOffset(file_offset))
     }
 }
 
@@ -118,9 +206,11 @@ impl UProbe {
 
     /// Attaches the program.
     ///
-    /// Attaches the uprobe to the function `fn_name` defined in the `target`.
-    /// If the attach point specifies an offset, it is added to the address of
-    /// the target function. `scope` specifies which processes should trigger
+    /// Attaches the uprobe to `point` in the `target`. If the attach point is a
+    /// symbol offset, the offset is added to the address of the target function.
+    /// Absolute offsets must already be target object file offsets; use
+    /// [`UProbeAttachLocation::from_virtual_address()`] to construct one from an
+    /// ELF virtual address. `scope` specifies which processes should trigger
     /// the uprobe.
     ///
     /// The `target` argument can be an absolute or relative path to a binary or
@@ -819,6 +909,37 @@ mod tests {
     #[test_case("foo/", false; "trailing_separator")]
     fn test_is_basename_only(input: &str, expected: bool) {
         assert_eq!(is_basename_only(Path::new(input)), expected);
+    }
+
+    #[test]
+    fn test_uprobe_attach_location_from_virtual_address() {
+        assert_matches!(
+            UProbeAttachLocation::from_virtual_address(0x601300, 0x35ff00, 0x15ff00),
+            Ok(UProbeAttachLocation::AbsoluteOffset(0x401300))
+        );
+    }
+
+    #[test]
+    fn test_uprobe_attach_location_from_virtual_address_errors_on_underflow() {
+        assert_matches!(
+            UProbeAttachLocation::from_virtual_address(1, 2, 0),
+            Err(UProbeAttachLocationError::AddressNotInSection {
+                instruction_address: 1,
+                section_address: 2,
+            })
+        );
+    }
+
+    #[test]
+    fn test_uprobe_attach_location_from_virtual_address_errors_on_overflow() {
+        assert_matches!(
+            UProbeAttachLocation::from_virtual_address(u64::MAX, 0, 1),
+            Err(UProbeAttachLocationError::FileOffsetOverflow {
+                instruction_address: u64::MAX,
+                section_address: 0,
+                section_offset: 1,
+            })
+        );
     }
 
     #[test]

--- a/xtask/public-api/aya.txt
+++ b/xtask/public-api/aya.txt
@@ -4903,10 +4903,14 @@ pub enum aya::programs::uprobe::UProbeAttachLocation<'a>
 pub aya::programs::uprobe::UProbeAttachLocation::AbsoluteOffset(u64)
 pub aya::programs::uprobe::UProbeAttachLocation::Symbol(&'a str)
 pub aya::programs::uprobe::UProbeAttachLocation::SymbolOffset(&'a str, u64)
+impl aya::programs::uprobe::UProbeAttachLocation<'static>
+pub fn aya::programs::uprobe::UProbeAttachLocation<'static>::from_virtual_address(instruction_address: u64, section_address: u64, section_offset: u64) -> core::result::Result<Self, aya::programs::uprobe::UProbeAttachLocationError>
 impl core::convert::From<u64> for aya::programs::uprobe::UProbeAttachLocation<'static>
 pub fn aya::programs::uprobe::UProbeAttachLocation<'static>::from(offset: u64) -> Self
 impl<'a> core::convert::From<&'a str> for aya::programs::uprobe::UProbeAttachLocation<'a>
 pub fn aya::programs::uprobe::UProbeAttachLocation<'a>::from(s: &'a str) -> Self
+impl<'a> core::fmt::Debug for aya::programs::uprobe::UProbeAttachLocation<'a>
+pub fn aya::programs::uprobe::UProbeAttachLocation<'a>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl<'a> core::marker::Freeze for aya::programs::uprobe::UProbeAttachLocation<'a>
 impl<'a> core::marker::Send for aya::programs::uprobe::UProbeAttachLocation<'a>
 impl<'a> core::marker::Sync for aya::programs::uprobe::UProbeAttachLocation<'a>
@@ -4914,6 +4918,26 @@ impl<'a> core::marker::Unpin for aya::programs::uprobe::UProbeAttachLocation<'a>
 impl<'a> core::marker::UnsafeUnpin for aya::programs::uprobe::UProbeAttachLocation<'a>
 impl<'a> core::panic::unwind_safe::RefUnwindSafe for aya::programs::uprobe::UProbeAttachLocation<'a>
 impl<'a> core::panic::unwind_safe::UnwindSafe for aya::programs::uprobe::UProbeAttachLocation<'a>
+pub enum aya::programs::uprobe::UProbeAttachLocationError
+pub aya::programs::uprobe::UProbeAttachLocationError::AddressNotInSection
+pub aya::programs::uprobe::UProbeAttachLocationError::AddressNotInSection::instruction_address: u64
+pub aya::programs::uprobe::UProbeAttachLocationError::AddressNotInSection::section_address: u64
+pub aya::programs::uprobe::UProbeAttachLocationError::FileOffsetOverflow
+pub aya::programs::uprobe::UProbeAttachLocationError::FileOffsetOverflow::instruction_address: u64
+pub aya::programs::uprobe::UProbeAttachLocationError::FileOffsetOverflow::section_address: u64
+pub aya::programs::uprobe::UProbeAttachLocationError::FileOffsetOverflow::section_offset: u64
+impl core::error::Error for aya::programs::uprobe::UProbeAttachLocationError
+impl core::fmt::Debug for aya::programs::uprobe::UProbeAttachLocationError
+pub fn aya::programs::uprobe::UProbeAttachLocationError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::fmt::Display for aya::programs::uprobe::UProbeAttachLocationError
+pub fn aya::programs::uprobe::UProbeAttachLocationError::fmt(&self, __formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for aya::programs::uprobe::UProbeAttachLocationError
+impl core::marker::Send for aya::programs::uprobe::UProbeAttachLocationError
+impl core::marker::Sync for aya::programs::uprobe::UProbeAttachLocationError
+impl core::marker::Unpin for aya::programs::uprobe::UProbeAttachLocationError
+impl core::marker::UnsafeUnpin for aya::programs::uprobe::UProbeAttachLocationError
+impl core::panic::unwind_safe::RefUnwindSafe for aya::programs::uprobe::UProbeAttachLocationError
+impl core::panic::unwind_safe::UnwindSafe for aya::programs::uprobe::UProbeAttachLocationError
 pub enum aya::programs::uprobe::UProbeError
 pub aya::programs::uprobe::UProbeError::FileError
 pub aya::programs::uprobe::UProbeError::FileError::filename: std::path::PathBuf


### PR DESCRIPTION
Add a fallible `UProbeAttachLocation` constructor for callers that have already resolved a symbol or instruction to an ELF virtual address. The helper converts that address, together with the containing section's address and file offset, into the target object file offset expected by uprobes.

Return a typed error when the instruction address is below the section address or when the computed file offset overflows.

Fixes #1198.
Closes #1258.

<!-- markdownlint-disable first-line-heading -->

<!--
    Thank you for your contribution to Aya! 🎉

    For Work In Progress Pull Requests, please use the Draft PR feature.

    Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Aya Contributing Guide: https://github.com/aya-rs/aya/blob/main/CONTRIBUTING.md
     - 📖 Read the Aya Code of Conduct: https://github.com/aya-rs/aya/blob/main/CODE_OF_CONDUCT.md
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages: https://cbea.ms/git-commit/
     - 📗 Update any related documentation.

-->

<!---
      Summarize the changes you're making here. Detailed information belongs in
      the Git commit messages. If your pull request contains just one commit,
      it's best to use its message as a summary. Otherwise, if there are multiple
      atomic commits, write a summary for the entire PR. Feel free to flag
      anything you think needs a reviewer's attention.
-->

<!--
      If your changes address an issue, link it with the *Fixes* tag so
      the issue gets closed when the PR is merged, for example:

      Fixes: #1234

      If you are only referencing an issue without fully addressing it, feel
      free to link it anywhere in the summary.
-->

### Added/updated tests?

_We strongly encourage you to add a test for your changes._

- [x] Yes

### Checklist

- [x] Rust code has been formatted with `cargo +nightly fmt`.
- [x] All clippy lints have been fixed.
      You can find failing lints with `cargo xtask clippy`.
- [x] Unit tests are passing locally with `cargo test`.
- [x] The [Integration tests] are passing locally.
- [x] I have blessed any API changes with `cargo xtask public-api --bless`.

[Integration tests]: https://github.com/aya-rs/aya/blob/main/test/README.md

### (Optional) What GIF best describes this PR or how it makes you feel?

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aya-rs/aya/1559)
<!-- Reviewable:end -->
