### PR TITLE
aya: return errors instead of panicking on invalid CString inputs

### DIFF
--- a/aya/src/maps/info.rs
+++ b/aya/src/maps/info.rs
@@ -117,8 +117,13 @@ impl MapInfo {
     pub fn from_pin<P: AsRef<Path>>(path: P) -> Result<Self, MapError> {
         use std::os::unix::ffi::OsStrExt as _;
 
-        // TODO: avoid this unwrap by adding a new error variant.
-        let path_string = CString::new(path.as_ref().as_os_str().as_bytes()).unwrap();
+        let path = path.as_ref();
+        let path_string = CString::new(path.as_os_str().as_bytes()).map_err(|source| {
+            MapError::InvalidPinPath {
+                path: path.into(),
+                source,
+            }
+        })?;
         let fd = bpf_get_object(&path_string).map_err(|io_error| SyscallError {
             call: "BPF_OBJ_GET",
             io_error,

--- a/aya/src/maps/mod.rs
+++ b/aya/src/maps/mod.rs
@@ -114,6 +114,9 @@ pub enum MapError {
     InvalidName {
         /// The map name
         name: String,
+        #[source]
+        /// The source error.
+        source: std::ffi::NulError,
     },
 
     /// Failed to create map
@@ -608,8 +611,10 @@ impl MapData {
         name: &str,
         btf_fd: Option<BorrowedFd<'_>>,
     ) -> Result<Self, MapError> {
-        let c_name = CString::new(name)
-            .map_err(|std::ffi::NulError { .. }| MapError::InvalidName { name: name.into() })?;
+        let c_name = CString::new(name).map_err(|source| MapError::InvalidName {
+            name: name.into(),
+            source,
+        })?;
 
         // BPF_MAP_TYPE_PERF_EVENT_ARRAY's max_entries should not exceed the number of
         // CPUs.

--- a/aya/src/maps/mod.rs
+++ b/aya/src/maps/mod.rs
@@ -768,10 +768,10 @@ impl MapData {
 
         let Self { fd, obj: _ } = self;
         let path = path.as_ref();
-        let path_string = CString::new(path.as_os_str().as_bytes()).map_err(|error| {
+        let path_string = CString::new(path.as_os_str().as_bytes()).map_err(|source| {
             PinError::InvalidPinPath {
                 path: path.to_path_buf(),
-                error,
+                source,
             }
         })?;
         bpf_pin_object(fd.as_fd(), &path_string).map_err(|io_error| SyscallError {

--- a/aya/src/maps/mod.rs
+++ b/aya/src/maps/mod.rs
@@ -215,6 +215,16 @@ pub enum MapError {
         /// The reason
         reason: &'static str,
     },
+
+    /// The path provided cannot be converted to a valid C string.
+    #[error("invalid pin path `{}`", path.display())]
+    InvalidPinPath {
+        /// The path.
+        path: std::path::PathBuf,
+        #[source]
+        /// The source error.
+        source: std::ffi::NulError,
+    },
 }
 
 impl From<InvalidTypeBinding<u32>> for MapError {
@@ -642,13 +652,10 @@ impl MapData {
         let path = path.as_ref();
         let path_string = match CString::new(path.as_os_str().as_bytes()) {
             Ok(path) => path,
-            Err(error) => {
-                return Err(MapError::PinError {
-                    name: Some(name.into()),
-                    error: PinError::InvalidPinPath {
-                        path: path.to_path_buf(),
-                        error,
-                    },
+            Err(source) => {
+                return Err(MapError::InvalidPinPath {
+                    path: path.to_path_buf(),
+                    source,
                 });
             }
         };
@@ -693,14 +700,12 @@ impl MapData {
         use std::os::unix::ffi::OsStrExt as _;
 
         let path = path.as_ref();
-        let path_string =
-            CString::new(path.as_os_str().as_bytes()).map_err(|error| MapError::PinError {
-                name: None,
-                error: PinError::InvalidPinPath {
-                    path: path.into(),
-                    error,
-                },
-            })?;
+        let path_string = CString::new(path.as_os_str().as_bytes()).map_err(|source| {
+            MapError::InvalidPinPath {
+                path: path.into(),
+                source,
+            }
+        })?;
 
         let fd = bpf_get_object(&path_string).map_err(|io_error| SyscallError {
             call: "BPF_OBJ_GET",

--- a/aya/src/pin.rs
+++ b/aya/src/pin.rs
@@ -18,10 +18,9 @@ pub enum PinError {
     InvalidPinPath {
         /// The path.
         path: std::path::PathBuf,
-
         #[source]
         /// The source error.
-        error: std::ffi::NulError,
+        source: std::ffi::NulError,
     },
     /// An error ocurred making a syscall.
     #[error(transparent)]

--- a/aya/src/programs/info.rs
+++ b/aya/src/programs/info.rs
@@ -224,8 +224,13 @@ impl ProgramInfo {
     pub fn from_pin<P: AsRef<Path>>(path: P) -> Result<Self, ProgramError> {
         use std::os::unix::ffi::OsStrExt as _;
 
-        // TODO: avoid this unwrap by adding a new error variant.
-        let path_string = CString::new(path.as_ref().as_os_str().as_bytes()).unwrap();
+        let path = path.as_ref();
+        let path_string = CString::new(path.as_os_str().as_bytes()).map_err(|source| {
+            ProgramError::InvalidPinPath {
+                path: path.into(),
+                source,
+            }
+        })?;
         let fd = bpf_get_object(&path_string).map_err(|io_error| SyscallError {
             call: "BPF_OBJ_GET",
             io_error,

--- a/aya/src/programs/links.rs
+++ b/aya/src/programs/links.rs
@@ -348,15 +348,20 @@ impl PinnedLink {
     pub fn from_pin<P: AsRef<Path>>(path: P) -> Result<Self, LinkError> {
         use std::os::unix::ffi::OsStrExt as _;
 
-        // TODO: avoid this unwrap by adding a new error variant.
-        let path_string = CString::new(path.as_ref().as_os_str().as_bytes()).unwrap();
+        let path = path.as_ref();
+        let path_string = CString::new(path.as_os_str().as_bytes()).map_err(|source| {
+            LinkError::InvalidPinPath {
+                path: path.into(),
+                source,
+            }
+        })?;
         let fd = bpf_get_object(&path_string).map_err(|io_error| {
             LinkError::SyscallError(SyscallError {
                 call: "BPF_OBJ_GET",
                 io_error,
             })
         })?;
-        Ok(Self::new(path.as_ref().to_path_buf(), FdLink::new(fd)))
+        Ok(Self::new(path.to_path_buf(), FdLink::new(fd)))
     }
 
     /// Removes the pinned link from the filesystem and returns an [`FdLink`].
@@ -614,6 +619,16 @@ pub enum LinkError {
     /// Please open an issue on GitHub if you encounter this error.
     #[error("unknown link type {0}")]
     UnknownLinkType(u32),
+
+    /// The path provided cannot be converted to a valid C string.
+    #[error("invalid pin path `{}`", path.display())]
+    InvalidPinPath {
+        /// The path.
+        path: PathBuf,
+        #[source]
+        /// The source error.
+        source: std::ffi::NulError,
+    },
 
     /// Syscall failed.
     #[error(transparent)]

--- a/aya/src/programs/links.rs
+++ b/aya/src/programs/links.rs
@@ -284,10 +284,10 @@ impl FdLink {
         use std::os::unix::ffi::OsStrExt as _;
 
         let path = path.as_ref();
-        let path_string = CString::new(path.as_os_str().as_bytes()).map_err(|error| {
+        let path_string = CString::new(path.as_os_str().as_bytes()).map_err(|source| {
             PinError::InvalidPinPath {
                 path: path.into(),
-                error,
+                source,
             }
         })?;
         bpf_pin_object(self.fd.as_fd(), &path_string).map_err(|io_error| SyscallError {

--- a/aya/src/programs/mod.rs
+++ b/aya/src/programs/mod.rs
@@ -257,6 +257,16 @@ pub enum ProgramError {
         source: std::ffi::NulError,
     },
 
+    /// The interface name cannot be converted to a valid C string.
+    #[error("invalid interface name `{name}`")]
+    InvalidInterfaceName {
+        /// The interface name.
+        name: String,
+        #[source]
+        /// The source error.
+        source: std::ffi::NulError,
+    },
+
     /// An error occurred while working with IO.
     #[error(transparent)]
     IOError(#[from] io::Error),

--- a/aya/src/programs/mod.rs
+++ b/aya/src/programs/mod.rs
@@ -237,6 +237,26 @@ pub enum ProgramError {
         name: String,
     },
 
+    /// The path provided cannot be converted to a valid C string.
+    #[error("invalid pin path `{}`", path.display())]
+    InvalidPinPath {
+        /// The path.
+        path: PathBuf,
+        #[source]
+        /// The source error.
+        source: std::ffi::NulError,
+    },
+
+    /// The tracepoint name cannot be converted to a valid C string.
+    #[error("invalid tracepoint name `{name}`")]
+    InvalidTracepointName {
+        /// The tracepoint name.
+        name: String,
+        #[source]
+        /// The source error.
+        source: std::ffi::NulError,
+    },
+
     /// An error occurred while working with IO.
     #[error(transparent)]
     IOError(#[from] io::Error),
@@ -600,8 +620,13 @@ impl<T: Link> ProgramData<T> {
     ) -> Result<Self, ProgramError> {
         use std::os::unix::ffi::OsStrExt as _;
 
-        // TODO: avoid this unwrap by adding a new error variant.
-        let path_string = CString::new(path.as_ref().as_os_str().as_bytes()).unwrap();
+        let path = path.as_ref();
+        let path_string = CString::new(path.as_os_str().as_bytes()).map_err(|source| {
+            ProgramError::InvalidPinPath {
+                path: path.into(),
+                source,
+            }
+        })?;
         let fd = bpf_get_object(&path_string).map_err(|io_error| SyscallError {
             call: "bpf_obj_get",
             io_error,
@@ -609,7 +634,7 @@ impl<T: Link> ProgramData<T> {
 
         let info = ProgramInfo::new_from_fd(fd.as_fd())?;
         let name = info.name_as_str().map(ToOwned::to_owned).map(Into::into);
-        Self::from_bpf_prog_info(name, fd, path.as_ref(), info.0, verifier_log_level)
+        Self::from_bpf_prog_info(name, fd, path, info.0, verifier_log_level)
     }
 }
 

--- a/aya/src/programs/mod.rs
+++ b/aya/src/programs/mod.rs
@@ -674,9 +674,9 @@ fn pin_program<T: Link, P: AsRef<Path>>(data: &ProgramData<T>, path: P) -> Resul
     })?;
     let path = path.as_ref();
     let path_string =
-        CString::new(path.as_os_str().as_bytes()).map_err(|error| PinError::InvalidPinPath {
+        CString::new(path.as_os_str().as_bytes()).map_err(|source| PinError::InvalidPinPath {
             path: path.into(),
-            error,
+            source,
         })?;
     bpf_pin_object(fd.as_fd(), &path_string).map_err(|io_error| SyscallError {
         call: "BPF_OBJ_PIN",

--- a/aya/src/programs/raw_trace_point.rs
+++ b/aya/src/programs/raw_trace_point.rs
@@ -52,7 +52,11 @@ impl RawTracePoint {
     ///
     /// The returned value can be used to detach, see [`RawTracePoint::detach`].
     pub fn attach(&mut self, tp_name: &str) -> Result<RawTracePointLinkId, ProgramError> {
-        let tp_name_c = CString::new(tp_name).unwrap();
+        let tp_name_c =
+            CString::new(tp_name).map_err(|source| ProgramError::InvalidTracepointName {
+                name: tp_name.to_string(),
+                source,
+            })?;
         attach_raw_tracepoint(&mut self.data, Some(&tp_name_c))
     }
 }

--- a/aya/src/programs/tc.rs
+++ b/aya/src/programs/tc.rs
@@ -88,9 +88,15 @@ pub enum TcError {
     /// a netlink error occurred.
     #[error(transparent)]
     NetlinkError(#[from] NetlinkError),
-    /// the provided string contains a nul byte.
-    #[error(transparent)]
-    NulError(#[from] std::ffi::NulError),
+    /// The name passed to a TC operation contains an interior nul byte.
+    #[error("tc operation received an invalid name `{name}`")]
+    NulError {
+        /// The name that contained the nul byte.
+        name: String,
+        #[source]
+        /// The source error.
+        source: std::ffi::NulError,
+    },
     /// an IO error occurred.
     #[error(transparent)]
     IoError(#[from] io::Error),
@@ -312,8 +318,10 @@ impl SchedClassifier {
         match options {
             TcAttachOptions::Netlink(options) => {
                 let name = self.data.name.as_deref().unwrap_or_default();
-                // TODO: avoid this unwrap by adding a new error variant.
-                let name = CString::new(name).unwrap();
+                let name = CString::new(name).map_err(|source| TcError::NulError {
+                    name: name.to_string(),
+                    source,
+                })?;
                 let (priority, handle) = unsafe {
                     netlink_qdisc_attach(
                         if_index as i32,
@@ -598,7 +606,10 @@ pub fn qdisc_detach_program(
     attach_type: TcAttachType,
     name: &str,
 ) -> Result<(), TcError> {
-    let cstr = CString::new(name).map_err(TcError::NulError)?;
+    let cstr = CString::new(name).map_err(|source| TcError::NulError {
+        name: name.to_string(),
+        source,
+    })?;
     let if_index = ifindex_from_ifname(if_name)? as i32;
 
     let sock = NetlinkSocket::open().map_err(NetlinkError::from)?;

--- a/aya/src/programs/xdp.rs
+++ b/aya/src/programs/xdp.rs
@@ -101,11 +101,18 @@ impl Xdp {
     /// If the given `interface` does not exist
     /// [`ProgramError::UnknownInterface`] is returned.
     ///
+    /// If the given `interface` contains an interior NUL byte and cannot be
+    /// converted to a C string, [`ProgramError::InvalidInterfaceName`] is
+    /// returned.
+    ///
     /// When `bpf_link_create` is unavailable or rejects the request, the call
     /// transparently falls back to the legacy netlink-based attach path.
     pub fn attach(&mut self, interface: &str, flags: XdpFlags) -> Result<XdpLinkId, ProgramError> {
-        // TODO: avoid this unwrap by adding a new error variant.
-        let c_interface = CString::new(interface).unwrap();
+        let c_interface =
+            CString::new(interface).map_err(|source| ProgramError::InvalidInterfaceName {
+                name: interface.to_string(),
+                source,
+            })?;
         let if_index = unsafe { libc::if_nametoindex(c_interface.as_ptr()) };
         if if_index == 0 {
             return Err(ProgramError::UnknownInterface {

--- a/xtask/public-api/aya.txt
+++ b/xtask/public-api/aya.txt
@@ -4376,9 +4376,9 @@ pub aya::programs::tc::TcError::InvalidLinkOperation
 pub aya::programs::tc::TcError::InvalidTcxAttach(u32)
 pub aya::programs::tc::TcError::IoError(std::io::error::Error)
 pub aya::programs::tc::TcError::NetlinkError(aya::sys::netlink::NetlinkError)
-pub aya::programs::tc::TcError::NulError(alloc::ffi::c_str::NulError)
-impl core::convert::From<alloc::ffi::c_str::NulError> for aya::programs::tc::TcError
-pub fn aya::programs::tc::TcError::from(source: alloc::ffi::c_str::NulError) -> Self
+pub aya::programs::tc::TcError::NulError
+pub aya::programs::tc::TcError::NulError::name: alloc::string::String
+pub aya::programs::tc::TcError::NulError::source: alloc::ffi::c_str::NulError
 impl core::convert::From<aya::programs::tc::TcError> for aya::programs::ProgramError
 pub fn aya::programs::ProgramError::from(source: aya::programs::tc::TcError) -> Self
 impl core::convert::From<std::io::error::Error> for aya::programs::tc::TcError
@@ -5568,9 +5568,9 @@ pub aya::programs::TcError::InvalidLinkOperation
 pub aya::programs::TcError::InvalidTcxAttach(u32)
 pub aya::programs::TcError::IoError(std::io::error::Error)
 pub aya::programs::TcError::NetlinkError(aya::sys::netlink::NetlinkError)
-pub aya::programs::TcError::NulError(alloc::ffi::c_str::NulError)
-impl core::convert::From<alloc::ffi::c_str::NulError> for aya::programs::tc::TcError
-pub fn aya::programs::tc::TcError::from(source: alloc::ffi::c_str::NulError) -> Self
+pub aya::programs::TcError::NulError
+pub aya::programs::TcError::NulError::name: alloc::string::String
+pub aya::programs::TcError::NulError::source: alloc::ffi::c_str::NulError
 impl core::convert::From<aya::programs::tc::TcError> for aya::programs::ProgramError
 pub fn aya::programs::ProgramError::from(source: aya::programs::tc::TcError) -> Self
 impl core::convert::From<std::io::error::Error> for aya::programs::tc::TcError

--- a/xtask/public-api/aya.txt
+++ b/xtask/public-api/aya.txt
@@ -936,6 +936,9 @@ pub aya::maps::MapError::InvalidMapType
 pub aya::maps::MapError::InvalidMapType::map_type: u32
 pub aya::maps::MapError::InvalidName
 pub aya::maps::MapError::InvalidName::name: alloc::string::String
+pub aya::maps::MapError::InvalidPinPath
+pub aya::maps::MapError::InvalidPinPath::path: std::path::PathBuf
+pub aya::maps::MapError::InvalidPinPath::source: alloc::ffi::c_str::NulError
 pub aya::maps::MapError::InvalidValueSize
 pub aya::maps::MapError::InvalidValueSize::expected: usize
 pub aya::maps::MapError::InvalidValueSize::size: usize
@@ -2800,6 +2803,9 @@ impl core::panic::unwind_safe::RefUnwindSafe for aya::programs::links::CgroupAtt
 impl core::panic::unwind_safe::UnwindSafe for aya::programs::links::CgroupAttachMode
 pub enum aya::programs::links::LinkError
 pub aya::programs::links::LinkError::InvalidLink
+pub aya::programs::links::LinkError::InvalidPinPath
+pub aya::programs::links::LinkError::InvalidPinPath::path: std::path::PathBuf
+pub aya::programs::links::LinkError::InvalidPinPath::source: alloc::ffi::c_str::NulError
 pub aya::programs::links::LinkError::SyscallError(aya::sys::SyscallError)
 pub aya::programs::links::LinkError::UnknownLinkType(u32)
 impl core::convert::From<aya::sys::SyscallError> for aya::programs::links::LinkError
@@ -5383,6 +5389,12 @@ pub aya::programs::ProgramError::ExtensionError(aya::programs::extension::Extens
 pub aya::programs::ProgramError::IOError(std::io::error::Error)
 pub aya::programs::ProgramError::InvalidName
 pub aya::programs::ProgramError::InvalidName::name: alloc::string::String
+pub aya::programs::ProgramError::InvalidPinPath
+pub aya::programs::ProgramError::InvalidPinPath::path: std::path::PathBuf
+pub aya::programs::ProgramError::InvalidPinPath::source: alloc::ffi::c_str::NulError
+pub aya::programs::ProgramError::InvalidTracepointName
+pub aya::programs::ProgramError::InvalidTracepointName::name: alloc::string::String
+pub aya::programs::ProgramError::InvalidTracepointName::source: alloc::ffi::c_str::NulError
 pub aya::programs::ProgramError::KProbeError(aya::programs::kprobe::KProbeError)
 pub aya::programs::ProgramError::LoadError
 pub aya::programs::ProgramError::LoadError::io_error: std::io::error::Error

--- a/xtask/public-api/aya.txt
+++ b/xtask/public-api/aya.txt
@@ -936,6 +936,7 @@ pub aya::maps::MapError::InvalidMapType
 pub aya::maps::MapError::InvalidMapType::map_type: u32
 pub aya::maps::MapError::InvalidName
 pub aya::maps::MapError::InvalidName::name: alloc::string::String
+pub aya::maps::MapError::InvalidName::source: alloc::ffi::c_str::NulError
 pub aya::maps::MapError::InvalidPinPath
 pub aya::maps::MapError::InvalidPinPath::path: std::path::PathBuf
 pub aya::maps::MapError::InvalidPinPath::source: alloc::ffi::c_str::NulError
@@ -1711,8 +1712,8 @@ pub fn aya::maps::loaded_maps() -> impl core::iter::traits::iterator::Iterator<I
 pub mod aya::pin
 pub enum aya::pin::PinError
 pub aya::pin::PinError::InvalidPinPath
-pub aya::pin::PinError::InvalidPinPath::error: alloc::ffi::c_str::NulError
 pub aya::pin::PinError::InvalidPinPath::path: std::path::PathBuf
+pub aya::pin::PinError::InvalidPinPath::source: alloc::ffi::c_str::NulError
 pub aya::pin::PinError::NoFd
 pub aya::pin::PinError::NoFd::name: alloc::string::String
 pub aya::pin::PinError::SyscallError(aya::sys::SyscallError)

--- a/xtask/public-api/aya.txt
+++ b/xtask/public-api/aya.txt
@@ -5387,6 +5387,9 @@ pub aya::programs::ProgramError::AttachCookieNotSupported
 pub aya::programs::ProgramError::Btf(aya_obj::btf::btf::BtfError)
 pub aya::programs::ProgramError::ExtensionError(aya::programs::extension::ExtensionError)
 pub aya::programs::ProgramError::IOError(std::io::error::Error)
+pub aya::programs::ProgramError::InvalidInterfaceName
+pub aya::programs::ProgramError::InvalidInterfaceName::name: alloc::string::String
+pub aya::programs::ProgramError::InvalidInterfaceName::source: alloc::ffi::c_str::NulError
 pub aya::programs::ProgramError::InvalidName
 pub aya::programs::ProgramError::InvalidName::name: alloc::string::String
 pub aya::programs::ProgramError::InvalidPinPath


### PR DESCRIPTION
## Summary

Resolves the six `// TODO: avoid this unwrap by adding a new error variant`
sites scattered across aya, and aligns the resulting error-variant shape
across the four enums that gained an `InvalidPinPath` variant. The unwraps
would panic if a caller passed a path or name containing an interior nul
byte; this PR converts each into a typed error. Picks up the work from
#1389 (stalled since April) and applies the review feedback from that
thread.

## Approach

Five commits, each scoped to one concern:

1. **`aya: return errors instead of panicking on invalid CString inputs`**
   - Pattern A — path → CString (4 sites): added `InvalidPinPath { path, source }`
     variants to `ProgramError`, `LinkError`, and `MapError`, mirroring the
     existing `PinError::InvalidPinPath` in `aya/src/pin.rs`.
   - Pattern B — name → CString: `RawTracePoint::attach` uses a new
     `ProgramError::InvalidTracepointName` variant. (This site had an
     unmarked `.unwrap()` not flagged by a TODO, but in the same family —
     caught from #1389's coverage.)

2. **`aya: report invalid TC name in NulError variant`**
   - Reshapes `TcError::NulError` from a tuple variant into
     `NulError { name, source }`, so callers can see which TC name was
     rejected. Updates `SchedClassifier::do_attach` and
     `qdisc_detach_program` to populate the new field.

3. **`aya: ProgramError::InvalidInterfaceName error variant`**
   - Adds a dedicated `ProgramError::InvalidInterfaceName { name, source }`
     for `Xdp::attach`, instead of folding the failure into the pre-existing
     `UnknownInterface` variant.

4. **`aya: rename PinError::InvalidPinPath field error to source`**
   - The pre-existing `PinError::InvalidPinPath` used `error: NulError`.
     With the new sibling variants in commits 1–3 settling on
     `source: NulError` (matching thiserror conventions and #1389's review
     feedback), this commit aligns the original to avoid a permanent
     inconsistency across the four parallel `InvalidPinPath` variants.

5. **`aya: include NulError source in MapError::InvalidName`**
   - `MapData::create` discarded the underlying `NulError` when the map
     name failed conversion. Adds a `source: NulError` field to
     `MapError::InvalidName` so error reporters can walk the chain,
     matching the source-handling pattern used elsewhere in this PR.

## SemVer notes

These are breaking changes for downstream callers that exhaustively match
on the affected enums. Per [Cargo's SemVer guide](https://doc.rust-lang.org/cargo/reference/semver.html)
they are technically *major*, though consistent with how variants are added
elsewhere in this repo:

- Adds new variants (`InvalidPinPath`, `InvalidTracepointName`,
  `InvalidInterfaceName`) to `ProgramError`, `LinkError`, and `MapError`
  (none of which are `#[non_exhaustive]`).
- Reshapes `TcError::NulError` from a tuple variant to a struct variant.
- Renames `PinError::InvalidPinPath`'s field `error` → `source`.
- Adds a `source` field to `MapError::InvalidName`.

`cargo xtask public-api` snapshot updated accordingly.

## Tests

I considered adding unit tests for the new error variants but did not see
precedent for testing similar variants (e.g. `PinError::InvalidPinPath`,
`ProgramError::InvalidName`). Happy to add them if you'd like.

## Test plan

- [x] `cargo check`
- [x] `cargo +nightly fmt --all -- --check`
- [x] `cargo clippy -p aya --all-targets -- -D warnings`
- [x] `cargo test -p aya --lib` (134 passing)
- [x] `cargo xtask public-api` (snapshot updated)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aya-rs/aya/1560)
<!-- Reviewable:end -->
