### PR TITLE
aya-ebpf: add BTF map definition for devmap and devmap_hash

### DIFF
--- a/ebpf/aya-ebpf/src/btf_maps/dev_map.rs
+++ b/ebpf/aya-ebpf/src/btf_maps/dev_map.rs
@@ -1,0 +1,117 @@
+use core::{num::NonZeroU32, ptr::NonNull};
+
+use crate::{
+    bindings::{bpf_devmap_val, xdp_action::XDP_REDIRECT},
+    btf_maps::btf_map_def,
+    cty::c_void,
+    helpers::bpf_redirect_map,
+    lookup,
+    maps::xdp::DevMapValue,
+};
+
+// Private helpers shared with DevMapHash.
+pub(super) fn devmap_get(ptr: *mut c_void, key: u32) -> Option<DevMapValue> {
+    let value = lookup(ptr, &key)?;
+    let value: &bpf_devmap_val = unsafe { value.as_ref() };
+    Some(DevMapValue {
+        if_index: value.ifindex,
+        // SAFETY: `bpf_devmap_val::bpf_prog` is a union of `fd` and `id`; the
+        // kernel populates `id` on map lookup (`fd` is only consumed on
+        // userspace writes), so reading from `id` is the active variant.
+        // https://github.com/torvalds/linux/blob/v6.2/include/uapi/linux/bpf.h#L6136
+        prog_id: NonZeroU32::new(unsafe { value.bpf_prog.id }),
+    })
+}
+
+pub(super) fn devmap_get_ifindex(ptr: *mut c_void, key: u32) -> Option<u32> {
+    let value: NonNull<u32> = lookup(ptr, &key)?;
+    // SAFETY: the first 4 bytes of every devmap value are `ifindex`, both for
+    // the legacy 4-byte layout (kernel < 5.8) and the 8-byte `bpf_devmap_val`
+    // layout (kernel >= 5.8); a 4-byte read at offset 0 is in-bounds either way.
+    Some(unsafe { *value.as_ptr() })
+}
+
+pub(super) fn devmap_redirect(ptr: *mut c_void, key: u32, flags: u64) -> Result<u32, u32> {
+    let ret = unsafe { bpf_redirect_map(ptr.cast(), key.into(), flags) };
+    match ret.unsigned_abs() as u32 {
+        XDP_REDIRECT => Ok(XDP_REDIRECT),
+        ret => Err(ret),
+    }
+}
+
+btf_map_def!(
+    /// A BTF-compatible array of network devices.
+    ///
+    /// XDP programs use this map to redirect packets to other network
+    /// devices via [`DevMap::redirect`]. Userspace populates each slot
+    /// with a `struct bpf_devmap_val` carrying the target `ifindex` and
+    /// an optional chained XDP program; [`DevMap::get`] reads the entry
+    /// back as a [`DevMapValue`].
+    ///
+    /// # Minimum kernel version
+    ///
+    /// The minimum kernel version required to use this feature is 4.14.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use aya_ebpf::{btf_maps::DevMap, macros::btf_map};
+    ///
+    /// #[btf_map]
+    /// static DEVS: DevMap<8> = DevMap::new();
+    /// ```
+    pub struct DevMap<; const MAX_ENTRIES: usize, const FLAGS: usize = 0>,
+    map_type: BPF_MAP_TYPE_DEVMAP,
+    max_entries: MAX_ENTRIES,
+    map_flags: FLAGS,
+    key_type: u32,
+    value_type: bpf_devmap_val,
+);
+
+impl<const MAX_ENTRIES: usize, const FLAGS: usize> DevMap<MAX_ENTRIES, FLAGS> {
+    const _CHECK: () = {
+        assert!(
+            MAX_ENTRIES > 0,
+            "DevMap max_entries must be greater than zero.",
+        );
+    };
+
+    /// Returns the device at `index`.
+    ///
+    /// Reads the entry as a [`DevMapValue`], including `prog_id`; this
+    /// requires kernel 5.8 or newer because `bpf_devmap_val::bpf_prog` was
+    /// only introduced then. On older kernels use
+    /// [`get_ifindex`](Self::get_ifindex) instead.
+    ///
+    /// Returns `None` when `index` is out of range or no entry has been
+    /// written there.
+    #[inline(always)]
+    pub fn get(&self, index: u32) -> Option<DevMapValue> {
+        let () = Self::_CHECK;
+        devmap_get(self.as_ptr(), index)
+    }
+
+    /// Returns the `ifindex` stored at `index`.
+    ///
+    /// Reads only the leading 4 bytes of the map value, so it works on every
+    /// kernel that supports `BPF_MAP_TYPE_DEVMAP` (4.14 and newer), unlike
+    /// [`get`](Self::get) which also reads `bpf_devmap_val::bpf_prog`.
+    ///
+    /// Returns `None` when `index` is out of range or no entry has been
+    /// written there.
+    #[inline(always)]
+    pub fn get_ifindex(&self, index: u32) -> Option<u32> {
+        let () = Self::_CHECK;
+        devmap_get_ifindex(self.as_ptr(), index)
+    }
+
+    /// Redirects the current packet to the device at `index`.
+    ///
+    /// On lookup miss the kernel encodes the fallback XDP action in the
+    /// lower two bits of `flags`, propagated as the `Err` variant.
+    #[inline(always)]
+    pub fn redirect(&self, index: u32, flags: u64) -> Result<u32, u32> {
+        let () = Self::_CHECK;
+        devmap_redirect(self.as_ptr(), index, flags)
+    }
+}

--- a/ebpf/aya-ebpf/src/btf_maps/dev_map_hash.rs
+++ b/ebpf/aya-ebpf/src/btf_maps/dev_map_hash.rs
@@ -1,0 +1,83 @@
+use crate::{
+    bindings::bpf_devmap_val,
+    btf_maps::{
+        btf_map_def,
+        dev_map::{devmap_get, devmap_get_ifindex, devmap_redirect},
+    },
+    maps::xdp::DevMapValue,
+};
+
+btf_map_def!(
+    /// A BTF-compatible hash map of network devices.
+    ///
+    /// Similar to [`super::DevMap`], but indexed by an arbitrary `u32`
+    /// key rather than a contiguous slot, at the cost of a hashing step
+    /// per lookup. Userspace populates each entry with a
+    /// `struct bpf_devmap_val` carrying the target `ifindex` and an
+    /// optional chained XDP program.
+    ///
+    /// # Minimum kernel version
+    ///
+    /// The minimum kernel version required to use this feature is 5.4.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use aya_ebpf::{btf_maps::DevMapHash, macros::btf_map};
+    ///
+    /// #[btf_map]
+    /// static DEVS: DevMapHash<8> = DevMapHash::new();
+    /// ```
+    pub struct DevMapHash<; const MAX_ENTRIES: usize, const FLAGS: usize = 0>,
+    map_type: BPF_MAP_TYPE_DEVMAP_HASH,
+    max_entries: MAX_ENTRIES,
+    map_flags: FLAGS,
+    key_type: u32,
+    value_type: bpf_devmap_val,
+);
+
+impl<const MAX_ENTRIES: usize, const FLAGS: usize> DevMapHash<MAX_ENTRIES, FLAGS> {
+    const _CHECK: () = {
+        assert!(
+            MAX_ENTRIES > 0,
+            "DevMapHash max_entries must be greater than zero.",
+        );
+    };
+
+    /// Returns the device stored under `key`.
+    ///
+    /// Reads the entry as a [`DevMapValue`], including `prog_id`; this
+    /// requires kernel 5.8 or newer because `bpf_devmap_val::bpf_prog` was
+    /// only introduced then. On older kernels use
+    /// [`get_ifindex`](Self::get_ifindex) instead.
+    ///
+    /// Returns `None` when no entry exists for `key`.
+    #[inline(always)]
+    pub fn get(&self, key: u32) -> Option<DevMapValue> {
+        let () = Self::_CHECK;
+        devmap_get(self.as_ptr(), key)
+    }
+
+    /// Returns the `ifindex` stored under `key`.
+    ///
+    /// Reads only the leading 4 bytes of the map value, so it works on every
+    /// kernel that supports `BPF_MAP_TYPE_DEVMAP_HASH` (5.4 and newer), unlike
+    /// [`get`](Self::get) which also reads `bpf_devmap_val::bpf_prog`.
+    ///
+    /// Returns `None` when no entry exists for `key`.
+    #[inline(always)]
+    pub fn get_ifindex(&self, key: u32) -> Option<u32> {
+        let () = Self::_CHECK;
+        devmap_get_ifindex(self.as_ptr(), key)
+    }
+
+    /// Redirects the current packet to the device stored under `key`.
+    ///
+    /// On lookup miss the kernel encodes the fallback XDP action in the
+    /// lower two bits of `flags`, propagated as the `Err` variant.
+    #[inline(always)]
+    pub fn redirect(&self, key: u32, flags: u64) -> Result<u32, u32> {
+        let () = Self::_CHECK;
+        devmap_redirect(self.as_ptr(), key, flags)
+    }
+}

--- a/ebpf/aya-ebpf/src/btf_maps/mod.rs
+++ b/ebpf/aya-ebpf/src/btf_maps/mod.rs
@@ -1,5 +1,7 @@
 pub mod array;
 pub mod bloom_filter;
+pub mod dev_map;
+pub mod dev_map_hash;
 pub mod lpm_trie;
 pub mod per_cpu_array;
 pub mod perf_event_array;
@@ -16,6 +18,8 @@ pub mod stack_trace;
 
 pub use array::Array;
 pub use bloom_filter::BloomFilter;
+pub use dev_map::DevMap;
+pub use dev_map_hash::DevMapHash;
 pub use lpm_trie::LpmTrie;
 pub use per_cpu_array::PerCpuArray;
 pub use perf_event_array::PerfEventArray;

--- a/ebpf/aya-ebpf/src/maps/xdp/dev_map.rs
+++ b/ebpf/aya-ebpf/src/maps/xdp/dev_map.rs
@@ -1,4 +1,4 @@
-use core::num::NonZeroU32;
+use core::{num::NonZeroU32, ptr::NonNull};
 
 use aya_ebpf_bindings::bindings::bpf_devmap_val;
 
@@ -67,7 +67,12 @@ impl DevMap {
         },
     );
 
-    /// Retrieves the interface index at `index` in the array.
+    /// Retrieves the device at `index` in the array.
+    ///
+    /// Reads the entry as a [`DevMapValue`] including `prog_id`, which
+    /// requires kernel 5.8 or newer because `bpf_devmap_val::bpf_prog` was
+    /// only introduced then. On older kernels use
+    /// [`get_ifindex`](Self::get_ifindex) instead.
     ///
     /// To actually redirect a packet, see [`DevMap::redirect`].
     ///
@@ -89,10 +94,29 @@ impl DevMap {
         let value: &bpf_devmap_val = unsafe { value.as_ref() };
         Some(DevMapValue {
             if_index: value.ifindex,
-            // SAFETY: map writes use fd, map reads use id.
-            // https://elixir.bootlin.com/linux/v6.2/source/include/uapi/linux/bpf.h#L6136
+            // SAFETY: `bpf_devmap_val::bpf_prog` is a union of `fd` and `id`; the
+            // kernel populates `id` on map lookup (`fd` is only consumed on
+            // userspace writes), so reading from `id` is the active variant.
+            // https://github.com/torvalds/linux/blob/v6.2/include/uapi/linux/bpf.h#L6136
             prog_id: NonZeroU32::new(unsafe { value.bpf_prog.id }),
         })
+    }
+
+    /// Retrieves the interface index at `index` in the array.
+    ///
+    /// Reads only the leading 4 bytes of the map value, so it works on every
+    /// kernel that supports `BPF_MAP_TYPE_DEVMAP` (4.14 and newer), unlike
+    /// [`get`](Self::get) which also reads `bpf_devmap_val::bpf_prog`.
+    ///
+    /// To actually redirect a packet, see [`DevMap::redirect`].
+    #[inline(always)]
+    pub fn get_ifindex(&self, index: u32) -> Option<u32> {
+        let value: NonNull<u32> = lookup(self.def.as_ptr(), &index)?;
+        // SAFETY: the first 4 bytes of every devmap value are `ifindex`, both
+        // for the legacy 4-byte layout (kernel < 5.8) and the 8-byte
+        // `bpf_devmap_val` layout (kernel >= 5.8); a 4-byte read at offset 0 is
+        // in-bounds either way.
+        Some(unsafe { *value.as_ptr() })
     }
 
     /// Redirects the current packet on the interface at `index`.
@@ -119,12 +143,8 @@ impl DevMap {
     }
 }
 
-#[derive(Clone, Copy)]
-#[expect(
-    unnameable_types,
-    reason = "this value type is exposed via the map API, not by path"
-)]
 /// The value of a device map.
+#[derive(Clone, Copy)]
 pub struct DevMapValue {
     /// Target interface index to redirect to.
     pub if_index: u32,

--- a/ebpf/aya-ebpf/src/maps/xdp/dev_map_hash.rs
+++ b/ebpf/aya-ebpf/src/maps/xdp/dev_map_hash.rs
@@ -1,4 +1,4 @@
-use core::num::NonZeroU32;
+use core::{num::NonZeroU32, ptr::NonNull};
 
 use aya_ebpf_bindings::bindings::bpf_devmap_val;
 
@@ -69,7 +69,12 @@ impl DevMapHash {
         },
     );
 
-    /// Retrieves the interface index with `key` in the map.
+    /// Retrieves the device stored under `key` in the map.
+    ///
+    /// Reads the entry as a [`DevMapValue`] including `prog_id`, which
+    /// requires kernel 5.8 or newer because `bpf_devmap_val::bpf_prog` was
+    /// only introduced then. On older kernels use
+    /// [`get_ifindex`](Self::get_ifindex) instead.
     ///
     /// To actually redirect a packet, see [`DevMapHash::redirect`].
     ///
@@ -91,10 +96,29 @@ impl DevMapHash {
         let value: &bpf_devmap_val = unsafe { value.as_ref() };
         Some(DevMapValue {
             if_index: value.ifindex,
-            // SAFETY: map writes use fd, map reads use id.
-            // https://elixir.bootlin.com/linux/v6.2/source/include/uapi/linux/bpf.h#L6136
+            // SAFETY: `bpf_devmap_val::bpf_prog` is a union of `fd` and `id`; the
+            // kernel populates `id` on map lookup (`fd` is only consumed on
+            // userspace writes), so reading from `id` is the active variant.
+            // https://github.com/torvalds/linux/blob/v6.2/include/uapi/linux/bpf.h#L6136
             prog_id: NonZeroU32::new(unsafe { value.bpf_prog.id }),
         })
+    }
+
+    /// Retrieves the interface index stored under `key` in the map.
+    ///
+    /// Reads only the leading 4 bytes of the map value, so it works on every
+    /// kernel that supports `BPF_MAP_TYPE_DEVMAP_HASH` (5.4 and newer), unlike
+    /// [`get`](Self::get) which also reads `bpf_devmap_val::bpf_prog`.
+    ///
+    /// To actually redirect a packet, see [`DevMapHash::redirect`].
+    #[inline(always)]
+    pub fn get_ifindex(&self, key: u32) -> Option<u32> {
+        let value: NonNull<u32> = lookup(self.def.as_ptr(), &key)?;
+        // SAFETY: the first 4 bytes of every devmap value are `ifindex`, both
+        // for the legacy 4-byte layout (kernel < 5.8) and the 8-byte
+        // `bpf_devmap_val` layout (kernel >= 5.8); a 4-byte read at offset 0 is
+        // in-bounds either way.
+        Some(unsafe { *value.as_ptr() })
     }
 
     /// Redirects the current packet on the interface at `key`.

--- a/ebpf/aya-ebpf/src/maps/xdp/mod.rs
+++ b/ebpf/aya-ebpf/src/maps/xdp/mod.rs
@@ -6,7 +6,7 @@ mod xsk_map;
 use aya_ebpf_bindings::{bindings::xdp_action::XDP_REDIRECT, helpers::bpf_redirect_map};
 use aya_ebpf_cty::c_void;
 pub use cpu_map::CpuMap;
-pub use dev_map::DevMap;
+pub use dev_map::{DevMap, DevMapValue};
 pub use dev_map_hash::DevMapHash;
 pub use xsk_map::XskMap;
 

--- a/test/integration-ebpf/Cargo.toml
+++ b/test/integration-ebpf/Cargo.toml
@@ -41,6 +41,10 @@ name = "btf_maps_plain"
 path = "src/btf_maps_plain.rs"
 
 [[bin]]
+name = "dev_map"
+path = "src/dev_map.rs"
+
+[[bin]]
 name = "kprobe"
 path = "src/kprobe.rs"
 

--- a/test/integration-ebpf/src/dev_map.rs
+++ b/test/integration-ebpf/src/dev_map.rs
@@ -1,0 +1,116 @@
+#![no_std]
+#![no_main]
+#![expect(unused_crate_dependencies, reason = "used in other bins")]
+
+use aya_ebpf::{
+    bindings::xdp_action,
+    btf_maps::{DevMap as BtfDevMap, DevMapHash as BtfDevMapHash},
+    macros::{btf_map, map, xdp},
+    maps::{DevMap, DevMapHash, xdp::DevMapValue},
+    programs::XdpContext,
+};
+#[cfg(not(test))]
+extern crate ebpf_panic;
+
+#[map]
+static DEVS: DevMap = DevMap::with_max_entries(1, 0);
+#[map]
+static DEVS_HASH: DevMapHash = DevMapHash::with_max_entries(1, 0);
+
+#[btf_map]
+static DEVS_BTF: BtfDevMap<1> = BtfDevMap::new();
+#[btf_map]
+static DEVS_HASH_BTF: BtfDevMapHash<1> = BtfDevMapHash::new();
+
+#[xdp]
+fn redirect_dev(_ctx: XdpContext) -> u32 {
+    DEVS.redirect(0, 0).unwrap_or(xdp_action::XDP_ABORTED)
+}
+
+#[xdp]
+fn redirect_dev_hash(_ctx: XdpContext) -> u32 {
+    DEVS_HASH.redirect(10, 0).unwrap_or(xdp_action::XDP_ABORTED)
+}
+
+#[xdp]
+fn redirect_dev_btf(_ctx: XdpContext) -> u32 {
+    DEVS_BTF.redirect(0, 0).unwrap_or(xdp_action::XDP_ABORTED)
+}
+
+#[xdp]
+fn redirect_dev_hash_btf(_ctx: XdpContext) -> u32 {
+    DEVS_HASH_BTF
+        .redirect(10, 0)
+        .unwrap_or(xdp_action::XDP_ABORTED)
+}
+
+#[xdp]
+fn get_dev(_ctx: XdpContext) -> u32 {
+    DEVS.get(0).map_or(xdp_action::XDP_ABORTED, devmap_action)
+}
+
+#[xdp]
+fn get_dev_hash(_ctx: XdpContext) -> u32 {
+    DEVS_HASH
+        .get(10)
+        .map_or(xdp_action::XDP_ABORTED, devmap_action)
+}
+
+#[xdp]
+fn get_dev_btf(_ctx: XdpContext) -> u32 {
+    DEVS_BTF
+        .get(0)
+        .map_or(xdp_action::XDP_ABORTED, devmap_action)
+}
+
+#[xdp]
+fn get_dev_hash_btf(_ctx: XdpContext) -> u32 {
+    DEVS_HASH_BTF
+        .get(10)
+        .map_or(xdp_action::XDP_ABORTED, devmap_action)
+}
+
+#[xdp]
+fn get_ifindex_dev(_ctx: XdpContext) -> u32 {
+    DEVS.get_ifindex(0)
+        .map_or(xdp_action::XDP_ABORTED, ifindex_action)
+}
+
+#[xdp]
+fn get_ifindex_dev_hash(_ctx: XdpContext) -> u32 {
+    DEVS_HASH
+        .get_ifindex(10)
+        .map_or(xdp_action::XDP_ABORTED, ifindex_action)
+}
+
+#[xdp]
+fn get_ifindex_dev_btf(_ctx: XdpContext) -> u32 {
+    DEVS_BTF
+        .get_ifindex(0)
+        .map_or(xdp_action::XDP_ABORTED, ifindex_action)
+}
+
+#[xdp]
+fn get_ifindex_dev_hash_btf(_ctx: XdpContext) -> u32 {
+    DEVS_HASH_BTF
+        .get_ifindex(10)
+        .map_or(xdp_action::XDP_ABORTED, ifindex_action)
+}
+
+#[inline(always)]
+const fn ifindex_action(if_index: u32) -> u32 {
+    if if_index != 0 {
+        xdp_action::XDP_PASS
+    } else {
+        xdp_action::XDP_DROP
+    }
+}
+
+#[inline(always)]
+const fn devmap_action(v: DevMapValue) -> u32 {
+    if v.prog_id.is_some() && v.if_index != 0 {
+        xdp_action::XDP_PASS
+    } else {
+        xdp_action::XDP_DROP
+    }
+}

--- a/test/integration-ebpf/src/redirect.rs
+++ b/test/integration-ebpf/src/redirect.rs
@@ -5,7 +5,7 @@
 use aya_ebpf::{
     bindings::xdp_action,
     macros::{map, xdp},
-    maps::{Array, CpuMap, DevMap, DevMapHash, XskMap},
+    maps::{Array, CpuMap, XskMap},
     programs::XdpContext,
 };
 #[cfg(not(test))]
@@ -13,10 +13,6 @@ extern crate ebpf_panic;
 
 #[map]
 static SOCKS: XskMap = XskMap::with_max_entries(1, 0);
-#[map]
-static DEVS: DevMap = DevMap::with_max_entries(1, 0);
-#[map]
-static DEVS_HASH: DevMapHash = DevMapHash::with_max_entries(1, 0);
 #[map]
 static CPUS: CpuMap = CpuMap::with_max_entries(1, 0);
 
@@ -39,18 +35,6 @@ fn redirect_sock(ctx: XdpContext) -> u32 {
         // Queue ID did not match, pass packet to kernel network stack.
         xdp_action::XDP_PASS
     }
-}
-
-#[xdp]
-fn redirect_dev(_ctx: XdpContext) -> u32 {
-    inc_hit(0);
-    DEVS.redirect(0, 0).unwrap_or(xdp_action::XDP_ABORTED)
-}
-
-#[xdp]
-fn redirect_dev_hash(_ctx: XdpContext) -> u32 {
-    inc_hit(0);
-    DEVS_HASH.redirect(10, 0).unwrap_or(xdp_action::XDP_ABORTED)
 }
 
 #[xdp]

--- a/test/integration-test/src/lib.rs
+++ b/test/integration-test/src/lib.rs
@@ -43,6 +43,7 @@ bpf_file!(
     BLOOM_FILTER => "bloom_filter",
     BPF_PROBE_READ => "bpf_probe_read",
     BTF_MAPS_PLAIN => "btf_maps_plain",
+    DEV_MAP => "dev_map",
     KPROBE => "kprobe",
     LINEAR_DATA_STRUCTURES => "linear_data_structures",
     LOG => "log",

--- a/test/integration-test/src/tests/xdp.rs
+++ b/test/integration-test/src/tests/xdp.rs
@@ -1,13 +1,14 @@
-use std::{net::UdpSocket, num::NonZeroU32, time::Duration};
+use std::{ffi::CString, net::UdpSocket, num::NonZeroU32, time::Duration};
 
 use assert_matches::assert_matches;
 use aya::{
     Ebpf,
-    maps::{Array, CpuMap, XskMap},
+    maps::{Array, CpuMap, DevMap, DevMapHash, XskMap},
     programs::{ProgramError, Xdp, XdpError, XdpMode, xdp::XdpLinkId},
     util::KernelVersion,
 };
 use object::{Object as _, ObjectSection as _, ObjectSymbol as _, SymbolSection};
+use test_case::test_case;
 use xdpilone::{BufIdx, IfInfo, Socket, SocketConfig, Umem, UmemConfig};
 
 use crate::utils::NetNsGuard;
@@ -216,4 +217,72 @@ fn cpumap_chain() {
     assert_eq!(&buf[..n], PAYLOAD.as_bytes());
     assert_eq!(hits.get(&0, 0).unwrap(), 1);
     assert_eq!(hits.get(&1, 0).unwrap(), 1);
+}
+
+#[test_case(
+    "DEVS", "DEVS_HASH",
+    "redirect_dev", "redirect_dev_hash",
+    "get_dev", "get_dev_hash";
+    "legacy"
+)]
+#[test_case(
+    "DEVS_BTF", "DEVS_HASH_BTF",
+    "redirect_dev_btf", "redirect_dev_hash_btf",
+    "get_dev_btf", "get_dev_hash_btf";
+    "btf"
+)]
+#[test_log::test]
+fn devmap_set(
+    devs_name: &str,
+    devs_hash_name: &str,
+    dev_prog: &str,
+    dev_hash_prog: &str,
+    dev_get_prog: &str,
+    dev_hash_get_prog: &str,
+) {
+    let _netns = NetNsGuard::new();
+
+    let mut bpf = Ebpf::load(crate::DEV_MAP).unwrap();
+    let mut devs: DevMap<_> = bpf.take_map(devs_name).unwrap().try_into().unwrap();
+    let mut devs_hash: DevMapHash<_> = bpf.take_map(devs_hash_name).unwrap().try_into().unwrap();
+
+    let lo = {
+        let name = CString::new("lo").unwrap();
+        let idx = unsafe { libc::if_nametoindex(name.as_ptr()) };
+        assert!(idx != 0, "interface `lo` not found");
+        idx
+    };
+    devs.set(0, lo, None, 0).unwrap();
+    devs_hash.insert(10, lo, None, 0).unwrap();
+
+    // Load each probe so the BPF verifier validates the wrapper-generated
+    // bytecode. `redirect` works on every kernel that supports the map type;
+    // `get` reads `bpf_devmap_val::bpf_prog.id` so it requires 5.8+.
+    for prog in [dev_prog, dev_hash_prog] {
+        let xdp: &mut Xdp = bpf.program_mut(prog).unwrap().try_into().unwrap();
+        xdp.load().unwrap();
+    }
+    let kernel_version = KernelVersion::current().unwrap();
+    if kernel_version < KernelVersion::new(5, 8, 0) {
+        eprintln!(
+            "skipping {dev_get_prog} and {dev_hash_get_prog} on kernel {kernel_version:?}, bpf_devmap_val was added in 5.8; see https://github.com/torvalds/linux/commit/fbee97feed9b"
+        );
+        return;
+    }
+    for prog in [dev_get_prog, dev_hash_get_prog] {
+        let xdp: &mut Xdp = bpf.program_mut(prog).unwrap().try_into().unwrap();
+        xdp.load().unwrap();
+    }
+}
+
+#[test_case("get_ifindex_dev"; "legacy_array")]
+#[test_case("get_ifindex_dev_hash"; "legacy_hash")]
+#[test_case("get_ifindex_dev_btf"; "btf_array")]
+#[test_case("get_ifindex_dev_hash_btf"; "btf_hash")]
+#[test_log::test]
+fn devmap_get_ifindex(prog_name: &str) {
+    let _netns = NetNsGuard::new();
+    let mut bpf = Ebpf::load(crate::DEV_MAP).unwrap();
+    let xdp: &mut Xdp = bpf.program_mut(prog_name).unwrap().try_into().unwrap();
+    xdp.load().unwrap();
 }

--- a/xtask/public-api/aya-ebpf.txt
+++ b/xtask/public-api/aya-ebpf.txt
@@ -39,6 +39,40 @@ impl<T, const MAX_ENTRIES: usize, const FLAGS: usize, const HASH_FUNCS: usize> c
 impl<T, const MAX_ENTRIES: usize, const FLAGS: usize, const HASH_FUNCS: usize> core::marker::UnsafeUnpin for aya_ebpf::btf_maps::bloom_filter::BloomFilter<T, MAX_ENTRIES, FLAGS, HASH_FUNCS>
 impl<T, const MAX_ENTRIES: usize, const FLAGS: usize, const HASH_FUNCS: usize> core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::btf_maps::bloom_filter::BloomFilter<T, MAX_ENTRIES, FLAGS, HASH_FUNCS> where T: core::panic::unwind_safe::RefUnwindSafe
 impl<T, const MAX_ENTRIES: usize, const FLAGS: usize, const HASH_FUNCS: usize> core::panic::unwind_safe::UnwindSafe for aya_ebpf::btf_maps::bloom_filter::BloomFilter<T, MAX_ENTRIES, FLAGS, HASH_FUNCS> where T: core::panic::unwind_safe::RefUnwindSafe
+pub mod aya_ebpf::btf_maps::dev_map
+#[repr(C)] pub struct aya_ebpf::btf_maps::dev_map::DevMap<const MAX_ENTRIES: usize, const FLAGS: usize>
+impl<const MAX_ENTRIES: usize, const FLAGS: usize> aya_ebpf::btf_maps::dev_map::DevMap<MAX_ENTRIES, FLAGS>
+pub fn aya_ebpf::btf_maps::dev_map::DevMap<MAX_ENTRIES, FLAGS>::get(&self, index: u32) -> core::option::Option<aya_ebpf::maps::xdp::DevMapValue>
+pub fn aya_ebpf::btf_maps::dev_map::DevMap<MAX_ENTRIES, FLAGS>::get_ifindex(&self, index: u32) -> core::option::Option<u32>
+pub fn aya_ebpf::btf_maps::dev_map::DevMap<MAX_ENTRIES, FLAGS>::redirect(&self, index: u32, flags: u64) -> core::result::Result<u32, u32>
+impl<const MAX_ENTRIES: usize, const FLAGS: usize> aya_ebpf::btf_maps::dev_map::DevMap<MAX_ENTRIES, FLAGS>
+pub const fn aya_ebpf::btf_maps::dev_map::DevMap<MAX_ENTRIES, FLAGS>::new() -> Self
+impl<const MAX_ENTRIES: usize, const FLAGS: usize> core::default::Default for aya_ebpf::btf_maps::dev_map::DevMap<MAX_ENTRIES, FLAGS>
+pub fn aya_ebpf::btf_maps::dev_map::DevMap<MAX_ENTRIES, FLAGS>::default() -> Self
+impl<const MAX_ENTRIES: usize, const FLAGS: usize> core::marker::Sync for aya_ebpf::btf_maps::dev_map::DevMap<MAX_ENTRIES, FLAGS>
+impl<const MAX_ENTRIES: usize, const FLAGS: usize> core::marker::Freeze for aya_ebpf::btf_maps::dev_map::DevMap<MAX_ENTRIES, FLAGS>
+impl<const MAX_ENTRIES: usize, const FLAGS: usize> !core::marker::Send for aya_ebpf::btf_maps::dev_map::DevMap<MAX_ENTRIES, FLAGS>
+impl<const MAX_ENTRIES: usize, const FLAGS: usize> core::marker::Unpin for aya_ebpf::btf_maps::dev_map::DevMap<MAX_ENTRIES, FLAGS>
+impl<const MAX_ENTRIES: usize, const FLAGS: usize> core::marker::UnsafeUnpin for aya_ebpf::btf_maps::dev_map::DevMap<MAX_ENTRIES, FLAGS>
+impl<const MAX_ENTRIES: usize, const FLAGS: usize> core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::btf_maps::dev_map::DevMap<MAX_ENTRIES, FLAGS>
+impl<const MAX_ENTRIES: usize, const FLAGS: usize> core::panic::unwind_safe::UnwindSafe for aya_ebpf::btf_maps::dev_map::DevMap<MAX_ENTRIES, FLAGS>
+pub mod aya_ebpf::btf_maps::dev_map_hash
+#[repr(C)] pub struct aya_ebpf::btf_maps::dev_map_hash::DevMapHash<const MAX_ENTRIES: usize, const FLAGS: usize>
+impl<const MAX_ENTRIES: usize, const FLAGS: usize> aya_ebpf::btf_maps::dev_map_hash::DevMapHash<MAX_ENTRIES, FLAGS>
+pub fn aya_ebpf::btf_maps::dev_map_hash::DevMapHash<MAX_ENTRIES, FLAGS>::get(&self, key: u32) -> core::option::Option<aya_ebpf::maps::xdp::DevMapValue>
+pub fn aya_ebpf::btf_maps::dev_map_hash::DevMapHash<MAX_ENTRIES, FLAGS>::get_ifindex(&self, key: u32) -> core::option::Option<u32>
+pub fn aya_ebpf::btf_maps::dev_map_hash::DevMapHash<MAX_ENTRIES, FLAGS>::redirect(&self, key: u32, flags: u64) -> core::result::Result<u32, u32>
+impl<const MAX_ENTRIES: usize, const FLAGS: usize> aya_ebpf::btf_maps::dev_map_hash::DevMapHash<MAX_ENTRIES, FLAGS>
+pub const fn aya_ebpf::btf_maps::dev_map_hash::DevMapHash<MAX_ENTRIES, FLAGS>::new() -> Self
+impl<const MAX_ENTRIES: usize, const FLAGS: usize> core::default::Default for aya_ebpf::btf_maps::dev_map_hash::DevMapHash<MAX_ENTRIES, FLAGS>
+pub fn aya_ebpf::btf_maps::dev_map_hash::DevMapHash<MAX_ENTRIES, FLAGS>::default() -> Self
+impl<const MAX_ENTRIES: usize, const FLAGS: usize> core::marker::Sync for aya_ebpf::btf_maps::dev_map_hash::DevMapHash<MAX_ENTRIES, FLAGS>
+impl<const MAX_ENTRIES: usize, const FLAGS: usize> core::marker::Freeze for aya_ebpf::btf_maps::dev_map_hash::DevMapHash<MAX_ENTRIES, FLAGS>
+impl<const MAX_ENTRIES: usize, const FLAGS: usize> !core::marker::Send for aya_ebpf::btf_maps::dev_map_hash::DevMapHash<MAX_ENTRIES, FLAGS>
+impl<const MAX_ENTRIES: usize, const FLAGS: usize> core::marker::Unpin for aya_ebpf::btf_maps::dev_map_hash::DevMapHash<MAX_ENTRIES, FLAGS>
+impl<const MAX_ENTRIES: usize, const FLAGS: usize> core::marker::UnsafeUnpin for aya_ebpf::btf_maps::dev_map_hash::DevMapHash<MAX_ENTRIES, FLAGS>
+impl<const MAX_ENTRIES: usize, const FLAGS: usize> core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::btf_maps::dev_map_hash::DevMapHash<MAX_ENTRIES, FLAGS>
+impl<const MAX_ENTRIES: usize, const FLAGS: usize> core::panic::unwind_safe::UnwindSafe for aya_ebpf::btf_maps::dev_map_hash::DevMapHash<MAX_ENTRIES, FLAGS>
 pub mod aya_ebpf::btf_maps::lpm_trie
 #[repr(C, packed(1))] pub struct aya_ebpf::btf_maps::lpm_trie::Key<K>
 pub aya_ebpf::btf_maps::lpm_trie::Key::data: K
@@ -300,6 +334,38 @@ impl<T, const MAX_ENTRIES: usize, const FLAGS: usize, const HASH_FUNCS: usize> c
 impl<T, const MAX_ENTRIES: usize, const FLAGS: usize, const HASH_FUNCS: usize> core::marker::UnsafeUnpin for aya_ebpf::btf_maps::bloom_filter::BloomFilter<T, MAX_ENTRIES, FLAGS, HASH_FUNCS>
 impl<T, const MAX_ENTRIES: usize, const FLAGS: usize, const HASH_FUNCS: usize> core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::btf_maps::bloom_filter::BloomFilter<T, MAX_ENTRIES, FLAGS, HASH_FUNCS> where T: core::panic::unwind_safe::RefUnwindSafe
 impl<T, const MAX_ENTRIES: usize, const FLAGS: usize, const HASH_FUNCS: usize> core::panic::unwind_safe::UnwindSafe for aya_ebpf::btf_maps::bloom_filter::BloomFilter<T, MAX_ENTRIES, FLAGS, HASH_FUNCS> where T: core::panic::unwind_safe::RefUnwindSafe
+#[repr(C)] pub struct aya_ebpf::btf_maps::DevMap<const MAX_ENTRIES: usize, const FLAGS: usize>
+impl<const MAX_ENTRIES: usize, const FLAGS: usize> aya_ebpf::btf_maps::dev_map::DevMap<MAX_ENTRIES, FLAGS>
+pub fn aya_ebpf::btf_maps::dev_map::DevMap<MAX_ENTRIES, FLAGS>::get(&self, index: u32) -> core::option::Option<aya_ebpf::maps::xdp::DevMapValue>
+pub fn aya_ebpf::btf_maps::dev_map::DevMap<MAX_ENTRIES, FLAGS>::get_ifindex(&self, index: u32) -> core::option::Option<u32>
+pub fn aya_ebpf::btf_maps::dev_map::DevMap<MAX_ENTRIES, FLAGS>::redirect(&self, index: u32, flags: u64) -> core::result::Result<u32, u32>
+impl<const MAX_ENTRIES: usize, const FLAGS: usize> aya_ebpf::btf_maps::dev_map::DevMap<MAX_ENTRIES, FLAGS>
+pub const fn aya_ebpf::btf_maps::dev_map::DevMap<MAX_ENTRIES, FLAGS>::new() -> Self
+impl<const MAX_ENTRIES: usize, const FLAGS: usize> core::default::Default for aya_ebpf::btf_maps::dev_map::DevMap<MAX_ENTRIES, FLAGS>
+pub fn aya_ebpf::btf_maps::dev_map::DevMap<MAX_ENTRIES, FLAGS>::default() -> Self
+impl<const MAX_ENTRIES: usize, const FLAGS: usize> core::marker::Sync for aya_ebpf::btf_maps::dev_map::DevMap<MAX_ENTRIES, FLAGS>
+impl<const MAX_ENTRIES: usize, const FLAGS: usize> core::marker::Freeze for aya_ebpf::btf_maps::dev_map::DevMap<MAX_ENTRIES, FLAGS>
+impl<const MAX_ENTRIES: usize, const FLAGS: usize> !core::marker::Send for aya_ebpf::btf_maps::dev_map::DevMap<MAX_ENTRIES, FLAGS>
+impl<const MAX_ENTRIES: usize, const FLAGS: usize> core::marker::Unpin for aya_ebpf::btf_maps::dev_map::DevMap<MAX_ENTRIES, FLAGS>
+impl<const MAX_ENTRIES: usize, const FLAGS: usize> core::marker::UnsafeUnpin for aya_ebpf::btf_maps::dev_map::DevMap<MAX_ENTRIES, FLAGS>
+impl<const MAX_ENTRIES: usize, const FLAGS: usize> core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::btf_maps::dev_map::DevMap<MAX_ENTRIES, FLAGS>
+impl<const MAX_ENTRIES: usize, const FLAGS: usize> core::panic::unwind_safe::UnwindSafe for aya_ebpf::btf_maps::dev_map::DevMap<MAX_ENTRIES, FLAGS>
+#[repr(C)] pub struct aya_ebpf::btf_maps::DevMapHash<const MAX_ENTRIES: usize, const FLAGS: usize>
+impl<const MAX_ENTRIES: usize, const FLAGS: usize> aya_ebpf::btf_maps::dev_map_hash::DevMapHash<MAX_ENTRIES, FLAGS>
+pub fn aya_ebpf::btf_maps::dev_map_hash::DevMapHash<MAX_ENTRIES, FLAGS>::get(&self, key: u32) -> core::option::Option<aya_ebpf::maps::xdp::DevMapValue>
+pub fn aya_ebpf::btf_maps::dev_map_hash::DevMapHash<MAX_ENTRIES, FLAGS>::get_ifindex(&self, key: u32) -> core::option::Option<u32>
+pub fn aya_ebpf::btf_maps::dev_map_hash::DevMapHash<MAX_ENTRIES, FLAGS>::redirect(&self, key: u32, flags: u64) -> core::result::Result<u32, u32>
+impl<const MAX_ENTRIES: usize, const FLAGS: usize> aya_ebpf::btf_maps::dev_map_hash::DevMapHash<MAX_ENTRIES, FLAGS>
+pub const fn aya_ebpf::btf_maps::dev_map_hash::DevMapHash<MAX_ENTRIES, FLAGS>::new() -> Self
+impl<const MAX_ENTRIES: usize, const FLAGS: usize> core::default::Default for aya_ebpf::btf_maps::dev_map_hash::DevMapHash<MAX_ENTRIES, FLAGS>
+pub fn aya_ebpf::btf_maps::dev_map_hash::DevMapHash<MAX_ENTRIES, FLAGS>::default() -> Self
+impl<const MAX_ENTRIES: usize, const FLAGS: usize> core::marker::Sync for aya_ebpf::btf_maps::dev_map_hash::DevMapHash<MAX_ENTRIES, FLAGS>
+impl<const MAX_ENTRIES: usize, const FLAGS: usize> core::marker::Freeze for aya_ebpf::btf_maps::dev_map_hash::DevMapHash<MAX_ENTRIES, FLAGS>
+impl<const MAX_ENTRIES: usize, const FLAGS: usize> !core::marker::Send for aya_ebpf::btf_maps::dev_map_hash::DevMapHash<MAX_ENTRIES, FLAGS>
+impl<const MAX_ENTRIES: usize, const FLAGS: usize> core::marker::Unpin for aya_ebpf::btf_maps::dev_map_hash::DevMapHash<MAX_ENTRIES, FLAGS>
+impl<const MAX_ENTRIES: usize, const FLAGS: usize> core::marker::UnsafeUnpin for aya_ebpf::btf_maps::dev_map_hash::DevMapHash<MAX_ENTRIES, FLAGS>
+impl<const MAX_ENTRIES: usize, const FLAGS: usize> core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::btf_maps::dev_map_hash::DevMapHash<MAX_ENTRIES, FLAGS>
+impl<const MAX_ENTRIES: usize, const FLAGS: usize> core::panic::unwind_safe::UnwindSafe for aya_ebpf::btf_maps::dev_map_hash::DevMapHash<MAX_ENTRIES, FLAGS>
 #[repr(C)] pub struct aya_ebpf::btf_maps::LpmTrie<K, V, const MAX_ENTRIES: usize, const FLAGS: usize>
 impl<K, V, const MAX_ENTRIES: usize, const FLAGS: usize> aya_ebpf::btf_maps::lpm_trie::LpmTrie<K, V, MAX_ENTRIES, FLAGS>
 pub fn aya_ebpf::btf_maps::lpm_trie::LpmTrie<K, V, MAX_ENTRIES, FLAGS>::get(&self, key: &aya_ebpf::maps::lpm_trie::Key<K>) -> core::option::Option<&V>
@@ -839,7 +905,8 @@ impl !core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::maps::CpuMap
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf::maps::CpuMap
 #[repr(transparent)] pub struct aya_ebpf::maps::xdp::DevMap
 impl aya_ebpf::maps::DevMap
-pub fn aya_ebpf::maps::DevMap::get(&self, index: u32) -> core::option::Option<aya_ebpf::maps::xdp::dev_map::DevMapValue>
+pub fn aya_ebpf::maps::DevMap::get(&self, index: u32) -> core::option::Option<aya_ebpf::maps::xdp::DevMapValue>
+pub fn aya_ebpf::maps::DevMap::get_ifindex(&self, index: u32) -> core::option::Option<u32>
 pub const fn aya_ebpf::maps::DevMap::pinned(max_entries: u32, flags: u32) -> Self
 pub fn aya_ebpf::maps::DevMap::redirect(&self, index: u32, flags: u64) -> core::result::Result<u32, u32>
 pub const fn aya_ebpf::maps::DevMap::with_max_entries(max_entries: u32, flags: u32) -> Self
@@ -852,7 +919,8 @@ impl !core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::maps::DevMap
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf::maps::DevMap
 #[repr(transparent)] pub struct aya_ebpf::maps::xdp::DevMapHash
 impl aya_ebpf::maps::DevMapHash
-pub fn aya_ebpf::maps::DevMapHash::get(&self, key: u32) -> core::option::Option<aya_ebpf::maps::xdp::dev_map::DevMapValue>
+pub fn aya_ebpf::maps::DevMapHash::get(&self, key: u32) -> core::option::Option<aya_ebpf::maps::xdp::DevMapValue>
+pub fn aya_ebpf::maps::DevMapHash::get_ifindex(&self, key: u32) -> core::option::Option<u32>
 pub const fn aya_ebpf::maps::DevMapHash::pinned(max_entries: u32, flags: u32) -> Self
 pub fn aya_ebpf::maps::DevMapHash::redirect(&self, key: u32, flags: u64) -> core::result::Result<u32, u32>
 pub const fn aya_ebpf::maps::DevMapHash::with_max_entries(max_entries: u32, flags: u32) -> Self
@@ -863,6 +931,19 @@ impl core::marker::Unpin for aya_ebpf::maps::DevMapHash
 impl core::marker::UnsafeUnpin for aya_ebpf::maps::DevMapHash
 impl !core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::maps::DevMapHash
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf::maps::DevMapHash
+pub struct aya_ebpf::maps::xdp::DevMapValue
+pub aya_ebpf::maps::xdp::DevMapValue::if_index: u32
+pub aya_ebpf::maps::xdp::DevMapValue::prog_id: core::option::Option<core::num::nonzero::NonZeroU32>
+impl core::clone::Clone for aya_ebpf::maps::xdp::DevMapValue
+pub fn aya_ebpf::maps::xdp::DevMapValue::clone(&self) -> aya_ebpf::maps::xdp::DevMapValue
+impl core::marker::Copy for aya_ebpf::maps::xdp::DevMapValue
+impl core::marker::Freeze for aya_ebpf::maps::xdp::DevMapValue
+impl core::marker::Send for aya_ebpf::maps::xdp::DevMapValue
+impl core::marker::Sync for aya_ebpf::maps::xdp::DevMapValue
+impl core::marker::Unpin for aya_ebpf::maps::xdp::DevMapValue
+impl core::marker::UnsafeUnpin for aya_ebpf::maps::xdp::DevMapValue
+impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::maps::xdp::DevMapValue
+impl core::panic::unwind_safe::UnwindSafe for aya_ebpf::maps::xdp::DevMapValue
 #[repr(transparent)] pub struct aya_ebpf::maps::xdp::XskMap
 impl aya_ebpf::maps::XskMap
 pub fn aya_ebpf::maps::XskMap::get(&self, index: u32) -> core::option::Option<u32>
@@ -918,7 +999,8 @@ impl !core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::maps::CpuMap
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf::maps::CpuMap
 #[repr(transparent)] pub struct aya_ebpf::maps::DevMap
 impl aya_ebpf::maps::DevMap
-pub fn aya_ebpf::maps::DevMap::get(&self, index: u32) -> core::option::Option<aya_ebpf::maps::xdp::dev_map::DevMapValue>
+pub fn aya_ebpf::maps::DevMap::get(&self, index: u32) -> core::option::Option<aya_ebpf::maps::xdp::DevMapValue>
+pub fn aya_ebpf::maps::DevMap::get_ifindex(&self, index: u32) -> core::option::Option<u32>
 pub const fn aya_ebpf::maps::DevMap::pinned(max_entries: u32, flags: u32) -> Self
 pub fn aya_ebpf::maps::DevMap::redirect(&self, index: u32, flags: u64) -> core::result::Result<u32, u32>
 pub const fn aya_ebpf::maps::DevMap::with_max_entries(max_entries: u32, flags: u32) -> Self
@@ -931,7 +1013,8 @@ impl !core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::maps::DevMap
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf::maps::DevMap
 #[repr(transparent)] pub struct aya_ebpf::maps::DevMapHash
 impl aya_ebpf::maps::DevMapHash
-pub fn aya_ebpf::maps::DevMapHash::get(&self, key: u32) -> core::option::Option<aya_ebpf::maps::xdp::dev_map::DevMapValue>
+pub fn aya_ebpf::maps::DevMapHash::get(&self, key: u32) -> core::option::Option<aya_ebpf::maps::xdp::DevMapValue>
+pub fn aya_ebpf::maps::DevMapHash::get_ifindex(&self, key: u32) -> core::option::Option<u32>
 pub const fn aya_ebpf::maps::DevMapHash::pinned(max_entries: u32, flags: u32) -> Self
 pub fn aya_ebpf::maps::DevMapHash::redirect(&self, key: u32, flags: u64) -> core::result::Result<u32, u32>
 pub const fn aya_ebpf::maps::DevMapHash::with_max_entries(max_entries: u32, flags: u32) -> Self


### PR DESCRIPTION
Adds `DevMap<MAX_ENTRIES, FLAGS>` and `DevMapHash<MAX_ENTRIES, FLAGS>`
to `aya_ebpf::btf_maps`, mirroring the existing legacy types in
`aya_ebpf::maps::xdp`.

`DevMapValue` is now publicly nameable at
`aya_ebpf::maps::xdp::DevMapValue` so the BTF wrappers can refer to
it in their public signatures.

Integration tests in `xdp::devmap_set` cover both legacy and BTF
variants; the test exercises `set` / `insert` from userspace and
loads the redirect and get probes so the BPF verifier validates
the wrapper-generated bytecode.

### Added/updated tests?

- [x] Yes

### Checklist

- [x] Rust code has been formatted with `cargo +nightly fmt`.
- [x] All clippy lints have been fixed.
      You can find failing lints with `cargo xtask clippy`.
- [x] Unit tests are passing locally with `cargo test`.
- [x] The integration tests are passing locally.
- [x] I have blessed any API changes with `cargo xtask public-api --bless`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aya-rs/aya/1566)
<!-- Reviewable:end -->
