### PR TITLE
codegen: add bpf_cgroup_storage_key

### DIFF
--- a/xtask/src/codegen/aya.rs
+++ b/xtask/src/codegen/aya.rs
@@ -87,6 +87,7 @@ fn codegen_bindings(opts: &SysrootOptions, libbpf_dir: &Path) -> Result<()> {
             "bpf_func_info",
             "bpf_line_info",
             "bpf_lpm_trie_key",
+            "bpf_cgroup_storage_key",
             "bpf_cpumap_val",
             "bpf_devmap_val",
             "bpf_stats_type",


### PR DESCRIPTION
This will generate the bpf_cgroup_storage_key binding the next time the
codegen job runs. The struct keys cgroup storage map entries by cgroup
inode id and attach type, and will be needed by a follow-up PR adding
`CgroupStorage` and `PerCpuCgroupStorage` map support.

### Added/updated tests?

- [x] No, and this is why: this only adds a type to the codegen allowlist.

### Checklist

- [x] Rust code has been formatted with `cargo +nightly fmt`.
- [x] All clippy lints have been fixed.
- [x] Unit tests are passing locally with `cargo test`.
- [x] The Integration tests are passing locally.
- [x] I have blessed any API changes with `cargo xtask public-api --bless`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aya-rs/aya/1581)
<!-- Reviewable:end -->
