### PR TITLE
aya-ebpf: add BTF map definitions for hash maps

### DIFF
--- a/ebpf/aya-ebpf/src/btf_maps/array.rs
+++ b/ebpf/aya-ebpf/src/btf_maps/array.rs
@@ -23,6 +23,11 @@ btf_map_def!(
     value_type: T,
 );
 
+impl<T, const MAX_ENTRIES: usize, const FLAGS: usize> crate::btf_maps::private::SafeInnerLookup
+    for Array<T, MAX_ENTRIES, FLAGS>
+{
+}
+
 impl<T, const MAX_ENTRIES: usize, const FLAGS: usize> Array<T, MAX_ENTRIES, FLAGS> {
     #[inline(always)]
     pub fn get(&self, index: u32) -> Option<&T> {

--- a/ebpf/aya-ebpf/src/btf_maps/hash_map.rs
+++ b/ebpf/aya-ebpf/src/btf_maps/hash_map.rs
@@ -1,0 +1,322 @@
+//! BTF-compatible BPF hash map variants.
+
+#![deny(missing_docs)]
+
+use core::{borrow::Borrow, ptr::NonNull};
+
+use aya_ebpf_bindings::bindings::{BPF_F_NO_COMMON_LRU, BPF_F_NO_PREALLOC};
+
+use crate::{btf_maps::btf_map_def, insert, lookup, remove};
+
+macro_rules! define_btf_hash_map {
+    // Enforces kernel constraints from kernel/bpf/hashtab.c
+    // htab_map_alloc_check. The 8-byte value-alignment ceiling applies to
+    // all four variants: shared hashtab slots sit at
+    // `htab_elem.key[__aligned(8)] + round_up(key_size, 8)`, and per-CPU
+    // slots come from `bpf_map_alloc_percpu(..., 8, ...)`. Values with
+    // stricter alignment would be under-aligned for `&V` returned by
+    // `get`.
+    (
+        $(#[$top_attr:meta])*
+        $name:ident,
+        map_type: $map_type:ident,
+        rejected_flag: ($rejected_flag:expr, $rejected_flag_msg:literal $(,)?),
+        get_doc: { $(#[$get_attr:meta])+ } $(,)?
+    ) => {
+        btf_map_def!(
+            $(#[$top_attr])*
+            pub struct $name<K, V; const MAX_ENTRIES: usize, const FLAGS: usize = 0>,
+            map_type: $map_type,
+            max_entries: MAX_ENTRIES,
+            map_flags: FLAGS,
+            key_type: K,
+            value_type: V,
+        );
+
+        impl<K, V, const MAX_ENTRIES: usize, const FLAGS: usize> $name<K, V, MAX_ENTRIES, FLAGS> {
+            const _CHECK: () = {
+                assert!(
+                    size_of::<K>() > 0,
+                    concat!(stringify!($name), " key must be non-zero sized."),
+                );
+                assert!(
+                    size_of::<V>() > 0,
+                    concat!(stringify!($name), " value must be non-zero sized."),
+                );
+                assert!(
+                    MAX_ENTRIES > 0,
+                    concat!(stringify!($name), " max_entries must be greater than zero."),
+                );
+                assert!(FLAGS & $rejected_flag as usize == 0, $rejected_flag_msg);
+                assert!(
+                    align_of::<V>() <= 8,
+                    concat!(
+                        stringify!($name),
+                        " value alignment must be at most 8 bytes.",
+                    ),
+                );
+            };
+
+            $(#[$get_attr])+
+            #[inline(always)]
+            pub unsafe fn get(&self, key: impl Borrow<K>) -> Option<&V> {
+                let () = Self::_CHECK;
+                // SAFETY: The caller upholds the aliasing invariants documented above.
+                unsafe { self.lookup(key.borrow()).map(|p| p.as_ref()) }
+            }
+
+            /// Returns a `*const V` for the value associated with `key`.
+            ///
+            /// The same aliasing caveat as [`Self::get`] applies; it is the
+            /// caller's responsibility to decide whether dereferencing the
+            /// pointer is safe.
+            #[inline(always)]
+            pub fn get_ptr(&self, key: impl Borrow<K>) -> Option<*const V> {
+                let () = Self::_CHECK;
+                unsafe { self.lookup(key.borrow()).map(|p| p.as_ptr().cast_const()) }
+            }
+
+            /// Returns a `*mut V` for the value associated with `key`.
+            ///
+            /// The same aliasing caveat as [`Self::get`] applies, and the
+            /// caller must additionally avoid concurrent writes.
+            #[inline(always)]
+            pub fn get_ptr_mut(&self, key: impl Borrow<K>) -> Option<*mut V> {
+                let () = Self::_CHECK;
+                unsafe { self.lookup(key.borrow()).map(NonNull::as_ptr) }
+            }
+
+            #[inline(always)]
+            unsafe fn lookup(&self, key: &K) -> Option<NonNull<V>> {
+                lookup(self.as_ptr(), key)
+            }
+
+            /// Inserts `value` under `key`.
+            ///
+            /// `flags` is forwarded to `bpf_map_update_elem`; common choices
+            /// are `BPF_ANY`, `BPF_NOEXIST`, and `BPF_EXIST`.
+            #[inline(always)]
+            pub fn insert(
+                &self,
+                key: impl Borrow<K>,
+                value: impl Borrow<V>,
+                flags: u64,
+            ) -> Result<(), i32> {
+                let () = Self::_CHECK;
+                insert(self.as_ptr(), key.borrow(), value.borrow(), flags)
+            }
+
+            /// Removes the entry for `key`.
+            #[inline(always)]
+            pub fn remove(&self, key: impl Borrow<K>) -> Result<(), i32> {
+                let () = Self::_CHECK;
+                remove(self.as_ptr(), key.borrow())
+            }
+        }
+    };
+}
+
+define_btf_hash_map!(
+    /// A BTF-compatible BPF hash map.
+    ///
+    /// Stores values of type `V` keyed by `K` with kernel-managed collision
+    /// chaining. Entries persist until explicitly removed or the map is
+    /// dropped.
+    ///
+    /// # Minimum kernel version
+    ///
+    /// The minimum kernel version required to use this feature is 4.19.
+    ///
+    /// # Flag and size restrictions
+    ///
+    /// `BPF_F_NO_COMMON_LRU` is rejected by the kernel on non-LRU hash maps
+    /// and returns `EINVAL`. The key and value must both be non-zero sized
+    /// and `max_entries` must be at least 1.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use aya_ebpf::{btf_maps::HashMap, macros::btf_map};
+    ///
+    /// #[btf_map]
+    /// static COUNTS: HashMap<u32, u64, 1024> = HashMap::new();
+    /// ```
+    HashMap,
+    map_type: BPF_MAP_TYPE_HASH,
+    rejected_flag: (
+        BPF_F_NO_COMMON_LRU,
+        "BPF_F_NO_COMMON_LRU is only valid on LRU hash variants.",
+    ),
+    get_doc: {
+        /// Returns a reference to the value associated with `key`.
+        ///
+        /// # Safety
+        ///
+        /// The returned reference is only valid until the next `insert` or
+        /// `remove` on this map. Unless the map was created with
+        /// `BPF_F_NO_PREALLOC`, the kernel keeps a preallocated freelist
+        /// and recycles a slot the moment its entry is removed; a
+        /// subsequent `insert` into that slot reuses the bytes the
+        /// reference points to, causing garbage to be read or corruption
+        /// on write.
+    },
+);
+
+define_btf_hash_map!(
+    /// A BTF-compatible BPF LRU hash map.
+    ///
+    /// Stores values of type `V` keyed by `K`. When the map is full, the
+    /// kernel evicts the least-recently-used entry on insert. Lookups from
+    /// BPF context bump the LRU position; passing `BPF_F_NO_COMMON_LRU`
+    /// switches bookkeeping to per-CPU LRU lists at the cost of rounding
+    /// `max_entries` up to a multiple of `num_possible_cpus()`.
+    ///
+    /// # Minimum kernel version
+    ///
+    /// The minimum kernel version required to use this feature is 4.19.
+    /// `BPF_MAP_TYPE_LRU_HASH` itself dates back to 4.10, but BTF map
+    /// definitions require the BTF pretty-print path for hashtab maps,
+    /// which landed in 4.19.
+    ///
+    /// # Flag and size restrictions
+    ///
+    /// `BPF_F_NO_PREALLOC` is rejected by the kernel on LRU hash maps and
+    /// returns `ENOTSUPP`. The key and value must both be non-zero sized
+    /// and `max_entries` must be at least 1.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use aya_ebpf::{btf_maps::LruHashMap, macros::btf_map};
+    ///
+    /// #[btf_map]
+    /// static RECENT: LruHashMap<u32, u64, 1024> = LruHashMap::new();
+    /// ```
+    LruHashMap,
+    map_type: BPF_MAP_TYPE_LRU_HASH,
+    rejected_flag: (
+        BPF_F_NO_PREALLOC,
+        "BPF_F_NO_PREALLOC is rejected by LRU hash maps.",
+    ),
+    get_doc: {
+        /// Returns a reference to the value associated with `key`, bumping
+        /// its LRU position.
+        ///
+        /// # Safety
+        ///
+        /// The returned reference is only valid until the next `insert` or
+        /// `remove` on this map. When the map is full, an `insert` evicts
+        /// the least-recently-used entry and recycles its slot; if that
+        /// slot held the borrowed entry, the reference now aliases the new
+        /// value. A `remove` of the borrowed entry has the same effect.
+    },
+);
+
+define_btf_hash_map!(
+    /// A BTF-compatible BPF per-CPU hash map.
+    ///
+    /// Stores a distinct value of type `V` per CPU, keyed by `K`. Reads and
+    /// writes from BPF context reference the slot belonging to the CPU that
+    /// executes the program; other CPUs' slots are accessible only from
+    /// user space via `bpf_map_lookup_elem` with a `num_possible_cpus()`-sized
+    /// value buffer.
+    ///
+    /// # Minimum kernel version
+    ///
+    /// The minimum kernel version required to use this feature is 4.19.
+    /// `BPF_MAP_TYPE_PERCPU_HASH` itself dates back to 4.6, but BTF map
+    /// definitions require the BTF pretty-print path for hashtab maps,
+    /// which landed in 4.19.
+    ///
+    /// # Flag and size restrictions
+    ///
+    /// `BPF_F_NO_COMMON_LRU` is rejected by the kernel on non-LRU hash maps
+    /// and returns `EINVAL`. Each per-CPU value must also satisfy
+    /// `round_up(size_of::<V>(), 8) <= PCPU_MIN_UNIT_SIZE` (32 KiB on most
+    /// kernel builds); violations fail with `E2BIG` at load time. The key
+    /// and value must both be non-zero sized and `max_entries` must be at
+    /// least 1.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use aya_ebpf::{btf_maps::PerCpuHashMap, macros::btf_map};
+    ///
+    /// #[btf_map]
+    /// static COUNTS: PerCpuHashMap<u32, u64, 1024> = PerCpuHashMap::new();
+    /// ```
+    PerCpuHashMap,
+    map_type: BPF_MAP_TYPE_PERCPU_HASH,
+    rejected_flag: (
+        BPF_F_NO_COMMON_LRU,
+        "BPF_F_NO_COMMON_LRU is only valid on LRU hash variants.",
+    ),
+    get_doc: {
+        /// Returns a reference to the current CPU's value for `key`.
+        ///
+        /// # Safety
+        ///
+        /// The returned reference is only valid until the next `insert` or
+        /// `remove` on this map. Unless the map was created with
+        /// `BPF_F_NO_PREALLOC`, the kernel keeps a preallocated freelist
+        /// and recycles a slot the moment its entry is removed; a
+        /// subsequent `insert` into that slot reuses the bytes the
+        /// reference points to, causing garbage to be read or corruption
+        /// on write.
+    },
+);
+
+define_btf_hash_map!(
+    /// A BTF-compatible BPF LRU per-CPU hash map.
+    ///
+    /// Stores a distinct value of type `V` per CPU, keyed by `K`, with LRU
+    /// eviction when the map fills. Reads and writes from BPF context
+    /// reference the slot belonging to the CPU that executes the program;
+    /// LRU bookkeeping defaults to a single shared list across CPUs and may
+    /// be switched to per-CPU LRU lists with `BPF_F_NO_COMMON_LRU`, at the
+    /// cost of rounding `max_entries` up to a multiple of
+    /// `num_possible_cpus()`.
+    ///
+    /// # Minimum kernel version
+    ///
+    /// The minimum kernel version required to use this feature is 4.19.
+    /// `BPF_MAP_TYPE_LRU_PERCPU_HASH` itself dates back to 4.10, but BTF
+    /// map definitions require the BTF pretty-print path for hashtab maps,
+    /// which landed in 4.19.
+    ///
+    /// # Flag and size restrictions
+    ///
+    /// `BPF_F_NO_PREALLOC` is rejected by the kernel on LRU hash maps and
+    /// returns `ENOTSUPP`. Each per-CPU value must also satisfy
+    /// `round_up(size_of::<V>(), 8) <= PCPU_MIN_UNIT_SIZE` (32 KiB on most
+    /// kernel builds); violations fail with `E2BIG` at load time. The key
+    /// and value must both be non-zero sized and `max_entries` must be at
+    /// least 1.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use aya_ebpf::{btf_maps::LruPerCpuHashMap, macros::btf_map};
+    ///
+    /// #[btf_map]
+    /// static RECENT: LruPerCpuHashMap<u32, u64, 1024> = LruPerCpuHashMap::new();
+    /// ```
+    LruPerCpuHashMap,
+    map_type: BPF_MAP_TYPE_LRU_PERCPU_HASH,
+    rejected_flag: (
+        BPF_F_NO_PREALLOC,
+        "BPF_F_NO_PREALLOC is rejected by LRU hash maps.",
+    ),
+    get_doc: {
+        /// Returns a reference to the current CPU's value for `key`,
+        /// bumping its LRU position.
+        ///
+        /// # Safety
+        ///
+        /// The returned reference is only valid until the next `insert` or
+        /// `remove` on this map. When the map is full, an `insert` evicts
+        /// the least-recently-used entry and recycles its slot; if that
+        /// slot held the borrowed entry, the reference now aliases the new
+        /// value. A `remove` of the borrowed entry has the same effect.
+    },
+);

--- a/ebpf/aya-ebpf/src/btf_maps/mod.rs
+++ b/ebpf/aya-ebpf/src/btf_maps/mod.rs
@@ -3,6 +3,7 @@ pub mod bloom_filter;
 pub mod cpu_map;
 pub mod dev_map;
 pub mod dev_map_hash;
+pub mod hash_map;
 pub mod lpm_trie;
 pub mod of_maps;
 pub mod per_cpu_array;
@@ -24,6 +25,7 @@ pub use bloom_filter::BloomFilter;
 pub use cpu_map::CpuMap;
 pub use dev_map::DevMap;
 pub use dev_map_hash::DevMapHash;
+pub use hash_map::{HashMap, LruHashMap, LruPerCpuHashMap, PerCpuHashMap};
 pub use lpm_trie::LpmTrie;
 pub use of_maps::{ArrayOfMaps, HashOfMaps};
 pub use per_cpu_array::PerCpuArray;
@@ -52,6 +54,18 @@ mod private {
         /// The value type of this map.
         type Value;
     }
+
+    /// Sealed marker for inner-map types whose `bpf_map_lookup_elem` returns
+    /// a reference that stays valid for the lifetime of the BPF program. Only
+    /// implemented for map families whose entries occupy stable, preallocated
+    /// slots (BPF arrays and per-CPU arrays); hash families opt out because
+    /// the entry behind a reference can be reused by any subsequent `insert`,
+    /// `remove`, or LRU eviction.
+    #[expect(
+        unnameable_types,
+        reason = "sealed trait pattern requires pub trait in private mod"
+    )]
+    pub trait SafeInnerLookup: MapDef {}
 }
 
 /// Key and value types of a BTF map definition.
@@ -63,6 +77,19 @@ mod private {
 pub trait MapDef: private::MapDef {}
 
 impl<T: private::MapDef> MapDef for T {}
+
+/// Marks a BTF map type whose fused inner lookup via [`ArrayOfMaps::get_value`]
+/// is safe without an additional `unsafe` contract from the caller.
+///
+/// Implemented for [`Array`] and [`PerCpuArray`]. Hash families do not
+/// implement this trait because their kernel-side allocators reuse slots on
+/// `insert`/`remove`/eviction, so a reference obtained by a previous lookup
+/// can alias an unrelated entry.
+///
+/// This trait is sealed and cannot be implemented outside this crate.
+pub trait SafeInnerLookup: private::SafeInnerLookup {}
+
+impl<T: private::SafeInnerLookup> SafeInnerLookup for T {}
 
 /// Wraps `bpf_redirect_map` for XDP redirect maps.
 ///
@@ -206,6 +233,13 @@ macro_rules! btf_map_def {
             $($extra_field: $extra_ty,)*
         }
 
+        // SAFETY: The struct fields are placeholder raw pointers that the
+        // BTF loader patches at load time; they are never dereferenced
+        // from Rust code, so the wrapper has no aliasable state. Static
+        // declaration of BPF maps via `#[btf_map]` requires `Sync`. For
+        // per-CPU map types the current-CPU access semantic is enforced
+        // by the kernel inside `bpf_map_lookup_elem`, not by the wrapper,
+        // so this impl applies uniformly to shared and per-CPU variants.
         unsafe impl<
             $($ty_gen,)*
             $($(const $const_gen : $const_ty,)+)?
@@ -233,6 +267,7 @@ macro_rules! btf_map_def {
             $($ty_gen,)*
             $($($const_gen,)+)?
         > {
+            /// Returns a placeholder definition that the BPF loader patches at load time.
             pub const fn new() -> Self {
                 Self {
                     r#type: ::core::ptr::null(),

--- a/ebpf/aya-ebpf/src/btf_maps/of_maps/array.rs
+++ b/ebpf/aya-ebpf/src/btf_maps/of_maps/array.rs
@@ -48,7 +48,7 @@ impl<V, const MAX_ENTRIES: usize, const FLAGS: usize> ArrayOfMaps<V, MAX_ENTRIES
     }
 }
 
-impl<V: crate::btf_maps::MapDef, const MAX_ENTRIES: usize, const FLAGS: usize>
+impl<V: crate::btf_maps::SafeInnerLookup, const MAX_ENTRIES: usize, const FLAGS: usize>
     ArrayOfMaps<V, MAX_ENTRIES, FLAGS>
 {
     /// Looks up a value directly in the inner map at `outer_index`.
@@ -59,11 +59,23 @@ impl<V: crate::btf_maps::MapDef, const MAX_ENTRIES: usize, const FLAGS: usize>
     #[inline(always)]
     pub fn get_value(&self, outer_index: u32, inner_key: &V::Key) -> Option<&V::Value> {
         let inner: NonNull<V> = lookup(self.as_ptr(), &outer_index)?;
-        // SAFETY: Array lookups are safe (no BPF_F_NO_PREALLOC aliasing concern).
+        // SAFETY: `V: SafeInnerLookup` guarantees the kernel returns a
+        // reference that stays valid for the lifetime of the BPF program,
+        // so the produced shared reference is sound.
         unsafe { crate::btf_maps::lookup_inner(inner, inner_key) }
     }
+}
 
-    /// Same as [`get_value`](Self::get_value) but returns a mutable pointer.
+impl<V: crate::btf_maps::MapDef, const MAX_ENTRIES: usize, const FLAGS: usize>
+    ArrayOfMaps<V, MAX_ENTRIES, FLAGS>
+{
+    /// Returns a `*mut V::Value` to the entry at `inner_key` of the inner map at
+    /// `outer_index`.
+    ///
+    /// Like [`get_value`](Self::get_value), this combines the outer and inner
+    /// `bpf_map_lookup_elem` calls in a single method. The pointer's lifetime
+    /// is not enforced by Rust; it is the caller's responsibility to ensure
+    /// dereferences are sound for the inner map type.
     #[inline(always)]
     pub fn get_value_ptr_mut(&self, outer_index: u32, inner_key: &V::Key) -> Option<*mut V::Value> {
         let inner: NonNull<V> = lookup(self.as_ptr(), &outer_index)?;

--- a/ebpf/aya-ebpf/src/btf_maps/per_cpu_array.rs
+++ b/ebpf/aya-ebpf/src/btf_maps/per_cpu_array.rs
@@ -48,6 +48,11 @@ btf_map_def!(
     value_type: T,
 );
 
+impl<T, const MAX_ENTRIES: usize, const FLAGS: usize> crate::btf_maps::private::SafeInnerLookup
+    for PerCpuArray<T, MAX_ENTRIES, FLAGS>
+{
+}
+
 impl<T, const MAX_ENTRIES: usize, const FLAGS: usize> PerCpuArray<T, MAX_ENTRIES, FLAGS> {
     // Enforces kernel constraints from kernel/bpf/arraymap.c and the
     // per-CPU allocator alignment invariant. `const _: ()` is forbidden in

--- a/test/integration-ebpf/Cargo.toml
+++ b/test/integration-ebpf/Cargo.toml
@@ -49,6 +49,10 @@ name = "dev_map"
 path = "src/dev_map.rs"
 
 [[bin]]
+name = "hash_map"
+path = "src/hash_map.rs"
+
+[[bin]]
 name = "kprobe"
 path = "src/kprobe.rs"
 

--- a/test/integration-ebpf/src/hash_map.rs
+++ b/test/integration-ebpf/src/hash_map.rs
@@ -1,0 +1,76 @@
+#![no_std]
+#![no_main]
+#![expect(unused_crate_dependencies, reason = "used in other bins")]
+
+#[cfg(not(test))]
+extern crate ebpf_panic;
+
+use aya_ebpf::{
+    btf_maps::{
+        Array as BtfArray, HashMap as BtfHashMap, LruHashMap as BtfLruHashMap,
+        LruPerCpuHashMap as BtfLruPerCpuHashMap, PerCpuHashMap as BtfPerCpuHashMap,
+    },
+    cty::c_long,
+    macros::{btf_map, map, uprobe},
+    maps::{Array, HashMap, LruHashMap, LruPerCpuHashMap, PerCpuHashMap},
+    programs::ProbeContext,
+};
+
+#[btf_map]
+static RESULT: BtfArray<u64, 1, 0> = BtfArray::new();
+
+#[btf_map]
+static HASH_BTF: BtfHashMap<u32, u64, 1> = BtfHashMap::new();
+
+#[btf_map]
+static LRU_HASH_BTF: BtfLruHashMap<u32, u64, 1> = BtfLruHashMap::new();
+
+#[btf_map]
+static PER_CPU_HASH_BTF: BtfPerCpuHashMap<u32, u64, 1> = BtfPerCpuHashMap::new();
+
+#[btf_map]
+static LRU_PER_CPU_HASH_BTF: BtfLruPerCpuHashMap<u32, u64, 1> = BtfLruPerCpuHashMap::new();
+
+#[map]
+static RESULT_LEGACY: Array<u64> = Array::<u64>::with_max_entries(1, 0);
+
+#[map]
+static HASH_LEGACY: HashMap<u32, u64> = HashMap::with_max_entries(1, 0);
+
+#[map]
+static LRU_HASH_LEGACY: LruHashMap<u32, u64> = LruHashMap::with_max_entries(1, 0);
+
+#[map]
+static PER_CPU_HASH_LEGACY: PerCpuHashMap<u32, u64> = PerCpuHashMap::with_max_entries(1, 0);
+
+#[map]
+static LRU_PER_CPU_HASH_LEGACY: LruPerCpuHashMap<u32, u64> =
+    LruPerCpuHashMap::with_max_entries(1, 0);
+
+macro_rules! define_hash_lookup {
+    ($map:ident, $result_map:ident, $fn:ident) => {
+        #[uprobe]
+        fn $fn(_: ProbeContext) -> Result<(), c_long> {
+            let value = unsafe { $map.get(&0u32) }.ok_or(-1)?;
+            let ptr = $result_map.get_ptr_mut(0).ok_or(-1)?;
+            unsafe {
+                *ptr = *value;
+            }
+            Ok(())
+        }
+    };
+}
+
+define_hash_lookup!(HASH_BTF, RESULT, test_hash_btf);
+define_hash_lookup!(LRU_HASH_BTF, RESULT, test_lru_hash_btf);
+define_hash_lookup!(PER_CPU_HASH_BTF, RESULT, test_per_cpu_hash_btf);
+define_hash_lookup!(LRU_PER_CPU_HASH_BTF, RESULT, test_lru_per_cpu_hash_btf);
+
+define_hash_lookup!(HASH_LEGACY, RESULT_LEGACY, test_hash_legacy);
+define_hash_lookup!(LRU_HASH_LEGACY, RESULT_LEGACY, test_lru_hash_legacy);
+define_hash_lookup!(PER_CPU_HASH_LEGACY, RESULT_LEGACY, test_per_cpu_hash_legacy);
+define_hash_lookup!(
+    LRU_PER_CPU_HASH_LEGACY,
+    RESULT_LEGACY,
+    test_lru_per_cpu_hash_legacy
+);

--- a/test/integration-test/src/lib.rs
+++ b/test/integration-test/src/lib.rs
@@ -45,6 +45,7 @@ bpf_file!(
     BTF_MAPS_PLAIN => "btf_maps_plain",
     CPU_MAP => "cpu_map",
     DEV_MAP => "dev_map",
+    HASH_MAP => "hash_map",
     KPROBE => "kprobe",
     LINEAR_DATA_STRUCTURES => "linear_data_structures",
     LOG => "log",

--- a/test/integration-test/src/tests.rs
+++ b/test/integration-test/src/tests.rs
@@ -16,6 +16,7 @@ mod btf_maps;
 mod btf_relocations;
 mod elf;
 mod feature_probe;
+mod hash_map;
 mod info;
 mod iter;
 mod kprobe;

--- a/test/integration-test/src/tests/hash_map.rs
+++ b/test/integration-test/src/tests/hash_map.rs
@@ -1,0 +1,81 @@
+use aya::{
+    EbpfLoader,
+    maps::{Array, HashMap, MapType, PerCpuHashMap, PerCpuValues},
+    programs::{UProbe, uprobe::UProbeScope},
+    sys::is_map_supported,
+    util::nr_cpus,
+};
+use test_case::test_case;
+
+const EXPECTED: u64 = 42;
+
+#[unsafe(no_mangle)]
+#[inline(never)]
+extern "C" fn trigger_hash_lookup() {
+    std::hint::black_box(());
+}
+
+#[test_log::test(test_case(MapType::Hash, "test_hash_btf", "HASH_BTF", "RESULT" ; "hash_btf"))]
+#[test_case(MapType::LruHash, "test_lru_hash_btf", "LRU_HASH_BTF", "RESULT" ; "lru_hash_btf")]
+#[test_case(MapType::PerCpuHash, "test_per_cpu_hash_btf", "PER_CPU_HASH_BTF", "RESULT" ; "per_cpu_hash_btf")]
+#[test_case(MapType::LruPerCpuHash, "test_lru_per_cpu_hash_btf", "LRU_PER_CPU_HASH_BTF", "RESULT" ; "lru_per_cpu_hash_btf")]
+#[test_case(MapType::Hash, "test_hash_legacy", "HASH_LEGACY", "RESULT_LEGACY" ; "hash_legacy")]
+#[test_case(MapType::LruHash, "test_lru_hash_legacy", "LRU_HASH_LEGACY", "RESULT_LEGACY" ; "lru_hash_legacy")]
+#[test_case(MapType::PerCpuHash, "test_per_cpu_hash_legacy", "PER_CPU_HASH_LEGACY", "RESULT_LEGACY" ; "per_cpu_hash_legacy")]
+#[test_case(MapType::LruPerCpuHash, "test_lru_per_cpu_hash_legacy", "LRU_PER_CPU_HASH_LEGACY", "RESULT_LEGACY" ; "lru_per_cpu_hash_legacy")]
+fn hash_basic(map_type: MapType, prog_name: &str, map_name: &str, result_map: &str) {
+    if matches!(map_type, MapType::LruHash | MapType::LruPerCpuHash)
+        && !is_map_supported(map_type).unwrap()
+    {
+        eprintln!("skipping test - {map_type:?} not supported");
+        return;
+    }
+    let per_cpu = matches!(map_type, MapType::PerCpuHash | MapType::LruPerCpuHash);
+    let mut bpf = EbpfLoader::new().load(crate::HASH_MAP).unwrap();
+
+    if per_cpu {
+        let mut map: PerCpuHashMap<_, u32, u64> =
+            bpf.map_mut(map_name).unwrap().try_into().unwrap();
+        // Distinct value per CPU exercises per-CPU divergence: the
+        // kernel must keep slots independent across CPUs.
+        let expected_per_cpu: Vec<u64> = (0..nr_cpus().unwrap())
+            .map(|i| EXPECTED + i as u64)
+            .collect();
+        map.insert(
+            0u32,
+            PerCpuValues::try_from(expected_per_cpu.clone()).unwrap(),
+            0,
+        )
+        .unwrap();
+        let readback = map.get(&0u32, 0).unwrap();
+        for (cpu, slot) in readback.iter().enumerate() {
+            assert_eq!(*slot, expected_per_cpu[cpu], "per-CPU slot {cpu}");
+        }
+    } else {
+        let mut map: HashMap<_, u32, u64> = bpf.map_mut(map_name).unwrap().try_into().unwrap();
+        map.insert(0u32, EXPECTED, 0).unwrap();
+    }
+
+    let prog: &mut UProbe = bpf.program_mut(prog_name).unwrap().try_into().unwrap();
+    prog.load().unwrap();
+    prog.attach(
+        "trigger_hash_lookup",
+        "/proc/self/exe",
+        UProbeScope::AllProcesses,
+    )
+    .unwrap();
+
+    trigger_hash_lookup();
+
+    let result: Array<_, u64> = bpf.map(result_map).unwrap().try_into().unwrap();
+    let observed = result.get(&0, 0).unwrap();
+    if per_cpu {
+        let range = EXPECTED..EXPECTED + nr_cpus().unwrap() as u64;
+        assert!(
+            range.contains(&observed),
+            "per-CPU read {observed} not in {range:?}",
+        );
+    } else {
+        assert_eq!(observed, EXPECTED);
+    }
+}

--- a/xtask/public-api/aya-ebpf.txt
+++ b/xtask/public-api/aya-ebpf.txt
@@ -88,6 +88,79 @@ impl<const MAX_ENTRIES: usize, const FLAGS: usize> core::marker::Unpin for aya_e
 impl<const MAX_ENTRIES: usize, const FLAGS: usize> core::marker::UnsafeUnpin for aya_ebpf::btf_maps::dev_map_hash::DevMapHash<MAX_ENTRIES, FLAGS>
 impl<const MAX_ENTRIES: usize, const FLAGS: usize> core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::btf_maps::dev_map_hash::DevMapHash<MAX_ENTRIES, FLAGS>
 impl<const MAX_ENTRIES: usize, const FLAGS: usize> core::panic::unwind_safe::UnwindSafe for aya_ebpf::btf_maps::dev_map_hash::DevMapHash<MAX_ENTRIES, FLAGS>
+pub mod aya_ebpf::btf_maps::hash_map
+#[repr(C)] pub struct aya_ebpf::btf_maps::hash_map::HashMap<K, V, const MAX_ENTRIES: usize, const FLAGS: usize>
+impl<K, V, const MAX_ENTRIES: usize, const FLAGS: usize> aya_ebpf::btf_maps::hash_map::HashMap<K, V, MAX_ENTRIES, FLAGS>
+pub unsafe fn aya_ebpf::btf_maps::hash_map::HashMap<K, V, MAX_ENTRIES, FLAGS>::get(&self, key: impl core::borrow::Borrow<K>) -> core::option::Option<&V>
+pub fn aya_ebpf::btf_maps::hash_map::HashMap<K, V, MAX_ENTRIES, FLAGS>::get_ptr(&self, key: impl core::borrow::Borrow<K>) -> core::option::Option<*const V>
+pub fn aya_ebpf::btf_maps::hash_map::HashMap<K, V, MAX_ENTRIES, FLAGS>::get_ptr_mut(&self, key: impl core::borrow::Borrow<K>) -> core::option::Option<*mut V>
+pub fn aya_ebpf::btf_maps::hash_map::HashMap<K, V, MAX_ENTRIES, FLAGS>::insert(&self, key: impl core::borrow::Borrow<K>, value: impl core::borrow::Borrow<V>, flags: u64) -> core::result::Result<(), i32>
+pub fn aya_ebpf::btf_maps::hash_map::HashMap<K, V, MAX_ENTRIES, FLAGS>::remove(&self, key: impl core::borrow::Borrow<K>) -> core::result::Result<(), i32>
+impl<K, V, const MAX_ENTRIES: usize, const FLAGS: usize> aya_ebpf::btf_maps::hash_map::HashMap<K, V, MAX_ENTRIES, FLAGS>
+pub const fn aya_ebpf::btf_maps::hash_map::HashMap<K, V, MAX_ENTRIES, FLAGS>::new() -> Self
+impl<K, V, const MAX_ENTRIES: usize, const FLAGS: usize> core::default::Default for aya_ebpf::btf_maps::hash_map::HashMap<K, V, MAX_ENTRIES, FLAGS>
+pub fn aya_ebpf::btf_maps::hash_map::HashMap<K, V, MAX_ENTRIES, FLAGS>::default() -> Self
+impl<K, V, const MAX_ENTRIES: usize, const FLAGS: usize> core::marker::Sync for aya_ebpf::btf_maps::hash_map::HashMap<K, V, MAX_ENTRIES, FLAGS>
+impl<K, V, const MAX_ENTRIES: usize, const FLAGS: usize> core::marker::Freeze for aya_ebpf::btf_maps::hash_map::HashMap<K, V, MAX_ENTRIES, FLAGS>
+impl<K, V, const MAX_ENTRIES: usize, const FLAGS: usize> !core::marker::Send for aya_ebpf::btf_maps::hash_map::HashMap<K, V, MAX_ENTRIES, FLAGS>
+impl<K, V, const MAX_ENTRIES: usize, const FLAGS: usize> core::marker::Unpin for aya_ebpf::btf_maps::hash_map::HashMap<K, V, MAX_ENTRIES, FLAGS>
+impl<K, V, const MAX_ENTRIES: usize, const FLAGS: usize> core::marker::UnsafeUnpin for aya_ebpf::btf_maps::hash_map::HashMap<K, V, MAX_ENTRIES, FLAGS>
+impl<K, V, const MAX_ENTRIES: usize, const FLAGS: usize> core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::btf_maps::hash_map::HashMap<K, V, MAX_ENTRIES, FLAGS> where K: core::panic::unwind_safe::RefUnwindSafe, V: core::panic::unwind_safe::RefUnwindSafe
+impl<K, V, const MAX_ENTRIES: usize, const FLAGS: usize> core::panic::unwind_safe::UnwindSafe for aya_ebpf::btf_maps::hash_map::HashMap<K, V, MAX_ENTRIES, FLAGS> where K: core::panic::unwind_safe::RefUnwindSafe, V: core::panic::unwind_safe::RefUnwindSafe
+#[repr(C)] pub struct aya_ebpf::btf_maps::hash_map::LruHashMap<K, V, const MAX_ENTRIES: usize, const FLAGS: usize>
+impl<K, V, const MAX_ENTRIES: usize, const FLAGS: usize> aya_ebpf::btf_maps::hash_map::LruHashMap<K, V, MAX_ENTRIES, FLAGS>
+pub unsafe fn aya_ebpf::btf_maps::hash_map::LruHashMap<K, V, MAX_ENTRIES, FLAGS>::get(&self, key: impl core::borrow::Borrow<K>) -> core::option::Option<&V>
+pub fn aya_ebpf::btf_maps::hash_map::LruHashMap<K, V, MAX_ENTRIES, FLAGS>::get_ptr(&self, key: impl core::borrow::Borrow<K>) -> core::option::Option<*const V>
+pub fn aya_ebpf::btf_maps::hash_map::LruHashMap<K, V, MAX_ENTRIES, FLAGS>::get_ptr_mut(&self, key: impl core::borrow::Borrow<K>) -> core::option::Option<*mut V>
+pub fn aya_ebpf::btf_maps::hash_map::LruHashMap<K, V, MAX_ENTRIES, FLAGS>::insert(&self, key: impl core::borrow::Borrow<K>, value: impl core::borrow::Borrow<V>, flags: u64) -> core::result::Result<(), i32>
+pub fn aya_ebpf::btf_maps::hash_map::LruHashMap<K, V, MAX_ENTRIES, FLAGS>::remove(&self, key: impl core::borrow::Borrow<K>) -> core::result::Result<(), i32>
+impl<K, V, const MAX_ENTRIES: usize, const FLAGS: usize> aya_ebpf::btf_maps::hash_map::LruHashMap<K, V, MAX_ENTRIES, FLAGS>
+pub const fn aya_ebpf::btf_maps::hash_map::LruHashMap<K, V, MAX_ENTRIES, FLAGS>::new() -> Self
+impl<K, V, const MAX_ENTRIES: usize, const FLAGS: usize> core::default::Default for aya_ebpf::btf_maps::hash_map::LruHashMap<K, V, MAX_ENTRIES, FLAGS>
+pub fn aya_ebpf::btf_maps::hash_map::LruHashMap<K, V, MAX_ENTRIES, FLAGS>::default() -> Self
+impl<K, V, const MAX_ENTRIES: usize, const FLAGS: usize> core::marker::Sync for aya_ebpf::btf_maps::hash_map::LruHashMap<K, V, MAX_ENTRIES, FLAGS>
+impl<K, V, const MAX_ENTRIES: usize, const FLAGS: usize> core::marker::Freeze for aya_ebpf::btf_maps::hash_map::LruHashMap<K, V, MAX_ENTRIES, FLAGS>
+impl<K, V, const MAX_ENTRIES: usize, const FLAGS: usize> !core::marker::Send for aya_ebpf::btf_maps::hash_map::LruHashMap<K, V, MAX_ENTRIES, FLAGS>
+impl<K, V, const MAX_ENTRIES: usize, const FLAGS: usize> core::marker::Unpin for aya_ebpf::btf_maps::hash_map::LruHashMap<K, V, MAX_ENTRIES, FLAGS>
+impl<K, V, const MAX_ENTRIES: usize, const FLAGS: usize> core::marker::UnsafeUnpin for aya_ebpf::btf_maps::hash_map::LruHashMap<K, V, MAX_ENTRIES, FLAGS>
+impl<K, V, const MAX_ENTRIES: usize, const FLAGS: usize> core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::btf_maps::hash_map::LruHashMap<K, V, MAX_ENTRIES, FLAGS> where K: core::panic::unwind_safe::RefUnwindSafe, V: core::panic::unwind_safe::RefUnwindSafe
+impl<K, V, const MAX_ENTRIES: usize, const FLAGS: usize> core::panic::unwind_safe::UnwindSafe for aya_ebpf::btf_maps::hash_map::LruHashMap<K, V, MAX_ENTRIES, FLAGS> where K: core::panic::unwind_safe::RefUnwindSafe, V: core::panic::unwind_safe::RefUnwindSafe
+#[repr(C)] pub struct aya_ebpf::btf_maps::hash_map::LruPerCpuHashMap<K, V, const MAX_ENTRIES: usize, const FLAGS: usize>
+impl<K, V, const MAX_ENTRIES: usize, const FLAGS: usize> aya_ebpf::btf_maps::hash_map::LruPerCpuHashMap<K, V, MAX_ENTRIES, FLAGS>
+pub unsafe fn aya_ebpf::btf_maps::hash_map::LruPerCpuHashMap<K, V, MAX_ENTRIES, FLAGS>::get(&self, key: impl core::borrow::Borrow<K>) -> core::option::Option<&V>
+pub fn aya_ebpf::btf_maps::hash_map::LruPerCpuHashMap<K, V, MAX_ENTRIES, FLAGS>::get_ptr(&self, key: impl core::borrow::Borrow<K>) -> core::option::Option<*const V>
+pub fn aya_ebpf::btf_maps::hash_map::LruPerCpuHashMap<K, V, MAX_ENTRIES, FLAGS>::get_ptr_mut(&self, key: impl core::borrow::Borrow<K>) -> core::option::Option<*mut V>
+pub fn aya_ebpf::btf_maps::hash_map::LruPerCpuHashMap<K, V, MAX_ENTRIES, FLAGS>::insert(&self, key: impl core::borrow::Borrow<K>, value: impl core::borrow::Borrow<V>, flags: u64) -> core::result::Result<(), i32>
+pub fn aya_ebpf::btf_maps::hash_map::LruPerCpuHashMap<K, V, MAX_ENTRIES, FLAGS>::remove(&self, key: impl core::borrow::Borrow<K>) -> core::result::Result<(), i32>
+impl<K, V, const MAX_ENTRIES: usize, const FLAGS: usize> aya_ebpf::btf_maps::hash_map::LruPerCpuHashMap<K, V, MAX_ENTRIES, FLAGS>
+pub const fn aya_ebpf::btf_maps::hash_map::LruPerCpuHashMap<K, V, MAX_ENTRIES, FLAGS>::new() -> Self
+impl<K, V, const MAX_ENTRIES: usize, const FLAGS: usize> core::default::Default for aya_ebpf::btf_maps::hash_map::LruPerCpuHashMap<K, V, MAX_ENTRIES, FLAGS>
+pub fn aya_ebpf::btf_maps::hash_map::LruPerCpuHashMap<K, V, MAX_ENTRIES, FLAGS>::default() -> Self
+impl<K, V, const MAX_ENTRIES: usize, const FLAGS: usize> core::marker::Sync for aya_ebpf::btf_maps::hash_map::LruPerCpuHashMap<K, V, MAX_ENTRIES, FLAGS>
+impl<K, V, const MAX_ENTRIES: usize, const FLAGS: usize> core::marker::Freeze for aya_ebpf::btf_maps::hash_map::LruPerCpuHashMap<K, V, MAX_ENTRIES, FLAGS>
+impl<K, V, const MAX_ENTRIES: usize, const FLAGS: usize> !core::marker::Send for aya_ebpf::btf_maps::hash_map::LruPerCpuHashMap<K, V, MAX_ENTRIES, FLAGS>
+impl<K, V, const MAX_ENTRIES: usize, const FLAGS: usize> core::marker::Unpin for aya_ebpf::btf_maps::hash_map::LruPerCpuHashMap<K, V, MAX_ENTRIES, FLAGS>
+impl<K, V, const MAX_ENTRIES: usize, const FLAGS: usize> core::marker::UnsafeUnpin for aya_ebpf::btf_maps::hash_map::LruPerCpuHashMap<K, V, MAX_ENTRIES, FLAGS>
+impl<K, V, const MAX_ENTRIES: usize, const FLAGS: usize> core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::btf_maps::hash_map::LruPerCpuHashMap<K, V, MAX_ENTRIES, FLAGS> where K: core::panic::unwind_safe::RefUnwindSafe, V: core::panic::unwind_safe::RefUnwindSafe
+impl<K, V, const MAX_ENTRIES: usize, const FLAGS: usize> core::panic::unwind_safe::UnwindSafe for aya_ebpf::btf_maps::hash_map::LruPerCpuHashMap<K, V, MAX_ENTRIES, FLAGS> where K: core::panic::unwind_safe::RefUnwindSafe, V: core::panic::unwind_safe::RefUnwindSafe
+#[repr(C)] pub struct aya_ebpf::btf_maps::hash_map::PerCpuHashMap<K, V, const MAX_ENTRIES: usize, const FLAGS: usize>
+impl<K, V, const MAX_ENTRIES: usize, const FLAGS: usize> aya_ebpf::btf_maps::hash_map::PerCpuHashMap<K, V, MAX_ENTRIES, FLAGS>
+pub unsafe fn aya_ebpf::btf_maps::hash_map::PerCpuHashMap<K, V, MAX_ENTRIES, FLAGS>::get(&self, key: impl core::borrow::Borrow<K>) -> core::option::Option<&V>
+pub fn aya_ebpf::btf_maps::hash_map::PerCpuHashMap<K, V, MAX_ENTRIES, FLAGS>::get_ptr(&self, key: impl core::borrow::Borrow<K>) -> core::option::Option<*const V>
+pub fn aya_ebpf::btf_maps::hash_map::PerCpuHashMap<K, V, MAX_ENTRIES, FLAGS>::get_ptr_mut(&self, key: impl core::borrow::Borrow<K>) -> core::option::Option<*mut V>
+pub fn aya_ebpf::btf_maps::hash_map::PerCpuHashMap<K, V, MAX_ENTRIES, FLAGS>::insert(&self, key: impl core::borrow::Borrow<K>, value: impl core::borrow::Borrow<V>, flags: u64) -> core::result::Result<(), i32>
+pub fn aya_ebpf::btf_maps::hash_map::PerCpuHashMap<K, V, MAX_ENTRIES, FLAGS>::remove(&self, key: impl core::borrow::Borrow<K>) -> core::result::Result<(), i32>
+impl<K, V, const MAX_ENTRIES: usize, const FLAGS: usize> aya_ebpf::btf_maps::hash_map::PerCpuHashMap<K, V, MAX_ENTRIES, FLAGS>
+pub const fn aya_ebpf::btf_maps::hash_map::PerCpuHashMap<K, V, MAX_ENTRIES, FLAGS>::new() -> Self
+impl<K, V, const MAX_ENTRIES: usize, const FLAGS: usize> core::default::Default for aya_ebpf::btf_maps::hash_map::PerCpuHashMap<K, V, MAX_ENTRIES, FLAGS>
+pub fn aya_ebpf::btf_maps::hash_map::PerCpuHashMap<K, V, MAX_ENTRIES, FLAGS>::default() -> Self
+impl<K, V, const MAX_ENTRIES: usize, const FLAGS: usize> core::marker::Sync for aya_ebpf::btf_maps::hash_map::PerCpuHashMap<K, V, MAX_ENTRIES, FLAGS>
+impl<K, V, const MAX_ENTRIES: usize, const FLAGS: usize> core::marker::Freeze for aya_ebpf::btf_maps::hash_map::PerCpuHashMap<K, V, MAX_ENTRIES, FLAGS>
+impl<K, V, const MAX_ENTRIES: usize, const FLAGS: usize> !core::marker::Send for aya_ebpf::btf_maps::hash_map::PerCpuHashMap<K, V, MAX_ENTRIES, FLAGS>
+impl<K, V, const MAX_ENTRIES: usize, const FLAGS: usize> core::marker::Unpin for aya_ebpf::btf_maps::hash_map::PerCpuHashMap<K, V, MAX_ENTRIES, FLAGS>
+impl<K, V, const MAX_ENTRIES: usize, const FLAGS: usize> core::marker::UnsafeUnpin for aya_ebpf::btf_maps::hash_map::PerCpuHashMap<K, V, MAX_ENTRIES, FLAGS>
+impl<K, V, const MAX_ENTRIES: usize, const FLAGS: usize> core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::btf_maps::hash_map::PerCpuHashMap<K, V, MAX_ENTRIES, FLAGS> where K: core::panic::unwind_safe::RefUnwindSafe, V: core::panic::unwind_safe::RefUnwindSafe
+impl<K, V, const MAX_ENTRIES: usize, const FLAGS: usize> core::panic::unwind_safe::UnwindSafe for aya_ebpf::btf_maps::hash_map::PerCpuHashMap<K, V, MAX_ENTRIES, FLAGS> where K: core::panic::unwind_safe::RefUnwindSafe, V: core::panic::unwind_safe::RefUnwindSafe
 pub mod aya_ebpf::btf_maps::lpm_trie
 #[repr(C, packed(1))] pub struct aya_ebpf::btf_maps::lpm_trie::Key<K>
 pub aya_ebpf::btf_maps::lpm_trie::Key::data: K
@@ -124,8 +197,9 @@ pub fn aya_ebpf::btf_maps::ArrayOfMaps<V, MAX_ENTRIES, FLAGS>::get(&self, index:
 impl<V, const MAX_ENTRIES: usize, const FLAGS: usize> aya_ebpf::btf_maps::ArrayOfMaps<V, MAX_ENTRIES, FLAGS>
 pub const fn aya_ebpf::btf_maps::ArrayOfMaps<V, MAX_ENTRIES, FLAGS>::new() -> Self
 impl<V: aya_ebpf::btf_maps::MapDef, const MAX_ENTRIES: usize, const FLAGS: usize> aya_ebpf::btf_maps::ArrayOfMaps<V, MAX_ENTRIES, FLAGS>
-pub fn aya_ebpf::btf_maps::ArrayOfMaps<V, MAX_ENTRIES, FLAGS>::get_value(&self, outer_index: u32, inner_key: &<V as aya_ebpf::btf_maps::private::MapDef>::Key) -> core::option::Option<&<V as aya_ebpf::btf_maps::private::MapDef>::Value>
 pub fn aya_ebpf::btf_maps::ArrayOfMaps<V, MAX_ENTRIES, FLAGS>::get_value_ptr_mut(&self, outer_index: u32, inner_key: &<V as aya_ebpf::btf_maps::private::MapDef>::Key) -> core::option::Option<*mut <V as aya_ebpf::btf_maps::private::MapDef>::Value>
+impl<V: aya_ebpf::btf_maps::SafeInnerLookup, const MAX_ENTRIES: usize, const FLAGS: usize> aya_ebpf::btf_maps::ArrayOfMaps<V, MAX_ENTRIES, FLAGS>
+pub fn aya_ebpf::btf_maps::ArrayOfMaps<V, MAX_ENTRIES, FLAGS>::get_value(&self, outer_index: u32, inner_key: &<V as aya_ebpf::btf_maps::private::MapDef>::Key) -> core::option::Option<&<V as aya_ebpf::btf_maps::private::MapDef>::Value>
 impl<V, const MAX_ENTRIES: usize, const FLAGS: usize> core::default::Default for aya_ebpf::btf_maps::ArrayOfMaps<V, MAX_ENTRIES, FLAGS>
 pub fn aya_ebpf::btf_maps::ArrayOfMaps<V, MAX_ENTRIES, FLAGS>::default() -> Self
 impl<V, const MAX_ENTRIES: usize, const FLAGS: usize> core::marker::Sync for aya_ebpf::btf_maps::ArrayOfMaps<V, MAX_ENTRIES, FLAGS>
@@ -391,8 +465,9 @@ pub fn aya_ebpf::btf_maps::ArrayOfMaps<V, MAX_ENTRIES, FLAGS>::get(&self, index:
 impl<V, const MAX_ENTRIES: usize, const FLAGS: usize> aya_ebpf::btf_maps::ArrayOfMaps<V, MAX_ENTRIES, FLAGS>
 pub const fn aya_ebpf::btf_maps::ArrayOfMaps<V, MAX_ENTRIES, FLAGS>::new() -> Self
 impl<V: aya_ebpf::btf_maps::MapDef, const MAX_ENTRIES: usize, const FLAGS: usize> aya_ebpf::btf_maps::ArrayOfMaps<V, MAX_ENTRIES, FLAGS>
-pub fn aya_ebpf::btf_maps::ArrayOfMaps<V, MAX_ENTRIES, FLAGS>::get_value(&self, outer_index: u32, inner_key: &<V as aya_ebpf::btf_maps::private::MapDef>::Key) -> core::option::Option<&<V as aya_ebpf::btf_maps::private::MapDef>::Value>
 pub fn aya_ebpf::btf_maps::ArrayOfMaps<V, MAX_ENTRIES, FLAGS>::get_value_ptr_mut(&self, outer_index: u32, inner_key: &<V as aya_ebpf::btf_maps::private::MapDef>::Key) -> core::option::Option<*mut <V as aya_ebpf::btf_maps::private::MapDef>::Value>
+impl<V: aya_ebpf::btf_maps::SafeInnerLookup, const MAX_ENTRIES: usize, const FLAGS: usize> aya_ebpf::btf_maps::ArrayOfMaps<V, MAX_ENTRIES, FLAGS>
+pub fn aya_ebpf::btf_maps::ArrayOfMaps<V, MAX_ENTRIES, FLAGS>::get_value(&self, outer_index: u32, inner_key: &<V as aya_ebpf::btf_maps::private::MapDef>::Key) -> core::option::Option<&<V as aya_ebpf::btf_maps::private::MapDef>::Value>
 impl<V, const MAX_ENTRIES: usize, const FLAGS: usize> core::default::Default for aya_ebpf::btf_maps::ArrayOfMaps<V, MAX_ENTRIES, FLAGS>
 pub fn aya_ebpf::btf_maps::ArrayOfMaps<V, MAX_ENTRIES, FLAGS>::default() -> Self
 impl<V, const MAX_ENTRIES: usize, const FLAGS: usize> core::marker::Sync for aya_ebpf::btf_maps::ArrayOfMaps<V, MAX_ENTRIES, FLAGS>
@@ -463,6 +538,24 @@ impl<const MAX_ENTRIES: usize, const FLAGS: usize> core::marker::Unpin for aya_e
 impl<const MAX_ENTRIES: usize, const FLAGS: usize> core::marker::UnsafeUnpin for aya_ebpf::btf_maps::dev_map_hash::DevMapHash<MAX_ENTRIES, FLAGS>
 impl<const MAX_ENTRIES: usize, const FLAGS: usize> core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::btf_maps::dev_map_hash::DevMapHash<MAX_ENTRIES, FLAGS>
 impl<const MAX_ENTRIES: usize, const FLAGS: usize> core::panic::unwind_safe::UnwindSafe for aya_ebpf::btf_maps::dev_map_hash::DevMapHash<MAX_ENTRIES, FLAGS>
+#[repr(C)] pub struct aya_ebpf::btf_maps::HashMap<K, V, const MAX_ENTRIES: usize, const FLAGS: usize>
+impl<K, V, const MAX_ENTRIES: usize, const FLAGS: usize> aya_ebpf::btf_maps::hash_map::HashMap<K, V, MAX_ENTRIES, FLAGS>
+pub unsafe fn aya_ebpf::btf_maps::hash_map::HashMap<K, V, MAX_ENTRIES, FLAGS>::get(&self, key: impl core::borrow::Borrow<K>) -> core::option::Option<&V>
+pub fn aya_ebpf::btf_maps::hash_map::HashMap<K, V, MAX_ENTRIES, FLAGS>::get_ptr(&self, key: impl core::borrow::Borrow<K>) -> core::option::Option<*const V>
+pub fn aya_ebpf::btf_maps::hash_map::HashMap<K, V, MAX_ENTRIES, FLAGS>::get_ptr_mut(&self, key: impl core::borrow::Borrow<K>) -> core::option::Option<*mut V>
+pub fn aya_ebpf::btf_maps::hash_map::HashMap<K, V, MAX_ENTRIES, FLAGS>::insert(&self, key: impl core::borrow::Borrow<K>, value: impl core::borrow::Borrow<V>, flags: u64) -> core::result::Result<(), i32>
+pub fn aya_ebpf::btf_maps::hash_map::HashMap<K, V, MAX_ENTRIES, FLAGS>::remove(&self, key: impl core::borrow::Borrow<K>) -> core::result::Result<(), i32>
+impl<K, V, const MAX_ENTRIES: usize, const FLAGS: usize> aya_ebpf::btf_maps::hash_map::HashMap<K, V, MAX_ENTRIES, FLAGS>
+pub const fn aya_ebpf::btf_maps::hash_map::HashMap<K, V, MAX_ENTRIES, FLAGS>::new() -> Self
+impl<K, V, const MAX_ENTRIES: usize, const FLAGS: usize> core::default::Default for aya_ebpf::btf_maps::hash_map::HashMap<K, V, MAX_ENTRIES, FLAGS>
+pub fn aya_ebpf::btf_maps::hash_map::HashMap<K, V, MAX_ENTRIES, FLAGS>::default() -> Self
+impl<K, V, const MAX_ENTRIES: usize, const FLAGS: usize> core::marker::Sync for aya_ebpf::btf_maps::hash_map::HashMap<K, V, MAX_ENTRIES, FLAGS>
+impl<K, V, const MAX_ENTRIES: usize, const FLAGS: usize> core::marker::Freeze for aya_ebpf::btf_maps::hash_map::HashMap<K, V, MAX_ENTRIES, FLAGS>
+impl<K, V, const MAX_ENTRIES: usize, const FLAGS: usize> !core::marker::Send for aya_ebpf::btf_maps::hash_map::HashMap<K, V, MAX_ENTRIES, FLAGS>
+impl<K, V, const MAX_ENTRIES: usize, const FLAGS: usize> core::marker::Unpin for aya_ebpf::btf_maps::hash_map::HashMap<K, V, MAX_ENTRIES, FLAGS>
+impl<K, V, const MAX_ENTRIES: usize, const FLAGS: usize> core::marker::UnsafeUnpin for aya_ebpf::btf_maps::hash_map::HashMap<K, V, MAX_ENTRIES, FLAGS>
+impl<K, V, const MAX_ENTRIES: usize, const FLAGS: usize> core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::btf_maps::hash_map::HashMap<K, V, MAX_ENTRIES, FLAGS> where K: core::panic::unwind_safe::RefUnwindSafe, V: core::panic::unwind_safe::RefUnwindSafe
+impl<K, V, const MAX_ENTRIES: usize, const FLAGS: usize> core::panic::unwind_safe::UnwindSafe for aya_ebpf::btf_maps::hash_map::HashMap<K, V, MAX_ENTRIES, FLAGS> where K: core::panic::unwind_safe::RefUnwindSafe, V: core::panic::unwind_safe::RefUnwindSafe
 #[repr(C)] pub struct aya_ebpf::btf_maps::HashOfMaps<K, V, const MAX_ENTRIES: usize, const FLAGS: usize>
 impl<K, V, const MAX_ENTRIES: usize, const FLAGS: usize> aya_ebpf::btf_maps::HashOfMaps<K, V, MAX_ENTRIES, FLAGS>
 pub unsafe fn aya_ebpf::btf_maps::HashOfMaps<K, V, MAX_ENTRIES, FLAGS>::get(&self, key: &K) -> core::option::Option<&V>
@@ -496,6 +589,42 @@ impl<K, V, const MAX_ENTRIES: usize, const FLAGS: usize> core::marker::Unpin for
 impl<K, V, const MAX_ENTRIES: usize, const FLAGS: usize> core::marker::UnsafeUnpin for aya_ebpf::btf_maps::lpm_trie::LpmTrie<K, V, MAX_ENTRIES, FLAGS>
 impl<K, V, const MAX_ENTRIES: usize, const FLAGS: usize> core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::btf_maps::lpm_trie::LpmTrie<K, V, MAX_ENTRIES, FLAGS> where V: core::panic::unwind_safe::RefUnwindSafe, K: core::panic::unwind_safe::RefUnwindSafe
 impl<K, V, const MAX_ENTRIES: usize, const FLAGS: usize> core::panic::unwind_safe::UnwindSafe for aya_ebpf::btf_maps::lpm_trie::LpmTrie<K, V, MAX_ENTRIES, FLAGS> where V: core::panic::unwind_safe::RefUnwindSafe, K: core::panic::unwind_safe::RefUnwindSafe
+#[repr(C)] pub struct aya_ebpf::btf_maps::LruHashMap<K, V, const MAX_ENTRIES: usize, const FLAGS: usize>
+impl<K, V, const MAX_ENTRIES: usize, const FLAGS: usize> aya_ebpf::btf_maps::hash_map::LruHashMap<K, V, MAX_ENTRIES, FLAGS>
+pub unsafe fn aya_ebpf::btf_maps::hash_map::LruHashMap<K, V, MAX_ENTRIES, FLAGS>::get(&self, key: impl core::borrow::Borrow<K>) -> core::option::Option<&V>
+pub fn aya_ebpf::btf_maps::hash_map::LruHashMap<K, V, MAX_ENTRIES, FLAGS>::get_ptr(&self, key: impl core::borrow::Borrow<K>) -> core::option::Option<*const V>
+pub fn aya_ebpf::btf_maps::hash_map::LruHashMap<K, V, MAX_ENTRIES, FLAGS>::get_ptr_mut(&self, key: impl core::borrow::Borrow<K>) -> core::option::Option<*mut V>
+pub fn aya_ebpf::btf_maps::hash_map::LruHashMap<K, V, MAX_ENTRIES, FLAGS>::insert(&self, key: impl core::borrow::Borrow<K>, value: impl core::borrow::Borrow<V>, flags: u64) -> core::result::Result<(), i32>
+pub fn aya_ebpf::btf_maps::hash_map::LruHashMap<K, V, MAX_ENTRIES, FLAGS>::remove(&self, key: impl core::borrow::Borrow<K>) -> core::result::Result<(), i32>
+impl<K, V, const MAX_ENTRIES: usize, const FLAGS: usize> aya_ebpf::btf_maps::hash_map::LruHashMap<K, V, MAX_ENTRIES, FLAGS>
+pub const fn aya_ebpf::btf_maps::hash_map::LruHashMap<K, V, MAX_ENTRIES, FLAGS>::new() -> Self
+impl<K, V, const MAX_ENTRIES: usize, const FLAGS: usize> core::default::Default for aya_ebpf::btf_maps::hash_map::LruHashMap<K, V, MAX_ENTRIES, FLAGS>
+pub fn aya_ebpf::btf_maps::hash_map::LruHashMap<K, V, MAX_ENTRIES, FLAGS>::default() -> Self
+impl<K, V, const MAX_ENTRIES: usize, const FLAGS: usize> core::marker::Sync for aya_ebpf::btf_maps::hash_map::LruHashMap<K, V, MAX_ENTRIES, FLAGS>
+impl<K, V, const MAX_ENTRIES: usize, const FLAGS: usize> core::marker::Freeze for aya_ebpf::btf_maps::hash_map::LruHashMap<K, V, MAX_ENTRIES, FLAGS>
+impl<K, V, const MAX_ENTRIES: usize, const FLAGS: usize> !core::marker::Send for aya_ebpf::btf_maps::hash_map::LruHashMap<K, V, MAX_ENTRIES, FLAGS>
+impl<K, V, const MAX_ENTRIES: usize, const FLAGS: usize> core::marker::Unpin for aya_ebpf::btf_maps::hash_map::LruHashMap<K, V, MAX_ENTRIES, FLAGS>
+impl<K, V, const MAX_ENTRIES: usize, const FLAGS: usize> core::marker::UnsafeUnpin for aya_ebpf::btf_maps::hash_map::LruHashMap<K, V, MAX_ENTRIES, FLAGS>
+impl<K, V, const MAX_ENTRIES: usize, const FLAGS: usize> core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::btf_maps::hash_map::LruHashMap<K, V, MAX_ENTRIES, FLAGS> where K: core::panic::unwind_safe::RefUnwindSafe, V: core::panic::unwind_safe::RefUnwindSafe
+impl<K, V, const MAX_ENTRIES: usize, const FLAGS: usize> core::panic::unwind_safe::UnwindSafe for aya_ebpf::btf_maps::hash_map::LruHashMap<K, V, MAX_ENTRIES, FLAGS> where K: core::panic::unwind_safe::RefUnwindSafe, V: core::panic::unwind_safe::RefUnwindSafe
+#[repr(C)] pub struct aya_ebpf::btf_maps::LruPerCpuHashMap<K, V, const MAX_ENTRIES: usize, const FLAGS: usize>
+impl<K, V, const MAX_ENTRIES: usize, const FLAGS: usize> aya_ebpf::btf_maps::hash_map::LruPerCpuHashMap<K, V, MAX_ENTRIES, FLAGS>
+pub unsafe fn aya_ebpf::btf_maps::hash_map::LruPerCpuHashMap<K, V, MAX_ENTRIES, FLAGS>::get(&self, key: impl core::borrow::Borrow<K>) -> core::option::Option<&V>
+pub fn aya_ebpf::btf_maps::hash_map::LruPerCpuHashMap<K, V, MAX_ENTRIES, FLAGS>::get_ptr(&self, key: impl core::borrow::Borrow<K>) -> core::option::Option<*const V>
+pub fn aya_ebpf::btf_maps::hash_map::LruPerCpuHashMap<K, V, MAX_ENTRIES, FLAGS>::get_ptr_mut(&self, key: impl core::borrow::Borrow<K>) -> core::option::Option<*mut V>
+pub fn aya_ebpf::btf_maps::hash_map::LruPerCpuHashMap<K, V, MAX_ENTRIES, FLAGS>::insert(&self, key: impl core::borrow::Borrow<K>, value: impl core::borrow::Borrow<V>, flags: u64) -> core::result::Result<(), i32>
+pub fn aya_ebpf::btf_maps::hash_map::LruPerCpuHashMap<K, V, MAX_ENTRIES, FLAGS>::remove(&self, key: impl core::borrow::Borrow<K>) -> core::result::Result<(), i32>
+impl<K, V, const MAX_ENTRIES: usize, const FLAGS: usize> aya_ebpf::btf_maps::hash_map::LruPerCpuHashMap<K, V, MAX_ENTRIES, FLAGS>
+pub const fn aya_ebpf::btf_maps::hash_map::LruPerCpuHashMap<K, V, MAX_ENTRIES, FLAGS>::new() -> Self
+impl<K, V, const MAX_ENTRIES: usize, const FLAGS: usize> core::default::Default for aya_ebpf::btf_maps::hash_map::LruPerCpuHashMap<K, V, MAX_ENTRIES, FLAGS>
+pub fn aya_ebpf::btf_maps::hash_map::LruPerCpuHashMap<K, V, MAX_ENTRIES, FLAGS>::default() -> Self
+impl<K, V, const MAX_ENTRIES: usize, const FLAGS: usize> core::marker::Sync for aya_ebpf::btf_maps::hash_map::LruPerCpuHashMap<K, V, MAX_ENTRIES, FLAGS>
+impl<K, V, const MAX_ENTRIES: usize, const FLAGS: usize> core::marker::Freeze for aya_ebpf::btf_maps::hash_map::LruPerCpuHashMap<K, V, MAX_ENTRIES, FLAGS>
+impl<K, V, const MAX_ENTRIES: usize, const FLAGS: usize> !core::marker::Send for aya_ebpf::btf_maps::hash_map::LruPerCpuHashMap<K, V, MAX_ENTRIES, FLAGS>
+impl<K, V, const MAX_ENTRIES: usize, const FLAGS: usize> core::marker::Unpin for aya_ebpf::btf_maps::hash_map::LruPerCpuHashMap<K, V, MAX_ENTRIES, FLAGS>
+impl<K, V, const MAX_ENTRIES: usize, const FLAGS: usize> core::marker::UnsafeUnpin for aya_ebpf::btf_maps::hash_map::LruPerCpuHashMap<K, V, MAX_ENTRIES, FLAGS>
+impl<K, V, const MAX_ENTRIES: usize, const FLAGS: usize> core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::btf_maps::hash_map::LruPerCpuHashMap<K, V, MAX_ENTRIES, FLAGS> where K: core::panic::unwind_safe::RefUnwindSafe, V: core::panic::unwind_safe::RefUnwindSafe
+impl<K, V, const MAX_ENTRIES: usize, const FLAGS: usize> core::panic::unwind_safe::UnwindSafe for aya_ebpf::btf_maps::hash_map::LruPerCpuHashMap<K, V, MAX_ENTRIES, FLAGS> where K: core::panic::unwind_safe::RefUnwindSafe, V: core::panic::unwind_safe::RefUnwindSafe
 #[repr(C)] pub struct aya_ebpf::btf_maps::PerCpuArray<T, const MAX_ENTRIES: usize, const FLAGS: usize>
 impl<T, const MAX_ENTRIES: usize, const FLAGS: usize> aya_ebpf::btf_maps::per_cpu_array::PerCpuArray<T, MAX_ENTRIES, FLAGS>
 pub fn aya_ebpf::btf_maps::per_cpu_array::PerCpuArray<T, MAX_ENTRIES, FLAGS>::get(&self, index: u32) -> core::option::Option<&T>
@@ -513,6 +642,24 @@ impl<T, const MAX_ENTRIES: usize, const FLAGS: usize> core::marker::Unpin for ay
 impl<T, const MAX_ENTRIES: usize, const FLAGS: usize> core::marker::UnsafeUnpin for aya_ebpf::btf_maps::per_cpu_array::PerCpuArray<T, MAX_ENTRIES, FLAGS>
 impl<T, const MAX_ENTRIES: usize, const FLAGS: usize> core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::btf_maps::per_cpu_array::PerCpuArray<T, MAX_ENTRIES, FLAGS> where T: core::panic::unwind_safe::RefUnwindSafe
 impl<T, const MAX_ENTRIES: usize, const FLAGS: usize> core::panic::unwind_safe::UnwindSafe for aya_ebpf::btf_maps::per_cpu_array::PerCpuArray<T, MAX_ENTRIES, FLAGS> where T: core::panic::unwind_safe::RefUnwindSafe
+#[repr(C)] pub struct aya_ebpf::btf_maps::PerCpuHashMap<K, V, const MAX_ENTRIES: usize, const FLAGS: usize>
+impl<K, V, const MAX_ENTRIES: usize, const FLAGS: usize> aya_ebpf::btf_maps::hash_map::PerCpuHashMap<K, V, MAX_ENTRIES, FLAGS>
+pub unsafe fn aya_ebpf::btf_maps::hash_map::PerCpuHashMap<K, V, MAX_ENTRIES, FLAGS>::get(&self, key: impl core::borrow::Borrow<K>) -> core::option::Option<&V>
+pub fn aya_ebpf::btf_maps::hash_map::PerCpuHashMap<K, V, MAX_ENTRIES, FLAGS>::get_ptr(&self, key: impl core::borrow::Borrow<K>) -> core::option::Option<*const V>
+pub fn aya_ebpf::btf_maps::hash_map::PerCpuHashMap<K, V, MAX_ENTRIES, FLAGS>::get_ptr_mut(&self, key: impl core::borrow::Borrow<K>) -> core::option::Option<*mut V>
+pub fn aya_ebpf::btf_maps::hash_map::PerCpuHashMap<K, V, MAX_ENTRIES, FLAGS>::insert(&self, key: impl core::borrow::Borrow<K>, value: impl core::borrow::Borrow<V>, flags: u64) -> core::result::Result<(), i32>
+pub fn aya_ebpf::btf_maps::hash_map::PerCpuHashMap<K, V, MAX_ENTRIES, FLAGS>::remove(&self, key: impl core::borrow::Borrow<K>) -> core::result::Result<(), i32>
+impl<K, V, const MAX_ENTRIES: usize, const FLAGS: usize> aya_ebpf::btf_maps::hash_map::PerCpuHashMap<K, V, MAX_ENTRIES, FLAGS>
+pub const fn aya_ebpf::btf_maps::hash_map::PerCpuHashMap<K, V, MAX_ENTRIES, FLAGS>::new() -> Self
+impl<K, V, const MAX_ENTRIES: usize, const FLAGS: usize> core::default::Default for aya_ebpf::btf_maps::hash_map::PerCpuHashMap<K, V, MAX_ENTRIES, FLAGS>
+pub fn aya_ebpf::btf_maps::hash_map::PerCpuHashMap<K, V, MAX_ENTRIES, FLAGS>::default() -> Self
+impl<K, V, const MAX_ENTRIES: usize, const FLAGS: usize> core::marker::Sync for aya_ebpf::btf_maps::hash_map::PerCpuHashMap<K, V, MAX_ENTRIES, FLAGS>
+impl<K, V, const MAX_ENTRIES: usize, const FLAGS: usize> core::marker::Freeze for aya_ebpf::btf_maps::hash_map::PerCpuHashMap<K, V, MAX_ENTRIES, FLAGS>
+impl<K, V, const MAX_ENTRIES: usize, const FLAGS: usize> !core::marker::Send for aya_ebpf::btf_maps::hash_map::PerCpuHashMap<K, V, MAX_ENTRIES, FLAGS>
+impl<K, V, const MAX_ENTRIES: usize, const FLAGS: usize> core::marker::Unpin for aya_ebpf::btf_maps::hash_map::PerCpuHashMap<K, V, MAX_ENTRIES, FLAGS>
+impl<K, V, const MAX_ENTRIES: usize, const FLAGS: usize> core::marker::UnsafeUnpin for aya_ebpf::btf_maps::hash_map::PerCpuHashMap<K, V, MAX_ENTRIES, FLAGS>
+impl<K, V, const MAX_ENTRIES: usize, const FLAGS: usize> core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::btf_maps::hash_map::PerCpuHashMap<K, V, MAX_ENTRIES, FLAGS> where K: core::panic::unwind_safe::RefUnwindSafe, V: core::panic::unwind_safe::RefUnwindSafe
+impl<K, V, const MAX_ENTRIES: usize, const FLAGS: usize> core::panic::unwind_safe::UnwindSafe for aya_ebpf::btf_maps::hash_map::PerCpuHashMap<K, V, MAX_ENTRIES, FLAGS> where K: core::panic::unwind_safe::RefUnwindSafe, V: core::panic::unwind_safe::RefUnwindSafe
 #[repr(C)] pub struct aya_ebpf::btf_maps::PerfEventArray<const FLAGS: usize>
 impl<const FLAGS: usize> aya_ebpf::btf_maps::perf_event_array::PerfEventArray<FLAGS>
 pub const fn aya_ebpf::btf_maps::perf_event_array::PerfEventArray<FLAGS>::new() -> Self
@@ -686,6 +833,8 @@ impl<const MAX_ENTRIES: usize, const FLAGS: usize> core::panic::unwind_safe::Ref
 impl<const MAX_ENTRIES: usize, const FLAGS: usize> core::panic::unwind_safe::UnwindSafe for aya_ebpf::btf_maps::xsk_map::XskMap<MAX_ENTRIES, FLAGS>
 pub trait aya_ebpf::btf_maps::MapDef: aya_ebpf::btf_maps::private::MapDef
 impl<T: aya_ebpf::btf_maps::private::MapDef> aya_ebpf::btf_maps::MapDef for T
+pub trait aya_ebpf::btf_maps::SafeInnerLookup: aya_ebpf::btf_maps::private::SafeInnerLookup
+impl<T: aya_ebpf::btf_maps::private::SafeInnerLookup> aya_ebpf::btf_maps::SafeInnerLookup for T
 pub type aya_ebpf::btf_maps::ReusePortSockArray<const MAX_ENTRIES: usize, const FLAGS: usize> = aya_ebpf::btf_maps::reuseport_sock_array::ReusePortSockArrayImpl<u32, MAX_ENTRIES, FLAGS>
 pub mod aya_ebpf::helpers
 pub use aya_ebpf::helpers::generated


### PR DESCRIPTION
Adds `HashMap<K, V, MAX_ENTRIES, FLAGS>`, `LruHashMap`, `PerCpuHashMap`,
and `LruPerCpuHashMap` to `aya_ebpf::btf_maps`, mirroring the existing
legacy types in `aya_ebpf::maps`.

The four wrappers expose `get`, `get_ptr`, `get_ptr_mut`, `insert`, and
`remove`. `get` is `unsafe` because, without `BPF_F_NO_PREALLOC`, a
returned reference can be aliased by a later `insert`, `remove`, or
eviction. Compile-time assertions enforce the kernel's
`htab_map_alloc_check` constraints.

Adding a hash type as an `ArrayOfMaps` inner map would let the safe
`ArrayOfMaps::get_value` hand out a `&V` into reusable memory. A sealed
`SafeInnerLookup` marker, implemented only for `Array` and `PerCpuArray`,
gates that path; the hash family opts out. `get_value_ptr_mut` keeps the
looser bound because dereferencing its raw pointer is the caller's
responsibility. `HashOfMaps::get_value` is already unconditionally
`unsafe` (its outer lookup is itself aliasable) and is unaffected.

Integration tests cover all four BTF variants and their legacy
counterparts via `#[test_case]`; per-CPU variants assert per-CPU
divergence by writing a distinct value per CPU and reading each slot
back.

Supersedes #1367.

### Added/updated tests?

- [x] Yes

### Checklist

- [x] Rust code has been formatted with `cargo +nightly fmt`.
- [x] All clippy lints have been fixed.
      You can find failing lints with `cargo xtask clippy`.
- [x] Unit tests are passing locally with `cargo test`.
- [x] The integration tests are passing locally.
- [x] I have blessed any API changes with `cargo xtask public-api --bless`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aya-rs/aya/1576)
<!-- Reviewable:end -->
