### PR TITLE
aya-ebpf, integration-ebpf: make map APIs safe

### DIFF
--- a/ebpf/aya-ebpf/src/btf_maps/cgrp_storage.rs
+++ b/ebpf/aya-ebpf/src/btf_maps/cgrp_storage.rs
@@ -26,28 +26,16 @@ impl<T> CgrpStorage<T> {
     }
 
     /// Gets a mutable reference to the value associated with `cgroup`.
-    ///
-    /// # Safety
-    ///
-    /// This function may dereference the pointer `cgroup`.
     #[inline(always)]
-    pub unsafe fn get_ptr_mut(&self, cgroup: *mut cgroup) -> *mut T {
+    pub fn get_ptr_mut(&self, cgroup: *mut cgroup) -> *mut T {
         self.get_ptr(cgroup, ptr::null_mut(), 0)
     }
 
     /// Gets a mutable reference to the value associated with `cgroup`.
     ///
     /// If no value is associated with `cgroup`, `value` will be inserted.
-    ///
-    /// # Safety
-    ///
-    /// This function may dereference the pointer `cgroup`.
     #[inline(always)]
-    pub unsafe fn get_or_insert_ptr_mut(
-        &self,
-        cgroup: *mut cgroup,
-        value: Option<&mut T>,
-    ) -> *mut T {
+    pub fn get_or_insert_ptr_mut(&self, cgroup: *mut cgroup, value: Option<&mut T>) -> *mut T {
         self.get_ptr(
             cgroup,
             value.map_or(ptr::null_mut(), ptr::from_mut),
@@ -56,12 +44,13 @@ impl<T> CgrpStorage<T> {
     }
 
     /// Deletes the value associated with `cgroup`.
-    ///
-    /// # Safety
-    ///
-    /// This function may dereference the pointer `cgroup`.
+    #[expect(
+        clippy::not_unsafe_ptr_arg_deref,
+        reason = "the verifier validates the cgroup pointer as ARG_PTR_TO_BTF_ID at load time; \
+                  this wrapper forwards it to the helper without dereferencing it"
+    )]
     #[inline(always)]
-    pub unsafe fn delete(&self, cgroup: *mut cgroup) -> Result<(), i32> {
+    pub fn delete(&self, cgroup: *mut cgroup) -> Result<(), i32> {
         let ret = unsafe { bpf_cgrp_storage_delete(self.as_ptr(), cgroup) };
         if ret == 0 { Ok(()) } else { Err(ret as i32) }
     }

--- a/ebpf/aya-ebpf/src/btf_maps/inode_storage.rs
+++ b/ebpf/aya-ebpf/src/btf_maps/inode_storage.rs
@@ -27,24 +27,16 @@ impl<T> InodeStorage<T> {
     }
 
     /// Gets a mutable reference to the value associated with `inode`.
-    ///
-    /// # Safety
-    ///
-    /// This function may dereference the pointer `inode`.
     #[inline(always)]
-    pub unsafe fn get_ptr_mut(&self, inode: *mut inode) -> *mut T {
+    pub fn get_ptr_mut(&self, inode: *mut inode) -> *mut T {
         self.get_ptr(inode, ptr::null_mut(), 0)
     }
 
     /// Gets a mutable reference to the value associated with `inode`.
     ///
     /// If no value is associated with `inode`, `value` will be inserted.
-    ///
-    /// # Safety
-    ///
-    /// This function may dereference the pointer `inode`.
     #[inline(always)]
-    pub unsafe fn get_or_insert_ptr_mut(&self, inode: *mut inode, value: Option<&mut T>) -> *mut T {
+    pub fn get_or_insert_ptr_mut(&self, inode: *mut inode, value: Option<&mut T>) -> *mut T {
         self.get_ptr(
             inode,
             value.map_or(ptr::null_mut(), ptr::from_mut),
@@ -53,12 +45,8 @@ impl<T> InodeStorage<T> {
     }
 
     /// Deletes the value associated with `inode`.
-    ///
-    /// # Safety
-    ///
-    /// This function may dereference the pointer `inode`.
     #[inline(always)]
-    pub unsafe fn delete(&self, inode: *mut inode) -> Result<(), i32> {
+    pub fn delete(&self, inode: *mut inode) -> Result<(), i32> {
         let ret = unsafe { bpf_inode_storage_delete(self.as_ptr(), inode.cast()) };
         if ret == 0 { Ok(()) } else { Err(ret) }
     }

--- a/ebpf/aya-ebpf/src/btf_maps/sk_storage.rs
+++ b/ebpf/aya-ebpf/src/btf_maps/sk_storage.rs
@@ -31,29 +31,17 @@ impl<T> SkStorage<T> {
         unsafe { bpf_sk_storage_get(self.as_ptr(), sk.cast(), value.cast(), flags) }.cast::<T>()
     }
 
-    /// Gets a mutable reference to the value associated with `sk`.
-    ///
-    /// # Safety
-    ///
-    /// This function may dereference the pointer `sk`.
+    /// Gets a mutable reference to the value associated with the socket in `ctx`.
     #[inline(always)]
-    pub unsafe fn get_ptr_mut(&self, ctx: &SockAddrContext) -> *mut T {
+    pub fn get_ptr_mut(&self, ctx: &SockAddrContext) -> *mut T {
         self.get_ptr(ctx, ptr::null_mut(), 0)
     }
 
-    /// Gets a mutable reference to the value associated with `sk`.
+    /// Gets a mutable reference to the value associated with the socket in `ctx`.
     ///
-    /// If no value is associated with `sk`, `value` will be inserted.
-    ///
-    /// # Safety
-    ///
-    /// This function may dereference the pointer `sk`.
+    /// If no value is associated with the socket, `value` will be inserted.
     #[inline(always)]
-    pub unsafe fn get_or_insert_ptr_mut(
-        &self,
-        ctx: &SockAddrContext,
-        value: Option<&mut T>,
-    ) -> *mut T {
+    pub fn get_or_insert_ptr_mut(&self, ctx: &SockAddrContext, value: Option<&mut T>) -> *mut T {
         self.get_ptr(
             ctx,
             value.map_or(ptr::null_mut(), ptr::from_mut),
@@ -62,12 +50,8 @@ impl<T> SkStorage<T> {
     }
 
     /// Deletes the value associated with `sk`.
-    ///
-    /// # Safety
-    ///
-    /// This function may dereference the pointer `sk`.
     #[inline(always)]
-    pub unsafe fn delete(&self, sk: *mut bpf_sock) -> Result<(), i32> {
+    pub fn delete(&self, sk: *mut bpf_sock) -> Result<(), i32> {
         let ret = unsafe { bpf_sk_storage_delete(self.as_ptr(), sk.cast()) };
         if ret == 0 { Ok(()) } else { Err(ret as i32) }
     }

--- a/ebpf/aya-ebpf/src/maps/sock_map.rs
+++ b/ebpf/aya-ebpf/src/maps/sock_map.rs
@@ -24,7 +24,17 @@ impl super::private::Map for SockMap {
 impl SockMap {
     map_constructors!(u32, u32, BPF_MAP_TYPE_SOCKMAP);
 
-    #[expect(clippy::missing_safety_doc, reason = "TODO")]
+    /// Inserts the socket from `sk_ops` into the map at `index`.
+    ///
+    /// Wraps `bpf_sock_map_update`. Intended for `SOCK_OPS` programs.
+    ///
+    /// # Safety
+    ///
+    /// `sk_ops` must be a valid pointer to a `bpf_sock_ops` structure,
+    /// typically the `ops` field of a [`SockOpsContext`]. The kernel
+    /// guarantees its validity within the program's execution context.
+    ///
+    /// [`SockOpsContext`]: crate::programs::SockOpsContext
     pub unsafe fn update(
         &self,
         mut index: u32,
@@ -42,13 +52,13 @@ impl SockMap {
         if ret == 0 { Ok(()) } else { Err(ret as i32) }
     }
 
-    #[expect(clippy::missing_safety_doc, reason = "TODO")]
-    pub unsafe fn redirect_msg(&self, ctx: &SkMsgContext, index: u32, flags: u64) -> c_long {
+    /// Redirects the message in `ctx` to the socket at `index`.
+    pub fn redirect_msg(&self, ctx: &SkMsgContext, index: u32, flags: u64) -> c_long {
         unsafe { bpf_msg_redirect_map(ctx.as_ptr().cast(), self.def.as_ptr().cast(), index, flags) }
     }
 
-    #[expect(clippy::missing_safety_doc, reason = "TODO")]
-    pub unsafe fn redirect_skb(&self, ctx: &SkBuffContext, index: u32, flags: u64) -> c_long {
+    /// Redirects the socket buffer in `ctx` to the socket at `index`.
+    pub fn redirect_skb(&self, ctx: &SkBuffContext, index: u32, flags: u64) -> c_long {
         unsafe { bpf_sk_redirect_map(ctx.as_ptr().cast(), self.def.as_ptr().cast(), index, flags) }
     }
 

--- a/test/integration-ebpf/src/cgrp_storage.rs
+++ b/test/integration-ebpf/src/cgrp_storage.rs
@@ -21,7 +21,7 @@ fn cgrp_storage_test(ctx: BtfTracePointContext) -> i32 {
     // `cgroup_mkdir(struct cgroup *cgrp, const char *path)` exposes the new
     // cgroup as the first argument.
     let cgrp: *mut cgroup = ctx.arg(0);
-    let storage = unsafe { CGRP_STORAGE.get_or_insert_ptr_mut(cgrp, None) };
+    let storage = CGRP_STORAGE.get_or_insert_ptr_mut(cgrp, None);
     if !storage.is_null() {
         unsafe { *storage = SENTINEL }
     }

--- a/test/integration-ebpf/src/inode_storage.rs
+++ b/test/integration-ebpf/src/inode_storage.rs
@@ -32,7 +32,7 @@ fn inode_storage_test(ctx: LsmContext) -> i32 {
         return retval;
     }
     let inode: *mut inode = ctx.arg(0);
-    let storage = unsafe { INODE_STORAGE.get_or_insert_ptr_mut(inode, None) };
+    let storage = INODE_STORAGE.get_or_insert_ptr_mut(inode, None);
     if !storage.is_null() {
         unsafe { *storage = SENTINEL }
     }

--- a/test/integration-ebpf/src/sk_storage.rs
+++ b/test/integration-ebpf/src/sk_storage.rs
@@ -19,7 +19,7 @@ static SOCKET_STORAGE: SkStorage<Value> = SkStorage::new();
 pub(crate) fn sk_storage_connect4(ctx: SockAddrContext) -> i32 {
     let sock_addr = unsafe { &*ctx.sock_addr };
 
-    let storage = unsafe { SOCKET_STORAGE.get_or_insert_ptr_mut(&ctx, None) };
+    let storage = SOCKET_STORAGE.get_or_insert_ptr_mut(&ctx, None);
     if !storage.is_null() {
         unsafe {
             *storage = Value {
@@ -40,7 +40,7 @@ pub(crate) fn sk_storage_connect4(ctx: SockAddrContext) -> i32 {
 pub(crate) fn sk_storage_connect6(ctx: SockAddrContext) -> i32 {
     let sock_addr = unsafe { &*ctx.sock_addr };
 
-    let storage = unsafe { SOCKET_STORAGE.get_or_insert_ptr_mut(&ctx, None) };
+    let storage = SOCKET_STORAGE.get_or_insert_ptr_mut(&ctx, None);
     if !storage.is_null() {
         let mut user_ip6 = [0u32; 4];
         unsafe {

--- a/xtask/public-api/aya-ebpf.txt
+++ b/xtask/public-api/aya-ebpf.txt
@@ -86,9 +86,9 @@ impl<V> core::panic::unwind_safe::UnwindSafe for aya_ebpf::btf_maps::cgroup_stor
 pub mod aya_ebpf::btf_maps::cgrp_storage
 #[repr(C)] pub struct aya_ebpf::btf_maps::cgrp_storage::CgrpStorage<T>
 impl<T> aya_ebpf::btf_maps::cgrp_storage::CgrpStorage<T>
-pub unsafe fn aya_ebpf::btf_maps::cgrp_storage::CgrpStorage<T>::delete(&self, *mut aya_ebpf_bindings::x86_64::bindings::cgroup) -> core::result::Result<(), i32>
-pub unsafe fn aya_ebpf::btf_maps::cgrp_storage::CgrpStorage<T>::get_or_insert_ptr_mut(&self, *mut aya_ebpf_bindings::x86_64::bindings::cgroup, core::option::Option<&mut T>) -> *mut T
-pub unsafe fn aya_ebpf::btf_maps::cgrp_storage::CgrpStorage<T>::get_ptr_mut(&self, *mut aya_ebpf_bindings::x86_64::bindings::cgroup) -> *mut T
+pub fn aya_ebpf::btf_maps::cgrp_storage::CgrpStorage<T>::delete(&self, *mut aya_ebpf_bindings::x86_64::bindings::cgroup) -> core::result::Result<(), i32>
+pub fn aya_ebpf::btf_maps::cgrp_storage::CgrpStorage<T>::get_or_insert_ptr_mut(&self, *mut aya_ebpf_bindings::x86_64::bindings::cgroup, core::option::Option<&mut T>) -> *mut T
+pub fn aya_ebpf::btf_maps::cgrp_storage::CgrpStorage<T>::get_ptr_mut(&self, *mut aya_ebpf_bindings::x86_64::bindings::cgroup) -> *mut T
 impl<T> aya_ebpf::btf_maps::cgrp_storage::CgrpStorage<T>
 pub const fn aya_ebpf::btf_maps::cgrp_storage::CgrpStorage<T>::new() -> Self
 impl<T> core::default::Default for aya_ebpf::btf_maps::cgrp_storage::CgrpStorage<T>
@@ -225,9 +225,9 @@ impl<K, V, const MAX_ENTRIES: usize, const FLAGS: usize> core::panic::unwind_saf
 pub mod aya_ebpf::btf_maps::inode_storage
 #[repr(C)] pub struct aya_ebpf::btf_maps::inode_storage::InodeStorage<T>
 impl<T> aya_ebpf::btf_maps::inode_storage::InodeStorage<T>
-pub unsafe fn aya_ebpf::btf_maps::inode_storage::InodeStorage<T>::delete(&self, *mut aya_ebpf_bindings::x86_64::bindings::inode) -> core::result::Result<(), i32>
-pub unsafe fn aya_ebpf::btf_maps::inode_storage::InodeStorage<T>::get_or_insert_ptr_mut(&self, *mut aya_ebpf_bindings::x86_64::bindings::inode, core::option::Option<&mut T>) -> *mut T
-pub unsafe fn aya_ebpf::btf_maps::inode_storage::InodeStorage<T>::get_ptr_mut(&self, *mut aya_ebpf_bindings::x86_64::bindings::inode) -> *mut T
+pub fn aya_ebpf::btf_maps::inode_storage::InodeStorage<T>::delete(&self, *mut aya_ebpf_bindings::x86_64::bindings::inode) -> core::result::Result<(), i32>
+pub fn aya_ebpf::btf_maps::inode_storage::InodeStorage<T>::get_or_insert_ptr_mut(&self, *mut aya_ebpf_bindings::x86_64::bindings::inode, core::option::Option<&mut T>) -> *mut T
+pub fn aya_ebpf::btf_maps::inode_storage::InodeStorage<T>::get_ptr_mut(&self, *mut aya_ebpf_bindings::x86_64::bindings::inode) -> *mut T
 impl<T> aya_ebpf::btf_maps::inode_storage::InodeStorage<T>
 pub const fn aya_ebpf::btf_maps::inode_storage::InodeStorage<T>::new() -> Self
 impl<T> core::default::Default for aya_ebpf::btf_maps::inode_storage::InodeStorage<T>
@@ -424,9 +424,9 @@ impl<T, const MAX_ENTRIES: usize, const FLAGS: usize> core::panic::unwind_safe::
 pub mod aya_ebpf::btf_maps::sk_storage
 #[repr(C)] pub struct aya_ebpf::btf_maps::sk_storage::SkStorage<T>
 impl<T> aya_ebpf::btf_maps::sk_storage::SkStorage<T>
-pub unsafe fn aya_ebpf::btf_maps::sk_storage::SkStorage<T>::delete(&self, *mut aya_ebpf_bindings::x86_64::bindings::bpf_sock) -> core::result::Result<(), i32>
-pub unsafe fn aya_ebpf::btf_maps::sk_storage::SkStorage<T>::get_or_insert_ptr_mut(&self, &aya_ebpf::programs::sock_addr::SockAddrContext, core::option::Option<&mut T>) -> *mut T
-pub unsafe fn aya_ebpf::btf_maps::sk_storage::SkStorage<T>::get_ptr_mut(&self, &aya_ebpf::programs::sock_addr::SockAddrContext) -> *mut T
+pub fn aya_ebpf::btf_maps::sk_storage::SkStorage<T>::delete(&self, *mut aya_ebpf_bindings::x86_64::bindings::bpf_sock) -> core::result::Result<(), i32>
+pub fn aya_ebpf::btf_maps::sk_storage::SkStorage<T>::get_or_insert_ptr_mut(&self, &aya_ebpf::programs::sock_addr::SockAddrContext, core::option::Option<&mut T>) -> *mut T
+pub fn aya_ebpf::btf_maps::sk_storage::SkStorage<T>::get_ptr_mut(&self, &aya_ebpf::programs::sock_addr::SockAddrContext) -> *mut T
 impl<T> aya_ebpf::btf_maps::sk_storage::SkStorage<T>
 pub const fn aya_ebpf::btf_maps::sk_storage::SkStorage<T>::new() -> Self
 impl<T> core::default::Default for aya_ebpf::btf_maps::sk_storage::SkStorage<T>
@@ -600,9 +600,9 @@ impl<V> core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::btf_maps::cgroup_s
 impl<V> core::panic::unwind_safe::UnwindSafe for aya_ebpf::btf_maps::cgroup_storage::CgroupStorage<V> where V: core::panic::unwind_safe::RefUnwindSafe
 #[repr(C)] pub struct aya_ebpf::btf_maps::CgrpStorage<T>
 impl<T> aya_ebpf::btf_maps::cgrp_storage::CgrpStorage<T>
-pub unsafe fn aya_ebpf::btf_maps::cgrp_storage::CgrpStorage<T>::delete(&self, *mut aya_ebpf_bindings::x86_64::bindings::cgroup) -> core::result::Result<(), i32>
-pub unsafe fn aya_ebpf::btf_maps::cgrp_storage::CgrpStorage<T>::get_or_insert_ptr_mut(&self, *mut aya_ebpf_bindings::x86_64::bindings::cgroup, core::option::Option<&mut T>) -> *mut T
-pub unsafe fn aya_ebpf::btf_maps::cgrp_storage::CgrpStorage<T>::get_ptr_mut(&self, *mut aya_ebpf_bindings::x86_64::bindings::cgroup) -> *mut T
+pub fn aya_ebpf::btf_maps::cgrp_storage::CgrpStorage<T>::delete(&self, *mut aya_ebpf_bindings::x86_64::bindings::cgroup) -> core::result::Result<(), i32>
+pub fn aya_ebpf::btf_maps::cgrp_storage::CgrpStorage<T>::get_or_insert_ptr_mut(&self, *mut aya_ebpf_bindings::x86_64::bindings::cgroup, core::option::Option<&mut T>) -> *mut T
+pub fn aya_ebpf::btf_maps::cgrp_storage::CgrpStorage<T>::get_ptr_mut(&self, *mut aya_ebpf_bindings::x86_64::bindings::cgroup) -> *mut T
 impl<T> aya_ebpf::btf_maps::cgrp_storage::CgrpStorage<T>
 pub const fn aya_ebpf::btf_maps::cgrp_storage::CgrpStorage<T>::new() -> Self
 impl<T> core::default::Default for aya_ebpf::btf_maps::cgrp_storage::CgrpStorage<T>
@@ -697,9 +697,9 @@ impl<K, V, const MAX_ENTRIES: usize, const FLAGS: usize> core::panic::unwind_saf
 impl<K, V, const MAX_ENTRIES: usize, const FLAGS: usize> core::panic::unwind_safe::UnwindSafe for aya_ebpf::btf_maps::HashOfMaps<K, V, MAX_ENTRIES, FLAGS> where K: core::panic::unwind_safe::RefUnwindSafe, V: core::panic::unwind_safe::RefUnwindSafe
 #[repr(C)] pub struct aya_ebpf::btf_maps::InodeStorage<T>
 impl<T> aya_ebpf::btf_maps::inode_storage::InodeStorage<T>
-pub unsafe fn aya_ebpf::btf_maps::inode_storage::InodeStorage<T>::delete(&self, *mut aya_ebpf_bindings::x86_64::bindings::inode) -> core::result::Result<(), i32>
-pub unsafe fn aya_ebpf::btf_maps::inode_storage::InodeStorage<T>::get_or_insert_ptr_mut(&self, *mut aya_ebpf_bindings::x86_64::bindings::inode, core::option::Option<&mut T>) -> *mut T
-pub unsafe fn aya_ebpf::btf_maps::inode_storage::InodeStorage<T>::get_ptr_mut(&self, *mut aya_ebpf_bindings::x86_64::bindings::inode) -> *mut T
+pub fn aya_ebpf::btf_maps::inode_storage::InodeStorage<T>::delete(&self, *mut aya_ebpf_bindings::x86_64::bindings::inode) -> core::result::Result<(), i32>
+pub fn aya_ebpf::btf_maps::inode_storage::InodeStorage<T>::get_or_insert_ptr_mut(&self, *mut aya_ebpf_bindings::x86_64::bindings::inode, core::option::Option<&mut T>) -> *mut T
+pub fn aya_ebpf::btf_maps::inode_storage::InodeStorage<T>::get_ptr_mut(&self, *mut aya_ebpf_bindings::x86_64::bindings::inode) -> *mut T
 impl<T> aya_ebpf::btf_maps::inode_storage::InodeStorage<T>
 pub const fn aya_ebpf::btf_maps::inode_storage::InodeStorage<T>::new() -> Self
 impl<T> core::default::Default for aya_ebpf::btf_maps::inode_storage::InodeStorage<T>
@@ -892,9 +892,9 @@ impl<T, const MAX_ENTRIES: usize, const FLAGS: usize> core::panic::unwind_safe::
 impl<T, const MAX_ENTRIES: usize, const FLAGS: usize> core::panic::unwind_safe::UnwindSafe for aya_ebpf::btf_maps::ring_buf::RingBuf<T, MAX_ENTRIES, FLAGS> where T: core::panic::unwind_safe::RefUnwindSafe
 #[repr(C)] pub struct aya_ebpf::btf_maps::SkStorage<T>
 impl<T> aya_ebpf::btf_maps::sk_storage::SkStorage<T>
-pub unsafe fn aya_ebpf::btf_maps::sk_storage::SkStorage<T>::delete(&self, *mut aya_ebpf_bindings::x86_64::bindings::bpf_sock) -> core::result::Result<(), i32>
-pub unsafe fn aya_ebpf::btf_maps::sk_storage::SkStorage<T>::get_or_insert_ptr_mut(&self, &aya_ebpf::programs::sock_addr::SockAddrContext, core::option::Option<&mut T>) -> *mut T
-pub unsafe fn aya_ebpf::btf_maps::sk_storage::SkStorage<T>::get_ptr_mut(&self, &aya_ebpf::programs::sock_addr::SockAddrContext) -> *mut T
+pub fn aya_ebpf::btf_maps::sk_storage::SkStorage<T>::delete(&self, *mut aya_ebpf_bindings::x86_64::bindings::bpf_sock) -> core::result::Result<(), i32>
+pub fn aya_ebpf::btf_maps::sk_storage::SkStorage<T>::get_or_insert_ptr_mut(&self, &aya_ebpf::programs::sock_addr::SockAddrContext, core::option::Option<&mut T>) -> *mut T
+pub fn aya_ebpf::btf_maps::sk_storage::SkStorage<T>::get_ptr_mut(&self, &aya_ebpf::programs::sock_addr::SockAddrContext) -> *mut T
 impl<T> aya_ebpf::btf_maps::sk_storage::SkStorage<T>
 pub const fn aya_ebpf::btf_maps::sk_storage::SkStorage<T>::new() -> Self
 impl<T> core::default::Default for aya_ebpf::btf_maps::sk_storage::SkStorage<T>

--- a/xtask/public-api/aya-ebpf.txt
+++ b/xtask/public-api/aya-ebpf.txt
@@ -1325,9 +1325,9 @@ pub mod aya_ebpf::maps::sock_map
 #[repr(transparent)] pub struct aya_ebpf::maps::sock_map::SockMap
 impl aya_ebpf::maps::sock_map::SockMap
 pub const fn aya_ebpf::maps::sock_map::SockMap::pinned(u32, u32) -> Self
-pub unsafe fn aya_ebpf::maps::sock_map::SockMap::redirect_msg(&self, &aya_ebpf::programs::sk_msg::SkMsgContext, u32, u64) -> aya_ebpf_cty::od::c_long
+pub fn aya_ebpf::maps::sock_map::SockMap::redirect_msg(&self, &aya_ebpf::programs::sk_msg::SkMsgContext, u32, u64) -> aya_ebpf_cty::od::c_long
 pub fn aya_ebpf::maps::sock_map::SockMap::redirect_sk_lookup(&self, &aya_ebpf::programs::sk_lookup::SkLookupContext, u32, u64) -> core::result::Result<(), i32>
-pub unsafe fn aya_ebpf::maps::sock_map::SockMap::redirect_skb(&self, &aya_ebpf::programs::sk_buff::SkBuffContext, u32, u64) -> aya_ebpf_cty::od::c_long
+pub fn aya_ebpf::maps::sock_map::SockMap::redirect_skb(&self, &aya_ebpf::programs::sk_buff::SkBuffContext, u32, u64) -> aya_ebpf_cty::od::c_long
 pub unsafe fn aya_ebpf::maps::sock_map::SockMap::update(&self, u32, *mut aya_ebpf_bindings::x86_64::bindings::bpf_sock_ops, u64) -> core::result::Result<(), i32>
 pub const fn aya_ebpf::maps::sock_map::SockMap::with_max_entries(u32, u32) -> Self
 impl !core::marker::Freeze for aya_ebpf::maps::sock_map::SockMap
@@ -1729,9 +1729,9 @@ impl<K> core::panic::unwind_safe::UnwindSafe for aya_ebpf::maps::sock_hash::Sock
 #[repr(transparent)] pub struct aya_ebpf::maps::SockMap
 impl aya_ebpf::maps::sock_map::SockMap
 pub const fn aya_ebpf::maps::sock_map::SockMap::pinned(u32, u32) -> Self
-pub unsafe fn aya_ebpf::maps::sock_map::SockMap::redirect_msg(&self, &aya_ebpf::programs::sk_msg::SkMsgContext, u32, u64) -> aya_ebpf_cty::od::c_long
+pub fn aya_ebpf::maps::sock_map::SockMap::redirect_msg(&self, &aya_ebpf::programs::sk_msg::SkMsgContext, u32, u64) -> aya_ebpf_cty::od::c_long
 pub fn aya_ebpf::maps::sock_map::SockMap::redirect_sk_lookup(&self, &aya_ebpf::programs::sk_lookup::SkLookupContext, u32, u64) -> core::result::Result<(), i32>
-pub unsafe fn aya_ebpf::maps::sock_map::SockMap::redirect_skb(&self, &aya_ebpf::programs::sk_buff::SkBuffContext, u32, u64) -> aya_ebpf_cty::od::c_long
+pub fn aya_ebpf::maps::sock_map::SockMap::redirect_skb(&self, &aya_ebpf::programs::sk_buff::SkBuffContext, u32, u64) -> aya_ebpf_cty::od::c_long
 pub unsafe fn aya_ebpf::maps::sock_map::SockMap::update(&self, u32, *mut aya_ebpf_bindings::x86_64::bindings::bpf_sock_ops, u64) -> core::result::Result<(), i32>
 pub const fn aya_ebpf::maps::sock_map::SockMap::with_max_entries(u32, u32) -> Self
 impl !core::marker::Freeze for aya_ebpf::maps::sock_map::SockMap


### PR DESCRIPTION
The modern local-storage maps and the non-BTF sockmap expose wrapper
methods that operate on a kernel object or context pointer the BPF
program already holds. The verifier validates those pointers at load
time, so the methods can be safe, on the same basis the existing
context accessors such as `SkBuffContext::len` are safe. Writing
end-user BPF should not require `unsafe` for them. Follow-up to #1587.

`SkStorage`, `InodeStorage` and `CgrpStorage` make `get_ptr_mut`,
`get_or_insert_ptr_mut` and `delete` safe `pub fn`. `CgrpStorage::delete`
passes the `cgroup` pointer to the helper un-cast, so it carries an
`#[expect]` for `clippy::not_unsafe_ptr_arg_deref`. The dereference of
the returned `*mut T` stays the caller's `unsafe`. Callers in
`integration-ebpf` drop the now redundant `unsafe`.

The non-BTF `SockMap::redirect_msg` and `redirect_skb` become safe,
matching the already-safe BTF `SockMap`. `SockMap::update` keeps
`unsafe` because it takes a raw `bpf_sock_ops` pointer; it gains a real
safety doc in place of the previous lint suppression.

### Added/updated tests?

- [x] Yes

### Checklist

- [x] Rust code has been formatted with `cargo +nightly fmt`.
- [x] All clippy lints have been fixed.
      You can find failing lints with `cargo xtask clippy`.
- [x] Unit tests are passing locally with `cargo test`.
- [x] The integration tests are passing locally.
- [x] I have blessed any API changes with `cargo xtask public-api --bless`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aya-rs/aya/1589)
<!-- Reviewable:end -->
