### PR TITLE
aya: remove SocketFilter link abstraction

### DIFF
--- a/aya/src/programs/mod.rs
+++ b/aya/src/programs/mod.rs
@@ -819,9 +819,10 @@ macro_rules! impl_program_unload {
             impl $struct_name {
                 /// Unloads the program from the kernel.
                 ///
-                /// Links will be detached before unloading the program.  Note
-                /// that owned links obtained using `take_link()` will not be
-                /// detached.
+                /// Tracked links will be detached before unloading the program.
+                /// Attachment mechanisms that do not create tracked links are
+                /// not affected. Note that owned links obtained using
+                /// `take_link()` will not be detached.
                 pub fn unload(&mut self) -> Result<(), ProgramError> {
                     unload_program(&mut self.data)
                 }
@@ -1263,7 +1264,6 @@ macro_rules! impl_from_pin {
 // Use impl_from_pin if the program doesn't require additional data
 impl_from_pin!(
     TracePoint,
-    SocketFilter,
     SkMsg,
     CgroupSysctl,
     LircMode2,

--- a/aya/src/programs/sk_reuseport.rs
+++ b/aya/src/programs/sk_reuseport.rs
@@ -171,7 +171,7 @@ impl SkReuseport {
     /// operation. Dropping the program object does not detach it; call
     /// [`SkReuseport::detach`] with any socket from the same group to remove it
     /// again, or close all sockets in the group.
-    pub fn attach<T: AsFd>(&mut self, socket: T) -> Result<(), ProgramError> {
+    pub fn attach<T: AsFd>(&self, socket: T) -> Result<(), ProgramError> {
         let prog_fd = self.fd()?.as_fd().as_raw_fd();
         let socket = socket.as_fd().as_raw_fd();
 
@@ -186,7 +186,7 @@ impl SkReuseport {
     /// from the entire group, regardless of which socket in that group was
     /// used to attach it. Unlike [`SkReuseport::attach`], this operation does
     /// not require the program to remain loaded in this process.
-    pub fn detach<T: AsFd>(&mut self, socket: T) -> Result<(), ProgramError> {
+    pub fn detach<T: AsFd>(socket: T) -> Result<(), ProgramError> {
         let socket = socket.as_fd().as_raw_fd();
         let dummy: libc::c_int = 0;
 

--- a/aya/src/programs/socket_filter.rs
+++ b/aya/src/programs/socket_filter.rs
@@ -1,7 +1,9 @@
 //! Socket filter programs.
 use std::{
     io,
-    os::fd::{AsFd, AsRawFd as _, RawFd},
+    os::fd::{AsFd, AsRawFd as _},
+    path::Path,
+    ptr,
 };
 
 use aya_obj::generated::{
@@ -10,17 +12,45 @@ use aya_obj::generated::{
 use libc::{SOL_SOCKET, setsockopt};
 use thiserror::Error;
 
-use crate::programs::{
-    Link, ProgramData, ProgramError, ProgramType, id_as_key, load_program_without_attach_type,
+use crate::{
+    VerifierLogLevel,
+    programs::{
+        ProgramData, ProgramError, ProgramType, links::FdLink, load_program_without_attach_type,
+    },
 };
 
-/// The type returned when attaching a [`SocketFilter`] fails.
+macro_rules! setsockopt_socket_filter {
+    ($socket:expr, $option:ident, $value:expr) => {{
+        let value = $value;
+        let ret = unsafe {
+            setsockopt(
+                $socket,
+                SOL_SOCKET,
+                $option as libc::c_int,
+                ptr::from_ref(value).cast(),
+                size_of_val(value) as libc::socklen_t,
+            )
+        };
+        if ret < 0 {
+            Err(SocketFilterError::SetsockoptError {
+                option: stringify!($option),
+                io_error: io::Error::last_os_error(),
+            })
+        } else {
+            Ok(())
+        }
+    }};
+}
+
+/// The type returned when a [`SocketFilter`] socket option operation fails.
 #[derive(Debug, Error)]
 pub enum SocketFilterError {
-    /// Setting the `SO_ATTACH_BPF` socket option failed.
-    #[error("setsockopt SO_ATTACH_BPF failed")]
-    SoAttachEbpfError {
-        /// original [`io::Error`]
+    /// Setting a socket filter socket option failed.
+    #[error("setsockopt {option} failed")]
+    SetsockoptError {
+        /// Socket option passed to `setsockopt`.
+        option: &'static str,
+        /// Underlying OS error.
         #[source]
         io_error: io::Error,
     },
@@ -31,9 +61,21 @@ pub enum SocketFilterError {
 /// [`SocketFilter`] programs are attached on sockets and can be used to inspect
 /// and filter incoming packets.
 ///
+/// Each socket has one filter slot. Attaching a new [`SocketFilter`] replaces
+/// the socket's current filter, and detaching clears that current filter
+/// regardless of which program installed it. Aya therefore does not expose a
+/// link-style attachment handle for [`SocketFilter`] or automatically track
+/// socket filter attachments for cleanup. Dropping [`SocketFilter`] or
+/// [`crate::Ebpf`] does not detach the filter; call [`SocketFilter::detach`]
+/// explicitly when you want to remove it, or close the socket.
+///
 /// # Minimum kernel version
 ///
-/// The minimum kernel version required to use this feature is 4.0.
+/// The minimum kernel version required to use this feature is 3.19.
+/// `BPF_PROG_TYPE_SOCKET_FILTER` and `SO_ATTACH_BPF` are present in Linux
+/// v3.19:
+/// <https://github.com/torvalds/linux/blob/v3.19/include/uapi/linux/bpf.h#L118-L120>
+/// <https://github.com/torvalds/linux/blob/v3.19/include/uapi/asm-generic/socket.h#L87-L88>
 ///
 /// # Examples
 ///
@@ -62,7 +104,7 @@ pub enum SocketFilterError {
 #[derive(Debug)]
 #[doc(alias = "BPF_PROG_TYPE_SOCKET_FILTER")]
 pub struct SocketFilter {
-    pub(crate) data: ProgramData<SocketFilterLink>,
+    pub(crate) data: ProgramData<FdLink>,
 }
 
 impl SocketFilter {
@@ -77,82 +119,53 @@ impl SocketFilter {
 
     /// Attaches the filter on the given socket.
     ///
-    /// The returned value can be used to detach from the socket, see [`SocketFilter::detach`].
-    pub fn attach<T: AsFd>(&mut self, socket: T) -> Result<SocketFilterLinkId, ProgramError> {
+    /// If the socket already has a filter attached, attaching again replaces
+    /// the current filter instead of returning an already-attached error. This
+    /// follows the kernel model: each socket has one filter slot and cannot run
+    /// multiple socket filters together. The kernel detach API also clears the
+    /// socket's current filter slot; it cannot detach a specific program
+    /// attachment. For that reason, Aya does not provide link-level RAII
+    /// semantics for socket filters. Dropping [`SocketFilter`] or [`crate::Ebpf`]
+    /// does not detach the filter. Call [`SocketFilter::detach`] explicitly when
+    /// you want to remove it, or close the socket.
+    pub fn attach<T: AsFd>(&self, socket: T) -> Result<(), ProgramError> {
         let prog_fd = self.fd()?;
-        let prog_fd = prog_fd.as_fd();
-        let prog_fd = prog_fd.as_raw_fd();
-        let socket = socket.as_fd();
-        let socket = socket.as_raw_fd();
+        let prog_fd = prog_fd.as_fd().as_raw_fd();
+        let socket = socket.as_fd().as_raw_fd();
 
-        let ret = unsafe {
-            setsockopt(
-                socket,
-                SOL_SOCKET,
-                SO_ATTACH_BPF as i32,
-                std::ptr::from_ref(&prog_fd).cast(),
-                size_of_val(&prog_fd) as u32,
-            )
-        };
-        if ret < 0 {
-            return Err(SocketFilterError::SoAttachEbpfError {
-                io_error: io::Error::last_os_error(),
-            }
-            .into());
-        }
-
-        self.data.links.insert(SocketFilterLink { socket, prog_fd })
-    }
-
-    /// Detaches the program.
-    ///
-    /// See [`Self::attach`].
-    pub fn detach(&mut self, link_id: SocketFilterLinkId) -> Result<(), ProgramError> {
-        self.data.links.remove(link_id)
-    }
-
-    /// Takes ownership of the link referenced by the provided `link_id`.
-    ///
-    /// The caller takes the responsibility of managing the lifetime of the link. When the returned
-    /// [`SocketFilterLink`] is dropped, the link is detached.
-    pub fn take_link(
-        &mut self,
-        link_id: SocketFilterLinkId,
-    ) -> Result<SocketFilterLink, ProgramError> {
-        self.data.links.forget(link_id)
-    }
-}
-
-/// The type returned by [`SocketFilter::attach`]. Can be passed to [`SocketFilter::detach`].
-#[derive(Debug, Hash, Eq, PartialEq)]
-pub struct SocketFilterLinkId(RawFd, RawFd);
-
-/// A [`SocketFilter`] Link.
-#[derive(Debug)]
-pub struct SocketFilterLink {
-    socket: RawFd,
-    prog_fd: RawFd,
-}
-
-impl Link for SocketFilterLink {
-    type Id = SocketFilterLinkId;
-
-    fn id(&self) -> Self::Id {
-        SocketFilterLinkId(self.socket, self.prog_fd)
-    }
-
-    fn detach(self) -> Result<(), ProgramError> {
-        unsafe {
-            setsockopt(
-                self.socket,
-                SOL_SOCKET,
-                SO_DETACH_BPF as i32,
-                std::ptr::from_ref(&self.prog_fd).cast(),
-                size_of_val(&self.prog_fd) as u32,
-            );
-        }
+        setsockopt_socket_filter!(socket, SO_ATTACH_BPF, &prog_fd)?;
         Ok(())
     }
-}
 
-id_as_key!(SocketFilterLink, SocketFilterLinkId);
+    /// Detaches the current filter from the given socket.
+    ///
+    /// Detaching clears the socket's current filter slot, regardless of which
+    /// program was used to attach that filter. Unlike [`SocketFilter::attach`],
+    /// this operation does not require the program to remain loaded in this
+    /// process. If another filter replaced this program on the same socket,
+    /// detaching will remove that replacement filter.
+    pub fn detach<T: AsFd>(socket: T) -> Result<(), ProgramError> {
+        let socket = socket.as_fd().as_raw_fd();
+
+        // `SO_DETACH_BPF` is an alias for `SO_DETACH_FILTER`; Linux's
+        // `sk_setsockopt()` requires an `int` optval, but the detach branch only
+        // calls `sk_detach_filter(sk)` and does not use a program fd:
+        // https://github.com/torvalds/linux/blob/v6.9/net/core/sock.c#L1413-L1414
+        let dummy: libc::c_int = 0;
+        setsockopt_socket_filter!(socket, SO_DETACH_BPF, &dummy)?;
+        Ok(())
+    }
+
+    /// Creates a program from a pinned entry on a bpffs.
+    ///
+    /// `SocketFilter` does not use link-style attachments, so this only
+    /// restores access to the pinned program itself.
+    ///
+    /// Dropping the returned value unloads the local program FD, but does not
+    /// detach the filter from any socket. This will also not unload the program
+    /// from the kernel while it remains pinned.
+    pub fn from_pin<P: AsRef<Path>>(path: P) -> Result<Self, ProgramError> {
+        let data = ProgramData::from_pinned_path(path, VerifierLogLevel::default())?;
+        Ok(Self { data })
+    }
+}

--- a/test/integration-common/src/lib.rs
+++ b/test/integration-common/src/lib.rs
@@ -164,8 +164,16 @@ pub mod sk_reuseport {
     pub const SELECT_HITS_INDEX: u32 = 0;
     pub const MIGRATE_HITS_INDEX: u32 = 1;
     pub const CLEAR_FALLBACK_HITS_INDEX: u32 = 2;
+    pub const PATH_HITS_MAX_ENTRIES: u32 = 3;
     pub const SELECT_SOCKET_INDEX: u32 = 0;
     pub const MIGRATE_SOCKET_INDEX: u32 = 2;
+}
+
+pub mod socket_filter {
+    pub const PASS_HITS_INDEX: u32 = 0;
+    pub const TRIM_HITS_INDEX: u32 = 1;
+    pub const PATH_HITS_MAX_ENTRIES: u32 = 2;
+    pub const TRIM_DELTA_BYTES: u32 = 4;
 }
 
 pub mod stack_trace {

--- a/test/integration-ebpf/Cargo.toml
+++ b/test/integration-ebpf/Cargo.toml
@@ -121,6 +121,10 @@ name = "sk_reuseport"
 path = "src/sk_reuseport.rs"
 
 [[bin]]
+name = "socket_filter"
+path = "src/socket_filter.rs"
+
+[[bin]]
 name = "strncmp"
 path = "src/strncmp.rs"
 

--- a/test/integration-ebpf/src/sk_reuseport.rs
+++ b/test/integration-ebpf/src/sk_reuseport.rs
@@ -10,8 +10,8 @@ use aya_ebpf::{
     programs::SkReuseportContext,
 };
 use integration_common::sk_reuseport::{
-    CLEAR_FALLBACK_HITS_INDEX, MIGRATE_HITS_INDEX, MIGRATE_SOCKET_INDEX, SELECT_HITS_INDEX,
-    SELECT_SOCKET_INDEX,
+    CLEAR_FALLBACK_HITS_INDEX, MIGRATE_HITS_INDEX, MIGRATE_SOCKET_INDEX, PATH_HITS_MAX_ENTRIES,
+    SELECT_HITS_INDEX, SELECT_SOCKET_INDEX,
 };
 #[cfg(not(test))]
 extern crate ebpf_panic;
@@ -30,7 +30,7 @@ static SOCKET_MAP_BTF: BtfReusePortSockArray<SOCKET_COUNT_USIZE, 0> = BtfReusePo
 #[map(name = "path_hits")]
 // Test-only counters used to verify that the expected BPF path actually ran,
 // instead of the kernel falling back to its default reuseport selection logic.
-static PATH_HITS: Array<u64> = Array::with_max_entries(3, 0);
+static PATH_HITS: Array<u64> = Array::with_max_entries(PATH_HITS_MAX_ENTRIES, 0);
 
 #[inline]
 fn record_hit(index: u32) {

--- a/test/integration-ebpf/src/socket_filter.rs
+++ b/test/integration-ebpf/src/socket_filter.rs
@@ -1,0 +1,40 @@
+#![no_std]
+#![no_main]
+#![expect(unused_crate_dependencies, reason = "used in other bins")]
+
+use aya_ebpf::{
+    macros::{map, socket_filter},
+    maps::Array,
+    programs::SkBuffContext,
+};
+use integration_common::socket_filter::{
+    PASS_HITS_INDEX, PATH_HITS_MAX_ENTRIES, TRIM_DELTA_BYTES, TRIM_HITS_INDEX,
+};
+#[cfg(not(test))]
+extern crate ebpf_panic;
+
+#[map(name = "path_hits")]
+static PATH_HITS: Array<u64> = Array::with_max_entries(PATH_HITS_MAX_ENTRIES, 0);
+
+#[inline]
+fn record_hit(index: u32) {
+    let Some(hit) = PATH_HITS.get_ptr_mut(index) else {
+        return;
+    };
+
+    unsafe {
+        *hit += 1;
+    }
+}
+
+#[socket_filter]
+fn pass_packets(ctx: SkBuffContext) -> i64 {
+    record_hit(PASS_HITS_INDEX);
+    i64::from(ctx.len())
+}
+
+#[socket_filter]
+fn trim_packets(ctx: SkBuffContext) -> i64 {
+    record_hit(TRIM_HITS_INDEX);
+    i64::from(ctx.len().saturating_sub(TRIM_DELTA_BYTES))
+}

--- a/test/integration-test/src/lib.rs
+++ b/test/integration-test/src/lib.rs
@@ -61,6 +61,7 @@ bpf_file!(
     RING_BUF => "ring_buf",
     SIMPLE_PROG => "simple_prog",
     SK_REUSEPORT => "sk_reuseport",
+    SOCKET_FILTER => "socket_filter",
     SK_STORAGE => "sk_storage",
     SOCK_HASH => "sock_hash",
     SOCK_MAP => "sock_map",

--- a/test/integration-test/src/tests.rs
+++ b/test/integration-test/src/tests.rs
@@ -39,6 +39,7 @@ mod sk_lookup;
 mod sk_reuseport;
 mod sk_storage;
 mod smoke;
+mod socket_filter;
 mod stack_trace;
 mod stack_trace_lsm;
 mod strncmp;

--- a/test/integration-test/src/tests/sk_reuseport.rs
+++ b/test/integration-test/src/tests/sk_reuseport.rs
@@ -187,15 +187,13 @@ async fn sk_reuseport_selects_expected_listener(socket_map: &str, select_prog: &
     assert_eq!(read_hits(&path_hits, CLEAR_FALLBACK_HITS_INDEX), 0);
     assert_connection_works(client, server).await;
 
-    let prog: &mut SkReuseport = ebpf.program_mut(select_prog).unwrap().try_into().unwrap();
-
     // `SkReuseport` attachments are group-scoped: detaching through any socket in
     // the reuseport group removes the program from the whole group, even if that
     // socket was not used for attach, so a second detach through listener A yields
     // ENOENT.
-    prog.detach(&second).unwrap();
+    SkReuseport::detach(&second).unwrap();
 
-    let err = prog.detach(&first).unwrap_err();
+    let err = SkReuseport::detach(&first).unwrap_err();
     assert_matches!(
         err,
         ProgramError::SkReuseportError(SkReuseportError::SetsockoptError {
@@ -267,7 +265,7 @@ async fn sk_reuseport_clear_index_changes_selection(socket_map: &str, clear_prog
 #[test_case("select_socket"; "legacy")]
 #[test_case("select_socket_btf"; "btf")]
 #[test_log::test(tokio::test)]
-async fn sk_reuseport_detaches_after_unload(select_prog: &str) {
+async fn sk_reuseport_stays_attached_until_explicit_detach(select_prog: &str) {
     let _netns = NetNsGuard::new();
 
     let mut ebpf = Ebpf::load(crate::SK_REUSEPORT).unwrap();
@@ -276,14 +274,14 @@ async fn sk_reuseport_detaches_after_unload(select_prog: &str) {
     let prog: &mut SkReuseport = ebpf.program_mut(select_prog).unwrap().try_into().unwrap();
     prog.load().unwrap();
     prog.attach(&first).unwrap();
-    prog.unload().unwrap();
+    drop(ebpf);
 
     // `SO_DETACH_REUSEPORT_BPF` identifies the group solely from the
-    // socket, so detaching should still succeed after the local program FD
-    // has been unloaded.
-    prog.detach(&second).unwrap();
+    // socket, so detaching should still succeed after the local program has
+    // been unloaded.
+    SkReuseport::detach(&second).unwrap();
 
-    let err = prog.detach(&first).unwrap_err();
+    let err = SkReuseport::detach(&first).unwrap_err();
     assert_matches!(
         err,
         ProgramError::SkReuseportError(SkReuseportError::SetsockoptError {

--- a/test/integration-test/src/tests/socket_filter.rs
+++ b/test/integration-test/src/tests/socket_filter.rs
@@ -1,0 +1,203 @@
+use std::time::Duration;
+
+use aya::{
+    Ebpf,
+    maps::{Array, MapData},
+    programs::{ProgramType, SocketFilter},
+    sys::is_program_supported,
+};
+use integration_common::socket_filter::{PASS_HITS_INDEX, TRIM_DELTA_BYTES, TRIM_HITS_INDEX};
+use tokio::{net::UnixDatagram, time::timeout};
+
+const IO_TIMEOUT: Duration = Duration::from_secs(10);
+const TEST_PAYLOAD: &[u8] = b"hello-world";
+// Leave room for one extra byte so an unexpectedly long datagram is not
+// truncated to the expected length.
+const RECV_BUF_LEN: usize = TEST_PAYLOAD.len() + 1;
+
+fn read_hits(hits: &Array<MapData, u64>, index: u32) -> u64 {
+    hits.get(&index, 0).unwrap()
+}
+
+async fn send_and_assert(sender: &UnixDatagram, receiver: &UnixDatagram, trim_bytes: usize) {
+    sender
+        .send(TEST_PAYLOAD)
+        .await
+        .expect("failed to send datagram");
+
+    let mut buf = [0u8; RECV_BUF_LEN];
+    let len = timeout(IO_TIMEOUT, receiver.recv(&mut buf))
+        .await
+        .expect("timed out waiting for datagram")
+        .expect("failed to receive datagram");
+    let expected_len = TEST_PAYLOAD.len().saturating_sub(trim_bytes);
+    let expected = &TEST_PAYLOAD[..expected_len];
+    assert_eq!(&buf[..len], expected);
+}
+
+#[test_log::test(tokio::test)]
+async fn socket_filter_program_can_pass_packets() {
+    if !is_program_supported(ProgramType::SocketFilter).unwrap() {
+        eprintln!("skipping test - socket_filter program not supported");
+        return;
+    }
+
+    let (sender, receiver) = UnixDatagram::pair().unwrap();
+
+    let mut ebpf = Ebpf::load(crate::SOCKET_FILTER).unwrap();
+    let path_hits: Array<_, u64> = ebpf.take_map("path_hits").unwrap().try_into().unwrap();
+    let prog: &mut SocketFilter = ebpf
+        .program_mut("pass_packets")
+        .unwrap()
+        .try_into()
+        .unwrap();
+    prog.load().unwrap();
+    prog.attach(&receiver).unwrap();
+
+    send_and_assert(&sender, &receiver, 0).await;
+    assert!(
+        read_hits(&path_hits, PASS_HITS_INDEX) > 0,
+        "pass path did not run",
+    );
+}
+
+#[test_log::test(tokio::test)]
+async fn socket_filter_program_can_trim_packets_and_detach() {
+    if !is_program_supported(ProgramType::SocketFilter).unwrap() {
+        eprintln!("skipping test - socket_filter program not supported");
+        return;
+    }
+
+    let (sender, receiver) = UnixDatagram::pair().unwrap();
+
+    let mut ebpf = Ebpf::load(crate::SOCKET_FILTER).unwrap();
+    let path_hits: Array<_, u64> = ebpf.take_map("path_hits").unwrap().try_into().unwrap();
+    let prog: &mut SocketFilter = ebpf
+        .program_mut("trim_packets")
+        .unwrap()
+        .try_into()
+        .unwrap();
+    prog.load().unwrap();
+    prog.attach(&receiver).unwrap();
+
+    send_and_assert(&sender, &receiver, TRIM_DELTA_BYTES as usize).await;
+    let trim_hits_before_detach = read_hits(&path_hits, TRIM_HITS_INDEX);
+    assert!(trim_hits_before_detach > 0, "trim path did not run");
+
+    SocketFilter::detach(&receiver).unwrap();
+
+    send_and_assert(&sender, &receiver, 0).await;
+    assert_eq!(
+        read_hits(&path_hits, TRIM_HITS_INDEX),
+        trim_hits_before_detach,
+        "trim path ran after detach",
+    );
+}
+
+#[test_log::test(tokio::test)]
+async fn socket_filter_replacement_stays_attached_until_explicit_detach() {
+    if !is_program_supported(ProgramType::SocketFilter).unwrap() {
+        eprintln!("skipping test - socket_filter program not supported");
+        return;
+    }
+
+    let (sender, receiver) = UnixDatagram::pair().unwrap();
+
+    let mut ebpf = Ebpf::load(crate::SOCKET_FILTER).unwrap();
+    let path_hits: Array<_, u64> = ebpf.take_map("path_hits").unwrap().try_into().unwrap();
+
+    let pass_prog: &mut SocketFilter = ebpf
+        .program_mut("pass_packets")
+        .unwrap()
+        .try_into()
+        .unwrap();
+    pass_prog.load().unwrap();
+    pass_prog.attach(&receiver).unwrap();
+
+    send_and_assert(&sender, &receiver, 0).await;
+    assert!(
+        read_hits(&path_hits, PASS_HITS_INDEX) > 0,
+        "pass path did not run",
+    );
+    let pass_hits_before_replacement = read_hits(&path_hits, PASS_HITS_INDEX);
+
+    let trim_prog: &mut SocketFilter = ebpf
+        .program_mut("trim_packets")
+        .unwrap()
+        .try_into()
+        .unwrap();
+    trim_prog.load().unwrap();
+    trim_prog.attach(&receiver).unwrap();
+
+    send_and_assert(&sender, &receiver, TRIM_DELTA_BYTES as usize).await;
+    let trim_hits_before_unload = read_hits(&path_hits, TRIM_HITS_INDEX);
+    assert!(trim_hits_before_unload > 0, "trim path did not run");
+    // Socket filters use a single per-socket slot, so the second attach
+    // replaces the pass filter instead of running both filters.
+    assert_eq!(
+        read_hits(&path_hits, PASS_HITS_INDEX),
+        pass_hits_before_replacement,
+        "pass path ran after replacement",
+    );
+
+    let pass_prog: &mut SocketFilter = ebpf
+        .program_mut("pass_packets")
+        .unwrap()
+        .try_into()
+        .unwrap();
+    pass_prog.unload().unwrap();
+
+    send_and_assert(&sender, &receiver, TRIM_DELTA_BYTES as usize).await;
+    assert!(
+        read_hits(&path_hits, TRIM_HITS_INDEX) > trim_hits_before_unload,
+        "unloading the replaced program detached the replacement filter",
+    );
+    let trim_hits_before_detach = read_hits(&path_hits, TRIM_HITS_INDEX);
+
+    SocketFilter::detach(&receiver).unwrap();
+
+    send_and_assert(&sender, &receiver, 0).await;
+    assert_eq!(
+        read_hits(&path_hits, TRIM_HITS_INDEX),
+        trim_hits_before_detach,
+        "trim path ran after detach",
+    );
+}
+
+#[test_log::test(tokio::test)]
+async fn socket_filter_stays_attached_after_ebpf_drop() {
+    if !is_program_supported(ProgramType::SocketFilter).unwrap() {
+        eprintln!("skipping test - socket_filter program not supported");
+        return;
+    }
+
+    let (sender, receiver) = UnixDatagram::pair().unwrap();
+    let path_hits: Array<_, u64> = {
+        let mut ebpf = Ebpf::load(crate::SOCKET_FILTER).unwrap();
+        let path_hits: Array<_, u64> = ebpf.take_map("path_hits").unwrap().try_into().unwrap();
+        let prog: &mut SocketFilter = ebpf
+            .program_mut("trim_packets")
+            .unwrap()
+            .try_into()
+            .unwrap();
+        prog.load().unwrap();
+        prog.attach(&receiver).unwrap();
+        path_hits
+    };
+
+    send_and_assert(&sender, &receiver, TRIM_DELTA_BYTES as usize).await;
+    let trim_hits_before_detach = read_hits(&path_hits, TRIM_HITS_INDEX);
+    assert!(
+        trim_hits_before_detach > 0,
+        "dropping Ebpf detached the socket filter",
+    );
+
+    SocketFilter::detach(&receiver).unwrap();
+
+    send_and_assert(&sender, &receiver, 0).await;
+    assert_eq!(
+        read_hits(&path_hits, TRIM_HITS_INDEX),
+        trim_hits_before_detach,
+        "trim path ran after detach",
+    );
+}

--- a/xtask/public-api/aya.txt
+++ b/xtask/public-api/aya.txt
@@ -4045,8 +4045,8 @@ impl !core::panic::unwind_safe::UnwindSafe for aya::programs::sk_reuseport::SkRe
 pub struct aya::programs::sk_reuseport::SkReuseport
 impl aya::programs::sk_reuseport::SkReuseport
 pub const aya::programs::sk_reuseport::SkReuseport::PROGRAM_TYPE: aya::programs::ProgramType
-pub fn aya::programs::sk_reuseport::SkReuseport::attach<T: std::os::fd::owned::AsFd>(&mut self, socket: T) -> core::result::Result<(), aya::programs::ProgramError>
-pub fn aya::programs::sk_reuseport::SkReuseport::detach<T: std::os::fd::owned::AsFd>(&mut self, socket: T) -> core::result::Result<(), aya::programs::ProgramError>
+pub fn aya::programs::sk_reuseport::SkReuseport::attach<T: std::os::fd::owned::AsFd>(&self, socket: T) -> core::result::Result<(), aya::programs::ProgramError>
+pub fn aya::programs::sk_reuseport::SkReuseport::detach<T: std::os::fd::owned::AsFd>(socket: T) -> core::result::Result<(), aya::programs::ProgramError>
 pub fn aya::programs::sk_reuseport::SkReuseport::from_pin<P: core::convert::AsRef<std::path::Path>>(path: P, attach_type: aya_obj::programs::sk_reuseport::SkReuseportAttachType) -> core::result::Result<Self, aya::programs::ProgramError>
 pub fn aya::programs::sk_reuseport::SkReuseport::load(&mut self) -> core::result::Result<(), aya::programs::ProgramError>
 impl aya::programs::sk_reuseport::SkReuseport
@@ -6491,8 +6491,8 @@ impl core::panic::unwind_safe::UnwindSafe for aya::programs::sk_msg::SkMsg
 pub struct aya::programs::SkReuseport
 impl aya::programs::sk_reuseport::SkReuseport
 pub const aya::programs::sk_reuseport::SkReuseport::PROGRAM_TYPE: aya::programs::ProgramType
-pub fn aya::programs::sk_reuseport::SkReuseport::attach<T: std::os::fd::owned::AsFd>(&mut self, socket: T) -> core::result::Result<(), aya::programs::ProgramError>
-pub fn aya::programs::sk_reuseport::SkReuseport::detach<T: std::os::fd::owned::AsFd>(&mut self, socket: T) -> core::result::Result<(), aya::programs::ProgramError>
+pub fn aya::programs::sk_reuseport::SkReuseport::attach<T: std::os::fd::owned::AsFd>(&self, socket: T) -> core::result::Result<(), aya::programs::ProgramError>
+pub fn aya::programs::sk_reuseport::SkReuseport::detach<T: std::os::fd::owned::AsFd>(socket: T) -> core::result::Result<(), aya::programs::ProgramError>
 pub fn aya::programs::sk_reuseport::SkReuseport::from_pin<P: core::convert::AsRef<std::path::Path>>(path: P, attach_type: aya_obj::programs::sk_reuseport::SkReuseportAttachType) -> core::result::Result<Self, aya::programs::ProgramError>
 pub fn aya::programs::sk_reuseport::SkReuseport::load(&mut self) -> core::result::Result<(), aya::programs::ProgramError>
 impl aya::programs::sk_reuseport::SkReuseport

--- a/xtask/public-api/aya.txt
+++ b/xtask/public-api/aya.txt
@@ -3185,10 +3185,6 @@ impl aya::programs::links::Link for aya::programs::sock_ops::SockOpsLink
 pub type aya::programs::sock_ops::SockOpsLink::Id = aya::programs::sock_ops::SockOpsLinkId
 pub fn aya::programs::sock_ops::SockOpsLink::detach(self) -> core::result::Result<(), aya::programs::ProgramError>
 pub fn aya::programs::sock_ops::SockOpsLink::id(&self) -> Self::Id
-impl aya::programs::links::Link for aya::programs::socket_filter::SocketFilterLink
-pub type aya::programs::socket_filter::SocketFilterLink::Id = aya::programs::socket_filter::SocketFilterLinkId
-pub fn aya::programs::socket_filter::SocketFilterLink::detach(self) -> core::result::Result<(), aya::programs::ProgramError>
-pub fn aya::programs::socket_filter::SocketFilterLink::id(&self) -> Self::Id
 impl aya::programs::links::Link for aya::programs::tc::SchedClassifierLink
 pub type aya::programs::tc::SchedClassifierLink::Id = aya::programs::tc::SchedClassifierLinkId
 pub fn aya::programs::tc::SchedClassifierLink::detach(self) -> core::result::Result<(), aya::programs::ProgramError>
@@ -4250,8 +4246,9 @@ impl core::panic::unwind_safe::RefUnwindSafe for aya::programs::sock_ops::SockOp
 impl core::panic::unwind_safe::UnwindSafe for aya::programs::sock_ops::SockOpsLinkId
 pub mod aya::programs::socket_filter
 pub enum aya::programs::socket_filter::SocketFilterError
-pub aya::programs::socket_filter::SocketFilterError::SoAttachEbpfError
-pub aya::programs::socket_filter::SocketFilterError::SoAttachEbpfError::io_error: std::io::error::Error
+pub aya::programs::socket_filter::SocketFilterError::SetsockoptError
+pub aya::programs::socket_filter::SocketFilterError::SetsockoptError::io_error: std::io::error::Error
+pub aya::programs::socket_filter::SocketFilterError::SetsockoptError::option: &'static str
 impl core::convert::From<aya::programs::socket_filter::SocketFilterError> for aya::programs::ProgramError
 pub fn aya::programs::ProgramError::from(source: aya::programs::socket_filter::SocketFilterError) -> Self
 impl core::error::Error for aya::programs::socket_filter::SocketFilterError
@@ -4270,14 +4267,12 @@ impl !core::panic::unwind_safe::UnwindSafe for aya::programs::socket_filter::Soc
 pub struct aya::programs::socket_filter::SocketFilter
 impl aya::programs::socket_filter::SocketFilter
 pub const aya::programs::socket_filter::SocketFilter::PROGRAM_TYPE: aya::programs::ProgramType
-pub fn aya::programs::socket_filter::SocketFilter::attach<T: std::os::fd::owned::AsFd>(&mut self, socket: T) -> core::result::Result<aya::programs::socket_filter::SocketFilterLinkId, aya::programs::ProgramError>
-pub fn aya::programs::socket_filter::SocketFilter::detach(&mut self, link_id: aya::programs::socket_filter::SocketFilterLinkId) -> core::result::Result<(), aya::programs::ProgramError>
+pub fn aya::programs::socket_filter::SocketFilter::attach<T: std::os::fd::owned::AsFd>(&self, socket: T) -> core::result::Result<(), aya::programs::ProgramError>
+pub fn aya::programs::socket_filter::SocketFilter::detach<T: std::os::fd::owned::AsFd>(socket: T) -> core::result::Result<(), aya::programs::ProgramError>
+pub fn aya::programs::socket_filter::SocketFilter::from_pin<P: core::convert::AsRef<std::path::Path>>(path: P) -> core::result::Result<Self, aya::programs::ProgramError>
 pub fn aya::programs::socket_filter::SocketFilter::load(&mut self) -> core::result::Result<(), aya::programs::ProgramError>
-pub fn aya::programs::socket_filter::SocketFilter::take_link(&mut self, link_id: aya::programs::socket_filter::SocketFilterLinkId) -> core::result::Result<aya::programs::socket_filter::SocketFilterLink, aya::programs::ProgramError>
 impl aya::programs::socket_filter::SocketFilter
 pub fn aya::programs::socket_filter::SocketFilter::fd(&self) -> core::result::Result<&aya::programs::ProgramFd, aya::programs::ProgramError>
-impl aya::programs::socket_filter::SocketFilter
-pub fn aya::programs::socket_filter::SocketFilter::from_pin<P: core::convert::AsRef<std::path::Path>>(path: P) -> core::result::Result<Self, aya::programs::ProgramError>
 impl aya::programs::socket_filter::SocketFilter
 pub fn aya::programs::socket_filter::SocketFilter::info(&self) -> core::result::Result<aya::programs::ProgramInfo, aya::programs::ProgramError>
 impl aya::programs::socket_filter::SocketFilter
@@ -4306,45 +4301,6 @@ impl core::marker::Unpin for aya::programs::socket_filter::SocketFilter
 impl core::marker::UnsafeUnpin for aya::programs::socket_filter::SocketFilter
 impl core::panic::unwind_safe::RefUnwindSafe for aya::programs::socket_filter::SocketFilter
 impl core::panic::unwind_safe::UnwindSafe for aya::programs::socket_filter::SocketFilter
-pub struct aya::programs::socket_filter::SocketFilterLink
-impl aya::programs::links::Link for aya::programs::socket_filter::SocketFilterLink
-pub type aya::programs::socket_filter::SocketFilterLink::Id = aya::programs::socket_filter::SocketFilterLinkId
-pub fn aya::programs::socket_filter::SocketFilterLink::detach(self) -> core::result::Result<(), aya::programs::ProgramError>
-pub fn aya::programs::socket_filter::SocketFilterLink::id(&self) -> Self::Id
-impl core::cmp::Eq for aya::programs::socket_filter::SocketFilterLink
-impl core::cmp::PartialEq for aya::programs::socket_filter::SocketFilterLink
-pub fn aya::programs::socket_filter::SocketFilterLink::eq(&self, other: &Self) -> bool
-impl core::fmt::Debug for aya::programs::socket_filter::SocketFilterLink
-pub fn aya::programs::socket_filter::SocketFilterLink::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl core::hash::Hash for aya::programs::socket_filter::SocketFilterLink
-pub fn aya::programs::socket_filter::SocketFilterLink::hash<H: core::hash::Hasher>(&self, state: &mut H)
-impl equivalent::Equivalent<aya::programs::socket_filter::SocketFilterLink> for aya::programs::socket_filter::SocketFilterLinkId
-pub fn aya::programs::socket_filter::SocketFilterLinkId::equivalent(&self, key: &aya::programs::socket_filter::SocketFilterLink) -> bool
-impl core::marker::Freeze for aya::programs::socket_filter::SocketFilterLink
-impl core::marker::Send for aya::programs::socket_filter::SocketFilterLink
-impl core::marker::Sync for aya::programs::socket_filter::SocketFilterLink
-impl core::marker::Unpin for aya::programs::socket_filter::SocketFilterLink
-impl core::marker::UnsafeUnpin for aya::programs::socket_filter::SocketFilterLink
-impl core::panic::unwind_safe::RefUnwindSafe for aya::programs::socket_filter::SocketFilterLink
-impl core::panic::unwind_safe::UnwindSafe for aya::programs::socket_filter::SocketFilterLink
-pub struct aya::programs::socket_filter::SocketFilterLinkId(_, _)
-impl core::cmp::Eq for aya::programs::socket_filter::SocketFilterLinkId
-impl core::cmp::PartialEq for aya::programs::socket_filter::SocketFilterLinkId
-pub fn aya::programs::socket_filter::SocketFilterLinkId::eq(&self, other: &aya::programs::socket_filter::SocketFilterLinkId) -> bool
-impl core::fmt::Debug for aya::programs::socket_filter::SocketFilterLinkId
-pub fn aya::programs::socket_filter::SocketFilterLinkId::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl core::hash::Hash for aya::programs::socket_filter::SocketFilterLinkId
-pub fn aya::programs::socket_filter::SocketFilterLinkId::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
-impl core::marker::StructuralPartialEq for aya::programs::socket_filter::SocketFilterLinkId
-impl equivalent::Equivalent<aya::programs::socket_filter::SocketFilterLink> for aya::programs::socket_filter::SocketFilterLinkId
-pub fn aya::programs::socket_filter::SocketFilterLinkId::equivalent(&self, key: &aya::programs::socket_filter::SocketFilterLink) -> bool
-impl core::marker::Freeze for aya::programs::socket_filter::SocketFilterLinkId
-impl core::marker::Send for aya::programs::socket_filter::SocketFilterLinkId
-impl core::marker::Sync for aya::programs::socket_filter::SocketFilterLinkId
-impl core::marker::Unpin for aya::programs::socket_filter::SocketFilterLinkId
-impl core::marker::UnsafeUnpin for aya::programs::socket_filter::SocketFilterLinkId
-impl core::panic::unwind_safe::RefUnwindSafe for aya::programs::socket_filter::SocketFilterLinkId
-impl core::panic::unwind_safe::UnwindSafe for aya::programs::socket_filter::SocketFilterLinkId
 pub mod aya::programs::tc
 pub enum aya::programs::tc::TcAttachOptions
 pub aya::programs::tc::TcAttachOptions::Netlink(aya::programs::tc::NlOptions)
@@ -5468,8 +5424,9 @@ impl core::marker::UnsafeUnpin for aya::programs::sk_reuseport::SkReuseportError
 impl !core::panic::unwind_safe::RefUnwindSafe for aya::programs::sk_reuseport::SkReuseportError
 impl !core::panic::unwind_safe::UnwindSafe for aya::programs::sk_reuseport::SkReuseportError
 pub enum aya::programs::SocketFilterError
-pub aya::programs::SocketFilterError::SoAttachEbpfError
-pub aya::programs::SocketFilterError::SoAttachEbpfError::io_error: std::io::error::Error
+pub aya::programs::SocketFilterError::SetsockoptError
+pub aya::programs::SocketFilterError::SetsockoptError::io_error: std::io::error::Error
+pub aya::programs::SocketFilterError::SetsockoptError::option: &'static str
 impl core::convert::From<aya::programs::socket_filter::SocketFilterError> for aya::programs::ProgramError
 pub fn aya::programs::ProgramError::from(source: aya::programs::socket_filter::SocketFilterError) -> Self
 impl core::error::Error for aya::programs::socket_filter::SocketFilterError
@@ -6644,14 +6601,12 @@ impl core::panic::unwind_safe::UnwindSafe for aya::programs::sock_ops::SockOps
 pub struct aya::programs::SocketFilter
 impl aya::programs::socket_filter::SocketFilter
 pub const aya::programs::socket_filter::SocketFilter::PROGRAM_TYPE: aya::programs::ProgramType
-pub fn aya::programs::socket_filter::SocketFilter::attach<T: std::os::fd::owned::AsFd>(&mut self, socket: T) -> core::result::Result<aya::programs::socket_filter::SocketFilterLinkId, aya::programs::ProgramError>
-pub fn aya::programs::socket_filter::SocketFilter::detach(&mut self, link_id: aya::programs::socket_filter::SocketFilterLinkId) -> core::result::Result<(), aya::programs::ProgramError>
+pub fn aya::programs::socket_filter::SocketFilter::attach<T: std::os::fd::owned::AsFd>(&self, socket: T) -> core::result::Result<(), aya::programs::ProgramError>
+pub fn aya::programs::socket_filter::SocketFilter::detach<T: std::os::fd::owned::AsFd>(socket: T) -> core::result::Result<(), aya::programs::ProgramError>
+pub fn aya::programs::socket_filter::SocketFilter::from_pin<P: core::convert::AsRef<std::path::Path>>(path: P) -> core::result::Result<Self, aya::programs::ProgramError>
 pub fn aya::programs::socket_filter::SocketFilter::load(&mut self) -> core::result::Result<(), aya::programs::ProgramError>
-pub fn aya::programs::socket_filter::SocketFilter::take_link(&mut self, link_id: aya::programs::socket_filter::SocketFilterLinkId) -> core::result::Result<aya::programs::socket_filter::SocketFilterLink, aya::programs::ProgramError>
 impl aya::programs::socket_filter::SocketFilter
 pub fn aya::programs::socket_filter::SocketFilter::fd(&self) -> core::result::Result<&aya::programs::ProgramFd, aya::programs::ProgramError>
-impl aya::programs::socket_filter::SocketFilter
-pub fn aya::programs::socket_filter::SocketFilter::from_pin<P: core::convert::AsRef<std::path::Path>>(path: P) -> core::result::Result<Self, aya::programs::ProgramError>
 impl aya::programs::socket_filter::SocketFilter
 pub fn aya::programs::socket_filter::SocketFilter::info(&self) -> core::result::Result<aya::programs::ProgramInfo, aya::programs::ProgramError>
 impl aya::programs::socket_filter::SocketFilter
@@ -6944,10 +6899,6 @@ impl aya::programs::links::Link for aya::programs::sock_ops::SockOpsLink
 pub type aya::programs::sock_ops::SockOpsLink::Id = aya::programs::sock_ops::SockOpsLinkId
 pub fn aya::programs::sock_ops::SockOpsLink::detach(self) -> core::result::Result<(), aya::programs::ProgramError>
 pub fn aya::programs::sock_ops::SockOpsLink::id(&self) -> Self::Id
-impl aya::programs::links::Link for aya::programs::socket_filter::SocketFilterLink
-pub type aya::programs::socket_filter::SocketFilterLink::Id = aya::programs::socket_filter::SocketFilterLinkId
-pub fn aya::programs::socket_filter::SocketFilterLink::detach(self) -> core::result::Result<(), aya::programs::ProgramError>
-pub fn aya::programs::socket_filter::SocketFilterLink::id(&self) -> Self::Id
 impl aya::programs::links::Link for aya::programs::tc::SchedClassifierLink
 pub type aya::programs::tc::SchedClassifierLink::Id = aya::programs::tc::SchedClassifierLinkId
 pub fn aya::programs::tc::SchedClassifierLink::detach(self) -> core::result::Result<(), aya::programs::ProgramError>


### PR DESCRIPTION
While working on #441, I found that SocketFilter's link abstraction was incomplete. During review, we also found a deeper issue: the kernel models socket filters as a single per-socket filter slot, so a link-level RAII abstraction is not suitable for SocketFilter.

This PR removes the SocketFilter link abstraction and switches to explicit detach semantics, matching the kernel behavior more closely.

<!-- markdownlint-disable first-line-heading -->

<!--
    Thank you for your contribution to Aya! 🎉

    For Work In Progress Pull Requests, please use the Draft PR feature.

    Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Aya Contributing Guide: https://github.com/aya-rs/aya/blob/main/CONTRIBUTING.md
     - 📖 Read the Aya Code of Conduct: https://github.com/aya-rs/aya/blob/main/CODE_OF_CONDUCT.md
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages: https://cbea.ms/git-commit/
     - 📗 Update any related documentation.

-->

<!---
      Summarize the changes you're making here. Detailed information belongs in
      the Git commit messages. If your pull request contains just one commit,
      it's best to use its message as a summary. Otherwise, if there are multiple
      atomic commits, write a summary for the entire PR. Feel free to flag
      anything you think needs a reviewer's attention.
-->

<!--
      If your changes address an issue, link it with the *Fixes* tag so
      the issue gets closed when the PR is merged, for example:

      Fixes: #1234

      If you are only referencing an issue without fully addressing it, feel
      free to link it anywhere in the summary.
-->

### Added/updated tests?

_We strongly encourage you to add a test for your changes._

- [x] Yes

### Checklist

- [x] Rust code has been formatted with `cargo +nightly fmt`.
- [x] All clippy lints have been fixed.
      You can find failing lints with `cargo xtask clippy`.
- [x] Unit tests are passing locally with `cargo test`.
- [x] The [Integration tests] are passing locally.
- [x] I have blessed any API changes with `cargo xtask public-api --bless`.

[Integration tests]: https://github.com/aya-rs/aya/blob/main/test/README.md

### (Optional) What GIF best describes this PR or how it makes you feel?
<img width="346" height="222" alt="image" src="https://github.com/user-attachments/assets/39ea4d31-29dd-40e5-a25b-c0bc41c9f4cd" />

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aya-rs/aya/1563)
<!-- Reviewable:end -->
