### PR TITLE
aya-obj: add several accessors for BTF types parsed by aya-obj

### DIFF
--- a/aya-obj/src/btf/btf.rs
+++ b/aya-obj/src/btf/btf.rs
@@ -313,7 +313,8 @@ impl Btf {
         self.types.types.len() < 2
     }
 
-    pub(crate) fn types(&self) -> impl Iterator<Item = &BtfType> {
+    /// An iterator over all types in this BTF, ordered by type index
+    pub fn types(&self) -> impl Iterator<Item = &BtfType> {
         self.types.types.iter()
     }
 
@@ -404,7 +405,11 @@ impl Btf {
         Ok(types)
     }
 
-    pub(crate) fn string_at(&self, offset: u32) -> Result<Cow<'_, str>, BtfError> {
+    /// Get string pointed by offset.
+    ///
+    /// This `offset` is usually retrieved from the `name_offset` field
+    /// of several BTF types.
+    pub fn string_at(&self, offset: u32) -> Result<Cow<'_, str>, BtfError> {
         let btf_header {
             hdr_len,
             mut str_off,
@@ -426,7 +431,8 @@ impl Btf {
         Ok(s.to_string_lossy())
     }
 
-    pub(crate) fn type_by_id(&self, type_id: u32) -> Result<&BtfType, BtfError> {
+    /// Gets BTF type of given id, which can be retrieved from [`id_by_type_name_kind`][Self::id_by_type_name_kind].
+    pub fn type_by_id(&self, type_id: u32) -> Result<&BtfType, BtfError> {
         self.types.type_by_id(type_id)
     }
 
@@ -434,7 +440,8 @@ impl Btf {
         self.types.resolve_type(root_type_id)
     }
 
-    pub(crate) fn type_name(&self, ty: &BtfType) -> Result<Cow<'_, str>, BtfError> {
+    /// Gets type name of given BTF type
+    pub fn type_name(&self, ty: &BtfType) -> Result<Cow<'_, str>, BtfError> {
         self.string_at(ty.name_offset())
     }
 

--- a/aya-obj/src/btf/types.rs
+++ b/aya-obj/src/btf/types.rs
@@ -51,6 +51,11 @@ impl Fwd {
     pub(crate) const fn type_info_size(&self) -> usize {
         size_of::<Self>()
     }
+
+    /// Kind flag of fwd
+    pub const fn kind_flag(&self) -> bool {
+        (self.info >> 31) == 1
+    }
 }
 
 #[repr(C)]
@@ -82,6 +87,11 @@ impl Const {
             btf_type,
         }
     }
+
+    /// BTF type index this const refers to
+    pub const fn referred_btf_type(&self) -> u32 {
+        self.btf_type
+    }
 }
 
 #[repr(C)]
@@ -104,6 +114,11 @@ impl Volatile {
     pub(crate) const fn type_info_size(&self) -> usize {
         size_of::<Self>()
     }
+
+    /// BTF type index this volatile refers to
+    pub const fn referred_btf_type(&self) -> u32 {
+        self.btf_type
+    }
 }
 
 #[derive(Clone, Debug)]
@@ -124,6 +139,11 @@ impl Restrict {
 
     pub(crate) const fn type_info_size(&self) -> usize {
         size_of::<Self>()
+    }
+
+    /// BTF type index this restrict refers to
+    pub const fn referred_btf_type(&self) -> u32 {
+        self.btf_type
     }
 }
 
@@ -156,6 +176,11 @@ impl Ptr {
             btf_type,
         }
     }
+
+    /// BTF type index this ptr refers to
+    pub const fn referred_btf_type(&self) -> u32 {
+        self.btf_type
+    }
 }
 
 #[repr(C)]
@@ -187,6 +212,11 @@ impl Typedef {
             btf_type,
         }
     }
+
+    /// BTF type index this typedef refers to
+    pub const fn referred_btf_type(&self) -> u32 {
+        self.btf_type
+    }
 }
 
 #[repr(C)]
@@ -216,6 +246,11 @@ impl Float {
             info,
             size,
         }
+    }
+
+    /// Size of this float
+    pub const fn size(&self) -> u32 {
+        self.size
     }
 }
 
@@ -269,8 +304,14 @@ impl Func {
         }
     }
 
-    pub(crate) fn linkage(&self) -> FuncLinkage {
+    /// Linkage of this func
+    pub fn linkage(&self) -> FuncLinkage {
         (self.info & 0xFFFF).into()
+    }
+
+    /// Proto of this func
+    pub const fn proto(&self) -> u32 {
+        self.btf_type
     }
 
     pub(crate) const fn set_linkage(&mut self, linkage: FuncLinkage) {
@@ -306,6 +347,11 @@ impl TypeTag {
             info,
             btf_type,
         }
+    }
+
+    /// BTF type index this typetag refers to
+    pub const fn referred_btf_type(&self) -> u32 {
+        self.btf_type
     }
 }
 
@@ -378,17 +424,18 @@ impl Int {
         }
     }
 
-    pub(crate) fn encoding(&self) -> IntEncoding {
+    /// Encoding of this int
+    pub fn encoding(&self) -> IntEncoding {
         ((self.data & 0x0f000000) >> 24).into()
     }
 
-    pub(crate) const fn offset(&self) -> u32 {
+    /// Offset of this int
+    pub const fn offset(&self) -> u32 {
         (self.data & 0x00ff0000) >> 16
     }
 
-    // TODO: Remove directive this when this crate is pub
-    #[cfg(test)]
-    pub(crate) const fn bits(&self) -> u32 {
+    /// Size of this int in bits
+    pub const fn bits(&self) -> u32 {
         self.data & 0x000000ff
     }
 }
@@ -459,8 +506,19 @@ impl Enum {
         }
     }
 
-    pub(crate) const fn is_signed(&self) -> bool {
+    /// Whether this enum is signed
+    pub const fn is_signed(&self) -> bool {
         self.info >> 31 == 1
+    }
+
+    /// Variants of this enum
+    pub fn variants(&self) -> &[BtfEnum] {
+        &self.variants
+    }
+
+    /// Size of this enum
+    pub const fn size(&self) -> u32 {
+        self.size
     }
 
     pub(crate) const fn set_signed(&mut self, signed: bool) {
@@ -475,9 +533,9 @@ impl Enum {
 #[repr(C)]
 #[derive(Debug, Clone, Copy)]
 pub struct BtfEnum64 {
-    pub(crate) name_offset: u32,
-    pub(crate) value_low: u32,
-    pub(crate) value_high: u32,
+    pub name_offset: u32,
+    pub value_low: u32,
+    pub value_high: u32,
 }
 
 impl BtfEnum64 {
@@ -539,8 +597,19 @@ impl Enum64 {
         size_of::<Fwd>() + size_of::<BtfEnum64>() * self.variants.len()
     }
 
-    pub(crate) const fn is_signed(&self) -> bool {
+    /// Whether this enum64 is signed
+    pub const fn is_signed(&self) -> bool {
         self.info >> 31 == 1
+    }
+
+    /// Variants of this enum64
+    pub fn variants(&self) -> &[BtfEnum64] {
+        &self.variants
+    }
+
+    /// Size of this enum64
+    pub const fn size(&self) -> u32 {
+        self.size
     }
 
     pub const fn new(name_offset: u32, signed: bool, variants: Vec<BtfEnum64>) -> Self {
@@ -566,10 +635,10 @@ impl Enum64 {
 
 #[repr(C)]
 #[derive(Clone, Debug)]
-pub(crate) struct BtfMember {
-    pub(crate) name_offset: u32,
-    pub(crate) btf_type: u32,
-    pub(crate) offset: u32,
+pub struct BtfMember {
+    pub name_offset: u32,
+    pub btf_type: u32,
+    pub offset: u32,
 }
 
 #[repr(C)]
@@ -632,7 +701,18 @@ impl Struct {
         }
     }
 
-    pub(crate) const fn member_bit_offset(&self, member: &BtfMember) -> usize {
+    /// Members of this struct
+    pub fn members(&self) -> &[BtfMember] {
+        &self.members
+    }
+
+    /// Size of this struct
+    pub const fn size(&self) -> u32 {
+        self.size
+    }
+
+    /// Bit offset of given member
+    pub const fn member_bit_offset(&self, member: &BtfMember) -> usize {
         let k_flag = self.info >> 31 == 1;
         let bit_offset = if k_flag {
             member.offset & 0xFFFFFF
@@ -643,7 +723,8 @@ impl Struct {
         bit_offset as usize
     }
 
-    pub(crate) const fn member_bit_field_size(&self, member: &BtfMember) -> usize {
+    /// Bit field size of given member
+    pub const fn member_bit_field_size(&self, member: &BtfMember) -> usize {
         let k_flag = (self.info >> 31) == 1;
         let size = if k_flag { member.offset >> 24 } else { 0 };
 
@@ -735,7 +816,18 @@ impl Union {
         size_of::<Fwd>() + size_of::<BtfMember>() * self.members.len()
     }
 
-    pub(crate) const fn member_bit_offset(&self, member: &BtfMember) -> usize {
+    /// Members of this union
+    pub fn members(&self) -> &[BtfMember] {
+        &self.members
+    }
+
+    /// Size of this union
+    pub const fn size(&self) -> u32 {
+        self.size
+    }
+
+    /// Bit offset of given member
+    pub const fn member_bit_offset(&self, member: &BtfMember) -> usize {
         let k_flag = self.info >> 31 == 1;
         let bit_offset = if k_flag {
             member.offset & 0xFFFFFF
@@ -746,7 +838,8 @@ impl Union {
         bit_offset as usize
     }
 
-    pub(crate) const fn member_bit_field_size(&self, member: &BtfMember) -> usize {
+    /// Bit field size of given member
+    pub const fn member_bit_field_size(&self, member: &BtfMember) -> usize {
         let k_flag = (self.info >> 31) == 1;
         let size = if k_flag { member.offset >> 24 } else { 0 };
 
@@ -817,6 +910,21 @@ impl Array {
             },
         }
     }
+
+    /// Length of this array
+    pub const fn len(&self) -> usize {
+        self.array.len as usize
+    }
+
+    /// BTF type index of array element
+    pub const fn btf_element_type(&self) -> u32 {
+        self.array.element_type
+    }
+
+    /// BTF type index of array index
+    pub const fn btf_index_type(&self) -> u32 {
+        self.array.index_type
+    }
 }
 
 #[repr(C)]
@@ -878,10 +986,20 @@ impl FuncProto {
             params,
         }
     }
+
+    /// Params of this func proto
+    pub fn params(&self) -> &[BtfParam] {
+        &self.params
+    }
+
+    /// BTF type index of this func proto's return type
+    pub const fn return_type(&self) -> u32 {
+        self.return_type
+    }
 }
 
 #[repr(u32)]
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum VarLinkage {
     Static,
     Global,
@@ -942,6 +1060,16 @@ impl Var {
             btf_type,
             linkage,
         }
+    }
+
+    /// BTF type index this var refers to
+    pub const fn referred_btf_type(&self) -> u32 {
+        self.btf_type
+    }
+
+    /// Linkage of this var
+    pub const fn linkage(&self) -> VarLinkage {
+        self.linkage
     }
 }
 
@@ -1012,6 +1140,16 @@ impl DataSec {
             entries,
         }
     }
+
+    /// Entries of this datasec
+    pub fn entries(&self) -> &[DataSecEntry] {
+        &self.entries
+    }
+
+    /// Size of this datasec
+    pub const fn size(&self) -> u32 {
+        self.size
+    }
 }
 
 #[repr(C)]
@@ -1056,6 +1194,16 @@ impl DeclTag {
             btf_type,
             component_index,
         }
+    }
+
+    /// BTF type index this declare tag refers to
+    pub const fn referred_btf_type(&self) -> u32 {
+        self.btf_type
+    }
+
+    /// Component index of this declare tag
+    pub const fn component_index(&self) -> i32 {
+        self.component_index
     }
 }
 
@@ -1393,7 +1541,8 @@ impl BtfType {
         }
     }
 
-    pub(crate) const fn kind(&self) -> BtfKind {
+    /// Kind of this BTF type
+    pub const fn kind(&self) -> BtfKind {
         match self {
             Self::Unknown => BtfKind::Unknown,
             Self::Fwd(t) => t.kind(),

--- a/xtask/public-api/aya-obj.txt
+++ b/xtask/public-api/aya-obj.txt
@@ -124,6 +124,8 @@ pub aya_obj::btf::BtfType::Union(aya_obj::btf::Union)
 pub aya_obj::btf::BtfType::Unknown
 pub aya_obj::btf::BtfType::Var(aya_obj::btf::Var)
 pub aya_obj::btf::BtfType::Volatile(aya_obj::btf::Volatile)
+impl aya_obj::btf::BtfType
+pub const fn aya_obj::btf::BtfType::kind(&self) -> aya_obj::btf::BtfKind
 impl core::clone::Clone for aya_obj::btf::BtfType
 pub fn aya_obj::btf::BtfType::clone(&self) -> aya_obj::btf::BtfType
 impl core::fmt::Debug for aya_obj::btf::BtfType
@@ -194,6 +196,7 @@ impl core::convert::From<u32> for aya_obj::btf::VarLinkage
 pub fn aya_obj::btf::VarLinkage::from(v: u32) -> Self
 impl core::fmt::Debug for aya_obj::btf::VarLinkage
 pub fn aya_obj::btf::VarLinkage::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Copy for aya_obj::btf::VarLinkage
 impl core::marker::StructuralPartialEq for aya_obj::btf::VarLinkage
 impl core::marker::Freeze for aya_obj::btf::VarLinkage
 impl core::marker::Send for aya_obj::btf::VarLinkage
@@ -203,6 +206,10 @@ impl core::marker::UnsafeUnpin for aya_obj::btf::VarLinkage
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::btf::VarLinkage
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::btf::VarLinkage
 #[repr(C)] pub struct aya_obj::btf::Array
+impl aya_obj::btf::Array
+pub const fn aya_obj::btf::Array::btf_element_type(&self) -> u32
+pub const fn aya_obj::btf::Array::btf_index_type(&self) -> u32
+pub const fn aya_obj::btf::Array::len(&self) -> usize
 impl core::clone::Clone for aya_obj::btf::Array
 pub fn aya_obj::btf::Array::clone(&self) -> aya_obj::btf::Array
 impl core::fmt::Debug for aya_obj::btf::Array
@@ -223,7 +230,11 @@ pub fn aya_obj::btf::Btf::id_by_type_name_kind(&self, name: &str, kind: aya_obj:
 pub fn aya_obj::btf::Btf::new() -> Self
 pub fn aya_obj::btf::Btf::parse(data: &[u8], endianness: object::endian::Endianness) -> core::result::Result<Self, aya_obj::btf::BtfError>
 pub fn aya_obj::btf::Btf::parse_file<P: core::convert::AsRef<std::path::Path>>(path: P, endianness: object::endian::Endianness) -> core::result::Result<Self, aya_obj::btf::BtfError>
+pub fn aya_obj::btf::Btf::string_at(&self, offset: u32) -> core::result::Result<alloc::borrow::Cow<'_, str>, aya_obj::btf::BtfError>
 pub fn aya_obj::btf::Btf::to_bytes(&self) -> alloc::vec::Vec<u8>
+pub fn aya_obj::btf::Btf::type_by_id(&self, type_id: u32) -> core::result::Result<&aya_obj::btf::BtfType, aya_obj::btf::BtfError>
+pub fn aya_obj::btf::Btf::type_name(&self, ty: &aya_obj::btf::BtfType) -> core::result::Result<alloc::borrow::Cow<'_, str>, aya_obj::btf::BtfError>
+pub fn aya_obj::btf::Btf::types(&self) -> impl core::iter::traits::iterator::Iterator<Item = &aya_obj::btf::BtfType>
 impl core::clone::Clone for aya_obj::btf::Btf
 pub fn aya_obj::btf::Btf::clone(&self) -> aya_obj::btf::Btf
 impl core::default::Default for aya_obj::btf::Btf
@@ -254,6 +265,9 @@ impl core::marker::UnsafeUnpin for aya_obj::btf::BtfEnum
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::btf::BtfEnum
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::btf::BtfEnum
 #[repr(C)] pub struct aya_obj::btf::BtfEnum64
+pub aya_obj::btf::BtfEnum64::name_offset: u32
+pub aya_obj::btf::BtfEnum64::value_high: u32
+pub aya_obj::btf::BtfEnum64::value_low: u32
 impl aya_obj::btf::BtfEnum64
 pub const fn aya_obj::btf::BtfEnum64::new(name_offset: u32, value: u64) -> Self
 impl core::clone::Clone for aya_obj::btf::BtfEnum64
@@ -302,6 +316,21 @@ impl core::marker::Unpin for aya_obj::btf::BtfFeatures
 impl core::marker::UnsafeUnpin for aya_obj::btf::BtfFeatures
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::btf::BtfFeatures
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::btf::BtfFeatures
+#[repr(C)] pub struct aya_obj::btf::BtfMember
+pub aya_obj::btf::BtfMember::btf_type: u32
+pub aya_obj::btf::BtfMember::name_offset: u32
+pub aya_obj::btf::BtfMember::offset: u32
+impl core::clone::Clone for aya_obj::btf::BtfMember
+pub fn aya_obj::btf::BtfMember::clone(&self) -> aya_obj::btf::BtfMember
+impl core::fmt::Debug for aya_obj::btf::BtfMember
+pub fn aya_obj::btf::BtfMember::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for aya_obj::btf::BtfMember
+impl core::marker::Send for aya_obj::btf::BtfMember
+impl core::marker::Sync for aya_obj::btf::BtfMember
+impl core::marker::Unpin for aya_obj::btf::BtfMember
+impl core::marker::UnsafeUnpin for aya_obj::btf::BtfMember
+impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::btf::BtfMember
+impl core::panic::unwind_safe::UnwindSafe for aya_obj::btf::BtfMember
 #[repr(C)] pub struct aya_obj::btf::BtfParam
 pub aya_obj::btf::BtfParam::btf_type: u32
 pub aya_obj::btf::BtfParam::name_offset: u32
@@ -332,6 +361,8 @@ impl core::marker::UnsafeUnpin for aya_obj::btf::BtfRelocationError
 impl !core::panic::unwind_safe::RefUnwindSafe for aya_obj::btf::BtfRelocationError
 impl !core::panic::unwind_safe::UnwindSafe for aya_obj::btf::BtfRelocationError
 #[repr(C)] pub struct aya_obj::btf::Const
+impl aya_obj::btf::Const
+pub const fn aya_obj::btf::Const::referred_btf_type(&self) -> u32
 impl core::clone::Clone for aya_obj::btf::Const
 pub fn aya_obj::btf::Const::clone(&self) -> aya_obj::btf::Const
 impl core::fmt::Debug for aya_obj::btf::Const
@@ -345,7 +376,9 @@ impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::btf::Const
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::btf::Const
 #[repr(C)] pub struct aya_obj::btf::DataSec
 impl aya_obj::btf::DataSec
+pub fn aya_obj::btf::DataSec::entries(&self) -> &[aya_obj::btf::DataSecEntry]
 pub const fn aya_obj::btf::DataSec::new(name_offset: u32, entries: alloc::vec::Vec<aya_obj::btf::DataSecEntry>, size: u32) -> Self
+pub const fn aya_obj::btf::DataSec::size(&self) -> u32
 impl core::clone::Clone for aya_obj::btf::DataSec
 pub fn aya_obj::btf::DataSec::clone(&self) -> aya_obj::btf::DataSec
 impl core::fmt::Debug for aya_obj::btf::DataSec
@@ -374,7 +407,9 @@ impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::btf::DataSecEntry
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::btf::DataSecEntry
 #[repr(C)] pub struct aya_obj::btf::DeclTag
 impl aya_obj::btf::DeclTag
+pub const fn aya_obj::btf::DeclTag::component_index(&self) -> i32
 pub const fn aya_obj::btf::DeclTag::new(name_offset: u32, btf_type: u32, component_index: i32) -> Self
+pub const fn aya_obj::btf::DeclTag::referred_btf_type(&self) -> u32
 impl core::clone::Clone for aya_obj::btf::DeclTag
 pub fn aya_obj::btf::DeclTag::clone(&self) -> aya_obj::btf::DeclTag
 impl core::fmt::Debug for aya_obj::btf::DeclTag
@@ -388,7 +423,10 @@ impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::btf::DeclTag
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::btf::DeclTag
 #[repr(C)] pub struct aya_obj::btf::Enum
 impl aya_obj::btf::Enum
+pub const fn aya_obj::btf::Enum::is_signed(&self) -> bool
 pub const fn aya_obj::btf::Enum::new(name_offset: u32, signed: bool, variants: alloc::vec::Vec<aya_obj::btf::BtfEnum>) -> Self
+pub const fn aya_obj::btf::Enum::size(&self) -> u32
+pub fn aya_obj::btf::Enum::variants(&self) -> &[aya_obj::btf::BtfEnum]
 impl core::clone::Clone for aya_obj::btf::Enum
 pub fn aya_obj::btf::Enum::clone(&self) -> aya_obj::btf::Enum
 impl core::fmt::Debug for aya_obj::btf::Enum
@@ -402,7 +440,10 @@ impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::btf::Enum
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::btf::Enum
 #[repr(C)] pub struct aya_obj::btf::Enum64
 impl aya_obj::btf::Enum64
+pub const fn aya_obj::btf::Enum64::is_signed(&self) -> bool
 pub const fn aya_obj::btf::Enum64::new(name_offset: u32, signed: bool, variants: alloc::vec::Vec<aya_obj::btf::BtfEnum64>) -> Self
+pub const fn aya_obj::btf::Enum64::size(&self) -> u32
+pub fn aya_obj::btf::Enum64::variants(&self) -> &[aya_obj::btf::BtfEnum64]
 impl core::clone::Clone for aya_obj::btf::Enum64
 pub fn aya_obj::btf::Enum64::clone(&self) -> aya_obj::btf::Enum64
 impl core::fmt::Debug for aya_obj::btf::Enum64
@@ -417,6 +458,7 @@ impl core::panic::unwind_safe::UnwindSafe for aya_obj::btf::Enum64
 #[repr(C)] pub struct aya_obj::btf::Float
 impl aya_obj::btf::Float
 pub const fn aya_obj::btf::Float::new(name_offset: u32, size: u32) -> Self
+pub const fn aya_obj::btf::Float::size(&self) -> u32
 impl core::clone::Clone for aya_obj::btf::Float
 pub fn aya_obj::btf::Float::clone(&self) -> aya_obj::btf::Float
 impl core::fmt::Debug for aya_obj::btf::Float
@@ -430,7 +472,9 @@ impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::btf::Float
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::btf::Float
 #[repr(C)] pub struct aya_obj::btf::Func
 impl aya_obj::btf::Func
+pub fn aya_obj::btf::Func::linkage(&self) -> aya_obj::btf::FuncLinkage
 pub const fn aya_obj::btf::Func::new(name_offset: u32, proto: u32, linkage: aya_obj::btf::FuncLinkage) -> Self
+pub const fn aya_obj::btf::Func::proto(&self) -> u32
 impl core::clone::Clone for aya_obj::btf::Func
 pub fn aya_obj::btf::Func::clone(&self) -> aya_obj::btf::Func
 impl core::fmt::Debug for aya_obj::btf::Func
@@ -458,6 +502,8 @@ impl core::panic::unwind_safe::UnwindSafe for aya_obj::btf::FuncInfo
 #[repr(C)] pub struct aya_obj::btf::FuncProto
 impl aya_obj::btf::FuncProto
 pub const fn aya_obj::btf::FuncProto::new(params: alloc::vec::Vec<aya_obj::btf::BtfParam>, return_type: u32) -> Self
+pub fn aya_obj::btf::FuncProto::params(&self) -> &[aya_obj::btf::BtfParam]
+pub const fn aya_obj::btf::FuncProto::return_type(&self) -> u32
 impl core::clone::Clone for aya_obj::btf::FuncProto
 pub fn aya_obj::btf::FuncProto::clone(&self) -> aya_obj::btf::FuncProto
 impl core::fmt::Debug for aya_obj::btf::FuncProto
@@ -489,6 +535,8 @@ impl core::marker::UnsafeUnpin for aya_obj::btf::FuncSecInfo
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::btf::FuncSecInfo
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::btf::FuncSecInfo
 #[repr(C)] pub struct aya_obj::btf::Fwd
+impl aya_obj::btf::Fwd
+pub const fn aya_obj::btf::Fwd::kind_flag(&self) -> bool
 impl core::clone::Clone for aya_obj::btf::Fwd
 pub fn aya_obj::btf::Fwd::clone(&self) -> aya_obj::btf::Fwd
 impl core::fmt::Debug for aya_obj::btf::Fwd
@@ -502,7 +550,10 @@ impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::btf::Fwd
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::btf::Fwd
 #[repr(C)] pub struct aya_obj::btf::Int
 impl aya_obj::btf::Int
+pub const fn aya_obj::btf::Int::bits(&self) -> u32
+pub fn aya_obj::btf::Int::encoding(&self) -> aya_obj::btf::IntEncoding
 pub const fn aya_obj::btf::Int::new(name_offset: u32, size: u32, encoding: aya_obj::btf::IntEncoding, offset: u32) -> Self
+pub const fn aya_obj::btf::Int::offset(&self) -> u32
 impl core::clone::Clone for aya_obj::btf::Int
 pub fn aya_obj::btf::Int::clone(&self) -> aya_obj::btf::Int
 impl core::fmt::Debug for aya_obj::btf::Int
@@ -536,6 +587,7 @@ impl core::panic::unwind_safe::UnwindSafe for aya_obj::btf::LineSecInfo
 #[repr(C)] pub struct aya_obj::btf::Ptr
 impl aya_obj::btf::Ptr
 pub const fn aya_obj::btf::Ptr::new(name_offset: u32, btf_type: u32) -> Self
+pub const fn aya_obj::btf::Ptr::referred_btf_type(&self) -> u32
 impl core::clone::Clone for aya_obj::btf::Ptr
 pub fn aya_obj::btf::Ptr::clone(&self) -> aya_obj::btf::Ptr
 impl core::fmt::Debug for aya_obj::btf::Ptr
@@ -548,6 +600,8 @@ impl core::marker::UnsafeUnpin for aya_obj::btf::Ptr
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::btf::Ptr
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::btf::Ptr
 pub struct aya_obj::btf::Restrict
+impl aya_obj::btf::Restrict
+pub const fn aya_obj::btf::Restrict::referred_btf_type(&self) -> u32
 impl core::clone::Clone for aya_obj::btf::Restrict
 pub fn aya_obj::btf::Restrict::clone(&self) -> aya_obj::btf::Restrict
 impl core::fmt::Debug for aya_obj::btf::Restrict
@@ -560,6 +614,11 @@ impl core::marker::UnsafeUnpin for aya_obj::btf::Restrict
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::btf::Restrict
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::btf::Restrict
 #[repr(C)] pub struct aya_obj::btf::Struct
+impl aya_obj::btf::Struct
+pub const fn aya_obj::btf::Struct::member_bit_field_size(&self, member: &aya_obj::btf::BtfMember) -> usize
+pub const fn aya_obj::btf::Struct::member_bit_offset(&self, member: &aya_obj::btf::BtfMember) -> usize
+pub fn aya_obj::btf::Struct::members(&self) -> &[aya_obj::btf::BtfMember]
+pub const fn aya_obj::btf::Struct::size(&self) -> u32
 impl core::clone::Clone for aya_obj::btf::Struct
 pub fn aya_obj::btf::Struct::clone(&self) -> aya_obj::btf::Struct
 impl core::fmt::Debug for aya_obj::btf::Struct
@@ -574,6 +633,7 @@ impl core::panic::unwind_safe::UnwindSafe for aya_obj::btf::Struct
 #[repr(C)] pub struct aya_obj::btf::TypeTag
 impl aya_obj::btf::TypeTag
 pub const fn aya_obj::btf::TypeTag::new(name_offset: u32, btf_type: u32) -> Self
+pub const fn aya_obj::btf::TypeTag::referred_btf_type(&self) -> u32
 impl core::clone::Clone for aya_obj::btf::TypeTag
 pub fn aya_obj::btf::TypeTag::clone(&self) -> aya_obj::btf::TypeTag
 impl core::fmt::Debug for aya_obj::btf::TypeTag
@@ -586,6 +646,8 @@ impl core::marker::UnsafeUnpin for aya_obj::btf::TypeTag
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::btf::TypeTag
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::btf::TypeTag
 #[repr(C)] pub struct aya_obj::btf::Typedef
+impl aya_obj::btf::Typedef
+pub const fn aya_obj::btf::Typedef::referred_btf_type(&self) -> u32
 impl core::clone::Clone for aya_obj::btf::Typedef
 pub fn aya_obj::btf::Typedef::clone(&self) -> aya_obj::btf::Typedef
 impl core::fmt::Debug for aya_obj::btf::Typedef
@@ -598,6 +660,11 @@ impl core::marker::UnsafeUnpin for aya_obj::btf::Typedef
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::btf::Typedef
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::btf::Typedef
 #[repr(C)] pub struct aya_obj::btf::Union
+impl aya_obj::btf::Union
+pub const fn aya_obj::btf::Union::member_bit_field_size(&self, member: &aya_obj::btf::BtfMember) -> usize
+pub const fn aya_obj::btf::Union::member_bit_offset(&self, member: &aya_obj::btf::BtfMember) -> usize
+pub fn aya_obj::btf::Union::members(&self) -> &[aya_obj::btf::BtfMember]
+pub const fn aya_obj::btf::Union::size(&self) -> u32
 impl core::clone::Clone for aya_obj::btf::Union
 pub fn aya_obj::btf::Union::clone(&self) -> aya_obj::btf::Union
 impl core::fmt::Debug for aya_obj::btf::Union
@@ -611,7 +678,9 @@ impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::btf::Union
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::btf::Union
 #[repr(C)] pub struct aya_obj::btf::Var
 impl aya_obj::btf::Var
+pub const fn aya_obj::btf::Var::linkage(&self) -> aya_obj::btf::VarLinkage
 pub const fn aya_obj::btf::Var::new(name_offset: u32, btf_type: u32, linkage: aya_obj::btf::VarLinkage) -> Self
+pub const fn aya_obj::btf::Var::referred_btf_type(&self) -> u32
 impl core::clone::Clone for aya_obj::btf::Var
 pub fn aya_obj::btf::Var::clone(&self) -> aya_obj::btf::Var
 impl core::fmt::Debug for aya_obj::btf::Var
@@ -624,6 +693,8 @@ impl core::marker::UnsafeUnpin for aya_obj::btf::Var
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::btf::Var
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::btf::Var
 #[repr(C)] pub struct aya_obj::btf::Volatile
+impl aya_obj::btf::Volatile
+pub const fn aya_obj::btf::Volatile::referred_btf_type(&self) -> u32
 impl core::clone::Clone for aya_obj::btf::Volatile
 pub fn aya_obj::btf::Volatile::clone(&self) -> aya_obj::btf::Volatile
 impl core::fmt::Debug for aya_obj::btf::Volatile


### PR DESCRIPTION
<!-- markdownlint-disable first-line-heading -->

<!--
    Thank you for your contribution to Aya! 🎉

    For Work In Progress Pull Requests, please use the Draft PR feature.

    Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Aya Contributing Guide: https://github.com/aya-rs/aya/blob/main/CONTRIBUTING.md
     - 📖 Read the Aya Code of Conduct: https://github.com/aya-rs/aya/blob/main/CODE_OF_CONDUCT.md
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages: https://cbea.ms/git-commit/
     - 📗 Update any related documentation.

-->

<!---
      Summarize the changes you're making here. Detailed information belongs in
      the Git commit messages. If your pull request contains just one commit,
      it's best to use its message as a summary. Otherwise, if there are multiple
      atomic commits, write a summary for the entire PR. Feel free to flag
      anything you think needs a reviewer's attention.
-->

I'm new to this project, and I want to use aya to extract BTF information in an ebpf object. I find aya extremely powerful in parsing ebpf objects, with `aya_obj::Object::parse` (by printing the parsed object, I'm sure that all BTF information is parsed). However, current API design makes it hardly to do anything with parsed BTF information. Almost all accessors are `pub(crate)`. The only thing I can do is `id_by_type_name_kind`, which has far less information than aya actually got.

So in this PR, I make some `pub(crate)` APIs public, and add some new accessors.

<!--
      If your changes address an issue, link it with the *Fixes* tag so
      the issue gets closed when the PR is merged, for example:

      Fixes: #1234

      If you are only referencing an issue without fully addressing it, feel
      free to link it anywhere in the summary.
-->

### Added/updated tests?

_We strongly encourage you to add a test for your changes._

- [ ] Yes
- [x] No, and this is why: the `pub(crate)` APIs are already tested previously
- [ ] I need help with writing tests

### Checklist

- [x] Rust code has been formatted with `cargo +nightly fmt`.
- [x] All clippy lints have been fixed.
      You can find failing lints with `cargo xtask clippy`.
- [x] Unit tests are passing locally with `cargo test`.
- [x] The [Integration tests] are passing locally.
- [x] I have blessed any API changes with `cargo xtask public-api --bless`.

[Integration tests]: https://github.com/aya-rs/aya/blob/main/test/README.md

### (Optional) What GIF best describes this PR or how it makes you feel?

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aya-rs/aya/1580)
<!-- Reviewable:end -->
