### PR TITLE
test: replace test-case with rstest

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -97,6 +97,7 @@ public-api = { version = "0.51.0", default-features = false }
 quote = { version = "1", default-features = false }
 rand = { version = "0.10", default-features = false }
 rbpf = { version = "0.4.0", default-features = false }
+rstest = { version = "0.26.1", default-features = false }
 rustc_version = { version = "0.4.1", default-features = false }
 rustdoc-json = { version = "0.9.0", default-features = false }
 rustup-toolchain = { version = "0.1.5", default-features = false }
@@ -105,7 +106,6 @@ scopeguard = { version = "1.2.0", default-features = false }
 syn = { version = "2", default-features = false }
 tar = { version = "0.4.44", default-features = false }
 tempfile = { version = "3", default-features = false }
-test-case = { version = "3.1.0", default-features = false }
 test-log = { version = "0.2.13", default-features = false }
 testing_logger = { version = "0.1.1", default-features = false }
 thiserror = { version = "2.0.3", default-features = false }

--- a/aya-ebpf-macros/Cargo.toml
+++ b/aya-ebpf-macros/Cargo.toml
@@ -24,4 +24,4 @@ syn = { workspace = true, default-features = true, features = ["full"] }
 
 [dev-dependencies]
 aya-ebpf = { path = "../ebpf/aya-ebpf", default-features = false }
-test-case = { workspace = true }
+rstest = { workspace = true }

--- a/aya-ebpf-macros/src/uprobe.rs
+++ b/aya-ebpf-macros/src/uprobe.rs
@@ -125,47 +125,39 @@ impl UProbe {
 
 #[cfg(test)]
 mod tests {
+    use rstest::rstest;
     use syn::parse_quote;
-    use test_case::test_case;
 
     use super::*;
 
-    #[test_case(UProbeKind::UProbe, "", "uprobe"; "uprobe")]
-    #[test_case(UProbeKind::UProbe, "sleepable", "uprobe.s"; "uprobe_sleepable")]
-    #[test_case(
+    #[rstest]
+    #[case::uprobe(UProbeKind::UProbe, "", "uprobe")]
+    #[case::uprobe_sleepable(UProbeKind::UProbe, "sleepable", "uprobe.s")]
+    #[case::uprobe_with_path(
         UProbeKind::UProbe,
         r#"path = "/self/proc/exe", function = "trigger_uprobe""#,
-        "uprobe/self/proc/exe:trigger_uprobe";
-        "uprobe_with_path"
+        "uprobe/self/proc/exe:trigger_uprobe"
     )]
-    #[test_case(
+    #[case::uprobe_with_path_and_offset(
         UProbeKind::UProbe,
         r#"path = "/self/proc/exe", function = "foo", offset = "123""#,
-        "uprobe/self/proc/exe:foo+123";
-        "uprobe_with_path_and_offset"
+        "uprobe/self/proc/exe:foo+123"
     )]
-    #[test_case(UProbeKind::URetProbe, "", "uretprobe"; "uretprobe")]
-    #[test_case(UProbeKind::UProbe, "multi", "uprobe.multi"; "uprobe_multi")]
-    #[test_case(
-        UProbeKind::UProbe,
-        "multi, sleepable",
-        "uprobe.multi.s";
-        "uprobe_multi_sleepable"
-    )]
-    #[test_case(
+    #[case::uretprobe(UProbeKind::URetProbe, "", "uretprobe")]
+    #[case::uprobe_multi(UProbeKind::UProbe, "multi", "uprobe.multi")]
+    #[case::uprobe_multi_sleepable(UProbeKind::UProbe, "multi, sleepable", "uprobe.multi.s")]
+    #[case::uprobe_multi_with_path(
         UProbeKind::UProbe,
         r#"multi, path = "/self/proc/exe", function = "trigger_uprobe""#,
-        "uprobe.multi/self/proc/exe:trigger_uprobe";
-        "uprobe_multi_with_path"
+        "uprobe.multi/self/proc/exe:trigger_uprobe"
     )]
-    #[test_case(UProbeKind::URetProbe, "multi", "uretprobe.multi"; "uretprobe_multi")]
-    #[test_case(
+    #[case::uretprobe_multi(UProbeKind::URetProbe, "multi", "uretprobe.multi")]
+    #[case::uretprobe_multi_sleepable(
         UProbeKind::URetProbe,
         "multi, sleepable",
-        "uretprobe.multi.s";
-        "uretprobe_multi_sleepable"
+        "uretprobe.multi.s"
     )]
-    fn uprobe(kind: UProbeKind, attrs: &str, section_name: &str) {
+    fn uprobe(#[case] kind: UProbeKind, #[case] attrs: &str, #[case] section_name: &str) {
         let uprobe = UProbe::parse(
             kind,
             attrs.parse().unwrap(),

--- a/aya/Cargo.toml
+++ b/aya/Cargo.toml
@@ -32,8 +32,8 @@ thiserror = { workspace = true }
 
 [dev-dependencies]
 nix = { workspace = true, features = ["net", "socket"] }
+rstest = { workspace = true }
 tempfile = { workspace = true }
-test-case = { workspace = true }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/aya/src/maps/perf/perf_buffer.rs
+++ b/aya/src/maps/perf/perf_buffer.rs
@@ -348,7 +348,7 @@ mod tests {
     use std::fmt::Debug;
 
     use assert_matches::assert_matches;
-    use test_case::test_case;
+    use rstest::rstest;
 
     use super::*;
     use crate::sys::{Syscall, TEST_MMAP_RET, override_syscall};
@@ -439,10 +439,11 @@ mod tests {
         v
     }
 
-    #[test_case(&[] ; "empty")]
-    #[test_case(&[0xCAFEBABEu32] ; "single")]
-    #[test_case(&[0xCAFEBABEu32, 0xBADCAFEu32] ; "consecutive")]
-    fn test_for_each_samples(expected: &[u32]) {
+    #[rstest]
+    #[case::empty(&[])]
+    #[case::single(&[0xCAFEBABEu32])]
+    #[case::consecutive(&[0xCAFEBABEu32, 0xBADCAFEu32])]
+    fn test_for_each_samples(#[case] expected: &[u32]) {
         let mut mmapped_buf = MMappedBuf {
             data: [0; PAGE_SIZE * 2],
         };

--- a/aya/src/programs/uprobe.rs
+++ b/aya/src/programs/uprobe.rs
@@ -864,7 +864,7 @@ fn symbol_translated_address(
 mod tests {
     use assert_matches::assert_matches;
     use object::{Architecture, BinaryFormat, Endianness, write::SectionKind};
-    use test_case::test_case;
+    use rstest::rstest;
 
     use super::*;
 
@@ -894,20 +894,21 @@ mod tests {
         );
     }
 
-    #[test_case("libssl.so", true; "shared_object_basename")]
-    #[test_case("bash", true; "binary_basename")]
-    #[test_case("foo.so.1", true; "versioned_shared_object_basename")]
-    #[test_case("/usr/bin/bash", false; "absolute_path")]
-    #[test_case("/aa", false; "root_absolute_path")]
-    #[test_case("./bin/foo", false; "current_dir_relative_path")]
-    #[test_case("./aa", false; "current_dir_relative_file")]
-    #[test_case("subdir/lib.so", false; "subdir_relative_path")]
-    #[test_case("../lib/foo", false; "parent_dir_relative_path")]
-    #[test_case("/", false; "root_dir")]
-    #[test_case(".", false; "current_dir")]
-    #[test_case("..", false; "parent_dir")]
-    #[test_case("foo/", false; "trailing_separator")]
-    fn test_is_basename_only(input: &str, expected: bool) {
+    #[rstest]
+    #[case::shared_object_basename("libssl.so", true)]
+    #[case::binary_basename("bash", true)]
+    #[case::versioned_shared_object_basename("foo.so.1", true)]
+    #[case::absolute_path("/usr/bin/bash", false)]
+    #[case::root_absolute_path("/aa", false)]
+    #[case::current_dir_relative_path("./bin/foo", false)]
+    #[case::current_dir_relative_file("./aa", false)]
+    #[case::subdir_relative_path("subdir/lib.so", false)]
+    #[case::parent_dir_relative_path("../lib/foo", false)]
+    #[case::root_dir("/", false)]
+    #[case::current_dir(".", false)]
+    #[case::parent_dir("..", false)]
+    #[case::trailing_separator("foo/", false)]
+    fn test_is_basename_only(#[case] input: &str, #[case] expected: bool) {
         assert_eq!(is_basename_only(Path::new(input)), expected);
     }
 
@@ -1131,7 +1132,8 @@ mod tests {
         path: Option<&'static str>,
     }
 
-    #[test_case(
+    #[rstest]
+    #[case::bracketed_name(
         b"7ffd6fbea000-7ffd6fbec000  r-xp  00000000  00:00  0  [vdso]",
         ExpectedProcMapEntry {
             address: 0x7ffd6fbea000,
@@ -1141,10 +1143,8 @@ mod tests {
             dev: "00:00",
             inode: 0,
             path: Some("[vdso]"),
-        };
-        "bracketed_name"
-    )]
-    #[test_case(
+        })]
+    #[case::absolute_path(
         b"7f1bca83a000-7f1bca83c000  rw-p  00036000  fd:01  2895508  /usr/lib64/ld-linux-x86-64.so.2",
         ExpectedProcMapEntry {
             address: 0x7f1bca83a000,
@@ -1154,10 +1154,8 @@ mod tests {
             dev: "fd:01",
             inode: 2895508,
             path: Some("/usr/lib64/ld-linux-x86-64.so.2"),
-        };
-        "absolute_path"
-    )]
-    #[test_case(
+        })]
+    #[case::no_path(
         b"7f1bca5f9000-7f1bca601000  rw-p  00000000  00:00  0",
         ExpectedProcMapEntry {
             address: 0x7f1bca5f9000,
@@ -1167,10 +1165,8 @@ mod tests {
             dev: "00:00",
             inode: 0,
             path: None,
-        };
-        "no_path"
-    )]
-    #[test_case(
+        })]
+    #[case::relative_path_token(
         b"7f1bca5f9000-7f1bca601000  rw-p  00000000  00:00  0  deadbeef",
         ExpectedProcMapEntry {
             address: 0x7f1bca5f9000,
@@ -1180,10 +1176,8 @@ mod tests {
             dev: "00:00",
             inode: 0,
             path: Some("deadbeef"),
-        };
-        "relative_path_token"
-    )]
-    #[test_case(
+        })]
+    #[case::deleted_suffix_in_path(
         b"7f1bca83a000-7f1bca83c000  rw-p  00036000  fd:01  2895508  /usr/lib/libc.so.6 (deleted)",
         ExpectedProcMapEntry {
             address: 0x7f1bca83a000,
@@ -1193,11 +1187,9 @@ mod tests {
             dev: "fd:01",
             inode: 2895508,
             path: Some("/usr/lib/libc.so.6 (deleted)"),
-        };
-        "deleted_suffix_in_path"
-    )]
+        })]
     // The path field is the remainder of the line. It may contain whitespace and arbitrary tokens.
-    #[test_case(
+    #[case::path_remainder_with_spaces(
         b"71064dc000-71064df000 ---p 00000000 00:00 0  [page size compat] extra",
         ExpectedProcMapEntry {
             address: 0x71064dc000,
@@ -1207,10 +1199,8 @@ mod tests {
             dev: "00:00",
             inode: 0,
             path: Some("[page size compat] extra"),
-        };
-        "path_remainder_with_spaces"
-    )]
-    #[test_case(
+        })]
+    #[case::bracketed_name_with_spaces(
         b"724a0000-72aab000 rw-p 00000000 00:00 0 [anon:dalvik-zygote space] (deleted) extra",
         ExpectedProcMapEntry {
             address: 0x724a0000,
@@ -1220,10 +1210,8 @@ mod tests {
             dev: "00:00",
             inode: 0,
             path: Some("[anon:dalvik-zygote space] (deleted) extra"),
-        };
-        "bracketed_name_with_spaces"
-    )]
-    #[test_case(
+        })]
+    #[case::memfd_deleted(
         b"5ba3b000-5da3b000 r--s 00000000 00:01 1033 /memfd:jit-zygote-cache (deleted)",
         ExpectedProcMapEntry {
             address: 0x5ba3b000,
@@ -1233,10 +1221,8 @@ mod tests {
             dev: "00:01",
             inode: 1033,
             path: Some("/memfd:jit-zygote-cache (deleted)"),
-        };
-        "memfd_deleted"
-    )]
-    #[test_case(
+        })]
+    #[case::ashmem_with_spaces(
         b"6cd539c000-6cd559c000 rw-s 00000000 00:01 7215 /dev/ashmem/CursorWindow: /data/user/0/package/databases/kitefly.db (deleted)",
         ExpectedProcMapEntry {
             address: 0x6cd539c000,
@@ -1246,10 +1232,11 @@ mod tests {
             dev: "00:01",
             inode: 7215,
             path: Some("/dev/ashmem/CursorWindow: /data/user/0/package/databases/kitefly.db (deleted)"),
-        };
-        "ashmem_with_spaces"
-    )]
-    fn test_parse_proc_map_entry_ok(line: &'static [u8], expected: ExpectedProcMapEntry) {
+        })]
+    fn test_parse_proc_map_entry_ok(
+        #[case] line: &'static [u8],
+        #[case] expected: ExpectedProcMapEntry,
+    ) {
         use std::ffi::OsStr;
 
         let ExpectedProcMapEntry {
@@ -1273,13 +1260,14 @@ mod tests {
         });
     }
 
-    #[test_case(b"zzzz-7ffd6fbea000  r-xp  00000000  00:00  0  [vdso]"; "bad_address")]
-    #[test_case(b"7f1bca5f9000-7f1bca601000  r-xp  zzzz  00:00  0  [vdso]"; "bad_offset")]
-    #[test_case(b"7f1bca5f9000-7f1bca601000  r-xp  00000000  00:00  zzzz  [vdso]"; "bad_inode")]
-    #[test_case(b"7f1bca5f90007ffd6fbea000  r-xp  00000000  00:00  0  [vdso]"; "bad_address_range")]
-    #[test_case(b"7f1bca5f9000-7f1bca601000  r-xp  00000000"; "missing_fields")]
-    #[test_case(b"7f1bca5f9000-7f1bca601000-deadbeef  rw-p  00000000  00:00  0"; "bad_address_delimiter")]
-    fn test_parse_proc_map_entry_err(line: &'static [u8]) {
+    #[rstest]
+    #[case::bad_address(b"zzzz-7ffd6fbea000  r-xp  00000000  00:00  0  [vdso]")]
+    #[case::bad_offset(b"7f1bca5f9000-7f1bca601000  r-xp  zzzz  00:00  0  [vdso]")]
+    #[case::bad_inode(b"7f1bca5f9000-7f1bca601000  r-xp  00000000  00:00  zzzz  [vdso]")]
+    #[case::bad_address_range(b"7f1bca5f90007ffd6fbea000  r-xp  00000000  00:00  0  [vdso]")]
+    #[case::missing_fields(b"7f1bca5f9000-7f1bca601000  r-xp  00000000")]
+    #[case::bad_address_delimiter(b"7f1bca5f9000-7f1bca601000-deadbeef  rw-p  00000000  00:00  0")]
+    fn test_parse_proc_map_entry_err(#[case] line: &'static [u8]) {
         assert_matches!(
             ProcMapEntry::parse(line),
             Err(ProcMapError::ParseLine { line: _ })

--- a/aya/src/sys/bpf.rs
+++ b/aya/src/sys/bpf.rs
@@ -1440,7 +1440,7 @@ mod tests {
         generated::bpf_map_type::BPF_MAP_TYPE_BLOOM_FILTER, maps::PinningType, obj::parse_map_info,
     };
     use libc::EINVAL;
-    use test_case::test_case;
+    use rstest::rstest;
 
     use super::*;
     use crate::sys::override_syscall;
@@ -1571,21 +1571,22 @@ bpf_map_type::BPF_MAP_TYPE_DEVMAP_HASH`"]
         bpf_create_map(&name, &map, Some(btf_fd), None).unwrap();
     }
 
-    #[test_case(bpf_map_type::BPF_MAP_TYPE_PERF_EVENT_ARRAY ; "perf_event_array")]
-    #[test_case(bpf_map_type::BPF_MAP_TYPE_CGROUP_ARRAY ; "cgroup_array")]
-    #[test_case(bpf_map_type::BPF_MAP_TYPE_STACK_TRACE ; "stack_trace")]
-    #[test_case(bpf_map_type::BPF_MAP_TYPE_ARRAY_OF_MAPS ; "array_of_maps")]
-    #[test_case(bpf_map_type::BPF_MAP_TYPE_HASH_OF_MAPS ; "hash_of_maps")]
-    #[test_case(bpf_map_type::BPF_MAP_TYPE_DEVMAP ; "devmap")]
-    #[test_case(bpf_map_type::BPF_MAP_TYPE_DEVMAP_HASH ; "devmap_hash")]
-    #[test_case(bpf_map_type::BPF_MAP_TYPE_CPUMAP ; "cpumap")]
-    #[test_case(bpf_map_type::BPF_MAP_TYPE_XSKMAP ; "xskmap")]
-    #[test_case(bpf_map_type::BPF_MAP_TYPE_SOCKMAP ; "sockmap")]
-    #[test_case(bpf_map_type::BPF_MAP_TYPE_SOCKHASH ; "sockhash")]
-    #[test_case(bpf_map_type::BPF_MAP_TYPE_QUEUE ; "queue")]
-    #[test_case(bpf_map_type::BPF_MAP_TYPE_STACK ; "stack")]
-    #[test_case(bpf_map_type::BPF_MAP_TYPE_RINGBUF ; "ringbuf")]
-    fn test_btf_blocklist_strips_type_ids(map_type: bpf_map_type) {
+    #[rstest]
+    #[case::perf_event_array(bpf_map_type::BPF_MAP_TYPE_PERF_EVENT_ARRAY)]
+    #[case::cgroup_array(bpf_map_type::BPF_MAP_TYPE_CGROUP_ARRAY)]
+    #[case::stack_trace(bpf_map_type::BPF_MAP_TYPE_STACK_TRACE)]
+    #[case::array_of_maps(bpf_map_type::BPF_MAP_TYPE_ARRAY_OF_MAPS)]
+    #[case::hash_of_maps(bpf_map_type::BPF_MAP_TYPE_HASH_OF_MAPS)]
+    #[case::devmap(bpf_map_type::BPF_MAP_TYPE_DEVMAP)]
+    #[case::devmap_hash(bpf_map_type::BPF_MAP_TYPE_DEVMAP_HASH)]
+    #[case::cpumap(bpf_map_type::BPF_MAP_TYPE_CPUMAP)]
+    #[case::xskmap(bpf_map_type::BPF_MAP_TYPE_XSKMAP)]
+    #[case::sockmap(bpf_map_type::BPF_MAP_TYPE_SOCKMAP)]
+    #[case::sockhash(bpf_map_type::BPF_MAP_TYPE_SOCKHASH)]
+    #[case::queue(bpf_map_type::BPF_MAP_TYPE_QUEUE)]
+    #[case::stack(bpf_map_type::BPF_MAP_TYPE_STACK)]
+    #[case::ringbuf(bpf_map_type::BPF_MAP_TYPE_RINGBUF)]
+    fn test_btf_blocklist_strips_type_ids(#[case] map_type: bpf_map_type) {
         const BTF_FD: i32 = 42;
 
         override_syscall(|call| match call {

--- a/aya/src/sys/netlink.rs
+++ b/aya/src/sys/netlink.rs
@@ -849,7 +849,7 @@ unsafe fn request_attributes<T>(req: &mut T, msg_len: usize) -> &mut [u8] {
 
 #[cfg(test)]
 mod tests {
-    use test_case::test_case;
+    use rstest::rstest;
 
     use super::*;
 
@@ -1019,9 +1019,10 @@ mod tests {
     /// Verify that the `classid` value supplied to [`write_tc_attach_attrs`]
     /// round-trips through the serialized netlink attributes. The absent case
     /// mirrors iproute2's behavior when `classid` is not on the command line.
-    #[test_case(Some(TcHandle::new(1, 1)) ; "set")]
-    #[test_case(None ; "unset")]
-    fn tc_request_classid_serialization(classid: Option<TcHandle>) {
+    #[rstest]
+    #[case::set(Some(TcHandle::new(1, 1)))]
+    #[case::unset(None)]
+    fn tc_request_classid_serialization(#[case] classid: Option<TcHandle>) {
         let req = tc_request(b"foo\0", classid).unwrap();
         assert_eq!(classid_in_request(&req), classid);
     }

--- a/test/integration-test/Cargo.toml
+++ b/test/integration-test/Cargo.toml
@@ -32,8 +32,8 @@ object = { workspace = true, features = ["elf", "read_core", "std"] }
 procfs = { workspace = true, features = ["flate2"] }
 rand = { workspace = true, features = ["thread_rng"] }
 rbpf = { workspace = true }
+rstest = { workspace = true }
 scopeguard = { workspace = true }
-test-case = { workspace = true }
 test-log = { workspace = true, features = ["log"] }
 tokio = { workspace = true, features = [
     "io-util",

--- a/test/integration-test/src/tests/array.rs
+++ b/test/integration-test/src/tests/array.rs
@@ -4,7 +4,7 @@ use aya::{
     programs::{UProbe, uprobe::UProbeScope},
 };
 use integration_common::array::{ARRAY_LEN, GET_INDEX, GET_PTR_INDEX, GET_PTR_MUT_INDEX};
-use test_case::test_case;
+use rstest::rstest;
 
 #[unsafe(no_mangle)]
 #[inline(never)]
@@ -30,31 +30,24 @@ extern "C" fn get_ptr_mut(index: u32) {
     std::hint::black_box(index);
 }
 
-#[test_log::test(test_case(
+#[rstest]
+#[case::legacy(
     "RESULT_LEGACY",
     "ARRAY_LEGACY",
     "set_legacy",
     "get_legacy",
     "get_ptr_legacy",
     "get_ptr_mut_legacy"
-    ; "legacy"
-))]
-#[test_case(
-    "RESULT",
-    "ARRAY",
-    "set",
-    "get",
-    "get_ptr",
-    "get_ptr_mut"
-    ; "btf"
 )]
+#[case::btf("RESULT", "ARRAY", "set", "get", "get_ptr", "get_ptr_mut")]
+#[test_attr(test_log::test)]
 fn test_array(
-    result_map: &str,
-    array_map: &str,
-    set_prog: &str,
-    get_prog: &str,
-    get_ptr_prog: &str,
-    get_ptr_mut_prog: &str,
+    #[case] result_map: &str,
+    #[case] array_map: &str,
+    #[case] set_prog: &str,
+    #[case] get_prog: &str,
+    #[case] get_ptr_prog: &str,
+    #[case] get_ptr_mut_prog: &str,
 ) {
     let mut ebpf = EbpfLoader::new().load(crate::ARRAY).unwrap();
 

--- a/test/integration-test/src/tests/bloom_filter.rs
+++ b/test/integration-test/src/tests/bloom_filter.rs
@@ -7,7 +7,7 @@ use aya::{
 use integration_common::bloom_filter::{
     CONTAINS_ABSENT_INDEX, CONTAINS_PRESENT_INDEX, INSERT_INDEX,
 };
-use test_case::test_case;
+use rstest::rstest;
 
 #[unsafe(no_mangle)]
 #[inline(never)]
@@ -23,19 +23,26 @@ extern "C" fn trigger_bloom_contains(result_index: u32, value: u32) {
     core::hint::black_box(value);
 }
 
-#[test_log::test(test_case(
+#[rstest]
+#[case::legacy(
     "RESULT_LEGACY",
     "FILTER_LEGACY",
     "bloom_filter_insert_legacy",
-    "bloom_filter_contains_legacy" ; "legacy"
-))]
-#[test_case(
+    "bloom_filter_contains_legacy"
+)]
+#[case::btf(
     "RESULT",
     "FILTER",
     "btf_bloom_filter_insert",
-    "btf_bloom_filter_contains" ; "btf"
+    "btf_bloom_filter_contains"
 )]
-fn bloom_filter_basic(result_map: &str, filter_map: &str, insert_prog: &str, contains_prog: &str) {
+#[test_attr(test_log::test)]
+fn bloom_filter_basic(
+    #[case] result_map: &str,
+    #[case] filter_map: &str,
+    #[case] insert_prog: &str,
+    #[case] contains_prog: &str,
+) {
     if !is_map_supported(MapType::BloomFilter).unwrap() {
         eprintln!("skipping test - bloom filter map not supported");
         return;

--- a/test/integration-test/src/tests/btf_map_of_maps.rs
+++ b/test/integration-test/src/tests/btf_map_of_maps.rs
@@ -4,7 +4,7 @@ use aya::{
     programs::{UProbe, uprobe::UProbeScope},
 };
 use integration_common::btf_map_of_maps::INNER_MAX_ENTRIES;
-use test_case::test_case;
+use rstest::rstest;
 
 #[derive(Clone, Copy, Debug)]
 enum MapKind {
@@ -94,9 +94,16 @@ extern "C" fn trigger_btf_hash_of_maps_get_value() {
     std::hint::black_box(());
 }
 
-#[test_log::test(test_case(MapKind::Array, "btf_array_of_maps", 0, 42 ; "array_of_maps"))]
-#[test_case(MapKind::Hash, "btf_hash_of_maps", 1, 55 ; "hash_of_maps")]
-fn btf_map_of_maps(kind: MapKind, name: &str, result_index: u32, expected: u32) {
+#[rstest]
+#[case::array_of_maps(MapKind::Array, "btf_array_of_maps", 0, 42)]
+#[case::hash_of_maps(MapKind::Hash, "btf_hash_of_maps", 1, 55)]
+#[test_attr(test_log::test)]
+fn btf_map_of_maps(
+    #[case] kind: MapKind,
+    #[case] name: &str,
+    #[case] result_index: u32,
+    #[case] expected: u32,
+) {
     let mut ebpf = Ebpf::load(crate::BTF_MAP_OF_MAPS).unwrap();
 
     let mut inner: Array<MapData, u32> = Array::create(INNER_MAX_ENTRIES, 0).unwrap();
@@ -109,14 +116,16 @@ fn btf_map_of_maps(kind: MapKind, name: &str, result_index: u32, expected: u32) 
     assert_result(&ebpf, result_index, expected);
 }
 
-#[test_log::test(test_case(MapKind::Array, "btf_array_of_maps_get_value", 2, 77, 99 ; "array_of_maps"))]
-#[test_case(MapKind::Hash, "btf_hash_of_maps_get_value", 3, 55, 88 ; "hash_of_maps")]
+#[rstest]
+#[case::array_of_maps(MapKind::Array, "btf_array_of_maps_get_value", 2, 77, 99)]
+#[case::hash_of_maps(MapKind::Hash, "btf_hash_of_maps_get_value", 3, 55, 88)]
+#[test_attr(test_log::test)]
 fn btf_map_of_maps_get_value(
-    kind: MapKind,
-    name: &str,
-    result_index: u32,
-    expected_get: u32,
-    expected_mut_write: u32,
+    #[case] kind: MapKind,
+    #[case] name: &str,
+    #[case] result_index: u32,
+    #[case] expected_get: u32,
+    #[case] expected_mut_write: u32,
 ) {
     let mut ebpf = Ebpf::load(crate::BTF_MAP_OF_MAPS).unwrap();
 

--- a/test/integration-test/src/tests/btf_relocations.rs
+++ b/test/integration-test/src/tests/btf_relocations.rs
@@ -4,73 +4,75 @@ use aya::{
     programs::{UProbe, uprobe::UProbeScope},
 };
 use aya_obj::btf::Btf;
-use test_case::test_case;
+use rstest::rstest;
 
 #[derive(Debug)]
 enum Requirements {}
 
-#[test_log::test(test_case(crate::ENUM_SIGNED_32_RELOC_BPF, None, None,-0x7AAAAAAAi32 as u64))]
-#[test_case(crate::ENUM_SIGNED_32_RELOC_BPF, Some(crate::ENUM_SIGNED_32_RELOC_BTF),  None, -0x7BBBBBBBi32 as u64)]
-#[test_case(crate::ENUM_SIGNED_32_CHECKED_VARIANTS_RELOC_BPF, None, None,-0x7AAAAAAAi32 as u64)]
-#[test_case(crate::ENUM_SIGNED_32_CHECKED_VARIANTS_RELOC_BPF, Some(crate::ENUM_SIGNED_32_CHECKED_VARIANTS_RELOC_BTF),  None, -0x7BBBBBBBi32 as u64)]
-#[test_case(crate::ENUM_SIGNED_64_RELOC_BPF, None, None,-0xAAAAAAABBBBBBBBi64 as u64)]
-#[test_case(crate::ENUM_SIGNED_64_RELOC_BPF, Some(crate::ENUM_SIGNED_64_RELOC_BTF),  None, -0xCCCCCCCDDDDDDDDi64 as u64)]
-#[test_case(crate::ENUM_SIGNED_64_CHECKED_VARIANTS_RELOC_BPF, None, None,-0xAAAAAAABBBBBBBi64 as u64)]
-#[test_case(crate::ENUM_SIGNED_64_CHECKED_VARIANTS_RELOC_BPF, Some(crate::ENUM_SIGNED_64_CHECKED_VARIANTS_RELOC_BTF),  None, -0xCCCCCCCDDDDDDDi64 as u64)]
-#[test_case(crate::ENUM_UNSIGNED_32_RELOC_BPF, None, None, 0xAAAAAAAA)]
-#[test_case(
+#[rstest]
+#[case(crate::ENUM_SIGNED_32_RELOC_BPF, None, None,-0x7AAAAAAAi32 as u64)]
+#[case(crate::ENUM_SIGNED_32_RELOC_BPF, Some(crate::ENUM_SIGNED_32_RELOC_BTF),  None, -0x7BBBBBBBi32 as u64)]
+#[case(crate::ENUM_SIGNED_32_CHECKED_VARIANTS_RELOC_BPF, None, None,-0x7AAAAAAAi32 as u64)]
+#[case(crate::ENUM_SIGNED_32_CHECKED_VARIANTS_RELOC_BPF, Some(crate::ENUM_SIGNED_32_CHECKED_VARIANTS_RELOC_BTF),  None, -0x7BBBBBBBi32 as u64)]
+#[case(crate::ENUM_SIGNED_64_RELOC_BPF, None, None,-0xAAAAAAABBBBBBBBi64 as u64)]
+#[case(crate::ENUM_SIGNED_64_RELOC_BPF, Some(crate::ENUM_SIGNED_64_RELOC_BTF),  None, -0xCCCCCCCDDDDDDDDi64 as u64)]
+#[case(crate::ENUM_SIGNED_64_CHECKED_VARIANTS_RELOC_BPF, None, None,-0xAAAAAAABBBBBBBi64 as u64)]
+#[case(crate::ENUM_SIGNED_64_CHECKED_VARIANTS_RELOC_BPF, Some(crate::ENUM_SIGNED_64_CHECKED_VARIANTS_RELOC_BTF),  None, -0xCCCCCCCDDDDDDDi64 as u64)]
+#[case(crate::ENUM_UNSIGNED_32_RELOC_BPF, None, None, 0xAAAAAAAA)]
+#[case(
     crate::ENUM_UNSIGNED_32_RELOC_BPF,
     Some(crate::ENUM_UNSIGNED_32_RELOC_BTF),
     None,
     0xBBBBBBBB
 )]
-#[test_case(
+#[case(
     crate::ENUM_UNSIGNED_32_CHECKED_VARIANTS_RELOC_BPF,
     None,
     None,
     0xAAAAAAAA
 )]
-#[test_case(
+#[case(
     crate::ENUM_UNSIGNED_32_CHECKED_VARIANTS_RELOC_BPF,
     Some(crate::ENUM_UNSIGNED_32_CHECKED_VARIANTS_RELOC_BTF),
     None,
     0xBBBBBBBB
 )]
-#[test_case(crate::ENUM_UNSIGNED_64_RELOC_BPF, None, None, 0xAAAAAAAABBBBBBBB)]
-#[test_case(
+#[case(crate::ENUM_UNSIGNED_64_RELOC_BPF, None, None, 0xAAAAAAAABBBBBBBB)]
+#[case(
     crate::ENUM_UNSIGNED_64_RELOC_BPF,
     Some(crate::ENUM_UNSIGNED_64_RELOC_BTF),
     None,
     0xCCCCCCCCDDDDDDDD
 )]
-#[test_case(
+#[case(
     crate::ENUM_UNSIGNED_64_CHECKED_VARIANTS_RELOC_BPF,
     None,
     None,
     0xAAAAAAAABBBBBBBB
 )]
-#[test_case(
+#[case(
     crate::ENUM_UNSIGNED_64_CHECKED_VARIANTS_RELOC_BPF,
     Some(crate::ENUM_UNSIGNED_64_CHECKED_VARIANTS_RELOC_BTF),
     None,
     0xCCCCCCCCDDDDDDDD
 )]
-#[test_case(crate::FIELD_RELOC_BPF, None, None, 2)]
-#[test_case(crate::FIELD_RELOC_BPF, Some(crate::FIELD_RELOC_BTF), None, 1)]
-#[test_case(crate::POINTER_RELOC_BPF, None, None, 42)]
-#[test_case(crate::POINTER_RELOC_BPF, Some(crate::POINTER_RELOC_BTF), None, 21)]
-#[test_case(crate::STRUCT_FLAVORS_RELOC_BPF, None, None, 1)]
-#[test_case(
+#[case(crate::FIELD_RELOC_BPF, None, None, 2)]
+#[case(crate::FIELD_RELOC_BPF, Some(crate::FIELD_RELOC_BTF), None, 1)]
+#[case(crate::POINTER_RELOC_BPF, None, None, 42)]
+#[case(crate::POINTER_RELOC_BPF, Some(crate::POINTER_RELOC_BTF), None, 21)]
+#[case(crate::STRUCT_FLAVORS_RELOC_BPF, None, None, 1)]
+#[case(
     crate::STRUCT_FLAVORS_RELOC_BPF,
     Some(crate::STRUCT_FLAVORS_RELOC_BTF),
     None,
     2
 )]
+#[test_attr(test_log::test)]
 fn relocation_tests(
-    bpf: &[u8],
-    btf: Option<&[u8]>,
-    requirements: Option<Requirements>,
-    expected: u64,
+    #[case] bpf: &[u8],
+    #[case] btf: Option<&[u8]>,
+    #[case] requirements: Option<Requirements>,
+    #[case] expected: u64,
 ) {
     let features = aya::features();
 

--- a/test/integration-test/src/tests/cgroup_array.rs
+++ b/test/integration-test/src/tests/cgroup_array.rs
@@ -8,7 +8,7 @@ use aya::{
     util::KernelVersion,
 };
 use integration_common::cgroup_array::{NOT_UNDER_INDEX, TestResult, UNDER_INDEX};
-use test_case::test_case;
+use rstest::rstest;
 
 use crate::utils::{Cgroup, is_cgroup2};
 
@@ -18,19 +18,15 @@ extern "C" fn trigger_current_task_under_cgroup() {
     std::hint::black_box(());
 }
 
-#[test_log::test(test_case(
-    "CGROUPS_LEGACY",
-    "RESULT_LEGACY",
-    "current_task_under_cgroup_legacy"
-    ; "legacy"
-))]
-#[test_case(
-    "CGROUPS",
-    "RESULT",
-    "current_task_under_cgroup_btf"
-    ; "btf"
-)]
-fn current_task_under_cgroup(cgroups_map: &str, result_map: &str, prog: &str) {
+#[rstest]
+#[case::legacy("CGROUPS_LEGACY", "RESULT_LEGACY", "current_task_under_cgroup_legacy")]
+#[case::btf("CGROUPS", "RESULT", "current_task_under_cgroup_btf")]
+#[test_attr(test_log::test)]
+fn current_task_under_cgroup(
+    #[case] cgroups_map: &str,
+    #[case] result_map: &str,
+    #[case] prog: &str,
+) {
     if !is_map_supported(MapType::CgroupArray).unwrap() {
         eprintln!("skipping test - cgroup array map not supported");
         return;

--- a/test/integration-test/src/tests/fexit.rs
+++ b/test/integration-test/src/tests/fexit.rs
@@ -11,7 +11,7 @@ use integration_common::fexit::{
     TEST4_INDEX, TEST5_INDEX, TEST6_INDEX, TEST7_INDEX, TEST8_INDEX, TEST9_INDEX, TEST10_INDEX,
     TestResult,
 };
-use test_case::test_case;
+use rstest::rstest;
 
 fn fexit_error_name(error: i32) -> &'static str {
     match error {
@@ -24,20 +24,21 @@ fn fexit_error_name(error: i32) -> &'static str {
 
 // Mirrors libbpf's tracing test-run trigger:
 // https://github.com/torvalds/linux/blob/v7.1-rc4/tools/testing/selftests/bpf/prog_tests/fentry_fexit.c#L24-L42
-#[test_case("test1", "bpf_fentry_test1", TEST1_INDEX ; "test1")]
-#[test_case("test2", "bpf_fentry_test2", TEST2_INDEX ; "test2")]
-#[test_case("test3", "bpf_fentry_test3", TEST3_INDEX ; "test3")]
-#[test_case("test4", "bpf_fentry_test4", TEST4_INDEX ; "test4")]
-#[test_case("test5", "bpf_fentry_test5", TEST5_INDEX ; "test5")]
-#[test_case("test6", "bpf_fentry_test6", TEST6_INDEX ; "test6")]
-#[test_case("test7", "bpf_fentry_test7", TEST7_INDEX ; "test7")]
-#[test_case("test8", "bpf_fentry_test8", TEST8_INDEX ; "test8")]
-#[test_case("test9", "bpf_fentry_test9", TEST9_INDEX ; "test9")]
-#[test_case("test10", "bpf_fentry_test10", TEST10_INDEX ; "test10")]
+#[rstest]
+#[case::test1("test1", "bpf_fentry_test1", TEST1_INDEX)]
+#[case::test2("test2", "bpf_fentry_test2", TEST2_INDEX)]
+#[case::test3("test3", "bpf_fentry_test3", TEST3_INDEX)]
+#[case::test4("test4", "bpf_fentry_test4", TEST4_INDEX)]
+#[case::test5("test5", "bpf_fentry_test5", TEST5_INDEX)]
+#[case::test6("test6", "bpf_fentry_test6", TEST6_INDEX)]
+#[case::test7("test7", "bpf_fentry_test7", TEST7_INDEX)]
+#[case::test8("test8", "bpf_fentry_test8", TEST8_INDEX)]
+#[case::test9("test9", "bpf_fentry_test9", TEST9_INDEX)]
+#[case::test10("test10", "bpf_fentry_test10", TEST10_INDEX)]
 fn fexit_reads_args_and_return_values_from_prog_test_run_targets(
-    program: &str,
-    target: &str,
-    index: u32,
+    #[case] program: &str,
+    #[case] target: &str,
+    #[case] index: u32,
 ) {
     // The fexit program itself requires Linux 5.5, but FExitContext::ret uses
     // bpf_get_func_ret, which was added in Linux 5.17:

--- a/test/integration-test/src/tests/hash_map.rs
+++ b/test/integration-test/src/tests/hash_map.rs
@@ -5,7 +5,7 @@ use aya::{
     sys::is_map_supported,
     util::nr_cpus,
 };
-use test_case::test_case;
+use rstest::rstest;
 
 const EXPECTED: u64 = 42;
 
@@ -15,15 +15,47 @@ extern "C" fn trigger_hash_lookup() {
     std::hint::black_box(());
 }
 
-#[test_log::test(test_case(MapType::Hash, "test_hash_btf", "HASH_BTF", "RESULT" ; "hash_btf"))]
-#[test_case(MapType::LruHash, "test_lru_hash_btf", "LRU_HASH_BTF", "RESULT" ; "lru_hash_btf")]
-#[test_case(MapType::PerCpuHash, "test_per_cpu_hash_btf", "PER_CPU_HASH_BTF", "RESULT" ; "per_cpu_hash_btf")]
-#[test_case(MapType::LruPerCpuHash, "test_lru_per_cpu_hash_btf", "LRU_PER_CPU_HASH_BTF", "RESULT" ; "lru_per_cpu_hash_btf")]
-#[test_case(MapType::Hash, "test_hash_legacy", "HASH_LEGACY", "RESULT_LEGACY" ; "hash_legacy")]
-#[test_case(MapType::LruHash, "test_lru_hash_legacy", "LRU_HASH_LEGACY", "RESULT_LEGACY" ; "lru_hash_legacy")]
-#[test_case(MapType::PerCpuHash, "test_per_cpu_hash_legacy", "PER_CPU_HASH_LEGACY", "RESULT_LEGACY" ; "per_cpu_hash_legacy")]
-#[test_case(MapType::LruPerCpuHash, "test_lru_per_cpu_hash_legacy", "LRU_PER_CPU_HASH_LEGACY", "RESULT_LEGACY" ; "lru_per_cpu_hash_legacy")]
-fn hash_basic(map_type: MapType, prog_name: &str, map_name: &str, result_map: &str) {
+#[rstest]
+#[case::hash_btf(MapType::Hash, "test_hash_btf", "HASH_BTF", "RESULT")]
+#[case::lru_hash_btf(MapType::LruHash, "test_lru_hash_btf", "LRU_HASH_BTF", "RESULT")]
+#[case::per_cpu_hash_btf(
+    MapType::PerCpuHash,
+    "test_per_cpu_hash_btf",
+    "PER_CPU_HASH_BTF",
+    "RESULT"
+)]
+#[case::lru_per_cpu_hash_btf(
+    MapType::LruPerCpuHash,
+    "test_lru_per_cpu_hash_btf",
+    "LRU_PER_CPU_HASH_BTF",
+    "RESULT"
+)]
+#[case::hash_legacy(MapType::Hash, "test_hash_legacy", "HASH_LEGACY", "RESULT_LEGACY")]
+#[case::lru_hash_legacy(
+    MapType::LruHash,
+    "test_lru_hash_legacy",
+    "LRU_HASH_LEGACY",
+    "RESULT_LEGACY"
+)]
+#[case::per_cpu_hash_legacy(
+    MapType::PerCpuHash,
+    "test_per_cpu_hash_legacy",
+    "PER_CPU_HASH_LEGACY",
+    "RESULT_LEGACY"
+)]
+#[case::lru_per_cpu_hash_legacy(
+    MapType::LruPerCpuHash,
+    "test_lru_per_cpu_hash_legacy",
+    "LRU_PER_CPU_HASH_LEGACY",
+    "RESULT_LEGACY"
+)]
+#[test_attr(test_log::test)]
+fn hash_basic(
+    #[case] map_type: MapType,
+    #[case] prog_name: &str,
+    #[case] map_name: &str,
+    #[case] result_map: &str,
+) {
     if matches!(map_type, MapType::LruHash | MapType::LruPerCpuHash)
         && !is_map_supported(map_type).unwrap()
     {

--- a/test/integration-test/src/tests/load.rs
+++ b/test/integration-test/src/tests/load.rs
@@ -22,7 +22,7 @@ use aya::{
     util::KernelVersion,
 };
 use aya_obj::programs::XdpAttachType;
-use test_case::test_case;
+use rstest::rstest;
 
 const MAX_RETRIES: usize = 100;
 pub(crate) const RETRY_DURATION: Duration = Duration::from_millis(10);
@@ -367,13 +367,13 @@ fn basic_tracepoint() {
     );
 }
 
-#[test_log::test(test_case(UProbeScope::AllProcesses; "all_processes"))]
-#[test_case(UProbeScope::CallingProcess; "calling_process")]
-#[test_case(
-    UProbeScope::OneProcess(NonZeroU32::new(std::process::id()).unwrap());
-    "one_process"
-)]
-fn basic_uprobe_scopes(scope: UProbeScope) {
+#[rstest]
+#[case::all_processes(UProbeScope::AllProcesses)]
+#[case::calling_process(UProbeScope::CallingProcess)]
+#[case::one_process(
+    UProbeScope::OneProcess(NonZeroU32::new(std::process::id()).unwrap()))]
+#[test_attr(test_log::test)]
+fn basic_uprobe_scopes(#[case] scope: UProbeScope) {
     type P = UProbe;
 
     let program_name = "test_uprobe";

--- a/test/integration-test/src/tests/lpm_trie.rs
+++ b/test/integration-test/src/tests/lpm_trie.rs
@@ -4,7 +4,7 @@ use aya::{
     programs::{UProbe, uprobe::UProbeScope},
 };
 use integration_common::lpm_trie::{LPM_MATCH_SLOT, NO_MATCH_SLOT, REMOVE_SLOT, TestResult};
-use test_case::test_case;
+use rstest::rstest;
 
 #[unsafe(no_mangle)]
 #[inline(never)]
@@ -12,9 +12,11 @@ extern "C" fn trigger_lpm_trie() {
     core::hint::black_box(());
 }
 
-#[test_log::test(test_case("test_btf_lpm_trie", "ROUTES", "RESULTS" ; "btf"))]
-#[test_case("test_lpm_trie_legacy", "ROUTES_LEGACY", "RESULTS_LEGACY" ; "legacy")]
-fn lpm_trie_basic(prog_name: &str, routes_map: &str, results_map: &str) {
+#[rstest]
+#[case::btf("test_btf_lpm_trie", "ROUTES", "RESULTS")]
+#[case::legacy("test_lpm_trie_legacy", "ROUTES_LEGACY", "RESULTS_LEGACY")]
+#[test_attr(test_log::test)]
+fn lpm_trie_basic(#[case] prog_name: &str, #[case] routes_map: &str, #[case] results_map: &str) {
     let mut bpf = Ebpf::load(crate::LPM_TRIE).unwrap();
 
     {

--- a/test/integration-test/src/tests/per_cpu_array.rs
+++ b/test/integration-test/src/tests/per_cpu_array.rs
@@ -6,7 +6,7 @@ use aya::{
     util::nr_cpus,
 };
 use integration_common::array::{GET_INDEX, GET_PTR_INDEX, GET_PTR_MUT_INDEX};
-use test_case::test_case;
+use rstest::rstest;
 
 #[unsafe(no_mangle)]
 #[inline(never)]
@@ -32,31 +32,24 @@ extern "C" fn trigger_set(index: u32, value: u32) {
     std::hint::black_box((index, value));
 }
 
-#[test_log::test(test_case(
+#[rstest]
+#[case::legacy(
     "RESULT_LEGACY",
     "ARRAY_LEGACY",
     "get_legacy",
     "get_ptr_legacy",
     "get_ptr_mut_legacy",
     "set_legacy"
-    ; "legacy"
-))]
-#[test_case(
-    "RESULT",
-    "ARRAY",
-    "get",
-    "get_ptr",
-    "get_ptr_mut",
-    "set"
-    ; "btf"
 )]
+#[case::btf("RESULT", "ARRAY", "get", "get_ptr", "get_ptr_mut", "set")]
+#[test_attr(test_log::test)]
 fn per_cpu_array_basic(
-    result_map: &str,
-    array_map: &str,
-    get_prog: &str,
-    get_ptr_prog: &str,
-    get_ptr_mut_prog: &str,
-    set_prog: &str,
+    #[case] result_map: &str,
+    #[case] array_map: &str,
+    #[case] get_prog: &str,
+    #[case] get_ptr_prog: &str,
+    #[case] get_ptr_mut_prog: &str,
+    #[case] set_prog: &str,
 ) {
     if !is_map_supported(MapType::PerCpuArray).unwrap() {
         eprintln!("skipping test - per-cpu array map not supported");

--- a/test/integration-test/src/tests/perf_event_array.rs
+++ b/test/integration-test/src/tests/perf_event_array.rs
@@ -4,7 +4,7 @@ use aya::{
     programs::{UProbe, uprobe::UProbeScope},
     util::online_cpus,
 };
-use test_case::test_case;
+use rstest::rstest;
 
 #[unsafe(no_mangle)]
 #[inline(never)]
@@ -12,11 +12,13 @@ extern "C" fn trigger_emit_event() {
     std::hint::black_box(());
 }
 
-#[test_log::test(test_case(crate::PERF_EVENT_ARRAY, "EVENTS_LEGACY", "emit_event_legacy" ; "legacy"))]
-#[test_case(crate::PERF_EVENT_ARRAY, "EVENTS", "emit_event" ; "btf")]
-#[test_case(crate::PERF_EVENT_BYTE_ARRAY, "EVENTS_LEGACY", "emit_event_legacy" ; "byte_legacy")]
-#[test_case(crate::PERF_EVENT_BYTE_ARRAY, "EVENTS", "emit_event" ; "byte_btf")]
-fn emit_event(bpf_obj: &[u8], events_map: &str, prog: &str) {
+#[rstest]
+#[case::legacy(crate::PERF_EVENT_ARRAY, "EVENTS_LEGACY", "emit_event_legacy")]
+#[case::btf(crate::PERF_EVENT_ARRAY, "EVENTS", "emit_event")]
+#[case::byte_legacy(crate::PERF_EVENT_BYTE_ARRAY, "EVENTS_LEGACY", "emit_event_legacy")]
+#[case::byte_btf(crate::PERF_EVENT_BYTE_ARRAY, "EVENTS", "emit_event")]
+#[test_attr(test_log::test)]
+fn emit_event(#[case] bpf_obj: &[u8], #[case] events_map: &str, #[case] prog: &str) {
     let mut bpf = EbpfLoader::new()
         .load(bpf_obj)
         .expect("load perf event array program");

--- a/test/integration-test/src/tests/printk.rs
+++ b/test/integration-test/src/tests/printk.rs
@@ -24,13 +24,14 @@ use integration_common::printk::{
     MARKER, TEST_CHAR, TEST_I8, TEST_I16, TEST_I32, TEST_I64, TEST_ISIZE, TEST_U8, TEST_U16,
     TEST_U32, TEST_U64, TEST_USIZE,
 };
-use test_case::test_case;
+use rstest::rstest;
 use tokio::{
     io::{Interest, unix::AsyncFd},
     time::{Duration, timeout},
 };
 
-#[test_case(
+#[rstest]
+#[case::few(
     None,
     "test_bpf_printk",
     vec![
@@ -47,22 +48,18 @@ use tokio::{
         format!("{MARKER}_I64:{TEST_I64:x}"),
         format!("{MARKER}_ISIZE:{TEST_ISIZE}"),
         format!("{MARKER}_MULTI_printk:{TEST_U8:x},{TEST_I32:x}"),
-    ];
-    "few"
-)]
-#[test_case(
+    ])]
+#[case::many(
     Some(("bpf_trace_vprintk", KernelVersion::new(5, 15, 0))),
     "test_bpf_printk_for_many_args",
     vec![
         format!("{MARKER}_MULTI_vprintk:{TEST_U8},{TEST_U16},{TEST_I8},{TEST_I16}")
-    ];
-    "many"
-)]
-#[tokio::test]
+    ])]
+#[test_attr(tokio::test)]
 async fn bpf_printk(
-    minimum_kernel_version: Option<(&str, KernelVersion)>,
-    bpf_program_name: &str,
-    expected: Vec<String>,
+    #[case] minimum_kernel_version: Option<(&str, KernelVersion)>,
+    #[case] bpf_program_name: &str,
+    #[case] expected: Vec<String>,
 ) {
     if let Some((helper_name, minimum_kernel_version)) = minimum_kernel_version {
         let kernel_version = KernelVersion::current().unwrap();

--- a/test/integration-test/src/tests/prog_array.rs
+++ b/test/integration-test/src/tests/prog_array.rs
@@ -7,7 +7,7 @@ use aya::{
 use integration_common::prog_array::{
     FAILURE_SENTINEL, RESULT_INDEX, SUCCESS_INDEX, SUCCESS_SENTINEL,
 };
-use test_case::test_case;
+use rstest::rstest;
 
 #[unsafe(no_mangle)]
 #[inline(never)]
@@ -21,17 +21,11 @@ extern "C" fn trigger_tail_call_success() {
     std::hint::black_box(());
 }
 
-#[test_log::test(test_case(
-    "RESULT_LEGACY",
-    "tail_call_empty_legacy"
-    ; "legacy"
-))]
-#[test_case(
-    "RESULT",
-    "tail_call_empty"
-    ; "btf"
-)]
-fn tail_call_empty(result_map: &str, entry_prog: &str) {
+#[rstest]
+#[case::legacy("RESULT_LEGACY", "tail_call_empty_legacy")]
+#[case::btf("RESULT", "tail_call_empty")]
+#[test_attr(test_log::test)]
+fn tail_call_empty(#[case] result_map: &str, #[case] entry_prog: &str) {
     if !is_map_supported(MapType::ProgramArray).unwrap() {
         eprintln!("skipping test - program array map not supported");
         return;
@@ -66,21 +60,21 @@ fn tail_call_empty(result_map: &str, entry_prog: &str) {
     );
 }
 
-#[test_log::test(test_case(
+#[rstest]
+#[case::legacy(
     "RESULT_LEGACY",
     "ARRAY_LEGACY",
     "tail_call_empty_legacy",
     "tail_call_target_legacy"
-    ; "legacy"
-))]
-#[test_case(
-    "RESULT",
-    "ARRAY",
-    "tail_call_empty",
-    "tail_call_target"
-    ; "btf"
 )]
-fn tail_call_success(result_map: &str, array_map: &str, entry_prog: &str, target_prog: &str) {
+#[case::btf("RESULT", "ARRAY", "tail_call_empty", "tail_call_target")]
+#[test_attr(test_log::test)]
+fn tail_call_success(
+    #[case] result_map: &str,
+    #[case] array_map: &str,
+    #[case] entry_prog: &str,
+    #[case] target_prog: &str,
+) {
     if !is_map_supported(MapType::ProgramArray).unwrap() {
         eprintln!("skipping test - program array map not supported");
         return;

--- a/test/integration-test/src/tests/ring_buf.rs
+++ b/test/integration-test/src/tests/ring_buf.rs
@@ -19,6 +19,7 @@ use aya::{
 use aya_obj::generated::BPF_RINGBUF_HDR_SZ;
 use integration_common::ring_buf::Registers;
 use rand::RngExt as _;
+use rstest::rstest;
 use scopeguard::defer;
 use tokio::io::{Interest, unix::AsyncFd};
 
@@ -116,12 +117,13 @@ impl WithData {
     }
 }
 
-#[test_case::test_case(0; "write zero items")]
-#[test_case::test_case(1; "write one item")]
-#[test_case::test_case(RING_BUF_MAX_ENTRIES / 2; "write half the capacity items")]
-#[test_case::test_case(RING_BUF_MAX_ENTRIES - 1; "write one less than capacity items")]
-#[test_case::test_case(RING_BUF_MAX_ENTRIES * 8; "write more items than capacity")]
-fn ring_buf(n: usize) {
+#[rstest]
+#[case::write_zero_items(0)]
+#[case::write_one_item(1)]
+#[case::write_half_the_capacity_items(RING_BUF_MAX_ENTRIES / 2)]
+#[case::write_one_less_than_capacity_items(RING_BUF_MAX_ENTRIES - 1)]
+#[case::write_more_items_than_capacity(RING_BUF_MAX_ENTRIES * 8)]
+fn ring_buf(#[case] n: usize) {
     for &variant in RING_BUF_VARIANTS {
         let WithData(
             RingBufTest {

--- a/test/integration-test/src/tests/sk_lookup.rs
+++ b/test/integration-test/src/tests/sk_lookup.rs
@@ -12,7 +12,7 @@ use aya::{
     sys::{is_map_supported, is_program_supported},
 };
 use libc::ENOENT;
-use test_case::test_case;
+use rstest::rstest;
 
 use crate::utils::NetNsGuard;
 
@@ -56,11 +56,18 @@ impl MapKind {
     }
 }
 
-#[test_log::test(test_case(crate::SOCK_HASH, MapKind::Hash, "SOCKETS_LEGACY", "sk_lookup_legacy" ; "sock_hash legacy"))]
-#[test_case(crate::SOCK_HASH, MapKind::Hash, "SOCKETS_BTF", "sk_lookup_btf" ; "sock_hash btf")]
-#[test_case(crate::SOCK_MAP, MapKind::Map, "SOCKETS_LEGACY", "sk_lookup_legacy" ; "sock_map legacy")]
-#[test_case(crate::SOCK_MAP, MapKind::Map, "SOCKETS_BTF", "sk_lookup_btf" ; "sock_map btf")]
-fn redirect_sk_lookup(bpf_bytes: &[u8], kind: MapKind, map_name: &str, prog_name: &str) {
+#[rstest]
+#[case::sock_hash_legacy(crate::SOCK_HASH, MapKind::Hash, "SOCKETS_LEGACY", "sk_lookup_legacy")]
+#[case::sock_hash_btf(crate::SOCK_HASH, MapKind::Hash, "SOCKETS_BTF", "sk_lookup_btf")]
+#[case::sock_map_legacy(crate::SOCK_MAP, MapKind::Map, "SOCKETS_LEGACY", "sk_lookup_legacy")]
+#[case::sock_map_btf(crate::SOCK_MAP, MapKind::Map, "SOCKETS_BTF", "sk_lookup_btf")]
+#[test_attr(test_log::test)]
+fn redirect_sk_lookup(
+    #[case] bpf_bytes: &[u8],
+    #[case] kind: MapKind,
+    #[case] map_name: &str,
+    #[case] prog_name: &str,
+) {
     if !is_map_supported(kind.map_type()).unwrap() {
         eprintln!("skipping test - {:?} not supported", kind.map_type());
         return;
@@ -103,11 +110,17 @@ fn redirect_sk_lookup(bpf_bytes: &[u8], kind: MapKind, map_name: &str, prog_name
     drop(stream);
 }
 
-#[test_log::test(test_case(crate::SOCK_HASH, MapKind::Hash, "sk_lookup_legacy" ; "sock_hash legacy"))]
-#[test_case(crate::SOCK_HASH, MapKind::Hash, "sk_lookup_btf" ; "sock_hash btf")]
-#[test_case(crate::SOCK_MAP, MapKind::Map, "sk_lookup_legacy" ; "sock_map legacy")]
-#[test_case(crate::SOCK_MAP, MapKind::Map, "sk_lookup_btf" ; "sock_map btf")]
-fn redirect_sk_lookup_miss_propagates_enoent(bpf_bytes: &[u8], kind: MapKind, prog_name: &str) {
+#[rstest]
+#[case::sock_hash_legacy(crate::SOCK_HASH, MapKind::Hash, "sk_lookup_legacy")]
+#[case::sock_hash_btf(crate::SOCK_HASH, MapKind::Hash, "sk_lookup_btf")]
+#[case::sock_map_legacy(crate::SOCK_MAP, MapKind::Map, "sk_lookup_legacy")]
+#[case::sock_map_btf(crate::SOCK_MAP, MapKind::Map, "sk_lookup_btf")]
+#[test_attr(test_log::test)]
+fn redirect_sk_lookup_miss_propagates_enoent(
+    #[case] bpf_bytes: &[u8],
+    #[case] kind: MapKind,
+    #[case] prog_name: &str,
+) {
     if !is_map_supported(kind.map_type()).unwrap() {
         eprintln!("skipping test - {:?} not supported", kind.map_type());
         return;

--- a/test/integration-test/src/tests/sk_reuseport.rs
+++ b/test/integration-test/src/tests/sk_reuseport.rs
@@ -18,7 +18,7 @@ use integration_common::sk_reuseport::{
     SELECT_SOCKET_INDEX,
 };
 use libc::{EINVAL, ENOENT};
-use test_case::test_case;
+use rstest::rstest;
 use tokio::{
     io::{AsyncReadExt as _, AsyncWriteExt as _},
     net::{TcpListener as TokioTcpListener, TcpSocket, TcpStream as TokioTcpStream},
@@ -146,10 +146,14 @@ async fn assert_connection_works(mut client: TokioTcpStream, mut server: TokioTc
 
 // `NetNsGuard` switches the current thread into a dedicated network namespace,
 // so these async tests must stay on a single runtime thread.
-#[test_case("socket_map", "select_socket"; "legacy")]
-#[test_case("socket_map_btf", "select_socket_btf"; "btf")]
-#[test_log::test(tokio::test)]
-async fn sk_reuseport_selects_expected_listener(socket_map: &str, select_prog: &str) {
+#[rstest]
+#[case::legacy("socket_map", "select_socket")]
+#[case::btf("socket_map_btf", "select_socket_btf")]
+#[test_attr(test_log::test(tokio::test))]
+async fn sk_reuseport_selects_expected_listener(
+    #[case] socket_map: &str,
+    #[case] select_prog: &str,
+) {
     let _netns = NetNsGuard::new();
 
     let mut ebpf = Ebpf::load(crate::SK_REUSEPORT).unwrap();
@@ -203,10 +207,14 @@ async fn sk_reuseport_selects_expected_listener(socket_map: &str, select_prog: &
     );
 }
 
-#[test_case("socket_map", "select_socket_after_clear"; "legacy")]
-#[test_case("socket_map_btf", "select_socket_after_clear_btf"; "btf")]
-#[test_log::test(tokio::test)]
-async fn sk_reuseport_clear_index_changes_selection(socket_map: &str, clear_prog: &str) {
+#[rstest]
+#[case::legacy("socket_map", "select_socket_after_clear")]
+#[case::btf("socket_map_btf", "select_socket_after_clear_btf")]
+#[test_attr(test_log::test(tokio::test))]
+async fn sk_reuseport_clear_index_changes_selection(
+    #[case] socket_map: &str,
+    #[case] clear_prog: &str,
+) {
     let _netns = NetNsGuard::new();
 
     let mut ebpf = Ebpf::load(crate::SK_REUSEPORT).unwrap();
@@ -262,10 +270,11 @@ async fn sk_reuseport_clear_index_changes_selection(socket_map: &str, clear_prog
     assert_connection_works(second_client, second_server).await;
 }
 
-#[test_case("select_socket"; "legacy")]
-#[test_case("select_socket_btf"; "btf")]
-#[test_log::test(tokio::test)]
-async fn sk_reuseport_stays_attached_until_explicit_detach(select_prog: &str) {
+#[rstest]
+#[case::legacy("select_socket")]
+#[case::btf("select_socket_btf")]
+#[test_attr(test_log::test(tokio::test))]
+async fn sk_reuseport_stays_attached_until_explicit_detach(#[case] select_prog: &str) {
     let _netns = NetNsGuard::new();
 
     let mut ebpf = Ebpf::load(crate::SK_REUSEPORT).unwrap();
@@ -291,10 +300,14 @@ async fn sk_reuseport_stays_attached_until_explicit_detach(select_prog: &str) {
     );
 }
 
-#[test_case("socket_map", "select_or_migrate_socket"; "legacy")]
-#[test_case("socket_map_btf", "select_or_migrate_socket_btf"; "btf")]
-#[test_log::test(tokio::test)]
-async fn sk_reuseport_migrates_to_expected_listener(socket_map: &str, migrate_prog: &str) {
+#[rstest]
+#[case::legacy("socket_map", "select_or_migrate_socket")]
+#[case::btf("socket_map_btf", "select_or_migrate_socket_btf")]
+#[test_attr(test_log::test(tokio::test))]
+async fn sk_reuseport_migrates_to_expected_listener(
+    #[case] socket_map: &str,
+    #[case] migrate_prog: &str,
+) {
     let kernel_version = KernelVersion::current().unwrap();
     if kernel_version < KernelVersion::new(5, 14, 0) {
         eprintln!("skipping test on kernel {kernel_version:?}, sk_reuseport/migrate requires 5.14");

--- a/test/integration-test/src/tests/stack_trace.rs
+++ b/test/integration-test/src/tests/stack_trace.rs
@@ -5,7 +5,7 @@ use aya::{
     sys::is_map_supported,
 };
 use integration_common::stack_trace::TestResult;
-use test_case::test_case;
+use rstest::rstest;
 
 #[unsafe(no_mangle)]
 #[inline(never)]
@@ -13,9 +13,11 @@ extern "C" fn trigger_record_stackid() {
     std::hint::black_box(());
 }
 
-#[test_log::test(test_case("STACKS_LEGACY", "RESULT_LEGACY", "record_stackid_legacy" ; "legacy"))]
-#[test_case("STACKS", "RESULT", "record_stackid" ; "btf")]
-fn record_stackid(stacks_map: &str, result_map: &str, prog: &str) {
+#[rstest]
+#[case::legacy("STACKS_LEGACY", "RESULT_LEGACY", "record_stackid_legacy")]
+#[case::btf("STACKS", "RESULT", "record_stackid")]
+#[test_attr(test_log::test)]
+fn record_stackid(#[case] stacks_map: &str, #[case] result_map: &str, #[case] prog: &str) {
     if !is_map_supported(MapType::StackTrace).unwrap() {
         eprintln!("skipping test - stack trace map not supported");
         return;

--- a/test/integration-test/src/tests/stack_trace_lsm.rs
+++ b/test/integration-test/src/tests/stack_trace_lsm.rs
@@ -6,11 +6,13 @@ use aya::{
     sys::{SyscallError, is_map_supported, is_program_supported},
 };
 use integration_common::stack_trace::TestResult;
-use test_case::test_case;
+use rstest::rstest;
 
-#[test_log::test(test_case("STACKS_LEGACY", "RESULT_LEGACY", "record_stackid_lsm_legacy" ; "legacy"))]
-#[test_case("STACKS", "RESULT", "record_stackid_lsm" ; "btf")]
-fn record_stackid_lsm(stacks_map: &str, result_map: &str, prog: &str) {
+#[rstest]
+#[case::legacy("STACKS_LEGACY", "RESULT_LEGACY", "record_stackid_lsm_legacy")]
+#[case::btf("STACKS", "RESULT", "record_stackid_lsm")]
+#[test_attr(test_log::test)]
+fn record_stackid_lsm(#[case] stacks_map: &str, #[case] result_map: &str, #[case] prog: &str) {
     if !is_map_supported(MapType::StackTrace).unwrap() {
         eprintln!("skipping test - stack trace map not supported");
         return;

--- a/test/integration-test/src/tests/xdp.rs
+++ b/test/integration-test/src/tests/xdp.rs
@@ -8,14 +8,16 @@ use aya::{
     util::KernelVersion,
 };
 use object::{Object as _, ObjectSection as _, ObjectSymbol as _, SymbolSection};
-use test_case::test_case;
+use rstest::rstest;
 use xdpilone::{BufIdx, IfInfo, Socket, SocketConfig, Umem, UmemConfig};
 
 use crate::utils::NetNsGuard;
 
-#[test_log::test(test_case("SOCKS", "redirect_sock"; "legacy"))]
-#[test_case("SOCKS_BTF", "redirect_sock_btf"; "btf")]
-fn af_xdp(socks_name: &str, prog_name: &str) {
+#[rstest]
+#[case::legacy("SOCKS", "redirect_sock")]
+#[case::btf("SOCKS_BTF", "redirect_sock_btf")]
+#[test_attr(test_log::test)]
+fn af_xdp(#[case] socks_name: &str, #[case] prog_name: &str) {
     let _netns = NetNsGuard::new();
 
     let mut bpf = Ebpf::load(crate::XSK_MAP).unwrap();
@@ -159,9 +161,11 @@ fn map_load() {
     bpf.program("xdp_frags_devmap").unwrap();
 }
 
-#[test_log::test(test_case("CPUS", "redirect_cpu"; "legacy"))]
-#[test_case("CPUS_BTF", "redirect_cpu_btf"; "btf")]
-fn cpumap_chain(cpus_name: &str, prog_name: &str) {
+#[rstest]
+#[case::legacy("CPUS", "redirect_cpu")]
+#[case::btf("CPUS_BTF", "redirect_cpu_btf")]
+#[test_attr(test_log::test)]
+fn cpumap_chain(#[case] cpus_name: &str, #[case] prog_name: &str) {
     let _netns = NetNsGuard::new();
 
     let mut bpf = Ebpf::load(crate::CPU_MAP).unwrap();
@@ -218,25 +222,31 @@ fn cpumap_chain(cpus_name: &str, prog_name: &str) {
     assert_eq!(hits.get(&1, 0).unwrap(), 1);
 }
 
-#[test_log::test(test_case(
-    "DEVS", "DEVS_HASH",
-    "redirect_dev", "redirect_dev_hash",
-    "get_dev", "get_dev_hash";
-    "legacy"
-))]
-#[test_case(
-    "DEVS_BTF", "DEVS_HASH_BTF",
-    "redirect_dev_btf", "redirect_dev_hash_btf",
-    "get_dev_btf", "get_dev_hash_btf";
-    "btf"
+#[rstest]
+#[case::legacy(
+    "DEVS",
+    "DEVS_HASH",
+    "redirect_dev",
+    "redirect_dev_hash",
+    "get_dev",
+    "get_dev_hash"
 )]
+#[case::btf(
+    "DEVS_BTF",
+    "DEVS_HASH_BTF",
+    "redirect_dev_btf",
+    "redirect_dev_hash_btf",
+    "get_dev_btf",
+    "get_dev_hash_btf"
+)]
+#[test_attr(test_log::test)]
 fn devmap_set(
-    devs_name: &str,
-    devs_hash_name: &str,
-    dev_prog: &str,
-    dev_hash_prog: &str,
-    dev_get_prog: &str,
-    dev_hash_get_prog: &str,
+    #[case] devs_name: &str,
+    #[case] devs_hash_name: &str,
+    #[case] dev_prog: &str,
+    #[case] dev_hash_prog: &str,
+    #[case] dev_get_prog: &str,
+    #[case] dev_hash_get_prog: &str,
 ) {
     let _netns = NetNsGuard::new();
 
@@ -273,11 +283,13 @@ fn devmap_set(
     }
 }
 
-#[test_log::test(test_case("get_ifindex_dev"; "legacy_array"))]
-#[test_case("get_ifindex_dev_hash"; "legacy_hash")]
-#[test_case("get_ifindex_dev_btf"; "btf_array")]
-#[test_case("get_ifindex_dev_hash_btf"; "btf_hash")]
-fn devmap_get_ifindex(prog_name: &str) {
+#[rstest]
+#[case::legacy_array("get_ifindex_dev")]
+#[case::legacy_hash("get_ifindex_dev_hash")]
+#[case::btf_array("get_ifindex_dev_btf")]
+#[case::btf_hash("get_ifindex_dev_hash_btf")]
+#[test_attr(test_log::test)]
+fn devmap_get_ifindex(#[case] prog_name: &str) {
     let _netns = NetNsGuard::new();
     let mut bpf = Ebpf::load(crate::DEV_MAP).unwrap();
     let xdp: &mut Xdp = bpf.program_mut(prog_name).unwrap().try_into().unwrap();


### PR DESCRIPTION
test-case relies on cooperating attribute macros when wrapping generated parameterized tests. Stacking it with test_log can register each generated case twice, so passing tests may run more than once and mask order-sensitive or flaky behavior.

Move the parameterized tests to rstest, but do not rely on rstest's implicit test-attribute detection. rstest treats attributes whose path ends in test as test attributes; that has its own failure mode if a non-test decorator matches, potentially producing cases that do not run as intended.

Use explicit #[test_attr(...)] wrappers for every rstest case that needs test_log or tokio, so generated tests get the intended harness attribute instead of depending on implicit detection.

Refs: #1573

<!-- markdownlint-disable first-line-heading -->

<!--
    Thank you for your contribution to Aya! 🎉

    For Work In Progress Pull Requests, please use the Draft PR feature.

    Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Aya Contributing Guide: https://github.com/aya-rs/aya/blob/main/CONTRIBUTING.md
     - 📖 Read the Aya Code of Conduct: https://github.com/aya-rs/aya/blob/main/CODE_OF_CONDUCT.md
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages: https://cbea.ms/git-commit/
     - 📗 Update any related documentation.

-->

<!---
      Summarize the changes you're making here. Detailed information belongs in
      the Git commit messages. If your pull request contains just one commit,
      it's best to use its message as a summary. Otherwise, if there are multiple
      atomic commits, write a summary for the entire PR. Feel free to flag
      anything you think needs a reviewer's attention.
-->

<!--
      If your changes address an issue, link it with the *Fixes* tag so
      the issue gets closed when the PR is merged, for example:

      Fixes: #1234

      If you are only referencing an issue without fully addressing it, feel
      free to link it anywhere in the summary.
-->

### Added/updated tests?

_We strongly encourage you to add a test for your changes._

- [x] No, and this is why: this only changes the test macros.

### Checklist

- [x] Rust code has been formatted with `cargo +nightly fmt`.
- [x] All clippy lints have been fixed.
      You can find failing lints with `cargo xtask clippy`.
- [x] Unit tests are passing locally with `cargo test`.
- [x] The [Integration tests] are passing locally.
- [x] I have blessed any API changes with `cargo xtask public-api --bless`.

[Integration tests]: https://github.com/aya-rs/aya/blob/main/test/README.md

### (Optional) What GIF best describes this PR or how it makes you feel?

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aya-rs/aya/1579)
<!-- Reviewable:end -->
