### PR TITLE
aya-ebpf: add BTF map definition for queue and stack

### DIFF
--- a/ebpf/aya-ebpf/src/btf_maps/mod.rs
+++ b/ebpf/aya-ebpf/src/btf_maps/mod.rs
@@ -5,11 +5,13 @@ pub mod per_cpu_array;
 pub mod perf_event_array;
 pub mod perf_event_byte_array;
 pub mod program_array;
+pub mod queue;
 pub mod reuseport_sock_array;
 pub mod ring_buf;
 pub mod sk_storage;
 pub mod sock_hash;
 pub mod sock_map;
+pub mod stack;
 pub mod stack_trace;
 
 pub use array::Array;
@@ -19,11 +21,13 @@ pub use per_cpu_array::PerCpuArray;
 pub use perf_event_array::PerfEventArray;
 pub use perf_event_byte_array::PerfEventByteArray;
 pub use program_array::ProgramArray;
+pub use queue::Queue;
 pub use reuseport_sock_array::ReusePortSockArray;
 pub use ring_buf::RingBuf;
 pub use sk_storage::SkStorage;
 pub use sock_hash::SockHash;
 pub use sock_map::SockMap;
+pub use stack::Stack;
 pub use stack_trace::StackTrace;
 
 /// Defines a BTF-compatible map struct with flat `#[repr(C)]` layout.

--- a/ebpf/aya-ebpf/src/btf_maps/queue.rs
+++ b/ebpf/aya-ebpf/src/btf_maps/queue.rs
@@ -1,0 +1,115 @@
+use core::{borrow::Borrow, mem::MaybeUninit, ptr};
+
+use aya_ebpf_bindings::bindings::BPF_F_NO_PREALLOC;
+
+use crate::{
+    ENOENT,
+    btf_maps::btf_map_def,
+    helpers::{bpf_map_peek_elem, bpf_map_pop_elem, bpf_map_push_elem},
+};
+
+btf_map_def!(
+    /// A BTF-compatible BPF queue map.
+    ///
+    /// Queues store values of type `T` in FIFO order. Push appends to the
+    /// tail; pop and peek read from the head. There is no per-element key.
+    ///
+    /// # Minimum kernel version
+    ///
+    /// The minimum kernel version required to use this feature is 4.20.
+    /// `BPF_MAP_TYPE_QUEUE` and `BPF_MAP_TYPE_STACK` landed together.
+    ///
+    /// # Flag and size restrictions
+    ///
+    /// The kernel rejects queue maps with `BPF_F_NO_PREALLOC` and returns
+    /// `EINVAL`. The value must be non-zero sized and `max_entries` must
+    /// be at least 1.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use aya_ebpf::{btf_maps::Queue, macros::btf_map};
+    ///
+    /// #[btf_map]
+    /// static EVENTS: Queue<u64, 64> = Queue::new();
+    /// ```
+    pub struct Queue<T; const MAX_ENTRIES: usize, const FLAGS: usize = 0>,
+    map_type: BPF_MAP_TYPE_QUEUE,
+    max_entries: MAX_ENTRIES,
+    map_flags: FLAGS,
+    key_type: (),
+    value_type: T,
+);
+
+impl<T, const MAX_ENTRIES: usize, const FLAGS: usize> Queue<T, MAX_ENTRIES, FLAGS> {
+    const _CHECK: () = {
+        assert!(size_of::<T>() > 0, "queue value must be non-zero sized.");
+        assert!(
+            MAX_ENTRIES > 0,
+            "queue max_entries must be greater than zero.",
+        );
+        assert!(
+            FLAGS & BPF_F_NO_PREALLOC as usize == 0,
+            "BPF_F_NO_PREALLOC is rejected by queue maps.",
+        );
+    };
+
+    /// Pushes `value` onto the tail of the queue.
+    ///
+    /// `flags` is forwarded to `bpf_map_push_elem`; setting `BPF_EXIST`
+    /// evicts the oldest element when the queue is full.
+    #[inline(always)]
+    pub fn push(&self, value: impl Borrow<T>, flags: u64) -> Result<(), i32> {
+        let () = Self::_CHECK;
+        let ret = unsafe {
+            bpf_map_push_elem(self.as_ptr(), ptr::from_ref(value.borrow()).cast(), flags)
+        };
+        (ret == 0).then_some(()).ok_or(ret as i32)
+    }
+
+    /// Removes and returns the head of the queue.
+    ///
+    /// Returns `Ok(None)` when the queue is empty.
+    ///
+    /// # Errors
+    ///
+    /// Propagates any non-zero errno from [`bpf_map_pop_elem`] (e.g.
+    /// `-EBUSY` under lock contention).
+    ///
+    /// [`bpf_map_pop_elem`]: https://docs.ebpf.io/linux/helper-function/bpf_map_pop_elem/
+    #[inline(always)]
+    pub fn pop(&self) -> Result<Option<T>, i32> {
+        let () = Self::_CHECK;
+        unsafe {
+            let mut value = MaybeUninit::<T>::uninit();
+            match bpf_map_pop_elem(self.as_ptr(), value.as_mut_ptr().cast()) as i32 {
+                0 => Ok(Some(value.assume_init())),
+                err if err == -ENOENT => Ok(None),
+                err => Err(err),
+            }
+        }
+    }
+
+    /// Returns the head of the queue without removing it.
+    ///
+    /// Returns `Ok(None)` when the queue is empty.
+    ///
+    /// # Errors
+    ///
+    /// Propagates any non-zero errno from [`bpf_map_peek_elem`] (e.g.
+    /// `-EBUSY` under lock contention).
+    ///
+    /// [`bpf_map_peek_elem`]: https://docs.ebpf.io/linux/helper-function/bpf_map_peek_elem/
+    #[inline(always)]
+    pub fn peek(&self) -> Result<Option<T>, i32> {
+        let () = Self::_CHECK;
+        unsafe {
+            let mut value = MaybeUninit::<T>::uninit();
+            match bpf_map_peek_elem(self.as_ptr(), value.as_mut_ptr().cast()) as i32 {
+                0 => Ok(Some(value.assume_init())),
+                err if err == -ENOENT => Ok(None),
+                err => Err(err),
+            }
+        }
+    }
+}

--- a/ebpf/aya-ebpf/src/btf_maps/stack.rs
+++ b/ebpf/aya-ebpf/src/btf_maps/stack.rs
@@ -1,0 +1,115 @@
+use core::{borrow::Borrow, mem::MaybeUninit, ptr};
+
+use aya_ebpf_bindings::bindings::BPF_F_NO_PREALLOC;
+
+use crate::{
+    ENOENT,
+    btf_maps::btf_map_def,
+    helpers::{bpf_map_peek_elem, bpf_map_pop_elem, bpf_map_push_elem},
+};
+
+btf_map_def!(
+    /// A BTF-compatible BPF stack map.
+    ///
+    /// Stacks store values of type `T` in LIFO order. Push appends to the
+    /// top; pop and peek read from the top. There is no per-element key.
+    ///
+    /// # Minimum kernel version
+    ///
+    /// The minimum kernel version required to use this feature is 4.20.
+    /// `BPF_MAP_TYPE_STACK` and `BPF_MAP_TYPE_QUEUE` landed together.
+    ///
+    /// # Flag and size restrictions
+    ///
+    /// The kernel rejects stack maps with `BPF_F_NO_PREALLOC` and returns
+    /// `EINVAL`. The value must be non-zero sized and `max_entries` must
+    /// be at least 1.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use aya_ebpf::{btf_maps::Stack, macros::btf_map};
+    ///
+    /// #[btf_map]
+    /// static FRAMES: Stack<u64, 64> = Stack::new();
+    /// ```
+    pub struct Stack<T; const MAX_ENTRIES: usize, const FLAGS: usize = 0>,
+    map_type: BPF_MAP_TYPE_STACK,
+    max_entries: MAX_ENTRIES,
+    map_flags: FLAGS,
+    key_type: (),
+    value_type: T,
+);
+
+impl<T, const MAX_ENTRIES: usize, const FLAGS: usize> Stack<T, MAX_ENTRIES, FLAGS> {
+    const _CHECK: () = {
+        assert!(size_of::<T>() > 0, "stack value must be non-zero sized.");
+        assert!(
+            MAX_ENTRIES > 0,
+            "stack max_entries must be greater than zero.",
+        );
+        assert!(
+            FLAGS & BPF_F_NO_PREALLOC as usize == 0,
+            "BPF_F_NO_PREALLOC is rejected by stack maps.",
+        );
+    };
+
+    /// Pushes `value` onto the top of the stack.
+    ///
+    /// `flags` is forwarded to `bpf_map_push_elem`; setting `BPF_EXIST`
+    /// evicts the bottom element when the stack is full.
+    #[inline(always)]
+    pub fn push(&self, value: impl Borrow<T>, flags: u64) -> Result<(), i32> {
+        let () = Self::_CHECK;
+        let ret = unsafe {
+            bpf_map_push_elem(self.as_ptr(), ptr::from_ref(value.borrow()).cast(), flags)
+        };
+        (ret == 0).then_some(()).ok_or(ret as i32)
+    }
+
+    /// Removes and returns the top of the stack.
+    ///
+    /// Returns `Ok(None)` when the stack is empty.
+    ///
+    /// # Errors
+    ///
+    /// Propagates any non-zero errno from [`bpf_map_pop_elem`] (e.g.
+    /// `-EBUSY` under lock contention).
+    ///
+    /// [`bpf_map_pop_elem`]: https://docs.ebpf.io/linux/helper-function/bpf_map_pop_elem/
+    #[inline(always)]
+    pub fn pop(&self) -> Result<Option<T>, i32> {
+        let () = Self::_CHECK;
+        unsafe {
+            let mut value = MaybeUninit::<T>::uninit();
+            match bpf_map_pop_elem(self.as_ptr(), value.as_mut_ptr().cast()) as i32 {
+                0 => Ok(Some(value.assume_init())),
+                err if err == -ENOENT => Ok(None),
+                err => Err(err),
+            }
+        }
+    }
+
+    /// Returns the top of the stack without removing it.
+    ///
+    /// Returns `Ok(None)` when the stack is empty.
+    ///
+    /// # Errors
+    ///
+    /// Propagates any non-zero errno from [`bpf_map_peek_elem`] (e.g.
+    /// `-EBUSY` under lock contention).
+    ///
+    /// [`bpf_map_peek_elem`]: https://docs.ebpf.io/linux/helper-function/bpf_map_peek_elem/
+    #[inline(always)]
+    pub fn peek(&self) -> Result<Option<T>, i32> {
+        let () = Self::_CHECK;
+        unsafe {
+            let mut value = MaybeUninit::<T>::uninit();
+            match bpf_map_peek_elem(self.as_ptr(), value.as_mut_ptr().cast()) as i32 {
+                0 => Ok(Some(value.assume_init())),
+                err if err == -ENOENT => Ok(None),
+                err => Err(err),
+            }
+        }
+    }
+}

--- a/ebpf/aya-ebpf/src/maps/queue.rs
+++ b/ebpf/aya-ebpf/src/maps/queue.rs
@@ -1,6 +1,7 @@
-use core::{borrow::Borrow, marker::PhantomData, mem, ptr};
+use core::{borrow::Borrow, marker::PhantomData, mem::MaybeUninit, ptr};
 
 use crate::{
+    ENOENT,
     bindings::bpf_map_type::BPF_MAP_TYPE_QUEUE,
     helpers::{bpf_map_peek_elem, bpf_map_pop_elem, bpf_map_push_elem},
     maps::{MapDef, PinningType},
@@ -26,19 +27,45 @@ impl<T> Queue<T> {
         (ret == 0).then_some(()).ok_or(ret as i32)
     }
 
-    pub fn pop(&self) -> Option<T> {
+    /// Removes and returns the head of the queue.
+    ///
+    /// Returns `Ok(None)` when the queue is empty.
+    ///
+    /// # Errors
+    ///
+    /// Propagates any non-zero errno from [`bpf_map_pop_elem`] (e.g.
+    /// `-EBUSY` under lock contention).
+    ///
+    /// [`bpf_map_pop_elem`]: https://docs.ebpf.io/linux/helper-function/bpf_map_pop_elem/
+    pub fn pop(&self) -> Result<Option<T>, i32> {
         unsafe {
-            let mut value = mem::MaybeUninit::<T>::uninit();
-            let ret = bpf_map_pop_elem(self.def.as_ptr().cast(), value.as_mut_ptr().cast());
-            (ret == 0).then_some(value.assume_init())
+            let mut value = MaybeUninit::<T>::uninit();
+            match bpf_map_pop_elem(self.def.as_ptr().cast(), value.as_mut_ptr().cast()) as i32 {
+                0 => Ok(Some(value.assume_init())),
+                err if err == -ENOENT => Ok(None),
+                err => Err(err),
+            }
         }
     }
 
-    pub fn peek(&self) -> Option<T> {
+    /// Returns the head of the queue without removing it.
+    ///
+    /// Returns `Ok(None)` when the queue is empty.
+    ///
+    /// # Errors
+    ///
+    /// Propagates any non-zero errno from [`bpf_map_peek_elem`] (e.g.
+    /// `-EBUSY` under lock contention).
+    ///
+    /// [`bpf_map_peek_elem`]: https://docs.ebpf.io/linux/helper-function/bpf_map_peek_elem/
+    pub fn peek(&self) -> Result<Option<T>, i32> {
         unsafe {
-            let mut value = mem::MaybeUninit::<T>::uninit();
-            let ret = bpf_map_peek_elem(self.def.as_ptr().cast(), value.as_mut_ptr().cast());
-            (ret == 0).then_some(value.assume_init())
+            let mut value = MaybeUninit::<T>::uninit();
+            match bpf_map_peek_elem(self.def.as_ptr().cast(), value.as_mut_ptr().cast()) as i32 {
+                0 => Ok(Some(value.assume_init())),
+                err if err == -ENOENT => Ok(None),
+                err => Err(err),
+            }
         }
     }
 }

--- a/ebpf/aya-ebpf/src/maps/stack.rs
+++ b/ebpf/aya-ebpf/src/maps/stack.rs
@@ -1,6 +1,7 @@
-use core::{borrow::Borrow, marker::PhantomData, mem, ptr};
+use core::{borrow::Borrow, marker::PhantomData, mem::MaybeUninit, ptr};
 
 use crate::{
+    ENOENT,
     bindings::bpf_map_type::BPF_MAP_TYPE_STACK,
     helpers::{bpf_map_peek_elem, bpf_map_pop_elem, bpf_map_push_elem},
     maps::{MapDef, PinningType},
@@ -26,19 +27,45 @@ impl<T> Stack<T> {
         (ret == 0).then_some(()).ok_or(ret as i32)
     }
 
-    pub fn pop(&self) -> Option<T> {
+    /// Removes and returns the top of the stack.
+    ///
+    /// Returns `Ok(None)` when the stack is empty.
+    ///
+    /// # Errors
+    ///
+    /// Propagates any non-zero errno from [`bpf_map_pop_elem`] (e.g.
+    /// `-EBUSY` under lock contention).
+    ///
+    /// [`bpf_map_pop_elem`]: https://docs.ebpf.io/linux/helper-function/bpf_map_pop_elem/
+    pub fn pop(&self) -> Result<Option<T>, i32> {
         unsafe {
-            let mut value = mem::MaybeUninit::<T>::uninit();
-            let ret = bpf_map_pop_elem(self.def.as_ptr().cast(), value.as_mut_ptr().cast());
-            (ret == 0).then_some(value.assume_init())
+            let mut value = MaybeUninit::<T>::uninit();
+            match bpf_map_pop_elem(self.def.as_ptr().cast(), value.as_mut_ptr().cast()) as i32 {
+                0 => Ok(Some(value.assume_init())),
+                err if err == -ENOENT => Ok(None),
+                err => Err(err),
+            }
         }
     }
 
-    pub fn peek(&self) -> Option<T> {
+    /// Returns the top of the stack without removing it.
+    ///
+    /// Returns `Ok(None)` when the stack is empty.
+    ///
+    /// # Errors
+    ///
+    /// Propagates any non-zero errno from [`bpf_map_peek_elem`] (e.g.
+    /// `-EBUSY` under lock contention).
+    ///
+    /// [`bpf_map_peek_elem`]: https://docs.ebpf.io/linux/helper-function/bpf_map_peek_elem/
+    pub fn peek(&self) -> Result<Option<T>, i32> {
         unsafe {
-            let mut value = mem::MaybeUninit::<T>::uninit();
-            let ret = bpf_map_peek_elem(self.def.as_ptr().cast(), value.as_mut_ptr().cast());
-            (ret == 0).then_some(value.assume_init())
+            let mut value = MaybeUninit::<T>::uninit();
+            match bpf_map_peek_elem(self.def.as_ptr().cast(), value.as_mut_ptr().cast()) as i32 {
+                0 => Ok(Some(value.assume_init())),
+                err if err == -ENOENT => Ok(None),
+                err => Err(err),
+            }
         }
     }
 }

--- a/test/integration-ebpf/src/linear_data_structures.rs
+++ b/test/integration-ebpf/src/linear_data_structures.rs
@@ -6,65 +6,83 @@
 extern crate ebpf_panic;
 
 use aya_ebpf::{
+    btf_maps::{Array as BtfArray, Queue as BtfQueue, Stack as BtfStack},
     cty::c_long,
-    macros::{map, uprobe},
+    macros::{btf_map, map, uprobe},
     maps::{Array, Queue, Stack},
     programs::ProbeContext,
 };
 use integration_common::linear_data_structures::{PEEK_INDEX, POP_INDEX};
 
-#[map]
-static RESULT: Array<u64> = Array::<u64>::with_max_entries(2, 0);
+#[btf_map]
+static RESULT: BtfArray<u64, 2, 0> = BtfArray::new();
 
-#[inline(always)]
-fn result_set(index: u32, value: u64) -> Result<(), c_long> {
-    let ptr = RESULT.get_ptr_mut(index).ok_or(-1)?;
-    let dst = unsafe { ptr.as_mut() };
-    let dst_res = dst.ok_or(-1)?;
-    *dst_res = value;
-    Ok(())
-}
+#[btf_map]
+static TEST_QUEUE: BtfQueue<u64, 10> = BtfQueue::new();
+
+#[btf_map]
+static TEST_STACK: BtfStack<u64, 10> = BtfStack::new();
+
+#[map]
+static RESULT_LEGACY: Array<u64> = Array::<u64>::with_max_entries(2, 0);
+
+#[map]
+static TEST_QUEUE_LEGACY: Queue<u64> = Queue::with_max_entries(10, 0);
+
+#[map]
+static TEST_STACK_LEGACY: Stack<u64> = Stack::with_max_entries(10, 0);
 
 macro_rules! define_linear_ds_test {
-    ($Type:ident, $map_ident:ident,
+    ($map:ident, $result_map:ident,
         push_fn: $push_fn:ident,
         pop_fn: $pop_fn:ident,
-        peek_fn: $peek_fn:ident,
+        peek_fn: $peek_fn:ident
+        $(,)?
     ) => {
-        #[map]
-        static $map_ident: $Type<u64> = $Type::with_max_entries(10, 0);
-
         #[uprobe]
         fn $push_fn(ctx: ProbeContext) -> Result<(), c_long> {
             let value = ctx.arg(0).ok_or(-1)?;
-            $map_ident.push(&value, 0)?;
+            $map.push(&value, 0)?;
             Ok(())
         }
 
-        #[uprobe]
-        fn $pop_fn(_: ProbeContext) -> Result<(), c_long> {
-            let value = $map_ident.pop().ok_or(-1)?;
-            result_set(POP_INDEX, value)?;
-            Ok(())
-        }
+        define_linear_ds_test!(@probe $map, $result_map, $pop_fn, pop, POP_INDEX);
+        define_linear_ds_test!(@probe $map, $result_map, $peek_fn, peek, PEEK_INDEX);
+    };
 
+    (@probe $map:ident, $result_map:ident, $fn:ident, $method:ident, $idx:ident) => {
         #[uprobe]
-        fn $peek_fn(_: ProbeContext) -> Result<(), c_long> {
-            let value = $map_ident.peek().ok_or(-1)?;
-            result_set(PEEK_INDEX, value)?;
+        fn $fn(_: ProbeContext) -> Result<(), c_long> {
+            let value = $map.$method()?.ok_or(-1)?;
+            let ptr = $result_map.get_ptr_mut($idx).ok_or(-1)?;
+            let dst = unsafe { ptr.as_mut() };
+            let dst_res = dst.ok_or(-1)?;
+            *dst_res = value;
             Ok(())
         }
     };
 }
 
-define_linear_ds_test!(Stack, TEST_STACK,
+define_linear_ds_test!(TEST_STACK, RESULT,
     push_fn: test_stack_push,
     pop_fn: test_stack_pop,
     peek_fn: test_stack_peek,
 );
 
-define_linear_ds_test!(Queue, TEST_QUEUE,
+define_linear_ds_test!(TEST_STACK_LEGACY, RESULT_LEGACY,
+    push_fn: test_stack_push_legacy,
+    pop_fn: test_stack_pop_legacy,
+    peek_fn: test_stack_peek_legacy,
+);
+
+define_linear_ds_test!(TEST_QUEUE, RESULT,
     push_fn: test_queue_push,
     pop_fn: test_queue_pop,
     peek_fn: test_queue_peek,
+);
+
+define_linear_ds_test!(TEST_QUEUE_LEGACY, RESULT_LEGACY,
+    push_fn: test_queue_push_legacy,
+    pop_fn: test_queue_pop_legacy,
+    peek_fn: test_queue_peek_legacy,
 );

--- a/test/integration-test/src/tests/linear_data_structures.rs
+++ b/test/integration-test/src/tests/linear_data_structures.rs
@@ -1,7 +1,8 @@
 use aya::{
     EbpfLoader,
-    maps::Array,
+    maps::{Array, MapType},
     programs::{UProbe, uprobe::UProbeScope},
+    sys::is_map_supported,
 };
 use integration_common::linear_data_structures::{PEEK_INDEX, POP_INDEX};
 
@@ -15,10 +16,12 @@ macro_rules! define_linear_ds_host_test {
         push_prog: $push_prog:literal,
         pop_prog: $pop_prog:literal,
         peek_prog: $peek_prog:literal,
+        result_map: $result_map:literal,
         push_fn: $push_fn:ident,
         pop_fn: $pop_fn:ident,
         peek_fn: $peek_fn:ident,
         test_fn: $test_fn:ident,
+        map_type: $map_type:expr,
         order: $order:expr,
     ) => {
         #[unsafe(no_mangle)]
@@ -41,6 +44,10 @@ macro_rules! define_linear_ds_host_test {
 
         #[test_log::test]
         fn $test_fn() {
+            if !is_map_supported($map_type).unwrap() {
+                eprintln!("skipping test - {:?} map not supported", $map_type);
+                return;
+            }
             let mut bpf = EbpfLoader::new()
                 .load(crate::LINEAR_DATA_STRUCTURES)
                 .unwrap();
@@ -54,8 +61,7 @@ macro_rules! define_linear_ds_host_test {
                 prog.attach(symbol, "/proc/self/exe", UProbeScope::AllProcesses)
                     .unwrap();
             }
-            let array_map = bpf.map("RESULT").unwrap();
-            let array = Array::<_, u64>::try_from(array_map).unwrap();
+            let array = Array::<_, u64>::try_from(bpf.map($result_map).unwrap()).unwrap();
             let seq = 0..9;
             for i in seq.clone() {
                 $push_fn(i);
@@ -77,23 +83,53 @@ macro_rules! define_linear_ds_host_test {
 }
 
 define_linear_ds_host_test!(
+    push_prog: "test_stack_push_legacy",
+    pop_prog: "test_stack_pop_legacy",
+    peek_prog: "test_stack_peek_legacy",
+    result_map: "RESULT_LEGACY",
+    push_fn: trigger_stack_push_legacy,
+    pop_fn: trigger_stack_pop_legacy,
+    peek_fn: trigger_stack_peek_legacy,
+    test_fn: stack_basic_legacy,
+    map_type: MapType::Stack,
+    order: Order::Lifo,
+);
+
+define_linear_ds_host_test!(
     push_prog: "test_stack_push",
     pop_prog: "test_stack_pop",
     peek_prog: "test_stack_peek",
+    result_map: "RESULT",
     push_fn: trigger_stack_push,
     pop_fn: trigger_stack_pop,
     peek_fn: trigger_stack_peek,
-    test_fn: stack_basic,
+    test_fn: stack_basic_btf,
+    map_type: MapType::Stack,
     order: Order::Lifo,
+);
+
+define_linear_ds_host_test!(
+    push_prog: "test_queue_push_legacy",
+    pop_prog: "test_queue_pop_legacy",
+    peek_prog: "test_queue_peek_legacy",
+    result_map: "RESULT_LEGACY",
+    push_fn: trigger_queue_push_legacy,
+    pop_fn: trigger_queue_pop_legacy,
+    peek_fn: trigger_queue_peek_legacy,
+    test_fn: queue_basic_legacy,
+    map_type: MapType::Queue,
+    order: Order::Fifo,
 );
 
 define_linear_ds_host_test!(
     push_prog: "test_queue_push",
     pop_prog: "test_queue_pop",
     peek_prog: "test_queue_peek",
+    result_map: "RESULT",
     push_fn: trigger_queue_push,
     pop_fn: trigger_queue_pop,
     peek_fn: trigger_queue_peek,
-    test_fn: queue_basic,
+    test_fn: queue_basic_btf,
+    map_type: MapType::Queue,
     order: Order::Fifo,
 );

--- a/xtask/public-api/aya-ebpf.txt
+++ b/xtask/public-api/aya-ebpf.txt
@@ -133,6 +133,23 @@ impl<const MAX_ENTRIES: usize, const FLAGS: usize> core::marker::Unpin for aya_e
 impl<const MAX_ENTRIES: usize, const FLAGS: usize> core::marker::UnsafeUnpin for aya_ebpf::btf_maps::program_array::ProgramArray<MAX_ENTRIES, FLAGS>
 impl<const MAX_ENTRIES: usize, const FLAGS: usize> core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::btf_maps::program_array::ProgramArray<MAX_ENTRIES, FLAGS>
 impl<const MAX_ENTRIES: usize, const FLAGS: usize> core::panic::unwind_safe::UnwindSafe for aya_ebpf::btf_maps::program_array::ProgramArray<MAX_ENTRIES, FLAGS>
+pub mod aya_ebpf::btf_maps::queue
+#[repr(C)] pub struct aya_ebpf::btf_maps::queue::Queue<T, const MAX_ENTRIES: usize, const FLAGS: usize>
+impl<T, const MAX_ENTRIES: usize, const FLAGS: usize> aya_ebpf::btf_maps::queue::Queue<T, MAX_ENTRIES, FLAGS>
+pub const fn aya_ebpf::btf_maps::queue::Queue<T, MAX_ENTRIES, FLAGS>::new() -> Self
+impl<T, const MAX_ENTRIES: usize, const FLAGS: usize> aya_ebpf::btf_maps::queue::Queue<T, MAX_ENTRIES, FLAGS>
+pub fn aya_ebpf::btf_maps::queue::Queue<T, MAX_ENTRIES, FLAGS>::peek(&self) -> core::result::Result<core::option::Option<T>, i32>
+pub fn aya_ebpf::btf_maps::queue::Queue<T, MAX_ENTRIES, FLAGS>::pop(&self) -> core::result::Result<core::option::Option<T>, i32>
+pub fn aya_ebpf::btf_maps::queue::Queue<T, MAX_ENTRIES, FLAGS>::push(&self, value: impl core::borrow::Borrow<T>, flags: u64) -> core::result::Result<(), i32>
+impl<T, const MAX_ENTRIES: usize, const FLAGS: usize> core::default::Default for aya_ebpf::btf_maps::queue::Queue<T, MAX_ENTRIES, FLAGS>
+pub fn aya_ebpf::btf_maps::queue::Queue<T, MAX_ENTRIES, FLAGS>::default() -> Self
+impl<T, const MAX_ENTRIES: usize, const FLAGS: usize> core::marker::Sync for aya_ebpf::btf_maps::queue::Queue<T, MAX_ENTRIES, FLAGS>
+impl<T, const MAX_ENTRIES: usize, const FLAGS: usize> core::marker::Freeze for aya_ebpf::btf_maps::queue::Queue<T, MAX_ENTRIES, FLAGS>
+impl<T, const MAX_ENTRIES: usize, const FLAGS: usize> !core::marker::Send for aya_ebpf::btf_maps::queue::Queue<T, MAX_ENTRIES, FLAGS>
+impl<T, const MAX_ENTRIES: usize, const FLAGS: usize> core::marker::Unpin for aya_ebpf::btf_maps::queue::Queue<T, MAX_ENTRIES, FLAGS>
+impl<T, const MAX_ENTRIES: usize, const FLAGS: usize> core::marker::UnsafeUnpin for aya_ebpf::btf_maps::queue::Queue<T, MAX_ENTRIES, FLAGS>
+impl<T, const MAX_ENTRIES: usize, const FLAGS: usize> core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::btf_maps::queue::Queue<T, MAX_ENTRIES, FLAGS> where T: core::panic::unwind_safe::RefUnwindSafe
+impl<T, const MAX_ENTRIES: usize, const FLAGS: usize> core::panic::unwind_safe::UnwindSafe for aya_ebpf::btf_maps::queue::Queue<T, MAX_ENTRIES, FLAGS> where T: core::panic::unwind_safe::RefUnwindSafe
 pub mod aya_ebpf::btf_maps::reuseport_sock_array
 #[repr(C)] pub struct aya_ebpf::btf_maps::reuseport_sock_array::ReusePortSockArrayImpl<T, const MAX_ENTRIES: usize, const FLAGS: usize>
 impl<T, const MAX_ENTRIES: usize, const FLAGS: usize> aya_ebpf::btf_maps::reuseport_sock_array::ReusePortSockArrayImpl<T, MAX_ENTRIES, FLAGS>
@@ -221,6 +238,23 @@ impl<const MAX_ENTRIES: usize, const FLAGS: usize> core::marker::Unpin for aya_e
 impl<const MAX_ENTRIES: usize, const FLAGS: usize> core::marker::UnsafeUnpin for aya_ebpf::btf_maps::sock_map::SockMap<MAX_ENTRIES, FLAGS>
 impl<const MAX_ENTRIES: usize, const FLAGS: usize> core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::btf_maps::sock_map::SockMap<MAX_ENTRIES, FLAGS>
 impl<const MAX_ENTRIES: usize, const FLAGS: usize> core::panic::unwind_safe::UnwindSafe for aya_ebpf::btf_maps::sock_map::SockMap<MAX_ENTRIES, FLAGS>
+pub mod aya_ebpf::btf_maps::stack
+#[repr(C)] pub struct aya_ebpf::btf_maps::stack::Stack<T, const MAX_ENTRIES: usize, const FLAGS: usize>
+impl<T, const MAX_ENTRIES: usize, const FLAGS: usize> aya_ebpf::btf_maps::stack::Stack<T, MAX_ENTRIES, FLAGS>
+pub const fn aya_ebpf::btf_maps::stack::Stack<T, MAX_ENTRIES, FLAGS>::new() -> Self
+impl<T, const MAX_ENTRIES: usize, const FLAGS: usize> aya_ebpf::btf_maps::stack::Stack<T, MAX_ENTRIES, FLAGS>
+pub fn aya_ebpf::btf_maps::stack::Stack<T, MAX_ENTRIES, FLAGS>::peek(&self) -> core::result::Result<core::option::Option<T>, i32>
+pub fn aya_ebpf::btf_maps::stack::Stack<T, MAX_ENTRIES, FLAGS>::pop(&self) -> core::result::Result<core::option::Option<T>, i32>
+pub fn aya_ebpf::btf_maps::stack::Stack<T, MAX_ENTRIES, FLAGS>::push(&self, value: impl core::borrow::Borrow<T>, flags: u64) -> core::result::Result<(), i32>
+impl<T, const MAX_ENTRIES: usize, const FLAGS: usize> core::default::Default for aya_ebpf::btf_maps::stack::Stack<T, MAX_ENTRIES, FLAGS>
+pub fn aya_ebpf::btf_maps::stack::Stack<T, MAX_ENTRIES, FLAGS>::default() -> Self
+impl<T, const MAX_ENTRIES: usize, const FLAGS: usize> core::marker::Sync for aya_ebpf::btf_maps::stack::Stack<T, MAX_ENTRIES, FLAGS>
+impl<T, const MAX_ENTRIES: usize, const FLAGS: usize> core::marker::Freeze for aya_ebpf::btf_maps::stack::Stack<T, MAX_ENTRIES, FLAGS>
+impl<T, const MAX_ENTRIES: usize, const FLAGS: usize> !core::marker::Send for aya_ebpf::btf_maps::stack::Stack<T, MAX_ENTRIES, FLAGS>
+impl<T, const MAX_ENTRIES: usize, const FLAGS: usize> core::marker::Unpin for aya_ebpf::btf_maps::stack::Stack<T, MAX_ENTRIES, FLAGS>
+impl<T, const MAX_ENTRIES: usize, const FLAGS: usize> core::marker::UnsafeUnpin for aya_ebpf::btf_maps::stack::Stack<T, MAX_ENTRIES, FLAGS>
+impl<T, const MAX_ENTRIES: usize, const FLAGS: usize> core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::btf_maps::stack::Stack<T, MAX_ENTRIES, FLAGS> where T: core::panic::unwind_safe::RefUnwindSafe
+impl<T, const MAX_ENTRIES: usize, const FLAGS: usize> core::panic::unwind_safe::UnwindSafe for aya_ebpf::btf_maps::stack::Stack<T, MAX_ENTRIES, FLAGS> where T: core::panic::unwind_safe::RefUnwindSafe
 pub mod aya_ebpf::btf_maps::stack_trace
 #[repr(C)] pub struct aya_ebpf::btf_maps::stack_trace::StackTrace<const MAX_ENTRIES: usize, const FLAGS: usize, const DEPTH: usize>
 impl<const MAX_ENTRIES: usize, const FLAGS: usize, const DEPTH: usize> aya_ebpf::btf_maps::stack_trace::StackTrace<MAX_ENTRIES, FLAGS, DEPTH>
@@ -343,6 +377,22 @@ impl<const MAX_ENTRIES: usize, const FLAGS: usize> core::marker::Unpin for aya_e
 impl<const MAX_ENTRIES: usize, const FLAGS: usize> core::marker::UnsafeUnpin for aya_ebpf::btf_maps::program_array::ProgramArray<MAX_ENTRIES, FLAGS>
 impl<const MAX_ENTRIES: usize, const FLAGS: usize> core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::btf_maps::program_array::ProgramArray<MAX_ENTRIES, FLAGS>
 impl<const MAX_ENTRIES: usize, const FLAGS: usize> core::panic::unwind_safe::UnwindSafe for aya_ebpf::btf_maps::program_array::ProgramArray<MAX_ENTRIES, FLAGS>
+#[repr(C)] pub struct aya_ebpf::btf_maps::Queue<T, const MAX_ENTRIES: usize, const FLAGS: usize>
+impl<T, const MAX_ENTRIES: usize, const FLAGS: usize> aya_ebpf::btf_maps::queue::Queue<T, MAX_ENTRIES, FLAGS>
+pub const fn aya_ebpf::btf_maps::queue::Queue<T, MAX_ENTRIES, FLAGS>::new() -> Self
+impl<T, const MAX_ENTRIES: usize, const FLAGS: usize> aya_ebpf::btf_maps::queue::Queue<T, MAX_ENTRIES, FLAGS>
+pub fn aya_ebpf::btf_maps::queue::Queue<T, MAX_ENTRIES, FLAGS>::peek(&self) -> core::result::Result<core::option::Option<T>, i32>
+pub fn aya_ebpf::btf_maps::queue::Queue<T, MAX_ENTRIES, FLAGS>::pop(&self) -> core::result::Result<core::option::Option<T>, i32>
+pub fn aya_ebpf::btf_maps::queue::Queue<T, MAX_ENTRIES, FLAGS>::push(&self, value: impl core::borrow::Borrow<T>, flags: u64) -> core::result::Result<(), i32>
+impl<T, const MAX_ENTRIES: usize, const FLAGS: usize> core::default::Default for aya_ebpf::btf_maps::queue::Queue<T, MAX_ENTRIES, FLAGS>
+pub fn aya_ebpf::btf_maps::queue::Queue<T, MAX_ENTRIES, FLAGS>::default() -> Self
+impl<T, const MAX_ENTRIES: usize, const FLAGS: usize> core::marker::Sync for aya_ebpf::btf_maps::queue::Queue<T, MAX_ENTRIES, FLAGS>
+impl<T, const MAX_ENTRIES: usize, const FLAGS: usize> core::marker::Freeze for aya_ebpf::btf_maps::queue::Queue<T, MAX_ENTRIES, FLAGS>
+impl<T, const MAX_ENTRIES: usize, const FLAGS: usize> !core::marker::Send for aya_ebpf::btf_maps::queue::Queue<T, MAX_ENTRIES, FLAGS>
+impl<T, const MAX_ENTRIES: usize, const FLAGS: usize> core::marker::Unpin for aya_ebpf::btf_maps::queue::Queue<T, MAX_ENTRIES, FLAGS>
+impl<T, const MAX_ENTRIES: usize, const FLAGS: usize> core::marker::UnsafeUnpin for aya_ebpf::btf_maps::queue::Queue<T, MAX_ENTRIES, FLAGS>
+impl<T, const MAX_ENTRIES: usize, const FLAGS: usize> core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::btf_maps::queue::Queue<T, MAX_ENTRIES, FLAGS> where T: core::panic::unwind_safe::RefUnwindSafe
+impl<T, const MAX_ENTRIES: usize, const FLAGS: usize> core::panic::unwind_safe::UnwindSafe for aya_ebpf::btf_maps::queue::Queue<T, MAX_ENTRIES, FLAGS> where T: core::panic::unwind_safe::RefUnwindSafe
 #[repr(C)] pub struct aya_ebpf::btf_maps::RingBuf<T, const MAX_ENTRIES: usize, const FLAGS: usize>
 impl<T, const MAX_ENTRIES: usize, const FLAGS: usize> aya_ebpf::btf_maps::ring_buf::RingBuf<T, MAX_ENTRIES, FLAGS>
 pub const fn aya_ebpf::btf_maps::ring_buf::RingBuf<T, MAX_ENTRIES, FLAGS>::new() -> Self
@@ -411,6 +461,22 @@ impl<const MAX_ENTRIES: usize, const FLAGS: usize> core::marker::Unpin for aya_e
 impl<const MAX_ENTRIES: usize, const FLAGS: usize> core::marker::UnsafeUnpin for aya_ebpf::btf_maps::sock_map::SockMap<MAX_ENTRIES, FLAGS>
 impl<const MAX_ENTRIES: usize, const FLAGS: usize> core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::btf_maps::sock_map::SockMap<MAX_ENTRIES, FLAGS>
 impl<const MAX_ENTRIES: usize, const FLAGS: usize> core::panic::unwind_safe::UnwindSafe for aya_ebpf::btf_maps::sock_map::SockMap<MAX_ENTRIES, FLAGS>
+#[repr(C)] pub struct aya_ebpf::btf_maps::Stack<T, const MAX_ENTRIES: usize, const FLAGS: usize>
+impl<T, const MAX_ENTRIES: usize, const FLAGS: usize> aya_ebpf::btf_maps::stack::Stack<T, MAX_ENTRIES, FLAGS>
+pub const fn aya_ebpf::btf_maps::stack::Stack<T, MAX_ENTRIES, FLAGS>::new() -> Self
+impl<T, const MAX_ENTRIES: usize, const FLAGS: usize> aya_ebpf::btf_maps::stack::Stack<T, MAX_ENTRIES, FLAGS>
+pub fn aya_ebpf::btf_maps::stack::Stack<T, MAX_ENTRIES, FLAGS>::peek(&self) -> core::result::Result<core::option::Option<T>, i32>
+pub fn aya_ebpf::btf_maps::stack::Stack<T, MAX_ENTRIES, FLAGS>::pop(&self) -> core::result::Result<core::option::Option<T>, i32>
+pub fn aya_ebpf::btf_maps::stack::Stack<T, MAX_ENTRIES, FLAGS>::push(&self, value: impl core::borrow::Borrow<T>, flags: u64) -> core::result::Result<(), i32>
+impl<T, const MAX_ENTRIES: usize, const FLAGS: usize> core::default::Default for aya_ebpf::btf_maps::stack::Stack<T, MAX_ENTRIES, FLAGS>
+pub fn aya_ebpf::btf_maps::stack::Stack<T, MAX_ENTRIES, FLAGS>::default() -> Self
+impl<T, const MAX_ENTRIES: usize, const FLAGS: usize> core::marker::Sync for aya_ebpf::btf_maps::stack::Stack<T, MAX_ENTRIES, FLAGS>
+impl<T, const MAX_ENTRIES: usize, const FLAGS: usize> core::marker::Freeze for aya_ebpf::btf_maps::stack::Stack<T, MAX_ENTRIES, FLAGS>
+impl<T, const MAX_ENTRIES: usize, const FLAGS: usize> !core::marker::Send for aya_ebpf::btf_maps::stack::Stack<T, MAX_ENTRIES, FLAGS>
+impl<T, const MAX_ENTRIES: usize, const FLAGS: usize> core::marker::Unpin for aya_ebpf::btf_maps::stack::Stack<T, MAX_ENTRIES, FLAGS>
+impl<T, const MAX_ENTRIES: usize, const FLAGS: usize> core::marker::UnsafeUnpin for aya_ebpf::btf_maps::stack::Stack<T, MAX_ENTRIES, FLAGS>
+impl<T, const MAX_ENTRIES: usize, const FLAGS: usize> core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::btf_maps::stack::Stack<T, MAX_ENTRIES, FLAGS> where T: core::panic::unwind_safe::RefUnwindSafe
+impl<T, const MAX_ENTRIES: usize, const FLAGS: usize> core::panic::unwind_safe::UnwindSafe for aya_ebpf::btf_maps::stack::Stack<T, MAX_ENTRIES, FLAGS> where T: core::panic::unwind_safe::RefUnwindSafe
 #[repr(C)] pub struct aya_ebpf::btf_maps::StackTrace<const MAX_ENTRIES: usize, const FLAGS: usize, const DEPTH: usize>
 impl<const MAX_ENTRIES: usize, const FLAGS: usize, const DEPTH: usize> aya_ebpf::btf_maps::stack_trace::StackTrace<MAX_ENTRIES, FLAGS, DEPTH>
 pub const fn aya_ebpf::btf_maps::stack_trace::StackTrace<MAX_ENTRIES, FLAGS, DEPTH>::new() -> Self
@@ -626,9 +692,9 @@ impl core::panic::unwind_safe::UnwindSafe for aya_ebpf::maps::program_array::Pro
 pub mod aya_ebpf::maps::queue
 #[repr(transparent)] pub struct aya_ebpf::maps::queue::Queue<T>
 impl<T> aya_ebpf::maps::queue::Queue<T>
-pub fn aya_ebpf::maps::queue::Queue<T>::peek(&self) -> core::option::Option<T>
+pub fn aya_ebpf::maps::queue::Queue<T>::peek(&self) -> core::result::Result<core::option::Option<T>, i32>
 pub const fn aya_ebpf::maps::queue::Queue<T>::pinned(max_entries: u32, flags: u32) -> Self
-pub fn aya_ebpf::maps::queue::Queue<T>::pop(&self) -> core::option::Option<T>
+pub fn aya_ebpf::maps::queue::Queue<T>::pop(&self) -> core::result::Result<core::option::Option<T>, i32>
 pub fn aya_ebpf::maps::queue::Queue<T>::push(&self, value: impl core::borrow::Borrow<T>, flags: u64) -> core::result::Result<(), i32>
 pub const fn aya_ebpf::maps::queue::Queue<T>::with_max_entries(max_entries: u32, flags: u32) -> Self
 impl<T> !core::marker::Freeze for aya_ebpf::maps::queue::Queue<T>
@@ -734,9 +800,9 @@ impl core::panic::unwind_safe::UnwindSafe for aya_ebpf::maps::sock_map::SockMap
 pub mod aya_ebpf::maps::stack
 #[repr(transparent)] pub struct aya_ebpf::maps::stack::Stack<T>
 impl<T> aya_ebpf::maps::stack::Stack<T>
-pub fn aya_ebpf::maps::stack::Stack<T>::peek(&self) -> core::option::Option<T>
+pub fn aya_ebpf::maps::stack::Stack<T>::peek(&self) -> core::result::Result<core::option::Option<T>, i32>
 pub const fn aya_ebpf::maps::stack::Stack<T>::pinned(max_entries: u32, flags: u32) -> Self
-pub fn aya_ebpf::maps::stack::Stack<T>::pop(&self) -> core::option::Option<T>
+pub fn aya_ebpf::maps::stack::Stack<T>::pop(&self) -> core::result::Result<core::option::Option<T>, i32>
 pub fn aya_ebpf::maps::stack::Stack<T>::push(&self, value: impl core::borrow::Borrow<T>, flags: u64) -> core::result::Result<(), i32>
 pub const fn aya_ebpf::maps::stack::Stack<T>::with_max_entries(max_entries: u32, flags: u32) -> Self
 impl<T> !core::marker::Freeze for aya_ebpf::maps::stack::Stack<T>
@@ -1009,9 +1075,9 @@ impl !core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::maps::program_array:
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf::maps::program_array::ProgramArray
 #[repr(transparent)] pub struct aya_ebpf::maps::Queue<T>
 impl<T> aya_ebpf::maps::queue::Queue<T>
-pub fn aya_ebpf::maps::queue::Queue<T>::peek(&self) -> core::option::Option<T>
+pub fn aya_ebpf::maps::queue::Queue<T>::peek(&self) -> core::result::Result<core::option::Option<T>, i32>
 pub const fn aya_ebpf::maps::queue::Queue<T>::pinned(max_entries: u32, flags: u32) -> Self
-pub fn aya_ebpf::maps::queue::Queue<T>::pop(&self) -> core::option::Option<T>
+pub fn aya_ebpf::maps::queue::Queue<T>::pop(&self) -> core::result::Result<core::option::Option<T>, i32>
 pub fn aya_ebpf::maps::queue::Queue<T>::push(&self, value: impl core::borrow::Borrow<T>, flags: u64) -> core::result::Result<(), i32>
 pub const fn aya_ebpf::maps::queue::Queue<T>::with_max_entries(max_entries: u32, flags: u32) -> Self
 impl<T> !core::marker::Freeze for aya_ebpf::maps::queue::Queue<T>
@@ -1080,9 +1146,9 @@ impl !core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::maps::sock_map::Sock
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf::maps::sock_map::SockMap
 #[repr(transparent)] pub struct aya_ebpf::maps::Stack<T>
 impl<T> aya_ebpf::maps::stack::Stack<T>
-pub fn aya_ebpf::maps::stack::Stack<T>::peek(&self) -> core::option::Option<T>
+pub fn aya_ebpf::maps::stack::Stack<T>::peek(&self) -> core::result::Result<core::option::Option<T>, i32>
 pub const fn aya_ebpf::maps::stack::Stack<T>::pinned(max_entries: u32, flags: u32) -> Self
-pub fn aya_ebpf::maps::stack::Stack<T>::pop(&self) -> core::option::Option<T>
+pub fn aya_ebpf::maps::stack::Stack<T>::pop(&self) -> core::result::Result<core::option::Option<T>, i32>
 pub fn aya_ebpf::maps::stack::Stack<T>::push(&self, value: impl core::borrow::Borrow<T>, flags: u64) -> core::result::Result<(), i32>
 pub const fn aya_ebpf::maps::stack::Stack<T>::with_max_entries(max_entries: u32, flags: u32) -> Self
 impl<T> !core::marker::Freeze for aya_ebpf::maps::stack::Stack<T>


### PR DESCRIPTION
Adds `Queue<T, MAX_ENTRIES, FLAGS>` and `Stack<T, MAX_ENTRIES, FLAGS>`
to `aya_ebpf::btf_maps`, mirroring the existing legacy types in
`aya_ebpf::maps`.

Compile-time `assert!`s enforce non-zero value size, `max_entries > 0`,
and reject `BPF_F_NO_PREALLOC` (which the kernel rejects in
`queue_stack_map_alloc_check`).

Integration tests in `linear_data_structures` extend to cover both
legacy and BTF variants for queue and stack.

### Added/updated tests?

- [x] Yes

### Checklist

- [x] Rust code has been formatted with `cargo +nightly fmt`.
- [x] All clippy lints have been fixed.
      You can find failing lints with `cargo xtask clippy`.
- [x] Unit tests are passing locally with `cargo test`.
- [x] The integration tests are passing locally.
- [x] I have blessed any API changes with `cargo xtask public-api --bless`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aya-rs/aya/1561)
<!-- Reviewable:end -->
