### PR TITLE
aya, aya-ebpf: add CgroupArray

### DIFF
--- a/aya/src/bpf.rs
+++ b/aya/src/bpf.rs
@@ -804,6 +804,7 @@ fn parse_map(
         bpf_map_type::BPF_MAP_TYPE_ARRAY => Map::Array(map),
         bpf_map_type::BPF_MAP_TYPE_PERCPU_ARRAY => Map::PerCpuArray(map),
         bpf_map_type::BPF_MAP_TYPE_PROG_ARRAY => Map::ProgramArray(map),
+        bpf_map_type::BPF_MAP_TYPE_CGROUP_ARRAY => Map::CgroupArray(map),
         bpf_map_type::BPF_MAP_TYPE_HASH => Map::HashMap(map),
         bpf_map_type::BPF_MAP_TYPE_LRU_HASH => Map::LruHashMap(map),
         bpf_map_type::BPF_MAP_TYPE_PERCPU_HASH => Map::PerCpuHashMap(map),

--- a/aya/src/maps/array/cgroup_array.rs
+++ b/aya/src/maps/array/cgroup_array.rs
@@ -1,0 +1,77 @@
+//! An array of cgroups.
+
+use std::{
+    borrow::{Borrow, BorrowMut},
+    os::fd::{AsRawFd, RawFd},
+};
+
+use crate::maps::{MapData, MapError, check_bounds, check_kv_size, hash_map};
+
+/// An array of cgroups.
+///
+/// eBPF programs can test whether a packet or the current task belongs to a
+/// cgroup by calling `bpf_skb_under_cgroup` or `bpf_current_task_under_cgroup`
+/// against this map. You populate it from userspace with the file descriptors
+/// of cgroup directories.
+///
+/// # Minimum kernel version
+///
+/// The minimum kernel version required to use this feature is 4.8.
+///
+/// # Examples
+/// ```no_run
+/// # let mut bpf = aya::Ebpf::load(&[])?;
+/// # let cgroup_fd = 1;
+/// use aya::maps::CgroupArray;
+///
+/// let mut array = CgroupArray::try_from(bpf.map_mut("CGROUPS").unwrap())?;
+/// // cgroup_fd is the RawFd of an open cgroup directory.
+/// array.set(0, cgroup_fd, 0);
+/// # Ok::<(), aya::EbpfError>(())
+/// ```
+#[doc(alias = "BPF_MAP_TYPE_CGROUP_ARRAY")]
+pub struct CgroupArray<T> {
+    pub(crate) inner: T,
+}
+
+impl<T: Borrow<MapData>> CgroupArray<T> {
+    pub(crate) fn new(map: T) -> Result<Self, MapError> {
+        let data = map.borrow();
+        check_kv_size::<u32, RawFd>(data)?;
+
+        Ok(Self { inner: map })
+    }
+
+    /// Returns the number of elements in the array.
+    ///
+    /// This corresponds to the value of `bpf_map_def::max_entries` on the eBPF side.
+    pub fn len(&self) -> u32 {
+        self.inner.borrow().obj.max_entries()
+    }
+}
+
+impl<T: BorrowMut<MapData>> CgroupArray<T> {
+    /// Stores a cgroup file descriptor at the given index.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`MapError::OutOfBounds`] if `index` is out of bounds,
+    /// [`MapError::SyscallError`] if `bpf_map_update_elem` fails.
+    pub fn set(&mut self, index: u32, cgroup_fd: impl AsRawFd, flags: u64) -> Result<(), MapError> {
+        let data = self.inner.borrow_mut();
+        check_bounds(data, index)?;
+        hash_map::insert(data, &index, &cgroup_fd.as_raw_fd(), flags)
+    }
+
+    /// Un-sets the cgroup at the given index.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`MapError::OutOfBounds`] if `index` is out of bounds,
+    /// [`MapError::SyscallError`] if `bpf_map_delete_elem` fails.
+    pub fn unset(&mut self, index: u32) -> Result<(), MapError> {
+        let data = self.inner.borrow_mut();
+        check_bounds(data, index)?;
+        hash_map::remove(data, &index)
+    }
+}

--- a/aya/src/maps/array/mod.rs
+++ b/aya/src/maps/array/mod.rs
@@ -5,9 +5,11 @@
     reason = "module name matches the exported type"
 )]
 mod array;
+mod cgroup_array;
 mod per_cpu_array;
 mod program_array;
 
 pub use array::*;
+pub use cgroup_array::CgroupArray;
 pub use per_cpu_array::PerCpuArray;
 pub use program_array::ProgramArray;

--- a/aya/src/maps/mod.rs
+++ b/aya/src/maps/mod.rs
@@ -86,7 +86,7 @@ pub mod stack;
 pub mod stack_trace;
 pub mod xdp;
 
-pub use array::{Array, PerCpuArray, ProgramArray};
+pub use array::{Array, CgroupArray, PerCpuArray, ProgramArray};
 pub use bloom_filter::BloomFilter;
 pub use hash_map::{HashMap, PerCpuHashMap};
 pub use info::{MapInfo, MapType, loaded_maps};
@@ -300,6 +300,8 @@ pub enum Map {
     ArrayOfMaps(MapData),
     /// A [`BloomFilter`] map.
     BloomFilter(MapData),
+    /// A [`CgroupArray`] map.
+    CgroupArray(MapData),
     /// A [`CpuMap`] map.
     CpuMap(MapData),
     /// A [`DevMap`] map.
@@ -353,6 +355,7 @@ impl Map {
             Self::Array(map) => map.obj.map_type(),
             Self::ArrayOfMaps(map) => map.obj.map_type(),
             Self::BloomFilter(map) => map.obj.map_type(),
+            Self::CgroupArray(map) => map.obj.map_type(),
             Self::CpuMap(map) => map.obj.map_type(),
             Self::DevMap(map) => map.obj.map_type(),
             Self::DevMapHash(map) => map.obj.map_type(),
@@ -387,6 +390,7 @@ impl Map {
             Self::Array(map) => map.pin(path),
             Self::ArrayOfMaps(map) => map.pin(path),
             Self::BloomFilter(map) => map.pin(path),
+            Self::CgroupArray(map) => map.pin(path),
             Self::CpuMap(map) => map.pin(path),
             Self::DevMap(map) => map.pin(path),
             Self::DevMapHash(map) => map.pin(path),
@@ -445,7 +449,7 @@ impl Map {
             bpf_map_type::BPF_MAP_TYPE_DEVMAP_HASH => Self::DevMapHash(map_data),
             bpf_map_type::BPF_MAP_TYPE_RINGBUF => Self::RingBuf(map_data),
             bpf_map_type::BPF_MAP_TYPE_BLOOM_FILTER => Self::BloomFilter(map_data),
-            bpf_map_type::BPF_MAP_TYPE_CGROUP_ARRAY => Self::Unsupported(map_data),
+            bpf_map_type::BPF_MAP_TYPE_CGROUP_ARRAY => Self::CgroupArray(map_data),
             bpf_map_type::BPF_MAP_TYPE_ARRAY_OF_MAPS => Self::ArrayOfMaps(map_data),
             bpf_map_type::BPF_MAP_TYPE_HASH_OF_MAPS => Self::HashOfMaps(map_data),
             bpf_map_type::BPF_MAP_TYPE_CGROUP_STORAGE_DEPRECATED => Self::Unsupported(map_data),
@@ -494,6 +498,7 @@ macro_rules! impl_map_pin {
 }
 
 impl_map_pin!(() {
+    CgroupArray,
     ProgramArray,
     ReusePortSockArray,
     SockMap,
@@ -574,6 +579,7 @@ macro_rules! impl_try_from_map {
 }
 
 impl_try_from_map!(() {
+    CgroupArray,
     CpuMap,
     DevMap,
     DevMapHash,

--- a/ebpf/aya-ebpf/src/btf_maps/cgroup_array.rs
+++ b/ebpf/aya-ebpf/src/btf_maps/cgroup_array.rs
@@ -1,0 +1,68 @@
+use aya_ebpf_cty::c_long;
+
+use crate::{btf_maps::btf_map_def, helpers::bpf_current_task_under_cgroup};
+
+btf_map_def!(
+    /// A BTF-compatible array of cgroups.
+    ///
+    /// `CgroupArray` stores cgroups, set from userspace by writing a cgroup
+    /// directory file descriptor into a slot. eBPF programs use it with the
+    /// `bpf_skb_under_cgroup` and `bpf_current_task_under_cgroup` helpers to
+    /// test whether a packet or the current task belongs to one of those
+    /// cgroups.
+    ///
+    /// # Minimum kernel version
+    ///
+    /// The minimum kernel version required to use this feature is 4.8.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use aya_ebpf::{btf_maps::CgroupArray, macros::btf_map};
+    ///
+    /// #[btf_map]
+    /// static CGROUPS: CgroupArray<8> = CgroupArray::new();
+    /// ```
+    pub struct CgroupArray<; const MAX_ENTRIES: usize, const FLAGS: usize = 0>,
+    map_type: BPF_MAP_TYPE_CGROUP_ARRAY,
+    max_entries: MAX_ENTRIES,
+    map_flags: FLAGS,
+    key_type: u32,
+    value_type: u32,
+);
+
+impl<const MAX_ENTRIES: usize, const FLAGS: usize> CgroupArray<MAX_ENTRIES, FLAGS> {
+    const _CHECK: () = {
+        assert!(
+            MAX_ENTRIES > 0,
+            "CgroupArray max_entries must be greater than zero."
+        );
+    };
+
+    /// Returns whether the current task is a descendant of the cgroup at `index`.
+    ///
+    /// Wraps the `bpf_current_task_under_cgroup` helper, which requires kernel
+    /// 4.9 or newer. This is only callable from tracing programs, for example
+    /// kprobes and tracepoints.
+    pub fn current_task_under_cgroup(&self, index: u32) -> Result<bool, c_long> {
+        let () = Self::_CHECK;
+        // SAFETY: `self` is a valid pointer managed by aya.
+        let ret = unsafe { bpf_current_task_under_cgroup(self.as_ptr().cast(), index) };
+        match ret {
+            1 => Ok(true),
+            0 => Ok(false),
+            ret => Err(ret),
+        }
+    }
+}
+
+impl<const MAX_ENTRIES: usize, const FLAGS: usize> crate::programs::tc::sealed::CgroupArrayMap
+    for CgroupArray<MAX_ENTRIES, FLAGS>
+{
+    fn as_ptr(&self) -> *mut core::ffi::c_void {
+        // `skb_under_cgroup` reaches the map only through this method, so it is
+        // the sole enforcement site for `_CHECK` on that path.
+        let () = Self::_CHECK;
+        self.as_ptr()
+    }
+}

--- a/ebpf/aya-ebpf/src/btf_maps/mod.rs
+++ b/ebpf/aya-ebpf/src/btf_maps/mod.rs
@@ -1,5 +1,6 @@
 pub mod array;
 pub mod bloom_filter;
+pub mod cgroup_array;
 pub mod cpu_map;
 pub mod dev_map;
 pub mod dev_map_hash;
@@ -22,6 +23,7 @@ pub mod xsk_map;
 
 pub use array::Array;
 pub use bloom_filter::BloomFilter;
+pub use cgroup_array::CgroupArray;
 pub use cpu_map::CpuMap;
 pub use dev_map::DevMap;
 pub use dev_map_hash::DevMapHash;

--- a/ebpf/aya-ebpf/src/maps/cgroup_array.rs
+++ b/ebpf/aya-ebpf/src/maps/cgroup_array.rs
@@ -1,0 +1,63 @@
+use aya_ebpf_cty::c_long;
+
+use crate::{
+    bindings::bpf_map_type::BPF_MAP_TYPE_CGROUP_ARRAY,
+    helpers::bpf_current_task_under_cgroup,
+    maps::{MapDef, PinningType},
+};
+
+/// An array of cgroups.
+///
+/// `CgroupArray` stores cgroups, set from userspace by writing a cgroup
+/// directory file descriptor into a slot. eBPF programs use it with the
+/// `bpf_skb_under_cgroup` and `bpf_current_task_under_cgroup` helpers to test
+/// whether a packet or the current task belongs to one of those cgroups.
+///
+/// # Minimum kernel version
+///
+/// The minimum kernel version required to use this feature is 4.8.
+///
+/// # Examples
+///
+/// ```no_run
+/// use aya_ebpf::{macros::map, maps::CgroupArray, programs::ProbeContext};
+///
+/// #[map]
+/// static CGROUPS: CgroupArray = CgroupArray::with_max_entries(8, 0);
+///
+/// # fn try_test(_ctx: ProbeContext) -> Result<(), i64> {
+/// if CGROUPS.current_task_under_cgroup(0)? {
+///     // The current task is under the cgroup at index 0.
+/// }
+/// # Ok(())
+/// # }
+/// ```
+#[repr(transparent)]
+pub struct CgroupArray {
+    def: MapDef,
+}
+
+impl CgroupArray {
+    map_constructors!(u32, u32, BPF_MAP_TYPE_CGROUP_ARRAY);
+
+    /// Returns whether the current task is a descendant of the cgroup at `index`.
+    ///
+    /// Wraps the `bpf_current_task_under_cgroup` helper, which requires kernel
+    /// 4.9 or newer. This is only callable from tracing programs, for example
+    /// kprobes and tracepoints.
+    pub fn current_task_under_cgroup(&self, index: u32) -> Result<bool, c_long> {
+        // SAFETY: `self.def` is a valid pointer managed by aya.
+        let ret = unsafe { bpf_current_task_under_cgroup(self.def.as_ptr(), index) };
+        match ret {
+            1 => Ok(true),
+            0 => Ok(false),
+            ret => Err(ret),
+        }
+    }
+}
+
+impl crate::programs::tc::sealed::CgroupArrayMap for CgroupArray {
+    fn as_ptr(&self) -> *mut core::ffi::c_void {
+        self.def.as_ptr().cast()
+    }
+}

--- a/ebpf/aya-ebpf/src/maps/mod.rs
+++ b/ebpf/aya-ebpf/src/maps/mod.rs
@@ -78,6 +78,7 @@ macro_rules! map_constructors {
 
 pub mod array;
 pub mod bloom_filter;
+pub mod cgroup_array;
 pub mod hash_map;
 pub mod lpm_trie;
 pub mod per_cpu_array;
@@ -94,6 +95,7 @@ pub mod xdp;
 
 pub use array::Array;
 pub use bloom_filter::BloomFilter;
+pub use cgroup_array::CgroupArray;
 pub use hash_map::{HashMap, LruHashMap, LruPerCpuHashMap, PerCpuHashMap};
 pub use lpm_trie::LpmTrie;
 pub use per_cpu_array::PerCpuArray;

--- a/ebpf/aya-ebpf/src/programs/tc.rs
+++ b/ebpf/aya-ebpf/src/programs/tc.rs
@@ -1,6 +1,23 @@
 use aya_ebpf_cty::{c_long, c_void};
 
-use crate::{EbpfContext, bindings::__sk_buff, programs::sk_buff::SkBuff};
+use crate::{
+    EbpfContext, bindings::__sk_buff, helpers::bpf_skb_under_cgroup, programs::sk_buff::SkBuff,
+};
+
+pub(crate) mod sealed {
+    #[expect(unnameable_types, reason = "this is the sealed trait pattern")]
+    pub trait CgroupArrayMap {
+        fn as_ptr(&self) -> *mut core::ffi::c_void;
+    }
+}
+
+/// Map types that [`TcContext::skb_under_cgroup`] can target.
+///
+/// This trait is sealed; aya implements it for both the legacy
+/// [`crate::maps::CgroupArray`] and the BTF [`crate::btf_maps::CgroupArray`].
+pub trait CgroupArrayMap: sealed::CgroupArrayMap {}
+
+impl<T: sealed::CgroupArrayMap> CgroupArrayMap for T {}
 
 pub struct TcContext {
     pub skb: SkBuff,
@@ -184,6 +201,25 @@ impl TcContext {
     #[inline(always)]
     pub fn pull_data(&self, len: u32) -> Result<(), c_long> {
         self.skb.pull_data(len)
+    }
+
+    /// Returns whether the skb is a descendant of the cgroup at `index`.
+    ///
+    /// Wraps the `bpf_skb_under_cgroup` helper. This is only callable from
+    /// classifier programs.
+    ///
+    /// # Minimum kernel version
+    ///
+    /// The minimum kernel version required to use this feature is 4.8.
+    #[inline]
+    pub fn skb_under_cgroup<M: CgroupArrayMap>(&self, map: &M, index: u32) -> Result<bool, c_long> {
+        // SAFETY: `self.skb.skb` and `map` are valid pointers managed by aya.
+        let ret = unsafe { bpf_skb_under_cgroup(self.skb.skb, map.as_ptr().cast(), index) };
+        match ret {
+            1 => Ok(true),
+            0 => Ok(false),
+            ret => Err(ret),
+        }
     }
 }
 

--- a/test/integration-common/src/lib.rs
+++ b/test/integration-common/src/lib.rs
@@ -44,6 +44,27 @@ pub mod bpf_probe_read {
     unsafe impl aya::Pod for TestResult {}
 }
 
+pub mod cgroup_array {
+    /// Index holding a cgroup the task is under (expect `1`).
+    pub const UNDER_INDEX: u32 = 0;
+    /// Index holding a cgroup the task is not under (expect `0`).
+    pub const NOT_UNDER_INDEX: u32 = 1;
+
+    #[repr(C)]
+    #[derive(Clone, Copy, Default)]
+    pub struct TestResult {
+        /// `current_task_under_cgroup` for `UNDER_INDEX`: 1 under, 0 not, negative errno.
+        pub under: i64,
+        /// `current_task_under_cgroup` for `NOT_UNDER_INDEX`.
+        pub not_under: i64,
+        /// Distinguishes a recorded result from a zero-initialised slot.
+        pub ran: bool,
+    }
+
+    #[cfg(feature = "user")]
+    unsafe impl aya::Pod for TestResult {}
+}
+
 pub mod log {
     pub const BUF_LEN: usize = 1024;
 

--- a/test/integration-ebpf/Cargo.toml
+++ b/test/integration-ebpf/Cargo.toml
@@ -187,3 +187,7 @@ path = "src/btf_map_of_maps.rs"
 [[bin]]
 name = "xsk_map"
 path = "src/xsk_map.rs"
+
+[[bin]]
+name = "cgroup_array"
+path = "src/cgroup_array.rs"

--- a/test/integration-ebpf/src/cgroup_array.rs
+++ b/test/integration-ebpf/src/cgroup_array.rs
@@ -1,0 +1,68 @@
+#![no_std]
+#![no_main]
+#![expect(unused_crate_dependencies, reason = "used in other bins")]
+
+#[cfg(not(test))]
+extern crate ebpf_panic;
+
+use aya_ebpf::{
+    btf_maps::{Array as BtfArray, CgroupArray as BtfCgroupArray},
+    cty::c_long,
+    macros::{btf_map, classifier, map, uprobe},
+    maps::{Array as LegacyArray, CgroupArray as LegacyCgroupArray},
+    programs::{ProbeContext, TcContext},
+};
+use integration_common::cgroup_array::{NOT_UNDER_INDEX, TestResult, UNDER_INDEX};
+
+#[btf_map]
+static CGROUPS: BtfCgroupArray<2, 0> = BtfCgroupArray::new();
+
+#[btf_map]
+static RESULT: BtfArray<TestResult, 1, 0> = BtfArray::new();
+
+#[map]
+static CGROUPS_LEGACY: LegacyCgroupArray = LegacyCgroupArray::with_max_entries(2, 0);
+
+#[map]
+static RESULT_LEGACY: LegacyArray<TestResult> = LegacyArray::with_max_entries(1, 0);
+
+const fn encode(result: Result<bool, c_long>) -> i64 {
+    match result {
+        Ok(true) => 1,
+        Ok(false) => 0,
+        Err(ret) => ret,
+    }
+}
+
+macro_rules! define_current_task_under_cgroup_test {
+    ($cgroups:ident, $result:ident, $probe:ident $(,)?) => {
+        #[uprobe]
+        fn $probe(_ctx: ProbeContext) -> Result<(), c_long> {
+            let under = encode($cgroups.current_task_under_cgroup(UNDER_INDEX));
+            let not_under = encode($cgroups.current_task_under_cgroup(NOT_UNDER_INDEX));
+            let ptr = $result.get_ptr_mut(0).ok_or(-1)?;
+            unsafe {
+                *ptr = TestResult {
+                    under,
+                    not_under,
+                    ran: true,
+                };
+            }
+            Ok(())
+        }
+    };
+}
+
+define_current_task_under_cgroup_test!(CGROUPS, RESULT, current_task_under_cgroup_btf);
+define_current_task_under_cgroup_test!(
+    CGROUPS_LEGACY,
+    RESULT_LEGACY,
+    current_task_under_cgroup_legacy,
+);
+
+#[classifier]
+fn skb_under_cgroup(ctx: TcContext) -> i32 {
+    let legacy = ctx.skb_under_cgroup(&CGROUPS_LEGACY, 0).unwrap_or(false);
+    let btf = ctx.skb_under_cgroup(&CGROUPS, 0).unwrap_or(false);
+    i32::from(legacy || btf)
+}

--- a/test/integration-test/src/lib.rs
+++ b/test/integration-test/src/lib.rs
@@ -43,6 +43,7 @@ bpf_file!(
     BLOOM_FILTER => "bloom_filter",
     BPF_PROBE_READ => "bpf_probe_read",
     BTF_MAPS_PLAIN => "btf_maps_plain",
+    CGROUP_ARRAY => "cgroup_array",
     CPU_MAP => "cpu_map",
     DEV_MAP => "dev_map",
     HASH_MAP => "hash_map",

--- a/test/integration-test/src/tests.rs
+++ b/test/integration-test/src/tests.rs
@@ -14,6 +14,7 @@ mod bpf_probe_read;
 mod btf_map_of_maps;
 mod btf_maps;
 mod btf_relocations;
+mod cgroup_array;
 mod elf;
 mod feature_probe;
 mod hash_map;

--- a/test/integration-test/src/tests/cgroup_array.rs
+++ b/test/integration-test/src/tests/cgroup_array.rs
@@ -1,0 +1,121 @@
+use std::{fs::File, os::fd::AsRawFd as _};
+
+use aya::{
+    EbpfLoader,
+    maps::{Array, CgroupArray, MapType},
+    programs::{SchedClassifier, UProbe, uprobe::UProbeScope},
+    sys::is_map_supported,
+    util::KernelVersion,
+};
+use integration_common::cgroup_array::{NOT_UNDER_INDEX, TestResult, UNDER_INDEX};
+use test_case::test_case;
+
+use crate::utils::{Cgroup, is_cgroup2};
+
+#[unsafe(no_mangle)]
+#[inline(never)]
+extern "C" fn trigger_current_task_under_cgroup() {
+    std::hint::black_box(());
+}
+
+#[test_log::test(test_case(
+    "CGROUPS_LEGACY",
+    "RESULT_LEGACY",
+    "current_task_under_cgroup_legacy"
+    ; "legacy"
+))]
+#[test_case(
+    "CGROUPS",
+    "RESULT",
+    "current_task_under_cgroup_btf"
+    ; "btf"
+)]
+fn current_task_under_cgroup(cgroups_map: &str, result_map: &str, prog: &str) {
+    if !is_map_supported(MapType::CgroupArray).unwrap() {
+        eprintln!("skipping test - cgroup array map not supported");
+        return;
+    }
+
+    if !is_cgroup2() {
+        eprintln!("skipping test - /sys/fs/cgroup is not cgroup2");
+        return;
+    }
+
+    let kernel_version = KernelVersion::current().unwrap();
+    if kernel_version < KernelVersion::new(4, 9, 0) {
+        eprintln!(
+            "skipping test - bpf_current_task_under_cgroup added in 4.9, kernel is {kernel_version:?}"
+        );
+        return;
+    }
+
+    let mut bpf = EbpfLoader::new()
+        .load(crate::CGROUP_ARRAY)
+        .expect("load cgroup_array program");
+
+    // Load and attach the uprobe first so the loaded program holds a reference
+    // to the cgroup array; the typed map below can then be dropped safely.
+    {
+        let program: &mut UProbe = bpf
+            .program_mut(prog)
+            .unwrap_or_else(|| panic!("missing program {prog}"))
+            .try_into()
+            .unwrap_or_else(|err| panic!("program {prog} is not a uprobe: {err}"));
+        program
+            .load()
+            .unwrap_or_else(|err| panic!("load {prog}: {err}"));
+        program
+            .attach(
+                "trigger_current_task_under_cgroup",
+                "/proc/self/exe",
+                UProbeScope::AllProcesses,
+            )
+            .unwrap_or_else(|err| panic!("attach {prog}: {err}"));
+    }
+
+    // The cgroup root is an ancestor of every task; a fresh child cgroup that
+    // the test process is not moved into is not.
+    let root = Cgroup::root();
+    let not_under = root.create_child(prog);
+    let under = File::open("/sys/fs/cgroup").expect("open cgroup root");
+
+    let mut cgroups: CgroupArray<_> = bpf.take_map(cgroups_map).unwrap().try_into().unwrap();
+    cgroups
+        .set(UNDER_INDEX, under.as_raw_fd(), 0)
+        .expect("set UNDER_INDEX");
+    cgroups
+        .set(NOT_UNDER_INDEX, not_under.fd().as_raw_fd(), 0)
+        .expect("set NOT_UNDER_INDEX");
+
+    let result = Array::<_, TestResult>::try_from(bpf.map(result_map).unwrap()).unwrap();
+
+    trigger_current_task_under_cgroup();
+
+    let TestResult {
+        under,
+        not_under: not_under_result,
+        ran,
+    } = result.get(&0, 0).unwrap();
+    assert!(ran, "uprobe did not run");
+    assert_eq!(under, 1);
+    assert_eq!(not_under_result, 0);
+}
+
+#[test_log::test]
+fn skb_under_cgroup_loads() {
+    if !is_map_supported(MapType::CgroupArray).unwrap() {
+        eprintln!("skipping test - cgroup array map not supported");
+        return;
+    }
+
+    let mut bpf = EbpfLoader::new()
+        .load(crate::CGROUP_ARRAY)
+        .expect("load cgroup_array program");
+
+    let program: &mut SchedClassifier = bpf
+        .program_mut("skb_under_cgroup")
+        .expect("missing program skb_under_cgroup")
+        .try_into()
+        .expect("program skb_under_cgroup is not a classifier");
+    program.load().expect("load skb_under_cgroup");
+}

--- a/test/integration-test/src/utils.rs
+++ b/test/integration-test/src/utils.rs
@@ -19,6 +19,11 @@ use libc::if_nametoindex;
 const CGROUP_ROOT: &str = "/sys/fs/cgroup";
 const CGROUP_PROCS: &str = "cgroup.procs";
 
+pub(crate) fn is_cgroup2() -> bool {
+    // `cgroup.controllers` exists only at the root of a cgroup2 mount.
+    Path::new(CGROUP_ROOT).join("cgroup.controllers").exists()
+}
+
 pub(crate) struct ChildCgroup<'a> {
     parent: &'a Cgroup<'a>,
     path: Cow<'a, Path>,

--- a/xtask/public-api/aya-ebpf.txt
+++ b/xtask/public-api/aya-ebpf.txt
@@ -39,6 +39,21 @@ impl<T, const MAX_ENTRIES: usize, const FLAGS: usize, const HASH_FUNCS: usize> c
 impl<T, const MAX_ENTRIES: usize, const FLAGS: usize, const HASH_FUNCS: usize> core::marker::UnsafeUnpin for aya_ebpf::btf_maps::bloom_filter::BloomFilter<T, MAX_ENTRIES, FLAGS, HASH_FUNCS>
 impl<T, const MAX_ENTRIES: usize, const FLAGS: usize, const HASH_FUNCS: usize> core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::btf_maps::bloom_filter::BloomFilter<T, MAX_ENTRIES, FLAGS, HASH_FUNCS> where T: core::panic::unwind_safe::RefUnwindSafe
 impl<T, const MAX_ENTRIES: usize, const FLAGS: usize, const HASH_FUNCS: usize> core::panic::unwind_safe::UnwindSafe for aya_ebpf::btf_maps::bloom_filter::BloomFilter<T, MAX_ENTRIES, FLAGS, HASH_FUNCS> where T: core::panic::unwind_safe::RefUnwindSafe
+pub mod aya_ebpf::btf_maps::cgroup_array
+#[repr(C)] pub struct aya_ebpf::btf_maps::cgroup_array::CgroupArray<const MAX_ENTRIES: usize, const FLAGS: usize>
+impl<const MAX_ENTRIES: usize, const FLAGS: usize> aya_ebpf::btf_maps::cgroup_array::CgroupArray<MAX_ENTRIES, FLAGS>
+pub fn aya_ebpf::btf_maps::cgroup_array::CgroupArray<MAX_ENTRIES, FLAGS>::current_task_under_cgroup(&self, index: u32) -> core::result::Result<bool, aya_ebpf_cty::od::c_long>
+impl<const MAX_ENTRIES: usize, const FLAGS: usize> aya_ebpf::btf_maps::cgroup_array::CgroupArray<MAX_ENTRIES, FLAGS>
+pub const fn aya_ebpf::btf_maps::cgroup_array::CgroupArray<MAX_ENTRIES, FLAGS>::new() -> Self
+impl<const MAX_ENTRIES: usize, const FLAGS: usize> core::default::Default for aya_ebpf::btf_maps::cgroup_array::CgroupArray<MAX_ENTRIES, FLAGS>
+pub fn aya_ebpf::btf_maps::cgroup_array::CgroupArray<MAX_ENTRIES, FLAGS>::default() -> Self
+impl<const MAX_ENTRIES: usize, const FLAGS: usize> core::marker::Sync for aya_ebpf::btf_maps::cgroup_array::CgroupArray<MAX_ENTRIES, FLAGS>
+impl<const MAX_ENTRIES: usize, const FLAGS: usize> core::marker::Freeze for aya_ebpf::btf_maps::cgroup_array::CgroupArray<MAX_ENTRIES, FLAGS>
+impl<const MAX_ENTRIES: usize, const FLAGS: usize> !core::marker::Send for aya_ebpf::btf_maps::cgroup_array::CgroupArray<MAX_ENTRIES, FLAGS>
+impl<const MAX_ENTRIES: usize, const FLAGS: usize> core::marker::Unpin for aya_ebpf::btf_maps::cgroup_array::CgroupArray<MAX_ENTRIES, FLAGS>
+impl<const MAX_ENTRIES: usize, const FLAGS: usize> core::marker::UnsafeUnpin for aya_ebpf::btf_maps::cgroup_array::CgroupArray<MAX_ENTRIES, FLAGS>
+impl<const MAX_ENTRIES: usize, const FLAGS: usize> core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::btf_maps::cgroup_array::CgroupArray<MAX_ENTRIES, FLAGS>
+impl<const MAX_ENTRIES: usize, const FLAGS: usize> core::panic::unwind_safe::UnwindSafe for aya_ebpf::btf_maps::cgroup_array::CgroupArray<MAX_ENTRIES, FLAGS>
 pub mod aya_ebpf::btf_maps::cpu_map
 #[repr(C)] pub struct aya_ebpf::btf_maps::cpu_map::CpuMap<const MAX_ENTRIES: usize, const FLAGS: usize>
 impl<const MAX_ENTRIES: usize, const FLAGS: usize> aya_ebpf::btf_maps::cpu_map::CpuMap<MAX_ENTRIES, FLAGS>
@@ -492,6 +507,20 @@ impl<T, const MAX_ENTRIES: usize, const FLAGS: usize, const HASH_FUNCS: usize> c
 impl<T, const MAX_ENTRIES: usize, const FLAGS: usize, const HASH_FUNCS: usize> core::marker::UnsafeUnpin for aya_ebpf::btf_maps::bloom_filter::BloomFilter<T, MAX_ENTRIES, FLAGS, HASH_FUNCS>
 impl<T, const MAX_ENTRIES: usize, const FLAGS: usize, const HASH_FUNCS: usize> core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::btf_maps::bloom_filter::BloomFilter<T, MAX_ENTRIES, FLAGS, HASH_FUNCS> where T: core::panic::unwind_safe::RefUnwindSafe
 impl<T, const MAX_ENTRIES: usize, const FLAGS: usize, const HASH_FUNCS: usize> core::panic::unwind_safe::UnwindSafe for aya_ebpf::btf_maps::bloom_filter::BloomFilter<T, MAX_ENTRIES, FLAGS, HASH_FUNCS> where T: core::panic::unwind_safe::RefUnwindSafe
+#[repr(C)] pub struct aya_ebpf::btf_maps::CgroupArray<const MAX_ENTRIES: usize, const FLAGS: usize>
+impl<const MAX_ENTRIES: usize, const FLAGS: usize> aya_ebpf::btf_maps::cgroup_array::CgroupArray<MAX_ENTRIES, FLAGS>
+pub fn aya_ebpf::btf_maps::cgroup_array::CgroupArray<MAX_ENTRIES, FLAGS>::current_task_under_cgroup(&self, index: u32) -> core::result::Result<bool, aya_ebpf_cty::od::c_long>
+impl<const MAX_ENTRIES: usize, const FLAGS: usize> aya_ebpf::btf_maps::cgroup_array::CgroupArray<MAX_ENTRIES, FLAGS>
+pub const fn aya_ebpf::btf_maps::cgroup_array::CgroupArray<MAX_ENTRIES, FLAGS>::new() -> Self
+impl<const MAX_ENTRIES: usize, const FLAGS: usize> core::default::Default for aya_ebpf::btf_maps::cgroup_array::CgroupArray<MAX_ENTRIES, FLAGS>
+pub fn aya_ebpf::btf_maps::cgroup_array::CgroupArray<MAX_ENTRIES, FLAGS>::default() -> Self
+impl<const MAX_ENTRIES: usize, const FLAGS: usize> core::marker::Sync for aya_ebpf::btf_maps::cgroup_array::CgroupArray<MAX_ENTRIES, FLAGS>
+impl<const MAX_ENTRIES: usize, const FLAGS: usize> core::marker::Freeze for aya_ebpf::btf_maps::cgroup_array::CgroupArray<MAX_ENTRIES, FLAGS>
+impl<const MAX_ENTRIES: usize, const FLAGS: usize> !core::marker::Send for aya_ebpf::btf_maps::cgroup_array::CgroupArray<MAX_ENTRIES, FLAGS>
+impl<const MAX_ENTRIES: usize, const FLAGS: usize> core::marker::Unpin for aya_ebpf::btf_maps::cgroup_array::CgroupArray<MAX_ENTRIES, FLAGS>
+impl<const MAX_ENTRIES: usize, const FLAGS: usize> core::marker::UnsafeUnpin for aya_ebpf::btf_maps::cgroup_array::CgroupArray<MAX_ENTRIES, FLAGS>
+impl<const MAX_ENTRIES: usize, const FLAGS: usize> core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::btf_maps::cgroup_array::CgroupArray<MAX_ENTRIES, FLAGS>
+impl<const MAX_ENTRIES: usize, const FLAGS: usize> core::panic::unwind_safe::UnwindSafe for aya_ebpf::btf_maps::cgroup_array::CgroupArray<MAX_ENTRIES, FLAGS>
 #[repr(C)] pub struct aya_ebpf::btf_maps::CpuMap<const MAX_ENTRIES: usize, const FLAGS: usize>
 impl<const MAX_ENTRIES: usize, const FLAGS: usize> aya_ebpf::btf_maps::cpu_map::CpuMap<MAX_ENTRIES, FLAGS>
 pub const fn aya_ebpf::btf_maps::cpu_map::CpuMap<MAX_ENTRIES, FLAGS>::new() -> Self
@@ -887,6 +916,19 @@ impl<T> core::marker::Unpin for aya_ebpf::maps::bloom_filter::BloomFilter<T> whe
 impl<T> core::marker::UnsafeUnpin for aya_ebpf::maps::bloom_filter::BloomFilter<T>
 impl<T> !core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::maps::bloom_filter::BloomFilter<T>
 impl<T> core::panic::unwind_safe::UnwindSafe for aya_ebpf::maps::bloom_filter::BloomFilter<T> where T: core::panic::unwind_safe::UnwindSafe
+pub mod aya_ebpf::maps::cgroup_array
+#[repr(transparent)] pub struct aya_ebpf::maps::cgroup_array::CgroupArray
+impl aya_ebpf::maps::cgroup_array::CgroupArray
+pub fn aya_ebpf::maps::cgroup_array::CgroupArray::current_task_under_cgroup(&self, index: u32) -> core::result::Result<bool, aya_ebpf_cty::od::c_long>
+pub const fn aya_ebpf::maps::cgroup_array::CgroupArray::pinned(max_entries: u32, flags: u32) -> Self
+pub const fn aya_ebpf::maps::cgroup_array::CgroupArray::with_max_entries(max_entries: u32, flags: u32) -> Self
+impl !core::marker::Freeze for aya_ebpf::maps::cgroup_array::CgroupArray
+impl core::marker::Send for aya_ebpf::maps::cgroup_array::CgroupArray
+impl core::marker::Sync for aya_ebpf::maps::cgroup_array::CgroupArray
+impl core::marker::Unpin for aya_ebpf::maps::cgroup_array::CgroupArray
+impl core::marker::UnsafeUnpin for aya_ebpf::maps::cgroup_array::CgroupArray
+impl !core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::maps::cgroup_array::CgroupArray
+impl core::panic::unwind_safe::UnwindSafe for aya_ebpf::maps::cgroup_array::CgroupArray
 pub mod aya_ebpf::maps::hash_map
 #[repr(transparent)] pub struct aya_ebpf::maps::hash_map::HashMap<K, V>
 impl<K, V> aya_ebpf::maps::hash_map::HashMap<K, V>
@@ -1265,6 +1307,18 @@ impl<T> core::marker::Unpin for aya_ebpf::maps::bloom_filter::BloomFilter<T> whe
 impl<T> core::marker::UnsafeUnpin for aya_ebpf::maps::bloom_filter::BloomFilter<T>
 impl<T> !core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::maps::bloom_filter::BloomFilter<T>
 impl<T> core::panic::unwind_safe::UnwindSafe for aya_ebpf::maps::bloom_filter::BloomFilter<T> where T: core::panic::unwind_safe::UnwindSafe
+#[repr(transparent)] pub struct aya_ebpf::maps::CgroupArray
+impl aya_ebpf::maps::cgroup_array::CgroupArray
+pub fn aya_ebpf::maps::cgroup_array::CgroupArray::current_task_under_cgroup(&self, index: u32) -> core::result::Result<bool, aya_ebpf_cty::od::c_long>
+pub const fn aya_ebpf::maps::cgroup_array::CgroupArray::pinned(max_entries: u32, flags: u32) -> Self
+pub const fn aya_ebpf::maps::cgroup_array::CgroupArray::with_max_entries(max_entries: u32, flags: u32) -> Self
+impl !core::marker::Freeze for aya_ebpf::maps::cgroup_array::CgroupArray
+impl core::marker::Send for aya_ebpf::maps::cgroup_array::CgroupArray
+impl core::marker::Sync for aya_ebpf::maps::cgroup_array::CgroupArray
+impl core::marker::Unpin for aya_ebpf::maps::cgroup_array::CgroupArray
+impl core::marker::UnsafeUnpin for aya_ebpf::maps::cgroup_array::CgroupArray
+impl !core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::maps::cgroup_array::CgroupArray
+impl core::panic::unwind_safe::UnwindSafe for aya_ebpf::maps::cgroup_array::CgroupArray
 #[repr(transparent)] pub struct aya_ebpf::maps::CpuMap
 impl aya_ebpf::maps::CpuMap
 pub const fn aya_ebpf::maps::CpuMap::pinned(max_entries: u32, flags: u32) -> Self
@@ -1991,6 +2045,7 @@ pub fn aya_ebpf::programs::tc::TcContext::load_bytes(&self, offset: usize, dst: 
 pub const fn aya_ebpf::programs::tc::TcContext::new(skb: *mut aya_ebpf_bindings::x86_64::bindings::__sk_buff) -> Self
 pub fn aya_ebpf::programs::tc::TcContext::pull_data(&self, len: u32) -> core::result::Result<(), aya_ebpf_cty::od::c_long>
 pub fn aya_ebpf::programs::tc::TcContext::set_mark(&self, mark: u32)
+pub fn aya_ebpf::programs::tc::TcContext::skb_under_cgroup<M: aya_ebpf::programs::tc::CgroupArrayMap>(&self, map: &M, index: u32) -> core::result::Result<bool, aya_ebpf_cty::od::c_long>
 pub fn aya_ebpf::programs::tc::TcContext::store<T>(&self, offset: usize, v: &T, flags: u64) -> core::result::Result<(), aya_ebpf_cty::od::c_long>
 impl aya_ebpf::EbpfContext for aya_ebpf::programs::tc::TcContext
 pub fn aya_ebpf::programs::tc::TcContext::as_ptr(&self) -> *mut aya_ebpf_cty::c_void
@@ -2006,6 +2061,8 @@ impl core::marker::Unpin for aya_ebpf::programs::tc::TcContext
 impl core::marker::UnsafeUnpin for aya_ebpf::programs::tc::TcContext
 impl core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::programs::tc::TcContext
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf::programs::tc::TcContext
+pub trait aya_ebpf::programs::tc::CgroupArrayMap: aya_ebpf::programs::tc::sealed::CgroupArrayMap
+impl<T: aya_ebpf::programs::tc::sealed::CgroupArrayMap> aya_ebpf::programs::tc::CgroupArrayMap for T
 pub mod aya_ebpf::programs::tp_btf
 pub struct aya_ebpf::programs::tp_btf::BtfTracePointContext
 impl aya_ebpf::programs::tp_btf::BtfTracePointContext
@@ -2484,6 +2541,7 @@ pub fn aya_ebpf::programs::tc::TcContext::load_bytes(&self, offset: usize, dst: 
 pub const fn aya_ebpf::programs::tc::TcContext::new(skb: *mut aya_ebpf_bindings::x86_64::bindings::__sk_buff) -> Self
 pub fn aya_ebpf::programs::tc::TcContext::pull_data(&self, len: u32) -> core::result::Result<(), aya_ebpf_cty::od::c_long>
 pub fn aya_ebpf::programs::tc::TcContext::set_mark(&self, mark: u32)
+pub fn aya_ebpf::programs::tc::TcContext::skb_under_cgroup<M: aya_ebpf::programs::tc::CgroupArrayMap>(&self, map: &M, index: u32) -> core::result::Result<bool, aya_ebpf_cty::od::c_long>
 pub fn aya_ebpf::programs::tc::TcContext::store<T>(&self, offset: usize, v: &T, flags: u64) -> core::result::Result<(), aya_ebpf_cty::od::c_long>
 impl aya_ebpf::EbpfContext for aya_ebpf::programs::tc::TcContext
 pub fn aya_ebpf::programs::tc::TcContext::as_ptr(&self) -> *mut aya_ebpf_cty::c_void

--- a/xtask/public-api/aya.txt
+++ b/xtask/public-api/aya.txt
@@ -36,6 +36,30 @@ impl<T, V> core::marker::Unpin for aya::maps::array::Array<T, V> where T: core::
 impl<T, V> core::marker::UnsafeUnpin for aya::maps::array::Array<T, V> where T: core::marker::UnsafeUnpin
 impl<T, V> core::panic::unwind_safe::RefUnwindSafe for aya::maps::array::Array<T, V> where T: core::panic::unwind_safe::RefUnwindSafe, V: core::panic::unwind_safe::RefUnwindSafe
 impl<T, V> core::panic::unwind_safe::UnwindSafe for aya::maps::array::Array<T, V> where T: core::panic::unwind_safe::UnwindSafe, V: core::panic::unwind_safe::UnwindSafe
+pub struct aya::maps::array::CgroupArray<T>
+impl<T: core::borrow::Borrow<aya::maps::MapData>> aya::maps::CgroupArray<T>
+pub fn aya::maps::CgroupArray<T>::len(&self) -> u32
+impl<T: core::borrow::Borrow<aya::maps::MapData>> aya::maps::CgroupArray<T>
+pub fn aya::maps::CgroupArray<T>::pin<P: core::convert::AsRef<std::path::Path>>(self, path: P) -> core::result::Result<(), aya::pin::PinError>
+impl<T: core::borrow::BorrowMut<aya::maps::MapData>> aya::maps::CgroupArray<T>
+pub fn aya::maps::CgroupArray<T>::set(&mut self, index: u32, cgroup_fd: impl std::os::fd::raw::AsRawFd, flags: u64) -> core::result::Result<(), aya::maps::MapError>
+pub fn aya::maps::CgroupArray<T>::unset(&mut self, index: u32) -> core::result::Result<(), aya::maps::MapError>
+impl core::convert::TryFrom<aya::maps::Map> for aya::maps::CgroupArray<aya::maps::MapData>
+pub type aya::maps::CgroupArray<aya::maps::MapData>::Error = aya::maps::MapError
+pub fn aya::maps::CgroupArray<aya::maps::MapData>::try_from(map: aya::maps::Map) -> core::result::Result<Self, Self::Error>
+impl<'a> core::convert::TryFrom<&'a aya::maps::Map> for aya::maps::CgroupArray<&'a aya::maps::MapData>
+pub type aya::maps::CgroupArray<&'a aya::maps::MapData>::Error = aya::maps::MapError
+pub fn aya::maps::CgroupArray<&'a aya::maps::MapData>::try_from(map: &'a aya::maps::Map) -> core::result::Result<Self, Self::Error>
+impl<'a> core::convert::TryFrom<&'a mut aya::maps::Map> for aya::maps::CgroupArray<&'a mut aya::maps::MapData>
+pub type aya::maps::CgroupArray<&'a mut aya::maps::MapData>::Error = aya::maps::MapError
+pub fn aya::maps::CgroupArray<&'a mut aya::maps::MapData>::try_from(map: &'a mut aya::maps::Map) -> core::result::Result<Self, Self::Error>
+impl<T> core::marker::Freeze for aya::maps::CgroupArray<T> where T: core::marker::Freeze
+impl<T> core::marker::Send for aya::maps::CgroupArray<T> where T: core::marker::Send
+impl<T> core::marker::Sync for aya::maps::CgroupArray<T> where T: core::marker::Sync
+impl<T> core::marker::Unpin for aya::maps::CgroupArray<T> where T: core::marker::Unpin
+impl<T> core::marker::UnsafeUnpin for aya::maps::CgroupArray<T> where T: core::marker::UnsafeUnpin
+impl<T> core::panic::unwind_safe::RefUnwindSafe for aya::maps::CgroupArray<T> where T: core::panic::unwind_safe::RefUnwindSafe
+impl<T> core::panic::unwind_safe::UnwindSafe for aya::maps::CgroupArray<T> where T: core::panic::unwind_safe::UnwindSafe
 pub struct aya::maps::array::PerCpuArray<T, V: aya::Pod>
 impl<T: core::borrow::Borrow<aya::maps::MapData>, V: aya::Pod> aya::maps::PerCpuArray<T, V>
 pub fn aya::maps::PerCpuArray<T, V>::get(&self, index: &u32, flags: u64) -> core::result::Result<aya::maps::PerCpuValues<V>, aya::maps::MapError>
@@ -786,6 +810,7 @@ pub enum aya::maps::Map
 pub aya::maps::Map::Array(aya::maps::MapData)
 pub aya::maps::Map::ArrayOfMaps(aya::maps::MapData)
 pub aya::maps::Map::BloomFilter(aya::maps::MapData)
+pub aya::maps::Map::CgroupArray(aya::maps::MapData)
 pub aya::maps::Map::CpuMap(aya::maps::MapData)
 pub aya::maps::Map::DevMap(aya::maps::MapData)
 pub aya::maps::Map::DevMapHash(aya::maps::MapData)
@@ -811,6 +836,9 @@ pub aya::maps::Map::XskMap(aya::maps::MapData)
 impl aya::maps::Map
 pub fn aya::maps::Map::from_map_data(map_data: aya::maps::MapData) -> core::result::Result<Self, aya::maps::MapError>
 pub fn aya::maps::Map::pin<P: core::convert::AsRef<std::path::Path>>(&self, path: P) -> core::result::Result<(), aya::pin::PinError>
+impl core::convert::TryFrom<aya::maps::Map> for aya::maps::CgroupArray<aya::maps::MapData>
+pub type aya::maps::CgroupArray<aya::maps::MapData>::Error = aya::maps::MapError
+pub fn aya::maps::CgroupArray<aya::maps::MapData>::try_from(map: aya::maps::Map) -> core::result::Result<Self, Self::Error>
 impl core::convert::TryFrom<aya::maps::Map> for aya::maps::CpuMap<aya::maps::MapData>
 pub type aya::maps::CpuMap<aya::maps::MapData>::Error = aya::maps::MapError
 pub fn aya::maps::CpuMap<aya::maps::MapData>::try_from(map: aya::maps::Map) -> core::result::Result<Self, Self::Error>
@@ -915,6 +943,9 @@ pub fn aya::maps::ArrayOfMaps<&'a aya::maps::MapData, V>::try_from(map: &'a aya:
 impl<'a, V: aya::maps::InnerMap> core::convert::TryFrom<&'a mut aya::maps::Map> for aya::maps::ArrayOfMaps<&'a mut aya::maps::MapData, V>
 pub type aya::maps::ArrayOfMaps<&'a mut aya::maps::MapData, V>::Error = aya::maps::MapError
 pub fn aya::maps::ArrayOfMaps<&'a mut aya::maps::MapData, V>::try_from(map: &'a mut aya::maps::Map) -> core::result::Result<Self, Self::Error>
+impl<'a> core::convert::TryFrom<&'a aya::maps::Map> for aya::maps::CgroupArray<&'a aya::maps::MapData>
+pub type aya::maps::CgroupArray<&'a aya::maps::MapData>::Error = aya::maps::MapError
+pub fn aya::maps::CgroupArray<&'a aya::maps::MapData>::try_from(map: &'a aya::maps::Map) -> core::result::Result<Self, Self::Error>
 impl<'a> core::convert::TryFrom<&'a aya::maps::Map> for aya::maps::CpuMap<&'a aya::maps::MapData>
 pub type aya::maps::CpuMap<&'a aya::maps::MapData>::Error = aya::maps::MapError
 pub fn aya::maps::CpuMap<&'a aya::maps::MapData>::try_from(map: &'a aya::maps::Map) -> core::result::Result<Self, Self::Error>
@@ -945,6 +976,9 @@ pub fn aya::maps::ring_buf::RingBuf<&'a aya::maps::MapData>::try_from(map: &'a a
 impl<'a> core::convert::TryFrom<&'a aya::maps::Map> for aya::maps::stack_trace::StackTraceMap<&'a aya::maps::MapData>
 pub type aya::maps::stack_trace::StackTraceMap<&'a aya::maps::MapData>::Error = aya::maps::MapError
 pub fn aya::maps::stack_trace::StackTraceMap<&'a aya::maps::MapData>::try_from(map: &'a aya::maps::Map) -> core::result::Result<Self, Self::Error>
+impl<'a> core::convert::TryFrom<&'a mut aya::maps::Map> for aya::maps::CgroupArray<&'a mut aya::maps::MapData>
+pub type aya::maps::CgroupArray<&'a mut aya::maps::MapData>::Error = aya::maps::MapError
+pub fn aya::maps::CgroupArray<&'a mut aya::maps::MapData>::try_from(map: &'a mut aya::maps::Map) -> core::result::Result<Self, Self::Error>
 impl<'a> core::convert::TryFrom<&'a mut aya::maps::Map> for aya::maps::CpuMap<&'a mut aya::maps::MapData>
 pub type aya::maps::CpuMap<&'a mut aya::maps::MapData>::Error = aya::maps::MapError
 pub fn aya::maps::CpuMap<&'a mut aya::maps::MapData>::try_from(map: &'a mut aya::maps::Map) -> core::result::Result<Self, Self::Error>
@@ -1218,6 +1252,30 @@ impl<T, V> core::marker::Unpin for aya::maps::bloom_filter::BloomFilter<T, V> wh
 impl<T, V> core::marker::UnsafeUnpin for aya::maps::bloom_filter::BloomFilter<T, V> where T: core::marker::UnsafeUnpin
 impl<T, V> core::panic::unwind_safe::RefUnwindSafe for aya::maps::bloom_filter::BloomFilter<T, V> where T: core::panic::unwind_safe::RefUnwindSafe, V: core::panic::unwind_safe::RefUnwindSafe
 impl<T, V> core::panic::unwind_safe::UnwindSafe for aya::maps::bloom_filter::BloomFilter<T, V> where T: core::panic::unwind_safe::UnwindSafe, V: core::panic::unwind_safe::UnwindSafe
+pub struct aya::maps::CgroupArray<T>
+impl<T: core::borrow::Borrow<aya::maps::MapData>> aya::maps::CgroupArray<T>
+pub fn aya::maps::CgroupArray<T>::len(&self) -> u32
+impl<T: core::borrow::Borrow<aya::maps::MapData>> aya::maps::CgroupArray<T>
+pub fn aya::maps::CgroupArray<T>::pin<P: core::convert::AsRef<std::path::Path>>(self, path: P) -> core::result::Result<(), aya::pin::PinError>
+impl<T: core::borrow::BorrowMut<aya::maps::MapData>> aya::maps::CgroupArray<T>
+pub fn aya::maps::CgroupArray<T>::set(&mut self, index: u32, cgroup_fd: impl std::os::fd::raw::AsRawFd, flags: u64) -> core::result::Result<(), aya::maps::MapError>
+pub fn aya::maps::CgroupArray<T>::unset(&mut self, index: u32) -> core::result::Result<(), aya::maps::MapError>
+impl core::convert::TryFrom<aya::maps::Map> for aya::maps::CgroupArray<aya::maps::MapData>
+pub type aya::maps::CgroupArray<aya::maps::MapData>::Error = aya::maps::MapError
+pub fn aya::maps::CgroupArray<aya::maps::MapData>::try_from(map: aya::maps::Map) -> core::result::Result<Self, Self::Error>
+impl<'a> core::convert::TryFrom<&'a aya::maps::Map> for aya::maps::CgroupArray<&'a aya::maps::MapData>
+pub type aya::maps::CgroupArray<&'a aya::maps::MapData>::Error = aya::maps::MapError
+pub fn aya::maps::CgroupArray<&'a aya::maps::MapData>::try_from(map: &'a aya::maps::Map) -> core::result::Result<Self, Self::Error>
+impl<'a> core::convert::TryFrom<&'a mut aya::maps::Map> for aya::maps::CgroupArray<&'a mut aya::maps::MapData>
+pub type aya::maps::CgroupArray<&'a mut aya::maps::MapData>::Error = aya::maps::MapError
+pub fn aya::maps::CgroupArray<&'a mut aya::maps::MapData>::try_from(map: &'a mut aya::maps::Map) -> core::result::Result<Self, Self::Error>
+impl<T> core::marker::Freeze for aya::maps::CgroupArray<T> where T: core::marker::Freeze
+impl<T> core::marker::Send for aya::maps::CgroupArray<T> where T: core::marker::Send
+impl<T> core::marker::Sync for aya::maps::CgroupArray<T> where T: core::marker::Sync
+impl<T> core::marker::Unpin for aya::maps::CgroupArray<T> where T: core::marker::Unpin
+impl<T> core::marker::UnsafeUnpin for aya::maps::CgroupArray<T> where T: core::marker::UnsafeUnpin
+impl<T> core::panic::unwind_safe::RefUnwindSafe for aya::maps::CgroupArray<T> where T: core::panic::unwind_safe::RefUnwindSafe
+impl<T> core::panic::unwind_safe::UnwindSafe for aya::maps::CgroupArray<T> where T: core::panic::unwind_safe::UnwindSafe
 pub struct aya::maps::CpuMap<T>
 impl<T: core::borrow::Borrow<aya::maps::MapData>> aya::maps::CpuMap<T>
 pub fn aya::maps::CpuMap<T>::get(&self, cpu_index: u32, flags: u64) -> core::result::Result<aya::maps::xdp::cpu_map::CpuMapValue, aya::maps::MapError>


### PR DESCRIPTION
Adds `CgroupArray` to `aya::maps`, `aya_ebpf::maps`, and
`aya_ebpf::btf_maps`, so `BPF_MAP_TYPE_CGROUP_ARRAY` is no longer
routed to `Map::Unsupported`. The map stores cgroup directory file
descriptors set from userspace; both the key and the value are `u32`.

The eBPF maps expose `current_task_under_cgroup`, wrapping
`bpf_current_task_under_cgroup`. `TcContext` gains `skb_under_cgroup`,
wrapping `bpf_skb_under_cgroup`; a sealed `CgroupArrayMap` trait
implemented for both map forms gates it to classifier programs, since
the kernel permits `bpf_skb_under_cgroup` only from TC and LWT and aya
has no LWT bindings. Userspace `set`/`unset` take a cgroup file
descriptor, like `XskMap`.

As with the other maps in the `map_check_no_btf` family (program
array, perf event array), the kernel rejects BTF key/value type ids,
so aya strips them at map creation and the legacy and BTF forms
produce an identical map.

Integration tests parametrize over the legacy and BTF maps via
`#[test_case]`: a uprobe stores the cgroup root and a fresh child
cgroup, then asserts the current task is reported under the former and
not the latter. They skip on kernels older than 4.9, where the map
(4.8) exists but `bpf_current_task_under_cgroup` (4.9) does not.

Closes #192.

### Added/updated tests?

- [x] Yes

### Checklist

- [x] Rust code has been formatted with `cargo +nightly fmt`.
- [x] All clippy lints have been fixed.
      You can find failing lints with `cargo xtask clippy`.
- [x] Unit tests are passing locally with `cargo test`.
- [x] The integration tests are passing locally.
- [x] I have blessed any API changes with `cargo xtask public-api --bless`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aya-rs/aya/1577)
<!-- Reviewable:end -->
