### PR TITLE
integration-test: fix flaky raw tracepoint test

### DIFF
--- a/ebpf/aya-ebpf/src/programs/raw_tracepoint.rs
+++ b/ebpf/aya-ebpf/src/programs/raw_tracepoint.rs
@@ -11,6 +11,22 @@ impl RawTracePointContext {
         Self { ctx: ctx.cast() }
     }
 
+    /// Returns the raw tracepoint argument at index `n`.
+    ///
+    /// Raw tracepoint arguments are the tracepoint's `TP_PROTO` arguments, not
+    /// fields from the `trace_event_raw_*` record used by regular tracepoints.
+    /// Their meaning and type depend on the tracepoint this program is attached
+    /// to.
+    ///
+    /// The kernel passes these values in [`bpf_raw_tracepoint_args`][bpf]:
+    /// `args[0]` is the first argument declared by the tracepoint's
+    /// `TP_PROTO`, `args[1]` is the second, and so on.
+    ///
+    /// For example, the [`sys_enter` tracepoint][sys] passes
+    /// `struct pt_regs *regs` as arg(0) and the syscall id as arg(1).
+    ///
+    /// [bpf]: https://github.com/torvalds/linux/blob/v6.15/include/uapi/linux/bpf.h#L7181-L7183
+    /// [sys]: https://github.com/torvalds/linux/blob/v6.15/include/trace/events/syscalls.h#L20
     pub fn arg<T: Argument>(&self, n: usize) -> T {
         raw_tracepoint_arg(unsafe { &*self.ctx }, n)
     }

--- a/test/integration-common/src/lib.rs
+++ b/test/integration-common/src/lib.rs
@@ -117,13 +117,22 @@ pub mod raw_tracepoint {
     #[repr(C)]
     #[derive(Clone, Copy)]
     pub struct SysEnterEvent {
-        pub common_type: u16,
-        pub common_flags: u8,
-        _padding: u8, // Padding must be explicit to ensure zero-initialization.
+        pub regs_addr: u64,
+        pub syscall_id: i64,
     }
 
     #[cfg(feature = "user")]
     unsafe impl aya::Pod for SysEnterEvent {}
+
+    #[repr(C)]
+    #[derive(Clone, Copy)]
+    pub struct TaskRenameEvent {
+        pub task_addr: u64,
+        pub comm_addr: u64,
+    }
+
+    #[cfg(feature = "user")]
+    unsafe impl aya::Pod for TaskRenameEvent {}
 }
 
 pub mod ring_buf {

--- a/test/integration-ebpf/src/raw_tracepoint.rs
+++ b/test/integration-ebpf/src/raw_tracepoint.rs
@@ -3,26 +3,68 @@
 #![expect(unused_crate_dependencies, reason = "used in other bins")]
 
 use aya_ebpf::{
+    EbpfContext as _, Global,
     macros::{map, raw_tracepoint},
     maps::Array,
     programs::RawTracePointContext,
 };
 #[cfg(not(test))]
 extern crate ebpf_panic;
-use integration_common::raw_tracepoint::SysEnterEvent;
+use integration_common::raw_tracepoint::{SysEnterEvent, TaskRenameEvent};
 
 #[map]
 static RESULT: Array<SysEnterEvent> = Array::with_max_entries(1, 0);
 
+#[map]
+static TASK_RENAME_RESULT: Array<TaskRenameEvent> = Array::with_max_entries(1, 0);
+
+#[unsafe(no_mangle)]
+static TARGET_TGID: Global<u32> = Global::new(0);
+
 #[raw_tracepoint(tracepoint = "sys_enter")]
 fn sys_enter(ctx: RawTracePointContext) -> i32 {
-    let common_type: u16 = ctx.arg(0);
-    let common_flags: u8 = ctx.arg(1);
+    let target_tgid = TARGET_TGID.load();
+    if ctx.tgid() != target_tgid {
+        return 0;
+    }
+
+    // Raw sys_enter args are `struct pt_regs *regs, long id`.
+    // https://github.com/torvalds/linux/blob/v6.15/include/trace/events/syscalls.h#L18-L22
+    let regs_addr: u64 = ctx.arg(0);
+    let syscall_id: i64 = ctx.arg(1);
 
     if let Some(ptr) = RESULT.get_ptr_mut(0) {
         unsafe {
-            (*ptr).common_type = common_type;
-            (*ptr).common_flags = common_flags;
+            if (*ptr).regs_addr != 0 {
+                return 0;
+            }
+            (*ptr).regs_addr = regs_addr;
+            (*ptr).syscall_id = syscall_id;
+        }
+    }
+
+    0
+}
+
+#[raw_tracepoint(tracepoint = "task_rename")]
+fn task_rename(ctx: RawTracePointContext) -> i32 {
+    let target_tgid = TARGET_TGID.load();
+    if ctx.tgid() != target_tgid {
+        return 0;
+    }
+
+    // Raw task_rename args are `struct task_struct *task, const char *comm`.
+    // https://github.com/torvalds/linux/blob/v6.15/include/trace/events/task.h#L34-L38
+    let task_addr: u64 = ctx.arg(0);
+    let comm_addr: u64 = ctx.arg(1);
+
+    if let Some(ptr) = TASK_RENAME_RESULT.get_ptr_mut(0) {
+        unsafe {
+            if (*ptr).task_addr != 0 {
+                return 0;
+            }
+            (*ptr).task_addr = task_addr;
+            (*ptr).comm_addr = comm_addr;
         }
     }
 

--- a/test/integration-test/src/tests/raw_tracepoint.rs
+++ b/test/integration-test/src/tests/raw_tracepoint.rs
@@ -1,40 +1,65 @@
-use aya::{Ebpf, maps::Array, programs::RawTracePoint};
-use integration_common::raw_tracepoint::SysEnterEvent;
+use std::fs::{self, File, read};
 
-fn get_event(bpf: &mut Ebpf) -> SysEnterEvent {
+use aya::{Ebpf, EbpfLoader, maps::Array, programs::RawTracePoint};
+use integration_common::raw_tracepoint::{SysEnterEvent, TaskRenameEvent};
+use scopeguard::defer;
+
+fn get_sys_enter_event(bpf: &mut Ebpf) -> SysEnterEvent {
     let map: Array<_, SysEnterEvent> = Array::try_from(bpf.map_mut("RESULT").unwrap()).unwrap();
     map.get(&0, 0).unwrap()
 }
 
+fn get_task_rename_event(bpf: &mut Ebpf) -> TaskRenameEvent {
+    let map: Array<_, TaskRenameEvent> =
+        Array::try_from(bpf.map_mut("TASK_RENAME_RESULT").unwrap()).unwrap();
+    map.get(&0, 0).unwrap()
+}
+
 #[test_log::test]
-fn raw_tracepoint() {
-    let mut bpf = Ebpf::load(crate::RAW_TRACEPOINT).unwrap();
+fn raw_tracepoint_sys_enter() {
+    let target_tgid = std::process::id();
+    let mut bpf = EbpfLoader::new()
+        .override_global("TARGET_TGID", &target_tgid, true)
+        .load(crate::RAW_TRACEPOINT)
+        .unwrap();
 
-    // Check start condition.
-    {
-        let SysEnterEvent {
-            common_type,
-            common_flags,
-            ..
-        } = get_event(&mut bpf);
-        assert_eq!(common_type, 0);
-        assert_eq!(common_flags, 0);
-    }
-
-    // NB: we cannot fetch `map` just once above because both `Ebpf::map_mut` and
-    // `Ebpf::program_mut` take &mut self, resulting in overlapping mutable borrows.
     let prog: &mut RawTracePoint = bpf.program_mut("sys_enter").unwrap().try_into().unwrap();
     prog.load().unwrap();
     prog.attach("sys_enter").unwrap();
 
-    // Check that a syscall was traced.
-    {
-        let SysEnterEvent {
-            common_type,
-            common_flags,
-            ..
-        } = get_event(&mut bpf);
-        assert_ne!(common_type, 0);
-        assert_ne!(common_flags, 0);
+    // Trigger a deterministic syscall after attaching the raw tracepoint.
+    File::open("/dev/null").unwrap();
+
+    let SysEnterEvent { regs_addr, .. } = get_sys_enter_event(&mut bpf);
+    assert_ne!(regs_addr, 0);
+}
+
+#[test_log::test]
+fn raw_tracepoint_task_rename() {
+    let target_tgid = std::process::id();
+    let mut bpf = EbpfLoader::new()
+        .override_global("TARGET_TGID", &target_tgid, true)
+        .load(crate::RAW_TRACEPOINT)
+        .unwrap();
+
+    let prog: &mut RawTracePoint = bpf.program_mut("task_rename").unwrap().try_into().unwrap();
+    prog.load().unwrap();
+    prog.attach("task_rename").unwrap();
+
+    let original_comm = read("/proc/self/comm").unwrap();
+    // Reading /proc/self/comm includes a trailing newline; don't restore it.
+    let restore_comm = original_comm.strip_suffix(b"\n").unwrap_or(&original_comm);
+    fs::write("/proc/self/comm", b"aya-raw-tp").unwrap();
+    defer! {
+        fs::write("/proc/self/comm", restore_comm).unwrap();
     }
+
+    // Check that the task_rename event was traced.
+    let TaskRenameEvent {
+        task_addr,
+        comm_addr,
+    } = get_task_rename_event(&mut bpf);
+
+    assert_ne!(task_addr, 0);
+    assert_ne!(comm_addr, 0);
 }


### PR DESCRIPTION
<!-- markdownlint-disable first-line-heading -->
I observed the flaky raw tracepoint integration test failure shown below. This PR fixes it.

```
---- tests::raw_tracepoint::raw_tracepoint stdout ----
thread 'tests::raw_tracepoint::raw_tracepoint' panicked at test/integration-test/src/tests/raw_tracepoint.rs:38:9:
assertion `left != right` failed
  left: 0
 right: 0
```
<!--
    Thank you for your contribution to Aya! 🎉

    For Work In Progress Pull Requests, please use the Draft PR feature.

    Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Aya Contributing Guide: https://github.com/aya-rs/aya/blob/main/CONTRIBUTING.md
     - 📖 Read the Aya Code of Conduct: https://github.com/aya-rs/aya/blob/main/CODE_OF_CONDUCT.md
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages: https://cbea.ms/git-commit/
     - 📗 Update any related documentation.

-->

<!---
      Summarize the changes you're making here. Detailed information belongs in
      the Git commit messages. If your pull request contains just one commit,
      it's best to use its message as a summary. Otherwise, if there are multiple
      atomic commits, write a summary for the entire PR. Feel free to flag
      anything you think needs a reviewer's attention.
-->

<!--
      If your changes address an issue, link it with the *Fixes* tag so
      the issue gets closed when the PR is merged, for example:

      Fixes: #1234

      If you are only referencing an issue without fully addressing it, feel
      free to link it anywhere in the summary.
-->

### Added/updated tests?

_We strongly encourage you to add a test for your changes._

- [x] Yes

### Checklist

- [x] Rust code has been formatted with `cargo +nightly fmt`.
- [x] All clippy lints have been fixed.
      You can find failing lints with `cargo xtask clippy`.
- [x] Unit tests are passing locally with `cargo test`.
- [x] The [Integration tests] are passing locally.
- [x] I have blessed any API changes with `cargo xtask public-api --bless`.

[Integration tests]: https://github.com/aya-rs/aya/blob/main/test/README.md

### (Optional) What GIF best describes this PR or how it makes you feel?

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aya-rs/aya/1586)
<!-- Reviewable:end -->
