### PR TITLE
aya-ebpf: document FExit ret kernel range

### DIFF
--- a/ebpf/aya-ebpf/src/programs/fexit.rs
+++ b/ebpf/aya-ebpf/src/programs/fexit.rs
@@ -83,10 +83,11 @@ impl FExitContext {
         // changing runtime semantics.
         //
         // See also:
-        // https://github.com/torvalds/linux/commit/4621202adc5b
-        // fixes the forward propagation variant in v6.8.
-        // https://github.com/torvalds/linux/commit/4bf79f9be434
-        // fixes a related backtracking variant in v6.12.
+        // https://github.com/torvalds/linux/commit/d028f87517d6775dccff4ddbca2740826f9e53f1
+        // fixes this verifier bug by tracking BPF_JNE "not equal" constraints.
+        // https://github.com/torvalds/linux/commit/9e314f5d8682e1fe6ac214fb34580a238b6fd3c4
+        // is also a prerequisite, because it preserves 32/64-bit bounds
+        // across reg_set_min_max().
         let err = core::hint::black_box(err);
         if err == 0 {
             Ok(T::from_register(ret_val))


### PR DESCRIPTION
### kernel verifier git-bisect
Follow-up to #1574.

I ran a kernel `git bisect` for the verifier issue hit by the `FExitContext::ret()` test, using this minimized C reproducer as the bisect test case:

https://gist.github.com/swananan/165cca6008f6c81870a28aa7a445d5ea

The bisect identified the upstream fix as:
  https://github.com/torvalds/linux/commit/d028f87517d6775dccff4ddbca2740826f9e53f1

One important note for 6.1.91 backporting: applying `d028f87517d6` alone is not sufficient. The backport also needs the verifier range-tracking semantics from:

https://github.com/torvalds/linux/commit/9e314f5d8682e1fe6ac214fb34580a238b6fd3c4

Without that prerequisite, the 6.1.91 verifier can still lose the refined bounds needed for this case.

### root cause analysis
I realized that the root cause was not explained clearly enough in #1574, so I dug deeper into the verifier logic. I also added temporary logging to the kernel verifier to confirm the state transitions, then re-analyzed the issue based on those logs.

A few verifier details were not obvious to me at first. Summarizing my current understanding here:

- The scalar ID is part of the verifier's register state, not something tied to source-level control-flow blocks like `{}`. Its lifetime follows the register value inside each verifier state: it can be created for an unknown scalar, copied by assignments such as `r7 = r0`, refined by branch conditions, and **lost or replaced when the register is overwritten or transformed**. So the shared ID only means that, in that verifier state, two registers are currently known to hold the same scalar value. It does not mean the verifier understands the original source-level logic.
- The verifier explores possible instruction-level paths and makes decisions based on the **register state** it has tracked for each path. It does not infer facts from the source-level intent unless those facts are represented in the register state.
- The verifier also uses state pruning to avoid re-analyzing the same program suffix for many similar paths. It caches register/stack states at selected instructions. When another path reaches the same instruction, the verifier compares the current state with the cached one using `regsafe()`/`states_equal()`. If the cached state is considered sufficient to prove the current state safe, the verifier treats the current path as already analyzed and stops exploring it. For scalar registers, this depends on liveness, precision marks, range/tnum constraints, and scalar ID relationships.

```
15: (85) call bpf_get_func_ret#184    ; R0_w=scalar() fp-8_w=mmmmmmmm
; if ret == 0 {
16: (79) r7 = *(u64 *)(r10 -8)        ; R7_w=scalar() R10=fp0
17: (15) if r0 == 0x0 goto pc+1       ; R0_w=scalar()
18: (bf) r7 = r0                      ; R0=scalar(id=1) R7=scalar(id=1)
; match ctx.ret::<T>() {
19: (55) if r0 != 0x0 goto pc+6       ; R0=0
20: (67) r7 <<= 32                    ; R7_w=0
21: (77) r7 >>= 32                    ; R7_w=0
22: (b7) r1 = 1                       ; R1_w=1
; if retval == expected {
23: (55) if r7 != 0xf goto pc+1
```
1. At line 15, `bpf_get_func_ret()` returns an unknown scalar to the verifier. At runtime, it succeeds, so `r0 == 0`.

2. At line 16, the traced function return value is loaded into `r7`. At runtime, this value is `15`.

3. At line 17, the program checks `if r0 == 0`. The jump target is the success path, while the fallthrough path is the failure path and should imply `r0 != 0`. **The verifier explores both paths: it continues with the fallthrough path first** and saves the jump target for later analysis.

4. On 6.1.91, **the verifier does not record the `r0 != 0` fact for the fallthrough path of line 17**. Then line 18 executes `r7 = r0`, so the verifier gives `r0` and `r7` the same scalar ID, but still treats both as possibly zero.

5. At line 19, the program checks `if r0 != 0`. This should be always true on the failure path, **but the verifier still thinks `r0` may be zero**, so it explores the fallthrough path as well.

6. Line 19 is a `JNE` instruction: `if r0 != 0 goto ...`. For this instruction, the jump target means `r0 != 0`, and the fallthrough path means `r0 == 0`. Because the verifier explores that fallthrough path, it narrows `r0` to `0`. **Since `r7` shares the same scalar ID as `r0`, the verifier also concludes `r7 == 0`**. **This creates an impossible path**: it came from the failure path of line 17, which should mean `r0 != 0`, but it is now analyzed as `r0 == 0`.

7. The impossible path continues to line 23. Since the verifier now thinks `r7 == 0`, it concludes that `if r7 != 15` is always true. So it only explores the branch that keeps `error = 1`.

8. Later, the verifier pops the saved success path from line 17. This path arrives at line 19 with `r0 == 0`, while `r7` still holds the traced function return value. **This is the real runtime path** that should eventually prove `r7 == 15` and set `error = 0`.

9. When this real success path reaches line 19, **the verifier performs state pruning**. It finds an earlier cached state at the same instruction from the previous exploration. According to `regsafe()`, the current state is considered safe against that cached state: the cached `r0` is an imprecise scalar, and the cached `r7` constraints are still loose enough to accept the current `r7`. Therefore the verifier stops analyzing this path.

10. Because the real success path is pruned at line 19, the verifier never analyzes the real continuation where `r0 == 0` and `r7 == 15` reaches line 23. The only explored continuation at line 23 came from the ghost path where `r7 == 0`, so the verifier treats `if r7 != 15` as always true. Later branch hard-wiring preserves that wrong conclusion, and the program reports `error = 1` at runtime.

https://github.com/torvalds/linux/commit/d028f87517d6775dccff4ddbca2740826f9e53f1 fixes the missing `!= 0` refinement on the fallthrough path of line 17, so the verifier can represent `r0` more precisely as `[1, U64_MAX]` instead of a fully unknown scalar.
 https://github.com/torvalds/linux/commit/9e314f5d8682e1fe6ac214fb34580a238b6fd3c4 fixes the later precision loss in the old range-combining logic. Without that semantic change, 6.1.91 can still discard the refined bounds after learning them.

Overall, this backport is a bit tricky because the verifier logic changed substantially between the tested 6.1.91 LTS baseline and the upstream fixed baseline (`v6.8`). Because of that, this is not a clean textual cherry-pick for 6.1.91.

However, the actual change needed for 6.1.91 looks manageable: the https://github.com/torvalds/linux/commit/9e314f5d8682e1fe6ac214fb34580a238b6fd3c4 semantics need to be preserved, and the https://github.com/torvalds/linux/commit/d028f87517d6775dccff4ddbca2740826f9e53f1 logic only needs a small adaptation to fit the older verifier code.

<!-- markdownlint-disable first-line-heading -->

<!--
    Thank you for your contribution to Aya! 🎉

    For Work In Progress Pull Requests, please use the Draft PR feature.

    Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Aya Contributing Guide: https://github.com/aya-rs/aya/blob/main/CONTRIBUTING.md
     - 📖 Read the Aya Code of Conduct: https://github.com/aya-rs/aya/blob/main/CODE_OF_CONDUCT.md
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages: https://cbea.ms/git-commit/
     - 📗 Update any related documentation.

-->

<!---
      Summarize the changes you're making here. Detailed information belongs in
      the Git commit messages. If your pull request contains just one commit,
      it's best to use its message as a summary. Otherwise, if there are multiple
      atomic commits, write a summary for the entire PR. Feel free to flag
      anything you think needs a reviewer's attention.
-->

<!--
      If your changes address an issue, link it with the *Fixes* tag so
      the issue gets closed when the PR is merged, for example:

      Fixes: #1234

      If you are only referencing an issue without fully addressing it, feel
      free to link it anywhere in the summary.
-->

### Added/updated tests?

_We strongly encourage you to add a test for your changes._

- [x] No, and this is why: just updated the doc

### Checklist

- [x] Rust code has been formatted with `cargo +nightly fmt`.
- [x] All clippy lints have been fixed.
      You can find failing lints with `cargo xtask clippy`.
- [x] Unit tests are passing locally with `cargo test`.
- [x] The [Integration tests] are passing locally.
- [x] I have blessed any API changes with `cargo xtask public-api --bless`.

[Integration tests]: https://github.com/aya-rs/aya/blob/main/test/README.md

### (Optional) What GIF best describes this PR or how it makes you feel?

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aya-rs/aya/1584)
<!-- Reviewable:end -->
