### PR TITLE
aya, aya-ebpf: add CgroupStorage and PerCpuCgroupStorage

### DIFF
--- a/aya/src/bpf.rs
+++ b/aya/src/bpf.rs
@@ -805,6 +805,10 @@ fn parse_map(
         bpf_map_type::BPF_MAP_TYPE_PERCPU_ARRAY => Map::PerCpuArray(map),
         bpf_map_type::BPF_MAP_TYPE_PROG_ARRAY => Map::ProgramArray(map),
         bpf_map_type::BPF_MAP_TYPE_CGROUP_ARRAY => Map::CgroupArray(map),
+        bpf_map_type::BPF_MAP_TYPE_CGROUP_STORAGE_DEPRECATED => Map::CgroupStorage(map),
+        bpf_map_type::BPF_MAP_TYPE_PERCPU_CGROUP_STORAGE_DEPRECATED => {
+            Map::PerCpuCgroupStorage(map)
+        }
         bpf_map_type::BPF_MAP_TYPE_HASH => Map::HashMap(map),
         bpf_map_type::BPF_MAP_TYPE_LRU_HASH => Map::LruHashMap(map),
         bpf_map_type::BPF_MAP_TYPE_PERCPU_HASH => Map::PerCpuHashMap(map),

--- a/aya/src/maps/cgroup_storage.rs
+++ b/aya/src/maps/cgroup_storage.rs
@@ -1,0 +1,171 @@
+//! Cgroup storage maps.
+#![expect(
+    deprecated,
+    reason = "this module implements the deprecated cgroup storage map types"
+)]
+
+use std::{
+    borrow::{Borrow, BorrowMut},
+    marker::PhantomData,
+    os::fd::AsFd as _,
+};
+
+use aya_obj::generated::bpf_cgroup_storage_key;
+
+use crate::{
+    Pod,
+    maps::{MapData, MapError, PerCpuValues, check_kv_size, hash_map},
+    sys::{SyscallError, bpf_map_lookup_elem_per_cpu, bpf_map_update_elem_per_cpu},
+};
+
+unsafe impl Pod for bpf_cgroup_storage_key {}
+
+/// A key into a [`CgroupStorage`] or [`PerCpuCgroupStorage`] map.
+///
+/// The kernel keys cgroup storage entries by the cgroup inode id and the attach
+/// type of the program that created them. Only this isolated key layout is
+/// supported; the shared `u64` cgroup-inode-id key added in Linux 5.9 is not.
+#[derive(Clone, Copy, Debug)]
+pub struct CgroupStorageKey {
+    cgroup_inode_id: u64,
+    attach_type: u32,
+}
+
+impl CgroupStorageKey {
+    /// Creates a key from a cgroup inode id and a program attach type.
+    pub const fn new(cgroup_inode_id: u64, attach_type: u32) -> Self {
+        Self {
+            cgroup_inode_id,
+            attach_type,
+        }
+    }
+
+    const fn to_kernel(self) -> bpf_cgroup_storage_key {
+        let Self {
+            cgroup_inode_id,
+            attach_type,
+        } = self;
+        bpf_cgroup_storage_key {
+            cgroup_inode_id,
+            attach_type,
+        }
+    }
+}
+
+/// A cgroup storage map backed by `BPF_MAP_TYPE_CGROUP_STORAGE`.
+///
+/// This map stores a single value per cgroup that an attached program runs in.
+/// eBPF programs access it through the `bpf_get_local_storage` helper; from user
+/// space the entry is read and updated with the methods on this type, keyed by
+/// [`CgroupStorageKey`]. The kernel creates entries when a program is attached to
+/// a cgroup, so user space can neither create nor delete them.
+///
+/// # Minimum kernel version
+///
+/// The minimum kernel version required to use this feature is 4.19.
+#[deprecated = "use the `BPF_MAP_TYPE_CGRP_STORAGE` map type, available since Linux 6.2"]
+#[doc(alias = "BPF_MAP_TYPE_CGROUP_STORAGE")]
+#[derive(Debug)]
+pub struct CgroupStorage<T, V: Pod> {
+    pub(crate) inner: T,
+    _v: PhantomData<V>,
+}
+
+impl<T: Borrow<MapData>, V: Pod> CgroupStorage<T, V> {
+    pub(crate) fn new(map: T) -> Result<Self, MapError> {
+        let data = map.borrow();
+        check_kv_size::<bpf_cgroup_storage_key, V>(data)?;
+
+        Ok(Self {
+            inner: map,
+            _v: PhantomData,
+        })
+    }
+
+    /// Returns the value stored for `key`.
+    pub fn get(&self, key: CgroupStorageKey, flags: u64) -> Result<V, MapError> {
+        hash_map::get(self.inner.borrow(), &key.to_kernel(), flags)
+    }
+}
+
+impl<T: BorrowMut<MapData>, V: Pod> CgroupStorage<T, V> {
+    /// Updates the value stored for `key`.
+    ///
+    /// Only existing entries can be updated; the kernel returns `ENOENT` for a
+    /// cgroup that has no attached program using this map.
+    pub fn insert(
+        &mut self,
+        key: CgroupStorageKey,
+        value: impl Borrow<V>,
+        flags: u64,
+    ) -> Result<(), MapError> {
+        hash_map::insert(
+            self.inner.borrow_mut(),
+            &key.to_kernel(),
+            value.borrow(),
+            flags,
+        )
+    }
+}
+
+/// A per-CPU cgroup storage map backed by `BPF_MAP_TYPE_PERCPU_CGROUP_STORAGE`.
+///
+/// Like [`CgroupStorage`] but each CPU holds a separate value for a given cgroup,
+/// so [`get`](Self::get) returns one value per CPU.
+///
+/// # Minimum kernel version
+///
+/// The minimum kernel version required to use this feature is 4.20.
+#[deprecated = "use the `BPF_MAP_TYPE_CGRP_STORAGE` map type, available since Linux 6.2"]
+#[doc(alias = "BPF_MAP_TYPE_PERCPU_CGROUP_STORAGE")]
+#[derive(Debug)]
+pub struct PerCpuCgroupStorage<T, V: Pod> {
+    pub(crate) inner: T,
+    _v: PhantomData<V>,
+}
+
+impl<T: Borrow<MapData>, V: Pod> PerCpuCgroupStorage<T, V> {
+    pub(crate) fn new(map: T) -> Result<Self, MapError> {
+        let data = map.borrow();
+        check_kv_size::<bpf_cgroup_storage_key, V>(data)?;
+
+        Ok(Self {
+            inner: map,
+            _v: PhantomData,
+        })
+    }
+
+    /// Returns a slice of values - one for each CPU - stored for `key`.
+    pub fn get(&self, key: CgroupStorageKey, flags: u64) -> Result<PerCpuValues<V>, MapError> {
+        let fd = self.inner.borrow().fd().as_fd();
+        let values =
+            bpf_map_lookup_elem_per_cpu(fd, &key.to_kernel(), flags).map_err(|io_error| {
+                SyscallError {
+                    call: "bpf_map_lookup_elem",
+                    io_error,
+                }
+            })?;
+        values.ok_or(MapError::KeyNotFound)
+    }
+}
+
+impl<T: BorrowMut<MapData>, V: Pod> PerCpuCgroupStorage<T, V> {
+    /// Updates the per-CPU values stored for `key`.
+    ///
+    /// Only existing entries can be updated; the kernel returns `ENOENT` for a
+    /// cgroup that has no attached program using this map.
+    pub fn insert(
+        &mut self,
+        key: CgroupStorageKey,
+        values: PerCpuValues<V>,
+        flags: u64,
+    ) -> Result<(), MapError> {
+        let fd = self.inner.borrow_mut().fd().as_fd();
+        bpf_map_update_elem_per_cpu(fd, &key.to_kernel(), &values, flags)
+            .map_err(|io_error| SyscallError {
+                call: "bpf_map_update_elem",
+                io_error,
+            })
+            .map_err(Into::into)
+    }
+}

--- a/aya/src/maps/mod.rs
+++ b/aya/src/maps/mod.rs
@@ -73,6 +73,7 @@ use crate::{
 
 pub mod array;
 pub mod bloom_filter;
+pub mod cgroup_storage;
 pub mod hash_map;
 mod info;
 pub mod lpm_trie;
@@ -88,6 +89,11 @@ pub mod xdp;
 
 pub use array::{Array, CgroupArray, PerCpuArray, ProgramArray};
 pub use bloom_filter::BloomFilter;
+#[expect(
+    deprecated,
+    reason = "re-exporting the deprecated cgroup storage map types"
+)]
+pub use cgroup_storage::{CgroupStorage, CgroupStorageKey, PerCpuCgroupStorage};
 pub use hash_map::{HashMap, PerCpuHashMap};
 pub use info::{MapInfo, MapType, loaded_maps};
 pub use lpm_trie::LpmTrie;
@@ -302,6 +308,8 @@ pub enum Map {
     BloomFilter(MapData),
     /// A [`CgroupArray`] map.
     CgroupArray(MapData),
+    /// A [`CgroupStorage`] map.
+    CgroupStorage(MapData),
     /// A [`CpuMap`] map.
     CpuMap(MapData),
     /// A [`DevMap`] map.
@@ -318,6 +326,8 @@ pub enum Map {
     LruHashMap(MapData),
     /// A [`PerCpuArray`] map.
     PerCpuArray(MapData),
+    /// A [`PerCpuCgroupStorage`] map.
+    PerCpuCgroupStorage(MapData),
     /// A [`PerCpuHashMap`] map.
     PerCpuHashMap(MapData),
     /// A [`PerCpuHashMap`] map that uses a LRU eviction policy.
@@ -356,6 +366,7 @@ impl Map {
             Self::ArrayOfMaps(map) => map.obj.map_type(),
             Self::BloomFilter(map) => map.obj.map_type(),
             Self::CgroupArray(map) => map.obj.map_type(),
+            Self::CgroupStorage(map) => map.obj.map_type(),
             Self::CpuMap(map) => map.obj.map_type(),
             Self::DevMap(map) => map.obj.map_type(),
             Self::DevMapHash(map) => map.obj.map_type(),
@@ -364,6 +375,7 @@ impl Map {
             Self::LpmTrie(map) => map.obj.map_type(),
             Self::LruHashMap(map) => map.obj.map_type(),
             Self::PerCpuArray(map) => map.obj.map_type(),
+            Self::PerCpuCgroupStorage(map) => map.obj.map_type(),
             Self::PerCpuHashMap(map) => map.obj.map_type(),
             Self::PerCpuLruHashMap(map) => map.obj.map_type(),
             Self::PerfEventArray(map) => map.obj.map_type(),
@@ -391,6 +403,7 @@ impl Map {
             Self::ArrayOfMaps(map) => map.pin(path),
             Self::BloomFilter(map) => map.pin(path),
             Self::CgroupArray(map) => map.pin(path),
+            Self::CgroupStorage(map) => map.pin(path),
             Self::CpuMap(map) => map.pin(path),
             Self::DevMap(map) => map.pin(path),
             Self::DevMapHash(map) => map.pin(path),
@@ -399,6 +412,7 @@ impl Map {
             Self::LpmTrie(map) => map.pin(path),
             Self::LruHashMap(map) => map.pin(path),
             Self::PerCpuArray(map) => map.pin(path),
+            Self::PerCpuCgroupStorage(map) => map.pin(path),
             Self::PerCpuHashMap(map) => map.pin(path),
             Self::PerCpuLruHashMap(map) => map.pin(path),
             Self::PerfEventArray(map) => map.pin(path),
@@ -452,7 +466,7 @@ impl Map {
             bpf_map_type::BPF_MAP_TYPE_CGROUP_ARRAY => Self::CgroupArray(map_data),
             bpf_map_type::BPF_MAP_TYPE_ARRAY_OF_MAPS => Self::ArrayOfMaps(map_data),
             bpf_map_type::BPF_MAP_TYPE_HASH_OF_MAPS => Self::HashOfMaps(map_data),
-            bpf_map_type::BPF_MAP_TYPE_CGROUP_STORAGE_DEPRECATED => Self::Unsupported(map_data),
+            bpf_map_type::BPF_MAP_TYPE_CGROUP_STORAGE_DEPRECATED => Self::CgroupStorage(map_data),
             bpf_map_type::BPF_MAP_TYPE_REUSEPORT_SOCKARRAY => Self::ReusePortSockArray(map_data),
             bpf_map_type::BPF_MAP_TYPE_SK_STORAGE => Self::SkStorage(map_data),
             bpf_map_type::BPF_MAP_TYPE_STRUCT_OPS => Self::Unsupported(map_data),
@@ -462,7 +476,7 @@ impl Map {
             bpf_map_type::BPF_MAP_TYPE_CGRP_STORAGE => Self::Unsupported(map_data),
             bpf_map_type::BPF_MAP_TYPE_ARENA => Self::Unsupported(map_data),
             bpf_map_type::BPF_MAP_TYPE_PERCPU_CGROUP_STORAGE_DEPRECATED => {
-                Self::Unsupported(map_data)
+                Self::PerCpuCgroupStorage(map_data)
             }
             bpf_map_type::BPF_MAP_TYPE_UNSPEC => return Err(MapError::InvalidMapType { map_type }),
             bpf_map_type::__MAX_BPF_MAP_TYPE => return Err(MapError::InvalidMapType { map_type }),
@@ -474,14 +488,16 @@ impl Map {
 // Implements map pinning for different map implementations
 macro_rules! impl_map_pin {
     ($ty_param:tt {
-        $($ty:ident),+ $(,)?
+        $($(#[$meta:meta])* $ty:ident),+ $(,)?
     }) => {
-        $(impl_map_pin!(<$ty_param> $ty);)+
+        $(impl_map_pin!($(#[$meta])* <$ty_param> $ty);)+
     };
     (
+      $(#[$meta:meta])*
       <($($ty_param:ident),*)>
       $ty:ident
     ) => {
+            $(#[$meta])*
             impl<T: Borrow<MapData>, $($ty_param: Pod),*> $ty<T, $($ty_param),*>
             {
                     /// Pins the map to a BPF filesystem.
@@ -511,7 +527,11 @@ impl_map_pin!(() {
 
 impl_map_pin!((V) {
     Array,
+    #[expect(deprecated, reason = "implementing pinning for the deprecated cgroup storage map types")]
+    CgroupStorage,
     PerCpuArray,
+    #[expect(deprecated, reason = "implementing pinning for the deprecated cgroup storage map types")]
+    PerCpuCgroupStorage,
     SockHash,
     BloomFilter,
     Queue,
@@ -595,7 +615,11 @@ impl_try_from_map!(() {
 impl_try_from_map!((V) {
     Array,
     BloomFilter,
+    #[expect(deprecated, reason = "implementing TryFrom for the deprecated cgroup storage map types")]
+    CgroupStorage,
     PerCpuArray,
+    #[expect(deprecated, reason = "implementing TryFrom for the deprecated cgroup storage map types")]
+    PerCpuCgroupStorage,
     Queue,
     SockHash,
     SkStorage,

--- a/ebpf/aya-ebpf/src/btf_maps/cgroup_storage.rs
+++ b/ebpf/aya-ebpf/src/btf_maps/cgroup_storage.rs
@@ -1,0 +1,109 @@
+#![expect(
+    deprecated,
+    reason = "this module implements the deprecated cgroup storage map types"
+)]
+
+use crate::{
+    bindings::bpf_cgroup_storage_key, btf_maps::btf_map_def, helpers::bpf_get_local_storage,
+};
+
+macro_rules! define_cgroup_storage {
+    ($(#[$doc:meta])* $name:ident, $map_type:ident $(,)?) => {
+        btf_map_def!(
+            $(#[$doc])*
+            #[deprecated = "use the `BPF_MAP_TYPE_CGRP_STORAGE` map type, available since Linux 6.2"]
+            pub struct $name<V>,
+            map_type: $map_type,
+            max_entries: 0,
+            map_flags: 0,
+            key_type: bpf_cgroup_storage_key,
+            value_type: V,
+        );
+
+        impl<V> $name<V> {
+            /// Returns a mutable pointer to the storage of the cgroup the program
+            /// is running in.
+            ///
+            /// Wraps the `bpf_get_local_storage` helper, which the kernel keys
+            /// implicitly by the current cgroup; there is no lookup that can fail,
+            /// so the returned pointer is always valid for the duration of the
+            /// program.
+            #[inline(always)]
+            pub fn get_ptr_mut(&self) -> *mut V {
+                // SAFETY: `self` is a valid pointer managed by aya, and the
+                // `flags` argument is reserved and must be zero.
+                unsafe { bpf_get_local_storage(self.as_ptr().cast(), 0) }.cast()
+            }
+        }
+    };
+}
+
+define_cgroup_storage!(
+    /// A BTF-compatible cgroup local storage map.
+    ///
+    /// Stores a value owned by the cgroup the program is attached to. The kernel
+    /// allocates one entry per cgroup on attach; eBPF programs read and write it
+    /// with [`get_ptr_mut`], and user space accesses it by
+    /// `bpf_cgroup_storage_key`.
+    ///
+    /// The kernel keeps one value per cgroup with no implicit synchronization, so
+    /// programs on different CPUs share it; read-modify-write updates can lose
+    /// writes under load. Use [`PerCpuCgroupStorage`] for lock-free per-CPU
+    /// accumulation, or guard the value with a `bpf_spin_lock`.
+    ///
+    /// # Minimum kernel version
+    ///
+    /// The minimum kernel version required to use this feature is 4.19.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # #![expect(deprecated, reason = "documenting the deprecated cgroup storage map type")]
+    /// use aya_ebpf::{btf_maps::CgroupStorage, macros::btf_map, programs::SkBuffContext};
+    ///
+    /// #[btf_map]
+    /// static STORAGE: CgroupStorage<u64> = CgroupStorage::new();
+    ///
+    /// # unsafe fn try_test(_ctx: SkBuffContext) -> Result<(), i64> {
+    /// let counter = STORAGE.get_ptr_mut();
+    /// unsafe { *counter += 1 };
+    /// # Ok(())
+    /// # }
+    /// ```
+    ///
+    /// [`get_ptr_mut`]: CgroupStorage::get_ptr_mut
+    CgroupStorage,
+    BPF_MAP_TYPE_CGROUP_STORAGE_DEPRECATED,
+);
+
+define_cgroup_storage!(
+    /// A BTF-compatible per-CPU cgroup local storage map.
+    ///
+    /// Like [`CgroupStorage`] but each CPU holds its own copy of the value, which
+    /// lets programs accumulate without locking. [`get_ptr_mut`] returns the
+    /// running CPU's copy; user space reads back one value per CPU.
+    ///
+    /// # Minimum kernel version
+    ///
+    /// The minimum kernel version required to use this feature is 4.20.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # #![expect(deprecated, reason = "documenting the deprecated cgroup storage map type")]
+    /// use aya_ebpf::{btf_maps::PerCpuCgroupStorage, macros::btf_map, programs::SkBuffContext};
+    ///
+    /// #[btf_map]
+    /// static STORAGE: PerCpuCgroupStorage<u64> = PerCpuCgroupStorage::new();
+    ///
+    /// # unsafe fn try_test(_ctx: SkBuffContext) -> Result<(), i64> {
+    /// let counter = STORAGE.get_ptr_mut();
+    /// unsafe { *counter += 1 };
+    /// # Ok(())
+    /// # }
+    /// ```
+    ///
+    /// [`get_ptr_mut`]: PerCpuCgroupStorage::get_ptr_mut
+    PerCpuCgroupStorage,
+    BPF_MAP_TYPE_PERCPU_CGROUP_STORAGE_DEPRECATED,
+);

--- a/ebpf/aya-ebpf/src/btf_maps/mod.rs
+++ b/ebpf/aya-ebpf/src/btf_maps/mod.rs
@@ -1,6 +1,7 @@
 pub mod array;
 pub mod bloom_filter;
 pub mod cgroup_array;
+pub mod cgroup_storage;
 pub mod cpu_map;
 pub mod dev_map;
 pub mod dev_map_hash;
@@ -24,6 +25,11 @@ pub mod xsk_map;
 pub use array::Array;
 pub use bloom_filter::BloomFilter;
 pub use cgroup_array::CgroupArray;
+#[expect(
+    deprecated,
+    reason = "re-exporting the deprecated cgroup storage map types"
+)]
+pub use cgroup_storage::{CgroupStorage, PerCpuCgroupStorage};
 pub use cpu_map::CpuMap;
 pub use dev_map::DevMap;
 pub use dev_map_hash::DevMapHash;

--- a/ebpf/aya-ebpf/src/maps/cgroup_storage.rs
+++ b/ebpf/aya-ebpf/src/maps/cgroup_storage.rs
@@ -1,0 +1,139 @@
+#![expect(
+    deprecated,
+    reason = "this module implements the deprecated cgroup storage map types"
+)]
+
+use core::marker::PhantomData;
+
+use crate::{
+    bindings::{bpf_cgroup_storage_key, bpf_map_type},
+    helpers::bpf_get_local_storage,
+    maps::{MapDef, PinningType},
+};
+
+macro_rules! define_cgroup_storage {
+    ($(#[$doc:meta])* $name:ident, $map_type:expr $(,)?) => {
+        $(#[$doc])*
+        #[deprecated = "use the `BPF_MAP_TYPE_CGRP_STORAGE` map type, available since Linux 6.2"]
+        #[repr(transparent)]
+        pub struct $name<V> {
+            def: MapDef,
+            _v: PhantomData<V>,
+        }
+
+        impl<V> $name<V> {
+            /// Creates the map definition. Cgroup storage maps have no capacity
+            /// of their own; the kernel allocates one entry per cgroup the
+            /// program is attached to, so `max_entries` is always zero.
+            pub const fn new() -> Self {
+                Self {
+                    def: MapDef::new::<bpf_cgroup_storage_key, V>($map_type, 0, 0, PinningType::None),
+                    _v: PhantomData,
+                }
+            }
+
+            /// Creates a map definition that is pinned to the BPF filesystem.
+            pub const fn pinned() -> Self {
+                Self {
+                    def: MapDef::new::<bpf_cgroup_storage_key, V>(
+                        $map_type,
+                        0,
+                        0,
+                        PinningType::ByName,
+                    ),
+                    _v: PhantomData,
+                }
+            }
+
+            /// Returns a mutable pointer to the storage of the cgroup the program
+            /// is running in.
+            ///
+            /// Wraps the `bpf_get_local_storage` helper, which the kernel keys
+            /// implicitly by the current cgroup; there is no lookup that can fail,
+            /// so the returned pointer is always valid for the duration of the
+            /// program.
+            #[inline(always)]
+            pub fn get_ptr_mut(&self) -> *mut V {
+                // SAFETY: `self.def` is a valid pointer managed by aya, and the
+                // `flags` argument is reserved and must be zero.
+                unsafe { bpf_get_local_storage(self.def.as_ptr(), 0) }.cast()
+            }
+        }
+
+        impl<V> Default for $name<V> {
+            fn default() -> Self {
+                Self::new()
+            }
+        }
+    };
+}
+
+define_cgroup_storage!(
+    /// Cgroup local storage.
+    ///
+    /// Stores a value owned by the cgroup the program is attached to. The kernel
+    /// allocates one entry per cgroup on attach; eBPF programs read and write it
+    /// with [`get_ptr_mut`], and user space accesses it by
+    /// `bpf_cgroup_storage_key`.
+    ///
+    /// The kernel keeps one value per cgroup with no implicit synchronization, so
+    /// programs on different CPUs share it; read-modify-write updates can lose
+    /// writes under load. Use [`PerCpuCgroupStorage`] for lock-free per-CPU
+    /// accumulation, or guard the value with a `bpf_spin_lock`.
+    ///
+    /// # Minimum kernel version
+    ///
+    /// The minimum kernel version required to use this feature is 4.19.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # #![expect(deprecated, reason = "documenting the deprecated cgroup storage map type")]
+    /// use aya_ebpf::{macros::map, maps::CgroupStorage, programs::SkBuffContext};
+    ///
+    /// #[map]
+    /// static STORAGE: CgroupStorage<u64> = CgroupStorage::new();
+    ///
+    /// # unsafe fn try_test(_ctx: SkBuffContext) -> Result<(), i64> {
+    /// let counter = STORAGE.get_ptr_mut();
+    /// unsafe { *counter += 1 };
+    /// # Ok(())
+    /// # }
+    /// ```
+    ///
+    /// [`get_ptr_mut`]: CgroupStorage::get_ptr_mut
+    CgroupStorage,
+    bpf_map_type::BPF_MAP_TYPE_CGROUP_STORAGE_DEPRECATED,
+);
+
+define_cgroup_storage!(
+    /// Per-CPU cgroup local storage.
+    ///
+    /// Like [`CgroupStorage`] but each CPU holds its own copy of the value, which
+    /// lets programs accumulate without locking. [`get_ptr_mut`] returns the
+    /// running CPU's copy; user space reads back one value per CPU.
+    ///
+    /// # Minimum kernel version
+    ///
+    /// The minimum kernel version required to use this feature is 4.20.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # #![expect(deprecated, reason = "documenting the deprecated cgroup storage map type")]
+    /// use aya_ebpf::{macros::map, maps::PerCpuCgroupStorage, programs::SkBuffContext};
+    ///
+    /// #[map]
+    /// static STORAGE: PerCpuCgroupStorage<u64> = PerCpuCgroupStorage::new();
+    ///
+    /// # unsafe fn try_test(_ctx: SkBuffContext) -> Result<(), i64> {
+    /// let counter = STORAGE.get_ptr_mut();
+    /// unsafe { *counter += 1 };
+    /// # Ok(())
+    /// # }
+    /// ```
+    ///
+    /// [`get_ptr_mut`]: PerCpuCgroupStorage::get_ptr_mut
+    PerCpuCgroupStorage,
+    bpf_map_type::BPF_MAP_TYPE_PERCPU_CGROUP_STORAGE_DEPRECATED,
+);

--- a/ebpf/aya-ebpf/src/maps/mod.rs
+++ b/ebpf/aya-ebpf/src/maps/mod.rs
@@ -79,6 +79,7 @@ macro_rules! map_constructors {
 pub mod array;
 pub mod bloom_filter;
 pub mod cgroup_array;
+pub mod cgroup_storage;
 pub mod hash_map;
 pub mod lpm_trie;
 pub mod per_cpu_array;
@@ -96,6 +97,11 @@ pub mod xdp;
 pub use array::Array;
 pub use bloom_filter::BloomFilter;
 pub use cgroup_array::CgroupArray;
+#[expect(
+    deprecated,
+    reason = "re-exporting the deprecated cgroup storage map types"
+)]
+pub use cgroup_storage::{CgroupStorage, PerCpuCgroupStorage};
 pub use hash_map::{HashMap, LruHashMap, LruPerCpuHashMap, PerCpuHashMap};
 pub use lpm_trie::LpmTrie;
 pub use per_cpu_array::PerCpuArray;

--- a/test/integration-ebpf/Cargo.toml
+++ b/test/integration-ebpf/Cargo.toml
@@ -195,3 +195,7 @@ path = "src/xsk_map.rs"
 [[bin]]
 name = "cgroup_array"
 path = "src/cgroup_array.rs"
+
+[[bin]]
+name = "cgroup_storage"
+path = "src/cgroup_storage.rs"

--- a/test/integration-ebpf/src/cgroup_storage.rs
+++ b/test/integration-ebpf/src/cgroup_storage.rs
@@ -1,0 +1,50 @@
+#![no_std]
+#![no_main]
+#![expect(unused_crate_dependencies, reason = "used in other bins")]
+#![expect(
+    deprecated,
+    reason = "exercising the deprecated cgroup storage map types"
+)]
+
+#[cfg(not(test))]
+extern crate ebpf_panic;
+
+use aya_ebpf::{
+    bindings::sk_action,
+    btf_maps::{CgroupStorage as BtfCgroupStorage, PerCpuCgroupStorage as BtfPerCpuCgroupStorage},
+    macros::{btf_map, cgroup_sock_addr, map},
+    maps::{
+        CgroupStorage as LegacyCgroupStorage, PerCpuCgroupStorage as LegacyPerCpuCgroupStorage,
+    },
+    programs::SockAddrContext,
+};
+
+#[map]
+static STORAGE_LEGACY: LegacyCgroupStorage<u64> = LegacyCgroupStorage::new();
+
+#[map]
+static PERCPU_LEGACY: LegacyPerCpuCgroupStorage<u64> = LegacyPerCpuCgroupStorage::new();
+
+#[btf_map]
+static STORAGE: BtfCgroupStorage<u64> = BtfCgroupStorage::new();
+
+#[btf_map]
+static PERCPU: BtfPerCpuCgroupStorage<u64> = BtfPerCpuCgroupStorage::new();
+
+// The kernel allows a program to reference at most one map of each cgroup
+// storage type, so the legacy and BTF maps are exercised by separate programs.
+macro_rules! define_connect4_test {
+    ($storage:ident, $percpu:ident, $prog:ident $(,)?) => {
+        #[cgroup_sock_addr(connect4)]
+        fn $prog(_ctx: SockAddrContext) -> i32 {
+            // The helper returns a valid pointer for any cgroup-attached program,
+            // so the dereference needs no null check.
+            unsafe { *$storage.get_ptr_mut() += 1 };
+            unsafe { *$percpu.get_ptr_mut() += 1 };
+            sk_action::SK_PASS as i32
+        }
+    };
+}
+
+define_connect4_test!(STORAGE_LEGACY, PERCPU_LEGACY, connect4_legacy);
+define_connect4_test!(STORAGE, PERCPU, connect4_btf);

--- a/test/integration-test/src/lib.rs
+++ b/test/integration-test/src/lib.rs
@@ -44,6 +44,7 @@ bpf_file!(
     BPF_PROBE_READ => "bpf_probe_read",
     BTF_MAPS_PLAIN => "btf_maps_plain",
     CGROUP_ARRAY => "cgroup_array",
+    CGROUP_STORAGE => "cgroup_storage",
     CPU_MAP => "cpu_map",
     DEV_MAP => "dev_map",
     FEXIT => "fexit",

--- a/test/integration-test/src/tests.rs
+++ b/test/integration-test/src/tests.rs
@@ -15,6 +15,7 @@ mod btf_map_of_maps;
 mod btf_maps;
 mod btf_relocations;
 mod cgroup_array;
+mod cgroup_storage;
 mod elf;
 mod feature_probe;
 mod fexit;

--- a/test/integration-test/src/tests/cgroup_storage.rs
+++ b/test/integration-test/src/tests/cgroup_storage.rs
@@ -1,0 +1,88 @@
+#![expect(
+    deprecated,
+    reason = "exercising the deprecated cgroup storage map types"
+)]
+
+use std::{
+    net::{Ipv4Addr, TcpListener, TcpStream},
+    os::unix::fs::MetadataExt as _,
+    process,
+};
+
+use aya::{
+    EbpfLoader,
+    maps::{CgroupStorage, CgroupStorageKey, MapType, PerCpuCgroupStorage},
+    programs::{CgroupAttachMode, CgroupSockAddr},
+    sys::is_map_supported,
+    util::KernelVersion,
+};
+use aya_obj::generated::bpf_attach_type::BPF_CGROUP_INET4_CONNECT;
+use rstest::rstest;
+
+use crate::utils::{Cgroup, NetNsGuard, is_cgroup2};
+
+#[rstest]
+#[case::legacy("STORAGE_LEGACY", "PERCPU_LEGACY", "connect4_legacy")]
+#[case::btf("STORAGE", "PERCPU", "connect4_btf")]
+#[test_attr(test_log::test)]
+fn cgroup_storage(#[case] storage_map: &str, #[case] percpu_map: &str, #[case] prog: &str) {
+    if !is_map_supported(MapType::CgroupStorage).unwrap()
+        || !is_map_supported(MapType::PerCpuCgroupStorage).unwrap()
+    {
+        eprintln!("skipping test - cgroup storage maps not supported");
+        return;
+    }
+
+    if !is_cgroup2() {
+        eprintln!("skipping test - /sys/fs/cgroup is not cgroup2");
+        return;
+    }
+
+    let kernel_version = KernelVersion::current().unwrap();
+    if kernel_version < KernelVersion::new(4, 20, 0) {
+        eprintln!(
+            "skipping test - per-cpu cgroup storage added in 4.20, kernel is {kernel_version:?}"
+        );
+        return;
+    }
+
+    let mut bpf = EbpfLoader::new()
+        .load(crate::CGROUP_STORAGE)
+        .expect("load cgroup_storage program");
+
+    let _netns = NetNsGuard::new();
+    let root = Cgroup::root();
+    let cgroup = root.create_child(prog);
+    let cgroup_inode_id = cgroup.fd().metadata().expect("cgroup metadata").ino();
+
+    {
+        let program: &mut CgroupSockAddr = bpf
+            .program_mut(prog)
+            .unwrap_or_else(|| panic!("missing program {prog}"))
+            .try_into()
+            .unwrap_or_else(|err| panic!("program {prog} is not a cgroup_sock_addr: {err}"));
+        program
+            .load()
+            .unwrap_or_else(|err| panic!("load {prog}: {err}"));
+        program
+            .attach(cgroup.fd(), CgroupAttachMode::Single)
+            .unwrap_or_else(|err| panic!("attach {prog}: {err}"));
+    }
+
+    let cgroup = cgroup.into_cgroup();
+    cgroup.write_pid(process::id());
+
+    // A single connect over loopback fires the connect4 program exactly once.
+    let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).unwrap();
+    let addr = listener.local_addr().unwrap();
+    TcpStream::connect(addr).unwrap();
+
+    let key = CgroupStorageKey::new(cgroup_inode_id, BPF_CGROUP_INET4_CONNECT as u32);
+
+    let storage = CgroupStorage::<_, u64>::try_from(bpf.map(storage_map).unwrap()).unwrap();
+    assert_eq!(storage.get(key, 0).unwrap(), 1);
+
+    let percpu = PerCpuCgroupStorage::<_, u64>::try_from(bpf.map(percpu_map).unwrap()).unwrap();
+    let percpu = percpu.get(key, 0).unwrap();
+    assert_eq!(percpu.iter().sum::<u64>(), 1);
+}

--- a/xtask/public-api/aya-ebpf.txt
+++ b/xtask/public-api/aya-ebpf.txt
@@ -54,6 +54,35 @@ impl<const MAX_ENTRIES: usize, const FLAGS: usize> core::marker::Unpin for aya_e
 impl<const MAX_ENTRIES: usize, const FLAGS: usize> core::marker::UnsafeUnpin for aya_ebpf::btf_maps::cgroup_array::CgroupArray<MAX_ENTRIES, FLAGS>
 impl<const MAX_ENTRIES: usize, const FLAGS: usize> core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::btf_maps::cgroup_array::CgroupArray<MAX_ENTRIES, FLAGS>
 impl<const MAX_ENTRIES: usize, const FLAGS: usize> core::panic::unwind_safe::UnwindSafe for aya_ebpf::btf_maps::cgroup_array::CgroupArray<MAX_ENTRIES, FLAGS>
+pub mod aya_ebpf::btf_maps::cgroup_storage
+#[repr(C)] pub struct aya_ebpf::btf_maps::cgroup_storage::CgroupStorage<V>
+impl<V> aya_ebpf::btf_maps::cgroup_storage::CgroupStorage<V>
+pub fn aya_ebpf::btf_maps::cgroup_storage::CgroupStorage<V>::get_ptr_mut(&self) -> *mut V
+impl<V> aya_ebpf::btf_maps::cgroup_storage::CgroupStorage<V>
+pub const fn aya_ebpf::btf_maps::cgroup_storage::CgroupStorage<V>::new() -> Self
+impl<V> core::default::Default for aya_ebpf::btf_maps::cgroup_storage::CgroupStorage<V>
+pub fn aya_ebpf::btf_maps::cgroup_storage::CgroupStorage<V>::default() -> Self
+impl<V> core::marker::Sync for aya_ebpf::btf_maps::cgroup_storage::CgroupStorage<V>
+impl<V> core::marker::Freeze for aya_ebpf::btf_maps::cgroup_storage::CgroupStorage<V>
+impl<V> !core::marker::Send for aya_ebpf::btf_maps::cgroup_storage::CgroupStorage<V>
+impl<V> core::marker::Unpin for aya_ebpf::btf_maps::cgroup_storage::CgroupStorage<V>
+impl<V> core::marker::UnsafeUnpin for aya_ebpf::btf_maps::cgroup_storage::CgroupStorage<V>
+impl<V> core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::btf_maps::cgroup_storage::CgroupStorage<V> where V: core::panic::unwind_safe::RefUnwindSafe
+impl<V> core::panic::unwind_safe::UnwindSafe for aya_ebpf::btf_maps::cgroup_storage::CgroupStorage<V> where V: core::panic::unwind_safe::RefUnwindSafe
+#[repr(C)] pub struct aya_ebpf::btf_maps::cgroup_storage::PerCpuCgroupStorage<V>
+impl<V> aya_ebpf::btf_maps::cgroup_storage::PerCpuCgroupStorage<V>
+pub fn aya_ebpf::btf_maps::cgroup_storage::PerCpuCgroupStorage<V>::get_ptr_mut(&self) -> *mut V
+impl<V> aya_ebpf::btf_maps::cgroup_storage::PerCpuCgroupStorage<V>
+pub const fn aya_ebpf::btf_maps::cgroup_storage::PerCpuCgroupStorage<V>::new() -> Self
+impl<V> core::default::Default for aya_ebpf::btf_maps::cgroup_storage::PerCpuCgroupStorage<V>
+pub fn aya_ebpf::btf_maps::cgroup_storage::PerCpuCgroupStorage<V>::default() -> Self
+impl<V> core::marker::Sync for aya_ebpf::btf_maps::cgroup_storage::PerCpuCgroupStorage<V>
+impl<V> core::marker::Freeze for aya_ebpf::btf_maps::cgroup_storage::PerCpuCgroupStorage<V>
+impl<V> !core::marker::Send for aya_ebpf::btf_maps::cgroup_storage::PerCpuCgroupStorage<V>
+impl<V> core::marker::Unpin for aya_ebpf::btf_maps::cgroup_storage::PerCpuCgroupStorage<V>
+impl<V> core::marker::UnsafeUnpin for aya_ebpf::btf_maps::cgroup_storage::PerCpuCgroupStorage<V>
+impl<V> core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::btf_maps::cgroup_storage::PerCpuCgroupStorage<V> where V: core::panic::unwind_safe::RefUnwindSafe
+impl<V> core::panic::unwind_safe::UnwindSafe for aya_ebpf::btf_maps::cgroup_storage::PerCpuCgroupStorage<V> where V: core::panic::unwind_safe::RefUnwindSafe
 pub mod aya_ebpf::btf_maps::cpu_map
 #[repr(C)] pub struct aya_ebpf::btf_maps::cpu_map::CpuMap<const MAX_ENTRIES: usize, const FLAGS: usize>
 impl<const MAX_ENTRIES: usize, const FLAGS: usize> aya_ebpf::btf_maps::cpu_map::CpuMap<MAX_ENTRIES, FLAGS>
@@ -521,6 +550,20 @@ impl<const MAX_ENTRIES: usize, const FLAGS: usize> core::marker::Unpin for aya_e
 impl<const MAX_ENTRIES: usize, const FLAGS: usize> core::marker::UnsafeUnpin for aya_ebpf::btf_maps::cgroup_array::CgroupArray<MAX_ENTRIES, FLAGS>
 impl<const MAX_ENTRIES: usize, const FLAGS: usize> core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::btf_maps::cgroup_array::CgroupArray<MAX_ENTRIES, FLAGS>
 impl<const MAX_ENTRIES: usize, const FLAGS: usize> core::panic::unwind_safe::UnwindSafe for aya_ebpf::btf_maps::cgroup_array::CgroupArray<MAX_ENTRIES, FLAGS>
+#[repr(C)] pub struct aya_ebpf::btf_maps::CgroupStorage<V>
+impl<V> aya_ebpf::btf_maps::cgroup_storage::CgroupStorage<V>
+pub fn aya_ebpf::btf_maps::cgroup_storage::CgroupStorage<V>::get_ptr_mut(&self) -> *mut V
+impl<V> aya_ebpf::btf_maps::cgroup_storage::CgroupStorage<V>
+pub const fn aya_ebpf::btf_maps::cgroup_storage::CgroupStorage<V>::new() -> Self
+impl<V> core::default::Default for aya_ebpf::btf_maps::cgroup_storage::CgroupStorage<V>
+pub fn aya_ebpf::btf_maps::cgroup_storage::CgroupStorage<V>::default() -> Self
+impl<V> core::marker::Sync for aya_ebpf::btf_maps::cgroup_storage::CgroupStorage<V>
+impl<V> core::marker::Freeze for aya_ebpf::btf_maps::cgroup_storage::CgroupStorage<V>
+impl<V> !core::marker::Send for aya_ebpf::btf_maps::cgroup_storage::CgroupStorage<V>
+impl<V> core::marker::Unpin for aya_ebpf::btf_maps::cgroup_storage::CgroupStorage<V>
+impl<V> core::marker::UnsafeUnpin for aya_ebpf::btf_maps::cgroup_storage::CgroupStorage<V>
+impl<V> core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::btf_maps::cgroup_storage::CgroupStorage<V> where V: core::panic::unwind_safe::RefUnwindSafe
+impl<V> core::panic::unwind_safe::UnwindSafe for aya_ebpf::btf_maps::cgroup_storage::CgroupStorage<V> where V: core::panic::unwind_safe::RefUnwindSafe
 #[repr(C)] pub struct aya_ebpf::btf_maps::CpuMap<const MAX_ENTRIES: usize, const FLAGS: usize>
 impl<const MAX_ENTRIES: usize, const FLAGS: usize> aya_ebpf::btf_maps::cpu_map::CpuMap<MAX_ENTRIES, FLAGS>
 pub const fn aya_ebpf::btf_maps::cpu_map::CpuMap<MAX_ENTRIES, FLAGS>::new() -> Self
@@ -671,6 +714,20 @@ impl<T, const MAX_ENTRIES: usize, const FLAGS: usize> core::marker::Unpin for ay
 impl<T, const MAX_ENTRIES: usize, const FLAGS: usize> core::marker::UnsafeUnpin for aya_ebpf::btf_maps::per_cpu_array::PerCpuArray<T, MAX_ENTRIES, FLAGS>
 impl<T, const MAX_ENTRIES: usize, const FLAGS: usize> core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::btf_maps::per_cpu_array::PerCpuArray<T, MAX_ENTRIES, FLAGS> where T: core::panic::unwind_safe::RefUnwindSafe
 impl<T, const MAX_ENTRIES: usize, const FLAGS: usize> core::panic::unwind_safe::UnwindSafe for aya_ebpf::btf_maps::per_cpu_array::PerCpuArray<T, MAX_ENTRIES, FLAGS> where T: core::panic::unwind_safe::RefUnwindSafe
+#[repr(C)] pub struct aya_ebpf::btf_maps::PerCpuCgroupStorage<V>
+impl<V> aya_ebpf::btf_maps::cgroup_storage::PerCpuCgroupStorage<V>
+pub fn aya_ebpf::btf_maps::cgroup_storage::PerCpuCgroupStorage<V>::get_ptr_mut(&self) -> *mut V
+impl<V> aya_ebpf::btf_maps::cgroup_storage::PerCpuCgroupStorage<V>
+pub const fn aya_ebpf::btf_maps::cgroup_storage::PerCpuCgroupStorage<V>::new() -> Self
+impl<V> core::default::Default for aya_ebpf::btf_maps::cgroup_storage::PerCpuCgroupStorage<V>
+pub fn aya_ebpf::btf_maps::cgroup_storage::PerCpuCgroupStorage<V>::default() -> Self
+impl<V> core::marker::Sync for aya_ebpf::btf_maps::cgroup_storage::PerCpuCgroupStorage<V>
+impl<V> core::marker::Freeze for aya_ebpf::btf_maps::cgroup_storage::PerCpuCgroupStorage<V>
+impl<V> !core::marker::Send for aya_ebpf::btf_maps::cgroup_storage::PerCpuCgroupStorage<V>
+impl<V> core::marker::Unpin for aya_ebpf::btf_maps::cgroup_storage::PerCpuCgroupStorage<V>
+impl<V> core::marker::UnsafeUnpin for aya_ebpf::btf_maps::cgroup_storage::PerCpuCgroupStorage<V>
+impl<V> core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::btf_maps::cgroup_storage::PerCpuCgroupStorage<V> where V: core::panic::unwind_safe::RefUnwindSafe
+impl<V> core::panic::unwind_safe::UnwindSafe for aya_ebpf::btf_maps::cgroup_storage::PerCpuCgroupStorage<V> where V: core::panic::unwind_safe::RefUnwindSafe
 #[repr(C)] pub struct aya_ebpf::btf_maps::PerCpuHashMap<K, V, const MAX_ENTRIES: usize, const FLAGS: usize>
 impl<K, V, const MAX_ENTRIES: usize, const FLAGS: usize> aya_ebpf::btf_maps::hash_map::PerCpuHashMap<K, V, MAX_ENTRIES, FLAGS>
 pub unsafe fn aya_ebpf::btf_maps::hash_map::PerCpuHashMap<K, V, MAX_ENTRIES, FLAGS>::get(&self, impl core::borrow::Borrow<K>) -> core::option::Option<&V>
@@ -929,6 +986,35 @@ impl core::marker::Unpin for aya_ebpf::maps::cgroup_array::CgroupArray
 impl core::marker::UnsafeUnpin for aya_ebpf::maps::cgroup_array::CgroupArray
 impl !core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::maps::cgroup_array::CgroupArray
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf::maps::cgroup_array::CgroupArray
+pub mod aya_ebpf::maps::cgroup_storage
+#[repr(transparent)] pub struct aya_ebpf::maps::cgroup_storage::CgroupStorage<V>
+impl<V> aya_ebpf::maps::cgroup_storage::CgroupStorage<V>
+pub fn aya_ebpf::maps::cgroup_storage::CgroupStorage<V>::get_ptr_mut(&self) -> *mut V
+pub const fn aya_ebpf::maps::cgroup_storage::CgroupStorage<V>::new() -> Self
+pub const fn aya_ebpf::maps::cgroup_storage::CgroupStorage<V>::pinned() -> Self
+impl<V> core::default::Default for aya_ebpf::maps::cgroup_storage::CgroupStorage<V>
+pub fn aya_ebpf::maps::cgroup_storage::CgroupStorage<V>::default() -> Self
+impl<V> !core::marker::Freeze for aya_ebpf::maps::cgroup_storage::CgroupStorage<V>
+impl<V> core::marker::Send for aya_ebpf::maps::cgroup_storage::CgroupStorage<V> where V: core::marker::Send
+impl<V> core::marker::Sync for aya_ebpf::maps::cgroup_storage::CgroupStorage<V> where V: core::marker::Sync
+impl<V> core::marker::Unpin for aya_ebpf::maps::cgroup_storage::CgroupStorage<V> where V: core::marker::Unpin
+impl<V> core::marker::UnsafeUnpin for aya_ebpf::maps::cgroup_storage::CgroupStorage<V>
+impl<V> !core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::maps::cgroup_storage::CgroupStorage<V>
+impl<V> core::panic::unwind_safe::UnwindSafe for aya_ebpf::maps::cgroup_storage::CgroupStorage<V> where V: core::panic::unwind_safe::UnwindSafe
+#[repr(transparent)] pub struct aya_ebpf::maps::cgroup_storage::PerCpuCgroupStorage<V>
+impl<V> aya_ebpf::maps::cgroup_storage::PerCpuCgroupStorage<V>
+pub fn aya_ebpf::maps::cgroup_storage::PerCpuCgroupStorage<V>::get_ptr_mut(&self) -> *mut V
+pub const fn aya_ebpf::maps::cgroup_storage::PerCpuCgroupStorage<V>::new() -> Self
+pub const fn aya_ebpf::maps::cgroup_storage::PerCpuCgroupStorage<V>::pinned() -> Self
+impl<V> core::default::Default for aya_ebpf::maps::cgroup_storage::PerCpuCgroupStorage<V>
+pub fn aya_ebpf::maps::cgroup_storage::PerCpuCgroupStorage<V>::default() -> Self
+impl<V> !core::marker::Freeze for aya_ebpf::maps::cgroup_storage::PerCpuCgroupStorage<V>
+impl<V> core::marker::Send for aya_ebpf::maps::cgroup_storage::PerCpuCgroupStorage<V> where V: core::marker::Send
+impl<V> core::marker::Sync for aya_ebpf::maps::cgroup_storage::PerCpuCgroupStorage<V> where V: core::marker::Sync
+impl<V> core::marker::Unpin for aya_ebpf::maps::cgroup_storage::PerCpuCgroupStorage<V> where V: core::marker::Unpin
+impl<V> core::marker::UnsafeUnpin for aya_ebpf::maps::cgroup_storage::PerCpuCgroupStorage<V>
+impl<V> !core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::maps::cgroup_storage::PerCpuCgroupStorage<V>
+impl<V> core::panic::unwind_safe::UnwindSafe for aya_ebpf::maps::cgroup_storage::PerCpuCgroupStorage<V> where V: core::panic::unwind_safe::UnwindSafe
 pub mod aya_ebpf::maps::hash_map
 #[repr(transparent)] pub struct aya_ebpf::maps::hash_map::HashMap<K, V>
 impl<K, V> aya_ebpf::maps::hash_map::HashMap<K, V>
@@ -1319,6 +1405,20 @@ impl core::marker::Unpin for aya_ebpf::maps::cgroup_array::CgroupArray
 impl core::marker::UnsafeUnpin for aya_ebpf::maps::cgroup_array::CgroupArray
 impl !core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::maps::cgroup_array::CgroupArray
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf::maps::cgroup_array::CgroupArray
+#[repr(transparent)] pub struct aya_ebpf::maps::CgroupStorage<V>
+impl<V> aya_ebpf::maps::cgroup_storage::CgroupStorage<V>
+pub fn aya_ebpf::maps::cgroup_storage::CgroupStorage<V>::get_ptr_mut(&self) -> *mut V
+pub const fn aya_ebpf::maps::cgroup_storage::CgroupStorage<V>::new() -> Self
+pub const fn aya_ebpf::maps::cgroup_storage::CgroupStorage<V>::pinned() -> Self
+impl<V> core::default::Default for aya_ebpf::maps::cgroup_storage::CgroupStorage<V>
+pub fn aya_ebpf::maps::cgroup_storage::CgroupStorage<V>::default() -> Self
+impl<V> !core::marker::Freeze for aya_ebpf::maps::cgroup_storage::CgroupStorage<V>
+impl<V> core::marker::Send for aya_ebpf::maps::cgroup_storage::CgroupStorage<V> where V: core::marker::Send
+impl<V> core::marker::Sync for aya_ebpf::maps::cgroup_storage::CgroupStorage<V> where V: core::marker::Sync
+impl<V> core::marker::Unpin for aya_ebpf::maps::cgroup_storage::CgroupStorage<V> where V: core::marker::Unpin
+impl<V> core::marker::UnsafeUnpin for aya_ebpf::maps::cgroup_storage::CgroupStorage<V>
+impl<V> !core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::maps::cgroup_storage::CgroupStorage<V>
+impl<V> core::panic::unwind_safe::UnwindSafe for aya_ebpf::maps::cgroup_storage::CgroupStorage<V> where V: core::panic::unwind_safe::UnwindSafe
 #[repr(transparent)] pub struct aya_ebpf::maps::CpuMap
 impl aya_ebpf::maps::CpuMap
 pub const fn aya_ebpf::maps::CpuMap::pinned(u32, u32) -> Self
@@ -1436,6 +1536,20 @@ impl<T> core::marker::Unpin for aya_ebpf::maps::per_cpu_array::PerCpuArray<T> wh
 impl<T> core::marker::UnsafeUnpin for aya_ebpf::maps::per_cpu_array::PerCpuArray<T>
 impl<T> !core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::maps::per_cpu_array::PerCpuArray<T>
 impl<T> core::panic::unwind_safe::UnwindSafe for aya_ebpf::maps::per_cpu_array::PerCpuArray<T> where T: core::panic::unwind_safe::UnwindSafe
+#[repr(transparent)] pub struct aya_ebpf::maps::PerCpuCgroupStorage<V>
+impl<V> aya_ebpf::maps::cgroup_storage::PerCpuCgroupStorage<V>
+pub fn aya_ebpf::maps::cgroup_storage::PerCpuCgroupStorage<V>::get_ptr_mut(&self) -> *mut V
+pub const fn aya_ebpf::maps::cgroup_storage::PerCpuCgroupStorage<V>::new() -> Self
+pub const fn aya_ebpf::maps::cgroup_storage::PerCpuCgroupStorage<V>::pinned() -> Self
+impl<V> core::default::Default for aya_ebpf::maps::cgroup_storage::PerCpuCgroupStorage<V>
+pub fn aya_ebpf::maps::cgroup_storage::PerCpuCgroupStorage<V>::default() -> Self
+impl<V> !core::marker::Freeze for aya_ebpf::maps::cgroup_storage::PerCpuCgroupStorage<V>
+impl<V> core::marker::Send for aya_ebpf::maps::cgroup_storage::PerCpuCgroupStorage<V> where V: core::marker::Send
+impl<V> core::marker::Sync for aya_ebpf::maps::cgroup_storage::PerCpuCgroupStorage<V> where V: core::marker::Sync
+impl<V> core::marker::Unpin for aya_ebpf::maps::cgroup_storage::PerCpuCgroupStorage<V> where V: core::marker::Unpin
+impl<V> core::marker::UnsafeUnpin for aya_ebpf::maps::cgroup_storage::PerCpuCgroupStorage<V>
+impl<V> !core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::maps::cgroup_storage::PerCpuCgroupStorage<V>
+impl<V> core::panic::unwind_safe::UnwindSafe for aya_ebpf::maps::cgroup_storage::PerCpuCgroupStorage<V> where V: core::panic::unwind_safe::UnwindSafe
 #[repr(transparent)] pub struct aya_ebpf::maps::PerCpuHashMap<K, V>
 impl<K, V> aya_ebpf::maps::hash_map::PerCpuHashMap<K, V>
 pub unsafe fn aya_ebpf::maps::hash_map::PerCpuHashMap<K, V>::get(&self, impl core::borrow::Borrow<K>) -> core::option::Option<&V>

--- a/xtask/public-api/aya.txt
+++ b/xtask/public-api/aya.txt
@@ -142,6 +142,72 @@ impl<T, V> core::marker::Unpin for aya::maps::bloom_filter::BloomFilter<T, V> wh
 impl<T, V> core::marker::UnsafeUnpin for aya::maps::bloom_filter::BloomFilter<T, V> where T: core::marker::UnsafeUnpin
 impl<T, V> core::panic::unwind_safe::RefUnwindSafe for aya::maps::bloom_filter::BloomFilter<T, V> where T: core::panic::unwind_safe::RefUnwindSafe, V: core::panic::unwind_safe::RefUnwindSafe
 impl<T, V> core::panic::unwind_safe::UnwindSafe for aya::maps::bloom_filter::BloomFilter<T, V> where T: core::panic::unwind_safe::UnwindSafe, V: core::panic::unwind_safe::UnwindSafe
+pub mod aya::maps::cgroup_storage
+pub struct aya::maps::cgroup_storage::CgroupStorage<T, V: aya::Pod>
+impl<T: core::borrow::Borrow<aya::maps::MapData>, V: aya::Pod> aya::maps::cgroup_storage::CgroupStorage<T, V>
+pub fn aya::maps::cgroup_storage::CgroupStorage<T, V>::get(&self, aya::maps::cgroup_storage::CgroupStorageKey, u64) -> core::result::Result<V, aya::maps::MapError>
+impl<T: core::borrow::Borrow<aya::maps::MapData>, V: aya::Pod> aya::maps::cgroup_storage::CgroupStorage<T, V>
+pub fn aya::maps::cgroup_storage::CgroupStorage<T, V>::pin<P: core::convert::AsRef<std::path::Path>>(self, P) -> core::result::Result<(), aya::pin::PinError>
+impl<T: core::borrow::BorrowMut<aya::maps::MapData>, V: aya::Pod> aya::maps::cgroup_storage::CgroupStorage<T, V>
+pub fn aya::maps::cgroup_storage::CgroupStorage<T, V>::insert(&mut self, aya::maps::cgroup_storage::CgroupStorageKey, impl core::borrow::Borrow<V>, u64) -> core::result::Result<(), aya::maps::MapError>
+impl<'a, V: aya::Pod> core::convert::TryFrom<&'a aya::maps::Map> for aya::maps::cgroup_storage::CgroupStorage<&'a aya::maps::MapData, V>
+pub type aya::maps::cgroup_storage::CgroupStorage<&'a aya::maps::MapData, V>::Error = aya::maps::MapError
+pub fn aya::maps::cgroup_storage::CgroupStorage<&'a aya::maps::MapData, V>::try_from(&'a aya::maps::Map) -> core::result::Result<Self, Self::Error>
+impl<'a, V: aya::Pod> core::convert::TryFrom<&'a mut aya::maps::Map> for aya::maps::cgroup_storage::CgroupStorage<&'a mut aya::maps::MapData, V>
+pub type aya::maps::cgroup_storage::CgroupStorage<&'a mut aya::maps::MapData, V>::Error = aya::maps::MapError
+pub fn aya::maps::cgroup_storage::CgroupStorage<&'a mut aya::maps::MapData, V>::try_from(&'a mut aya::maps::Map) -> core::result::Result<Self, Self::Error>
+impl<T: core::fmt::Debug, V: core::fmt::Debug + aya::Pod> core::fmt::Debug for aya::maps::cgroup_storage::CgroupStorage<T, V>
+pub fn aya::maps::cgroup_storage::CgroupStorage<T, V>::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl<V: aya::Pod> core::convert::TryFrom<aya::maps::Map> for aya::maps::cgroup_storage::CgroupStorage<aya::maps::MapData, V>
+pub type aya::maps::cgroup_storage::CgroupStorage<aya::maps::MapData, V>::Error = aya::maps::MapError
+pub fn aya::maps::cgroup_storage::CgroupStorage<aya::maps::MapData, V>::try_from(aya::maps::Map) -> core::result::Result<Self, Self::Error>
+impl<T, V> core::marker::Freeze for aya::maps::cgroup_storage::CgroupStorage<T, V> where T: core::marker::Freeze
+impl<T, V> core::marker::Send for aya::maps::cgroup_storage::CgroupStorage<T, V> where T: core::marker::Send, V: core::marker::Send
+impl<T, V> core::marker::Sync for aya::maps::cgroup_storage::CgroupStorage<T, V> where T: core::marker::Sync, V: core::marker::Sync
+impl<T, V> core::marker::Unpin for aya::maps::cgroup_storage::CgroupStorage<T, V> where T: core::marker::Unpin, V: core::marker::Unpin
+impl<T, V> core::marker::UnsafeUnpin for aya::maps::cgroup_storage::CgroupStorage<T, V> where T: core::marker::UnsafeUnpin
+impl<T, V> core::panic::unwind_safe::RefUnwindSafe for aya::maps::cgroup_storage::CgroupStorage<T, V> where T: core::panic::unwind_safe::RefUnwindSafe, V: core::panic::unwind_safe::RefUnwindSafe
+impl<T, V> core::panic::unwind_safe::UnwindSafe for aya::maps::cgroup_storage::CgroupStorage<T, V> where T: core::panic::unwind_safe::UnwindSafe, V: core::panic::unwind_safe::UnwindSafe
+pub struct aya::maps::cgroup_storage::CgroupStorageKey
+impl aya::maps::cgroup_storage::CgroupStorageKey
+pub const fn aya::maps::cgroup_storage::CgroupStorageKey::new(u64, u32) -> Self
+impl core::clone::Clone for aya::maps::cgroup_storage::CgroupStorageKey
+pub fn aya::maps::cgroup_storage::CgroupStorageKey::clone(&self) -> aya::maps::cgroup_storage::CgroupStorageKey
+impl core::fmt::Debug for aya::maps::cgroup_storage::CgroupStorageKey
+pub fn aya::maps::cgroup_storage::CgroupStorageKey::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Copy for aya::maps::cgroup_storage::CgroupStorageKey
+impl core::marker::Freeze for aya::maps::cgroup_storage::CgroupStorageKey
+impl core::marker::Send for aya::maps::cgroup_storage::CgroupStorageKey
+impl core::marker::Sync for aya::maps::cgroup_storage::CgroupStorageKey
+impl core::marker::Unpin for aya::maps::cgroup_storage::CgroupStorageKey
+impl core::marker::UnsafeUnpin for aya::maps::cgroup_storage::CgroupStorageKey
+impl core::panic::unwind_safe::RefUnwindSafe for aya::maps::cgroup_storage::CgroupStorageKey
+impl core::panic::unwind_safe::UnwindSafe for aya::maps::cgroup_storage::CgroupStorageKey
+pub struct aya::maps::cgroup_storage::PerCpuCgroupStorage<T, V: aya::Pod>
+impl<T: core::borrow::Borrow<aya::maps::MapData>, V: aya::Pod> aya::maps::cgroup_storage::PerCpuCgroupStorage<T, V>
+pub fn aya::maps::cgroup_storage::PerCpuCgroupStorage<T, V>::get(&self, aya::maps::cgroup_storage::CgroupStorageKey, u64) -> core::result::Result<aya::maps::PerCpuValues<V>, aya::maps::MapError>
+impl<T: core::borrow::Borrow<aya::maps::MapData>, V: aya::Pod> aya::maps::cgroup_storage::PerCpuCgroupStorage<T, V>
+pub fn aya::maps::cgroup_storage::PerCpuCgroupStorage<T, V>::pin<P: core::convert::AsRef<std::path::Path>>(self, P) -> core::result::Result<(), aya::pin::PinError>
+impl<T: core::borrow::BorrowMut<aya::maps::MapData>, V: aya::Pod> aya::maps::cgroup_storage::PerCpuCgroupStorage<T, V>
+pub fn aya::maps::cgroup_storage::PerCpuCgroupStorage<T, V>::insert(&mut self, aya::maps::cgroup_storage::CgroupStorageKey, aya::maps::PerCpuValues<V>, u64) -> core::result::Result<(), aya::maps::MapError>
+impl<'a, V: aya::Pod> core::convert::TryFrom<&'a aya::maps::Map> for aya::maps::cgroup_storage::PerCpuCgroupStorage<&'a aya::maps::MapData, V>
+pub type aya::maps::cgroup_storage::PerCpuCgroupStorage<&'a aya::maps::MapData, V>::Error = aya::maps::MapError
+pub fn aya::maps::cgroup_storage::PerCpuCgroupStorage<&'a aya::maps::MapData, V>::try_from(&'a aya::maps::Map) -> core::result::Result<Self, Self::Error>
+impl<'a, V: aya::Pod> core::convert::TryFrom<&'a mut aya::maps::Map> for aya::maps::cgroup_storage::PerCpuCgroupStorage<&'a mut aya::maps::MapData, V>
+pub type aya::maps::cgroup_storage::PerCpuCgroupStorage<&'a mut aya::maps::MapData, V>::Error = aya::maps::MapError
+pub fn aya::maps::cgroup_storage::PerCpuCgroupStorage<&'a mut aya::maps::MapData, V>::try_from(&'a mut aya::maps::Map) -> core::result::Result<Self, Self::Error>
+impl<T: core::fmt::Debug, V: core::fmt::Debug + aya::Pod> core::fmt::Debug for aya::maps::cgroup_storage::PerCpuCgroupStorage<T, V>
+pub fn aya::maps::cgroup_storage::PerCpuCgroupStorage<T, V>::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl<V: aya::Pod> core::convert::TryFrom<aya::maps::Map> for aya::maps::cgroup_storage::PerCpuCgroupStorage<aya::maps::MapData, V>
+pub type aya::maps::cgroup_storage::PerCpuCgroupStorage<aya::maps::MapData, V>::Error = aya::maps::MapError
+pub fn aya::maps::cgroup_storage::PerCpuCgroupStorage<aya::maps::MapData, V>::try_from(aya::maps::Map) -> core::result::Result<Self, Self::Error>
+impl<T, V> core::marker::Freeze for aya::maps::cgroup_storage::PerCpuCgroupStorage<T, V> where T: core::marker::Freeze
+impl<T, V> core::marker::Send for aya::maps::cgroup_storage::PerCpuCgroupStorage<T, V> where T: core::marker::Send, V: core::marker::Send
+impl<T, V> core::marker::Sync for aya::maps::cgroup_storage::PerCpuCgroupStorage<T, V> where T: core::marker::Sync, V: core::marker::Sync
+impl<T, V> core::marker::Unpin for aya::maps::cgroup_storage::PerCpuCgroupStorage<T, V> where T: core::marker::Unpin, V: core::marker::Unpin
+impl<T, V> core::marker::UnsafeUnpin for aya::maps::cgroup_storage::PerCpuCgroupStorage<T, V> where T: core::marker::UnsafeUnpin
+impl<T, V> core::panic::unwind_safe::RefUnwindSafe for aya::maps::cgroup_storage::PerCpuCgroupStorage<T, V> where T: core::panic::unwind_safe::RefUnwindSafe, V: core::panic::unwind_safe::RefUnwindSafe
+impl<T, V> core::panic::unwind_safe::UnwindSafe for aya::maps::cgroup_storage::PerCpuCgroupStorage<T, V> where T: core::panic::unwind_safe::UnwindSafe, V: core::panic::unwind_safe::UnwindSafe
 pub mod aya::maps::hash_map
 pub struct aya::maps::hash_map::HashMap<T, K, V>
 impl<K: aya::Pod, V: aya::Pod> aya::maps::hash_map::HashMap<aya::maps::MapData, K, V>
@@ -811,6 +877,7 @@ pub aya::maps::Map::Array(aya::maps::MapData)
 pub aya::maps::Map::ArrayOfMaps(aya::maps::MapData)
 pub aya::maps::Map::BloomFilter(aya::maps::MapData)
 pub aya::maps::Map::CgroupArray(aya::maps::MapData)
+pub aya::maps::Map::CgroupStorage(aya::maps::MapData)
 pub aya::maps::Map::CpuMap(aya::maps::MapData)
 pub aya::maps::Map::DevMap(aya::maps::MapData)
 pub aya::maps::Map::DevMapHash(aya::maps::MapData)
@@ -819,6 +886,7 @@ pub aya::maps::Map::HashOfMaps(aya::maps::MapData)
 pub aya::maps::Map::LpmTrie(aya::maps::MapData)
 pub aya::maps::Map::LruHashMap(aya::maps::MapData)
 pub aya::maps::Map::PerCpuArray(aya::maps::MapData)
+pub aya::maps::Map::PerCpuCgroupStorage(aya::maps::MapData)
 pub aya::maps::Map::PerCpuHashMap(aya::maps::MapData)
 pub aya::maps::Map::PerCpuLruHashMap(aya::maps::MapData)
 pub aya::maps::Map::PerfEventArray(aya::maps::MapData)
@@ -907,6 +975,12 @@ pub fn aya::maps::array::Array<&'a aya::maps::MapData, V>::try_from(&'a aya::map
 impl<'a, V: aya::Pod> core::convert::TryFrom<&'a aya::maps::Map> for aya::maps::bloom_filter::BloomFilter<&'a aya::maps::MapData, V>
 pub type aya::maps::bloom_filter::BloomFilter<&'a aya::maps::MapData, V>::Error = aya::maps::MapError
 pub fn aya::maps::bloom_filter::BloomFilter<&'a aya::maps::MapData, V>::try_from(&'a aya::maps::Map) -> core::result::Result<Self, Self::Error>
+impl<'a, V: aya::Pod> core::convert::TryFrom<&'a aya::maps::Map> for aya::maps::cgroup_storage::CgroupStorage<&'a aya::maps::MapData, V>
+pub type aya::maps::cgroup_storage::CgroupStorage<&'a aya::maps::MapData, V>::Error = aya::maps::MapError
+pub fn aya::maps::cgroup_storage::CgroupStorage<&'a aya::maps::MapData, V>::try_from(&'a aya::maps::Map) -> core::result::Result<Self, Self::Error>
+impl<'a, V: aya::Pod> core::convert::TryFrom<&'a aya::maps::Map> for aya::maps::cgroup_storage::PerCpuCgroupStorage<&'a aya::maps::MapData, V>
+pub type aya::maps::cgroup_storage::PerCpuCgroupStorage<&'a aya::maps::MapData, V>::Error = aya::maps::MapError
+pub fn aya::maps::cgroup_storage::PerCpuCgroupStorage<&'a aya::maps::MapData, V>::try_from(&'a aya::maps::Map) -> core::result::Result<Self, Self::Error>
 impl<'a, V: aya::Pod> core::convert::TryFrom<&'a aya::maps::Map> for aya::maps::queue::Queue<&'a aya::maps::MapData, V>
 pub type aya::maps::queue::Queue<&'a aya::maps::MapData, V>::Error = aya::maps::MapError
 pub fn aya::maps::queue::Queue<&'a aya::maps::MapData, V>::try_from(&'a aya::maps::Map) -> core::result::Result<Self, Self::Error>
@@ -928,6 +1002,12 @@ pub fn aya::maps::array::Array<&'a mut aya::maps::MapData, V>::try_from(&'a mut 
 impl<'a, V: aya::Pod> core::convert::TryFrom<&'a mut aya::maps::Map> for aya::maps::bloom_filter::BloomFilter<&'a mut aya::maps::MapData, V>
 pub type aya::maps::bloom_filter::BloomFilter<&'a mut aya::maps::MapData, V>::Error = aya::maps::MapError
 pub fn aya::maps::bloom_filter::BloomFilter<&'a mut aya::maps::MapData, V>::try_from(&'a mut aya::maps::Map) -> core::result::Result<Self, Self::Error>
+impl<'a, V: aya::Pod> core::convert::TryFrom<&'a mut aya::maps::Map> for aya::maps::cgroup_storage::CgroupStorage<&'a mut aya::maps::MapData, V>
+pub type aya::maps::cgroup_storage::CgroupStorage<&'a mut aya::maps::MapData, V>::Error = aya::maps::MapError
+pub fn aya::maps::cgroup_storage::CgroupStorage<&'a mut aya::maps::MapData, V>::try_from(&'a mut aya::maps::Map) -> core::result::Result<Self, Self::Error>
+impl<'a, V: aya::Pod> core::convert::TryFrom<&'a mut aya::maps::Map> for aya::maps::cgroup_storage::PerCpuCgroupStorage<&'a mut aya::maps::MapData, V>
+pub type aya::maps::cgroup_storage::PerCpuCgroupStorage<&'a mut aya::maps::MapData, V>::Error = aya::maps::MapError
+pub fn aya::maps::cgroup_storage::PerCpuCgroupStorage<&'a mut aya::maps::MapData, V>::try_from(&'a mut aya::maps::Map) -> core::result::Result<Self, Self::Error>
 impl<'a, V: aya::Pod> core::convert::TryFrom<&'a mut aya::maps::Map> for aya::maps::queue::Queue<&'a mut aya::maps::MapData, V>
 pub type aya::maps::queue::Queue<&'a mut aya::maps::MapData, V>::Error = aya::maps::MapError
 pub fn aya::maps::queue::Queue<&'a mut aya::maps::MapData, V>::try_from(&'a mut aya::maps::Map) -> core::result::Result<Self, Self::Error>
@@ -1033,6 +1113,12 @@ pub fn aya::maps::array::Array<aya::maps::MapData, V>::try_from(aya::maps::Map) 
 impl<V: aya::Pod> core::convert::TryFrom<aya::maps::Map> for aya::maps::bloom_filter::BloomFilter<aya::maps::MapData, V>
 pub type aya::maps::bloom_filter::BloomFilter<aya::maps::MapData, V>::Error = aya::maps::MapError
 pub fn aya::maps::bloom_filter::BloomFilter<aya::maps::MapData, V>::try_from(aya::maps::Map) -> core::result::Result<Self, Self::Error>
+impl<V: aya::Pod> core::convert::TryFrom<aya::maps::Map> for aya::maps::cgroup_storage::CgroupStorage<aya::maps::MapData, V>
+pub type aya::maps::cgroup_storage::CgroupStorage<aya::maps::MapData, V>::Error = aya::maps::MapError
+pub fn aya::maps::cgroup_storage::CgroupStorage<aya::maps::MapData, V>::try_from(aya::maps::Map) -> core::result::Result<Self, Self::Error>
+impl<V: aya::Pod> core::convert::TryFrom<aya::maps::Map> for aya::maps::cgroup_storage::PerCpuCgroupStorage<aya::maps::MapData, V>
+pub type aya::maps::cgroup_storage::PerCpuCgroupStorage<aya::maps::MapData, V>::Error = aya::maps::MapError
+pub fn aya::maps::cgroup_storage::PerCpuCgroupStorage<aya::maps::MapData, V>::try_from(aya::maps::Map) -> core::result::Result<Self, Self::Error>
 impl<V: aya::Pod> core::convert::TryFrom<aya::maps::Map> for aya::maps::queue::Queue<aya::maps::MapData, V>
 pub type aya::maps::queue::Queue<aya::maps::MapData, V>::Error = aya::maps::MapError
 pub fn aya::maps::queue::Queue<aya::maps::MapData, V>::try_from(aya::maps::Map) -> core::result::Result<Self, Self::Error>
@@ -1276,6 +1362,46 @@ impl<T> core::marker::Unpin for aya::maps::CgroupArray<T> where T: core::marker:
 impl<T> core::marker::UnsafeUnpin for aya::maps::CgroupArray<T> where T: core::marker::UnsafeUnpin
 impl<T> core::panic::unwind_safe::RefUnwindSafe for aya::maps::CgroupArray<T> where T: core::panic::unwind_safe::RefUnwindSafe
 impl<T> core::panic::unwind_safe::UnwindSafe for aya::maps::CgroupArray<T> where T: core::panic::unwind_safe::UnwindSafe
+pub struct aya::maps::CgroupStorage<T, V: aya::Pod>
+impl<T: core::borrow::Borrow<aya::maps::MapData>, V: aya::Pod> aya::maps::cgroup_storage::CgroupStorage<T, V>
+pub fn aya::maps::cgroup_storage::CgroupStorage<T, V>::get(&self, aya::maps::cgroup_storage::CgroupStorageKey, u64) -> core::result::Result<V, aya::maps::MapError>
+impl<T: core::borrow::Borrow<aya::maps::MapData>, V: aya::Pod> aya::maps::cgroup_storage::CgroupStorage<T, V>
+pub fn aya::maps::cgroup_storage::CgroupStorage<T, V>::pin<P: core::convert::AsRef<std::path::Path>>(self, P) -> core::result::Result<(), aya::pin::PinError>
+impl<T: core::borrow::BorrowMut<aya::maps::MapData>, V: aya::Pod> aya::maps::cgroup_storage::CgroupStorage<T, V>
+pub fn aya::maps::cgroup_storage::CgroupStorage<T, V>::insert(&mut self, aya::maps::cgroup_storage::CgroupStorageKey, impl core::borrow::Borrow<V>, u64) -> core::result::Result<(), aya::maps::MapError>
+impl<'a, V: aya::Pod> core::convert::TryFrom<&'a aya::maps::Map> for aya::maps::cgroup_storage::CgroupStorage<&'a aya::maps::MapData, V>
+pub type aya::maps::cgroup_storage::CgroupStorage<&'a aya::maps::MapData, V>::Error = aya::maps::MapError
+pub fn aya::maps::cgroup_storage::CgroupStorage<&'a aya::maps::MapData, V>::try_from(&'a aya::maps::Map) -> core::result::Result<Self, Self::Error>
+impl<'a, V: aya::Pod> core::convert::TryFrom<&'a mut aya::maps::Map> for aya::maps::cgroup_storage::CgroupStorage<&'a mut aya::maps::MapData, V>
+pub type aya::maps::cgroup_storage::CgroupStorage<&'a mut aya::maps::MapData, V>::Error = aya::maps::MapError
+pub fn aya::maps::cgroup_storage::CgroupStorage<&'a mut aya::maps::MapData, V>::try_from(&'a mut aya::maps::Map) -> core::result::Result<Self, Self::Error>
+impl<T: core::fmt::Debug, V: core::fmt::Debug + aya::Pod> core::fmt::Debug for aya::maps::cgroup_storage::CgroupStorage<T, V>
+pub fn aya::maps::cgroup_storage::CgroupStorage<T, V>::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl<V: aya::Pod> core::convert::TryFrom<aya::maps::Map> for aya::maps::cgroup_storage::CgroupStorage<aya::maps::MapData, V>
+pub type aya::maps::cgroup_storage::CgroupStorage<aya::maps::MapData, V>::Error = aya::maps::MapError
+pub fn aya::maps::cgroup_storage::CgroupStorage<aya::maps::MapData, V>::try_from(aya::maps::Map) -> core::result::Result<Self, Self::Error>
+impl<T, V> core::marker::Freeze for aya::maps::cgroup_storage::CgroupStorage<T, V> where T: core::marker::Freeze
+impl<T, V> core::marker::Send for aya::maps::cgroup_storage::CgroupStorage<T, V> where T: core::marker::Send, V: core::marker::Send
+impl<T, V> core::marker::Sync for aya::maps::cgroup_storage::CgroupStorage<T, V> where T: core::marker::Sync, V: core::marker::Sync
+impl<T, V> core::marker::Unpin for aya::maps::cgroup_storage::CgroupStorage<T, V> where T: core::marker::Unpin, V: core::marker::Unpin
+impl<T, V> core::marker::UnsafeUnpin for aya::maps::cgroup_storage::CgroupStorage<T, V> where T: core::marker::UnsafeUnpin
+impl<T, V> core::panic::unwind_safe::RefUnwindSafe for aya::maps::cgroup_storage::CgroupStorage<T, V> where T: core::panic::unwind_safe::RefUnwindSafe, V: core::panic::unwind_safe::RefUnwindSafe
+impl<T, V> core::panic::unwind_safe::UnwindSafe for aya::maps::cgroup_storage::CgroupStorage<T, V> where T: core::panic::unwind_safe::UnwindSafe, V: core::panic::unwind_safe::UnwindSafe
+pub struct aya::maps::CgroupStorageKey
+impl aya::maps::cgroup_storage::CgroupStorageKey
+pub const fn aya::maps::cgroup_storage::CgroupStorageKey::new(u64, u32) -> Self
+impl core::clone::Clone for aya::maps::cgroup_storage::CgroupStorageKey
+pub fn aya::maps::cgroup_storage::CgroupStorageKey::clone(&self) -> aya::maps::cgroup_storage::CgroupStorageKey
+impl core::fmt::Debug for aya::maps::cgroup_storage::CgroupStorageKey
+pub fn aya::maps::cgroup_storage::CgroupStorageKey::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Copy for aya::maps::cgroup_storage::CgroupStorageKey
+impl core::marker::Freeze for aya::maps::cgroup_storage::CgroupStorageKey
+impl core::marker::Send for aya::maps::cgroup_storage::CgroupStorageKey
+impl core::marker::Sync for aya::maps::cgroup_storage::CgroupStorageKey
+impl core::marker::Unpin for aya::maps::cgroup_storage::CgroupStorageKey
+impl core::marker::UnsafeUnpin for aya::maps::cgroup_storage::CgroupStorageKey
+impl core::panic::unwind_safe::RefUnwindSafe for aya::maps::cgroup_storage::CgroupStorageKey
+impl core::panic::unwind_safe::UnwindSafe for aya::maps::cgroup_storage::CgroupStorageKey
 pub struct aya::maps::CpuMap<T>
 impl<T: core::borrow::Borrow<aya::maps::MapData>> aya::maps::CpuMap<T>
 pub fn aya::maps::CpuMap<T>::get(&self, u32, u64) -> core::result::Result<aya::maps::xdp::cpu_map::CpuMapValue, aya::maps::MapError>
@@ -1563,6 +1689,31 @@ impl<T, V> core::marker::Unpin for aya::maps::PerCpuArray<T, V> where T: core::m
 impl<T, V> core::marker::UnsafeUnpin for aya::maps::PerCpuArray<T, V> where T: core::marker::UnsafeUnpin
 impl<T, V> core::panic::unwind_safe::RefUnwindSafe for aya::maps::PerCpuArray<T, V> where T: core::panic::unwind_safe::RefUnwindSafe, V: core::panic::unwind_safe::RefUnwindSafe
 impl<T, V> core::panic::unwind_safe::UnwindSafe for aya::maps::PerCpuArray<T, V> where T: core::panic::unwind_safe::UnwindSafe, V: core::panic::unwind_safe::UnwindSafe
+pub struct aya::maps::PerCpuCgroupStorage<T, V: aya::Pod>
+impl<T: core::borrow::Borrow<aya::maps::MapData>, V: aya::Pod> aya::maps::cgroup_storage::PerCpuCgroupStorage<T, V>
+pub fn aya::maps::cgroup_storage::PerCpuCgroupStorage<T, V>::get(&self, aya::maps::cgroup_storage::CgroupStorageKey, u64) -> core::result::Result<aya::maps::PerCpuValues<V>, aya::maps::MapError>
+impl<T: core::borrow::Borrow<aya::maps::MapData>, V: aya::Pod> aya::maps::cgroup_storage::PerCpuCgroupStorage<T, V>
+pub fn aya::maps::cgroup_storage::PerCpuCgroupStorage<T, V>::pin<P: core::convert::AsRef<std::path::Path>>(self, P) -> core::result::Result<(), aya::pin::PinError>
+impl<T: core::borrow::BorrowMut<aya::maps::MapData>, V: aya::Pod> aya::maps::cgroup_storage::PerCpuCgroupStorage<T, V>
+pub fn aya::maps::cgroup_storage::PerCpuCgroupStorage<T, V>::insert(&mut self, aya::maps::cgroup_storage::CgroupStorageKey, aya::maps::PerCpuValues<V>, u64) -> core::result::Result<(), aya::maps::MapError>
+impl<'a, V: aya::Pod> core::convert::TryFrom<&'a aya::maps::Map> for aya::maps::cgroup_storage::PerCpuCgroupStorage<&'a aya::maps::MapData, V>
+pub type aya::maps::cgroup_storage::PerCpuCgroupStorage<&'a aya::maps::MapData, V>::Error = aya::maps::MapError
+pub fn aya::maps::cgroup_storage::PerCpuCgroupStorage<&'a aya::maps::MapData, V>::try_from(&'a aya::maps::Map) -> core::result::Result<Self, Self::Error>
+impl<'a, V: aya::Pod> core::convert::TryFrom<&'a mut aya::maps::Map> for aya::maps::cgroup_storage::PerCpuCgroupStorage<&'a mut aya::maps::MapData, V>
+pub type aya::maps::cgroup_storage::PerCpuCgroupStorage<&'a mut aya::maps::MapData, V>::Error = aya::maps::MapError
+pub fn aya::maps::cgroup_storage::PerCpuCgroupStorage<&'a mut aya::maps::MapData, V>::try_from(&'a mut aya::maps::Map) -> core::result::Result<Self, Self::Error>
+impl<T: core::fmt::Debug, V: core::fmt::Debug + aya::Pod> core::fmt::Debug for aya::maps::cgroup_storage::PerCpuCgroupStorage<T, V>
+pub fn aya::maps::cgroup_storage::PerCpuCgroupStorage<T, V>::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl<V: aya::Pod> core::convert::TryFrom<aya::maps::Map> for aya::maps::cgroup_storage::PerCpuCgroupStorage<aya::maps::MapData, V>
+pub type aya::maps::cgroup_storage::PerCpuCgroupStorage<aya::maps::MapData, V>::Error = aya::maps::MapError
+pub fn aya::maps::cgroup_storage::PerCpuCgroupStorage<aya::maps::MapData, V>::try_from(aya::maps::Map) -> core::result::Result<Self, Self::Error>
+impl<T, V> core::marker::Freeze for aya::maps::cgroup_storage::PerCpuCgroupStorage<T, V> where T: core::marker::Freeze
+impl<T, V> core::marker::Send for aya::maps::cgroup_storage::PerCpuCgroupStorage<T, V> where T: core::marker::Send, V: core::marker::Send
+impl<T, V> core::marker::Sync for aya::maps::cgroup_storage::PerCpuCgroupStorage<T, V> where T: core::marker::Sync, V: core::marker::Sync
+impl<T, V> core::marker::Unpin for aya::maps::cgroup_storage::PerCpuCgroupStorage<T, V> where T: core::marker::Unpin, V: core::marker::Unpin
+impl<T, V> core::marker::UnsafeUnpin for aya::maps::cgroup_storage::PerCpuCgroupStorage<T, V> where T: core::marker::UnsafeUnpin
+impl<T, V> core::panic::unwind_safe::RefUnwindSafe for aya::maps::cgroup_storage::PerCpuCgroupStorage<T, V> where T: core::panic::unwind_safe::RefUnwindSafe, V: core::panic::unwind_safe::RefUnwindSafe
+impl<T, V> core::panic::unwind_safe::UnwindSafe for aya::maps::cgroup_storage::PerCpuCgroupStorage<T, V> where T: core::panic::unwind_safe::UnwindSafe, V: core::panic::unwind_safe::UnwindSafe
 pub struct aya::maps::PerCpuHashMap<T, K: aya::Pod, V: aya::Pod>
 impl<K: aya::Pod, V: aya::Pod> aya::maps::hash_map::PerCpuHashMap<aya::maps::MapData, K, V>
 pub fn aya::maps::hash_map::PerCpuHashMap<aya::maps::MapData, K, V>::create(u32, u32) -> core::result::Result<Self, aya::maps::MapError>
@@ -7626,6 +7777,7 @@ impl core::marker::UnsafeUnpin for aya::VerifierLogLevel
 impl core::panic::unwind_safe::RefUnwindSafe for aya::VerifierLogLevel
 impl core::panic::unwind_safe::UnwindSafe for aya::VerifierLogLevel
 pub unsafe trait aya::Pod: core::marker::Copy + 'static
+impl aya::Pod for aya_obj::generated::linux_bindings_x86_64::bpf_cgroup_storage_key
 impl aya::Pod for aya_obj::generated::linux_bindings_x86_64::bpf_cpumap_val
 impl aya::Pod for aya_obj::generated::linux_bindings_x86_64::bpf_devmap_val
 impl aya::Pod for i128


### PR DESCRIPTION
Adds `CgroupStorage` and `PerCpuCgroupStorage` to `aya::maps`,
`aya_ebpf::maps`, and `aya_ebpf::btf_maps`, so
`BPF_MAP_TYPE_CGROUP_STORAGE` and `BPF_MAP_TYPE_PERCPU_CGROUP_STORAGE`
are no longer routed to `Map::Unsupported`. These maps hold one value
per cgroup that an attached program runs in; the kernel allocates the
entries on attach, so `max_entries` is always zero.

The eBPF maps expose `get_ptr_mut`, wrapping `bpf_get_local_storage`,
which returns a pointer to the storage of the current cgroup. The
helper never returns null, so no lookup can fail; the per-CPU variant
returns the running CPU's copy.

Userspace `get`/`insert` read and update the kernel-managed entries,
keyed by `CgroupStorageKey` (cgroup inode id and attach type). User
space cannot create or delete entries; the kernel materializes them
when a cgroup program using the map is attached. `CgroupStorageKey` is
an aya-owned type rather than exposing the raw `bpf_cgroup_storage_key`
binding.

Both the legacy and BTF forms load as the same kernel map type, so the
userspace types serve both. Integration tests parametrize over them via
`rstest`: a `cgroup_sock_addr` program per form increments a per-cgroup
counter on `connect` -- separate programs because the kernel permits
only one map of each storage type per program -- and the test reads the
counter back from userspace. They skip on kernels older than 4.20, where
the per-CPU map is not yet available.

Closes #196.

### Added/updated tests?

- [x] Yes

### Checklist

- [x] Rust code has been formatted with `cargo +nightly fmt`.
- [x] All clippy lints have been fixed.
- [x] Unit tests are passing locally with `cargo test`.
- [x] The integration tests are passing locally.
- [x] I have blessed any API changes with `cargo xtask public-api --bless`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aya-rs/aya/1583)
<!-- Reviewable:end -->
