### PR TITLE
add FExitContext::ret and support test-run for fexit

### DIFF
--- a/aya-ebpf-macros/src/lib.rs
+++ b/aya-ebpf-macros/src/lib.rs
@@ -566,18 +566,19 @@ pub fn fentry(attrs: TokenStream, item: TokenStream) -> TokenStream {
 /// any function inside the kernel.
 ///
 /// The difference between fexit and kretprobe is that fexit has practically
-/// zero overhead to call after kernel function and it focuses on access to
-/// arguments rather than the return value. fexit programs can be also attached
-/// to other eBPF programs.
+/// zero overhead to call after the kernel function returns. Fexit programs can
+/// access arguments, can access the return value with `FExitContext::ret`, and
+/// can also be attached to other eBPF programs.
 ///
 /// # Minimum kernel version
 ///
-/// The minimum kernel version required to use this feature is 5.5.
+/// The minimum kernel version required to use fexit programs is 5.5. Accessing
+/// the return value with `FExitContext::ret` requires Linux 5.17 or later.
 ///
 /// # Examples
 ///
 /// ```no_run
-/// use aya_ebpf::{macros::fexit, programs::FExitContext};
+/// use aya_ebpf::{cty::c_int, macros::fexit, programs::FExitContext};
 /// # #[expect(non_camel_case_types)]
 /// # type filename = u32;
 /// # #[expect(non_camel_case_types)]
@@ -594,6 +595,7 @@ pub fn fentry(attrs: TokenStream, item: TokenStream) -> TokenStream {
 /// unsafe fn try_filename_lookup(ctx: FExitContext) -> Result<i32, i32> {
 ///     let _f: *const filename = ctx.arg(1);
 ///     let _p: *const path = ctx.arg(3);
+///     let _retval: c_int = ctx.ret()?;
 ///
 ///     Ok(0)
 /// }

--- a/aya/src/programs/fexit.rs
+++ b/aya/src/programs/fexit.rs
@@ -10,17 +10,30 @@ use crate::programs::{
     load_program_with_attach_type, utils::attach_raw_tracepoint,
 };
 
-/// A program that can be attached to the exit point of (almost) anny kernel
+/// A program that can be attached to the exit point of (almost) any kernel
 /// function.
 ///
 /// [`FExit`] programs are similar to [kretprobes](crate::programs::KProbe),
 /// but the difference is that fexit has practically zero overhead to call
-/// before kernel function. Fexit programs can be also attached to other eBPF
-/// programs.
+/// after the kernel function returns. Fexit programs can also be attached to
+/// other eBPF programs.
 ///
 /// # Minimum kernel version
 ///
 /// The minimum kernel version required to use this feature is 5.5.
+///
+/// # Test runs
+///
+/// [`TestRun`](crate::programs::TestRun) support for [`FExit`] programs uses
+/// the kernel's tracing `BPF_PROG_TEST_RUN` handler. That handler does not call
+/// the function passed to [`FExit::load`]. Instead, it runs the kernel's fixed
+/// `bpf_fentry_test*` sequence, so the [`FExit`] program is executed only when
+/// it is attached to one of those built-in test targets.
+/// <https://github.com/torvalds/linux/blob/v7.1-rc4/net/bpf/test_run.c#L702-L715>
+///
+/// A successful test-run syscall means the kernel sequence completed. To check
+/// that an [`FExit`] program ran, record and verify an explicit side effect such
+/// as a map update. `Ok(())` does not mean this [`FExit`] program ran.
 ///
 /// # Examples
 ///

--- a/aya/src/programs/mod.rs
+++ b/aya/src/programs/mod.rs
@@ -141,7 +141,8 @@ use crate::{
     sys::{
         EbpfLoadProgramAttrs, NetlinkError, ProgQueryTarget, SyscallError, bpf_btf_get_fd_by_id,
         bpf_get_object, bpf_link_get_fd_by_id, bpf_load_program, bpf_pin_object,
-        bpf_prog_get_fd_by_id, bpf_prog_query, iter_link_ids, retry_with_verifier_logs,
+        bpf_prog_get_fd_by_id, bpf_prog_query, bpf_prog_test_run, bpf_prog_test_run_raw_tp,
+        bpf_prog_test_run_tracing, iter_link_ids, retry_with_verifier_logs,
     },
     util::KernelVersion,
 };
@@ -624,7 +625,7 @@ fn test_run<T: Link>(
     opts: TestRunOptions<'_>,
 ) -> Result<TestRunResult, ProgramError> {
     let fd = data.fd()?.as_fd();
-    crate::sys::bpf_prog_test_run(fd, opts).map_err(Into::into)
+    bpf_prog_test_run(fd, opts).map_err(Into::into)
 }
 
 fn test_run_raw_tp<T: Link>(
@@ -632,7 +633,12 @@ fn test_run_raw_tp<T: Link>(
     opts: RawTracePointRunOptions,
 ) -> Result<RawTracePointTestRunResult, ProgramError> {
     let fd = data.fd()?.as_fd();
-    crate::sys::bpf_prog_test_run_raw_tp(fd, opts).map_err(Into::into)
+    bpf_prog_test_run_raw_tp(fd, opts).map_err(Into::into)
+}
+
+fn test_run_tracing<T: Link>(data: &ProgramData<T>) -> Result<(), ProgramError> {
+    let fd = data.fd()?.as_fd();
+    bpf_prog_test_run_tracing(fd).map_err(Into::into)
 }
 
 fn unload_program<T: Link>(data: &mut ProgramData<T>) -> Result<(), ProgramError> {
@@ -1059,8 +1065,9 @@ pub trait TestRun {
     /// The options type used to configure a single test invocation.
     ///
     /// Different program types require different options: skb/XDP programs use
-    /// [`TestRunOptions`], while [`RawTracePoint`] programs use
-    /// [`RawTracePointRunOptions`].
+    /// [`TestRunOptions`], raw tracepoint programs use
+    /// [`RawTracePointRunOptions`], and [`FExit`] programs use `()`. See
+    /// [`FExit`] for the tracing-specific test-run semantics.
     type Opts<'a>;
 
     /// The Result type for a single test invocation.
@@ -1080,7 +1087,8 @@ pub trait TestRun {
     /// Returns a [`Self::Result`] containing the program-specific test output.
     ///
     /// For most program types this is [`crate::TestRunResult`]. For
-    /// [`RawTracePoint`] it is [`RawTracePointTestRunResult`].
+    /// [`RawTracePoint`] it is [`RawTracePointTestRunResult`]. For [`FExit`]
+    /// it is `()`; see [`FExit`] for what a successful tracing test run means.
     ///
     /// # Errors
     ///
@@ -1130,6 +1138,21 @@ impl TestRun for RawTracePoint {
 
     fn test_run(&self, opts: Self::Opts<'_>) -> Result<Self::Result, ProgramError> {
         test_run_raw_tp(&self.data, opts)
+    }
+}
+
+impl TestRun for FExit {
+    // The kernel tracing test-run handler uses a fixed synthetic fentry/fexit
+    // call sequence; packet data, context data, repeat count, CPU pinning, and
+    // batch flags do not apply.
+    // https://github.com/torvalds/linux/blob/v7.1-rc4/net/bpf/test_run.c#L690-L735
+    type Opts<'a> = ();
+    // For fentry/fexit, test-run success only reports that the kernel's fixed
+    // synthetic call sequence ran.
+    type Result = ();
+
+    fn test_run(&self, _opts: Self::Opts<'_>) -> Result<Self::Result, ProgramError> {
+        test_run_tracing(&self.data)
     }
 }
 

--- a/aya/src/sys/bpf.rs
+++ b/aya/src/sys/bpf.rs
@@ -703,6 +703,25 @@ pub(crate) fn bpf_prog_test_run_raw_tp(
     })
 }
 
+/// Run a loaded tracing program through the kernel's synthetic fentry/fexit
+/// test path.
+pub(crate) fn bpf_prog_test_run_tracing(prog_fd: BorrowedFd<'_>) -> Result<(), SyscallError> {
+    let mut attr = unsafe { mem::zeroed::<bpf_attr>() };
+    // The tracing test-run handler uses a fixed synthetic call sequence instead
+    // of caller-provided input. It rejects non-zero flags, CPU, and batch size,
+    // so only prog_fd is set here.
+    // https://github.com/torvalds/linux/blob/v7.1-rc4/net/bpf/test_run.c#L699-L715
+    let test = unsafe { &mut attr.test };
+    test.prog_fd = prog_fd.as_raw_fd() as u32;
+
+    invoke_prog_test_run(&mut attr)?;
+    // For fentry/fexit, the tracing test-run handler writes 0 to attr.test.retval
+    // after the fixed synthetic call sequence succeeds. That value carries no
+    // extra information beyond syscall success.
+    // https://github.com/torvalds/linux/blob/v7.1-rc4/net/bpf/test_run.c#L695-L732
+    Ok(())
+}
+
 /// Introduced in kernel v4.13.
 fn bpf_obj_get_info_by_fd<T, F: FnOnce(&mut T)>(
     fd: BorrowedFd<'_>,

--- a/aya/src/sys/feature_probe.rs
+++ b/aya/src/sys/feature_probe.rs
@@ -270,15 +270,23 @@ pub fn is_program_supported(program_type: ProgramType) -> Result<bool, ProgramEr
                 })),
             },
             Ok(prog_fd) => {
-                // Some arm64 kernels (notably < 6.4) can load LSM programs but cannot attach them:
-                // `bpf_raw_tracepoint_open` fails with `-ENOTSUPP`. Probe attach support
-                // explicitly.
+                // Some kernels can load tracing and LSM programs but cannot attach BPF
+                // trampolines: `bpf_raw_tracepoint_open` routes them to
+                // `bpf_tracing_prog_attach()`, and trampoline registration can fail with
+                // `-ENOTSUPP`. Probe attach support explicitly. This is notably seen on arm64
+                // kernels before 6.4.
+                //
+                // https://github.com/torvalds/linux/blob/v6.3/kernel/bpf/syscall.c#L3319-L3333
+                // https://github.com/torvalds/linux/blob/v6.3/kernel/bpf/trampoline.c#L234-L237
                 //
                 // h/t to https://www.exein.io/blog/exploring-bpf-lsm-support-on-aarch64-with-ftrace.
                 //
                 // The same test for cGroup LSM programs would require attaching to a real cgroup,
                 // which is more involved and not possible in the general case.
-                if matches!(program_type, ProgramType::Lsm(LsmAttachType::Mac)) {
+                if matches!(
+                    program_type,
+                    ProgramType::Tracing | ProgramType::Lsm(LsmAttachType::Mac)
+                ) {
                     match bpf_raw_tracepoint_open(None, prog_fd.as_fd()) {
                         Ok(_) => Ok(true),
                         Err(io_error) => match io_error.raw_os_error() {

--- a/ebpf/aya-ebpf/src/programs/fexit.rs
+++ b/ebpf/aya-ebpf/src/programs/fexit.rs
@@ -1,6 +1,6 @@
 use core::ffi::c_void;
 
-use crate::{Argument, EbpfContext, args::btf_arg};
+use crate::{Argument, EbpfContext, args::btf_arg, helpers::bpf_get_func_ret};
 
 pub struct FExitContext {
     ctx: *mut c_void,
@@ -11,7 +11,7 @@ impl FExitContext {
         Self { ctx }
     }
 
-    /// Returns the `n`th argument to passed to the probe function, starting from 0.
+    /// Returns the `n`th argument passed to the probed function, starting from 0.
     ///
     /// # Examples
     ///
@@ -33,6 +33,66 @@ impl FExitContext {
     /// ```
     pub fn arg<T: Argument>(&self, n: usize) -> T {
         btf_arg(self, n)
+    }
+
+    /// Returns the value returned by the probed function.
+    ///
+    /// This uses the [`bpf_get_func_ret`] helper, so programs that call this
+    /// method require Linux 5.17 or later. On unsupported tracing attach types
+    /// the helper returns `-EOPNOTSUPP`.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use aya_ebpf::{cty::c_int, programs::FExitContext};
+    /// unsafe fn try_filename_lookup(ctx: FExitContext) -> Result<u32, i32> {
+    ///     let retval: c_int = ctx.ret()?;
+    ///
+    ///     // Do something with retval
+    ///
+    ///     Ok(0)
+    /// }
+    /// ```
+    ///
+    /// [`bpf_get_func_ret`]: crate::helpers::bpf_get_func_ret
+    pub fn ret<T: Argument>(&self) -> Result<T, i32> {
+        let mut ret_val = 0;
+        let err = unsafe { bpf_get_func_ret(self.as_ptr(), &raw mut ret_val) };
+
+        // Keep the helper status from becoming linked with the traced function
+        // return value in the verifier's scalar tracking.
+        //
+        // `bpf_get_func_ret` follows the normal BPF helper ABI: the helper
+        // status is returned in R0, while the traced function return value is
+        // written through `ret_val`. Kernels v5.10 through v6.7 can mishandle
+        // precision tracking for linked scalar registers. For this helper, the
+        // affected range starts at v5.17, when `bpf_get_func_ret` was added. If
+        // LLVM emits a phi merge that shares a scalar id between the helper
+        // status and `ret_val`, and the caller then narrows `ret_val` to `T`,
+        // the verifier can incorrectly conclude that the traced return value is
+        // zero and prune the caller's success branch.
+        //
+        // Rust makes this easy to trigger because `Result<T, i32>` keeps the
+        // helper status and the traced return value live across the same match.
+        // For integer-like `T`, both arms have similar scalar shapes and LLVM
+        // may reuse registers around the merge, followed by a narrowing
+        // sequence that the affected verifier mishandles.
+        //
+        // Passing the helper status through `black_box` forces a stack
+        // spill/reload, breaking that verifier-side scalar relationship without
+        // changing runtime semantics.
+        //
+        // See also:
+        // https://github.com/torvalds/linux/commit/4621202adc5b
+        // fixes the forward propagation variant in v6.8.
+        // https://github.com/torvalds/linux/commit/4bf79f9be434
+        // fixes a related backtracking variant in v6.12.
+        let err = core::hint::black_box(err);
+        if err == 0 {
+            Ok(T::from_register(ret_val))
+        } else {
+            Err(err as i32)
+        }
     }
 }
 

--- a/test/integration-common/src/lib.rs
+++ b/test/integration-common/src/lib.rs
@@ -30,6 +30,40 @@ pub mod bloom_filter {
     pub const CONTAINS_ABSENT_INDEX: u32 = 2;
 }
 
+pub mod fexit {
+    pub const TEST_RAN: u32 = 1;
+
+    pub const NO_ERROR: i32 = 0;
+    pub const RETVAL_MISMATCH: i32 = 1;
+    pub const ARG_MISMATCH: i32 = 2;
+
+    pub const TEST1_INDEX: u32 = 0;
+    pub const TEST2_INDEX: u32 = 1;
+    pub const TEST3_INDEX: u32 = 2;
+    pub const TEST4_INDEX: u32 = 3;
+    pub const TEST5_INDEX: u32 = 4;
+    pub const TEST6_INDEX: u32 = 5;
+    pub const TEST7_INDEX: u32 = 6;
+    pub const TEST8_INDEX: u32 = 7;
+    pub const TEST9_INDEX: u32 = 8;
+    pub const TEST10_INDEX: u32 = 9;
+
+    pub const TEST_COUNT: u32 = 10;
+
+    #[derive(Clone, Copy, Default)]
+    #[repr(C)]
+    pub struct TestResult {
+        /// Distinguishes a recorded result from a zero-initialised slot. Use a
+        /// `u32` flag instead of `bool` so this `Pod` type has no implicit
+        /// padding.
+        pub ran: u32,
+        pub error: i32,
+    }
+
+    #[cfg(feature = "user")]
+    unsafe impl aya::Pod for TestResult {}
+}
+
 pub mod bpf_probe_read {
     pub const RESULT_BUF_LEN: usize = 1024;
 

--- a/test/integration-ebpf/Cargo.toml
+++ b/test/integration-ebpf/Cargo.toml
@@ -49,6 +49,10 @@ name = "dev_map"
 path = "src/dev_map.rs"
 
 [[bin]]
+name = "fexit"
+path = "src/fexit.rs"
+
+[[bin]]
 name = "hash_map"
 path = "src/hash_map.rs"
 

--- a/test/integration-ebpf/src/fexit.rs
+++ b/test/integration-ebpf/src/fexit.rs
@@ -1,0 +1,189 @@
+#![no_std]
+#![no_main]
+#![expect(unused_crate_dependencies, reason = "used in other bins")]
+
+use core::ffi::c_void;
+
+use aya_ebpf::{
+    Argument,
+    macros::{fexit, map},
+    maps::Array,
+    programs::FExitContext,
+};
+use integration_common::fexit::{
+    ARG_MISMATCH, NO_ERROR, RETVAL_MISMATCH, TEST_COUNT, TEST_RAN, TEST1_INDEX, TEST2_INDEX,
+    TEST3_INDEX, TEST4_INDEX, TEST5_INDEX, TEST6_INDEX, TEST7_INDEX, TEST8_INDEX, TEST9_INDEX,
+    TEST10_INDEX, TestResult,
+};
+#[cfg(not(test))]
+extern crate ebpf_panic;
+
+// FEXIT program return values are ignored by the tracing test-run path.
+const DUMMY_FEXIT_PROG_RETVAL: i32 = 0xa7a;
+
+#[repr(C)]
+struct BpfFentryTest {
+    a: *mut Self,
+}
+
+#[map]
+static RESULTS: Array<TestResult> = Array::with_max_entries(TEST_COUNT, 0);
+
+#[inline(always)]
+fn record(index: u32, error: i32) {
+    if let Some(result) = RESULTS.get_ptr_mut(index) {
+        unsafe {
+            *result = TestResult {
+                ran: TEST_RAN,
+                error,
+            };
+        }
+    }
+}
+
+#[inline(always)]
+fn expect_ret<T: Argument + PartialEq>(ctx: &FExitContext, expected: T) -> i32 {
+    match ctx.ret::<T>() {
+        Ok(retval) => {
+            if retval == expected {
+                NO_ERROR
+            } else {
+                RETVAL_MISMATCH
+            }
+        }
+        Err(error) => error,
+    }
+}
+
+// Mirrors libbpf's fexit selftest and the kernel's synthetic tracing sequence.
+// The argument and return values below come from the kernel's fixed
+// BPF_PROG_TEST_RUN tracing target calls.
+// https://github.com/torvalds/linux/blob/v7.1-rc4/tools/testing/selftests/bpf/progs/fexit_test.c#L10-L80
+// https://github.com/torvalds/linux/blob/v7.1-rc4/net/bpf/test_run.c#L706-L715
+#[fexit(function = "bpf_fentry_test1")]
+fn test1(ctx: FExitContext) -> i32 {
+    let error = if ctx.arg::<i32>(0) == 1 {
+        expect_ret::<i32>(&ctx, 2)
+    } else {
+        ARG_MISMATCH
+    };
+    record(TEST1_INDEX, error);
+    DUMMY_FEXIT_PROG_RETVAL
+}
+
+#[fexit(function = "bpf_fentry_test2")]
+fn test2(ctx: FExitContext) -> i32 {
+    let error = if ctx.arg::<i32>(0) != 2 || ctx.arg::<u64>(1) != 3 {
+        ARG_MISMATCH
+    } else {
+        expect_ret::<i32>(&ctx, 5)
+    };
+    record(TEST2_INDEX, error);
+    DUMMY_FEXIT_PROG_RETVAL
+}
+
+#[fexit(function = "bpf_fentry_test3")]
+fn test3(ctx: FExitContext) -> i32 {
+    let error = if ctx.arg::<i8>(0) != 4 || ctx.arg::<i32>(1) != 5 || ctx.arg::<u64>(2) != 6 {
+        ARG_MISMATCH
+    } else {
+        expect_ret::<i32>(&ctx, 15)
+    };
+    record(TEST3_INDEX, error);
+    DUMMY_FEXIT_PROG_RETVAL
+}
+
+#[fexit(function = "bpf_fentry_test4")]
+fn test4(ctx: FExitContext) -> i32 {
+    let error = if ctx.arg::<*mut c_void>(0) as u64 != 7
+        || ctx.arg::<i8>(1) != 8
+        || ctx.arg::<i32>(2) != 9
+        || ctx.arg::<u64>(3) != 10
+    {
+        ARG_MISMATCH
+    } else {
+        expect_ret::<i32>(&ctx, 34)
+    };
+    record(TEST4_INDEX, error);
+    DUMMY_FEXIT_PROG_RETVAL
+}
+
+#[fexit(function = "bpf_fentry_test5")]
+fn test5(ctx: FExitContext) -> i32 {
+    let error = if ctx.arg::<u64>(0) != 11
+        || ctx.arg::<*mut c_void>(1) as u64 != 12
+        || ctx.arg::<i16>(2) != 13
+        || ctx.arg::<i32>(3) != 14
+        || ctx.arg::<u64>(4) != 15
+    {
+        ARG_MISMATCH
+    } else {
+        expect_ret::<i32>(&ctx, 65)
+    };
+    record(TEST5_INDEX, error);
+    DUMMY_FEXIT_PROG_RETVAL
+}
+
+#[fexit(function = "bpf_fentry_test6")]
+fn test6(ctx: FExitContext) -> i32 {
+    let error = if ctx.arg::<u64>(0) != 16
+        || ctx.arg::<*mut c_void>(1) as u64 != 17
+        || ctx.arg::<i16>(2) != 18
+        || ctx.arg::<i32>(3) != 19
+        || ctx.arg::<*mut c_void>(4) as u64 != 20
+        || ctx.arg::<u64>(5) != 21
+    {
+        ARG_MISMATCH
+    } else {
+        expect_ret::<i32>(&ctx, 111)
+    };
+    record(TEST6_INDEX, error);
+    DUMMY_FEXIT_PROG_RETVAL
+}
+
+#[fexit(function = "bpf_fentry_test7")]
+fn test7(ctx: FExitContext) -> i32 {
+    let arg = ctx.arg::<*mut BpfFentryTest>(0);
+    let error = if arg.is_null() {
+        expect_ret::<i32>(&ctx, 0)
+    } else {
+        ARG_MISMATCH
+    };
+    record(TEST7_INDEX, error);
+    DUMMY_FEXIT_PROG_RETVAL
+}
+
+#[fexit(function = "bpf_fentry_test8")]
+fn test8(ctx: FExitContext) -> i32 {
+    let arg = ctx.arg::<*mut BpfFentryTest>(0);
+    let error = if arg.is_null() {
+        ARG_MISMATCH
+    } else {
+        expect_ret::<i32>(&ctx, 0)
+    };
+    record(TEST8_INDEX, error);
+    DUMMY_FEXIT_PROG_RETVAL
+}
+
+#[fexit(function = "bpf_fentry_test9")]
+fn test9(ctx: FExitContext) -> i32 {
+    let arg = ctx.arg::<*mut u32>(0);
+    let error = if arg.is_null() {
+        ARG_MISMATCH
+    } else {
+        expect_ret::<u32>(&ctx, 0)
+    };
+    record(TEST9_INDEX, error);
+    DUMMY_FEXIT_PROG_RETVAL
+}
+
+#[fexit(function = "bpf_fentry_test10")]
+fn test10(ctx: FExitContext) -> i32 {
+    let error = if ctx.arg::<*const c_void>(0).is_null() {
+        expect_ret::<i32>(&ctx, 0)
+    } else {
+        ARG_MISMATCH
+    };
+    record(TEST10_INDEX, error);
+    DUMMY_FEXIT_PROG_RETVAL
+}

--- a/test/integration-test/src/lib.rs
+++ b/test/integration-test/src/lib.rs
@@ -45,6 +45,7 @@ bpf_file!(
     BTF_MAPS_PLAIN => "btf_maps_plain",
     CPU_MAP => "cpu_map",
     DEV_MAP => "dev_map",
+    FEXIT => "fexit",
     HASH_MAP => "hash_map",
     KPROBE => "kprobe",
     LINEAR_DATA_STRUCTURES => "linear_data_structures",

--- a/test/integration-test/src/tests.rs
+++ b/test/integration-test/src/tests.rs
@@ -16,6 +16,7 @@ mod btf_maps;
 mod btf_relocations;
 mod elf;
 mod feature_probe;
+mod fexit;
 mod hash_map;
 mod info;
 mod iter;

--- a/test/integration-test/src/tests/feature_probe.rs
+++ b/test/integration-test/src/tests/feature_probe.rs
@@ -103,7 +103,16 @@ fn probe_supported_programs() {
     let kern_version = KernelVersion::new(5, 3, 0);
     kernel_assert!(is_supported!(ProgramType::CgroupSockopt), kern_version);
 
-    let kern_version = KernelVersion::new(5, 5, 0);
+    // `is_program_supported` checks attach support through `BPF_RAW_TRACEPOINT_OPEN`;
+    // tracing and LSM programs go through `bpf_tracing_prog_attach()`, which links a
+    // BPF trampoline. On arm64 kernels before 6.4 this can fail with `-ENOTSUPP`.
+    // https://github.com/torvalds/linux/blob/v6.3/kernel/bpf/syscall.c#L3319-L3333
+    // https://github.com/torvalds/linux/blob/v6.3/kernel/bpf/trampoline.c#L234-L237
+    let kern_version = if cfg!(target_arch = "aarch64") {
+        KernelVersion::new(6, 4, 0)
+    } else {
+        KernelVersion::new(5, 5, 0)
+    };
     kernel_assert!(is_supported!(ProgramType::Tracing), kern_version); // Requires `CONFIG_DEBUG_INFO_BTF=y`
 
     let kern_version = KernelVersion::new(5, 6, 0);
@@ -112,6 +121,7 @@ fn probe_supported_programs() {
 
     {
         let kern_version = if cfg!(target_arch = "aarch64") {
+            // Same attach-time BPF trampoline limitation as tracing above.
             KernelVersion::new(6, 4, 0)
         } else {
             KernelVersion::new(5, 7, 0)

--- a/test/integration-test/src/tests/fexit.rs
+++ b/test/integration-test/src/tests/fexit.rs
@@ -1,0 +1,103 @@
+use aya::{
+    Btf, Ebpf,
+    maps::Array,
+    programs::{FExit, ProgramError, ProgramType, TestRun as _},
+    sys::is_program_supported,
+    util::KernelVersion,
+};
+use aya_obj::btf::BtfError;
+use integration_common::fexit::{
+    ARG_MISMATCH, NO_ERROR, RETVAL_MISMATCH, TEST_RAN, TEST1_INDEX, TEST2_INDEX, TEST3_INDEX,
+    TEST4_INDEX, TEST5_INDEX, TEST6_INDEX, TEST7_INDEX, TEST8_INDEX, TEST9_INDEX, TEST10_INDEX,
+    TestResult,
+};
+use test_case::test_case;
+
+fn fexit_error_name(error: i32) -> &'static str {
+    match error {
+        NO_ERROR => "NO_ERROR",
+        RETVAL_MISMATCH => "RETVAL_MISMATCH",
+        ARG_MISMATCH => "ARG_MISMATCH",
+        _ => "HELPER_ERROR",
+    }
+}
+
+// Mirrors libbpf's tracing test-run trigger:
+// https://github.com/torvalds/linux/blob/v7.1-rc4/tools/testing/selftests/bpf/prog_tests/fentry_fexit.c#L24-L42
+#[test_case("test1", "bpf_fentry_test1", TEST1_INDEX ; "test1")]
+#[test_case("test2", "bpf_fentry_test2", TEST2_INDEX ; "test2")]
+#[test_case("test3", "bpf_fentry_test3", TEST3_INDEX ; "test3")]
+#[test_case("test4", "bpf_fentry_test4", TEST4_INDEX ; "test4")]
+#[test_case("test5", "bpf_fentry_test5", TEST5_INDEX ; "test5")]
+#[test_case("test6", "bpf_fentry_test6", TEST6_INDEX ; "test6")]
+#[test_case("test7", "bpf_fentry_test7", TEST7_INDEX ; "test7")]
+#[test_case("test8", "bpf_fentry_test8", TEST8_INDEX ; "test8")]
+#[test_case("test9", "bpf_fentry_test9", TEST9_INDEX ; "test9")]
+#[test_case("test10", "bpf_fentry_test10", TEST10_INDEX ; "test10")]
+fn fexit_reads_args_and_return_values_from_prog_test_run_targets(
+    program: &str,
+    target: &str,
+    index: u32,
+) {
+    // The fexit program itself requires Linux 5.5, but FExitContext::ret uses
+    // bpf_get_func_ret, which was added in Linux 5.17:
+    // https://github.com/torvalds/linux/blob/v5.17/kernel/trace/bpf_trace.c#L1122-L1127
+    // https://github.com/torvalds/linux/blob/v5.17/kernel/trace/bpf_trace.c#L1679-L1683
+    let kernel_version = KernelVersion::current().unwrap();
+    if kernel_version < KernelVersion::new(5, 17, 0) {
+        eprintln!("skipping test on kernel {kernel_version:?} - bpf_get_func_ret requires 5.17");
+        return;
+    }
+
+    if !is_program_supported(ProgramType::Tracing).unwrap() {
+        eprintln!("skipping test - tracing programs not supported");
+        return;
+    }
+
+    let btf = match Btf::from_sys_fs() {
+        Ok(btf) => btf,
+        Err(err) => {
+            eprintln!("skipping test - kernel BTF not available: {err}");
+            return;
+        }
+    };
+
+    let mut bpf = Ebpf::load(crate::FEXIT).unwrap();
+
+    let mut results: Array<_, TestResult> = bpf.take_map("RESULTS").unwrap().try_into().unwrap();
+    results.set(index, TestResult::default(), 0).unwrap();
+
+    let prog: &mut FExit = bpf.program_mut(program).unwrap().try_into().unwrap();
+    match prog.load(target, &btf) {
+        Ok(()) => {}
+        // The kernel's tracing test-run targets have grown over time. Keep
+        // older kernels useful by skipping only the case whose target is not in
+        // BTF, instead of skipping the whole fexit test.
+        Err(ProgramError::Btf(BtfError::UnknownBtfTypeName { type_name }))
+            if type_name == target =>
+        {
+            eprintln!("skipping fexit target {target} - missing from kernel BTF");
+            return;
+        }
+        Err(err) => panic!("unexpected error loading {program}: {err}"),
+    }
+
+    prog.attach().unwrap();
+    // This triggers the kernel's fixed tracing test-run sequence. For FENTRY and
+    // FEXIT, a successful syscall only means that sequence ran; the test-run
+    // retval carries no additional result. The eBPF program checks the traced
+    // function's arguments and return value through FExitContext::{arg,ret}, then
+    // records the result in RESULTS.
+    // https://github.com/torvalds/linux/blob/v7.1-rc4/net/bpf/test_run.c#L706-L735
+    prog.test_run(()).unwrap();
+
+    let actual = results.get(&index, 0).unwrap();
+    assert_eq!(actual.ran, TEST_RAN, "{target} was not called");
+    assert_eq!(
+        actual.error,
+        NO_ERROR,
+        "{target} failed: {} ({})",
+        fexit_error_name(actual.error),
+        actual.error
+    );
+}

--- a/xtask/public-api/aya-ebpf.txt
+++ b/xtask/public-api/aya-ebpf.txt
@@ -1591,6 +1591,7 @@ pub struct aya_ebpf::programs::fexit::FExitContext
 impl aya_ebpf::programs::fexit::FExitContext
 pub fn aya_ebpf::programs::fexit::FExitContext::arg<T: aya_ebpf::Argument>(&self, n: usize) -> T
 pub const fn aya_ebpf::programs::fexit::FExitContext::new(ctx: *mut core::ffi::c_void) -> Self
+pub fn aya_ebpf::programs::fexit::FExitContext::ret<T: aya_ebpf::Argument>(&self) -> core::result::Result<T, i32>
 impl aya_ebpf::EbpfContext for aya_ebpf::programs::fexit::FExitContext
 pub fn aya_ebpf::programs::fexit::FExitContext::as_ptr(&self) -> *mut core::ffi::c_void
 pub fn aya_ebpf::programs::fexit::FExitContext::command(&self) -> core::result::Result<[u8; 16], i32>
@@ -2134,6 +2135,7 @@ pub struct aya_ebpf::programs::FExitContext
 impl aya_ebpf::programs::fexit::FExitContext
 pub fn aya_ebpf::programs::fexit::FExitContext::arg<T: aya_ebpf::Argument>(&self, n: usize) -> T
 pub const fn aya_ebpf::programs::fexit::FExitContext::new(ctx: *mut core::ffi::c_void) -> Self
+pub fn aya_ebpf::programs::fexit::FExitContext::ret<T: aya_ebpf::Argument>(&self) -> core::result::Result<T, i32>
 impl aya_ebpf::EbpfContext for aya_ebpf::programs::fexit::FExitContext
 pub fn aya_ebpf::programs::fexit::FExitContext::as_ptr(&self) -> *mut core::ffi::c_void
 pub fn aya_ebpf::programs::fexit::FExitContext::command(&self) -> core::result::Result<[u8; 16], i32>

--- a/xtask/public-api/aya.txt
+++ b/xtask/public-api/aya.txt
@@ -2606,6 +2606,10 @@ pub fn aya::programs::fexit::FExit::pin<P: core::convert::AsRef<std::path::Path>
 pub fn aya::programs::fexit::FExit::unpin(&mut self) -> core::result::Result<(), std::io::error::Error>
 impl aya::programs::fexit::FExit
 pub fn aya::programs::fexit::FExit::unload(&mut self) -> core::result::Result<(), aya::programs::ProgramError>
+impl aya::programs::TestRun for aya::programs::fexit::FExit
+pub type aya::programs::fexit::FExit::Opts<'a> = ()
+pub type aya::programs::fexit::FExit::Result = ()
+pub fn aya::programs::fexit::FExit::test_run(&self, _opts: Self::Opts) -> core::result::Result<Self::Result, aya::programs::ProgramError>
 impl core::fmt::Debug for aya::programs::fexit::FExit
 pub fn aya::programs::fexit::FExit::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::ops::drop::Drop for aya::programs::fexit::FExit
@@ -6169,6 +6173,10 @@ pub fn aya::programs::fexit::FExit::pin<P: core::convert::AsRef<std::path::Path>
 pub fn aya::programs::fexit::FExit::unpin(&mut self) -> core::result::Result<(), std::io::error::Error>
 impl aya::programs::fexit::FExit
 pub fn aya::programs::fexit::FExit::unload(&mut self) -> core::result::Result<(), aya::programs::ProgramError>
+impl aya::programs::TestRun for aya::programs::fexit::FExit
+pub type aya::programs::fexit::FExit::Opts<'a> = ()
+pub type aya::programs::fexit::FExit::Result = ()
+pub fn aya::programs::fexit::FExit::test_run(&self, _opts: Self::Opts) -> core::result::Result<Self::Result, aya::programs::ProgramError>
 impl core::fmt::Debug for aya::programs::fexit::FExit
 pub fn aya::programs::fexit::FExit::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::ops::drop::Drop for aya::programs::fexit::FExit
@@ -7190,6 +7198,10 @@ impl aya::programs::TestRun for aya::programs::cgroup_skb::CgroupSkb
 pub type aya::programs::cgroup_skb::CgroupSkb::Opts<'a> = aya::programs::TestRunOptions<'a>
 pub type aya::programs::cgroup_skb::CgroupSkb::Result = aya::programs::TestRunResult
 pub fn aya::programs::cgroup_skb::CgroupSkb::test_run(&self, opts: Self::Opts) -> core::result::Result<Self::Result, aya::programs::ProgramError>
+impl aya::programs::TestRun for aya::programs::fexit::FExit
+pub type aya::programs::fexit::FExit::Opts<'a> = ()
+pub type aya::programs::fexit::FExit::Result = ()
+pub fn aya::programs::fexit::FExit::test_run(&self, _opts: Self::Opts) -> core::result::Result<Self::Result, aya::programs::ProgramError>
 impl aya::programs::TestRun for aya::programs::flow_dissector::FlowDissector
 pub type aya::programs::flow_dissector::FlowDissector::Opts<'a> = aya::programs::TestRunOptions<'a>
 pub type aya::programs::flow_dissector::FlowDissector::Result = aya::programs::TestRunResult
@@ -7579,6 +7591,10 @@ impl aya::programs::TestRun for aya::programs::cgroup_skb::CgroupSkb
 pub type aya::programs::cgroup_skb::CgroupSkb::Opts<'a> = aya::programs::TestRunOptions<'a>
 pub type aya::programs::cgroup_skb::CgroupSkb::Result = aya::programs::TestRunResult
 pub fn aya::programs::cgroup_skb::CgroupSkb::test_run(&self, opts: Self::Opts) -> core::result::Result<Self::Result, aya::programs::ProgramError>
+impl aya::programs::TestRun for aya::programs::fexit::FExit
+pub type aya::programs::fexit::FExit::Opts<'a> = ()
+pub type aya::programs::fexit::FExit::Result = ()
+pub fn aya::programs::fexit::FExit::test_run(&self, _opts: Self::Opts) -> core::result::Result<Self::Result, aya::programs::ProgramError>
 impl aya::programs::TestRun for aya::programs::flow_dissector::FlowDissector
 pub type aya::programs::flow_dissector::FlowDissector::Opts<'a> = aya::programs::TestRunOptions<'a>
 pub type aya::programs::flow_dissector::FlowDissector::Result = aya::programs::TestRunResult


### PR DESCRIPTION
<!-- markdownlint-disable first-line-heading -->
Fixes #1296.

I found that writing fexit e2e tests is difficult without BPF_PROG_TEST_RUN, so I also add test-run support for fexit programs.

A possible follow-up is extending this to fentry or other tracing attach types that use the same kernel test-run path.

<!--
    Thank you for your contribution to Aya! 🎉

    For Work In Progress Pull Requests, please use the Draft PR feature.

    Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Aya Contributing Guide: https://github.com/aya-rs/aya/blob/main/CONTRIBUTING.md
     - 📖 Read the Aya Code of Conduct: https://github.com/aya-rs/aya/blob/main/CODE_OF_CONDUCT.md
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages: https://cbea.ms/git-commit/
     - 📗 Update any related documentation.

-->

<!---
      Summarize the changes you're making here. Detailed information belongs in
      the Git commit messages. If your pull request contains just one commit,
      it's best to use its message as a summary. Otherwise, if there are multiple
      atomic commits, write a summary for the entire PR. Feel free to flag
      anything you think needs a reviewer's attention.
-->

<!--
      If your changes address an issue, link it with the *Fixes* tag so
      the issue gets closed when the PR is merged, for example:

      Fixes: #1234

      If you are only referencing an issue without fully addressing it, feel
      free to link it anywhere in the summary.
-->

### Added/updated tests?

_We strongly encourage you to add a test for your changes._

- [x] Yes

### Checklist

- [x] Rust code has been formatted with `cargo +nightly fmt`.
- [x] All clippy lints have been fixed.
      You can find failing lints with `cargo xtask clippy`.
- [x] Unit tests are passing locally with `cargo test`.
- [x] The [Integration tests] are passing locally.
- [x] I have blessed any API changes with `cargo xtask public-api --bless`.

[Integration tests]: https://github.com/aya-rs/aya/blob/main/test/README.md

### (Optional) What GIF best describes this PR or how it makes you feel?

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aya-rs/aya/1574)
<!-- Reviewable:end -->
