### PR TITLE
feat(style,doc): added typos-cli workspace configuration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
 
       - uses: taiki-e/install-action@v2
         with:
-          tool: cargo-hack,taplo-cli,typos
+          tool: cargo-hack,taplo-cli,typos-cli
 
       - run: git ls-files -- '*.c' '*.h' | xargs clang-format --dry-run --Werror
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,13 +32,15 @@ jobs:
 
       - uses: taiki-e/install-action@v2
         with:
-          tool: cargo-hack,taplo-cli
+          tool: cargo-hack,taplo-cli,typos
 
       - run: git ls-files -- '*.c' '*.h' | xargs clang-format --dry-run --Werror
 
       - uses: DavidAnson/markdownlint-cli2-action@v23
 
       - run: taplo fmt --check
+
+      - run: typos
 
       - run: cargo +nightly fmt --all -- --check
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -375,3 +375,21 @@ unused_macro_rules = "warn"
 unused_qualifications = "warn"
 # unused_results = "warn" # We should make this warn.
 # variant_size_differences = "warn" # Never.
+
+# https://github.com/crate-ci/typos/blob/master/docs/reference.md
+[workspace.metadata.typos.default]
+extend-ignore-identifiers-re = [
+    # variables
+    "__PT_PARM",           # PARM
+    "BPF_F_WRONLY",        # WRONLY
+    "BPF_SOCK_OPS_RTO_CB", # RTO
+    # words
+    "UNIONs", # UNIO
+]
+extend-ignore-re = [
+    # memory range (i.e. "5ba3b000-5da3b000")
+    "[a-f0-9]+\\-[a-f0-9]+",
+]
+
+[workspace.metadata.typos.files]
+extend-exclude = ["CHANGELOG.md"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -383,13 +383,13 @@ extend-ignore-identifiers-re = [
     "__PT_PARM",           # PARM
     "BPF_F_WRONLY",        # WRONLY
     "BPF_SOCK_OPS_RTO_CB", # RTO
-    # words
-    "UNIONs", # UNIO
 ]
 extend-ignore-re = [
-    # memory range (i.e. "5ba3b000-5da3b000")
-    "[a-f0-9]+\\-[a-f0-9]+",
+    # abbreviated git commit SHA (e.g. "`8f3b1e2`")
+    "`[a-f0-9]{7}`",
+    # memory range (e.g. "5ba3b000-5da3b000")
+    "[a-f0-9]{8}\\-[a-f0-9]{8}",
 ]
 
 [workspace.metadata.typos.files]
-extend-exclude = ["CHANGELOG.md"]
+extend-exclude = ["xtask/libbpf"]

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 
 ## API Documentation
 
-[![Unreleased Documentation][git-docs-badge]][git-api-docs] [![Documentaiton][api-docs-badge]][api-docs]
+[![Unreleased Documentation][git-docs-badge]][git-api-docs] [![Documentation][api-docs-badge]][api-docs]
 
 [git-docs-badge]: https://img.shields.io/badge/docs-unreleased-red.svg?style=for-the-badge&logo=docsdotrs
 [git-api-docs]: https://docs.aya-rs.dev

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -10,7 +10,7 @@ which depending on the severity of the vulnerability may be immediate.
 ## Reporting a Vulnerability
 
 To report a vulnerability, please use the
-[Private Vulnerability Reporting Feature] on GitHub. We will endevour to respond
+[Private Vulnerability Reporting Feature] on GitHub. We will endeavour to respond
 within 48hrs of reporting.
 
 If a vulnerability is reported but considered low priority it may be converted

--- a/aya-ebpf-macros/src/lib.rs
+++ b/aya-ebpf-macros/src/lib.rs
@@ -525,7 +525,7 @@ pub fn socket_filter(attrs: TokenStream, item: TokenStream) -> TokenStream {
 /// overhead to call before kernel function. fentry programs can be also
 /// attached to other eBPF programs.
 ///
-/// # Minimumm kernel version
+/// # Minimum kernel version
 ///
 /// The minimum kernel version required to use this feature is 5.5.
 ///
@@ -570,7 +570,7 @@ pub fn fentry(attrs: TokenStream, item: TokenStream) -> TokenStream {
 /// arguments rather than the return value. fexit programs can be also attached
 /// to other eBPF programs.
 ///
-/// # Minimumm kernel version
+/// # Minimum kernel version
 ///
 /// The minimum kernel version required to use this feature is 5.5.
 ///

--- a/aya-log-common/CHANGELOG.md
+++ b/aya-log-common/CHANGELOG.md
@@ -111,7 +111,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
    These were missed when the code was updated.
  - <csr-id-ca3f70b16a705bf26d2ccc7ce754de403be36223/> s/Result<usize, ()>/Option<NonZeroUsize>/
    `Option<NonZeroUsize>` is guaranteed to have the same size as `usize`,
-   which is not guarnateed for `Result`. This is a minor optimization, but
+   which is not guaranteed for `Result`. This is a minor optimization, but
    also results in simpler code.
  - <csr-id-3cfd886dc512872fd3948cdf3baa8c99fe27ef0f/> annotate logging functions inlining
    Some of these functions fail to compile when not inlined, so we should

--- a/aya-log-ebpf-macros/CHANGELOG.md
+++ b/aya-log-ebpf-macros/CHANGELOG.md
@@ -75,7 +75,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
    High time we stop debating this; let the robots do the work.
  - <csr-id-ca3f70b16a705bf26d2ccc7ce754de403be36223/> s/Result<usize, ()>/Option<NonZeroUsize>/
    `Option<NonZeroUsize>` is guaranteed to have the same size as `usize`,
-   which is not guarnateed for `Result`. This is a minor optimization, but
+   which is not guaranteed for `Result`. This is a minor optimization, but
    also results in simpler code.
  - <csr-id-96fa08bd82233268154edf30b106876f5a4f0e30/> Define dependencies on the workspace level
    This way we will avoid version mismatches and make differences in

--- a/aya-log/CHANGELOG.md
+++ b/aya-log/CHANGELOG.md
@@ -187,7 +187,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   High time we stop debating this; let the robots do the work.
 - <csr-id-ca3f70b16a705bf26d2ccc7ce754de403be36223/> s/Result<usize, ()>/Option<NonZeroUsize>/
   `Option<NonZeroUsize>` is guaranteed to have the same size as `usize`,
-  which is not guarnateed for `Result`. This is a minor optimization, but
+  which is not guaranteed for `Result`. This is a minor optimization, but
   also results in simpler code.
 - <csr-id-96fa08bd82233268154edf30b106876f5a4f0e30/> Define dependencies on the workspace level
   This way we will avoid version mismatches and make differences in

--- a/aya-obj/CHANGELOG.md
+++ b/aya-obj/CHANGELOG.md
@@ -455,7 +455,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
    This commit fixes the (func|line)_info when we have multiple programs in
    the same section. The integration test reloc.bpf.c serves as our test
    case here. This required filtering down the (func|line)_info to only
-   that in scope of the current symbol + then adjusting the offets to
+   that in scope of the current symbol + then adjusting the offsets to
    appease the kernel.
  - <csr-id-cca9b8f1a7e345a39d852bd18a43974871d3ed4b/> Remove name from ProgramSection
    The name here is never used as we get the program name from the symbol
@@ -636,7 +636,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
       - aya::{bpf_map_def, BtfMapDef, PinningType},
       - aya::programs::{CgroupSock*AttachType},
    
-   The new crate is currenly allowing missing_docs. Member visibility
+   The new crate is currently allowing missing_docs. Member visibility
    will be adjusted later to minimize exposure of implementation details.
  - <csr-id-81bc307dce452f0aacbfbe8c304089d11ddd8c5e/> migrate bindgen destination
 
@@ -744,7 +744,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - Merge pull request #602 from marysaka/fix/btf-reloc-all-functions ([`3a9a54f`](https://github.com/aya-rs/aya/commit/3a9a54fd9b2f69e2427accbe0451761ecc537197))
     - Merge pull request #616 from nak3/fix-bump ([`3211d2c`](https://github.com/aya-rs/aya/commit/3211d2c92801d8208c76856cb271f2b7772a0313))
     - Apply BTF relocations to all functions ([`c4e721f`](https://github.com/aya-rs/aya/commit/c4e721f3d334a7c2e5e6d6cd6f4ade0f1334be72))
-    - [codegen] Update libbpf to f7eb43b90f4c8882edf6354f8585094f8f3aade0Update libbpf to f7eb43b90f4c8882edf6354f8585094f8f3aade0 ([`0bc886f`](https://github.com/aya-rs/aya/commit/0bc886f1634443d202e24f56cb74d3dce2e66e37))
+    - [codegen] Update libbpf to f7eb43b90f4c8882edf6354f8585094f8f3aade0 ([`0bc886f`](https://github.com/aya-rs/aya/commit/0bc886f1634443d202e24f56cb74d3dce2e66e37))
     - Merge pull request #585 from probulate/tag-len-value ([`5165bf2`](https://github.com/aya-rs/aya/commit/5165bf2f99cdc228122bdab505c2059723e95a9f))
     - Merge pull request #605 from marysaka/fix/global-data-reloc-ancient-kernels ([`9c437aa`](https://github.com/aya-rs/aya/commit/9c437aafd96bebc5c90fdc7f370b5415174b1019))
     - Merge pull request #604 from marysaka/fix/section-kind-from-str ([`3a9058e`](https://github.com/aya-rs/aya/commit/3a9058e7625b56ac26d6bb592dd4c3a93c61d6b0))
@@ -797,7 +797,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - Add new map types ([`3d03c8a`](https://github.com/aya-rs/aya/commit/3d03c8a8e0a9033be8c1ab020129db7790cc7493))
     - Merge pull request #483 from aya-rs/codegen ([`0399991`](https://github.com/aya-rs/aya/commit/03999913833ad576d9ba7d1c0123703f49b340a5))
     - Update `BPF_MAP_TYPE_CGROUP_STORAGE` name to `BPF_MAP_TYPE_CGRP_STORAGE` ([`cb28533`](https://github.com/aya-rs/aya/commit/cb28533e2f9eb0b2cd80f4bf9515cdec31763749))
-    - [codegen] Update libbpf to 3423d5e7cdab356d115aef7f987b4a1098ede448Update libbpf to 3423d5e7cdab356d115aef7f987b4a1098ede448 ([`5d13fd5`](https://github.com/aya-rs/aya/commit/5d13fd5acaa90efedb76d371b69431ac9a262fdd))
+    - [codegen] Update libbpf to 3423d5e7cdab356d115aef7f987b4a1098ede448 ([`5d13fd5`](https://github.com/aya-rs/aya/commit/5d13fd5acaa90efedb76d371b69431ac9a262fdd))
     - Merge pull request #475 from yesh0/aya-obj ([`897957a`](https://github.com/aya-rs/aya/commit/897957ac84370cd1ee463bdf2ff4859333b41012))
     - Update documentation and versioning info ([`9c451a3`](https://github.com/aya-rs/aya/commit/9c451a3357317405dd8e2e4df7d006cee943adcc))
     - Add documentation on program names ([`772af17`](https://github.com/aya-rs/aya/commit/772af170aea2feccb5e98cc84125e9e31b9fbe9a))

--- a/aya-obj/src/btf/relocation.rs
+++ b/aya-obj/src/btf/relocation.rs
@@ -504,7 +504,7 @@ fn match_candidate<'target>(
                     enum64_fallback: Some(fallback),
                     ..
                 }) => {
-                    // Local ENUM64 types become UNIONs during sanitisation; the fallback retains
+                    // Local ENUM64 types become UNION types during sanitisation; the fallback retains
                     // their original variant names so we can line them up with target enums.
                     match_enum(&mut fallback.variants.iter().map(|variant| variant.name_offset))
                 }

--- a/aya-obj/src/btf/relocation.rs
+++ b/aya-obj/src/btf/relocation.rs
@@ -755,7 +755,7 @@ impl<'a> AccessSpec<'a> {
                         spec: spec.to_string(),
                         index,
                         max_index: n_variants,
-                        error: "tried to access nonexistant enum variant",
+                        error: "tried to access nonexistent enum variant",
                     })?;
                 let name = btf.string_at(name_offset)?;
                 let accessors = vec![Accessor {

--- a/aya-obj/src/obj.rs
+++ b/aya-obj/src/obj.rs
@@ -1192,7 +1192,7 @@ fn parse_version(data: &[u8], endianness: Endianness) -> Result<Option<u32>, Par
     })
 }
 
-// Gets an integer value from a BTF map defintion K/V pair.
+// Gets an integer value from a BTF map definition K/V pair.
 // type_id should be a PTR to an ARRAY.
 // the value is encoded in the array nr_elems field.
 fn get_map_field(btf: &Btf, type_id: u32) -> Result<u32, BtfError> {
@@ -2639,7 +2639,7 @@ mod tests {
     }
 
     #[test]
-    fn test_parse_section_cgroup_skb_no_direction_unamed() {
+    fn test_parse_section_cgroup_skb_no_direction_unnamed() {
         let mut obj = fake_obj();
         fake_sym(&mut obj, 0, 0, "skb", FAKE_INS_LEN);
 

--- a/aya/CHANGELOG.md
+++ b/aya/CHANGELOG.md
@@ -332,7 +332,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - Use FdLink in SockOps programs ([`c44f8b0`](https://github.com/aya-rs/aya/commit/c44f8b0f5bddd820a4a98cff293126c0146b827a))
     - Remove unwrap and NonZero* in info ([`02d1db5`](https://github.com/aya-rs/aya/commit/02d1db5fc043fb7af90c14d13de6419ec5b9bcb5))
     - Merge pull request #985 from reyzell/main ([`40f3032`](https://github.com/aya-rs/aya/commit/40f303205f7a800877fe3f9a4fb1893141741e13))
-    - Add the option to support multiple and overrideable programs per cgroup ([`f790685`](https://github.com/aya-rs/aya/commit/f790685d759cbd97cb09ad48d87cdece28fbe579))
+    - Add the option to support multiple and overridable programs per cgroup ([`f790685`](https://github.com/aya-rs/aya/commit/f790685d759cbd97cb09ad48d87cdece28fbe579))
     - Merge pull request #1007 from tyrone-wu/aya/info-api ([`15eb935`](https://github.com/aya-rs/aya/commit/15eb935bce6d41fb67189c48ce582b074544e0ed))
     - Revamp MapInfo be more friendly with older kernels ([`fbb0930`](https://github.com/aya-rs/aya/commit/fbb09304a2de0d8baf7ea20c9727fcd2e4fb7f41))
     - Revamp ProgramInfo be more friendly with older kernels ([`88f5ac3`](https://github.com/aya-rs/aya/commit/88f5ac31142f1657b41b1ee0f217dcd9125b210a))
@@ -879,7 +879,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Bug Fixes
 
  - <csr-id-c31cce4a368ac56b42196604ef110139d28a2f8e/> invalid transmute when calling fd
-   Corrent an invalid transmutation for sock_map.
+   Correct an invalid transmutation for sock_map.
    fd is already a ref of MapFd, so transmuting &fd to &SockMapFd is
    equivalent to transmuting &&SockMapFd into &SockMapFd which is buggy.
  - <csr-id-243986c1da440c763393a4a37d5b3922b6baa3cc/> Relax unnecessarily strict atomic ordering on probe event_alias
@@ -1102,7 +1102,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
    the file descriptor we receive is valid. Additionally, this allows
    aya to internally easily duplicate this file descriptor using std
    library methods instead of manually calling `dup` which doesn't
-   duplicate with the CLOSE_ON_EXEC flag that is standard pratice to
+   duplicate with the CLOSE_ON_EXEC flag that is standard practice to
    avoid leaking the file descriptor when exec'ing.
  - <csr-id-d2e74e562dfa601397b3570ece1a51f5013b9928/> Use BorrowedFd when using the program fd in sys/bpf.rs
    This commit reveals but does not address a file descriptor leak in
@@ -1186,15 +1186,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
    
    To avoid lifetime issues while having minimal impact to UX the
    `OwnedFd` returned from the BPF_BTF_LOAD syscall will be wrapped in an
-   `Arc` and shared accross the programs and maps of the loaded BPF
+   `Arc` and shared across the programs and maps of the loaded BPF
    file.
  - <csr-id-683a1cf2e4cdfba05ba35d708fecc4f43b0e83b3/> Make SysResult generic on Ok variant
  - <csr-id-76c78e3bf82eb77c947dd125ed6624dfa6f4cc1c/> bpf_prog_get_fd_by_id returns OwnedFd
  - <csr-id-96fa08bd82233268154edf30b106876f5a4f0e30/> Define dependencies on the workspace level
    This way we will avoid version mismatches and make differences in
    features across our crates clearer.
- - <csr-id-74b546827cdde13872e141e9e5b6cc9ac39efe1e/> Ignore embedded BTF error if not truely required
-   This allows fallback to BTF manual relocation when BTF loading fail when not truely required.
+ - <csr-id-74b546827cdde13872e141e9e5b6cc9ac39efe1e/> Ignore embedded BTF error if not truly required
+   This allows fallback to BTF manual relocation when BTF loading fail when not truly required.
  - <csr-id-8c61fc9ea6d1d52b38a238541fb229bc850c82ac/> compile C probes using build.rs
    - Add libbpf as a submodule. This prevents having to plumb its location
      around (which can't be passed to Cargo build scripts) and also
@@ -1356,7 +1356,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
       - aya::{bpf_map_def, BtfMapDef, PinningType},
       - aya::programs::{CgroupSock*AttachType},
    
-   The new crate is currenly allowing missing_docs. Member visibility
+   The new crate is currently allowing missing_docs. Member visibility
    will be adjusted later to minimize exposure of implementation details.
  - <csr-id-81bc307dce452f0aacbfbe8c304089d11ddd8c5e/> migrate bindgen destination
  - <csr-id-aba99ea4b1f5694e115ae49e9dbe058d3e761fd8/> make btf::RelocationError private
@@ -1404,7 +1404,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
    2. Adds From<PinnedLink> for FdLink to allow for ^ to be converted
    3. Adds From<FdLink> for XdpLink
  - <csr-id-18584e2259382bbb4e56007eacbe81dba25db05a/> Fix segfault in define_link_wrapper
-   The From<$wrapper> for $base implemention is refers to itself,
+   The From<$wrapper> for $base implementation is refers to itself,
    eventually causing a segfault.
  - <csr-id-f34ebeba99e409bb369a74687e1664a50c430c1e/> Improved BTF Type API
    This commit removes reliance on generated BtfType structs, as
@@ -1675,7 +1675,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - Merge pull request #584 from marysaka/fix/btf-kern-optional ([`0766e70`](https://github.com/aya-rs/aya/commit/0766e705486df167b0d5cf736c1edc14880bce17))
     - Don't use env::tempdir ([`5407d4a`](https://github.com/aya-rs/aya/commit/5407d4a9a1885806a0f74abfc8cfe17baf13e124))
     - Remove "async" feature ([`fa91fb4`](https://github.com/aya-rs/aya/commit/fa91fb4f59be3505664f8088b6e3e8da2c372253))
-    - Ignore embedded BTF error if not truely required ([`74b5468`](https://github.com/aya-rs/aya/commit/74b546827cdde13872e141e9e5b6cc9ac39efe1e))
+    - Ignore embedded BTF error if not truly required ([`74b5468`](https://github.com/aya-rs/aya/commit/74b546827cdde13872e141e9e5b6cc9ac39efe1e))
     - Fix build ([`242d8c3`](https://github.com/aya-rs/aya/commit/242d8c33c4ff71f766f32f184f826d3216929faa))
     - Merge pull request #520 from astoycos/unsupported-map ([`eb60d65`](https://github.com/aya-rs/aya/commit/eb60d6561362e57955b2963b9a6b0a818281aabf))
     - Merge pull request #560 from astoycos/fix-perf-link-pin ([`edb7baf`](https://github.com/aya-rs/aya/commit/edb7baf9a37187027e4459a7c716b22c2204ca1f))
@@ -1841,7 +1841,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - Use & ([`9991ffb`](https://github.com/aya-rs/aya/commit/9991ffb093bff3a10678c48f8c4c7610558ab809))
     - Add test case ([`e9ec257`](https://github.com/aya-rs/aya/commit/e9ec257328299551a750883075095f8a60f1cce3))
     - Use Borrow<T> instead ([`1247ffc`](https://github.com/aya-rs/aya/commit/1247ffc19b8d68d37c032a7b916e3f2b3531972f))
-    - Use a struct for setting priority and handle in SchedClassfier attach ([`af3de84`](https://github.com/aya-rs/aya/commit/af3de84b081941bd3139c7089618a53dfa37ac83))
+    - Use a struct for setting priority and handle in SchedClassifier attach ([`af3de84`](https://github.com/aya-rs/aya/commit/af3de84b081941bd3139c7089618a53dfa37ac83))
     - Support using handle in tc programs ([`ac07608`](https://github.com/aya-rs/aya/commit/ac07608b7922a545cd1de1996b66dcbdeb7fbbe1))
     - Merge pull request #397 from astoycos/refactor-map-api2 ([`d6cb1a1`](https://github.com/aya-rs/aya/commit/d6cb1a16ad0f8df483e2234fb01ab55bdbeaa8b8))
     - Fix doc links, update rustdoc args ([`82edd68`](https://github.com/aya-rs/aya/commit/82edd681c398f73de026a695837dd37643ed124a))
@@ -2256,7 +2256,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  - <csr-id-bb8a813eefd86fbdb218174ccb7bfd2578ab9692/> use correct program name when relocating
  - <csr-id-e4d9774bf780eee5c3740d153df0682265089307/> Improve section detection
    This commit improves section detection.
-   Previously, a section named "xdp_metadata" would be interpretted as a
+   Previously, a section named "xdp_metadata" would be interpreted as a
    program section, which is incorrect. This commit first attempts to
    identify a BPF section by name, then by section.kind() ==
    SectionKind::Text (executable code). The computed section kind is
@@ -2640,7 +2640,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  - <csr-id-bb15e82c1d8373700dda52f69d6c4bf6f5489a03/> add missing load() in kprobe example
  - <csr-id-d8d311738c974f3b6fad22006ab2b827d0925ce8/> support both bpf_map_def layout variants
    Libbpf and iproute2 use two slightly different `bpf_map_def` layouts. This change implements support for loading both.
- - <csr-id-5f0ff1698a12141ffe50e160de252f664773c140/> netlink: tc: use ptr::read_unaligned instead of deferencing a potentially unaligned ptr
+ - <csr-id-5f0ff1698a12141ffe50e160de252f664773c140/> netlink: tc: use ptr::read_unaligned instead of dereferencing a potentially unaligned ptr
  - <csr-id-7f2ceaf12e3aeadd81a55a75c268f254192cf866/> netlink: port TC code to using new nlattr utils
  - <csr-id-d9b5ab575f6e2cbca793881094e1846a39332fa1/> netlink: refactor nlattr writing code
  - <csr-id-c240a2c73381a6864f343c79069abfd5f9e9b729/> netlink: introduce NestedAttrs builder and switch XDP to it
@@ -2693,7 +2693,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - Kprobe: remove pid argument ([`08c71df`](https://github.com/aya-rs/aya/commit/08c71dfeb19b2b4358d75baf5b95f8d4e6521935))
     - Add missing load() in kprobe example ([`bb15e82`](https://github.com/aya-rs/aya/commit/bb15e82c1d8373700dda52f69d6c4bf6f5489a03))
     - Support both bpf_map_def layout variants ([`d8d3117`](https://github.com/aya-rs/aya/commit/d8d311738c974f3b6fad22006ab2b827d0925ce8))
-    - Netlink: tc: use ptr::read_unaligned instead of deferencing a potentially unaligned ptr ([`5f0ff16`](https://github.com/aya-rs/aya/commit/5f0ff1698a12141ffe50e160de252f664773c140))
+    - Netlink: tc: use ptr::read_unaligned instead of dereferencing a potentially unaligned ptr ([`5f0ff16`](https://github.com/aya-rs/aya/commit/5f0ff1698a12141ffe50e160de252f664773c140))
     - Netlink: port TC code to using new nlattr utils ([`7f2ceaf`](https://github.com/aya-rs/aya/commit/7f2ceaf12e3aeadd81a55a75c268f254192cf866))
     - Netlink: refactor nlattr writing code ([`d9b5ab5`](https://github.com/aya-rs/aya/commit/d9b5ab575f6e2cbca793881094e1846a39332fa1))
     - Netlink: introduce NestedAttrs builder and switch XDP to it ([`c240a2c`](https://github.com/aya-rs/aya/commit/c240a2c73381a6864f343c79069abfd5f9e9b729))

--- a/aya/README.md
+++ b/aya/README.md
@@ -14,7 +14,7 @@
 
 ## API Documentation
 
-[![Unreleased Documentation][git-docs-badge]][git-api-docs] [![Documentaiton][api-docs-badge]][api-docs]
+[![Unreleased Documentation][git-docs-badge]][git-api-docs] [![Documentation][api-docs-badge]][api-docs]
 
 [git-docs-badge]: https://img.shields.io/badge/docs-unreleased-red.svg?style=for-the-badge&logo=docsdotrs
 [git-api-docs]: https://docs.aya-rs.dev

--- a/aya/src/maps/mod.rs
+++ b/aya/src/maps/mod.rs
@@ -132,7 +132,7 @@ mod sealed {
 }
 
 #[derive(Error, Debug)]
-/// Errors occuring from working with Maps
+/// Errors occurring from working with Maps
 pub enum MapError {
     /// Missing inner map BTF definition for a map-of-maps.
     #[error(
@@ -212,7 +212,7 @@ pub enum MapError {
     #[error("element not found")]
     ElementNotFound,
 
-    /// Progam Not Loaded
+    /// Program Not Loaded
     #[error("the program is not loaded")]
     ProgramNotLoaded,
 

--- a/aya/src/maps/xdp/mod.rs
+++ b/aya/src/maps/xdp/mod.rs
@@ -13,7 +13,7 @@ pub use xsk_map::XskMap;
 use super::MapError;
 
 #[derive(Error, Debug)]
-/// Errors occuring from working with XDP maps.
+/// Errors occurring from working with XDP maps.
 pub enum XdpMapError {
     /// Chained programs are not supported.
     #[error("chained programs are not supported by the current kernel")]

--- a/aya/src/maps/xdp/xsk_map.rs
+++ b/aya/src/maps/xdp/xsk_map.rs
@@ -55,8 +55,8 @@ impl<T: Borrow<MapData>> XskMap<T> {
 impl<T: BorrowMut<MapData>> XskMap<T> {
     /// Sets the `AF_XDP` socket at a given index.
     ///
-    /// When redirecting a packet, the `AF_XDP` socket at `index` will recieve the packet. Note
-    /// that it will do so only if the socket is bound to the same queue the packet was recieved
+    /// When redirecting a packet, the `AF_XDP` socket at `index` will receive the packet. Note
+    /// that it will do so only if the socket is bound to the same queue the packet was received
     /// on.
     ///
     /// # Errors

--- a/aya/src/pin.rs
+++ b/aya/src/pin.rs
@@ -4,7 +4,7 @@ use thiserror::Error;
 
 use crate::sys::SyscallError;
 
-/// An error ocurred working with a pinned BPF object.
+/// An error occurred working with a pinned BPF object.
 #[derive(Error, Debug)]
 pub enum PinError {
     /// The object FD is not known by Aya.
@@ -23,7 +23,7 @@ pub enum PinError {
         /// The source error.
         error: std::ffi::NulError,
     },
-    /// An error ocurred making a syscall.
+    /// An error occurred making a syscall.
     #[error(transparent)]
     SyscallError(#[from] SyscallError),
 }

--- a/aya/src/programs/mod.rs
+++ b/aya/src/programs/mod.rs
@@ -1310,7 +1310,7 @@ macro_rules! impl_from_prog_info {
                 if info.program_type() != Self::PROGRAM_TYPE.into() {
                     return Err(ProgramError::UnexpectedProgramType {});
                 }
-                let ProgramInfo(bpf_progam_info) = info;
+                let ProgramInfo(bpf_program_info) = info;
                 let fd = info.fd()?;
                 let fd = fd.as_fd().try_clone_to_owned()?;
 
@@ -1319,7 +1319,7 @@ macro_rules! impl_from_prog_info {
                         Some(name),
                         crate::MockableFd::from_fd(fd),
                         Path::new(""),
-                        bpf_progam_info,
+                        bpf_program_info,
                         VerifierLogLevel::default(),
                     )?,
                     $($var,)?

--- a/aya/src/programs/perf_event.rs
+++ b/aya/src/programs/perf_event.rs
@@ -156,7 +156,7 @@ pub enum SoftwareEvent {
     /// Number of page faults.
     #[doc(alias = "PERF_COUNT_SW_PAGE_FAULTS")]
     PageFaults = perf_sw_ids_to_u32(perf_sw_ids::PERF_COUNT_SW_PAGE_FAULTS),
-    /// Numer of context switches.
+    /// Number of context switches.
     #[doc(alias = "PERF_COUNT_SW_CONTEXT_SWITCHES")]
     ContextSwitches = perf_sw_ids_to_u32(perf_sw_ids::PERF_COUNT_SW_CONTEXT_SWITCHES),
     /// Number of times the process has migrated to a new CPU.

--- a/aya/src/programs/sk_lookup.rs
+++ b/aya/src/programs/sk_lookup.rs
@@ -15,7 +15,7 @@ use crate::{
 /// A program used to redirect incoming packets to a local socket.
 ///
 /// [`SkLookup`] programs are attached to network namespaces to provide programmable
-/// socket lookup for TCP/UDP when a packet is to be delievered locally.
+/// socket lookup for TCP/UDP when a packet is to be delivered locally.
 ///
 /// You may attach multiple programs to the same namespace and they are executed
 /// in the order they were attached.

--- a/ebpf/aya-ebpf/src/maps/xdp/xsk_map.rs
+++ b/ebpf/aya-ebpf/src/maps/xdp/xsk_map.rs
@@ -39,11 +39,11 @@ use crate::{
 /// Three strategies are possible:
 ///
 /// - Reduce the RX queue count to a single one. This option is great for development, but is
-///   detrimental for performance as the single CPU core recieving packets will get overwhelmed.
+///   detrimental for performance as the single CPU core receiving packets will get overwhelmed.
 ///   Setting the queue count for a NIC can be achieved using `ethtool -L <ifname> combined 1`.
 /// - Create a socket for every RX queue. Most modern NICs will have an RX queue per CPU thread, so
 ///   a socket per CPU thread is best for performance. To dynamically size the map depending on the
-///   recieve queue count, see the userspace documentation of `CpuMap`.
+///   receive queue count, see the userspace documentation of `CpuMap`.
 /// - Create a single socket and use a [`CpuMap`](super::CpuMap) to redirect the packet to the
 ///   correct CPU core. This way, the packet is sent to another CPU, and a chained XDP program can
 ///   the redirect to the `AF_XDP` socket. Using a single socket simplifies the userspace code but


### PR DESCRIPTION
<!-- markdownlint-disable first-line-heading -->

<!--
    Thank you for your contribution to Aya! 🎉

    For Work In Progress Pull Requests, please use the Draft PR feature.

    Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Aya Contributing Guide: https://github.com/aya-rs/aya/blob/main/CONTRIBUTING.md
     - 📖 Read the Aya Code of Conduct: https://github.com/aya-rs/aya/blob/main/CODE_OF_CONDUCT.md
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages: https://cbea.ms/git-commit/
     - 📗 Update any related documentation.

-->

<!---
      Summarize the changes you're making here. Detailed information belongs in
      the Git commit messages. If your pull request contains just one commit,
      it's best to use its message as a summary. Otherwise, if there are multiple
      atomic commits, write a summary for the entire PR. Feel free to flag
      anything you think needs a reviewer's attention.
-->

<!--
      If your changes address an issue, link it with the *Fixes* tag so
      the issue gets closed when the PR is merged, for example:

      Fixes: #1234

      If you are only referencing an issue without fully addressing it, feel
      free to link it anywhere in the summary.
-->

Hello, this PR just introduces a configuration for https://github.com/crate-ci/typo and corrects various typos.

By introducing `typos-cli`, we can detect and correct well-known typos simply by calling the `typos` command on the repository directory.

Integration with the `cargo xtask clippy` was excluded as it did not seem to align with the purpose of this PR. I expect the implementation to proceed smoothly.

### Added/updated tests?

- [ ] Yes
- [x] No, and this is why: this PR is about documentation
- [ ] I need help with writing tests

### Checklist

- [x] Rust code has been formatted with `cargo +nightly fmt`.
- [x] All clippy lints have been fixed.
      You can find failing lints with `cargo xtask clippy`.
- [x] Unit tests are passing locally with `cargo test`.
- [ ] The [Integration tests] are passing locally.
- [ ] I have blessed any API changes with `cargo xtask public-api --bless`.

[Integration tests]: https://github.com/aya-rs/aya/blob/main/test/README.md

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aya-rs/aya/1575)
<!-- Reviewable:end -->
