### PR TITLE
integration-test: dedupe test_case tests

### DIFF
--- a/test/integration-test/src/tests/array.rs
+++ b/test/integration-test/src/tests/array.rs
@@ -30,7 +30,7 @@ extern "C" fn get_ptr_mut(index: u32) {
     std::hint::black_box(index);
 }
 
-#[test_case(
+#[test_log::test(test_case(
     "RESULT_LEGACY",
     "ARRAY_LEGACY",
     "set_legacy",
@@ -38,7 +38,7 @@ extern "C" fn get_ptr_mut(index: u32) {
     "get_ptr_legacy",
     "get_ptr_mut_legacy"
     ; "legacy"
-)]
+))]
 #[test_case(
     "RESULT",
     "ARRAY",
@@ -48,7 +48,6 @@ extern "C" fn get_ptr_mut(index: u32) {
     "get_ptr_mut"
     ; "btf"
 )]
-#[test_log::test]
 fn test_array(
     result_map: &str,
     array_map: &str,

--- a/test/integration-test/src/tests/bloom_filter.rs
+++ b/test/integration-test/src/tests/bloom_filter.rs
@@ -23,19 +23,18 @@ extern "C" fn trigger_bloom_contains(result_index: u32, value: u32) {
     core::hint::black_box(value);
 }
 
-#[test_case(
+#[test_log::test(test_case(
     "RESULT_LEGACY",
     "FILTER_LEGACY",
     "bloom_filter_insert_legacy",
     "bloom_filter_contains_legacy" ; "legacy"
-)]
+))]
 #[test_case(
     "RESULT",
     "FILTER",
     "btf_bloom_filter_insert",
     "btf_bloom_filter_contains" ; "btf"
 )]
-#[test_log::test]
 fn bloom_filter_basic(result_map: &str, filter_map: &str, insert_prog: &str, contains_prog: &str) {
     if !is_map_supported(MapType::BloomFilter).unwrap() {
         eprintln!("skipping test - bloom filter map not supported");

--- a/test/integration-test/src/tests/btf_map_of_maps.rs
+++ b/test/integration-test/src/tests/btf_map_of_maps.rs
@@ -94,9 +94,8 @@ extern "C" fn trigger_btf_hash_of_maps_get_value() {
     std::hint::black_box(());
 }
 
-#[test_case(MapKind::Array, "btf_array_of_maps", 0, 42 ; "array_of_maps")]
+#[test_log::test(test_case(MapKind::Array, "btf_array_of_maps", 0, 42 ; "array_of_maps"))]
 #[test_case(MapKind::Hash, "btf_hash_of_maps", 1, 55 ; "hash_of_maps")]
-#[test_log::test]
 fn btf_map_of_maps(kind: MapKind, name: &str, result_index: u32, expected: u32) {
     let mut ebpf = Ebpf::load(crate::BTF_MAP_OF_MAPS).unwrap();
 
@@ -110,9 +109,8 @@ fn btf_map_of_maps(kind: MapKind, name: &str, result_index: u32, expected: u32) 
     assert_result(&ebpf, result_index, expected);
 }
 
-#[test_case(MapKind::Array, "btf_array_of_maps_get_value", 2, 77, 99 ; "array_of_maps")]
+#[test_log::test(test_case(MapKind::Array, "btf_array_of_maps_get_value", 2, 77, 99 ; "array_of_maps"))]
 #[test_case(MapKind::Hash, "btf_hash_of_maps_get_value", 3, 55, 88 ; "hash_of_maps")]
-#[test_log::test]
 fn btf_map_of_maps_get_value(
     kind: MapKind,
     name: &str,

--- a/test/integration-test/src/tests/btf_relocations.rs
+++ b/test/integration-test/src/tests/btf_relocations.rs
@@ -9,7 +9,7 @@ use test_case::test_case;
 #[derive(Debug)]
 enum Requirements {}
 
-#[test_case(crate::ENUM_SIGNED_32_RELOC_BPF, None, None,-0x7AAAAAAAi32 as u64)]
+#[test_log::test(test_case(crate::ENUM_SIGNED_32_RELOC_BPF, None, None,-0x7AAAAAAAi32 as u64))]
 #[test_case(crate::ENUM_SIGNED_32_RELOC_BPF, Some(crate::ENUM_SIGNED_32_RELOC_BTF),  None, -0x7BBBBBBBi32 as u64)]
 #[test_case(crate::ENUM_SIGNED_32_CHECKED_VARIANTS_RELOC_BPF, None, None,-0x7AAAAAAAi32 as u64)]
 #[test_case(crate::ENUM_SIGNED_32_CHECKED_VARIANTS_RELOC_BPF, Some(crate::ENUM_SIGNED_32_CHECKED_VARIANTS_RELOC_BTF),  None, -0x7BBBBBBBi32 as u64)]
@@ -66,7 +66,6 @@ enum Requirements {}
     None,
     2
 )]
-#[test_log::test]
 fn relocation_tests(
     bpf: &[u8],
     btf: Option<&[u8]>,

--- a/test/integration-test/src/tests/load.rs
+++ b/test/integration-test/src/tests/load.rs
@@ -367,13 +367,12 @@ fn basic_tracepoint() {
     );
 }
 
-#[test_case(UProbeScope::AllProcesses; "all_processes")]
+#[test_log::test(test_case(UProbeScope::AllProcesses; "all_processes"))]
 #[test_case(UProbeScope::CallingProcess; "calling_process")]
 #[test_case(
     UProbeScope::OneProcess(NonZeroU32::new(std::process::id()).unwrap());
     "one_process"
 )]
-#[test_log::test]
 fn basic_uprobe_scopes(scope: UProbeScope) {
     type P = UProbe;
 

--- a/test/integration-test/src/tests/lpm_trie.rs
+++ b/test/integration-test/src/tests/lpm_trie.rs
@@ -12,9 +12,8 @@ extern "C" fn trigger_lpm_trie() {
     core::hint::black_box(());
 }
 
-#[test_case("test_btf_lpm_trie", "ROUTES", "RESULTS" ; "btf")]
+#[test_log::test(test_case("test_btf_lpm_trie", "ROUTES", "RESULTS" ; "btf"))]
 #[test_case("test_lpm_trie_legacy", "ROUTES_LEGACY", "RESULTS_LEGACY" ; "legacy")]
-#[test_log::test]
 fn lpm_trie_basic(prog_name: &str, routes_map: &str, results_map: &str) {
     let mut bpf = Ebpf::load(crate::LPM_TRIE).unwrap();
 

--- a/test/integration-test/src/tests/per_cpu_array.rs
+++ b/test/integration-test/src/tests/per_cpu_array.rs
@@ -32,7 +32,7 @@ extern "C" fn trigger_set(index: u32, value: u32) {
     std::hint::black_box((index, value));
 }
 
-#[test_case(
+#[test_log::test(test_case(
     "RESULT_LEGACY",
     "ARRAY_LEGACY",
     "get_legacy",
@@ -40,7 +40,7 @@ extern "C" fn trigger_set(index: u32, value: u32) {
     "get_ptr_mut_legacy",
     "set_legacy"
     ; "legacy"
-)]
+))]
 #[test_case(
     "RESULT",
     "ARRAY",
@@ -50,7 +50,6 @@ extern "C" fn trigger_set(index: u32, value: u32) {
     "set"
     ; "btf"
 )]
-#[test_log::test]
 fn per_cpu_array_basic(
     result_map: &str,
     array_map: &str,

--- a/test/integration-test/src/tests/perf_event_array.rs
+++ b/test/integration-test/src/tests/perf_event_array.rs
@@ -12,11 +12,10 @@ extern "C" fn trigger_emit_event() {
     std::hint::black_box(());
 }
 
-#[test_case(crate::PERF_EVENT_ARRAY, "EVENTS_LEGACY", "emit_event_legacy" ; "legacy")]
+#[test_log::test(test_case(crate::PERF_EVENT_ARRAY, "EVENTS_LEGACY", "emit_event_legacy" ; "legacy"))]
 #[test_case(crate::PERF_EVENT_ARRAY, "EVENTS", "emit_event" ; "btf")]
 #[test_case(crate::PERF_EVENT_BYTE_ARRAY, "EVENTS_LEGACY", "emit_event_legacy" ; "byte_legacy")]
 #[test_case(crate::PERF_EVENT_BYTE_ARRAY, "EVENTS", "emit_event" ; "byte_btf")]
-#[test_log::test]
 fn emit_event(bpf_obj: &[u8], events_map: &str, prog: &str) {
     let mut bpf = EbpfLoader::new()
         .load(bpf_obj)

--- a/test/integration-test/src/tests/prog_array.rs
+++ b/test/integration-test/src/tests/prog_array.rs
@@ -21,17 +21,16 @@ extern "C" fn trigger_tail_call_success() {
     std::hint::black_box(());
 }
 
-#[test_case(
+#[test_log::test(test_case(
     "RESULT_LEGACY",
     "tail_call_empty_legacy"
     ; "legacy"
-)]
+))]
 #[test_case(
     "RESULT",
     "tail_call_empty"
     ; "btf"
 )]
-#[test_log::test]
 fn tail_call_empty(result_map: &str, entry_prog: &str) {
     if !is_map_supported(MapType::ProgramArray).unwrap() {
         eprintln!("skipping test - program array map not supported");
@@ -67,13 +66,13 @@ fn tail_call_empty(result_map: &str, entry_prog: &str) {
     );
 }
 
-#[test_case(
+#[test_log::test(test_case(
     "RESULT_LEGACY",
     "ARRAY_LEGACY",
     "tail_call_empty_legacy",
     "tail_call_target_legacy"
     ; "legacy"
-)]
+))]
 #[test_case(
     "RESULT",
     "ARRAY",
@@ -81,7 +80,6 @@ fn tail_call_empty(result_map: &str, entry_prog: &str) {
     "tail_call_target"
     ; "btf"
 )]
-#[test_log::test]
 fn tail_call_success(result_map: &str, array_map: &str, entry_prog: &str, target_prog: &str) {
     if !is_map_supported(MapType::ProgramArray).unwrap() {
         eprintln!("skipping test - program array map not supported");

--- a/test/integration-test/src/tests/sk_lookup.rs
+++ b/test/integration-test/src/tests/sk_lookup.rs
@@ -56,11 +56,10 @@ impl MapKind {
     }
 }
 
-#[test_case(crate::SOCK_HASH, MapKind::Hash, "SOCKETS_LEGACY", "sk_lookup_legacy" ; "sock_hash legacy")]
+#[test_log::test(test_case(crate::SOCK_HASH, MapKind::Hash, "SOCKETS_LEGACY", "sk_lookup_legacy" ; "sock_hash legacy"))]
 #[test_case(crate::SOCK_HASH, MapKind::Hash, "SOCKETS_BTF", "sk_lookup_btf" ; "sock_hash btf")]
 #[test_case(crate::SOCK_MAP, MapKind::Map, "SOCKETS_LEGACY", "sk_lookup_legacy" ; "sock_map legacy")]
 #[test_case(crate::SOCK_MAP, MapKind::Map, "SOCKETS_BTF", "sk_lookup_btf" ; "sock_map btf")]
-#[test_log::test]
 fn redirect_sk_lookup(bpf_bytes: &[u8], kind: MapKind, map_name: &str, prog_name: &str) {
     if !is_map_supported(kind.map_type()).unwrap() {
         eprintln!("skipping test - {:?} not supported", kind.map_type());
@@ -104,11 +103,10 @@ fn redirect_sk_lookup(bpf_bytes: &[u8], kind: MapKind, map_name: &str, prog_name
     drop(stream);
 }
 
-#[test_case(crate::SOCK_HASH, MapKind::Hash, "sk_lookup_legacy" ; "sock_hash legacy")]
+#[test_log::test(test_case(crate::SOCK_HASH, MapKind::Hash, "sk_lookup_legacy" ; "sock_hash legacy"))]
 #[test_case(crate::SOCK_HASH, MapKind::Hash, "sk_lookup_btf" ; "sock_hash btf")]
 #[test_case(crate::SOCK_MAP, MapKind::Map, "sk_lookup_legacy" ; "sock_map legacy")]
 #[test_case(crate::SOCK_MAP, MapKind::Map, "sk_lookup_btf" ; "sock_map btf")]
-#[test_log::test]
 fn redirect_sk_lookup_miss_propagates_enoent(bpf_bytes: &[u8], kind: MapKind, prog_name: &str) {
     if !is_map_supported(kind.map_type()).unwrap() {
         eprintln!("skipping test - {:?} not supported", kind.map_type());

--- a/test/integration-test/src/tests/stack_trace.rs
+++ b/test/integration-test/src/tests/stack_trace.rs
@@ -13,9 +13,8 @@ extern "C" fn trigger_record_stackid() {
     std::hint::black_box(());
 }
 
-#[test_case("STACKS_LEGACY", "RESULT_LEGACY", "record_stackid_legacy" ; "legacy")]
+#[test_log::test(test_case("STACKS_LEGACY", "RESULT_LEGACY", "record_stackid_legacy" ; "legacy"))]
 #[test_case("STACKS", "RESULT", "record_stackid" ; "btf")]
-#[test_log::test]
 fn record_stackid(stacks_map: &str, result_map: &str, prog: &str) {
     if !is_map_supported(MapType::StackTrace).unwrap() {
         eprintln!("skipping test - stack trace map not supported");

--- a/test/integration-test/src/tests/stack_trace_lsm.rs
+++ b/test/integration-test/src/tests/stack_trace_lsm.rs
@@ -8,9 +8,8 @@ use aya::{
 use integration_common::stack_trace::TestResult;
 use test_case::test_case;
 
-#[test_case("STACKS_LEGACY", "RESULT_LEGACY", "record_stackid_lsm_legacy" ; "legacy")]
+#[test_log::test(test_case("STACKS_LEGACY", "RESULT_LEGACY", "record_stackid_lsm_legacy" ; "legacy"))]
 #[test_case("STACKS", "RESULT", "record_stackid_lsm" ; "btf")]
-#[test_log::test]
 fn record_stackid_lsm(stacks_map: &str, result_map: &str, prog: &str) {
     if !is_map_supported(MapType::StackTrace).unwrap() {
         eprintln!("skipping test - stack trace map not supported");

--- a/test/integration-test/src/tests/xdp.rs
+++ b/test/integration-test/src/tests/xdp.rs
@@ -13,9 +13,8 @@ use xdpilone::{BufIdx, IfInfo, Socket, SocketConfig, Umem, UmemConfig};
 
 use crate::utils::NetNsGuard;
 
-#[test_case("SOCKS", "redirect_sock"; "legacy")]
+#[test_log::test(test_case("SOCKS", "redirect_sock"; "legacy"))]
 #[test_case("SOCKS_BTF", "redirect_sock_btf"; "btf")]
-#[test_log::test]
 fn af_xdp(socks_name: &str, prog_name: &str) {
     let _netns = NetNsGuard::new();
 
@@ -160,9 +159,8 @@ fn map_load() {
     bpf.program("xdp_frags_devmap").unwrap();
 }
 
-#[test_case("CPUS", "redirect_cpu"; "legacy")]
+#[test_log::test(test_case("CPUS", "redirect_cpu"; "legacy"))]
 #[test_case("CPUS_BTF", "redirect_cpu_btf"; "btf")]
-#[test_log::test]
 fn cpumap_chain(cpus_name: &str, prog_name: &str) {
     let _netns = NetNsGuard::new();
 
@@ -220,19 +218,18 @@ fn cpumap_chain(cpus_name: &str, prog_name: &str) {
     assert_eq!(hits.get(&1, 0).unwrap(), 1);
 }
 
-#[test_case(
+#[test_log::test(test_case(
     "DEVS", "DEVS_HASH",
     "redirect_dev", "redirect_dev_hash",
     "get_dev", "get_dev_hash";
     "legacy"
-)]
+))]
 #[test_case(
     "DEVS_BTF", "DEVS_HASH_BTF",
     "redirect_dev_btf", "redirect_dev_hash_btf",
     "get_dev_btf", "get_dev_hash_btf";
     "btf"
 )]
-#[test_log::test]
 fn devmap_set(
     devs_name: &str,
     devs_hash_name: &str,
@@ -276,11 +273,10 @@ fn devmap_set(
     }
 }
 
-#[test_case("get_ifindex_dev"; "legacy_array")]
+#[test_log::test(test_case("get_ifindex_dev"; "legacy_array"))]
 #[test_case("get_ifindex_dev_hash"; "legacy_hash")]
 #[test_case("get_ifindex_dev_btf"; "btf_array")]
 #[test_case("get_ifindex_dev_hash_btf"; "btf_hash")]
-#[test_log::test]
 fn devmap_get_ifindex(prog_name: &str) {
     let _netns = NetNsGuard::new();
     let mut bpf = Ebpf::load(crate::DEV_MAP).unwrap();


### PR DESCRIPTION
I just realized that some e2e tests were running twice. This PR fixes that issue.

```
test tests::btf_map_of_maps::btf_map_of_maps_get_value::array_of_maps ... ok
test tests::btf_map_of_maps::btf_map_of_maps_get_value::array_of_maps ... ok
test tests::btf_map_of_maps::btf_map_of_maps_get_value::hash_of_maps ... ok
test tests::btf_map_of_maps::btf_map_of_maps_get_value::hash_of_maps ... ok
test tests::btf_maps::libbpf_can_load_btf_maps ... ok
test tests::btf_relocations::relocation_tests::crate_enum_signed_32_checked_variants_reloc_bpf_none_none_0x7aaaaaaai32_as_u64_expects ... ok
test tests::btf_relocations::relocation_tests::crate_enum_signed_32_checked_variants_reloc_bpf_none_none_0x7aaaaaaai32_as_u64_expects ... ok
test tests::btf_relocations::relocation_tests::crate_enum_signed_32_checked_variants_reloc_bpf_some_crate_enum_signed_32_checked_variants_reloc_btf_none_0x7bbbbbbbi32_as_u64_expects ... ok
test tests::btf_relocations::relocation_tests::crate_enum_signed_32_checked_variants_reloc_bpf_some_crate_enum_signed_32_checked_variants_reloc_btf_none_0x7bbbbbbbi32_as_u64_expects ... ok
test tests::btf_relocations::relocation_tests::crate_enum_signed_32_reloc_bpf_none_none_0x7aaaaaaai32_as_u64_expects ... ok
test tests::btf_relocations::relocation_tests::crate_enum_signed_32_reloc_bpf_none_none_0x7aaaaaaai32_as_u64_expects ... ok

```

<!-- markdownlint-disable first-line-heading -->

<!--
    Thank you for your contribution to Aya! 🎉

    For Work In Progress Pull Requests, please use the Draft PR feature.

    Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Aya Contributing Guide: https://github.com/aya-rs/aya/blob/main/CONTRIBUTING.md
     - 📖 Read the Aya Code of Conduct: https://github.com/aya-rs/aya/blob/main/CODE_OF_CONDUCT.md
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages: https://cbea.ms/git-commit/
     - 📗 Update any related documentation.

-->

<!---
      Summarize the changes you're making here. Detailed information belongs in
      the Git commit messages. If your pull request contains just one commit,
      it's best to use its message as a summary. Otherwise, if there are multiple
      atomic commits, write a summary for the entire PR. Feel free to flag
      anything you think needs a reviewer's attention.
-->

<!--
      If your changes address an issue, link it with the *Fixes* tag so
      the issue gets closed when the PR is merged, for example:

      Fixes: #1234

      If you are only referencing an issue without fully addressing it, feel
      free to link it anywhere in the summary.
-->

### Added/updated tests?

_We strongly encourage you to add a test for your changes._

- [x] Yes

### Checklist

- [x] Rust code has been formatted with `cargo +nightly fmt`.
- [x] All clippy lints have been fixed.
      You can find failing lints with `cargo xtask clippy`.
- [x] Unit tests are passing locally with `cargo test`.
- [x] The [Integration tests] are passing locally.
- [x] I have blessed any API changes with `cargo xtask public-api --bless`.

[Integration tests]: https://github.com/aya-rs/aya/blob/main/test/README.md

### (Optional) What GIF best describes this PR or how it makes you feel?

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aya-rs/aya/1573)
<!-- Reviewable:end -->
