### PR TITLE
aya: add classid to SchedClassifier netlink attach

### DIFF
--- a/aya/src/programs/mod.rs
+++ b/aya/src/programs/mod.rs
@@ -121,7 +121,7 @@ pub use crate::programs::{
     sk_skb::{SkSkb, SkSkbKind},
     sock_ops::SockOps,
     socket_filter::{SocketFilter, SocketFilterError},
-    tc::{SchedClassifier, TcAttachType, TcError},
+    tc::{SchedClassifier, TcAttachType, TcError, TcHandle},
     tp_btf::BtfTracePoint,
     trace_point::{TracePoint, TracePointError},
     uprobe::{UProbe, UProbeError},

--- a/aya/src/programs/tc.rs
+++ b/aya/src/programs/tc.rs
@@ -190,6 +190,19 @@ pub struct NlOptions {
     ///
     /// Defaults to [`TcHandle::AUTO_ASSIGN`], which lets the kernel pick one.
     pub handle: TcHandle,
+    /// `classid` bound to this filter (also known as `flowid` in `tc(8)`).
+    ///
+    /// In direct-action mode the major 16 bits of the resulting class id come
+    /// from this attribute and the minor 16 bits come from the program at run
+    /// time via `__sk_buff::tc_classid`. This split requires Linux 4.6 (commit
+    /// [`3a461da1d03e`]).
+    ///
+    /// When [`None`], no attribute is sent and the filter is not bound to a
+    /// class.
+    ///
+    /// [`3a461da1d03e`]: https://github.com/torvalds/linux/commit/3a461da1d03e7a857edfa6a002040d07e118c639
+    #[doc(alias = "TCA_BPF_CLASSID")]
+    pub classid: Option<TcHandle>,
 }
 
 impl SchedClassifier {
@@ -332,10 +345,15 @@ impl SchedClassifier {
                 attach_type,
                 priority,
                 handle,
+                classid,
             }) => self.do_attach(
                 if_index,
                 attach_type,
-                TcAttachOptions::Netlink(NlOptions { priority, handle }),
+                TcAttachOptions::Netlink(NlOptions {
+                    priority,
+                    handle,
+                    classid,
+                }),
                 false,
             ),
         }
@@ -364,6 +382,7 @@ impl SchedClassifier {
                         &name,
                         options.priority,
                         options.handle,
+                        options.classid,
                         create,
                     )
                 }
@@ -376,6 +395,7 @@ impl SchedClassifier {
                         attach_type,
                         priority,
                         handle,
+                        classid: options.classid,
                     })))
             }
             TcAttachOptions::TcxOrder(options) => {
@@ -460,6 +480,7 @@ pub(crate) struct NlLink {
     attach_type: TcAttachType,
     priority: u16,
     handle: TcHandle,
+    classid: Option<TcHandle>,
 }
 
 impl Link for NlLink {
@@ -566,13 +587,14 @@ impl SchedClassifierLink {
     /// #     #[error(transparent)]
     /// #     IO(#[from] std::io::Error),
     /// # }
-    /// # fn read_persisted_link_details() -> (&'static str, TcAttachType, u16, TcHandle) {
-    /// #     ("eth0", TcAttachType::Ingress, 50, TcHandle::new(0, 1))
+    /// # fn read_persisted_link_details() -> (&'static str, TcAttachType, u16, TcHandle, Option<TcHandle>) {
+    /// #     ("eth0", TcAttachType::Ingress, 50, TcHandle::new(0, 1), None)
     /// # }
     /// // Get the link parameters from some external source. Where and how the parameters are
     /// // persisted is up to your application.
-    /// let (if_name, attach_type, priority, handle) = read_persisted_link_details();
-    /// let new_tc_link = SchedClassifierLink::attached(if_name, attach_type, priority, handle)?;
+    /// let (if_name, attach_type, priority, handle, classid) = read_persisted_link_details();
+    /// let new_tc_link =
+    ///     SchedClassifierLink::attached(if_name, attach_type, priority, handle, classid)?;
     ///
     /// # Ok::<(), Error>(())
     /// ```
@@ -581,6 +603,7 @@ impl SchedClassifierLink {
         attach_type: TcAttachType,
         priority: u16,
         handle: TcHandle,
+        classid: Option<TcHandle>,
     ) -> Result<Self, io::Error> {
         let if_index = ifindex_from_ifname(if_name)?;
         Ok(Self(Some(TcLinkInner::NlLink(NlLink {
@@ -588,6 +611,7 @@ impl SchedClassifierLink {
             attach_type,
             priority,
             handle,
+            classid,
         }))))
     }
 
@@ -613,6 +637,16 @@ impl SchedClassifierLink {
     pub fn handle(&self) -> Result<TcHandle, ProgramError> {
         if let TcLinkInner::NlLink(n) = self.inner() {
             Ok(n.handle)
+        } else {
+            Err(TcError::InvalidLinkOperation.into())
+        }
+    }
+
+    /// Returns the `classid` bound to this filter, or [`None`] if the filter
+    /// is not bound to a class. See [`NlOptions::classid`].
+    pub fn classid(&self) -> Result<Option<TcHandle>, ProgramError> {
+        if let TcLinkInner::NlLink(n) = self.inner() {
+            Ok(n.classid)
         } else {
             Err(TcError::InvalidLinkOperation.into())
         }

--- a/aya/src/programs/tc.rs
+++ b/aya/src/programs/tc.rs
@@ -139,6 +139,47 @@ pub enum TcAttachOptions {
     TcxOrder(LinkOrder),
 }
 
+/// A TC filter handle in `major:minor` form.
+///
+/// Matches the `M:N` syntax accepted by `tc(8)`. Use [`TcHandle::AUTO_ASSIGN`]
+/// to ask the kernel to allocate one.
+#[derive(Debug, Clone, Copy, Default, Hash, Eq, PartialEq)]
+#[doc(alias = "tcm_handle")]
+pub struct TcHandle {
+    /// Upper 16 bits when encoded as a u32.
+    major: u16,
+    /// Lower 16 bits when encoded as a u32.
+    minor: u16,
+}
+
+impl TcHandle {
+    /// Sentinel that asks the kernel to allocate a handle at attach time.
+    ///
+    /// Equal to [`Default::default`]. The allocated value is exposed by
+    /// [`SchedClassifierLink::handle`] after the program is attached.
+    pub const AUTO_ASSIGN: Self = Self { major: 0, minor: 0 };
+
+    /// Const equivalent of `Self { major, minor }`.
+    pub const fn new(major: u16, minor: u16) -> Self {
+        Self { major, minor }
+    }
+}
+
+impl From<TcHandle> for u32 {
+    fn from(TcHandle { major, minor }: TcHandle) -> Self {
+        (Self::from(major) << 16) | Self::from(minor)
+    }
+}
+
+impl From<u32> for TcHandle {
+    fn from(value: u32) -> Self {
+        Self {
+            major: (value >> 16) as u16,
+            minor: value as u16,
+        }
+    }
+}
+
 /// Options for [`SchedClassifier`] attach via netlink.
 #[derive(Debug, Default, Hash, Eq, PartialEq)]
 pub struct NlOptions {
@@ -146,8 +187,9 @@ pub struct NlOptions {
     /// If set to default (0), the system chooses the next highest priority or 49152 if no filters exist yet
     pub priority: u16,
     /// Handle used to uniquely identify a program at a given priority level.
-    /// If set to default (0), the system chooses a handle.
-    pub handle: u32,
+    ///
+    /// Defaults to [`TcHandle::AUTO_ASSIGN`], which lets the kernel pick one.
+    pub handle: TcHandle,
 }
 
 impl SchedClassifier {
@@ -410,14 +452,14 @@ impl SchedClassifier {
 }
 
 #[derive(Debug, Hash, Eq, PartialEq)]
-pub(crate) struct NlLinkId(u32, TcAttachType, u16, u32);
+pub(crate) struct NlLinkId(u32, TcAttachType, u16, TcHandle);
 
 #[derive(Debug)]
 pub(crate) struct NlLink {
     if_index: u32,
     attach_type: TcAttachType,
     priority: u16,
-    handle: u32,
+    handle: TcHandle,
 }
 
 impl Link for NlLink {
@@ -517,15 +559,15 @@ impl SchedClassifierLink {
     ///
     /// # Examples
     /// ```no_run
-    /// # use aya::programs::tc::SchedClassifierLink;
+    /// # use aya::programs::tc::{SchedClassifierLink, TcHandle};
     /// # use aya::programs::TcAttachType;
     /// # #[derive(Debug, thiserror::Error)]
     /// # enum Error {
     /// #     #[error(transparent)]
     /// #     IO(#[from] std::io::Error),
     /// # }
-    /// # fn read_persisted_link_details() -> (&'static str, TcAttachType, u16, u32) {
-    /// #     ("eth0", TcAttachType::Ingress, 50, 1)
+    /// # fn read_persisted_link_details() -> (&'static str, TcAttachType, u16, TcHandle) {
+    /// #     ("eth0", TcAttachType::Ingress, 50, TcHandle::new(0, 1))
     /// # }
     /// // Get the link parameters from some external source. Where and how the parameters are
     /// // persisted is up to your application.
@@ -538,7 +580,7 @@ impl SchedClassifierLink {
         if_name: &str,
         attach_type: TcAttachType,
         priority: u16,
-        handle: u32,
+        handle: TcHandle,
     ) -> Result<Self, io::Error> {
         let if_index = ifindex_from_ifname(if_name)?;
         Ok(Self(Some(TcLinkInner::NlLink(NlLink {
@@ -568,7 +610,7 @@ impl SchedClassifierLink {
     }
 
     /// Returns the assigned handle. If none was provided at attach time, this was allocated for you.
-    pub fn handle(&self) -> Result<u32, ProgramError> {
+    pub fn handle(&self) -> Result<TcHandle, ProgramError> {
         if let TcLinkInner::NlLink(n) = self.inner() {
             Ok(n.handle)
         } else {

--- a/aya/src/sys/netlink.rs
+++ b/aya/src/sys/netlink.rs
@@ -22,7 +22,7 @@ use thiserror::Error;
 
 use crate::{
     Pod,
-    programs::{TcAttachType, XdpMode},
+    programs::{TcAttachType, TcHandle, XdpMode},
     util::{bytes_of, tc_handler_make},
 };
 
@@ -223,9 +223,9 @@ pub(crate) unsafe fn netlink_qdisc_attach(
     prog_fd: BorrowedFd<'_>,
     prog_name: &CStr,
     priority: u16,
-    handle: u32,
+    handle: TcHandle,
     create: bool,
-) -> Result<(u16, u32), NetlinkError> {
+) -> Result<(u16, TcHandle), NetlinkError> {
     let sock = NetlinkSocket::open()?;
 
     let mut req = unsafe { mem::zeroed::<TcRequest>() };
@@ -252,7 +252,7 @@ pub(crate) unsafe fn netlink_qdisc_attach(
         nlmsg_seq: 1,
     };
     req.tc_info.tcm_family = AF_UNSPEC as u8;
-    req.tc_info.tcm_handle = handle; // auto-assigned, if zero
+    req.tc_info.tcm_handle = handle.into();
     req.tc_info.tcm_ifindex = if_index;
     req.tc_info.tcm_parent = attach_type.tc_parent();
     req.tc_info.tcm_info = tc_handler_make(
@@ -286,7 +286,7 @@ pub(crate) unsafe fn netlink_qdisc_attach(
         ))),
         [tc_msg] => {
             let priority = ((tc_msg.tcm_info & TC_H_MAJ_MASK) >> 16) as u16;
-            Ok((priority, tc_msg.tcm_handle))
+            Ok((priority, tc_msg.tcm_handle.into()))
         }
         _tc_msg => Err(NetlinkError(NetlinkErrorInternal::IoError(
             io::Error::other(
@@ -300,7 +300,7 @@ pub(crate) unsafe fn netlink_qdisc_detach(
     if_index: i32,
     attach_type: TcAttachType,
     priority: u16,
-    handle: u32,
+    handle: TcHandle,
 ) -> Result<(), NetlinkError> {
     let sock = NetlinkSocket::open()?;
 
@@ -315,7 +315,7 @@ pub(crate) unsafe fn netlink_qdisc_detach(
     };
 
     req.tc_info.tcm_family = AF_UNSPEC as u8;
-    req.tc_info.tcm_handle = handle; // auto-assigned, if zero
+    req.tc_info.tcm_handle = handle.into();
     req.tc_info.tcm_info = tc_handler_make(
         u32::from(priority) << 16,
         u32::from(htons(ETH_P_ALL as u16)),
@@ -337,7 +337,7 @@ pub(crate) fn netlink_find_filter_with_name(
     if_index: i32,
     attach_type: TcAttachType,
     name: &CStr,
-) -> Result<impl Iterator<Item = Result<(u16, u32), NetlinkError>>, NetlinkError> {
+) -> Result<impl Iterator<Item = Result<(u16, TcHandle), NetlinkError>>, NetlinkError> {
     let mut req = unsafe { mem::zeroed::<TcRequest>() };
 
     let nlmsg_len = size_of::<nlmsghdr>() + size_of::<tcmsg>();
@@ -395,7 +395,7 @@ pub(crate) fn netlink_find_filter_with_name(
                         if f_name != name {
                             continue;
                         }
-                        filter = Some((priority, tc_msg.tcm_handle));
+                        filter = Some((priority, tc_msg.tcm_handle.into()));
                     }
                 }
                 Ok(filter)

--- a/aya/src/sys/netlink.rs
+++ b/aya/src/sys/netlink.rs
@@ -7,9 +7,9 @@ use std::{
 
 use aya_obj::generated::{
     IFLA_XDP_EXPECTED_FD, IFLA_XDP_FD, IFLA_XDP_FLAGS, NLMSG_ALIGNTO, TC_H_CLSACT, TC_H_INGRESS,
-    TC_H_MAJ_MASK, TC_H_UNSPEC, TCA_BPF_FD, TCA_BPF_FLAG_ACT_DIRECT, TCA_BPF_FLAGS, TCA_BPF_NAME,
-    TCA_KIND, TCA_OPTIONS, XDP_FLAGS_REPLACE, XDP_FLAGS_UPDATE_IF_NOEXIST, ifinfomsg,
-    nlmsgerr_attrs::NLMSGERR_ATTR_MSG, tcmsg,
+    TC_H_MAJ_MASK, TC_H_UNSPEC, TCA_BPF_CLASSID, TCA_BPF_FD, TCA_BPF_FLAG_ACT_DIRECT,
+    TCA_BPF_FLAGS, TCA_BPF_NAME, TCA_KIND, TCA_OPTIONS, XDP_FLAGS_REPLACE,
+    XDP_FLAGS_UPDATE_IF_NOEXIST, ifinfomsg, nlmsgerr_attrs::NLMSGERR_ATTR_MSG, tcmsg,
 };
 use libc::{
     AF_NETLINK, AF_UNSPEC, ETH_P_ALL, IFF_UP, IFLA_XDP, NETLINK_CAP_ACK, NETLINK_EXT_ACK,
@@ -46,12 +46,15 @@ const NLA_HDR_ALIGN_LEN: usize = nla_align!(NLA_HDR_LEN);
 const CLS_BPF_NAME_LEN: usize = 256;
 
 // Size of the attribute buffer needed by write_tc_attach_attrs:
-// TCA_KIND + nested TCA_OPTIONS containing TCA_BPF_FD, TCA_BPF_NAME, TCA_BPF_FLAGS.
+// TCA_KIND + nested TCA_OPTIONS containing TCA_BPF_CLASSID, TCA_BPF_FD,
+// TCA_BPF_NAME, TCA_BPF_FLAGS.
 const fn tc_request_attrs_size() -> usize {
     // TCA_KIND
     NLA_HDR_ALIGN_LEN + nla_align!(c"bpf".to_bytes_with_nul().len())
     // TCA_OPTIONS header
     + NLA_HDR_ALIGN_LEN
+    // TCA_BPF_CLASSID
+    + NLA_HDR_ALIGN_LEN + nla_align!(size_of::<u32>())
     // TCA_BPF_FD
     + NLA_HDR_ALIGN_LEN + nla_align!(size_of::<i32>())
     // TCA_BPF_NAME
@@ -60,7 +63,7 @@ const fn tc_request_attrs_size() -> usize {
     + NLA_HDR_ALIGN_LEN + nla_align!(size_of::<u32>())
 }
 
-const _: () = assert!(tc_request_attrs_size() == 288);
+const _: () = assert!(tc_request_attrs_size() == 296);
 
 /// A private error type for internal use in this module.
 #[derive(Error, Debug)]
@@ -201,13 +204,23 @@ fn write_tc_attach_attrs(
     nlmsg_len: usize,
     prog_fd: i32,
     prog_name: &[u8],
+    classid: Option<TcHandle>,
 ) -> io::Result<()> {
+    if prog_name.len() > CLS_BPF_NAME_LEN {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "program name exceeds CLS_BPF_NAME_LEN",
+        ));
+    }
     let attrs_buf = unsafe { request_attributes(req, nlmsg_len) };
 
     let (attrs_buf, kind_len) =
         write_attr_bytes(attrs_buf, TCA_KIND as u16, c"bpf".to_bytes_with_nul())?;
 
     let mut options = NestedAttrs::new(attrs_buf, TCA_OPTIONS as u16);
+    if let Some(classid) = classid {
+        options.write_attr(TCA_BPF_CLASSID as u16, u32::from(classid))?;
+    }
     options.write_attr(TCA_BPF_FD as u16, prog_fd)?;
     options.write_attr_bytes(TCA_BPF_NAME as u16, prog_name)?;
     options.write_attr(TCA_BPF_FLAGS as u16, TCA_BPF_FLAG_ACT_DIRECT)?;
@@ -217,6 +230,7 @@ fn write_tc_attach_attrs(
     Ok(())
 }
 
+#[expect(clippy::too_many_arguments, reason = "internal netlink helper")]
 pub(crate) unsafe fn netlink_qdisc_attach(
     if_index: i32,
     attach_type: &TcAttachType,
@@ -224,6 +238,7 @@ pub(crate) unsafe fn netlink_qdisc_attach(
     prog_name: &CStr,
     priority: u16,
     handle: TcHandle,
+    classid: Option<TcHandle>,
     create: bool,
 ) -> Result<(u16, TcHandle), NetlinkError> {
     let sock = NetlinkSocket::open()?;
@@ -265,6 +280,7 @@ pub(crate) unsafe fn netlink_qdisc_attach(
         nlmsg_len,
         prog_fd.as_raw_fd(),
         prog_name.to_bytes_with_nul(),
+        classid,
     )
     .map_err(|e| NetlinkError(NetlinkErrorInternal::IoError(e)))?;
     sock.send(&bytes_of(&req)[..req.header.nlmsg_len as usize])?;
@@ -833,7 +849,7 @@ unsafe fn request_attributes<T>(req: &mut T, msg_len: usize) -> &mut [u8] {
 
 #[cfg(test)]
 mod tests {
-    use assert_matches::assert_matches;
+    use test_case::test_case;
 
     use super::*;
 
@@ -955,35 +971,58 @@ mod tests {
         assert_eq!(name.to_str().unwrap(), "foo");
     }
 
-    fn tc_request(name: &[u8]) -> io::Result<()> {
+    fn tc_request(name: &[u8], classid: Option<TcHandle>) -> io::Result<TcRequest> {
         let mut req = unsafe { mem::zeroed::<TcRequest>() };
         let nlmsg_len = size_of::<nlmsghdr>() + size_of::<tcmsg>();
         req.header.nlmsg_len = nlmsg_len as u32;
 
-        write_tc_attach_attrs(&mut req, nlmsg_len, 0, name)
+        write_tc_attach_attrs(&mut req, nlmsg_len, 0, name, classid)?;
+        Ok(req)
     }
 
-    /// Verify that [`TcRequest`] fits all the attributes [`write_tc_attach_attrs`]
-    /// writes, even with the kernel's maximum TC name length (`CLS_BPF_NAME_LEN`).
+    fn classid_in_request(req: &TcRequest) -> Option<TcHandle> {
+        let attrs_len = req.header.nlmsg_len as usize - size_of::<nlmsghdr>() - size_of::<tcmsg>();
+        let attrs = &req.attrs[..attrs_len];
+
+        let options = NlAttrsIterator::new(attrs)
+            .filter_map(Result::ok)
+            .find(|a| a.header.nla_type & NLA_TYPE_MASK as u16 == TCA_OPTIONS as u16)?;
+
+        let classid = NlAttrsIterator::new(options.data)
+            .filter_map(Result::ok)
+            .find(|a| a.header.nla_type & NLA_TYPE_MASK as u16 == TCA_BPF_CLASSID as u16)?;
+
+        let raw = u32::from_ne_bytes(classid.data.try_into().ok()?);
+        Some(raw.into())
+    }
+
+    /// Verify that [`TcRequest`] fits a `CLS_BPF_NAME_LEN`-byte program name.
     ///
     /// Before the buffer was enlarged, serializing the netlink attributes for
     /// long names failed with "no space left".
     #[test]
     fn tc_request_fits_max_length_name() {
-        assert_matches!(tc_request(&[b'a'; CLS_BPF_NAME_LEN]), Ok(()));
+        tc_request(&[b'a'; CLS_BPF_NAME_LEN], None).unwrap();
     }
 
-    /// Verify that a name exceeding `CLS_BPF_NAME_LEN` is rejected.
+    /// Verify that a name exceeding `CLS_BPF_NAME_LEN` is rejected before the
+    /// netlink request is built.
     #[test]
     fn tc_request_rejects_oversized_name() {
-        // One byte over the kernel's maximum — the attribute buffer is sized
-        // exactly for CLS_BPF_NAME_LEN, so this should fail with "no space left".
-        assert_matches!(
-            tc_request(&[b'a'; CLS_BPF_NAME_LEN + 1]),
-            Err(err) => {
-                assert_eq!(err.kind(), io::ErrorKind::Other);
-                assert_eq!(err.to_string(), "no space left");
-            }
-        );
+        let Err(err) = tc_request(&[b'a'; CLS_BPF_NAME_LEN + 1], None) else {
+            panic!("expected oversized name to be rejected");
+        };
+        assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
+        assert_eq!(err.to_string(), "program name exceeds CLS_BPF_NAME_LEN");
+    }
+
+    /// Verify that the `classid` value supplied to [`write_tc_attach_attrs`]
+    /// round-trips through the serialized netlink attributes. The absent case
+    /// mirrors iproute2's behavior when `classid` is not on the command line.
+    #[test_case(Some(TcHandle::new(1, 1)) ; "set")]
+    #[test_case(None ; "unset")]
+    fn tc_request_classid_serialization(classid: Option<TcHandle>) {
+        let req = tc_request(b"foo\0", classid).unwrap();
+        assert_eq!(classid_in_request(&req), classid);
     }
 }

--- a/test/integration-test/src/tests.rs
+++ b/test/integration-test/src/tests.rs
@@ -43,6 +43,7 @@ mod smoke;
 mod stack_trace;
 mod stack_trace_lsm;
 mod strncmp;
+mod tc_netlink;
 mod tcx;
 mod uprobe_cookie;
 mod xdp;

--- a/test/integration-test/src/tests/tc_netlink.rs
+++ b/test/integration-test/src/tests/tc_netlink.rs
@@ -1,0 +1,133 @@
+use aya::{
+    Ebpf,
+    programs::{
+        SchedClassifier, TcAttachType,
+        tc::{NlOptions, TcAttachOptions, TcHandle, qdisc_add_clsact},
+    },
+    util::KernelVersion,
+};
+
+use crate::{TCX, utils::NetNsGuard};
+
+/// Returns true if the kernel autoloads `cls_bpf` on netlink attach.
+///
+/// Before kernel commit 2c15a5ae ("net/sched: Load modules via their alias",
+/// released 6.10) the netlink TC code asks modprobe for `cls_bpf` by its
+/// canonical name. The test-distro modprobe stub only resolves modules through
+/// `modules.alias` entries, and `cls_bpf.ko` ships no self-alias, so the
+/// autoload fails inside the VM. The netlink TC features themselves only
+/// require 4.6.
+///
+/// See <https://github.com/torvalds/linux/commit/2c15a5aee2f32e341d1585fa1867eece76a1edb8>.
+fn cls_bpf_autoloads() -> bool {
+    let kernel_version = KernelVersion::current().unwrap();
+    if kernel_version < KernelVersion::new(6, 10, 0) {
+        eprintln!(
+            "skipping on kernel {kernel_version:?}: test-distro modprobe cannot autoload cls_bpf"
+        );
+        return false;
+    }
+    true
+}
+
+/// Verify that `classid` set on the initial netlink attach is preserved when
+/// the program is later replaced via [`SchedClassifier::attach_to_link`].
+///
+/// `cls_bpf_change` allocates a fresh `cls_bpf_prog` on every netlink replace
+/// and only sets `prog->res.classid` if the request carries `TCA_BPF_CLASSID`;
+/// without preservation in [`NlOptions::classid`] the binding would be
+/// silently cleared on program replacement.
+#[test_log::test]
+fn netlink_attach_to_link_preserves_classid() {
+    if !cls_bpf_autoloads() {
+        return;
+    }
+
+    let _netns = NetNsGuard::new();
+
+    qdisc_add_clsact("lo").unwrap();
+
+    let mut bpf = Ebpf::load(TCX).unwrap();
+    let prog: &mut SchedClassifier = bpf.program_mut("tcx_next").unwrap().try_into().unwrap();
+    prog.load().unwrap();
+
+    let classid = TcHandle::new(1, 1);
+
+    let link_id = prog
+        .attach_with_options(
+            "lo",
+            TcAttachType::Ingress,
+            TcAttachOptions::Netlink(NlOptions {
+                classid: Some(classid),
+                ..Default::default()
+            }),
+        )
+        .unwrap();
+
+    let link = prog.take_link(link_id).unwrap();
+    assert_eq!(link.classid().unwrap(), Some(classid));
+
+    let new_link_id = prog.attach_to_link(link).unwrap();
+    let new_link = prog.take_link(new_link_id).unwrap();
+    assert_eq!(new_link.classid().unwrap(), Some(classid));
+}
+
+/// Verify that [`TcHandle::AUTO_ASSIGN`] triggers kernel allocation: the
+/// handle reported after attach must differ from the sentinel.
+#[test_log::test]
+fn netlink_attach_auto_assigns_handle() {
+    if !cls_bpf_autoloads() {
+        return;
+    }
+
+    let _netns = NetNsGuard::new();
+
+    qdisc_add_clsact("lo").unwrap();
+
+    let mut bpf = Ebpf::load(TCX).unwrap();
+    let prog: &mut SchedClassifier = bpf.program_mut("tcx_next").unwrap().try_into().unwrap();
+    prog.load().unwrap();
+
+    let link_id = prog
+        .attach_with_options(
+            "lo",
+            TcAttachType::Ingress,
+            TcAttachOptions::Netlink(NlOptions::default()),
+        )
+        .unwrap();
+
+    let link = prog.take_link(link_id).unwrap();
+    assert_ne!(link.handle().unwrap(), TcHandle::AUTO_ASSIGN);
+}
+
+/// Verify that an explicit [`TcHandle`] is preserved across netlink attach.
+#[test_log::test]
+fn netlink_attach_preserves_explicit_handle() {
+    if !cls_bpf_autoloads() {
+        return;
+    }
+
+    let _netns = NetNsGuard::new();
+
+    qdisc_add_clsact("lo").unwrap();
+
+    let mut bpf = Ebpf::load(TCX).unwrap();
+    let prog: &mut SchedClassifier = bpf.program_mut("tcx_next").unwrap().try_into().unwrap();
+    prog.load().unwrap();
+
+    let handle = TcHandle::new(1, 0xfffe);
+
+    let link_id = prog
+        .attach_with_options(
+            "lo",
+            TcAttachType::Ingress,
+            TcAttachOptions::Netlink(NlOptions {
+                handle,
+                ..Default::default()
+            }),
+        )
+        .unwrap();
+
+    let link = prog.take_link(link_id).unwrap();
+    assert_eq!(link.handle().unwrap(), handle);
+}

--- a/xtask/public-api/aya.txt
+++ b/xtask/public-api/aya.txt
@@ -4580,7 +4580,7 @@ impl core::marker::UnsafeUnpin for aya::programs::tc::TcError
 impl !core::panic::unwind_safe::RefUnwindSafe for aya::programs::tc::TcError
 impl !core::panic::unwind_safe::UnwindSafe for aya::programs::tc::TcError
 pub struct aya::programs::tc::NlOptions
-pub aya::programs::tc::NlOptions::handle: u32
+pub aya::programs::tc::NlOptions::handle: aya::programs::tc::TcHandle
 pub aya::programs::tc::NlOptions::priority: u16
 impl core::cmp::Eq for aya::programs::tc::NlOptions
 impl core::cmp::PartialEq for aya::programs::tc::NlOptions
@@ -4648,8 +4648,8 @@ impl core::panic::unwind_safe::UnwindSafe for aya::programs::tc::SchedClassifier
 pub struct aya::programs::tc::SchedClassifierLink(_)
 impl aya::programs::tc::SchedClassifierLink
 pub fn aya::programs::tc::SchedClassifierLink::attach_type(&self) -> core::result::Result<aya::programs::tc::TcAttachType, aya::programs::ProgramError>
-pub fn aya::programs::tc::SchedClassifierLink::attached(if_name: &str, attach_type: aya::programs::tc::TcAttachType, priority: u16, handle: u32) -> core::result::Result<Self, std::io::error::Error>
-pub fn aya::programs::tc::SchedClassifierLink::handle(&self) -> core::result::Result<u32, aya::programs::ProgramError>
+pub fn aya::programs::tc::SchedClassifierLink::attached(if_name: &str, attach_type: aya::programs::tc::TcAttachType, priority: u16, handle: aya::programs::tc::TcHandle) -> core::result::Result<Self, std::io::error::Error>
+pub fn aya::programs::tc::SchedClassifierLink::handle(&self) -> core::result::Result<aya::programs::tc::TcHandle, aya::programs::ProgramError>
 pub fn aya::programs::tc::SchedClassifierLink::priority(&self) -> core::result::Result<u16, aya::programs::ProgramError>
 impl aya::programs::MultiProgLink for aya::programs::tc::SchedClassifierLink
 pub fn aya::programs::tc::SchedClassifierLink::fd(&self) -> core::result::Result<std::os::fd::owned::BorrowedFd<'_>, aya::programs::links::LinkError>
@@ -4702,6 +4702,34 @@ impl core::marker::Unpin for aya::programs::tc::SchedClassifierLinkId
 impl core::marker::UnsafeUnpin for aya::programs::tc::SchedClassifierLinkId
 impl core::panic::unwind_safe::RefUnwindSafe for aya::programs::tc::SchedClassifierLinkId
 impl core::panic::unwind_safe::UnwindSafe for aya::programs::tc::SchedClassifierLinkId
+pub struct aya::programs::tc::TcHandle
+impl aya::programs::tc::TcHandle
+pub const aya::programs::tc::TcHandle::AUTO_ASSIGN: Self
+pub const fn aya::programs::tc::TcHandle::new(major: u16, minor: u16) -> Self
+impl core::clone::Clone for aya::programs::tc::TcHandle
+pub fn aya::programs::tc::TcHandle::clone(&self) -> aya::programs::tc::TcHandle
+impl core::cmp::Eq for aya::programs::tc::TcHandle
+impl core::cmp::PartialEq for aya::programs::tc::TcHandle
+pub fn aya::programs::tc::TcHandle::eq(&self, other: &aya::programs::tc::TcHandle) -> bool
+impl core::convert::From<aya::programs::tc::TcHandle> for u32
+pub fn u32::from(_: aya::programs::tc::TcHandle) -> Self
+impl core::convert::From<u32> for aya::programs::tc::TcHandle
+pub fn aya::programs::tc::TcHandle::from(value: u32) -> Self
+impl core::default::Default for aya::programs::tc::TcHandle
+pub fn aya::programs::tc::TcHandle::default() -> aya::programs::tc::TcHandle
+impl core::fmt::Debug for aya::programs::tc::TcHandle
+pub fn aya::programs::tc::TcHandle::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::hash::Hash for aya::programs::tc::TcHandle
+pub fn aya::programs::tc::TcHandle::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+impl core::marker::Copy for aya::programs::tc::TcHandle
+impl core::marker::StructuralPartialEq for aya::programs::tc::TcHandle
+impl core::marker::Freeze for aya::programs::tc::TcHandle
+impl core::marker::Send for aya::programs::tc::TcHandle
+impl core::marker::Sync for aya::programs::tc::TcHandle
+impl core::marker::Unpin for aya::programs::tc::TcHandle
+impl core::marker::UnsafeUnpin for aya::programs::tc::TcHandle
+impl core::panic::unwind_safe::RefUnwindSafe for aya::programs::tc::TcHandle
+impl core::panic::unwind_safe::UnwindSafe for aya::programs::tc::TcHandle
 pub fn aya::programs::tc::qdisc_add_clsact(if_name: &str) -> core::result::Result<(), aya::programs::tc::TcError>
 pub fn aya::programs::tc::qdisc_detach_program(if_name: &str, attach_type: aya::programs::tc::TcAttachType, name: &str) -> core::result::Result<(), aya::programs::tc::TcError>
 pub mod aya::programs::tp_btf
@@ -6853,6 +6881,34 @@ impl core::marker::Unpin for aya::programs::socket_filter::SocketFilter
 impl core::marker::UnsafeUnpin for aya::programs::socket_filter::SocketFilter
 impl core::panic::unwind_safe::RefUnwindSafe for aya::programs::socket_filter::SocketFilter
 impl core::panic::unwind_safe::UnwindSafe for aya::programs::socket_filter::SocketFilter
+pub struct aya::programs::TcHandle
+impl aya::programs::tc::TcHandle
+pub const aya::programs::tc::TcHandle::AUTO_ASSIGN: Self
+pub const fn aya::programs::tc::TcHandle::new(major: u16, minor: u16) -> Self
+impl core::clone::Clone for aya::programs::tc::TcHandle
+pub fn aya::programs::tc::TcHandle::clone(&self) -> aya::programs::tc::TcHandle
+impl core::cmp::Eq for aya::programs::tc::TcHandle
+impl core::cmp::PartialEq for aya::programs::tc::TcHandle
+pub fn aya::programs::tc::TcHandle::eq(&self, other: &aya::programs::tc::TcHandle) -> bool
+impl core::convert::From<aya::programs::tc::TcHandle> for u32
+pub fn u32::from(_: aya::programs::tc::TcHandle) -> Self
+impl core::convert::From<u32> for aya::programs::tc::TcHandle
+pub fn aya::programs::tc::TcHandle::from(value: u32) -> Self
+impl core::default::Default for aya::programs::tc::TcHandle
+pub fn aya::programs::tc::TcHandle::default() -> aya::programs::tc::TcHandle
+impl core::fmt::Debug for aya::programs::tc::TcHandle
+pub fn aya::programs::tc::TcHandle::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::hash::Hash for aya::programs::tc::TcHandle
+pub fn aya::programs::tc::TcHandle::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+impl core::marker::Copy for aya::programs::tc::TcHandle
+impl core::marker::StructuralPartialEq for aya::programs::tc::TcHandle
+impl core::marker::Freeze for aya::programs::tc::TcHandle
+impl core::marker::Send for aya::programs::tc::TcHandle
+impl core::marker::Sync for aya::programs::tc::TcHandle
+impl core::marker::Unpin for aya::programs::tc::TcHandle
+impl core::marker::UnsafeUnpin for aya::programs::tc::TcHandle
+impl core::panic::unwind_safe::RefUnwindSafe for aya::programs::tc::TcHandle
+impl core::panic::unwind_safe::UnwindSafe for aya::programs::tc::TcHandle
 pub struct aya::programs::TestRunAttrs
 impl aya::programs::TestRunAttrs
 pub const fn aya::programs::TestRunAttrs::new() -> Self

--- a/xtask/public-api/aya.txt
+++ b/xtask/public-api/aya.txt
@@ -4580,6 +4580,7 @@ impl core::marker::UnsafeUnpin for aya::programs::tc::TcError
 impl !core::panic::unwind_safe::RefUnwindSafe for aya::programs::tc::TcError
 impl !core::panic::unwind_safe::UnwindSafe for aya::programs::tc::TcError
 pub struct aya::programs::tc::NlOptions
+pub aya::programs::tc::NlOptions::classid: core::option::Option<aya::programs::tc::TcHandle>
 pub aya::programs::tc::NlOptions::handle: aya::programs::tc::TcHandle
 pub aya::programs::tc::NlOptions::priority: u16
 impl core::cmp::Eq for aya::programs::tc::NlOptions
@@ -4648,7 +4649,8 @@ impl core::panic::unwind_safe::UnwindSafe for aya::programs::tc::SchedClassifier
 pub struct aya::programs::tc::SchedClassifierLink(_)
 impl aya::programs::tc::SchedClassifierLink
 pub fn aya::programs::tc::SchedClassifierLink::attach_type(&self) -> core::result::Result<aya::programs::tc::TcAttachType, aya::programs::ProgramError>
-pub fn aya::programs::tc::SchedClassifierLink::attached(if_name: &str, attach_type: aya::programs::tc::TcAttachType, priority: u16, handle: aya::programs::tc::TcHandle) -> core::result::Result<Self, std::io::error::Error>
+pub fn aya::programs::tc::SchedClassifierLink::attached(if_name: &str, attach_type: aya::programs::tc::TcAttachType, priority: u16, handle: aya::programs::tc::TcHandle, classid: core::option::Option<aya::programs::tc::TcHandle>) -> core::result::Result<Self, std::io::error::Error>
+pub fn aya::programs::tc::SchedClassifierLink::classid(&self) -> core::result::Result<core::option::Option<aya::programs::tc::TcHandle>, aya::programs::ProgramError>
 pub fn aya::programs::tc::SchedClassifierLink::handle(&self) -> core::result::Result<aya::programs::tc::TcHandle, aya::programs::ProgramError>
 pub fn aya::programs::tc::SchedClassifierLink::priority(&self) -> core::result::Result<u16, aya::programs::ProgramError>
 impl aya::programs::MultiProgLink for aya::programs::tc::SchedClassifierLink


### PR DESCRIPTION
Adds `classid` support to `SchedClassifier` netlink attach so a TC
filter can target a specific qdisc class. In direct-action mode the
kernel splits the resulting class id between the userspace-supplied
`TCA_BPF_CLASSID` (upper 16 bits) and the program-written
`__sk_buff::tc_classid` (lower 16 bits). Without setting the upper
half from userspace, programs writing `tc_classid` had no effect on
qdisc routing.

A new `TcHandle` newtype replaces the raw `u32` filter handle on
`NlOptions`/`NlLink` and is reused for `Option<TcHandle>` classid
since both encode `(major << 16) | minor`. `TcHandle::AUTO_ASSIGN`
documents the kernel's auto-allocate sentinel.

`SchedClassifierLink::attach_to_link` preserves the classid across
atomic program replacement: `cls_bpf_change` allocates a fresh
`cls_bpf_prog` on every replace and only binds `prog->res.classid`
if the request carries `TCA_BPF_CLASSID`, so the value is stored
on `NlLink` and reemitted on replace.

The integration tests in `tc_netlink.rs` cover classid preservation,
`AUTO_ASSIGN` triggering kernel allocation, and explicit handle
round-trip. They skip on kernels older than 6.10 where the
test-distro modprobe stub cannot autoload `cls_bpf`.

Fixes #886.

### Added/updated tests?

- [x] Yes

### Checklist

- [x] Rust code has been formatted with \`cargo +nightly fmt\`.
- [x] All clippy lints have been fixed.
      You can find failing lints with \`cargo xtask clippy\`.
- [x] Unit tests are passing locally with \`cargo test\`.
- [x] The integration tests are passing locally.
- [x] I have blessed any API changes with \`cargo xtask public-api --bless\`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aya-rs/aya/1571)
<!-- Reviewable:end -->
