### PR TITLE
Ksyms module btf fallback

### DIFF
--- a/.github/scripts/download_kernel_images.sh
+++ b/.github/scripts/download_kernel_images.sh
@@ -5,6 +5,7 @@ set -euo pipefail
 # Check for required arguments.
 if [ "$#" -lt 3 ]; then
   echo "Usage: $0 <output directory> <architecture> <version1> [<version2> ...]"
+  echo "       $0 <output directory> gentoo <architecture> <version1> [<version2> ...]"
   exit 1
 fi
 
@@ -15,42 +16,64 @@ escape_regex() {
 }
 
 OUTPUT_DIR=$1
-ARCHITECTURE=$2
+KERNEL_SOURCE_OR_ARCH=$2
 shift 2
-VERSIONS=("$@")
 
-URLS=$(lynx -dump -listonly -nonumbers https://mirrors.wikimedia.org/debian/pool/main/l/linux/)
-readonly URLS
-
-# Find the latest revision of each kernel version.
 FILES=()
-for VERSION in "${VERSIONS[@]}"; do
-  REGEX="linux-image-${VERSION//./\\.}\\.[0-9]+(-[0-9]+)?(\+bpo|\+deb[0-9]+)?-cloud-${ARCHITECTURE}-unsigned_.*\\.deb"
-  match=$(printf '%s\n' "$URLS" | grep -E "$REGEX" | sort -V | tail -n1) || {
-    printf '%s\nVERSION=%s\nREGEX=%s\n' "$URLS" "$VERSION" "$REGEX" >&2
+
+if [ "$KERNEL_SOURCE_OR_ARCH" = "gentoo" ]; then
+  if [ "$#" -lt 2 ]; then
+    echo "Usage: $0 <output directory> gentoo <architecture> <version1> [<version2> ...]"
     exit 1
-  }
-  FILES+=("$match")
+  fi
 
-  # The debug package contains the actual System.map. Debian has transitioned
-  # between -dbg and -dbgsym suffixes, so match either for the specific kernel
-  # we just selected.
-  kernel_basename=$(basename "$match")
-  kernel_prefix=${kernel_basename%%_*}
-  kernel_suffix=${kernel_basename#${kernel_prefix}_}
-  base_prefix=${kernel_prefix%-unsigned}
+  ARCHITECTURE=$1
+  shift
+  VERSIONS=("$@")
 
-  base_prefix_regex=$(escape_regex "$base_prefix")
-  kernel_suffix_regex=$(escape_regex "$kernel_suffix")
+  for VERSION in "${VERSIONS[@]}"; do
+    MINOR_VERSION=${VERSION#*.}
+    SERIES="${VERSION%%.*}.${MINOR_VERSION%%.*}"
+    FILES+=(
+      "https://mirror.netcologne.de/gentoo/pub/proj/dist-kernel/binpkg/${ARCHITECTURE}/${SERIES}/gentoo-kernel-${VERSION}.${ARCHITECTURE}.gpkg.tar"
+    )
+  done
+else
+  ARCHITECTURE=$KERNEL_SOURCE_OR_ARCH
+  VERSIONS=("$@")
 
-  DEBUG_REGEX="${base_prefix_regex}-dbg(sym)?_${kernel_suffix_regex}"
-  debug_match=$(printf '%s\n' "$URLS" | grep -E "$DEBUG_REGEX" | sort -V | tail -n1) || {
-    printf 'Failed to locate debug package matching %s\n%s\nVERSION=%s\nREGEX=%s\n' \
-      "$kernel_basename" "$URLS" "$VERSION" "$DEBUG_REGEX" >&2
-    exit 1
-  }
-  FILES+=("$debug_match")
-done
+  URLS=$(lynx -dump -listonly -nonumbers https://mirrors.wikimedia.org/debian/pool/main/l/linux/)
+  readonly URLS
+
+  # Find the latest revision of each kernel version.
+  for VERSION in "${VERSIONS[@]}"; do
+    REGEX="linux-image-${VERSION//./\\.}\\.[0-9]+(-[0-9]+)?(\+bpo|\+deb[0-9]+)?-cloud-${ARCHITECTURE}-unsigned_.*\\.deb"
+    match=$(printf '%s\n' "$URLS" | grep -E "$REGEX" | sort -V | tail -n1) || {
+      printf '%s\nVERSION=%s\nREGEX=%s\n' "$URLS" "$VERSION" "$REGEX" >&2
+      exit 1
+    }
+    FILES+=("$match")
+
+    # The debug package contains the actual System.map. Debian has transitioned
+    # between -dbg and -dbgsym suffixes, so match either for the specific kernel
+    # we just selected.
+    kernel_basename=$(basename "$match")
+    kernel_prefix=${kernel_basename%%_*}
+    kernel_suffix=${kernel_basename#${kernel_prefix}_}
+    base_prefix=${kernel_prefix%-unsigned}
+
+    base_prefix_regex=$(escape_regex "$base_prefix")
+    kernel_suffix_regex=$(escape_regex "$kernel_suffix")
+
+    DEBUG_REGEX="${base_prefix_regex}-dbg(sym)?_${kernel_suffix_regex}"
+    debug_match=$(printf '%s\n' "$URLS" | grep -E "$DEBUG_REGEX" | sort -V | tail -n1) || {
+      printf 'Failed to locate debug package matching %s\n%s\nVERSION=%s\nREGEX=%s\n' \
+        "$kernel_basename" "$URLS" "$VERSION" "$DEBUG_REGEX" >&2
+      exit 1
+    }
+    FILES+=("$debug_match")
+  done
+fi
 
 # Note: `--etag-{compare,save}` are not idempotent until curl 8.9.0 which included
 # https://github.com/curl/curl/commit/85efbb92b8e6679705e122cee45ce76c56414a3e. At the time of

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -272,6 +272,13 @@ jobs:
             # nested virtualization so running them here would be slow.
             download-kernel-images: local
 
+          - os: ubuntu-24.04-arm
+            # Run the full VM integration suite on one Gentoo distribution
+            # kernel. This covers the custom kmod/module-BTF path and checks
+            # that the Gentoo kernel config does not regress unrelated tests.
+            download-kernel-images: gentoo arm64 6.18.9-1
+            skip-local: true
+
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v6
@@ -296,6 +303,7 @@ jobs:
           # See https://github.com/libbpf/libbpf-sys/issues/137.
           sudo apt -y install \
             autopoint \
+            dwarves \
             linux-libc-dev \
             liblzma-dev \
             llvm \
@@ -337,12 +345,12 @@ jobs:
           path: test/.tmp
           key: ${{ runner.arch }}-${{ runner.os }}-test-cache-${{ matrix.download-kernel-images }}
 
-      - name: Download debian kernels
+      - name: Download kernels
         if: matrix.download-kernel-images != 'local'
         run: |
           set -euxo pipefail
 
-          .github/scripts/download_kernel_images.sh test/.tmp/debian-kernels ${{ matrix.download-kernel-images }}
+          .github/scripts/download_kernel_images.sh test/.tmp/kernels ${{ matrix.download-kernel-images }}
 
       - name: Cleanup stale kernels and modules
         run: rm -rf test/.tmp/boot test/.tmp/lib
@@ -352,13 +360,23 @@ jobs:
         run: cargo xtask integration-test local
 
       - name: Run virtualized integration tests
-        if: matrix.download-kernel-images != 'local'
+        if: matrix.download-kernel-images != 'local' && !startsWith(matrix.download-kernel-images, 'gentoo ')
         run: |
           set -euxo pipefail
 
-          find test/.tmp -name '*.deb' -print0 | sort -Vz | xargs -t -0 \
+          find test/.tmp/kernels -name '*.deb' -print0 | sort -Vz | xargs -t -0 \
             cargo xtask integration-test vm --cache-dir test/.tmp \
               --github-api-token ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Run Gentoo virtualized integration tests
+        if: startsWith(matrix.download-kernel-images, 'gentoo ')
+        run: |
+          set -euxo pipefail
+
+          find test/.tmp/kernels -name '*.gpkg.tar' -print0 | sort -Vz | xargs -t -0 \
+            cargo xtask integration-test vm --cache-dir test/.tmp \
+              --github-api-token ${{ secrets.GITHUB_TOKEN }} \
+              --kmod aya_ksyms_test
 
   check:
     if: always()

--- a/aya-obj/src/btf/btf.rs
+++ b/aya-obj/src/btf/btf.rs
@@ -18,6 +18,7 @@ use crate::{
         info::{FuncSecInfo, LineSecInfo},
         relocation::Relocation,
     },
+    extern_types::ExternCollection,
     generated::{btf_ext_header, btf_header},
     util::{HashMap, bytes_of},
 };
@@ -277,6 +278,8 @@ pub struct Btf {
     strings: Vec<u8>,
     types: BtfTypes,
     _endianness: Endianness,
+    /// Extern symbols parsed from the `.ksyms` section.
+    pub(crate) externs: ExternCollection,
 }
 
 fn add_type(header: &mut btf_header, types: &mut BtfTypes, btf_type: BtfType) -> u32 {
@@ -305,6 +308,7 @@ impl Btf {
             strings: vec![0],
             types: BtfTypes::default(),
             _endianness: Endianness::default(),
+            externs: ExternCollection::new(),
         }
     }
 
@@ -375,6 +379,7 @@ impl Btf {
             strings,
             types,
             _endianness: endianness,
+            externs: ExternCollection::new(),
         })
     }
 
@@ -511,6 +516,13 @@ impl Btf {
         symbol_offsets: &HashMap<String, u64>,
         features: &BtfFeatures,
     ) -> Result<(), BtfError> {
+        if !self.externs.is_empty() {
+            let datasec_id = self
+                .externs
+                .datasec_id
+                .expect("non-empty externs must have datasec_id");
+            self.fixup_ksyms_datasec(datasec_id, self.externs.ksym_func_placeholder_id)?;
+        }
         let enum64_placeholder_id = OnceCell::new();
         let filler_var_id = OnceCell::new();
         let mut types = mem::take(&mut self.types);
@@ -811,6 +823,135 @@ impl Btf {
             }
         }
         self.types = types;
+        Ok(())
+    }
+
+    /// Fixes up BTF for `.ksyms` datasec entries containing extern kernel symbols and
+    /// makes it acceptable by the kernel:
+    ///
+    /// * Changes linkage of extern functions to `GLOBAL`, fixes parameter names, injects
+    ///   a placeholder variable representing them in datasec.
+    /// * Changes linkage of extern variables to `GLOBAL`, replaces their type
+    ///   with `int`.
+    pub(crate) fn fixup_ksyms_datasec(
+        &mut self,
+        datasec_id: u32,
+        ksym_func_placeholder_id: Option<u32>,
+    ) -> Result<(), BtfError> {
+        // Use the placeholder var's name/type when present; otherwise fall back to a plain
+        // 4-byte int for `.ksyms` datasec fixup.
+        let (placeholder_name_offset, int_btf_id) =
+            if let Some(placeholder_id) = ksym_func_placeholder_id {
+                let placeholder_type = &self.types.types[placeholder_id as usize];
+                if let BtfType::Var(v) = placeholder_type {
+                    (Some(v.name_offset), v.btf_type)
+                } else {
+                    return Err(BtfError::InvalidDatasec);
+                }
+            } else {
+                let int_id = self
+                    .types
+                    .types
+                    .iter()
+                    .enumerate()
+                    .find_map(|(idx, t)| {
+                        if let BtfType::Int(int_type) = t {
+                            (int_type.size == 4).then_some(idx as u32)
+                        } else {
+                            None
+                        }
+                    })
+                    .unwrap_or_else(|| {
+                        let name_offset = self.add_string("int");
+                        self.add_type(BtfType::Int(Int::new(
+                            name_offset,
+                            4,
+                            IntEncoding::Signed,
+                            0,
+                        )))
+                    });
+
+                (None, int_id)
+            };
+
+        let datasec_name = {
+            let datasec = &self.types.types[datasec_id as usize];
+            let BtfType::DataSec(d) = datasec else {
+                return Err(BtfError::InvalidDatasec);
+            };
+            self.string_at(d.name_offset)?.into_owned()
+        };
+
+        debug!("DATASEC {datasec_name}: fixing up extern ksyms");
+
+        let entry_type_ids: Vec<u32> = {
+            let BtfType::DataSec(d) = &self.types.types[datasec_id as usize] else {
+                return Err(BtfError::InvalidDatasec);
+            };
+            d.entries.iter().map(|e| e.btf_type).collect()
+        };
+
+        let mut offset = 0u32;
+        let size = size_of::<i32>() as u32;
+
+        for (i, &type_id) in entry_type_ids.iter().enumerate() {
+            match &self.types.types[type_id as usize] {
+                BtfType::Func(f) => {
+                    let (func_name, proto_id) =
+                        { (self.string_at(f.name_offset)?.into_owned(), f.btf_type) };
+
+                    if let BtfType::Func(f) = &mut self.types.types[type_id as usize] {
+                        f.set_linkage(FuncLinkage::Global);
+                    }
+
+                    if let Some(placeholder_name_offset) = placeholder_name_offset {
+                        if let BtfType::FuncProto(func_proto) =
+                            &mut self.types.types[proto_id as usize]
+                        {
+                            for param in &mut func_proto.params {
+                                if param.btf_type != 0 && param.name_offset == 0 {
+                                    param.name_offset = placeholder_name_offset;
+                                }
+                            }
+                        }
+                    }
+
+                    if let (Some(placeholder_id), BtfType::DataSec(d)) = (
+                        ksym_func_placeholder_id,
+                        &mut self.types.types[datasec_id as usize],
+                    ) {
+                        d.entries[i].btf_type = placeholder_id;
+                    }
+
+                    debug!("DATASEC {datasec_name}: FUNC {func_name}: fixup offset {offset}");
+                }
+                BtfType::Var(v) => {
+                    let var_name = { self.string_at(v.name_offset)?.into_owned() };
+
+                    if let BtfType::Var(v) = &mut self.types.types[type_id as usize] {
+                        v.linkage = VarLinkage::Global;
+                        v.btf_type = int_btf_id;
+                    }
+
+                    debug!("DATASEC {datasec_name}: VAR {var_name}: fixup offset {offset}");
+                }
+                _ => return Err(BtfError::InvalidDatasec),
+            }
+
+            let BtfType::DataSec(d) = &mut self.types.types[datasec_id as usize] else {
+                return Err(BtfError::InvalidDatasec);
+            };
+            d.entries[i].offset = offset;
+            d.entries[i].size = size;
+
+            offset += size;
+        }
+
+        if let BtfType::DataSec(d) = &mut self.types.types[datasec_id as usize] {
+            d.size = offset;
+            debug!("DATASEC {datasec_name}: fixup size to {offset}");
+        }
+
         Ok(())
     }
 }
@@ -1579,6 +1720,61 @@ mod tests {
         // Ensure we can convert to bytes and back again
         let raw = btf.to_bytes();
         Btf::parse(&raw, Endianness::default()).unwrap();
+    }
+
+    #[test]
+    fn test_fixup_ksyms_datasec_creates_int_type_for_var_only_datasec() {
+        let mut btf = Btf::new();
+
+        let var_name_offset = btf.add_string("init_task");
+        let var_type_id = btf.add_type(BtfType::Var(Var::new(
+            var_name_offset,
+            0,
+            VarLinkage::Extern,
+        )));
+
+        let datasec_name_offset = btf.add_string(".ksyms");
+        let variables = vec![DataSecEntry {
+            btf_type: var_type_id,
+            offset: 0,
+            size: 0,
+        }];
+        let datasec_type_id = btf.add_type(BtfType::DataSec(DataSec::new(
+            datasec_name_offset,
+            variables,
+            0,
+        )));
+
+        btf.fixup_ksyms_datasec(datasec_type_id, None).unwrap();
+
+        let int_type_id = match btf.type_by_id(var_type_id).unwrap() {
+            BtfType::Var(fixed) => {
+                assert_eq!(fixed.linkage, VarLinkage::Global);
+                fixed.btf_type
+            }
+            other => panic!("expected var, got {other:?}"),
+        };
+
+        assert_matches!(btf.type_by_id(int_type_id).unwrap(), BtfType::Int(int) => {
+            assert_eq!(btf.string_at(int.name_offset).unwrap(), "int");
+            assert_eq!(int.size, 4);
+            assert_eq!(int.encoding(), IntEncoding::Signed);
+        });
+
+        assert_matches!(btf.type_by_id(datasec_type_id).unwrap(), BtfType::DataSec(fixed) => {
+            assert_eq!(fixed.size, 4);
+            assert_matches!(*fixed.entries, [
+                DataSecEntry {
+                    btf_type,
+                    offset,
+                    size,
+                },
+            ] => {
+                assert_eq!(btf_type, var_type_id);
+                assert_eq!(offset, 0);
+                assert_eq!(size, 4);
+            });
+        });
     }
 
     #[test]

--- a/aya-obj/src/btf/btf.rs
+++ b/aya-obj/src/btf/btf.rs
@@ -17,6 +17,7 @@ use crate::{
         LineInfo, Struct, Typedef, Union, Var, VarLinkage,
         info::{FuncSecInfo, LineSecInfo},
         relocation::Relocation,
+        view,
     },
     extern_types::ExternCollection,
     generated::{btf_ext_header, btf_header},
@@ -321,6 +322,14 @@ impl Btf {
         self.types.types.iter()
     }
 
+    pub(crate) const fn type_count(&self) -> u32 {
+        self.types.len() as u32
+    }
+
+    pub(crate) const fn string_len(&self) -> u32 {
+        self.header.str_len
+    }
+
     /// Adds a string to BTF metadata, returning an offset
     pub fn add_string(&mut self, name: &str) -> u32 {
         let str = name.bytes().chain(core::iter::once(0));
@@ -410,20 +419,10 @@ impl Btf {
     }
 
     pub(crate) fn string_at(&self, offset: u32) -> Result<Cow<'_, str>, BtfError> {
-        let btf_header {
-            hdr_len,
-            mut str_off,
-            str_len,
-            ..
-        } = self.header;
-        str_off += hdr_len;
-        if offset >= str_off + str_len {
-            return Err(BtfError::InvalidStringOffset {
-                offset: offset as usize,
-            });
-        }
-
         let offset = offset as usize;
+        if offset >= self.strings.len() {
+            return Err(BtfError::InvalidStringOffset { offset });
+        }
 
         let s = CStr::from_bytes_until_nul(&self.strings[offset..])
             .map_err(|FromBytesUntilNulError { .. }| BtfError::InvalidStringOffset { offset })?;
@@ -436,11 +435,11 @@ impl Btf {
     }
 
     pub(crate) fn resolve_type(&self, root_type_id: u32) -> Result<u32, BtfError> {
-        self.types.resolve_type(root_type_id)
+        <Self as view::BtfView>::resolve_type(self, root_type_id)
     }
 
     pub(crate) fn type_name(&self, ty: &BtfType) -> Result<Cow<'_, str>, BtfError> {
-        self.string_at(ty.name_offset())
+        <Self as view::BtfView>::type_name(self, ty)
     }
 
     pub(crate) fn err_type_name(&self, ty: &BtfType) -> Option<String> {
@@ -467,7 +466,7 @@ impl Btf {
         let mut type_id = root_type_id;
         let mut n_elems = 1;
         for () in core::iter::repeat_n((), MAX_RESOLVE_DEPTH) {
-            let ty = self.types.type_by_id(type_id)?;
+            let ty = self.type_by_id(type_id)?;
             let size = match ty {
                 BtfType::Array(Array { array, .. }) => {
                     n_elems = array.len;
@@ -1282,36 +1281,6 @@ impl BtfTypes {
             .get(type_id as usize)
             .ok_or(BtfError::UnknownBtfType { type_id })
     }
-
-    pub(crate) fn resolve_type(&self, root_type_id: u32) -> Result<u32, BtfError> {
-        let mut type_id = root_type_id;
-        for () in core::iter::repeat_n((), MAX_RESOLVE_DEPTH) {
-            let ty = self.type_by_id(type_id)?;
-
-            match ty {
-                BtfType::Volatile(ty) => {
-                    type_id = ty.btf_type;
-                }
-                BtfType::Const(ty) => {
-                    type_id = ty.btf_type;
-                }
-                BtfType::Restrict(ty) => {
-                    type_id = ty.btf_type;
-                }
-                BtfType::Typedef(ty) => {
-                    type_id = ty.btf_type;
-                }
-                BtfType::TypeTag(ty) => {
-                    type_id = ty.btf_type;
-                }
-                _ => return Ok(type_id),
-            }
-        }
-
-        Err(BtfError::MaximumTypeDepthReached {
-            type_id: root_type_id,
-        })
-    }
 }
 
 #[derive(Debug)]
@@ -1326,7 +1295,10 @@ mod tests {
     use assert_matches::assert_matches;
 
     use super::*;
-    use crate::btf::{BtfParam, DeclTag, Float, Func, FuncProto, Ptr, TypeTag};
+    use crate::btf::{
+        BtfParam, DeclTag, Float, Func, FuncProto, Ptr, TypeTag,
+        view::{BtfView as _, SplitBtf},
+    };
 
     #[test]
     fn test_parse_header() {
@@ -1548,6 +1520,94 @@ mod tests {
         let btf = Btf::parse(raw_btf, Endianness::default()).unwrap();
         assert_eq!(btf.string_at(1).unwrap(), "int");
         assert_eq!(btf.string_at(5).unwrap(), "widget");
+    }
+
+    #[test]
+    fn test_split_btf_type_and_string_lookup() {
+        let mut base = Btf::new();
+        let int_name = base.add_string("int");
+        let int_id = base.add_type(BtfType::Int(Int::new(int_name, 4, IntEncoding::Signed, 0)));
+        let start_id = base.type_count();
+        let start_str_off = base.string_len();
+
+        let mut module = Btf::new();
+        let func_name = module.add_string("my_mod_kfunc");
+        let visible_func_name = start_str_off + func_name;
+        let proto_id = module.add_type(BtfType::FuncProto(FuncProto::new(vec![], int_id)));
+        let visible_proto_id = start_id + proto_id - 1;
+        let func_id = module.add_type(BtfType::Func(Func::new(
+            visible_func_name,
+            visible_proto_id,
+            FuncLinkage::Global,
+        )));
+
+        let split = SplitBtf::new(&base, &module);
+        let visible_func_id = split.start_id() + func_id - 1;
+
+        assert_eq!(split.string_at(int_name).unwrap(), "int");
+        assert_eq!(split.string_at(visible_func_name).unwrap(), "my_mod_kfunc");
+        assert!(matches!(
+            split.string_at(visible_func_name + "my_mod_kfunc".len() as u32 + 1),
+            Err(BtfError::InvalidStringOffset { .. })
+        ));
+        assert_matches!(split.type_by_id(int_id).unwrap(), BtfType::Int(_));
+        assert_matches!(split.type_by_id(0).unwrap(), BtfType::Unknown);
+        assert_matches!(split.type_by_id(visible_func_id).unwrap(), BtfType::Func(_));
+        assert!(matches!(
+            split.type_by_id(visible_func_id + 1),
+            Err(BtfError::UnknownBtfType { .. })
+        ));
+    }
+
+    #[test]
+    fn test_split_btf_visible_vs_own_lookup() {
+        let mut base = Btf::new();
+        let task_name = base.add_string("task_struct");
+        let _task_id = base.add_type(BtfType::Struct(Struct::new(task_name, vec![], 0)));
+        let start_id = base.type_count();
+        let start_str_off = base.string_len();
+
+        let mut module = Btf::new();
+        let local_name = module.add_string("my_mod_kfunc");
+        let visible_name = start_str_off + local_name;
+        let local_proto_id = module.add_type(BtfType::FuncProto(FuncProto::new(vec![], 0)));
+        let visible_proto_id = start_id + local_proto_id - 1;
+        let local_func_id = module.add_type(BtfType::Func(Func::new(
+            visible_name,
+            visible_proto_id,
+            FuncLinkage::Global,
+        )));
+
+        let split = SplitBtf::new(&base, &module);
+        let visible_func_id = split.start_id() + local_func_id - 1;
+
+        assert_eq!(
+            split
+                .id_by_type_name_kind_visible("task_struct", BtfKind::Struct)
+                .unwrap(),
+            base.id_by_type_name_kind("task_struct", BtfKind::Struct)
+                .unwrap()
+        );
+        assert_eq!(
+            split
+                .id_by_type_name_kind_visible("my_mod_kfunc", BtfKind::Func)
+                .unwrap(),
+            visible_func_id
+        );
+        assert!(matches!(
+            split.id_by_type_name_kind_own("task_struct", BtfKind::Struct),
+            Err(BtfError::UnknownBtfTypeName { .. })
+        ));
+        assert_eq!(
+            split
+                .id_by_type_name_kind_own("my_mod_kfunc", BtfKind::Func)
+                .unwrap(),
+            visible_func_id
+        );
+        assert!(matches!(
+            module.id_by_type_name_kind("my_mod_kfunc", BtfKind::Func),
+            Err(BtfError::InvalidStringOffset { .. })
+        ));
     }
 
     #[test]

--- a/aya-obj/src/btf/extern_types.rs
+++ b/aya-obj/src/btf/extern_types.rs
@@ -1,0 +1,164 @@
+use log::debug;
+
+use crate::{
+    Object,
+    btf::{Btf, BtfError, BtfType, DataSec, DataSecEntry},
+    extern_types::{ExternDesc, ExternType},
+    relocation::Symbol,
+    util::HashMap,
+};
+
+impl Btf {
+    /// Creates a placeholder global variable for `.ksyms` function entries.
+    ///
+    /// Kernel BTF datasec entries are variable-oriented, so function entries in `.ksyms`
+    /// need a placeholder variable type during datasec fixup.
+    pub(crate) fn create_ksym_func_placeholder(&mut self) -> u32 {
+        let maybe_int_type_id = self.types().enumerate().find_map(|(idx, t)| match t {
+            BtfType::Int(int) if int.size == 4 => Some(idx as u32),
+            _ => None,
+        });
+
+        let int_type_id = maybe_int_type_id
+            .inspect(|id| debug!("found 4-byte int type_id: {id}"))
+            .unwrap_or_else(|| {
+                let name_offset = self.add_string("int");
+                let int_type_id = self.add_type(BtfType::Int(crate::btf::Int::new(
+                    name_offset,
+                    4,
+                    crate::btf::IntEncoding::Signed,
+                    0,
+                )));
+                debug!("created 4-byte int type_id: {int_type_id}");
+                int_type_id
+            });
+
+        let name_offset = self.add_string("ksym_func_placeholder");
+        let placeholder_id = self.add_type(BtfType::Var(crate::btf::Var::new(
+            name_offset,
+            int_type_id,
+            crate::btf::VarLinkage::Global,
+        )));
+
+        debug!("created ksym function placeholder type_id: {placeholder_id}");
+        placeholder_id
+    }
+
+    /// Searches for the `.ksyms` datasec in BTF, returns it if found.
+    fn find_ksyms_datasec(&self) -> Result<Option<(u32, DataSec)>, BtfError> {
+        for (idx, btf_type) in self.types().enumerate() {
+            if let BtfType::DataSec(datasec) = btf_type {
+                let name = self.type_name(btf_type)?;
+                if name == ".ksyms" {
+                    return Ok(Some((idx as u32, datasec.clone())));
+                }
+            }
+        }
+
+        Ok(None)
+    }
+
+    /// Checks if datasec contains any functions.
+    pub(crate) fn datasec_has_functions(&self, datasec: &DataSec) -> Result<bool, BtfError> {
+        for entry in &datasec.entries {
+            let t = self.type_by_id(entry.btf_type)?;
+            if matches!(t, BtfType::Func(_)) {
+                return Ok(true);
+            }
+        }
+        Ok(false)
+    }
+
+    /// Returns an iterator over extern descriptors from datasec entries.
+    pub(crate) fn extern_entries<'a>(
+        &'a self,
+        datasec: &'a DataSec,
+        symbol_table: &'a HashMap<usize, Symbol>,
+    ) -> impl Iterator<Item = Result<ExternDesc, BtfError>> + 'a {
+        datasec
+            .entries
+            .iter()
+            .map(move |entry| self.process_datasec_entry(entry, symbol_table))
+    }
+
+    /// Processes a single datasec entry into an [`ExternDesc`].
+    fn process_datasec_entry(
+        &self,
+        entry: &DataSecEntry,
+        symbol_table: &HashMap<usize, Symbol>,
+    ) -> Result<ExternDesc, BtfError> {
+        let btf_type = self.type_by_id(entry.btf_type)?;
+
+        let (name, is_func, var_btf_type) = match btf_type {
+            BtfType::Func(func) => {
+                let name = self.string_at(func.name_offset)?.into_owned();
+                (name, true, func.btf_type)
+            }
+            BtfType::Var(var) => {
+                let name = self.string_at(var.name_offset)?.into_owned();
+                (name, false, var.btf_type)
+            }
+            _ => return Err(BtfError::InvalidDatasec),
+        };
+
+        let symbol = find_symbol_by_name(symbol_table, &name).ok_or(BtfError::InvalidSymbolName)?;
+
+        // Resolve through modifiers (const, volatile, typedef, etc.)
+        // Type ID 0 represents void in BTF
+        let resolved_type_id = self.resolve_type(var_btf_type).unwrap_or(var_btf_type);
+
+        // Typeless ksyms are declared as `extern const void symbol __ksym`
+        // They resolve to void (type_id 0) and are resolved via /proc/kallsyms
+        let is_typeless = !is_func && resolved_type_id == 0;
+
+        let mut extern_desc =
+            ExternDesc::new(name, ExternType::Ksym, entry.btf_type, symbol.is_weak);
+
+        // For typeless ksyms, don't set type_id so they skip kernel BTF resolution
+        if !is_typeless {
+            extern_desc.type_id = Some(resolved_type_id);
+        }
+
+        Ok(extern_desc)
+    }
+}
+
+fn find_symbol_by_name<'a>(
+    symbol_table: &'a HashMap<usize, Symbol>,
+    name: &str,
+) -> Option<&'a Symbol> {
+    symbol_table
+        .values()
+        .find(|sym| sym.name.as_deref() == Some(name))
+}
+
+impl Object {
+    /// Collects extern kernel symbols from BTF datasec entries.
+    pub(crate) fn collect_ksyms_from_btf(&mut self) -> Result<(), BtfError> {
+        let Some(btf) = self.btf.as_mut() else {
+            return Ok(());
+        };
+        let Some((datasec_id, datasec)) = btf.find_ksyms_datasec()? else {
+            return Ok(());
+        };
+
+        if btf.datasec_has_functions(&datasec)? {
+            let placeholder_id = btf.create_ksym_func_placeholder();
+            btf.externs.set_ksym_func_placeholder_id(placeholder_id);
+        }
+
+        let collected: Vec<ExternDesc> = btf
+            .extern_entries(&datasec, &self.symbol_table)
+            .collect::<Result<Vec<_>, _>>()?;
+
+        for extern_desc in collected {
+            btf.externs.insert(extern_desc.name.clone(), extern_desc);
+        }
+
+        if !btf.externs.is_empty() {
+            btf.externs.datasec_id = Some(datasec_id);
+        }
+
+        Ok(())
+    }
+}

--- a/aya-obj/src/btf/mod.rs
+++ b/aya-obj/src/btf/mod.rs
@@ -2,6 +2,7 @@
 
 #[expect(clippy::module_inception, reason = "TODO")]
 mod btf;
+mod extern_types;
 mod info;
 mod relocation;
 mod types;

--- a/aya-obj/src/btf/mod.rs
+++ b/aya-obj/src/btf/mod.rs
@@ -6,6 +6,7 @@ mod extern_types;
 mod info;
 mod relocation;
 mod types;
+pub(crate) mod view;
 
 pub use btf::*;
 pub use info::*;

--- a/aya-obj/src/btf/types.rs
+++ b/aya-obj/src/btf/types.rs
@@ -5,7 +5,7 @@ use std::{fmt::Display, ptr, string::ToString as _};
 
 use object::Endianness;
 
-use crate::btf::{Btf, BtfError, MAX_RESOLVE_DEPTH};
+use crate::btf::{BtfError, MAX_RESOLVE_DEPTH, view::BtfView};
 
 #[derive(Clone, Debug)]
 pub enum BtfType {
@@ -1466,12 +1466,16 @@ const fn type_vlen(info: u32) -> usize {
     (info & 0xFFFF) as usize
 }
 
-pub(crate) fn types_are_compatible(
-    local_btf: &Btf,
+pub(crate) fn types_are_compatible<L, R>(
+    local_btf: &L,
     root_local_id: u32,
-    target_btf: &Btf,
+    target_btf: &R,
     root_target_id: u32,
-) -> Result<bool, BtfError> {
+) -> Result<bool, BtfError>
+where
+    L: BtfView + ?Sized,
+    R: BtfView + ?Sized,
+{
     let mut local_id = root_local_id;
     let mut target_id = root_target_id;
     let local_ty = local_btf.type_by_id(local_id)?;
@@ -1542,12 +1546,16 @@ pub(crate) fn types_are_compatible(
     Err(BtfError::MaximumTypeDepthReached { type_id: local_id })
 }
 
-pub(crate) fn fields_are_compatible(
-    local_btf: &Btf,
+pub(crate) fn fields_are_compatible<L, R>(
+    local_btf: &L,
     mut local_id: u32,
-    target_btf: &Btf,
+    target_btf: &R,
     mut target_id: u32,
-) -> Result<bool, BtfError> {
+) -> Result<bool, BtfError>
+where
+    L: BtfView + ?Sized,
+    R: BtfView + ?Sized,
+{
     for () in core::iter::repeat_n((), MAX_RESOLVE_DEPTH) {
         local_id = local_btf.resolve_type(local_id)?;
         target_id = target_btf.resolve_type(target_id)?;
@@ -1606,6 +1614,7 @@ mod tests {
     use assert_matches::assert_matches;
 
     use super::*;
+    use crate::btf::{Btf, view::SplitBtf};
 
     #[test]
     fn test_read_btf_type_int() {
@@ -1867,6 +1876,148 @@ mod tests {
         // int types are compatible if offsets match. size and encoding aren't compared
         assert!(types_are_compatible(&btf, u32t, &btf, u64t).unwrap());
         assert!(types_are_compatible(&btf, array_type, &btf, array_type).unwrap());
+    }
+
+    #[test]
+    fn test_types_are_compatible_across_split_btf_boundary() {
+        let mut base = Btf::new();
+        let int_name = base.add_string("int");
+        let int_id = base.add_type(BtfType::Int(Int::new(int_name, 4, IntEncoding::Signed, 0)));
+        let task_name = base.add_string("task_struct");
+        let task_id = base.add_type(BtfType::Struct(Struct::new(task_name, vec![], 0)));
+        let task_ptr_id = base.add_type(BtfType::Ptr(Ptr::new(0, task_id)));
+
+        let mut local_btf = Btf::new();
+        let local_int_name = local_btf.add_string("int");
+        let local_int_id = local_btf.add_type(BtfType::Int(Int::new(
+            local_int_name,
+            4,
+            IntEncoding::Signed,
+            0,
+        )));
+        let local_task_name = local_btf.add_string("task_struct");
+        let local_task_id =
+            local_btf.add_type(BtfType::Struct(Struct::new(local_task_name, vec![], 0)));
+        let local_task_ptr_id = local_btf.add_type(BtfType::Ptr(Ptr::new(0, local_task_id)));
+        let local_proto_id = local_btf.add_type(BtfType::FuncProto(FuncProto::new(
+            vec![BtfParam {
+                name_offset: 0,
+                btf_type: local_task_ptr_id,
+            }],
+            local_int_id,
+        )));
+
+        let mut module_btf = Btf::new();
+        let module_proto_id = module_btf.add_type(BtfType::FuncProto(FuncProto::new(
+            vec![BtfParam {
+                name_offset: 0,
+                btf_type: task_ptr_id,
+            }],
+            int_id,
+        )));
+
+        let split_btf = SplitBtf::new(&base, &module_btf);
+        let split_proto_id = split_btf.start_id() + module_proto_id - 1;
+
+        assert!(
+            types_are_compatible(&local_btf, local_proto_id, &split_btf, split_proto_id).unwrap()
+        );
+    }
+
+    #[test]
+    fn test_split_btf_resolve_type_crosses_module_modifiers_to_base() {
+        let mut base = Btf::new();
+        let int_name = base.add_string("int");
+        let int_id = base.add_type(BtfType::Int(Int::new(int_name, 4, IntEncoding::Signed, 0)));
+        let start_id = base.type_count();
+        let start_str_off = base.string_len();
+
+        let mut module_btf = Btf::new();
+        let const_id = module_btf.add_type(BtfType::Const(Const::new(int_id)));
+        let visible_const_id = start_id + const_id - 1;
+        let typedef_name = module_btf.add_string("module_int");
+        let visible_typedef_name = start_str_off + typedef_name;
+        let typedef_id = module_btf.add_type(BtfType::Typedef(Typedef::new(
+            visible_typedef_name,
+            visible_const_id,
+        )));
+
+        let split_btf = SplitBtf::new(&base, &module_btf);
+        let visible_typedef_id = split_btf.start_id() + typedef_id - 1;
+
+        assert_eq!(split_btf.resolve_type(visible_typedef_id).unwrap(), int_id);
+    }
+
+    #[test]
+    fn test_fields_are_compatible_across_split_btf_boundary() {
+        let mut base = Btf::new();
+        base.add_string("padding");
+        let start_id = base.type_count();
+        let start_str_off = base.string_len();
+
+        let mut local_btf = Btf::new();
+        let local_name = local_btf.add_string("module_enum");
+        let local_id = local_btf.add_type(BtfType::Enum(Enum::new(local_name, false, vec![])));
+
+        let mut module_btf = Btf::new();
+        let module_name = module_btf.add_string("module_enum");
+        let visible_module_name = start_str_off + module_name;
+        let module_id =
+            module_btf.add_type(BtfType::Enum(Enum::new(visible_module_name, false, vec![])));
+
+        let split_btf = SplitBtf::new(&base, &module_btf);
+        let visible_module_id = start_id + module_id - 1;
+
+        assert!(
+            fields_are_compatible(&local_btf, local_id, &split_btf, visible_module_id).unwrap()
+        );
+
+        let mut other_module_btf = Btf::new();
+        let other_name = other_module_btf.add_string("other_enum");
+        let visible_other_name = start_str_off + other_name;
+        let other_id =
+            other_module_btf.add_type(BtfType::Enum(Enum::new(visible_other_name, false, vec![])));
+        let other_split_btf = SplitBtf::new(&base, &other_module_btf);
+        let visible_other_id = start_id + other_id - 1;
+
+        assert!(
+            !fields_are_compatible(&local_btf, local_id, &other_split_btf, visible_other_id)
+                .unwrap()
+        );
+    }
+
+    #[test]
+    fn test_types_are_compatible_across_split_btf_boundary_rejects_mismatch() {
+        let mut base = Btf::new();
+        let int_name = base.add_string("int");
+        let int_id = base.add_type(BtfType::Int(Int::new(int_name, 4, IntEncoding::Signed, 0)));
+
+        let mut local_btf = Btf::new();
+        let local_int_name = local_btf.add_string("int");
+        let local_int_id = local_btf.add_type(BtfType::Int(Int::new(
+            local_int_name,
+            4,
+            IntEncoding::Signed,
+            0,
+        )));
+        let local_proto_id = local_btf.add_type(BtfType::FuncProto(FuncProto::new(
+            vec![BtfParam {
+                name_offset: 0,
+                btf_type: local_int_id,
+            }],
+            local_int_id,
+        )));
+
+        let mut module_btf = Btf::new();
+        let module_proto_id =
+            module_btf.add_type(BtfType::FuncProto(FuncProto::new(vec![], int_id)));
+
+        let split_btf = SplitBtf::new(&base, &module_btf);
+        let split_proto_id = split_btf.start_id() + module_proto_id - 1;
+
+        assert!(
+            !types_are_compatible(&local_btf, local_proto_id, &split_btf, split_proto_id).unwrap()
+        );
     }
 
     #[test]

--- a/aya-obj/src/btf/view.rs
+++ b/aya-obj/src/btf/view.rs
@@ -61,13 +61,6 @@ pub(crate) struct SplitBtf<'a> {
 }
 
 impl<'a> SplitBtf<'a> {
-    #[cfg_attr(
-        not(test),
-        expect(
-            dead_code,
-            reason = "exercised by split BTF tests until module BTF resolution uses it"
-        )
-    )]
     pub(crate) const fn new(base: &'a Btf, split: &'a Btf) -> Self {
         Self {
             base,
@@ -82,13 +75,6 @@ impl<'a> SplitBtf<'a> {
         self.start_id
     }
 
-    #[cfg_attr(
-        not(test),
-        expect(
-            dead_code,
-            reason = "exercised by split BTF tests until module BTF resolution uses it"
-        )
-    )]
     pub(crate) fn id_by_type_name_kind_own(
         &self,
         name: &str,

--- a/aya-obj/src/btf/view.rs
+++ b/aya-obj/src/btf/view.rs
@@ -1,0 +1,147 @@
+use std::borrow::Cow;
+
+use crate::btf::{Btf, BtfError, BtfKind, BtfType, MAX_RESOLVE_DEPTH};
+
+pub(crate) trait BtfView {
+    fn type_by_id(&self, type_id: u32) -> Result<&BtfType, BtfError>;
+
+    fn string_at(&self, offset: u32) -> Result<Cow<'_, str>, BtfError>;
+
+    fn resolve_type(&self, root_type_id: u32) -> Result<u32, BtfError> {
+        let mut type_id = root_type_id;
+        for () in core::iter::repeat_n((), MAX_RESOLVE_DEPTH) {
+            let ty = self.type_by_id(type_id)?;
+
+            match ty {
+                BtfType::Volatile(ty) => {
+                    type_id = ty.btf_type;
+                }
+                BtfType::Const(ty) => {
+                    type_id = ty.btf_type;
+                }
+                BtfType::Restrict(ty) => {
+                    type_id = ty.btf_type;
+                }
+                BtfType::Typedef(ty) => {
+                    type_id = ty.btf_type;
+                }
+                BtfType::TypeTag(ty) => {
+                    type_id = ty.btf_type;
+                }
+                _ => return Ok(type_id),
+            }
+        }
+
+        Err(BtfError::MaximumTypeDepthReached {
+            type_id: root_type_id,
+        })
+    }
+
+    fn type_name(&self, ty: &BtfType) -> Result<Cow<'_, str>, BtfError> {
+        self.string_at(ty.name_offset())
+    }
+}
+
+impl BtfView for Btf {
+    fn type_by_id(&self, type_id: u32) -> Result<&BtfType, BtfError> {
+        Self::type_by_id(self, type_id)
+    }
+
+    fn string_at(&self, offset: u32) -> Result<Cow<'_, str>, BtfError> {
+        Self::string_at(self, offset)
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct SplitBtf<'a> {
+    base: &'a Btf,
+    split: &'a Btf,
+    start_id: u32,
+    start_str_off: u32,
+}
+
+impl<'a> SplitBtf<'a> {
+    #[cfg_attr(
+        not(test),
+        expect(
+            dead_code,
+            reason = "exercised by split BTF tests until module BTF resolution uses it"
+        )
+    )]
+    pub(crate) const fn new(base: &'a Btf, split: &'a Btf) -> Self {
+        Self {
+            base,
+            split,
+            start_id: base.type_count(),
+            start_str_off: base.string_len(),
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) const fn start_id(&self) -> u32 {
+        self.start_id
+    }
+
+    #[cfg_attr(
+        not(test),
+        expect(
+            dead_code,
+            reason = "exercised by split BTF tests until module BTF resolution uses it"
+        )
+    )]
+    pub(crate) fn id_by_type_name_kind_own(
+        &self,
+        name: &str,
+        kind: BtfKind,
+    ) -> Result<u32, BtfError> {
+        for (local_id, ty) in self.split.types().enumerate() {
+            if ty.kind() != kind {
+                continue;
+            }
+            if self.type_name(ty)? == name {
+                return Ok(self.start_id + local_id as u32 - 1);
+            }
+        }
+
+        Err(BtfError::UnknownBtfTypeName {
+            type_name: name.to_owned(),
+        })
+    }
+
+    #[cfg(test)]
+    pub(crate) fn id_by_type_name_kind_visible(
+        &self,
+        name: &str,
+        kind: BtfKind,
+    ) -> Result<u32, BtfError> {
+        self.id_by_type_name_kind_own(name, kind)
+            .or_else(|_| self.base.id_by_type_name_kind(name, kind))
+    }
+}
+
+impl BtfView for SplitBtf<'_> {
+    fn type_by_id(&self, type_id: u32) -> Result<&BtfType, BtfError> {
+        if type_id == 0 {
+            return self.split.type_by_id(type_id);
+        }
+
+        // Split BTF type IDs share one visible namespace with base BTF: IDs
+        // below start_id belong to base, and IDs from start_id onward are
+        // translated back into the split BTF's local type ID space.
+        if type_id < self.start_id {
+            self.base.type_by_id(type_id)
+        } else {
+            self.split.type_by_id(type_id - self.start_id + 1)
+        }
+    }
+
+    fn string_at(&self, offset: u32) -> Result<Cow<'_, str>, BtfError> {
+        // Split BTF string offsets are visible as base string length + local
+        // offset.
+        if offset < self.start_str_off {
+            self.base.string_at(offset)
+        } else {
+            self.split.string_at(offset - self.start_str_off)
+        }
+    }
+}

--- a/aya-obj/src/extern_types.rs
+++ b/aya-obj/src/extern_types.rs
@@ -1,26 +1,108 @@
 //! Extern type resolution and relocation.
+use std::{os::fd::RawFd, string::ToString as _};
+
 use crate::{
     Object,
-    btf::{Btf, BtfError, BtfKind, BtfType},
+    btf::{
+        Btf, BtfError, BtfKind, BtfType,
+        view::{BtfView, SplitBtf},
+    },
     util::{HashMap, HashSet},
 };
 
 impl Object {
     /// Resolves extern kernel symbols through kernel `BTF` and `kallsyms`.
-    pub fn resolve_externs(&mut self, kernel_btf: Option<&Btf>) -> Result<(), KsymsError> {
+    ///
+    /// Module BTF discovery is performed lazily through `discover_modules` only when typed externs
+    /// cannot all be resolved from `vmlinux`.
+    pub fn resolve_externs<P, F>(
+        &mut self,
+        vmlinux: Option<&Btf>,
+        discover_modules: F,
+    ) -> Result<ResolvedExterns<P>, ResolveExternsError<P::Error>>
+    where
+        P: ExternModuleBtfProvider,
+        F: FnOnce() -> Result<P, P::Error>,
+    {
         if self.btf.is_none() {
-            return Ok(());
+            return Ok(ResolvedExterns::without_modules());
         }
 
-        if let Some(kernel_btf) = kernel_btf {
-            self.resolve_typed_externs(kernel_btf)?;
-        } else if self.has_strong_typed_ksyms() {
-            return Err(KsymsError::TypedKsymRequiresKernelBtf);
+        if self.has_strong_typed_ksyms() && vmlinux.is_none() {
+            return Err(KsymsError::TypedKsymRequiresKernelBtf.into());
         }
 
+        let modules = if self.needs_module_btf(vmlinux) {
+            Some(discover_modules().map_err(ResolveExternsError::ModuleBtf)?)
+        } else {
+            None
+        };
+
+        let resolver_modules = if let Some(modules) = &modules {
+            modules
+                .extern_resolution_modules()
+                .map_err(ResolveExternsError::ModuleBtf)?
+        } else {
+            Vec::new()
+        };
+
+        self.resolve_externs_with_resolver(&ExternResolver::new(vmlinux, &resolver_modules))?;
+
+        if self.has_resolved_module_btf_targets() {
+            Ok(ResolvedExterns::with_modules(modules.expect(
+                "module BTF target resolved without module BTF provider",
+            )))
+        } else {
+            Ok(ResolvedExterns::without_modules())
+        }
+    }
+
+    fn resolve_externs_with_resolver(
+        &mut self,
+        resolver: &ExternResolver<'_>,
+    ) -> Result<(), KsymsError> {
+        self.resolve_typed_externs(resolver)?;
         self.resolve_typeless_externs()?;
 
         Ok(())
+    }
+
+    fn needs_module_btf(&self, vmlinux: Option<&Btf>) -> bool {
+        let Some(obj_btf) = self.btf.as_ref() else {
+            return false;
+        };
+
+        if obj_btf.externs.is_empty() {
+            return false;
+        }
+
+        let Some(vmlinux) = vmlinux else {
+            return false;
+        };
+
+        for (name, extern_desc) in obj_btf
+            .externs
+            .iter()
+            .filter(|(_, extern_desc)| extern_desc.type_id.is_some())
+        {
+            let Ok(kind) = extern_btf_kind(obj_btf, name, extern_desc) else {
+                continue;
+            };
+            let lookup_name = extern_desc.lookup_name(name, kind);
+            if vmlinux.id_by_type_name_kind(lookup_name, kind).is_err() {
+                return true;
+            }
+        }
+
+        false
+    }
+
+    fn has_resolved_module_btf_targets(&self) -> bool {
+        self.btf.as_ref().is_some_and(|btf| {
+            btf.externs
+                .iter()
+                .any(|(_, ext)| matches!(ext.resolved, Some(ResolvedKsymTarget::ModuleBtf { .. })))
+        })
     }
 
     /// Returns whether the object contains strong typed ksyms that require kernel `BTF`.
@@ -33,7 +115,10 @@ impl Object {
     }
 
     /// Resolves typed externs through kernel `BTF`.
-    pub(crate) fn resolve_typed_externs(&mut self, kernel_btf: &Btf) -> Result<(), KsymsError> {
+    pub(crate) fn resolve_typed_externs(
+        &mut self,
+        resolver: &ExternResolver<'_>,
+    ) -> Result<(), KsymsError> {
         let mut resolutions = Vec::new();
         {
             let obj_btf = self
@@ -46,22 +131,15 @@ impl Object {
                 .iter()
                 .filter(|(_, extern_desc)| extern_desc.type_id.is_some())
             {
-                let btf_type = obj_btf.type_by_id(extern_desc.btf_id)?;
-                let kernel_btf_id = match btf_type {
-                    BtfType::Func(_) => {
-                        self.resolve_extern_function(name, extern_desc, kernel_btf)?
-                    }
-                    BtfType::Var(_) => {
-                        self.resolve_extern_variable(name, extern_desc, kernel_btf)?
-                    }
+                let resolution = match extern_btf_kind(obj_btf, name, extern_desc)? {
+                    BtfKind::Func => self.resolve_extern_function(name, extern_desc, resolver)?,
+                    BtfKind::Var => self.resolve_extern_variable(name, extern_desc, resolver)?,
                     _ => {
                         return Err(KsymsError::InvalidExternType { name: name.clone() });
                     }
                 };
 
-                if let Some(btf_id) = kernel_btf_id {
-                    resolutions.push((name.clone(), btf_id));
-                }
+                resolutions.push((name.clone(), resolution));
             }
         }
 
@@ -70,10 +148,9 @@ impl Object {
             .as_mut()
             .expect("resolve_typed_externs called without local BTF");
 
-        for (name, kernel_btf_id) in resolutions {
+        for (name, resolved) in resolutions {
             if let Some(ext) = obj_mut.externs.get_mut(&name) {
-                ext.kernel_btf_id = Some(kernel_btf_id);
-                ext.is_resolved = true;
+                ext.resolved = Some(resolved);
             }
         }
 
@@ -93,8 +170,12 @@ impl Object {
         // Default unresolved weak ksyms to address 0 so pointer checks evaluate to false.
         if let Some(obj_btf) = self.btf.as_mut() {
             for ext in obj_btf.externs.externs.values_mut() {
-                if ext.extern_type == ExternType::Ksym && !ext.is_resolved && ext.is_weak {
-                    ext.ksym_addr = Some(0);
+                if ext.extern_type == ExternType::Ksym
+                    && ext.resolved.is_none()
+                    && ext.is_weak
+                    && ext.type_id.is_none()
+                {
+                    ext.resolved = Some(ResolvedKsymTarget::WeakMissing);
                 }
             }
         }
@@ -140,28 +221,32 @@ impl Object {
             }
 
             if let Some(ext) = obj_btf.externs.get_mut(sym_name) {
-                if ext.is_resolved {
-                    if let Some(existing_addr) = ext.ksym_addr {
-                        if existing_addr != addr {
-                            return Err(KsymsError::AmbiguousResolution {
-                                name: sym_name.to_string(),
-                                first_addr: existing_addr,
-                                second_addr: addr,
-                            });
-                        }
+                if let Some(ResolvedKsymTarget::Address {
+                    addr: existing_addr,
+                }) = ext.resolved
+                {
+                    if existing_addr != addr {
+                        return Err(KsymsError::AmbiguousResolution {
+                            name: sym_name.to_string(),
+                            first_addr: existing_addr,
+                            second_addr: addr,
+                        });
                     }
                     continue;
                 }
 
-                ext.ksym_addr = Some(addr);
-                ext.is_resolved = true;
+                ext.resolved = Some(ResolvedKsymTarget::Address { addr });
             }
         }
 
         // Reject unresolved strong typeless ksyms after the kallsyms pass.
         // Typed ksyms fail earlier during BTF resolution.
         for (name, ext) in obj_btf.externs.iter() {
-            if ext.extern_type == ExternType::Ksym && !ext.is_resolved && !ext.is_weak {
+            if ext.extern_type == ExternType::Ksym
+                && ext.resolved.is_none()
+                && !ext.is_weak
+                && ext.type_id.is_none()
+            {
                 return Err(KsymsError::VariableNotFound { name: name.clone() });
             }
         }
@@ -180,97 +265,187 @@ impl Object {
             .externs
             .iter()
             .filter(|(_, ext)| {
-                ext.extern_type == ExternType::Ksym && !ext.is_resolved && ext.type_id.is_none()
+                ext.extern_type == ExternType::Ksym
+                    && ext.resolved.is_none()
+                    && ext.type_id.is_none()
             })
             .map(|(name, _)| name.clone())
             .collect()
     }
 
-    /// Resolves a single extern function. Returns BTF ID if found, otherwise
-    /// returns `None`.
     fn resolve_extern_function(
         &self,
         name: &str,
         extern_desc: &ExternDesc,
-        kernel_btf: &Btf,
-    ) -> Result<Option<u32>, KsymsError> {
-        let lookup_name = extern_desc.essential_name.as_deref().unwrap_or(name);
-        let Ok(kernel_func_id) = kernel_btf.id_by_type_name_kind(lookup_name, BtfKind::Func) else {
-            if extern_desc.is_weak {
-                return Ok(None);
+        resolver: &ExternResolver<'_>,
+    ) -> Result<ResolvedKsymTarget, KsymsError> {
+        let lookup_name = extern_desc.lookup_name(name, BtfKind::Func);
+
+        if let Some(vmlinux) = resolver.vmlinux {
+            match vmlinux.id_by_type_name_kind(lookup_name, BtfKind::Func) {
+                Ok(func_id) => {
+                    return self.resolve_extern_function_in_btf(
+                        lookup_name,
+                        extern_desc,
+                        vmlinux,
+                        func_id,
+                        BtfTarget::Vmlinux,
+                    );
+                }
+                Err(BtfError::UnknownBtfTypeName { .. }) => {}
+                Err(err) => return Err(err.into()),
             }
+        }
 
-            return Err(KsymsError::FunctionNotFound {
+        if let Some(vmlinux) = resolver.vmlinux {
+            for module in resolver.modules {
+                let split = SplitBtf::new(vmlinux, module.btf);
+                match split.id_by_type_name_kind_own(lookup_name, BtfKind::Func) {
+                    Ok(func_id) => {
+                        return self.resolve_extern_function_in_btf(
+                            lookup_name,
+                            extern_desc,
+                            &split,
+                            func_id,
+                            BtfTarget::Module {
+                                fd_idx: module.fd_idx,
+                                obj_fd: module.btf_obj_fd,
+                            },
+                        );
+                    }
+                    Err(BtfError::UnknownBtfTypeName { .. }) => {}
+                    Err(err) => return Err(err.into()),
+                }
+            }
+        }
+
+        if extern_desc.is_weak {
+            Ok(ResolvedKsymTarget::WeakMissing)
+        } else {
+            Err(KsymsError::FunctionNotFound {
                 name: lookup_name.to_string(),
-            });
-        };
+            })
+        }
+    }
 
-        let kernel_func_type = kernel_btf.type_by_id(kernel_func_id)?;
-        let kernel_proto_id = match kernel_func_type {
+    fn resolve_extern_variable(
+        &self,
+        name: &str,
+        extern_desc: &ExternDesc,
+        resolver: &ExternResolver<'_>,
+    ) -> Result<ResolvedKsymTarget, KsymsError> {
+        let lookup_name = extern_desc.lookup_name(name, BtfKind::Var);
+
+        if let Some(vmlinux) = resolver.vmlinux {
+            match vmlinux.id_by_type_name_kind(lookup_name, BtfKind::Var) {
+                Ok(var_id) => {
+                    return self.resolve_extern_variable_in_btf(
+                        lookup_name,
+                        extern_desc,
+                        vmlinux,
+                        var_id,
+                        BtfTarget::Vmlinux,
+                    );
+                }
+                Err(BtfError::UnknownBtfTypeName { .. }) => {}
+                Err(err) => return Err(err.into()),
+            }
+        }
+
+        if let Some(vmlinux) = resolver.vmlinux {
+            for module in resolver.modules {
+                let split = SplitBtf::new(vmlinux, module.btf);
+                match split.id_by_type_name_kind_own(lookup_name, BtfKind::Var) {
+                    Ok(var_id) => {
+                        return self.resolve_extern_variable_in_btf(
+                            lookup_name,
+                            extern_desc,
+                            &split,
+                            var_id,
+                            BtfTarget::Module {
+                                fd_idx: module.fd_idx,
+                                obj_fd: module.btf_obj_fd,
+                            },
+                        );
+                    }
+                    Err(BtfError::UnknownBtfTypeName { .. }) => {}
+                    Err(err) => return Err(err.into()),
+                }
+            }
+        }
+
+        if extern_desc.is_weak {
+            Ok(ResolvedKsymTarget::WeakMissing)
+        } else {
+            Err(KsymsError::VariableNotFound {
+                name: lookup_name.to_string(),
+            })
+        }
+    }
+
+    fn resolve_extern_function_in_btf<T: BtfView + ?Sized>(
+        &self,
+        name: &str,
+        extern_desc: &ExternDesc,
+        target_btf: &T,
+        target_func_id: u32,
+        target: BtfTarget,
+    ) -> Result<ResolvedKsymTarget, KsymsError> {
+        let target_func_type = target_btf.type_by_id(target_func_id)?;
+        let target_proto_id = match target_func_type {
             BtfType::Func(func) => func.btf_type,
             _ => {
                 return Err(KsymsError::BtfError(BtfError::UnexpectedBtfType {
-                    type_id: kernel_func_id,
+                    type_id: target_func_id,
                 }));
             }
         };
 
         let local_proto_id = extern_desc.type_id.expect("typed extern must have type_id");
-
         let obj_btf = self
             .btf
             .as_ref()
             .expect("resolve_extern_function called without local BTF");
         let compatible =
-            crate::btf::types_are_compatible(obj_btf, local_proto_id, kernel_btf, kernel_proto_id)?;
+            crate::btf::types_are_compatible(obj_btf, local_proto_id, target_btf, target_proto_id)?;
 
         if !compatible {
             if extern_desc.is_weak {
-                return Ok(None);
+                return Ok(ResolvedKsymTarget::WeakMissing);
             }
             return Err(KsymsError::IncompatibleFunctionSignature {
-                name: lookup_name.to_string(),
+                name: name.to_string(),
             });
         }
 
-        Ok(Some(kernel_func_id))
+        Ok(target.resolved(target_func_id))
     }
 
-    /// Resolves a single extern variable. Returns BTF ID if found, otherwise
-    /// returns `None`.
-    fn resolve_extern_variable(
+    fn resolve_extern_variable_in_btf<T: BtfView + ?Sized>(
         &self,
         name: &str,
         extern_desc: &ExternDesc,
-        kernel_btf: &Btf,
-    ) -> Result<Option<u32>, KsymsError> {
-        let Ok(kernel_var_id) = kernel_btf.id_by_type_name_kind(name, BtfKind::Var) else {
-            if extern_desc.is_weak {
-                return Ok(None);
-            }
-            return Err(KsymsError::VariableNotFound {
-                name: name.to_string(),
-            });
-        };
-
-        let kernel_var_type = kernel_btf.type_by_id(kernel_var_id)?;
-        let kernel_type_id = match kernel_var_type {
+        target_btf: &T,
+        target_var_id: u32,
+        target: BtfTarget,
+    ) -> Result<ResolvedKsymTarget, KsymsError> {
+        let target_var_type = target_btf.type_by_id(target_var_id)?;
+        let target_type_id = match target_var_type {
             BtfType::Var(var) => var.btf_type,
             _ => {
                 return Err(KsymsError::BtfError(BtfError::UnexpectedBtfType {
-                    type_id: kernel_var_id,
+                    type_id: target_var_id,
                 }));
             }
         };
 
         let local_type_id = extern_desc.type_id.expect("typed extern must have type_id");
-
         let obj_btf = self
             .btf
             .as_ref()
             .expect("resolve_extern_variable called without local BTF");
         let compatible =
-            crate::btf::types_are_compatible(obj_btf, local_type_id, kernel_btf, kernel_type_id)?;
+            crate::btf::types_are_compatible(obj_btf, local_type_id, target_btf, target_type_id)?;
 
         if !compatible {
             return Err(KsymsError::IncompatibleVariableType {
@@ -278,7 +453,17 @@ impl Object {
             });
         }
 
-        Ok(Some(kernel_var_id))
+        Ok(target.resolved(target_var_id))
+    }
+}
+
+fn extern_btf_kind(btf: &Btf, name: &str, extern_desc: &ExternDesc) -> Result<BtfKind, KsymsError> {
+    match btf.type_by_id(extern_desc.btf_id)? {
+        BtfType::Func(_) => Ok(BtfKind::Func),
+        BtfType::Var(_) => Ok(BtfKind::Var),
+        _ => Err(KsymsError::InvalidExternType {
+            name: name.to_owned(),
+        }),
     }
 }
 
@@ -348,6 +533,117 @@ pub enum KsymsError {
     },
 }
 
+pub(crate) struct ExternResolver<'a> {
+    vmlinux: Option<&'a Btf>,
+    modules: &'a [ExternResolverModule<'a>],
+}
+
+impl<'a> ExternResolver<'a> {
+    pub(crate) const fn new(
+        vmlinux: Option<&'a Btf>,
+        modules: &'a [ExternResolverModule<'a>],
+    ) -> Self {
+        Self { vmlinux, modules }
+    }
+
+    #[cfg(test)]
+    pub(crate) const fn vmlinux_only(vmlinux: Option<&'a Btf>) -> Self {
+        Self {
+            vmlinux,
+            modules: &[],
+        }
+    }
+}
+
+/// A module BTF made available to extern resolution.
+#[derive(Clone, Copy)]
+pub struct ExternResolverModule<'a> {
+    /// Parsed module BTF.
+    pub btf: &'a Btf,
+    /// Index into the loader's BTF fd array. Index 0 is reserved for vmlinux.
+    pub fd_idx: u16,
+    /// Literal module BTF object FD, used by `BPF_PSEUDO_BTF_ID` relocations.
+    pub btf_obj_fd: RawFd,
+}
+
+/// Supplies module BTFs to extern resolution after lazy discovery.
+pub trait ExternModuleBtfProvider {
+    /// Error returned while building module BTF resolution inputs.
+    type Error;
+
+    /// Returns module BTF descriptors available to extern resolution.
+    fn extern_resolution_modules(&self) -> Result<Vec<ExternResolverModule<'_>>, Self::Error>;
+}
+
+/// Error returned while resolving externs with lazy module BTF discovery.
+#[derive(Debug, thiserror::Error)]
+pub enum ResolveExternsError<E> {
+    /// Extern resolution failed.
+    #[error("kernel symbol error: {0}")]
+    Ksyms(#[from] KsymsError),
+    /// Module BTF discovery or preparation failed.
+    #[error("module BTF discovery failed: {0}")]
+    ModuleBtf(E),
+}
+
+/// Result of extern resolution, including module BTF ownership when it must stay alive.
+#[derive(Debug)]
+pub struct ResolvedExterns<P> {
+    modules: Option<P>,
+}
+
+impl<P> ResolvedExterns<P> {
+    const fn without_modules() -> Self {
+        Self { modules: None }
+    }
+
+    const fn with_modules(modules: P) -> Self {
+        Self {
+            modules: Some(modules),
+        }
+    }
+
+    /// Returns module BTF ownership when resolved externs require it for program load.
+    pub fn into_modules(self) -> Option<P> {
+        self.modules
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ResolvedKsymTarget {
+    VmlinuxBtf {
+        type_id: u32,
+    },
+    ModuleBtf {
+        type_id: u32,
+        btf_fd_idx: u16,
+        btf_obj_fd: RawFd,
+    },
+    Address {
+        addr: u64,
+    },
+    WeakMissing,
+}
+
+#[derive(Debug, Clone, Copy)]
+enum BtfTarget {
+    Vmlinux,
+    Module { fd_idx: u16, obj_fd: RawFd },
+}
+
+impl BtfTarget {
+    const fn resolved(self, type_id: u32) -> ResolvedKsymTarget {
+        match self {
+            Self::Vmlinux => ResolvedKsymTarget::VmlinuxBtf { type_id },
+            Self::Module { fd_idx, obj_fd } => ResolvedKsymTarget::ModuleBtf {
+                type_id,
+                btf_fd_idx: fd_idx,
+                btf_obj_fd: obj_fd,
+            },
+        }
+    }
+}
+
 /// Type of extern symbol.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum ExternType {
@@ -370,20 +666,14 @@ pub(crate) struct ExternDesc {
     /// Whether this is a weak symbol.
     pub(crate) is_weak: bool,
 
-    /// Whether extern has been resolved.
-    pub(crate) is_resolved: bool,
-
-    /// For ksym: kernel BTF ID (after resolution).
-    pub(crate) kernel_btf_id: Option<u32>,
-
-    /// For ksym variables: resolved kernel address.
-    pub(crate) ksym_addr: Option<u64>,
-
     /// For ksym: resolved type ID (after skipping modifiers/typedefs).
     pub(crate) type_id: Option<u32>,
 
     /// For names with flavors: stripped essential name.
     pub(crate) essential_name: Option<String>,
+
+    /// Resolved target for this extern.
+    pub(crate) resolved: Option<ResolvedKsymTarget>,
 }
 
 /// Given `some_struct_name___with_flavor` return the length of a name prefix
@@ -427,11 +717,17 @@ impl ExternDesc {
             extern_type,
             btf_id,
             is_weak,
-            is_resolved: false,
-            kernel_btf_id: None,
-            ksym_addr: None,
             type_id: None,
             essential_name,
+            resolved: None,
+        }
+    }
+
+    fn lookup_name<'a>(&'a self, symbol_name: &'a str, kind: BtfKind) -> &'a str {
+        match kind {
+            BtfKind::Func => self.essential_name.as_deref().unwrap_or(symbol_name),
+            BtfKind::Var => symbol_name,
+            _ => symbol_name,
         }
     }
 }
@@ -477,11 +773,14 @@ impl ExternCollection {
 
 #[cfg(test)]
 mod tests {
-    use std::{collections::BTreeMap, ffi::CString};
+    use std::{collections::BTreeMap, convert::Infallible, ffi::CString};
 
     use object::Endianness;
 
-    use super::{ExternCollection, ExternDesc, ExternType, KsymsError};
+    use super::{
+        ExternCollection, ExternDesc, ExternModuleBtfProvider, ExternResolver,
+        ExternResolverModule, ExternType, KsymsError, ResolveExternsError, ResolvedKsymTarget,
+    };
     use crate::{
         Object,
         btf::{
@@ -563,6 +862,54 @@ mod tests {
         )))
     }
 
+    fn add_split_var(base: &Btf, split: &mut Btf, name: &str, type_id: u32) -> u32 {
+        let name_offset = base.string_len() + split.add_string(name);
+        let local_id = split.add_type(BtfType::Var(Var::new(
+            name_offset,
+            type_id,
+            VarLinkage::Global,
+        )));
+        base.type_count() + local_id - 1
+    }
+
+    fn add_split_func(base: &Btf, split: &mut Btf, name: &str, proto_id: u32) -> u32 {
+        let name_offset = base.string_len() + split.add_string(name);
+        let local_id = split.add_type(BtfType::Func(Func::new(
+            name_offset,
+            proto_id,
+            FuncLinkage::Global,
+        )));
+        base.type_count() + local_id - 1
+    }
+
+    struct NoModuleBtfProvider;
+
+    impl ExternModuleBtfProvider for NoModuleBtfProvider {
+        type Error = Infallible;
+
+        fn extern_resolution_modules(&self) -> Result<Vec<ExternResolverModule<'_>>, Self::Error> {
+            Ok(Vec::new())
+        }
+    }
+
+    struct TestModuleBtfProvider<'a> {
+        btf: &'a Btf,
+        fd_idx: u16,
+        btf_obj_fd: i32,
+    }
+
+    impl ExternModuleBtfProvider for TestModuleBtfProvider<'_> {
+        type Error = Infallible;
+
+        fn extern_resolution_modules(&self) -> Result<Vec<ExternResolverModule<'_>>, Self::Error> {
+            Ok(vec![ExternResolverModule {
+                btf: self.btf,
+                fd_idx: self.fd_idx,
+                btf_obj_fd: self.btf_obj_fd,
+            }])
+        }
+    }
+
     #[test]
     fn resolve_externs_requires_kernel_btf_for_typed_ksyms() {
         let mut externs = ExternCollection::new();
@@ -573,25 +920,39 @@ mod tests {
 
         let mut object = object_with_externs(externs);
 
-        let err = object.resolve_externs(None).unwrap_err();
-        assert!(matches!(err, KsymsError::TypedKsymRequiresKernelBtf));
+        let err = object
+            .resolve_externs(None, || -> Result<NoModuleBtfProvider, Infallible> {
+                panic!("module BTF discovery should not run without vmlinux BTF")
+            })
+            .err()
+            .unwrap();
+        assert!(matches!(
+            err,
+            ResolveExternsError::Ksyms(KsymsError::TypedKsymRequiresKernelBtf)
+        ));
     }
 
     #[test]
     fn resolve_externs_allows_weak_typed_ksyms_without_kernel_btf() {
-        let mut externs = ExternCollection::new();
+        let mut btf = Btf::new();
+        let int_id = add_int(&mut btf, "int");
+        let var_id = add_var(&mut btf, "typed", int_id);
 
-        let mut typed = ExternDesc::new("typed".into(), ExternType::Ksym, 1, true);
-        typed.type_id = Some(42);
+        let mut externs = ExternCollection::new();
+        let mut typed = ExternDesc::new("typed".into(), ExternType::Ksym, var_id, true);
+        typed.type_id = Some(int_id);
         externs.insert(typed.name.clone(), typed);
 
-        let mut object = object_with_externs(externs);
+        let mut object = object_with_btf_and_externs(btf, externs);
 
-        object.resolve_externs(None).unwrap();
+        object
+            .resolve_externs(None, || -> Result<NoModuleBtfProvider, Infallible> {
+                panic!("module BTF discovery should not run without vmlinux BTF")
+            })
+            .unwrap();
 
         let ext = &object.btf.as_ref().unwrap().externs.externs["typed"];
-        assert!(!ext.is_resolved);
-        assert_eq!(ext.ksym_addr, Some(0));
+        assert_eq!(ext.resolved, Some(ResolvedKsymTarget::WeakMissing));
     }
 
     #[test]
@@ -607,7 +968,9 @@ mod tests {
         let mut object = object_with_btf_and_externs(btf, externs);
         let kernel_btf = Btf::new();
 
-        let err = object.resolve_typed_externs(&kernel_btf).unwrap_err();
+        let err = object
+            .resolve_typed_externs(&ExternResolver::vmlinux_only(Some(&kernel_btf)))
+            .unwrap_err();
         assert!(matches!(err, KsymsError::InvalidExternType { name } if name == "bad"));
     }
 
@@ -631,7 +994,9 @@ mod tests {
             kernel_btf.add_type(BtfType::Ptr(Ptr::new(ptr_name_offset, kernel_int_id)));
         add_var(&mut kernel_btf, "foo", kernel_ptr_id);
 
-        let err = object.resolve_typed_externs(&kernel_btf).unwrap_err();
+        let err = object
+            .resolve_typed_externs(&ExternResolver::vmlinux_only(Some(&kernel_btf)))
+            .unwrap_err();
         assert!(matches!(err, KsymsError::IncompatibleVariableType { name } if name == "foo"));
     }
 
@@ -658,8 +1023,160 @@ mod tests {
         let kernel_proto_id = add_func_proto(&mut kernel_btf, kernel_int_id, vec![kernel_param]);
         add_func(&mut kernel_btf, "bar", kernel_proto_id);
 
-        let err = object.resolve_typed_externs(&kernel_btf).unwrap_err();
+        let err = object
+            .resolve_typed_externs(&ExternResolver::vmlinux_only(Some(&kernel_btf)))
+            .unwrap_err();
         assert!(matches!(err, KsymsError::IncompatibleFunctionSignature { name } if name == "bar"));
+    }
+
+    #[test]
+    fn resolve_typed_variable_from_module_btf() {
+        let mut local_btf = Btf::new();
+        let local_int_id = add_int(&mut local_btf, "int");
+        let local_var_id = add_var(&mut local_btf, "module_var", local_int_id);
+
+        let mut externs = ExternCollection::new();
+        let mut ext = ExternDesc::new("module_var".into(), ExternType::Ksym, local_var_id, false);
+        ext.type_id = Some(local_int_id);
+        externs.insert(ext.name.clone(), ext);
+
+        let mut object = object_with_btf_and_externs(local_btf, externs);
+
+        let mut vmlinux = Btf::new();
+        let vmlinux_int_id = add_int(&mut vmlinux, "int");
+
+        let mut module_btf = Btf::new();
+        let module_var_id = add_split_var(&vmlinux, &mut module_btf, "module_var", vmlinux_int_id);
+
+        let modules = [ExternResolverModule {
+            btf: &module_btf,
+            fd_idx: 7,
+            btf_obj_fd: 70,
+        }];
+        let resolver = ExternResolver {
+            vmlinux: Some(&vmlinux),
+            modules: &modules,
+        };
+
+        object.resolve_typed_externs(&resolver).unwrap();
+
+        let ext = &object.btf.as_ref().unwrap().externs.externs["module_var"];
+        assert_eq!(
+            ext.resolved,
+            Some(ResolvedKsymTarget::ModuleBtf {
+                type_id: module_var_id,
+                btf_fd_idx: 7,
+                btf_obj_fd: 70,
+            })
+        );
+        assert!(object.has_resolved_module_btf_targets());
+    }
+
+    #[test]
+    fn resolve_typed_function_from_module_btf() {
+        let mut local_btf = Btf::new();
+        let local_int_id = add_int(&mut local_btf, "int");
+        let local_proto_id = add_func_proto(&mut local_btf, local_int_id, vec![]);
+        let local_func_id = add_func(&mut local_btf, "module_func", local_proto_id);
+
+        let mut externs = ExternCollection::new();
+        let mut ext = ExternDesc::new("module_func".into(), ExternType::Ksym, local_func_id, false);
+        ext.type_id = Some(local_proto_id);
+        externs.insert(ext.name.clone(), ext);
+
+        let mut object = object_with_btf_and_externs(local_btf, externs);
+
+        let mut vmlinux = Btf::new();
+        let vmlinux_int_id = add_int(&mut vmlinux, "int");
+
+        let mut module_btf = Btf::new();
+        let module_proto_id = add_func_proto(&mut module_btf, vmlinux_int_id, vec![]);
+        let module_proto_id = vmlinux.type_count() + module_proto_id - 1;
+        let module_func_id =
+            add_split_func(&vmlinux, &mut module_btf, "module_func", module_proto_id);
+
+        let modules = [ExternResolverModule {
+            btf: &module_btf,
+            fd_idx: 2,
+            btf_obj_fd: 20,
+        }];
+        let resolver = ExternResolver {
+            vmlinux: Some(&vmlinux),
+            modules: &modules,
+        };
+
+        object.resolve_typed_externs(&resolver).unwrap();
+
+        let ext = &object.btf.as_ref().unwrap().externs.externs["module_func"];
+        assert_eq!(
+            ext.resolved,
+            Some(ResolvedKsymTarget::ModuleBtf {
+                type_id: module_func_id,
+                btf_fd_idx: 2,
+                btf_obj_fd: 20,
+            })
+        );
+        assert!(object.has_resolved_module_btf_targets());
+    }
+
+    #[test]
+    fn resolve_externs_discovers_module_btf_lazily() {
+        let resolved = object_with_externs(ExternCollection::new())
+            .resolve_externs(None, || -> Result<NoModuleBtfProvider, Infallible> {
+                panic!("module BTF discovery should not run without externs")
+            })
+            .unwrap();
+        assert!(resolved.into_modules().is_none());
+
+        let mut local_btf = Btf::new();
+        let local_int_id = add_int(&mut local_btf, "int");
+        let local_var_id = add_var(&mut local_btf, "present", local_int_id);
+
+        let mut externs = ExternCollection::new();
+        let mut ext = ExternDesc::new("present".into(), ExternType::Ksym, local_var_id, false);
+        ext.type_id = Some(local_int_id);
+        externs.insert(ext.name.clone(), ext);
+        let mut object = object_with_btf_and_externs(local_btf, externs);
+
+        let mut vmlinux = Btf::new();
+        let vmlinux_int_id = add_int(&mut vmlinux, "int");
+        add_var(&mut vmlinux, "present", vmlinux_int_id);
+
+        let resolved = object
+            .resolve_externs(
+                Some(&vmlinux),
+                || -> Result<NoModuleBtfProvider, Infallible> {
+                    panic!("module BTF discovery should not run when vmlinux resolves all externs")
+                },
+            )
+            .unwrap();
+        assert!(resolved.into_modules().is_none());
+
+        let mut local_btf = Btf::new();
+        let local_int_id = add_int(&mut local_btf, "int");
+        let local_var_id = add_var(&mut local_btf, "module_var", local_int_id);
+
+        let mut externs = ExternCollection::new();
+        let mut ext = ExternDesc::new("module_var".into(), ExternType::Ksym, local_var_id, false);
+        ext.type_id = Some(local_int_id);
+        externs.insert(ext.name.clone(), ext);
+        let mut object = object_with_btf_and_externs(local_btf, externs);
+
+        let mut vmlinux = Btf::new();
+        let vmlinux_int_id = add_int(&mut vmlinux, "int");
+        let mut module_btf = Btf::new();
+        add_split_var(&vmlinux, &mut module_btf, "module_var", vmlinux_int_id);
+
+        let resolved = object
+            .resolve_externs(Some(&vmlinux), || {
+                Ok(TestModuleBtfProvider {
+                    btf: &module_btf,
+                    fd_idx: 7,
+                    btf_obj_fd: 70,
+                })
+            })
+            .unwrap();
+        assert!(resolved.into_modules().is_some());
     }
 
     mod kallsyms_tests {
@@ -688,8 +1205,11 @@ mod tests {
             fn finalize_weak_typeless_ksyms_for_test(&mut self) {
                 if let Some(obj_btf) = self.btf.as_mut() {
                     for ext in obj_btf.externs.externs.values_mut() {
-                        if ext.extern_type == ExternType::Ksym && !ext.is_resolved && ext.is_weak {
-                            ext.ksym_addr = Some(0);
+                        if ext.extern_type == ExternType::Ksym
+                            && ext.resolved.is_none()
+                            && ext.is_weak
+                        {
+                            ext.resolved = Some(ResolvedKsymTarget::WeakMissing);
                         }
                     }
                 }
@@ -790,7 +1310,7 @@ mod tests {
         }
 
         #[test]
-        fn resolve_typeless_externs_sets_weak_ksym_addr_to_zero() {
+        fn resolve_typeless_externs_sets_weak_missing_target() {
             let mut externs = ExternCollection::new();
             let ext = ExternDesc::new("missing".into(), ExternType::Ksym, 1, true);
             externs.insert(ext.name.clone(), ext);
@@ -800,8 +1320,7 @@ mod tests {
             object.finalize_weak_typeless_ksyms_for_test();
 
             let ext = &object.btf.as_ref().unwrap().externs.externs["missing"];
-            assert_eq!(ext.ksym_addr, Some(0));
-            assert!(!ext.is_resolved);
+            assert_eq!(ext.resolved, Some(ResolvedKsymTarget::WeakMissing));
         }
     }
 }

--- a/aya-obj/src/extern_types.rs
+++ b/aya-obj/src/extern_types.rs
@@ -1,0 +1,807 @@
+//! Extern type resolution and relocation.
+use crate::{
+    Object,
+    btf::{Btf, BtfError, BtfKind, BtfType},
+    util::{HashMap, HashSet},
+};
+
+impl Object {
+    /// Resolves extern kernel symbols through kernel `BTF` and `kallsyms`.
+    pub fn resolve_externs(&mut self, kernel_btf: Option<&Btf>) -> Result<(), KsymsError> {
+        if self.btf.is_none() {
+            return Ok(());
+        }
+
+        if let Some(kernel_btf) = kernel_btf {
+            self.resolve_typed_externs(kernel_btf)?;
+        } else if self.has_strong_typed_ksyms() {
+            return Err(KsymsError::TypedKsymRequiresKernelBtf);
+        }
+
+        self.resolve_typeless_externs()?;
+
+        Ok(())
+    }
+
+    /// Returns whether the object contains strong typed ksyms that require kernel `BTF`.
+    pub(crate) fn has_strong_typed_ksyms(&self) -> bool {
+        self.btf.as_ref().is_some_and(|btf| {
+            btf.externs.iter().any(|(_, ext)| {
+                ext.extern_type == ExternType::Ksym && ext.type_id.is_some() && !ext.is_weak
+            })
+        })
+    }
+
+    /// Resolves typed externs through kernel `BTF`.
+    pub(crate) fn resolve_typed_externs(&mut self, kernel_btf: &Btf) -> Result<(), KsymsError> {
+        let mut resolutions = Vec::new();
+        {
+            let obj_btf = self
+                .btf
+                .as_ref()
+                .expect("resolve_typed_externs called without local BTF");
+
+            for (name, extern_desc) in obj_btf
+                .externs
+                .iter()
+                .filter(|(_, extern_desc)| extern_desc.type_id.is_some())
+            {
+                let btf_type = obj_btf.type_by_id(extern_desc.btf_id)?;
+                let kernel_btf_id = match btf_type {
+                    BtfType::Func(_) => {
+                        self.resolve_extern_function(name, extern_desc, kernel_btf)?
+                    }
+                    BtfType::Var(_) => {
+                        self.resolve_extern_variable(name, extern_desc, kernel_btf)?
+                    }
+                    _ => {
+                        return Err(KsymsError::InvalidExternType { name: name.clone() });
+                    }
+                };
+
+                if let Some(btf_id) = kernel_btf_id {
+                    resolutions.push((name.clone(), btf_id));
+                }
+            }
+        }
+
+        let obj_mut = self
+            .btf
+            .as_mut()
+            .expect("resolve_typed_externs called without local BTF");
+
+        for (name, kernel_btf_id) in resolutions {
+            if let Some(ext) = obj_mut.externs.get_mut(&name) {
+                ext.kernel_btf_id = Some(kernel_btf_id);
+                ext.is_resolved = true;
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Resolves typeless extern vars found in `.ksyms` section through `kallsyms`.
+    pub(crate) fn resolve_typeless_externs(&mut self) -> Result<(), KsymsError> {
+        let unresolved: Vec<String> = self.unresolved_typeless_ksym_vars();
+
+        if !unresolved.is_empty() {
+            let file = std::fs::File::open("/proc/kallsyms")?;
+            let reader = std::io::BufReader::new(file);
+            self.resolve_kallsyms_from_reader(reader, &unresolved)?;
+        }
+
+        // Default unresolved weak ksyms to address 0 so pointer checks evaluate to false.
+        if let Some(obj_btf) = self.btf.as_mut() {
+            for ext in obj_btf.externs.externs.values_mut() {
+                if ext.extern_type == ExternType::Ksym && !ext.is_resolved && ext.is_weak {
+                    ext.ksym_addr = Some(0);
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Resolves typeless ksym addresses by matching symbol names against parsed kallsyms lines.
+    fn resolve_kallsyms_from_reader<R, S>(
+        &mut self,
+        reader: R,
+        unresolved: &[S],
+    ) -> Result<(), KsymsError>
+    where
+        R: std::io::BufRead,
+        S: AsRef<str>,
+    {
+        let obj_btf = self
+            .btf
+            .as_mut()
+            .expect("resolve_kallsyms_from_reader called without local BTF");
+
+        let unresolved: HashSet<_> = unresolved.iter().map(AsRef::as_ref).collect();
+
+        for line in reader.lines() {
+            let line = line?;
+            let mut parts = line.split_whitespace();
+            let (Some(addr_str), Some(_sym_type), Some(sym_name)) =
+                (parts.next(), parts.next(), parts.next())
+            else {
+                continue;
+            };
+
+            if !unresolved.contains(sym_name) {
+                continue;
+            }
+
+            let addr = u64::from_str_radix(addr_str, 16).map_err(|_err| {
+                KsymsError::KallsymsParseError(format!("invalid address: {addr_str}"))
+            })?;
+            if addr == 0 {
+                continue;
+            }
+
+            if let Some(ext) = obj_btf.externs.get_mut(sym_name) {
+                if ext.is_resolved {
+                    if let Some(existing_addr) = ext.ksym_addr {
+                        if existing_addr != addr {
+                            return Err(KsymsError::AmbiguousResolution {
+                                name: sym_name.to_string(),
+                                first_addr: existing_addr,
+                                second_addr: addr,
+                            });
+                        }
+                    }
+                    continue;
+                }
+
+                ext.ksym_addr = Some(addr);
+                ext.is_resolved = true;
+            }
+        }
+
+        // Reject unresolved strong typeless ksyms after the kallsyms pass.
+        // Typed ksyms fail earlier during BTF resolution.
+        for (name, ext) in obj_btf.externs.iter() {
+            if ext.extern_type == ExternType::Ksym && !ext.is_resolved && !ext.is_weak {
+                return Err(KsymsError::VariableNotFound { name: name.clone() });
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Returns unresolved typeless ksym variables from [`ExternCollection`].
+    fn unresolved_typeless_ksym_vars(&self) -> Vec<String> {
+        let Some(obj_btf) = self.btf.as_ref() else {
+            return Vec::new();
+        };
+
+        obj_btf
+            .externs
+            .externs
+            .iter()
+            .filter(|(_, ext)| {
+                ext.extern_type == ExternType::Ksym && !ext.is_resolved && ext.type_id.is_none()
+            })
+            .map(|(name, _)| name.clone())
+            .collect()
+    }
+
+    /// Resolves a single extern function. Returns BTF ID if found, otherwise
+    /// returns `None`.
+    fn resolve_extern_function(
+        &self,
+        name: &str,
+        extern_desc: &ExternDesc,
+        kernel_btf: &Btf,
+    ) -> Result<Option<u32>, KsymsError> {
+        let lookup_name = extern_desc.essential_name.as_deref().unwrap_or(name);
+        let Ok(kernel_func_id) = kernel_btf.id_by_type_name_kind(lookup_name, BtfKind::Func) else {
+            if extern_desc.is_weak {
+                return Ok(None);
+            }
+
+            return Err(KsymsError::FunctionNotFound {
+                name: lookup_name.to_string(),
+            });
+        };
+
+        let kernel_func_type = kernel_btf.type_by_id(kernel_func_id)?;
+        let kernel_proto_id = match kernel_func_type {
+            BtfType::Func(func) => func.btf_type,
+            _ => {
+                return Err(KsymsError::BtfError(BtfError::UnexpectedBtfType {
+                    type_id: kernel_func_id,
+                }));
+            }
+        };
+
+        let local_proto_id = extern_desc.type_id.expect("typed extern must have type_id");
+
+        let obj_btf = self
+            .btf
+            .as_ref()
+            .expect("resolve_extern_function called without local BTF");
+        let compatible =
+            crate::btf::types_are_compatible(obj_btf, local_proto_id, kernel_btf, kernel_proto_id)?;
+
+        if !compatible {
+            if extern_desc.is_weak {
+                return Ok(None);
+            }
+            return Err(KsymsError::IncompatibleFunctionSignature {
+                name: lookup_name.to_string(),
+            });
+        }
+
+        Ok(Some(kernel_func_id))
+    }
+
+    /// Resolves a single extern variable. Returns BTF ID if found, otherwise
+    /// returns `None`.
+    fn resolve_extern_variable(
+        &self,
+        name: &str,
+        extern_desc: &ExternDesc,
+        kernel_btf: &Btf,
+    ) -> Result<Option<u32>, KsymsError> {
+        let Ok(kernel_var_id) = kernel_btf.id_by_type_name_kind(name, BtfKind::Var) else {
+            if extern_desc.is_weak {
+                return Ok(None);
+            }
+            return Err(KsymsError::VariableNotFound {
+                name: name.to_string(),
+            });
+        };
+
+        let kernel_var_type = kernel_btf.type_by_id(kernel_var_id)?;
+        let kernel_type_id = match kernel_var_type {
+            BtfType::Var(var) => var.btf_type,
+            _ => {
+                return Err(KsymsError::BtfError(BtfError::UnexpectedBtfType {
+                    type_id: kernel_var_id,
+                }));
+            }
+        };
+
+        let local_type_id = extern_desc.type_id.expect("typed extern must have type_id");
+
+        let obj_btf = self
+            .btf
+            .as_ref()
+            .expect("resolve_extern_variable called without local BTF");
+        let compatible =
+            crate::btf::types_are_compatible(obj_btf, local_type_id, kernel_btf, kernel_type_id)?;
+
+        if !compatible {
+            return Err(KsymsError::IncompatibleVariableType {
+                name: name.to_string(),
+            });
+        }
+
+        Ok(Some(kernel_var_id))
+    }
+}
+
+/// Errors that can occur during ksyms operations.
+#[derive(Debug, thiserror::Error)]
+pub enum KsymsError {
+    /// A typed ksym was encountered but kernel BTF is unavailable.
+    #[error("typed ksyms require kernel BTF for resolution")]
+    TypedKsymRequiresKernelBtf,
+
+    /// A non-weak extern variable was not found in kernel BTF or kallsyms.
+    #[error("kernel variable '{name}' not found")]
+    VariableNotFound {
+        /// The name of the variable that was not found.
+        name: String,
+    },
+
+    /// The extern function's signature is incompatible with the kernel function.
+    #[error("kernel function '{name}' has incompatible signature")]
+    IncompatibleFunctionSignature {
+        /// The name of the function with incompatible signature.
+        name: String,
+    },
+
+    /// The extern variable's type is incompatible with the kernel variable.
+    #[error("kernel variable '{name}' has incompatible type")]
+    IncompatibleVariableType {
+        /// The name of the variable with incompatible type.
+        name: String,
+    },
+
+    /// The extern symbol has an invalid BTF type (neither `Func` nor `Var`).
+    #[error("extern '{name}' has invalid BTF type (neither Func nor Var)")]
+    InvalidExternType {
+        /// The name of the extern with invalid type.
+        name: String,
+    },
+
+    /// An error occurred while working with BTF data.
+    #[error("BTF error: {0}")]
+    BtfError(#[from] BtfError),
+
+    /// Resolved extern's kallsyms address does not match against the loaded kallsyms.
+    #[error("extern (ksym) '{name}': resolution is ambiguous: {first_addr:#x} or {second_addr:#x}")]
+    AmbiguousResolution {
+        /// The name of the symbol with ambiguous resolution.
+        name: String,
+        /// The first address found.
+        first_addr: u64,
+        /// The second (conflicting) address found.
+        second_addr: u64,
+    },
+
+    /// Could not read kallsyms entries.
+    #[error("failed to read /proc/kallsyms: {0}")]
+    KallsymsReadError(#[from] std::io::Error),
+
+    /// Failed to parse kallsyms data.
+    #[error("failed to parse kallsyms: {0}")]
+    KallsymsParseError(String),
+
+    /// A non-weak typed extern function was not found in kernel BTF.
+    #[error("kernel function '{name}' not found in kernel BTF")]
+    FunctionNotFound {
+        /// The function name.
+        name: String,
+    },
+}
+
+/// Type of extern symbol.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ExternType {
+    /// Kernel symbol - variable or function (`.ksyms` section).
+    Ksym,
+}
+
+/// Descriptor for an extern symbol.
+#[derive(Debug, Clone)]
+pub(crate) struct ExternDesc {
+    /// Symbol name.
+    pub(crate) name: String,
+
+    /// Type of extern.
+    pub(crate) extern_type: ExternType,
+
+    /// BTF type ID in local (program) BTF.
+    pub(crate) btf_id: u32,
+
+    /// Whether this is a weak symbol.
+    pub(crate) is_weak: bool,
+
+    /// Whether extern has been resolved.
+    pub(crate) is_resolved: bool,
+
+    /// For ksym: kernel BTF ID (after resolution).
+    pub(crate) kernel_btf_id: Option<u32>,
+
+    /// For ksym variables: resolved kernel address.
+    pub(crate) ksym_addr: Option<u64>,
+
+    /// For ksym: resolved type ID (after skipping modifiers/typedefs).
+    pub(crate) type_id: Option<u32>,
+
+    /// For names with flavors: stripped essential name.
+    pub(crate) essential_name: Option<String>,
+}
+
+/// Given `some_struct_name___with_flavor` return the length of a name prefix
+/// before last triple underscore. Struct name part after last triple
+/// underscore is ignored by BPF CO-RE relocation during relocation matching.
+fn essential_name_len(name: &str) -> usize {
+    let n = name.len();
+    if n < 5 {
+        return n;
+    }
+
+    for i in (0..=n - 5).rev() {
+        if is_flavor_sep(name, i) {
+            return i + 1;
+        }
+    }
+
+    n
+}
+
+fn is_flavor_sep(s: &str, pos: usize) -> bool {
+    let bytes = s.as_bytes();
+    if pos + 4 >= bytes.len() {
+        return false;
+    }
+    bytes[pos] != b'_'
+        && bytes[pos + 1] == b'_'
+        && bytes[pos + 2] == b'_'
+        && bytes[pos + 3] == b'_'
+        && bytes[pos + 4] != b'_'
+}
+
+impl ExternDesc {
+    pub(crate) fn new(name: String, extern_type: ExternType, btf_id: u32, is_weak: bool) -> Self {
+        let essential_len = essential_name_len(&name);
+        let essential_name =
+            (essential_len != name.len()).then(|| name[..essential_len].to_string());
+
+        Self {
+            name,
+            extern_type,
+            btf_id,
+            is_weak,
+            is_resolved: false,
+            kernel_btf_id: None,
+            ksym_addr: None,
+            type_id: None,
+            essential_name,
+        }
+    }
+}
+
+/// Collection of extern symbols.
+#[derive(Debug, Default, Clone)]
+pub(crate) struct ExternCollection {
+    /// Map of extern descriptors by name.
+    pub(crate) externs: HashMap<String, ExternDesc>,
+
+    /// BTF ID of the placeholder var used for `.ksyms` function entries (if created).
+    pub(crate) ksym_func_placeholder_id: Option<u32>,
+
+    /// Index ID of `.ksyms` datasec entry in BTF types.
+    pub(crate) datasec_id: Option<u32>,
+}
+
+impl ExternCollection {
+    pub(crate) fn new() -> Self {
+        Self::default()
+    }
+
+    pub(crate) fn insert(&mut self, name: String, desc: ExternDesc) {
+        self.externs.insert(name, desc);
+    }
+
+    pub(crate) fn get_mut(&mut self, name: &str) -> Option<&mut ExternDesc> {
+        self.externs.get_mut(name)
+    }
+
+    pub(crate) fn iter(&self) -> impl Iterator<Item = (&String, &ExternDesc)> {
+        self.externs.iter()
+    }
+
+    pub(crate) const fn set_ksym_func_placeholder_id(&mut self, id: u32) {
+        self.ksym_func_placeholder_id = Some(id);
+    }
+
+    pub(crate) fn is_empty(&self) -> bool {
+        self.externs.is_empty()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{collections::BTreeMap, ffi::CString};
+
+    use object::Endianness;
+
+    use super::{ExternCollection, ExternDesc, ExternType, KsymsError};
+    use crate::{
+        Object,
+        btf::{
+            Btf, BtfParam, BtfType, Func, FuncLinkage, FuncProto, Int, IntEncoding, Ptr, Var,
+            VarLinkage,
+        },
+    };
+
+    fn object_with_externs(externs: ExternCollection) -> Object {
+        let mut btf = Btf::new();
+        btf.externs = externs;
+
+        Object {
+            endianness: Endianness::default(),
+            license: CString::new("GPL").unwrap(),
+            kernel_version: None,
+            btf: Some(btf),
+            btf_ext: None,
+            maps: Default::default(),
+            programs: Default::default(),
+            functions: BTreeMap::new(),
+            relocations: Default::default(),
+            symbol_table: Default::default(),
+            symbols_by_section: Default::default(),
+            section_infos: Default::default(),
+            symbol_offset_by_name: Default::default(),
+        }
+    }
+
+    fn object_with_btf_and_externs(mut btf: Btf, externs: ExternCollection) -> Object {
+        btf.externs = externs;
+
+        Object {
+            endianness: Endianness::default(),
+            license: CString::new("GPL").unwrap(),
+            kernel_version: None,
+            btf: Some(btf),
+            btf_ext: None,
+            maps: Default::default(),
+            programs: Default::default(),
+            functions: BTreeMap::new(),
+            relocations: Default::default(),
+            symbol_table: Default::default(),
+            symbols_by_section: Default::default(),
+            section_infos: Default::default(),
+            symbol_offset_by_name: Default::default(),
+        }
+    }
+
+    fn add_int(btf: &mut Btf, name: &str) -> u32 {
+        let name_offset = btf.add_string(name);
+        btf.add_type(BtfType::Int(Int::new(
+            name_offset,
+            4,
+            IntEncoding::Signed,
+            0,
+        )))
+    }
+
+    fn add_var(btf: &mut Btf, name: &str, type_id: u32) -> u32 {
+        let name_offset = btf.add_string(name);
+        btf.add_type(BtfType::Var(Var::new(
+            name_offset,
+            type_id,
+            VarLinkage::Global,
+        )))
+    }
+
+    fn add_func_proto(btf: &mut Btf, return_type: u32, params: Vec<BtfParam>) -> u32 {
+        btf.add_type(BtfType::FuncProto(FuncProto::new(params, return_type)))
+    }
+
+    fn add_func(btf: &mut Btf, name: &str, proto_id: u32) -> u32 {
+        let name_offset = btf.add_string(name);
+        btf.add_type(BtfType::Func(Func::new(
+            name_offset,
+            proto_id,
+            FuncLinkage::Global,
+        )))
+    }
+
+    #[test]
+    fn resolve_externs_requires_kernel_btf_for_typed_ksyms() {
+        let mut externs = ExternCollection::new();
+
+        let mut typed = ExternDesc::new("typed".into(), ExternType::Ksym, 1, false);
+        typed.type_id = Some(42);
+        externs.insert(typed.name.clone(), typed);
+
+        let mut object = object_with_externs(externs);
+
+        let err = object.resolve_externs(None).unwrap_err();
+        assert!(matches!(err, KsymsError::TypedKsymRequiresKernelBtf));
+    }
+
+    #[test]
+    fn resolve_externs_allows_weak_typed_ksyms_without_kernel_btf() {
+        let mut externs = ExternCollection::new();
+
+        let mut typed = ExternDesc::new("typed".into(), ExternType::Ksym, 1, true);
+        typed.type_id = Some(42);
+        externs.insert(typed.name.clone(), typed);
+
+        let mut object = object_with_externs(externs);
+
+        object.resolve_externs(None).unwrap();
+
+        let ext = &object.btf.as_ref().unwrap().externs.externs["typed"];
+        assert!(!ext.is_resolved);
+        assert_eq!(ext.ksym_addr, Some(0));
+    }
+
+    #[test]
+    fn resolve_typed_externs_rejects_invalid_extern_type() {
+        let mut btf = Btf::new();
+        let int_id = add_int(&mut btf, "int");
+
+        let mut externs = ExternCollection::new();
+        let mut ext = ExternDesc::new("bad".into(), ExternType::Ksym, int_id, false);
+        ext.type_id = Some(int_id);
+        externs.insert(ext.name.clone(), ext);
+
+        let mut object = object_with_btf_and_externs(btf, externs);
+        let kernel_btf = Btf::new();
+
+        let err = object.resolve_typed_externs(&kernel_btf).unwrap_err();
+        assert!(matches!(err, KsymsError::InvalidExternType { name } if name == "bad"));
+    }
+
+    #[test]
+    fn resolve_extern_variable_incompatible_type() {
+        let mut local_btf = Btf::new();
+        let local_int_id = add_int(&mut local_btf, "int");
+        let local_var_id = add_var(&mut local_btf, "foo", local_int_id);
+
+        let mut externs = ExternCollection::new();
+        let mut ext = ExternDesc::new("foo".into(), ExternType::Ksym, local_var_id, false);
+        ext.type_id = Some(local_int_id);
+        externs.insert(ext.name.clone(), ext);
+
+        let mut object = object_with_btf_and_externs(local_btf, externs);
+
+        let mut kernel_btf = Btf::new();
+        let kernel_int_id = add_int(&mut kernel_btf, "int");
+        let ptr_name_offset = kernel_btf.add_string("int_ptr");
+        let kernel_ptr_id =
+            kernel_btf.add_type(BtfType::Ptr(Ptr::new(ptr_name_offset, kernel_int_id)));
+        add_var(&mut kernel_btf, "foo", kernel_ptr_id);
+
+        let err = object.resolve_typed_externs(&kernel_btf).unwrap_err();
+        assert!(matches!(err, KsymsError::IncompatibleVariableType { name } if name == "foo"));
+    }
+
+    #[test]
+    fn resolve_extern_function_incompatible_signature() {
+        let mut local_btf = Btf::new();
+        let local_int_id = add_int(&mut local_btf, "int");
+        let local_proto_id = add_func_proto(&mut local_btf, local_int_id, vec![]);
+        let local_func_id = add_func(&mut local_btf, "bar", local_proto_id);
+
+        let mut externs = ExternCollection::new();
+        let mut ext = ExternDesc::new("bar".into(), ExternType::Ksym, local_func_id, false);
+        ext.type_id = Some(local_proto_id);
+        externs.insert(ext.name.clone(), ext);
+
+        let mut object = object_with_btf_and_externs(local_btf, externs);
+
+        let mut kernel_btf = Btf::new();
+        let kernel_int_id = add_int(&mut kernel_btf, "int");
+        let kernel_param = BtfParam {
+            name_offset: kernel_btf.add_string("x"),
+            btf_type: kernel_int_id,
+        };
+        let kernel_proto_id = add_func_proto(&mut kernel_btf, kernel_int_id, vec![kernel_param]);
+        add_func(&mut kernel_btf, "bar", kernel_proto_id);
+
+        let err = object.resolve_typed_externs(&kernel_btf).unwrap_err();
+        assert!(matches!(err, KsymsError::IncompatibleFunctionSignature { name } if name == "bar"));
+    }
+
+    mod kallsyms_tests {
+        use super::*;
+
+        impl Object {
+            /// Resolves typeless ksym addresses by matching symbol names against parsed kallsyms lines.
+            fn resolve_kallsyms_from_lines<I, S, U>(
+                &mut self,
+                lines: I,
+                unresolved: &[U],
+            ) -> Result<(), KsymsError>
+            where
+                I: IntoIterator<Item = S>,
+                S: AsRef<str>,
+                U: AsRef<str>,
+            {
+                let text = lines
+                    .into_iter()
+                    .map(|line| String::from(line.as_ref()))
+                    .collect::<Vec<_>>()
+                    .join("\n");
+                self.resolve_kallsyms_from_reader(std::io::Cursor::new(text), unresolved)
+            }
+
+            fn finalize_weak_typeless_ksyms_for_test(&mut self) {
+                if let Some(obj_btf) = self.btf.as_mut() {
+                    for ext in obj_btf.externs.externs.values_mut() {
+                        if ext.extern_type == ExternType::Ksym && !ext.is_resolved && ext.is_weak {
+                            ext.ksym_addr = Some(0);
+                        }
+                    }
+                }
+            }
+        }
+
+        #[test]
+        fn unresolved_typeless_ksym_vars_excludes_typed_vars() {
+            let mut externs = ExternCollection::new();
+
+            let mut typed = ExternDesc::new("typed".into(), ExternType::Ksym, 1, true);
+            typed.type_id = Some(42);
+            externs.insert(typed.name.clone(), typed);
+
+            let typeless = ExternDesc::new("typeless".into(), ExternType::Ksym, 2, true);
+            externs.insert(typeless.name.clone(), typeless);
+
+            let object = object_with_externs(externs);
+
+            assert_eq!(
+                object.unresolved_typeless_ksym_vars(),
+                vec![String::from("typeless")]
+            );
+        }
+
+        #[test]
+        fn resolve_kallsyms_from_lines_ambiguous_address() {
+            let mut externs = ExternCollection::new();
+            let ext = ExternDesc::new("init_task".into(), ExternType::Ksym, 1, false);
+            externs.insert(ext.name.clone(), ext);
+
+            let mut object = object_with_externs(externs);
+            let lines = vec![
+                String::from("1000 D init_task"),
+                String::from("3000 D other"),
+                String::from("2000 D init_task"),
+            ];
+            let unresolved = vec![String::from("init_task")];
+
+            let err = object
+                .resolve_kallsyms_from_lines(&lines, &unresolved)
+                .unwrap_err();
+
+            match err {
+                KsymsError::AmbiguousResolution {
+                    name,
+                    first_addr,
+                    second_addr,
+                } => {
+                    assert_eq!(name, "init_task");
+                    assert_eq!(first_addr, 0x1000);
+                    assert_eq!(second_addr, 0x2000);
+                }
+                other => panic!("expected AmbiguousResolution, got {other:?}"),
+            }
+        }
+
+        #[test]
+        fn resolve_kallsyms_from_lines_bad_address() {
+            let mut externs = ExternCollection::new();
+            let ext = ExternDesc::new("init_task".into(), ExternType::Ksym, 1, false);
+            externs.insert(ext.name.clone(), ext);
+
+            let mut object = object_with_externs(externs);
+            let lines = vec![String::from("not_hex D init_task")];
+            let unresolved = vec![String::from("init_task")];
+
+            let err = object
+                .resolve_kallsyms_from_lines(&lines, &unresolved)
+                .unwrap_err();
+
+            match err {
+                KsymsError::KallsymsParseError(msg) => {
+                    assert!(msg.contains("invalid address"), "unexpected error: {msg}");
+                }
+                other => panic!("expected KallsymsParseError, got {other:?}"),
+            }
+        }
+
+        #[test]
+        fn resolve_kallsyms_from_lines_rejects_masked_strong_address() {
+            let mut externs = ExternCollection::new();
+            let ext = ExternDesc::new("init_task".into(), ExternType::Ksym, 1, false);
+            externs.insert(ext.name.clone(), ext);
+
+            let mut object = object_with_externs(externs);
+            let lines = vec![String::from("0000000000000000 D init_task")];
+            let unresolved = vec![String::from("init_task")];
+
+            let err = object
+                .resolve_kallsyms_from_lines(&lines, &unresolved)
+                .unwrap_err();
+
+            assert!(matches!(
+                err,
+                KsymsError::VariableNotFound { name } if name == "init_task"
+            ));
+        }
+
+        #[test]
+        fn resolve_typeless_externs_sets_weak_ksym_addr_to_zero() {
+            let mut externs = ExternCollection::new();
+            let ext = ExternDesc::new("missing".into(), ExternType::Ksym, 1, true);
+            externs.insert(ext.name.clone(), ext);
+
+            let mut object = object_with_externs(externs);
+
+            object.finalize_weak_typeless_ksyms_for_test();
+
+            let ext = &object.btf.as_ref().unwrap().externs.externs["missing"];
+            assert_eq!(ext.ksym_addr, Some(0));
+            assert!(!ext.is_resolved);
+        }
+    }
+}

--- a/aya-obj/src/lib.rs
+++ b/aya-obj/src/lib.rs
@@ -97,7 +97,9 @@ pub mod programs;
 pub mod relocation;
 mod util;
 
-pub use extern_types::KsymsError;
+pub use extern_types::{
+    ExternModuleBtfProvider, ExternResolverModule, KsymsError, ResolveExternsError, ResolvedExterns,
+};
 pub use maps::Map;
 pub use obj::*;
 

--- a/aya-obj/src/lib.rs
+++ b/aya-obj/src/lib.rs
@@ -65,6 +65,7 @@
 #![cfg_attr(test, expect(unused_crate_dependencies, reason = "used in doctests"))]
 
 pub mod btf;
+mod extern_types;
 #[expect(
     clippy::all,
     clippy::as_pointer_underscore,
@@ -96,6 +97,7 @@ pub mod programs;
 pub mod relocation;
 mod util;
 
+pub use extern_types::KsymsError;
 pub use maps::Map;
 pub use obj::*;
 

--- a/aya-obj/src/obj.rs
+++ b/aya-obj/src/obj.rs
@@ -23,8 +23,8 @@ use crate::{
         Struct,
     },
     generated::{
-        BPF_CALL, BPF_F_RDONLY_PROG, BPF_JMP, BPF_K, bpf_func_id, bpf_insn, bpf_map_info,
-        bpf_map_type::BPF_MAP_TYPE_ARRAY,
+        BPF_CALL, BPF_F_RDONLY_PROG, BPF_JMP, BPF_K, BPF_PSEUDO_BTF_ID, BPF_PSEUDO_KFUNC_CALL,
+        bpf_func_id, bpf_insn, bpf_map_info, bpf_map_type::BPF_MAP_TYPE_ARRAY,
     },
     maps::{BtfMap, BtfMapDef, LegacyMap, MINIMUM_MAP_SIZE, Map, PinningType, bpf_map_def},
     programs::{
@@ -929,7 +929,58 @@ fn insn_is_helper_call(ins: bpf_insn) -> bool {
     klass == BPF_JMP && op == BPF_CALL && src == BPF_K && ins.src_reg() == 0 && ins.dst_reg() == 0
 }
 
+/// Module BTF state required to load a relocated function.
+#[derive(Debug, Copy, Clone, Default, Eq, PartialEq)]
+pub struct ModuleBtfLoadRequirements {
+    needs_lifetime: bool,
+    needs_fd_array: bool,
+}
+
+impl ModuleBtfLoadRequirements {
+    /// Returns whether module BTF file descriptors must stay alive while the function is loaded.
+    pub const fn needs_lifetime(self) -> bool {
+        self.needs_lifetime
+    }
+
+    /// Returns whether `BPF_PROG_LOAD` needs the module BTF fd array.
+    pub const fn needs_fd_array(self) -> bool {
+        self.needs_fd_array
+    }
+}
+
 impl Function {
+    /// Returns this function's module BTF load requirements.
+    ///
+    /// This must be called after extern relocations have been applied.
+    pub fn module_btf_load_requirements(&self) -> ModuleBtfLoadRequirements {
+        let mut requirements = ModuleBtfLoadRequirements::default();
+
+        for (i, ins) in self.instructions.iter().enumerate() {
+            if ins.code == (BPF_JMP | BPF_CALL) as u8
+                && ins.src_reg() == BPF_PSEUDO_KFUNC_CALL as u8
+                && ins.off != 0
+            {
+                requirements.needs_lifetime = true;
+                requirements.needs_fd_array = true;
+            }
+
+            if ins.src_reg() == BPF_PSEUDO_BTF_ID as u8
+                && self
+                    .instructions
+                    .get(i + 1)
+                    .is_some_and(|next| next.imm != 0)
+            {
+                requirements.needs_lifetime = true;
+            }
+
+            if requirements.needs_lifetime() && requirements.needs_fd_array() {
+                break;
+            }
+        }
+
+        requirements
+    }
+
     fn sanitize(&mut self, features: &Features) {
         for inst in &mut self.instructions {
             if !insn_is_helper_call(*inst) {
@@ -1566,6 +1617,57 @@ mod tests {
             off: 0,
             imm: 0,
         }
+    }
+
+    fn fake_func(instructions: Vec<bpf_insn>) -> Function {
+        Function {
+            address: Default::default(),
+            name: "test".to_string(),
+            section_index: SectionIndex(0),
+            section_offset: Default::default(),
+            instructions,
+            func_info: Default::default(),
+            line_info: Default::default(),
+            func_info_rec_size: Default::default(),
+            line_info_rec_size: Default::default(),
+        }
+    }
+
+    #[test]
+    fn test_function_module_btf_load_requirements() {
+        let requirements = fake_func(vec![fake_ins()]).module_btf_load_requirements();
+        assert!(!requirements.needs_lifetime());
+        assert!(!requirements.needs_fd_array());
+
+        let mut module_kfunc = fake_ins();
+        module_kfunc.code = (BPF_JMP | BPF_CALL) as u8;
+        module_kfunc.set_src_reg(BPF_PSEUDO_KFUNC_CALL as u8);
+        module_kfunc.off = 1;
+        let requirements = fake_func(vec![module_kfunc]).module_btf_load_requirements();
+        assert!(requirements.needs_lifetime());
+        assert!(requirements.needs_fd_array());
+
+        let mut vmlinux_kfunc = module_kfunc;
+        vmlinux_kfunc.off = 0;
+        let requirements = fake_func(vec![vmlinux_kfunc]).module_btf_load_requirements();
+        assert!(!requirements.needs_lifetime());
+        assert!(!requirements.needs_fd_array());
+
+        let mut module_var = fake_ins();
+        module_var.set_src_reg(BPF_PSEUDO_BTF_ID as u8);
+        let mut module_var_fd = fake_ins();
+        module_var_fd.imm = 10;
+        let requirements =
+            fake_func(vec![module_var, module_var_fd]).module_btf_load_requirements();
+        assert!(requirements.needs_lifetime());
+        assert!(!requirements.needs_fd_array());
+
+        let mut vmlinux_var_fd = module_var_fd;
+        vmlinux_var_fd.imm = 0;
+        let requirements =
+            fake_func(vec![module_var, vmlinux_var_fd]).module_btf_load_requirements();
+        assert!(!requirements.needs_lifetime());
+        assert!(!requirements.needs_fd_array());
     }
 
     fn fake_sym(obj: &mut Object, section_index: usize, address: u64, name: &str, size: u64) {

--- a/aya-obj/src/obj.rs
+++ b/aya-obj/src/obj.rs
@@ -498,6 +498,7 @@ impl Object {
                     size: symbol.size(),
                     is_definition: symbol.is_definition(),
                     kind: symbol.kind(),
+                    is_weak: symbol.is_weak(),
                 };
                 bpf_obj.symbol_table.insert(symbol.index().0, sym);
                 if let Some(section_idx) = symbol.section().index() {
@@ -521,6 +522,8 @@ impl Object {
             if let Some(s) = obj.section_by_name(".BTF.ext") {
                 bpf_obj.parse_section(Section::try_from(&s)?)?;
             }
+
+            bpf_obj.collect_ksyms_from_btf()?;
         }
 
         for s in obj.sections() {
@@ -1577,6 +1580,7 @@ mod tests {
                 size,
                 is_definition: false,
                 kind: SymbolKind::Text,
+                is_weak: false,
             },
         );
         obj.symbols_by_section
@@ -2820,6 +2824,7 @@ mod tests {
                 size: 3,
                 is_definition: true,
                 kind: SymbolKind::Data,
+                is_weak: false,
             },
         );
 

--- a/aya-obj/src/relocation.rs
+++ b/aya-obj/src/relocation.rs
@@ -7,10 +7,10 @@ use object::{SectionIndex, SymbolKind};
 
 use crate::{
     EbpfSectionKind,
-    extern_types::ExternDesc,
+    extern_types::{ExternDesc, ResolvedKsymTarget},
     generated::{
-        BPF_CALL, BPF_JMP, BPF_K, BPF_PSEUDO_BTF_ID, BPF_PSEUDO_CALL, BPF_PSEUDO_FUNC,
-        BPF_PSEUDO_KFUNC_CALL, BPF_PSEUDO_MAP_FD, BPF_PSEUDO_MAP_VALUE, bpf_insn,
+        BPF_CALL, BPF_DW, BPF_IMM, BPF_JMP, BPF_K, BPF_LD, BPF_PSEUDO_BTF_ID, BPF_PSEUDO_CALL,
+        BPF_PSEUDO_FUNC, BPF_PSEUDO_KFUNC_CALL, BPF_PSEUDO_MAP_FD, BPF_PSEUDO_MAP_VALUE, bpf_insn,
     },
     maps::Map,
     obj::{Function, Object},
@@ -96,6 +96,42 @@ pub enum RelocationError {
         /// Name of the extern symbol
         name: String,
     },
+
+    /// Invalid extern relocation instruction.
+    #[error("invalid extern relocation instruction for `{name}` at instruction {ins_index}")]
+    InvalidExternRelocationInstruction {
+        /// Name of the extern symbol.
+        name: String,
+        /// Index of the instruction being relocated.
+        ins_index: usize,
+    },
+
+    /// Invalid `ldimm64` extern relocation.
+    #[error(
+        "invalid ldimm64 relocation for extern `{name}` at instruction {ins_index}; function has {function_len} instructions"
+    )]
+    InvalidLdImm64Relocation {
+        /// Name of the extern symbol.
+        name: String,
+        /// Index of the instruction being relocated.
+        ins_index: usize,
+        /// Number of instructions in the function.
+        function_len: usize,
+    },
+
+    /// Strong extern resolved as missing.
+    #[error("strong extern `{name}` resolved as missing")]
+    StrongExternMissing {
+        /// Name of the extern symbol.
+        name: String,
+    },
+
+    /// The module BTF fd array index is too large for `bpf_insn.off`.
+    #[error("module BTF fd index `{index}` is too large for kfunc call relocation")]
+    BtfFdIndexTooLarge {
+        /// The module BTF fd array index.
+        index: u16,
+    },
 }
 
 #[derive(Debug, Copy, Clone)]
@@ -172,10 +208,7 @@ impl Object {
         };
 
         for (name, extern_desc) in obj_btf.externs.iter() {
-            debug!(
-                "extern '{}': resolved={}, btf_id={:?}",
-                name, extern_desc.is_resolved, extern_desc.kernel_btf_id
-            );
+            debug!("extern '{}': resolved={:?}", name, extern_desc.resolved);
         }
 
         for function in self.functions.values_mut() {
@@ -278,49 +311,79 @@ fn patch_extern_relocations<'a, I: Iterator<Item = &'a Relocation>>(
                     name: extern_name.clone(),
                 })?;
 
-        let ins = &mut instructions[ins_index];
         // Extern relocations use CALL opcode to identify kfunc-call sites.
         // `insn_is_call()` is for internal pseudo-calls.
-        let is_call = ins.code == (BPF_JMP | BPF_CALL) as u8;
-
-        if is_call {
-            ins.set_src_reg(BPF_PSEUDO_KFUNC_CALL as u8);
-            if extern_desc.is_resolved {
-                let kernel_btf_id = extern_desc
-                    .kernel_btf_id
-                    .expect("resolved extern must have kernel_btf_id");
-                ins.imm = kernel_btf_id as i32;
-                ins.off = 0; // btf_fd_idx, typically 0 for vmlinux
-            } else if extern_desc.is_weak {
-                // Unresolved weak kfunc call
-                poison_kfunc_call(ins, rel.symbol_index);
-            } else {
-                return Err(RelocationError::UnresolvableSymbol {
-                    name: extern_name.clone(),
-                });
+        if insn_is_extern_call(instructions[ins_index]) {
+            let ins = &mut instructions[ins_index];
+            match extern_desc.resolved {
+                Some(ResolvedKsymTarget::VmlinuxBtf { type_id }) => {
+                    ins.set_src_reg(BPF_PSEUDO_KFUNC_CALL as u8);
+                    ins.imm = type_id as i32;
+                    ins.off = 0;
+                }
+                Some(ResolvedKsymTarget::ModuleBtf {
+                    type_id,
+                    btf_fd_idx,
+                    ..
+                }) => {
+                    ins.set_src_reg(BPF_PSEUDO_KFUNC_CALL as u8);
+                    ins.imm = type_id as i32;
+                    ins.off = i16::try_from(btf_fd_idx).map_err(|_err| {
+                        RelocationError::BtfFdIndexTooLarge { index: btf_fd_idx }
+                    })?;
+                }
+                Some(ResolvedKsymTarget::WeakMissing) => {
+                    if !extern_desc.is_weak {
+                        return Err(RelocationError::StrongExternMissing {
+                            name: extern_name.clone(),
+                        });
+                    }
+                    poison_kfunc_call(ins, rel.symbol_index);
+                }
+                Some(ResolvedKsymTarget::Address { .. }) | None => {
+                    return Err(RelocationError::UnresolvableSymbol {
+                        name: extern_name.clone(),
+                    });
+                }
             }
         } else {
-            match (extern_desc.kernel_btf_id, extern_desc.ksym_addr) {
-                // symbol found in kernel BTF
-                (Some(btf_id), _) => {
+            validate_extern_ldimm64_relocation(instructions, ins_index, extern_name)?;
+            let (ins, next_ins) = {
+                let (head, tail) = instructions.split_at_mut(ins_index + 1);
+                (&mut head[ins_index], &mut tail[0])
+            };
+
+            match extern_desc.resolved {
+                Some(ResolvedKsymTarget::VmlinuxBtf { type_id }) => {
                     ins.set_src_reg(BPF_PSEUDO_BTF_ID as u8);
-                    ins.imm = btf_id as i32;
-                    instructions[ins_index + 1].imm = 0; // vmlinux
+                    ins.imm = type_id as i32;
+                    next_ins.imm = 0;
                 }
-                // fallback to kallsyms (BTF missing but address found)
-                (None, Some(addr)) => {
-                    ins.set_src_reg(0); // Standard 64-bit absolute load
+                Some(ResolvedKsymTarget::ModuleBtf {
+                    type_id,
+                    btf_obj_fd,
+                    ..
+                }) => {
+                    ins.set_src_reg(BPF_PSEUDO_BTF_ID as u8);
+                    ins.imm = type_id as i32;
+                    next_ins.imm = btf_obj_fd;
+                }
+                Some(ResolvedKsymTarget::Address { addr }) => {
+                    ins.set_src_reg(0);
                     ins.imm = (addr & 0xFFFFFFFF) as i32;
-                    instructions[ins_index + 1].imm = (addr >> 32) as i32;
+                    next_ins.imm = (addr >> 32) as i32;
                 }
-                // weak symbol not found, null-patch
-                (None, None) if extern_desc.is_weak => {
+                Some(ResolvedKsymTarget::WeakMissing) => {
+                    if !extern_desc.is_weak {
+                        return Err(RelocationError::StrongExternMissing {
+                            name: extern_name.clone(),
+                        });
+                    }
                     ins.set_src_reg(0);
                     ins.imm = 0;
-                    instructions[ins_index + 1].imm = 0;
+                    next_ins.imm = 0;
                 }
-                // strong symbol not found anywhere
-                _ => {
+                None => {
                     return Err(RelocationError::UnresolvableSymbol {
                         name: extern_name.clone(),
                     });
@@ -333,6 +396,44 @@ fn patch_extern_relocations<'a, I: Iterator<Item = &'a Relocation>>(
 }
 
 const POISON_CALL_KFUNC_BASE: i32 = 2002000000;
+
+const fn insn_is_extern_call(ins: bpf_insn) -> bool {
+    ins.code == (BPF_JMP | BPF_CALL) as u8
+}
+
+const fn insn_is_ldimm64(ins: bpf_insn) -> bool {
+    ins.code == (BPF_LD | BPF_DW | BPF_IMM) as u8
+}
+
+fn validate_extern_ldimm64_relocation(
+    instructions: &[bpf_insn],
+    ins_index: usize,
+    name: &str,
+) -> Result<(), RelocationError> {
+    let Some(ins) = instructions.get(ins_index) else {
+        return Err(RelocationError::InvalidExternRelocationInstruction {
+            name: name.to_owned(),
+            ins_index,
+        });
+    };
+
+    if !insn_is_ldimm64(*ins) {
+        return Err(RelocationError::InvalidExternRelocationInstruction {
+            name: name.to_owned(),
+            ins_index,
+        });
+    }
+
+    if instructions.get(ins_index + 1).is_none() {
+        return Err(RelocationError::InvalidLdImm64Relocation {
+            name: name.to_owned(),
+            ins_index,
+            function_len: instructions.len(),
+        });
+    }
+
+    Ok(())
+}
 
 fn poison_kfunc_call(ins: &mut bpf_insn, ext_idx: usize) {
     ins.code = (BPF_JMP | BPF_CALL) as u8;
@@ -941,11 +1042,9 @@ mod test {
                 extern_type: ExternType::Ksym,
                 btf_id: 1,
                 is_weak: true,
-                is_resolved: false,
-                kernel_btf_id: None,
-                ksym_addr: None,
                 type_id: Some(1),
                 essential_name: None,
+                resolved: Some(ResolvedKsymTarget::WeakMissing),
             },
         )]);
 
@@ -981,11 +1080,9 @@ mod test {
                 extern_type: ExternType::Ksym,
                 btf_id: 1,
                 is_weak: false,
-                is_resolved: false,
-                kernel_btf_id: None,
-                ksym_addr: None,
                 type_id: Some(1),
                 essential_name: None,
+                resolved: None,
             },
         )]);
 
@@ -1026,11 +1123,9 @@ mod test {
                 extern_type: ExternType::Ksym,
                 btf_id: 1,
                 is_weak: true,
-                is_resolved: false,
-                kernel_btf_id: None,
-                ksym_addr: None,
                 type_id: None,
                 essential_name: None,
+                resolved: Some(ResolvedKsymTarget::WeakMissing),
             },
         )]);
 
@@ -1041,5 +1136,262 @@ mod test {
         assert_eq!(fun.instructions[0].src_reg(), 0);
         assert_eq!(fun.instructions[0].imm, 0);
         assert_eq!(fun.instructions[1].imm, 0);
+    }
+
+    #[test]
+    fn test_extern_ldimm64_relocation_rejects_missing_second_slot() {
+        let mut fun = fake_func(
+            "test",
+            vec![ins(&[0x18, 0x01, 0x00, 0x00, 0xaa, 0xbb, 0xcc, 0xdd])],
+        );
+
+        let relocations = [Relocation {
+            offset: 0,
+            symbol_index: 1,
+            size: 64,
+        }];
+
+        let externs = HashMap::from([(
+            "module_var".to_string(),
+            ExternDesc {
+                name: "module_var".to_string(),
+                extern_type: ExternType::Ksym,
+                btf_id: 1,
+                is_weak: false,
+                type_id: Some(1),
+                essential_name: None,
+                resolved: Some(ResolvedKsymTarget::ModuleBtf {
+                    type_id: 123,
+                    btf_fd_idx: 2,
+                    btf_obj_fd: 40_000,
+                }),
+            },
+        )]);
+
+        let symbol_table = HashMap::from([(1, fake_extern_sym(1, "module_var", false))]);
+
+        let err = patch_extern_relocations(&mut fun, relocations.iter(), &externs, &symbol_table)
+            .unwrap_err();
+
+        assert!(matches!(
+            err,
+            RelocationError::InvalidLdImm64Relocation {
+                name,
+                ins_index: 0,
+                function_len: 1,
+            } if name == "module_var"
+        ));
+    }
+
+    #[test]
+    fn test_extern_ldimm64_relocation_rejects_non_ldimm64_instruction() {
+        let mut fun = fake_func(
+            "test",
+            vec![ins(&[0xbf, 0x10, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00])],
+        );
+
+        let relocations = [Relocation {
+            offset: 0,
+            symbol_index: 1,
+            size: 64,
+        }];
+
+        let externs = HashMap::from([(
+            "module_var".to_string(),
+            ExternDesc {
+                name: "module_var".to_string(),
+                extern_type: ExternType::Ksym,
+                btf_id: 1,
+                is_weak: false,
+                type_id: Some(1),
+                essential_name: None,
+                resolved: Some(ResolvedKsymTarget::ModuleBtf {
+                    type_id: 123,
+                    btf_fd_idx: 2,
+                    btf_obj_fd: 40_000,
+                }),
+            },
+        )]);
+
+        let symbol_table = HashMap::from([(1, fake_extern_sym(1, "module_var", false))]);
+
+        let err = patch_extern_relocations(&mut fun, relocations.iter(), &externs, &symbol_table)
+            .unwrap_err();
+
+        assert!(matches!(
+            err,
+            RelocationError::InvalidExternRelocationInstruction {
+                name,
+                ins_index: 0,
+            } if name == "module_var"
+        ));
+    }
+
+    #[test]
+    fn test_strong_extern_resolved_as_weak_missing_is_rejected() {
+        let mut fun = fake_func(
+            "test",
+            vec![
+                ins(&[
+                    0x18, 0x01, 0x00, 0x00, 0xaa, 0xbb, 0xcc, 0xdd, 0x00, 0x00, 0x00, 0x00, 0x11,
+                    0x22, 0x33, 0x44,
+                ]),
+                ins(&[0; 8]),
+            ],
+        );
+
+        let relocations = [Relocation {
+            offset: 0,
+            symbol_index: 1,
+            size: 64,
+        }];
+
+        let externs = HashMap::from([(
+            "missing_var".to_string(),
+            ExternDesc {
+                name: "missing_var".to_string(),
+                extern_type: ExternType::Ksym,
+                btf_id: 1,
+                is_weak: false,
+                type_id: None,
+                essential_name: None,
+                resolved: Some(ResolvedKsymTarget::WeakMissing),
+            },
+        )]);
+
+        let symbol_table = HashMap::from([(1, fake_extern_sym(1, "missing_var", false))]);
+
+        let err = patch_extern_relocations(&mut fun, relocations.iter(), &externs, &symbol_table)
+            .unwrap_err();
+
+        assert!(matches!(
+            err,
+            RelocationError::StrongExternMissing { name } if name == "missing_var"
+        ));
+    }
+
+    #[test]
+    fn test_module_kfunc_call_sets_btf_fd_index() {
+        let mut fun = fake_func(
+            "test",
+            vec![ins(&[0x85, 0x10, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00])],
+        );
+
+        let relocations = [Relocation {
+            offset: 0,
+            symbol_index: 1,
+            size: 32,
+        }];
+
+        let externs = HashMap::from([(
+            "module_kfunc".to_string(),
+            ExternDesc {
+                name: "module_kfunc".to_string(),
+                extern_type: ExternType::Ksym,
+                btf_id: 1,
+                is_weak: false,
+                type_id: Some(1),
+                essential_name: None,
+                resolved: Some(ResolvedKsymTarget::ModuleBtf {
+                    type_id: 123,
+                    btf_fd_idx: 2,
+                    btf_obj_fd: 40_000,
+                }),
+            },
+        )]);
+
+        let symbol_table = HashMap::from([(1, fake_extern_sym(1, "module_kfunc", false))]);
+
+        patch_extern_relocations(&mut fun, relocations.iter(), &externs, &symbol_table).unwrap();
+
+        assert_eq!(fun.instructions[0].src_reg(), BPF_PSEUDO_KFUNC_CALL as u8);
+        assert_eq!(fun.instructions[0].imm, 123);
+        assert_eq!(fun.instructions[0].off, 2);
+    }
+
+    #[test]
+    fn test_module_kfunc_call_rejects_large_btf_fd_index() {
+        let mut fun = fake_func(
+            "test",
+            vec![ins(&[0x85, 0x10, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00])],
+        );
+
+        let relocations = [Relocation {
+            offset: 0,
+            symbol_index: 1,
+            size: 32,
+        }];
+
+        let externs = HashMap::from([(
+            "module_kfunc".to_string(),
+            ExternDesc {
+                name: "module_kfunc".to_string(),
+                extern_type: ExternType::Ksym,
+                btf_id: 1,
+                is_weak: false,
+                type_id: Some(1),
+                essential_name: None,
+                resolved: Some(ResolvedKsymTarget::ModuleBtf {
+                    type_id: 123,
+                    btf_fd_idx: 40_000,
+                    btf_obj_fd: 50_000,
+                }),
+            },
+        )]);
+
+        let symbol_table = HashMap::from([(1, fake_extern_sym(1, "module_kfunc", false))]);
+
+        let err = patch_extern_relocations(&mut fun, relocations.iter(), &externs, &symbol_table)
+            .unwrap_err();
+
+        assert!(matches!(
+            err,
+            RelocationError::BtfFdIndexTooLarge { index: 40_000 }
+        ));
+    }
+
+    #[test]
+    fn test_module_variable_reference_sets_btf_object_fd() {
+        let mut fun = fake_func(
+            "test",
+            vec![
+                ins(&[
+                    0x18, 0x01, 0x00, 0x00, 0xaa, 0xbb, 0xcc, 0xdd, 0x00, 0x00, 0x00, 0x00, 0x11,
+                    0x22, 0x33, 0x44,
+                ]),
+                ins(&[0; 8]),
+            ],
+        );
+
+        let relocations = [Relocation {
+            offset: 0,
+            symbol_index: 1,
+            size: 64,
+        }];
+
+        let externs = HashMap::from([(
+            "module_var".to_string(),
+            ExternDesc {
+                name: "module_var".to_string(),
+                extern_type: ExternType::Ksym,
+                btf_id: 1,
+                is_weak: false,
+                type_id: Some(1),
+                essential_name: None,
+                resolved: Some(ResolvedKsymTarget::ModuleBtf {
+                    type_id: 123,
+                    btf_fd_idx: 2,
+                    btf_obj_fd: 40_000,
+                }),
+            },
+        )]);
+
+        let symbol_table = HashMap::from([(1, fake_extern_sym(1, "module_var", false))]);
+
+        patch_extern_relocations(&mut fun, relocations.iter(), &externs, &symbol_table).unwrap();
+
+        assert_eq!(fun.instructions[0].src_reg(), BPF_PSEUDO_BTF_ID as u8);
+        assert_eq!(fun.instructions[0].imm, 123);
+        assert_eq!(fun.instructions[1].imm, 40_000);
     }
 }

--- a/aya-obj/src/relocation.rs
+++ b/aya-obj/src/relocation.rs
@@ -7,9 +7,10 @@ use object::{SectionIndex, SymbolKind};
 
 use crate::{
     EbpfSectionKind,
+    extern_types::ExternDesc,
     generated::{
-        BPF_CALL, BPF_JMP, BPF_K, BPF_PSEUDO_CALL, BPF_PSEUDO_FUNC, BPF_PSEUDO_MAP_FD,
-        BPF_PSEUDO_MAP_VALUE, bpf_insn,
+        BPF_CALL, BPF_JMP, BPF_K, BPF_PSEUDO_BTF_ID, BPF_PSEUDO_CALL, BPF_PSEUDO_FUNC,
+        BPF_PSEUDO_KFUNC_CALL, BPF_PSEUDO_MAP_FD, BPF_PSEUDO_MAP_VALUE, bpf_insn,
     },
     maps::Map,
     obj::{Function, Object},
@@ -81,6 +82,20 @@ pub enum RelocationError {
         /// The relocation number
         relocation_number: usize,
     },
+
+    /// Extern not found.
+    #[error("extern `{name}` not found")]
+    ExternNotFound {
+        /// Name of the extern symbol.
+        name: String,
+    },
+
+    /// Strong symbol not found anywhere (neither BTF nor kallsyms).
+    #[error("strong extern `{name}` not resolvable (not in kernel BTF or kallsyms)")]
+    UnresolvableSymbol {
+        /// Name of the extern symbol
+        name: String,
+    },
 }
 
 #[derive(Debug, Copy, Clone)]
@@ -101,6 +116,17 @@ pub(crate) struct Symbol {
     pub(crate) size: u64,
     pub(crate) is_definition: bool,
     pub(crate) kind: SymbolKind,
+    pub(crate) is_weak: bool,
+}
+
+impl Symbol {
+    /// Returns true if this symbol is an extern (undefined) symbol
+    pub(crate) fn is_extern(&self) -> bool {
+        self.section_index.is_none()
+            && self.name.is_some()
+            && !self.is_definition
+            && self.kind == SymbolKind::Unknown
+    }
 }
 
 impl Object {
@@ -128,6 +154,37 @@ impl Object {
                     &maps_by_symbol,
                     &self.symbol_table,
                     text_sections,
+                )
+                .map_err(|error| EbpfRelocationError {
+                    function: function.name.clone(),
+                    error,
+                })?;
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Relocates extern kernel symbol references after they have been resolved.
+    pub fn relocate_externs(&mut self) -> Result<(), EbpfRelocationError> {
+        let Some(obj_btf) = self.btf.as_mut() else {
+            return Ok(());
+        };
+
+        for (name, extern_desc) in obj_btf.externs.iter() {
+            debug!(
+                "extern '{}': resolved={}, btf_id={:?}",
+                name, extern_desc.is_resolved, extern_desc.kernel_btf_id
+            );
+        }
+
+        for function in self.functions.values_mut() {
+            if let Some(relocations) = self.relocations.get(&function.section_index) {
+                patch_extern_relocations(
+                    function,
+                    relocations.values(),
+                    &obj_btf.externs.externs,
+                    &self.symbol_table,
                 )
                 .map_err(|error| EbpfRelocationError {
                     function: function.name.clone(),
@@ -175,6 +232,114 @@ impl Object {
 
         Ok(())
     }
+}
+
+fn patch_extern_relocations<'a, I: Iterator<Item = &'a Relocation>>(
+    fun: &mut Function,
+    relocations: I,
+    externs: &HashMap<String, ExternDesc>,
+    symbol_table: &HashMap<usize, Symbol>,
+) -> Result<(), RelocationError> {
+    let section_offset = fun.section_offset;
+    let instructions = &mut fun.instructions;
+    let function_size = instructions.len() * INS_SIZE;
+
+    for (rel_n, rel) in relocations.enumerate() {
+        let rel_offset = rel.offset as usize;
+        if rel_offset < section_offset || rel_offset >= section_offset + function_size {
+            continue;
+        }
+
+        let ins_offset = rel_offset - section_offset;
+        if !ins_offset.is_multiple_of(INS_SIZE) {
+            return Err(RelocationError::InvalidRelocationOffset {
+                offset: rel.offset,
+                relocation_number: rel_n,
+            });
+        }
+        let ins_index = ins_offset / INS_SIZE;
+
+        let sym = symbol_table
+            .get(&rel.symbol_index)
+            .ok_or(RelocationError::UnknownSymbol {
+                index: rel.symbol_index,
+            })?;
+
+        // Only process extern symbols
+        if !sym.is_extern() {
+            continue;
+        }
+
+        let extern_name = sym.name.as_ref().expect("extern symbol must have a name");
+        let extern_desc =
+            externs
+                .get(extern_name)
+                .ok_or_else(|| RelocationError::ExternNotFound {
+                    name: extern_name.clone(),
+                })?;
+
+        let ins = &mut instructions[ins_index];
+        // Extern relocations use CALL opcode to identify kfunc-call sites.
+        // `insn_is_call()` is for internal pseudo-calls.
+        let is_call = ins.code == (BPF_JMP | BPF_CALL) as u8;
+
+        if is_call {
+            ins.set_src_reg(BPF_PSEUDO_KFUNC_CALL as u8);
+            if extern_desc.is_resolved {
+                let kernel_btf_id = extern_desc
+                    .kernel_btf_id
+                    .expect("resolved extern must have kernel_btf_id");
+                ins.imm = kernel_btf_id as i32;
+                ins.off = 0; // btf_fd_idx, typically 0 for vmlinux
+            } else if extern_desc.is_weak {
+                // Unresolved weak kfunc call
+                poison_kfunc_call(ins, rel.symbol_index);
+            } else {
+                return Err(RelocationError::UnresolvableSymbol {
+                    name: extern_name.clone(),
+                });
+            }
+        } else {
+            match (extern_desc.kernel_btf_id, extern_desc.ksym_addr) {
+                // symbol found in kernel BTF
+                (Some(btf_id), _) => {
+                    ins.set_src_reg(BPF_PSEUDO_BTF_ID as u8);
+                    ins.imm = btf_id as i32;
+                    instructions[ins_index + 1].imm = 0; // vmlinux
+                }
+                // fallback to kallsyms (BTF missing but address found)
+                (None, Some(addr)) => {
+                    ins.set_src_reg(0); // Standard 64-bit absolute load
+                    ins.imm = (addr & 0xFFFFFFFF) as i32;
+                    instructions[ins_index + 1].imm = (addr >> 32) as i32;
+                }
+                // weak symbol not found, null-patch
+                (None, None) if extern_desc.is_weak => {
+                    ins.set_src_reg(0);
+                    ins.imm = 0;
+                    instructions[ins_index + 1].imm = 0;
+                }
+                // strong symbol not found anywhere
+                _ => {
+                    return Err(RelocationError::UnresolvableSymbol {
+                        name: extern_name.clone(),
+                    });
+                }
+            }
+        }
+    }
+
+    Ok(())
+}
+
+const POISON_CALL_KFUNC_BASE: i32 = 2002000000;
+
+fn poison_kfunc_call(ins: &mut bpf_insn, ext_idx: usize) {
+    ins.code = (BPF_JMP | BPF_CALL) as u8;
+    ins.set_dst_reg(0);
+    ins.set_src_reg(0);
+    ins.off = 0;
+    ins.imm = POISON_CALL_KFUNC_BASE.wrapping_add(ext_idx as i32);
 }
 
 fn relocate_maps<'a, I: Iterator<Item = &'a Relocation>>(
@@ -365,8 +530,9 @@ impl<'a> FunctionLinker<'a> {
                         .map(|sym| (rel, sym))
                 })
                 .filter(|(_rel, sym)| {
-                    // only consider text relocations, data relocations are
-                    // relocated in relocate_maps()
+                    if sym.is_extern() {
+                        return false;
+                    }
                     sym.kind == SymbolKind::Text
                         || sym.section_index.is_some_and(|section_index| {
                             self.text_sections.contains(&section_index)
@@ -495,7 +661,10 @@ mod test {
     use std::string::ToString as _;
 
     use super::*;
-    use crate::maps::{BtfMap, LegacyMap};
+    use crate::{
+        extern_types::ExternType,
+        maps::{BtfMap, LegacyMap},
+    };
 
     fn fake_sym(index: usize, section_index: usize, address: u64, name: &str, size: u64) -> Symbol {
         Symbol {
@@ -506,6 +675,20 @@ mod test {
             size,
             is_definition: false,
             kind: SymbolKind::Data,
+            is_weak: false,
+        }
+    }
+
+    fn fake_extern_sym(index: usize, name: &str, is_weak: bool) -> Symbol {
+        Symbol {
+            index,
+            section_index: None,
+            name: Some(name.to_string()),
+            address: 0,
+            size: 0,
+            is_definition: false,
+            kind: SymbolKind::Unknown,
+            is_weak,
         }
     }
 
@@ -736,5 +919,127 @@ mod test {
 
         assert_eq!(fun.instructions[1].src_reg(), BPF_PSEUDO_MAP_FD as u8);
         assert_eq!(fun.instructions[1].imm, 2);
+    }
+
+    #[test]
+    fn test_unresolved_weak_kfunc_call_is_poisoned() {
+        let mut fun = fake_func(
+            "test",
+            vec![ins(&[0x85, 0x10, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00])],
+        );
+
+        let relocations = [Relocation {
+            offset: 0,
+            symbol_index: 1,
+            size: 32,
+        }];
+
+        let externs = HashMap::from([(
+            "missing_kfunc".to_string(),
+            ExternDesc {
+                name: "missing_kfunc".to_string(),
+                extern_type: ExternType::Ksym,
+                btf_id: 1,
+                is_weak: true,
+                is_resolved: false,
+                kernel_btf_id: None,
+                ksym_addr: None,
+                type_id: Some(1),
+                essential_name: None,
+            },
+        )]);
+
+        let symbol_table = HashMap::from([(1, fake_extern_sym(1, "missing_kfunc", true))]);
+
+        patch_extern_relocations(&mut fun, relocations.iter(), &externs, &symbol_table).unwrap();
+
+        let ins = fun.instructions[0];
+        assert_eq!(ins.code, (BPF_JMP | BPF_CALL) as u8);
+        assert_eq!(ins.src_reg(), 0);
+        assert_eq!(ins.dst_reg(), 0);
+        assert_eq!(ins.off, 0);
+        assert_eq!(ins.imm, POISON_CALL_KFUNC_BASE + 1);
+    }
+
+    #[test]
+    fn test_unresolved_strong_kfunc_call_is_rejected() {
+        let mut fun = fake_func(
+            "test",
+            vec![ins(&[0x85, 0x10, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00])],
+        );
+
+        let relocations = [Relocation {
+            offset: 0,
+            symbol_index: 1,
+            size: 32,
+        }];
+
+        let externs = HashMap::from([(
+            "missing_kfunc".to_string(),
+            ExternDesc {
+                name: "missing_kfunc".to_string(),
+                extern_type: ExternType::Ksym,
+                btf_id: 1,
+                is_weak: false,
+                is_resolved: false,
+                kernel_btf_id: None,
+                ksym_addr: None,
+                type_id: Some(1),
+                essential_name: None,
+            },
+        )]);
+
+        let symbol_table = HashMap::from([(1, fake_extern_sym(1, "missing_kfunc", false))]);
+
+        let err = patch_extern_relocations(&mut fun, relocations.iter(), &externs, &symbol_table)
+            .unwrap_err();
+
+        assert!(matches!(
+            err,
+            RelocationError::UnresolvableSymbol { name } if name == "missing_kfunc"
+        ));
+    }
+
+    #[test]
+    fn test_unresolved_weak_var_reference_is_null_patched() {
+        let mut fun = fake_func(
+            "test",
+            vec![
+                ins(&[
+                    0x18, 0x01, 0x00, 0x00, 0xaa, 0xbb, 0xcc, 0xdd, 0x00, 0x00, 0x00, 0x00, 0x11,
+                    0x22, 0x33, 0x44,
+                ]),
+                ins(&[0; 8]),
+            ],
+        );
+
+        let relocations = [Relocation {
+            offset: 0,
+            symbol_index: 1,
+            size: 64,
+        }];
+
+        let externs = HashMap::from([(
+            "missing_var".to_string(),
+            ExternDesc {
+                name: "missing_var".to_string(),
+                extern_type: ExternType::Ksym,
+                btf_id: 1,
+                is_weak: true,
+                is_resolved: false,
+                kernel_btf_id: None,
+                ksym_addr: None,
+                type_id: None,
+                essential_name: None,
+            },
+        )]);
+
+        let symbol_table = HashMap::from([(1, fake_extern_sym(1, "missing_var", true))]);
+
+        patch_extern_relocations(&mut fun, relocations.iter(), &externs, &symbol_table).unwrap();
+
+        assert_eq!(fun.instructions[0].src_reg(), 0);
+        assert_eq!(fun.instructions[0].imm, 0);
+        assert_eq!(fun.instructions[1].imm, 0);
     }
 }

--- a/aya/src/bpf.rs
+++ b/aya/src/bpf.rs
@@ -8,7 +8,7 @@ use std::{
 };
 
 use aya_obj::{
-    EbpfSectionKind, Features, Object, ParseError, ProgramSection,
+    EbpfSectionKind, Features, KsymsError, Object, ParseError, ProgramSection,
     btf::{Btf, BtfError, BtfFeatures, BtfRelocationError},
     generated::{BPF_F_SLEEPABLE, BPF_F_XDP_HAS_FRAGS, bpf_map_type},
     relocation::EbpfRelocationError,
@@ -496,6 +496,8 @@ impl<'a> EbpfLoader<'a> {
             obj.relocate_btf(btf)?;
         }
 
+        obj.resolve_externs(self.btf.as_deref())?;
+
         const fn is_map_of_maps(map_type: bpf_map_type) -> bool {
             matches!(
                 map_type,
@@ -604,6 +606,9 @@ impl<'a> EbpfLoader<'a> {
                 .map(|(s, data)| (s.as_str(), data.fd().as_fd().as_raw_fd(), data.obj())),
             &text_sections,
         )?;
+
+        obj.relocate_externs()?;
+
         obj.relocate_calls(&text_sections)?;
         obj.sanitize_functions(&FEATURES);
 
@@ -1246,6 +1251,10 @@ pub enum EbpfError {
     /// Error performing relocations
     #[error("error relocating section")]
     BtfRelocationError(#[from] BtfRelocationError),
+
+    /// Error resolving extern kernel symbols.
+    #[error("kernel symbol error: {0}")]
+    KsymsError(#[from] KsymsError),
 
     /// No BTF parsed for object
     #[error("no BTF parsed for object")]

--- a/aya/src/bpf.rs
+++ b/aya/src/bpf.rs
@@ -8,7 +8,7 @@ use std::{
 };
 
 use aya_obj::{
-    EbpfSectionKind, Features, KsymsError, Object, ParseError, ProgramSection,
+    EbpfSectionKind, Features, KsymsError, Object, ParseError, ProgramSection, ResolveExternsError,
     btf::{Btf, BtfError, BtfFeatures, BtfRelocationError},
     generated::{BPF_F_SLEEPABLE, BPF_F_XDP_HAS_FRAGS, bpf_map_type},
     relocation::EbpfRelocationError,
@@ -18,6 +18,7 @@ use thiserror::Error;
 
 use crate::{
     maps::{Map, MapData, MapError},
+    module_btf::KernelModuleBtfSet,
     programs::{
         BtfTracePoint, CgroupDevice, CgroupSkb, CgroupSock, CgroupSockAddr, CgroupSockopt,
         CgroupSysctl, Extension, FEntry, FExit, FlowDissector, Iter, KProbe, LircMode2, Lsm,
@@ -496,7 +497,14 @@ impl<'a> EbpfLoader<'a> {
             obj.relocate_btf(btf)?;
         }
 
-        obj.resolve_externs(self.btf.as_deref())?;
+        let resolved_externs = obj
+            .resolve_externs(self.btf.as_deref(), KernelModuleBtfSet::discover)
+            .map_err(|err| match err {
+                ResolveExternsError::Ksyms(err) => EbpfError::KsymsError(err),
+                ResolveExternsError::ModuleBtf(err) => err,
+            })?;
+
+        let program_module_btf = resolved_externs.into_modules().map(Arc::new);
 
         const fn is_map_of_maps(map_type: bpf_map_type) -> bool {
             matches!(
@@ -617,13 +625,14 @@ impl<'a> EbpfLoader<'a> {
             .drain()
             .map(|(name, prog_obj)| {
                 let function_obj = obj.functions[&prog_obj.function_key()].clone();
+                let module_btf_requirements = function_obj.module_btf_load_requirements();
 
                 let prog_name = FEATURES.bpf_name().then(|| name.clone().into());
                 let section = prog_obj.section.clone();
                 let obj = (prog_obj, function_obj);
 
                 let btf_fd = btf_fd.as_ref().map(Arc::clone);
-                let program = if extensions.contains(name.as_str()) {
+                let mut program = if extensions.contains(name.as_str()) {
                     Program::Extension(Extension {
                         data: ProgramData::new(prog_name, obj, btf_fd, *verifier_log_level),
                     })
@@ -787,6 +796,11 @@ impl<'a> EbpfLoader<'a> {
                         }
                     }
                 };
+                if module_btf_requirements.needs_lifetime() {
+                    if let Some(module_btf) = program_module_btf.as_ref().map(Arc::clone) {
+                        program.set_module_btf(module_btf);
+                    }
+                }
                 (name, program)
             })
             .collect();
@@ -1267,6 +1281,13 @@ pub enum EbpfError {
     #[error("program error: {0}")]
     /// A program error
     ProgramError(#[from] ProgramError),
+
+    /// Too many module BTF objects were loaded to address through the kernel fd array ABI.
+    #[error("too many module BTF objects: {count}")]
+    TooManyModuleBtfObjects {
+        /// Number of module BTF objects discovered.
+        count: usize,
+    },
 }
 
 /// The error type returned by [`Bpf::load_file`] and [`Bpf::load`].

--- a/aya/src/lib.rs
+++ b/aya/src/lib.rs
@@ -42,6 +42,7 @@
 
 mod bpf;
 pub mod maps;
+mod module_btf;
 pub mod pin;
 pub mod programs;
 pub mod sys;

--- a/aya/src/module_btf.rs
+++ b/aya/src/module_btf.rs
@@ -1,0 +1,201 @@
+use std::{
+    io,
+    os::fd::{AsFd as _, AsRawFd as _, RawFd},
+};
+
+use aya_obj::{ExternModuleBtfProvider, ExternResolverModule, btf::Btf};
+use libc::E2BIG;
+use log::{debug, warn};
+use object::Endianness;
+
+use crate::{
+    EbpfError, MockableFd,
+    programs::ProgramError,
+    sys::{bpf_btf_get_fd_by_id, bpf_btf_get_info_by_fd, iter_btf_ids},
+};
+
+#[derive(Debug)]
+pub(crate) struct KernelModuleBtfSet {
+    modules: Vec<LoadedModuleBtf>,
+}
+
+#[derive(Debug)]
+pub(crate) struct LoadedModuleBtf {
+    btf: Btf,
+    fd: MockableFd,
+}
+
+impl ExternModuleBtfProvider for KernelModuleBtfSet {
+    type Error = EbpfError;
+
+    fn extern_resolution_modules(&self) -> Result<Vec<ExternResolverModule<'_>>, Self::Error> {
+        self.modules()
+            .enumerate()
+            .map(|(i, module)| {
+                let fd_idx =
+                    i16::try_from(i + 1).map_err(|_err| EbpfError::TooManyModuleBtfObjects {
+                        count: self.modules.len(),
+                    })? as u16;
+
+                Ok(ExternResolverModule {
+                    btf: module.btf(),
+                    fd_idx,
+                    btf_obj_fd: module.raw_fd(),
+                })
+            })
+            .collect()
+    }
+}
+
+impl KernelModuleBtfSet {
+    pub(crate) fn discover() -> Result<Self, EbpfError> {
+        let mut modules = Vec::new();
+
+        for id in iter_btf_ids() {
+            let id = match id {
+                Ok(id) => id,
+                Err(err) if err.io_error.kind() == io::ErrorKind::PermissionDenied => {
+                    debug!("stopping module BTF loading, missing privileges");
+                    return Ok(Self { modules });
+                }
+                Err(err) => return Err(ProgramError::SyscallError(err).into()),
+            };
+
+            let fd = match bpf_btf_get_fd_by_id(id) {
+                Ok(fd) => fd,
+                Err(err) if err.io_error.kind() == io::ErrorKind::NotFound => continue,
+                Err(err) if err.io_error.kind() == io::ErrorKind::PermissionDenied => {
+                    debug!("stopping module BTF loading, missing privileges");
+                    return Ok(Self { modules });
+                }
+                Err(err) => return Err(ProgramError::SyscallError(err).into()),
+            };
+
+            let mut name_buf = [0u8; 64];
+            let info = match bpf_btf_get_info_by_fd(fd.as_fd(), |info| {
+                info.name = name_buf.as_mut_ptr() as u64;
+                info.name_len = name_buf.len() as u32;
+            }) {
+                Ok(info) => info,
+                Err(err) if err.io_error.kind() == io::ErrorKind::PermissionDenied => {
+                    debug!("stopping module BTF loading, missing privileges");
+                    return Ok(Self { modules });
+                }
+                Err(err) if err.io_error.raw_os_error() == Some(E2BIG) => {
+                    debug!("stopping module BTF loading, unsupported BTF info layout");
+                    return Ok(Self { modules });
+                }
+                Err(err) => return Err(EbpfError::from(ProgramError::SyscallError(err))),
+            };
+
+            if info.kernel_btf == 0 {
+                continue;
+            }
+
+            let name = name_from_buf(&name_buf, info.name_len);
+            if name.is_empty() || name == "vmlinux" {
+                continue;
+            }
+
+            let mut btf_buf = vec![0u8; info.btf_size as usize];
+            match bpf_btf_get_info_by_fd(fd.as_fd(), |info| {
+                info.btf = btf_buf.as_mut_ptr() as u64;
+                info.btf_size = btf_buf.len() as u32;
+            }) {
+                Ok(_info) => {}
+                Err(err) if err.io_error.kind() == io::ErrorKind::PermissionDenied => {
+                    debug!("stopping module BTF loading, missing privileges");
+                    return Ok(Self { modules });
+                }
+                Err(err) => return Err(EbpfError::from(ProgramError::SyscallError(err))),
+            }
+
+            let btf = match Btf::parse(&btf_buf, native_endianness()) {
+                Ok(btf) => btf,
+                Err(err) => {
+                    warn!("skipping module BTF {name}: {err}");
+                    continue;
+                }
+            };
+
+            modules.push(LoadedModuleBtf { btf, fd });
+        }
+
+        Ok(Self { modules })
+    }
+
+    pub(crate) fn modules(&self) -> impl Iterator<Item = &LoadedModuleBtf> {
+        self.modules.iter()
+    }
+
+    pub(crate) fn fd_array(&self) -> Vec<RawFd> {
+        let mut fds = Vec::with_capacity(self.modules.len() + 1);
+        fds.push(-1);
+        fds.extend(self.modules().map(LoadedModuleBtf::raw_fd));
+        fds
+    }
+}
+
+impl LoadedModuleBtf {
+    pub(crate) const fn btf(&self) -> &Btf {
+        &self.btf
+    }
+
+    pub(crate) fn raw_fd(&self) -> RawFd {
+        self.fd.as_raw_fd()
+    }
+}
+
+const fn native_endianness() -> Endianness {
+    if cfg!(target_endian = "big") {
+        Endianness::Big
+    } else {
+        Endianness::Little
+    }
+}
+
+fn name_from_buf(buf: &[u8], name_len: u32) -> String {
+    let len = usize::min(name_len as usize, buf.len());
+    let bytes = &buf[..len];
+    let len = bytes.iter().position(|b| *b == 0).unwrap_or(bytes.len());
+    String::from_utf8_lossy(&bytes[..len]).into_owned()
+}
+#[cfg(test)]
+mod tests {
+    use std::os::fd::FromRawFd as _;
+
+    use super::*;
+
+    fn fake_module(raw_fd: RawFd) -> LoadedModuleBtf {
+        LoadedModuleBtf {
+            btf: Btf::new(),
+            fd: unsafe { MockableFd::from_raw_fd(raw_fd) },
+        }
+    }
+
+    #[test]
+    fn fd_array_indices_match_extern_resolution_modules() {
+        let modules = KernelModuleBtfSet {
+            modules: vec![
+                fake_module(MockableFd::mock_signed_fd()),
+                fake_module(MockableFd::mock_signed_fd() + 1),
+            ],
+        };
+
+        let resolver_modules = modules.extern_resolution_modules().unwrap();
+        let fd_array = modules.fd_array();
+
+        assert_eq!(fd_array[0], -1);
+        assert_eq!(resolver_modules[0].fd_idx, 1);
+        assert_eq!(
+            fd_array[resolver_modules[0].fd_idx as usize],
+            resolver_modules[0].btf_obj_fd
+        );
+
+        assert_eq!(resolver_modules[1].fd_idx, 2);
+        assert_eq!(
+            fd_array[resolver_modules[1].fd_idx as usize],
+            resolver_modules[1].btf_obj_fd
+        );
+    }
+}

--- a/aya/src/programs/mod.rs
+++ b/aya/src/programs/mod.rs
@@ -142,6 +142,7 @@ pub use crate::programs::{
 use crate::{
     VerifierLogLevel,
     maps::MapError,
+    module_btf::KernelModuleBtfSet,
     pin::PinError,
     programs::{
         links::{
@@ -362,6 +363,40 @@ pub enum Program {
 }
 
 impl Program {
+    pub(crate) fn set_module_btf(&mut self, module_btf: Arc<KernelModuleBtfSet>) {
+        match self {
+            Self::KProbe(p) => p.data.module_btf = Some(module_btf),
+            Self::UProbe(p) => p.data.module_btf = Some(module_btf),
+            Self::TracePoint(p) => p.data.module_btf = Some(module_btf),
+            Self::SocketFilter(p) => p.data.module_btf = Some(module_btf),
+            Self::ReusePortSocketFilter(p) => p.data.module_btf = Some(module_btf),
+            Self::Xdp(p) => p.data.module_btf = Some(module_btf),
+            Self::SkMsg(p) => p.data.module_btf = Some(module_btf),
+            Self::SkSkb(p) => p.data.module_btf = Some(module_btf),
+            Self::CgroupSockAddr(p) => p.data.module_btf = Some(module_btf),
+            Self::SockOps(p) => p.data.module_btf = Some(module_btf),
+            Self::SchedClassifier(p) => p.data.module_btf = Some(module_btf),
+            Self::CgroupSkb(p) => p.data.module_btf = Some(module_btf),
+            Self::CgroupSysctl(p) => p.data.module_btf = Some(module_btf),
+            Self::CgroupSockopt(p) => p.data.module_btf = Some(module_btf),
+            Self::LircMode2(p) => p.data.module_btf = Some(module_btf),
+            Self::PerfEvent(p) => p.data.module_btf = Some(module_btf),
+            Self::RawTracePoint(p) => p.data.module_btf = Some(module_btf),
+            Self::Lsm(p) => p.data.module_btf = Some(module_btf),
+            Self::LsmCgroup(p) => p.data.module_btf = Some(module_btf),
+            Self::BtfTracePoint(p) => p.data.module_btf = Some(module_btf),
+            Self::FEntry(p) => p.data.module_btf = Some(module_btf),
+            Self::FExit(p) => p.data.module_btf = Some(module_btf),
+            Self::FlowDissector(p) => p.data.module_btf = Some(module_btf),
+            Self::Extension(p) => p.data.module_btf = Some(module_btf),
+            Self::SkLookup(p) => p.data.module_btf = Some(module_btf),
+            Self::SkReuseport(p) => p.data.module_btf = Some(module_btf),
+            Self::CgroupSock(p) => p.data.module_btf = Some(module_btf),
+            Self::CgroupDevice(p) => p.data.module_btf = Some(module_btf),
+            Self::Iter(p) => p.data.module_btf = Some(module_btf),
+        }
+    }
+
     /// Returns the program type.
     pub const fn prog_type(&self) -> ProgramType {
         match self {
@@ -559,6 +594,7 @@ pub(crate) struct ProgramData<T: Link> {
     pub(crate) attach_btf_id: Option<u32>,
     pub(crate) attach_prog_fd: Option<ProgramFd>,
     pub(crate) btf_fd: Option<Arc<crate::MockableFd>>,
+    pub(crate) module_btf: Option<Arc<KernelModuleBtfSet>>,
     pub(crate) verifier_log_level: VerifierLogLevel,
     pub(crate) path: Option<PathBuf>,
     pub(crate) flags: u32,
@@ -580,6 +616,7 @@ impl<T: Link> ProgramData<T> {
             attach_btf_id: None,
             attach_prog_fd: None,
             btf_fd,
+            module_btf: None,
             verifier_log_level,
             path: None,
             flags: 0,
@@ -607,6 +644,7 @@ impl<T: Link> ProgramData<T> {
             attach_btf_id,
             attach_prog_fd: None,
             btf_fd: None,
+            module_btf: None,
             verifier_log_level,
             path: Some(path.to_path_buf()),
             flags: 0,
@@ -719,6 +757,7 @@ fn load_program<T: Link>(
         attach_btf_id,
         attach_prog_fd,
         btf_fd,
+        module_btf,
         verifier_log_level,
         path: _,
         flags,
@@ -737,7 +776,7 @@ fn load_program<T: Link>(
             kernel_version,
             ..
         },
-        aya_obj::Function {
+        function @ aya_obj::Function {
             instructions,
             func_info,
             line_info,
@@ -761,6 +800,13 @@ fn load_program<T: Link>(
         None
     };
 
+    let module_btf_requirements = function.module_btf_load_requirements();
+    let fd_array = if module_btf_requirements.needs_fd_array() {
+        module_btf.as_ref().map(|module_btf| module_btf.fd_array())
+    } else {
+        None
+    };
+
     let attr = EbpfLoadProgramAttrs {
         name: prog_name,
         ty: prog_type,
@@ -777,6 +823,7 @@ fn load_program<T: Link>(
         line_info_rec_size: *line_info_rec_size,
         line_info: line_info.clone(),
         flags: *flags,
+        fd_array: fd_array.as_deref(),
     };
 
     let (ret, verifier_log) = retry_with_verifier_logs(10, |logger| {
@@ -786,6 +833,7 @@ fn load_program<T: Link>(
     match ret {
         Ok(prog_fd) => {
             *fd = Some(ProgramFd(prog_fd));
+            *module_btf = None;
             Ok(())
         }
         Err(io_error) => Err(ProgramError::LoadError {

--- a/aya/src/sys/bpf.rs
+++ b/aya/src/sys/bpf.rs
@@ -31,11 +31,11 @@ use log::warn;
 
 use super::feature_probe::{BpfHelper, is_helper_supported};
 use crate::{
-    Btf, Pod, TestRunAttrs, VerifierLogLevel,
+    Btf, Pod, VerifierLogLevel,
     maps::{MapData, PerCpuValues},
     programs::{
         LsmAttachType, ProgramType, RawTracePointRunOptions, RawTracePointTestRunResult,
-        TestRunOptions, TestRunResult, links::LinkRef,
+        TestRunAttrs, TestRunOptions, TestRunResult, links::LinkRef,
     },
     sys::{Syscall, SyscallError, syscall},
     util::KernelVersion,
@@ -158,6 +158,7 @@ pub(crate) struct EbpfLoadProgramAttrs<'a> {
     pub(crate) line_info_rec_size: usize,
     pub(crate) line_info: LineSecInfo,
     pub(crate) flags: u32,
+    pub(crate) fd_array: Option<&'a [RawFd]>,
 }
 
 pub(crate) fn bpf_load_program(
@@ -218,6 +219,9 @@ pub(crate) fn bpf_load_program(
 
     if let Some(v) = aya_attr.attach_btf_id {
         u.attach_btf_id = v;
+    }
+    if let Some(fd_array) = aya_attr.fd_array {
+        u.fd_array = fd_array.as_ptr() as u64;
     }
     bpf_prog_load(&mut attr)
 }
@@ -806,6 +810,13 @@ pub(crate) fn btf_obj_get_info_by_fd(
     })
 }
 
+pub(crate) fn bpf_btf_get_info_by_fd<F: FnOnce(&mut bpf_btf_info)>(
+    fd: BorrowedFd<'_>,
+    init: F,
+) -> Result<bpf_btf_info, SyscallError> {
+    bpf_obj_get_info_by_fd(fd, init)
+}
+
 pub(crate) fn bpf_raw_tracepoint_open(
     name: Option<&CStr>,
     prog_fd: BorrowedFd<'_>,
@@ -1388,6 +1399,11 @@ pub(crate) fn iter_map_ids() -> impl Iterator<Item = Result<u32, SyscallError>> 
 }
 
 /// Introduced in kernel v5.8.
+pub(crate) fn iter_btf_ids() -> impl Iterator<Item = Result<u32, SyscallError>> {
+    iter_obj_ids(bpf_cmd::BPF_BTF_GET_NEXT_ID, "bpf_btf_get_next_id")
+}
+
+/// Introduced in kernel v5.8.
 pub(crate) fn bpf_enable_stats(
     stats_type: bpf_stats_type,
 ) -> Result<crate::MockableFd, SyscallError> {
@@ -1533,6 +1549,49 @@ mod tests {
 bpf_map_type::BPF_MAP_TYPE_DEVMAP_HASH`"]
     fn test_prog_id_supported_reject_types() {
         is_prog_id_supported(bpf_map_type::BPF_MAP_TYPE_HASH);
+    }
+
+    #[test]
+    fn test_prog_load_encodes_fd_array() {
+        const FD_ARRAY: [RawFd; 3] = [-1, 42, 43];
+        let insns = [unsafe { mem::zeroed::<bpf_insn>() }];
+        let license = c"GPL";
+
+        override_syscall(|call| match call {
+            Syscall::Ebpf {
+                cmd: bpf_cmd::BPF_PROG_LOAD,
+                attr,
+            } => {
+                let u = unsafe { attr.__bindgen_anon_3 };
+                assert_eq!(u.core_relo_cnt, 0);
+                let fd_array =
+                    unsafe { core::slice::from_raw_parts(u.fd_array as *const RawFd, 3) };
+                assert_eq!(fd_array, FD_ARRAY);
+                Ok(crate::MockableFd::mock_signed_fd().into())
+            }
+            _ => Err((-1, io::Error::from_raw_os_error(EINVAL))),
+        });
+
+        let attr = EbpfLoadProgramAttrs {
+            name: None,
+            ty: bpf_prog_type::BPF_PROG_TYPE_SOCKET_FILTER,
+            insns: &insns,
+            license,
+            kernel_version: 0,
+            expected_attach_type: None,
+            prog_btf_fd: None,
+            attach_btf_obj_fd: None,
+            attach_btf_id: None,
+            attach_prog_fd: None,
+            func_info_rec_size: 0,
+            func_info: FuncSecInfo::default(),
+            line_info_rec_size: 0,
+            line_info: LineSecInfo::default(),
+            flags: 0,
+            fd_array: Some(&FD_ARRAY),
+        };
+
+        bpf_load_program(&attr, &mut [], VerifierLogLevel::default()).unwrap();
     }
 
     #[test]

--- a/test-distro/src/modprobe.rs
+++ b/test-distro/src/modprobe.rs
@@ -41,7 +41,13 @@ fn try_main(quiet: bool, name: String) -> anyhow::Result<()> {
     let modules_dir = resolve_modules_dir()?;
 
     output!(quiet, "resolving alias for module: {}", name);
-    let module = resolve_alias(quiet, &modules_dir, &name)?;
+    let module = match resolve_alias(quiet, &modules_dir, &name) {
+        Ok(module) => module,
+        Err(error) => {
+            output!(quiet, "alias not found ({error}); trying module name");
+            name.replace('-', "_")
+        }
+    };
 
     let pattern = format!(
         "{}/kernel/**/{}.ko*",

--- a/test/integration-test/bpf/ksyms.bpf.c
+++ b/test/integration-test/bpf/ksyms.bpf.c
@@ -1,0 +1,101 @@
+// clang-format off
+// SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
+#include <vmlinux.h>
+#include <bpf/bpf_core_read.h>
+#include <bpf/bpf_helpers.h>
+#include <bpf/bpf_tracing.h>
+// clang-format on
+
+#ifndef __ksym
+#define __ksym __attribute__((section(".ksyms")))
+#endif
+
+#ifndef __weak
+#define __weak __attribute__((weak))
+#endif
+
+char _license[] SEC("license") = "GPL";
+
+struct {
+  __uint(type, BPF_MAP_TYPE_ARRAY);
+  __uint(max_entries, 16);
+  __type(key, __u32);
+  __type(value, __u64);
+} output SEC(".maps");
+
+// Weak typed ksym for missing-symbol behavior.
+extern const int nonexistent_typed_ksym __ksym __weak;
+
+// Typeless ksyms exercise kallsyms-based resolution.
+extern const void init_task __ksym __weak;
+extern const void nonexistent_typeless_ksym __ksym __weak;
+
+// Weak kfuncs exercise typed function resolution and unresolved-call handling.
+extern void bpf_rcu_read_lock(void) __ksym __weak;
+extern void bpf_rcu_read_unlock(void) __ksym __weak;
+extern void bpf_rcu_read_lock_trace(void) __ksym __weak;
+extern void bpf_rcu_read_unlock_trace(void) __ksym __weak;
+
+SEC("tp_btf/sys_enter")
+int BPF_PROG(ksyms_typed_weak, struct pt_regs *regs, long id) {
+  __u32 key;
+  __u64 val;
+
+  key = 2;
+  val = (&nonexistent_typed_ksym) ? 1 : 0;
+  bpf_map_update_elem(&output, &key, &val, BPF_ANY);
+
+  key = 3;
+  val = (__u64)(unsigned long)bpf_rcu_read_lock;
+  bpf_map_update_elem(&output, &key, &val, BPF_ANY);
+
+  key = 4;
+  if (bpf_rcu_read_lock) {
+    bpf_rcu_read_lock();
+    val = 1;
+    bpf_rcu_read_unlock();
+  } else {
+    val = 0;
+  }
+  bpf_map_update_elem(&output, &key, &val, BPF_ANY);
+
+  key = 5;
+  val = 0xDEADBEEF;
+  bpf_map_update_elem(&output, &key, &val, BPF_ANY);
+
+  key = 6;
+  val = (__u64)(unsigned long)bpf_rcu_read_lock_trace;
+  bpf_map_update_elem(&output, &key, &val, BPF_ANY);
+
+  key = 7;
+  if (bpf_rcu_read_lock_trace) {
+    bpf_rcu_read_lock_trace();
+    val = 1;
+    bpf_rcu_read_unlock_trace();
+  } else {
+    val = 0;
+  }
+  bpf_map_update_elem(&output, &key, &val, BPF_ANY);
+
+  return 0;
+}
+
+SEC("tp_btf/sys_enter")
+int BPF_PROG(ksyms_typeless, struct pt_regs *regs, long id) {
+  __u32 key;
+  __u64 val;
+
+  key = 8;
+  val = (__u64)(unsigned long)&init_task;
+  bpf_map_update_elem(&output, &key, &val, BPF_ANY);
+
+  key = 9;
+  val = (__u64)(unsigned long)&nonexistent_typeless_ksym;
+  bpf_map_update_elem(&output, &key, &val, BPF_ANY);
+
+  key = 10;
+  val = 0xCAFEBABE;
+  bpf_map_update_elem(&output, &key, &val, BPF_ANY);
+
+  return 0;
+}

--- a/test/integration-test/bpf/ksyms_module.bpf.c
+++ b/test/integration-test/bpf/ksyms_module.bpf.c
@@ -1,0 +1,48 @@
+// clang-format off
+// SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
+#include <vmlinux.h>
+#include <bpf/bpf_core_read.h>
+#include <bpf/bpf_helpers.h>
+#include <bpf/bpf_tracing.h>
+// clang-format on
+
+#ifndef __ksym
+#define __ksym __attribute__((section(".ksyms")))
+#endif
+
+char _license[] SEC("license") = "GPL";
+
+struct {
+  __uint(type, BPF_MAP_TYPE_ARRAY);
+  __uint(max_entries, 8);
+  __type(key, __u32);
+  __type(value, __u64);
+} module_output SEC(".maps");
+
+extern const int aya_ksyms_test_var __ksym;
+
+SEC("tp_btf/sys_enter")
+int BPF_PROG(ksyms_module_btf, struct pt_regs *regs, long id) {
+  __u32 key;
+  __u64 val;
+  int *p;
+
+  key = 0;
+  p = bpf_this_cpu_ptr(&aya_ksyms_test_var);
+  val = (__u64)(unsigned long)p;
+  bpf_map_update_elem(&module_output, &key, &val, BPF_ANY);
+
+  key = 1;
+  val = p ? (__u64)*p : 0;
+  bpf_map_update_elem(&module_output, &key, &val, BPF_ANY);
+
+  key = 2;
+  val = p ? 0 : 1;
+  bpf_map_update_elem(&module_output, &key, &val, BPF_ANY);
+
+  key = 3;
+  val = 0xA11CEB7F;
+  bpf_map_update_elem(&module_output, &key, &val, BPF_ANY);
+
+  return 0;
+}

--- a/test/integration-test/bpf/ksyms_strong.bpf.c
+++ b/test/integration-test/bpf/ksyms_strong.bpf.c
@@ -1,0 +1,54 @@
+// clang-format off
+// SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
+#include <vmlinux.h>
+#include <bpf/bpf_core_read.h>
+#include <bpf/bpf_helpers.h>
+#include <bpf/bpf_tracing.h>
+// clang-format on
+
+#ifndef __ksym
+#define __ksym __attribute__((section(".ksyms")))
+#endif
+
+char _license[] SEC("license") = "GPL";
+
+struct {
+  __uint(type, BPF_MAP_TYPE_ARRAY);
+  __uint(max_entries, 8);
+  __type(key, __u32);
+  __type(value, __u64);
+} strong_output SEC(".maps");
+
+// Strong typed ksym used to exercise typed variable resolution and per-cpu
+// helpers.
+extern const int bpf_prog_active __ksym;
+
+SEC("tp_btf/sys_enter")
+int BPF_PROG(ksyms_typed_strong, struct pt_regs *regs, long id) {
+  __u32 key;
+  __u64 val;
+
+  key = 0;
+  int *p = bpf_this_cpu_ptr(&bpf_prog_active);
+  val = (__u64)(unsigned long)p;
+  bpf_map_update_elem(&strong_output, &key, &val, BPF_ANY);
+
+  key = 1;
+  val = p ? (__u64)*p : 0;
+  bpf_map_update_elem(&strong_output, &key, &val, BPF_ANY);
+
+  key = 2;
+  int *p0 = bpf_per_cpu_ptr(&bpf_prog_active, 0);
+  val = (__u64)(unsigned long)p0;
+  bpf_map_update_elem(&strong_output, &key, &val, BPF_ANY);
+
+  key = 3;
+  val = p0 ? (__u64)*p0 : 0xFFFFFFFF;
+  bpf_map_update_elem(&strong_output, &key, &val, BPF_ANY);
+
+  key = 4;
+  val = 0xBEEFCAFE;
+  bpf_map_update_elem(&strong_output, &key, &val, BPF_ANY);
+
+  return 0;
+}

--- a/test/integration-test/bpf/ksyms_typed_missing_kfunc.bpf.c
+++ b/test/integration-test/bpf/ksyms_typed_missing_kfunc.bpf.c
@@ -1,0 +1,20 @@
+// clang-format off
+// SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
+#include <vmlinux.h>
+#include <bpf/bpf_helpers.h>
+#include <bpf/bpf_tracing.h>
+// clang-format on
+
+#ifndef __ksym
+#define __ksym __attribute__((section(".ksyms")))
+#endif
+
+char _license[] SEC("license") = "GPL";
+
+extern void nonexistent_kfunc(void) __ksym;
+
+SEC("tp_btf/sys_enter")
+int BPF_PROG(ksyms_typed_missing_kfunc, struct pt_regs *regs, long id) {
+  nonexistent_kfunc();
+  return 0;
+}

--- a/test/integration-test/bpf/ksyms_typed_missing_var.bpf.c
+++ b/test/integration-test/bpf/ksyms_typed_missing_var.bpf.c
@@ -1,0 +1,19 @@
+// clang-format off
+// SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
+#include <vmlinux.h>
+#include <bpf/bpf_helpers.h>
+#include <bpf/bpf_tracing.h>
+// clang-format on
+
+#ifndef __ksym
+#define __ksym __attribute__((section(".ksyms")))
+#endif
+
+char _license[] SEC("license") = "GPL";
+
+extern const int totally_bogus_symbol __ksym;
+
+SEC("tp_btf/sys_enter")
+int BPF_PROG(ksyms_typed_missing_var, struct pt_regs *regs, long id) {
+  return (int)(unsigned long)&totally_bogus_symbol;
+}

--- a/test/integration-test/bpf/ksyms_typeless_missing.bpf.c
+++ b/test/integration-test/bpf/ksyms_typeless_missing.bpf.c
@@ -1,0 +1,19 @@
+// clang-format off
+// SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
+#include <vmlinux.h>
+#include <bpf/bpf_helpers.h>
+#include <bpf/bpf_tracing.h>
+// clang-format on
+
+#ifndef __ksym
+#define __ksym __attribute__((section(".ksyms")))
+#endif
+
+char _license[] SEC("license") = "GPL";
+
+extern const void totally_bogus_typeless_symbol __ksym;
+
+SEC("tp_btf/sys_enter")
+int BPF_PROG(ksyms_typeless_missing, struct pt_regs *regs, long id) {
+  return (int)(unsigned long)&totally_bogus_typeless_symbol;
+}

--- a/test/integration-test/build.rs
+++ b/test/integration-test/build.rs
@@ -93,6 +93,11 @@ fn main() -> Result<()> {
         ("struct_flavors_reloc.bpf.c", true),
         ("text_64_64_reloc.c", false),
         ("variables_reloc.bpf.c", false),
+        ("ksyms.bpf.c", true),
+        ("ksyms_strong.bpf.c", true),
+        ("ksyms_typed_missing_var.bpf.c", true),
+        ("ksyms_typed_missing_kfunc.bpf.c", true),
+        ("ksyms_typeless_missing.bpf.c", true),
     ];
     const C_BPF_HEADERS: &[&str] = &["reloc.h", "struct_with_scalars.h"];
 

--- a/test/integration-test/build.rs
+++ b/test/integration-test/build.rs
@@ -95,6 +95,7 @@ fn main() -> Result<()> {
         ("variables_reloc.bpf.c", false),
         ("ksyms.bpf.c", true),
         ("ksyms_strong.bpf.c", true),
+        ("ksyms_module.bpf.c", true),
         ("ksyms_typed_missing_var.bpf.c", true),
         ("ksyms_typed_missing_kfunc.bpf.c", true),
         ("ksyms_typeless_missing.bpf.c", true),

--- a/test/integration-test/kmod/aya_ksyms_test/Makefile
+++ b/test/integration-test/kmod/aya_ksyms_test/Makefile
@@ -1,0 +1,2 @@
+obj-m += aya_ksyms_test.o
+CFLAGS_aya_ksyms_test.o += -g

--- a/test/integration-test/kmod/aya_ksyms_test/aya_ksyms_test.c
+++ b/test/integration-test/kmod/aya_ksyms_test/aya_ksyms_test.c
@@ -1,0 +1,20 @@
+#include <linux/init.h>
+#include <linux/module.h>
+#include <linux/percpu-defs.h>
+
+DEFINE_PER_CPU(int, aya_ksyms_test_var) = 123;
+EXPORT_PER_CPU_SYMBOL_GPL(aya_ksyms_test_var);
+
+static int __init aya_ksyms_test_init(void) {
+  if (this_cpu_read(aya_ksyms_test_var) != 123)
+    return -EINVAL;
+
+  return 0;
+}
+
+static void __exit aya_ksyms_test_exit(void) {}
+
+module_init(aya_ksyms_test_init);
+module_exit(aya_ksyms_test_exit);
+
+MODULE_LICENSE("GPL");

--- a/test/integration-test/src/kmods.rs
+++ b/test/integration-test/src/kmods.rs
@@ -1,0 +1,11 @@
+macro_rules! kmod {
+    ($($uppercase:ident => $name:literal),* $(,)?) => {
+        $(
+            pub const $uppercase: &str = $name;
+        )*
+    };
+}
+
+kmod!(
+    KMOD_AYA_KSYMS_TEST => "aya_ksyms_test",
+);

--- a/test/integration-test/src/lib.rs
+++ b/test/integration-test/src/lib.rs
@@ -12,6 +12,11 @@ bpf_file!(
     MAIN => "main.bpf.o",
     MULTIMAP_BTF => "multimap-btf.bpf.o",
     RINGBUF_BTF => "ringbuf-btf.bpf.o",
+    KSYMS => "ksyms.bpf.o",
+    KSYMS_STRONG => "ksyms_strong.bpf.o",
+    KSYMS_TYPED_MISSING_VAR => "ksyms_typed_missing_var.bpf.o",
+    KSYMS_TYPED_MISSING_KFUNC => "ksyms_typed_missing_kfunc.bpf.o",
+    KSYMS_TYPELESS_MISSING => "ksyms_typeless_missing.bpf.o",
 
     ENUM_SIGNED_32_RELOC_BPF => "enum_signed_32_reloc.bpf.o",
     ENUM_SIGNED_32_RELOC_BTF => "enum_signed_32_reloc.bpf.target.o",

--- a/test/integration-test/src/lib.rs
+++ b/test/integration-test/src/lib.rs
@@ -1,3 +1,7 @@
+mod kmods;
+
+pub use kmods::*;
+
 macro_rules! bpf_file {
     ($($uppercase:ident => $lowercase:literal),* $(,)?) => {
         $(
@@ -14,6 +18,7 @@ bpf_file!(
     RINGBUF_BTF => "ringbuf-btf.bpf.o",
     KSYMS => "ksyms.bpf.o",
     KSYMS_STRONG => "ksyms_strong.bpf.o",
+    KSYMS_MODULE => "ksyms_module.bpf.o",
     KSYMS_TYPED_MISSING_VAR => "ksyms_typed_missing_var.bpf.o",
     KSYMS_TYPED_MISSING_KFUNC => "ksyms_typed_missing_kfunc.bpf.o",
     KSYMS_TYPELESS_MISSING => "ksyms_typeless_missing.bpf.o",

--- a/test/integration-test/src/tests.rs
+++ b/test/integration-test/src/tests.rs
@@ -25,6 +25,7 @@ mod info;
 mod inode_storage;
 mod iter;
 mod kprobe;
+mod ksyms;
 mod linear_data_structures;
 mod load;
 mod log;

--- a/test/integration-test/src/tests/ksyms.rs
+++ b/test/integration-test/src/tests/ksyms.rs
@@ -1,0 +1,335 @@
+//! Integration tests for kernel symbol (ksym) resolution.
+
+use std::{
+    fs::File,
+    io::{BufRead as _, BufReader},
+};
+
+use aya::{Btf, Ebpf, EbpfError, maps::Array, programs::BtfTracePoint, util::KernelVersion};
+use aya_obj::KsymsError;
+use test_log::test;
+
+const PROC_KALLSYMS: &str = "/proc/kallsyms";
+const SYS_ENTER: &str = "sys_enter";
+
+fn kallsyms_available() -> bool {
+    let file = File::open(PROC_KALLSYMS)
+        .unwrap_or_else(|e| panic!("failed to open {PROC_KALLSYMS}: {e:?}"));
+    for line in BufReader::new(file).lines() {
+        let line =
+            line.unwrap_or_else(|e| panic!("failed to read the line from {PROC_KALLSYMS}: {e:?}"));
+        if let Some(addr) = line.split_whitespace().next() {
+            let addr = u64::from_str_radix(addr, 16)
+                .unwrap_or_else(|e| panic!("failed to parse the address: {addr}: {e:?}"));
+            if addr != 0 {
+                return true;
+            }
+        }
+    }
+    false
+}
+
+fn kallsyms_find(symbol_name: &str) -> Option<u64> {
+    let file = File::open(PROC_KALLSYMS)
+        .unwrap_or_else(|e| panic!("failed to open {PROC_KALLSYMS}: {e:?}"));
+    for line in BufReader::new(file).lines() {
+        let line =
+            line.unwrap_or_else(|e| panic!("failed to read the line from {PROC_KALLSYMS}: {e:?}"));
+        let parts: Vec<&str> = line.split_whitespace().collect();
+        if let [addr, _type, name, ..] = parts.as_slice()
+            && *name == symbol_name
+        {
+            let addr = u64::from_str_radix(addr, 16)
+                .unwrap_or_else(|e| panic!("failed to parse the address: {addr}: {e:?}"));
+            return Some(addr);
+        }
+    }
+    None
+}
+
+/// Check if PERCPU DATASEC exists in kernel BTF.
+/// Required for `bpf_this_cpu_ptr`/`bpf_per_cpu_ptr` to work.
+fn btf_has_percpu_datasec(btf: &Btf) -> bool {
+    use aya_obj::btf::BtfKind;
+    btf.id_by_type_name_kind(".data..percpu", BtfKind::DataSec)
+        .is_ok()
+}
+
+mod output_keys {
+    pub(super) const WEAK_TYPED: u32 = 2;
+    pub(super) const KFUNC_ADDR: u32 = 3;
+    pub(super) const KFUNC_CALLED: u32 = 4;
+    pub(super) const TYPED_MARKER: u32 = 5;
+    pub(super) const KFUNC2_ADDR: u32 = 6;
+    pub(super) const KFUNC2_CALLED: u32 = 7;
+    pub(super) const TYPELESS_ADDR: u32 = 8;
+    pub(super) const WEAK_TYPELESS: u32 = 9;
+    pub(super) const TYPELESS_MARKER: u32 = 10;
+}
+
+mod output_keys_strong {
+    pub(super) const TYPED_ADDR: u32 = 0;
+    pub(super) const TYPED_VALUE: u32 = 1;
+    pub(super) const PER_CPU_PTR_ADDR: u32 = 2;
+    pub(super) const PER_CPU_PTR_VALUE: u32 = 3;
+    pub(super) const MARKER: u32 = 4;
+}
+
+/// Test STRONG typed ksym resolution with per-cpu helpers.
+/// Tests: strong ksym (`bpf_prog_active`), `bpf_this_cpu_ptr`, `bpf_per_cpu_ptr`.
+#[test]
+fn ksyms_typed_strong() {
+    let kernel_version = KernelVersion::current().unwrap();
+    if kernel_version < KernelVersion::new(5, 10, 0) {
+        eprintln!("skipping test on kernel {kernel_version:?}, typed ksyms require kernel >= 5.10");
+        return;
+    }
+
+    let btf = Btf::from_sys_fs().unwrap();
+
+    if !btf_has_percpu_datasec(&btf) {
+        eprintln!("skipping test, no PERCPU DATASEC in kernel BTF");
+        return;
+    }
+
+    // Strong typed ksyms require the symbol to be in kallsyms.
+    // With CONFIG_KALLSYMS_ALL=n, only function symbols are exported,
+    // not variables like bpf_prog_active. The verifier uses
+    // bpf_kallsyms_lookup_name() internally and will reject the program
+    // if the symbol address cannot be resolved.
+    if !kallsyms_available() {
+        eprintln!("skipping test, kallsyms not available");
+        return;
+    }
+    if kallsyms_find("bpf_prog_active").is_none() {
+        eprintln!(
+            "skipping test, bpf_prog_active kallsyms not available \
+            (usually due to CONFIG_KALLSYMS_ALL kernel configuration disabled)"
+        );
+        return;
+    }
+
+    let mut bpf = Ebpf::load(crate::KSYMS_STRONG).unwrap();
+
+    let prog: &mut BtfTracePoint = bpf
+        .program_mut("ksyms_typed_strong")
+        .unwrap()
+        .try_into()
+        .unwrap();
+
+    if let Err(e) = prog.load(SYS_ENTER, &btf) {
+        panic!("failed to load program {SYS_ENTER}: {e:?}");
+    }
+    prog.attach().unwrap();
+
+    // Trigger the tracepoint
+    drop(std::fs::metadata("/"));
+
+    let output: Array<_, u64> = Array::try_from(bpf.map("strong_output").unwrap()).unwrap();
+
+    // Verify BPF program executed
+    let marker = output.get(&output_keys_strong::MARKER, 0).unwrap();
+    assert_eq!(marker, 0xBEEFCAFE, "BPF program did not execute");
+
+    // bpf_this_cpu_ptr: address should be non-zero
+    let typed_addr = output.get(&output_keys_strong::TYPED_ADDR, 0).unwrap();
+    assert!(typed_addr != 0, "strong ksym address should be non-zero");
+
+    // bpf_this_cpu_ptr: value should be >= 0 (like libbpf)
+    let typed_value = output.get(&output_keys_strong::TYPED_VALUE, 0).unwrap();
+    let signed_value = typed_value as i32;
+    assert!(
+        signed_value >= 0,
+        "bpf_prog_active should be >= 0, got {signed_value}"
+    );
+
+    // bpf_per_cpu_ptr: address should be non-zero
+    let per_cpu_addr = output
+        .get(&output_keys_strong::PER_CPU_PTR_ADDR, 0)
+        .unwrap();
+    assert!(
+        per_cpu_addr != 0,
+        "bpf_per_cpu_ptr address should be non-zero"
+    );
+
+    // bpf_per_cpu_ptr: value should be >= 0
+    let per_cpu_value = output
+        .get(&output_keys_strong::PER_CPU_PTR_VALUE, 0)
+        .unwrap();
+    let signed_per_cpu = per_cpu_value as i32;
+    assert!(
+        signed_per_cpu >= 0,
+        "bpf_per_cpu_ptr value should be >= 0, got {signed_per_cpu}"
+    );
+}
+
+/// Test WEAK typed ksym resolution and kfunc calls.
+/// Tests: weak nonexistent typed ksym = 0, kfunc resolution.
+#[test]
+fn ksyms_typed_weak() {
+    let kernel_version = KernelVersion::current().unwrap();
+    if kernel_version < KernelVersion::new(5, 10, 0) {
+        eprintln!("skipping test on kernel {kernel_version:?}, typed ksyms require kernel >= 5.10");
+        return;
+    }
+
+    let mut bpf = Ebpf::load(crate::KSYMS).unwrap();
+    let prog: &mut BtfTracePoint = bpf
+        .program_mut("ksyms_typed_weak")
+        .unwrap()
+        .try_into()
+        .unwrap();
+
+    let btf = Btf::from_sys_fs().unwrap();
+    if let Err(e) = prog.load(SYS_ENTER, &btf) {
+        panic!("failed to load program {SYS_ENTER}: {e:?}");
+    }
+    prog.attach().unwrap();
+
+    // Trigger the tracepoint
+    drop(std::fs::metadata("/"));
+
+    let output: Array<_, u64> = Array::try_from(bpf.map("output").unwrap()).unwrap();
+
+    // Verify BPF program executed
+    let marker = output.get(&output_keys::TYPED_MARKER, 0).unwrap();
+    assert_eq!(marker, 0xDEADBEEF, "BPF program did not execute");
+
+    // Weak typed ksym (nonexistent) should resolve to 0
+    let weak_typed = output.get(&output_keys::WEAK_TYPED, 0).unwrap();
+    assert_eq!(
+        weak_typed, 0,
+        "weak nonexistent typed ksym should be 0, got {weak_typed}"
+    );
+
+    // Kfunc resolution - availability depends on kernel config, not just version
+    let kfunc_addr = output.get(&output_keys::KFUNC_ADDR, 0).unwrap();
+    let kfunc_called = output.get(&output_keys::KFUNC_CALLED, 0).unwrap();
+    let kfunc2_addr = output.get(&output_keys::KFUNC2_ADDR, 0).unwrap();
+    let kfunc2_called = output.get(&output_keys::KFUNC2_CALLED, 0).unwrap();
+
+    // Consistency: if resolved, must be callable
+    if kfunc_addr != 0 {
+        assert_eq!(kfunc_called, 1, "kfunc resolved but not called");
+    }
+    if kfunc2_addr != 0 {
+        assert_eq!(kfunc2_called, 1, "kfunc2 resolved but not called");
+    }
+}
+
+/// Test typeless ksym resolution (kallsyms-based).
+/// Tests: `init_task` address + kallsyms cross-check, weak nonexistent = 0.
+#[test]
+fn ksyms_typeless() {
+    let kernel_version = KernelVersion::current().unwrap();
+    if kernel_version < KernelVersion::new(5, 10, 0) {
+        eprintln!(
+            "skipping test on kernel {kernel_version:?}, typeless ksyms require kernel >= 5.10"
+        );
+        return;
+    }
+
+    let kallsyms_ok = kallsyms_available();
+    let expected_addr = if kallsyms_ok {
+        kallsyms_find("init_task")
+    } else {
+        None
+    };
+
+    let mut bpf = Ebpf::load(crate::KSYMS).unwrap();
+    let prog: &mut BtfTracePoint = bpf
+        .program_mut("ksyms_typeless")
+        .unwrap()
+        .try_into()
+        .unwrap();
+
+    let btf = Btf::from_sys_fs().unwrap();
+    if let Err(e) = prog.load(SYS_ENTER, &btf) {
+        panic!("failed to load program {SYS_ENTER}: {e:?}");
+    }
+    prog.attach().unwrap();
+
+    // Trigger the tracepoint
+    drop(std::fs::metadata("/"));
+
+    let output: Array<_, u64> = Array::try_from(bpf.map("output").unwrap()).unwrap();
+
+    // Verify BPF program executed
+    let marker = output.get(&output_keys::TYPELESS_MARKER, 0).unwrap();
+    assert_eq!(marker, 0xCAFEBABE, "BPF program did not execute");
+
+    // Typeless ksym: init_task - cross-verify with kallsyms when available
+    let typeless_addr = output.get(&output_keys::TYPELESS_ADDR, 0).unwrap();
+    if typeless_addr != 0 {
+        if let Some(kallsyms_addr) = expected_addr {
+            assert_eq!(
+                typeless_addr, kallsyms_addr,
+                "BPF-resolved init_task ({typeless_addr:#x}) != kallsyms ({kallsyms_addr:#x})"
+            );
+        }
+    }
+
+    // Weak typeless ksym (nonexistent) should be 0
+    let weak_typeless = output.get(&output_keys::WEAK_TYPELESS, 0).unwrap();
+    assert_eq!(
+        weak_typeless, 0,
+        "weak nonexistent typeless ksym should be 0, got {weak_typeless:#x}"
+    );
+}
+
+#[test]
+fn ksyms_typed_missing_var_fails_at_load() {
+    let kernel_version = KernelVersion::current().unwrap();
+    if kernel_version < KernelVersion::new(5, 10, 0) {
+        eprintln!("skipping test on kernel {kernel_version:?}, typed ksyms require kernel >= 5.10");
+        return;
+    }
+
+    let err = Ebpf::load(crate::KSYMS_TYPED_MISSING_VAR).unwrap_err();
+    match err {
+        EbpfError::KsymsError(KsymsError::VariableNotFound { name }) => {
+            assert_eq!(name, "totally_bogus_symbol");
+        }
+        other => panic!("expected VariableNotFound KsymsError, got {other:?}"),
+    }
+}
+
+#[test]
+fn ksyms_typed_missing_kfunc_fails_at_load() {
+    let kernel_version = KernelVersion::current().unwrap();
+    if kernel_version < KernelVersion::new(5, 10, 0) {
+        eprintln!("skipping test on kernel {kernel_version:?}, typed ksyms require kernel >= 5.10");
+        return;
+    }
+
+    let err = Ebpf::load(crate::KSYMS_TYPED_MISSING_KFUNC).unwrap_err();
+    match err {
+        EbpfError::KsymsError(KsymsError::FunctionNotFound { name }) => {
+            assert_eq!(name, "nonexistent_kfunc");
+        }
+        other => panic!("expected FunctionNotFound KsymsError, got {other:?}"),
+    }
+}
+
+#[test]
+fn ksyms_typeless_missing_fails_at_load() {
+    let kernel_version = KernelVersion::current().unwrap();
+    if kernel_version < KernelVersion::new(5, 10, 0) {
+        eprintln!(
+            "skipping test on kernel {kernel_version:?}, typeless ksyms require kernel >= 5.10"
+        );
+        return;
+    }
+    if !kallsyms_available() {
+        eprintln!("skipping test, kallsyms not available");
+        return;
+    }
+
+    let err = Ebpf::load(crate::KSYMS_TYPELESS_MISSING).unwrap_err();
+    match err {
+        EbpfError::KsymsError(KsymsError::VariableNotFound { name }) => {
+            assert_eq!(name, "totally_bogus_typeless_symbol");
+        }
+        other => panic!("expected VariableNotFound KsymsError, got {other:?}"),
+    }
+}

--- a/test/integration-test/src/tests/ksyms.rs
+++ b/test/integration-test/src/tests/ksyms.rs
@@ -3,6 +3,8 @@
 use std::{
     fs::File,
     io::{BufRead as _, BufReader},
+    path::Path,
+    process::Command,
 };
 
 use aya::{Btf, Ebpf, EbpfError, maps::Array, programs::BtfTracePoint, util::KernelVersion};
@@ -73,6 +75,39 @@ mod output_keys_strong {
     pub(super) const PER_CPU_PTR_ADDR: u32 = 2;
     pub(super) const PER_CPU_PTR_VALUE: u32 = 3;
     pub(super) const MARKER: u32 = 4;
+}
+
+mod output_keys_module {
+    pub(super) const VAR_ADDR: u32 = 0;
+    pub(super) const VAR_VALUE: u32 = 1;
+    pub(super) const READ_RET: u32 = 2;
+    pub(super) const MARKER: u32 = 3;
+}
+
+fn load_test_module(module: &str) -> bool {
+    match Command::new("/sbin/modprobe")
+        .arg("-q")
+        .arg(module)
+        .status()
+    {
+        Ok(status) if status.success() => {}
+        Ok(status) => {
+            eprintln!("skipping test, modprobe {module} failed with status {status}");
+            return false;
+        }
+        Err(e) => {
+            eprintln!("skipping test, failed to run modprobe {module}: {e:?}");
+            return false;
+        }
+    }
+
+    let btf_path = Path::new("/sys/kernel/btf").join(module);
+    if !btf_path.exists() {
+        eprintln!("skipping test, module BTF not available at {btf_path:?}");
+        return false;
+    }
+
+    true
 }
 
 /// Test STRONG typed ksym resolution with per-cpu helpers.
@@ -161,6 +196,64 @@ fn ksyms_typed_strong() {
         signed_per_cpu >= 0,
         "bpf_per_cpu_ptr value should be >= 0, got {signed_per_cpu}"
     );
+}
+
+#[test]
+fn ksyms_module_btf() {
+    let kernel_version = KernelVersion::current().unwrap();
+    if kernel_version < KernelVersion::new(5, 10, 0) {
+        eprintln!(
+            "skipping test on kernel {kernel_version:?}, module typed ksyms require kernel >= 5.10"
+        );
+        return;
+    }
+
+    if !load_test_module(crate::KMOD_AYA_KSYMS_TEST) {
+        return;
+    }
+
+    // Module typed ksyms require both module BTF for type resolution and
+    // kallsyms for the verifier's final symbol-address lookup.
+    if !kallsyms_available() {
+        eprintln!("skipping test, kallsyms not available");
+        return;
+    }
+    if kallsyms_find("aya_ksyms_test_var").is_none() {
+        eprintln!(
+            "skipping test, aya_ksyms_test_var kallsyms not available \
+            (usually due to CONFIG_KALLSYMS_ALL kernel configuration disabled)"
+        );
+        return;
+    }
+
+    let mut bpf = Ebpf::load(crate::KSYMS_MODULE).unwrap();
+    let prog: &mut BtfTracePoint = bpf
+        .program_mut("ksyms_module_btf")
+        .unwrap()
+        .try_into()
+        .unwrap();
+
+    let btf = Btf::from_sys_fs().unwrap();
+    if let Err(e) = prog.load(SYS_ENTER, &btf) {
+        panic!("failed to load program {SYS_ENTER}: {e:?}");
+    }
+    prog.attach().unwrap();
+
+    drop(std::fs::metadata("/"));
+
+    let output: Array<_, u64> = Array::try_from(bpf.map("module_output").unwrap()).unwrap();
+
+    let marker = output.get(&output_keys_module::MARKER, 0).unwrap();
+    assert_eq!(marker, 0xA11CEB7F, "BPF program did not execute");
+
+    let var_addr = output.get(&output_keys_module::VAR_ADDR, 0).unwrap();
+    assert_ne!(var_addr, 0, "module ksym address should be non-zero");
+
+    let read_ret = output.get(&output_keys_module::READ_RET, 0).unwrap();
+    assert_eq!(read_ret as i64, 0, "module ksym read failed");
+
+    let var_value = output.get(&output_keys_module::VAR_VALUE, 0).unwrap();
+    assert_eq!(var_value as i32, 123, "unexpected module ksym value");
 }
 
 /// Test WEAK typed ksym resolution and kfunc calls.

--- a/xtask/public-api/aya-obj.txt
+++ b/xtask/public-api/aya-obj.txt
@@ -44,6 +44,8 @@ pub aya_obj::btf::BtfError::UnknownBtfTypeName
 pub aya_obj::btf::BtfError::UnknownBtfTypeName::type_name: alloc::string::String
 pub aya_obj::btf::BtfError::UnknownSectionSize
 pub aya_obj::btf::BtfError::UnknownSectionSize::section_name: alloc::string::String
+impl core::convert::From<aya_obj::btf::BtfError> for aya_obj::KsymsError
+pub fn aya_obj::KsymsError::from(aya_obj::btf::BtfError) -> Self
 impl core::convert::From<aya_obj::btf::BtfError> for aya_obj::ParseError
 pub fn aya_obj::ParseError::from(aya_obj::btf::BtfError) -> Self
 impl core::error::Error for aya_obj::btf::BtfError
@@ -4853,7 +4855,10 @@ impl aya_obj::Object
 pub fn aya_obj::Object::relocate_btf(&mut self, &aya_obj::btf::Btf) -> core::result::Result<(), aya_obj::btf::BtfRelocationError>
 impl aya_obj::Object
 pub fn aya_obj::Object::relocate_calls(&mut self, &std::collections::hash::set::HashSet<usize>) -> core::result::Result<(), aya_obj::relocation::EbpfRelocationError>
+pub fn aya_obj::Object::relocate_externs(&mut self) -> core::result::Result<(), aya_obj::relocation::EbpfRelocationError>
 pub fn aya_obj::Object::relocate_maps<'a, I: core::iter::traits::iterator::Iterator<Item = (&'a str, std::os::fd::raw::RawFd, &'a aya_obj::maps::Map)>>(&mut self, I, &std::collections::hash::set::HashSet<usize>) -> core::result::Result<(), aya_obj::relocation::EbpfRelocationError>
+impl aya_obj::Object
+pub fn aya_obj::Object::resolve_externs(&mut self, core::option::Option<&aya_obj::btf::Btf>) -> core::result::Result<(), aya_obj::KsymsError>
 impl core::clone::Clone for aya_obj::Object
 pub fn aya_obj::Object::clone(&self) -> aya_obj::Object
 impl core::fmt::Debug for aya_obj::Object
@@ -5164,6 +5169,8 @@ impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::programs::xdp::XdpAtta
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::programs::xdp::XdpAttachType
 pub mod aya_obj::relocation
 pub enum aya_obj::relocation::RelocationError
+pub aya_obj::relocation::RelocationError::ExternNotFound
+pub aya_obj::relocation::RelocationError::ExternNotFound::name: alloc::string::String
 pub aya_obj::relocation::RelocationError::InvalidRelocationOffset
 pub aya_obj::relocation::RelocationError::InvalidRelocationOffset::offset: u64
 pub aya_obj::relocation::RelocationError::InvalidRelocationOffset::relocation_number: usize
@@ -5179,6 +5186,8 @@ pub aya_obj::relocation::RelocationError::UnknownProgram::address: u64
 pub aya_obj::relocation::RelocationError::UnknownProgram::section_index: usize
 pub aya_obj::relocation::RelocationError::UnknownSymbol
 pub aya_obj::relocation::RelocationError::UnknownSymbol::index: usize
+pub aya_obj::relocation::RelocationError::UnresolvableSymbol
+pub aya_obj::relocation::RelocationError::UnresolvableSymbol::name: alloc::string::String
 impl core::error::Error for aya_obj::relocation::RelocationError
 impl core::fmt::Debug for aya_obj::relocation::RelocationError
 pub fn aya_obj::relocation::RelocationError::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
@@ -5234,6 +5243,42 @@ impl core::marker::Unpin for aya_obj::EbpfSectionKind
 impl core::marker::UnsafeUnpin for aya_obj::EbpfSectionKind
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::EbpfSectionKind
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::EbpfSectionKind
+pub enum aya_obj::KsymsError
+pub aya_obj::KsymsError::AmbiguousResolution
+pub aya_obj::KsymsError::AmbiguousResolution::first_addr: u64
+pub aya_obj::KsymsError::AmbiguousResolution::name: alloc::string::String
+pub aya_obj::KsymsError::AmbiguousResolution::second_addr: u64
+pub aya_obj::KsymsError::BtfError(aya_obj::btf::BtfError)
+pub aya_obj::KsymsError::FunctionNotFound
+pub aya_obj::KsymsError::FunctionNotFound::name: alloc::string::String
+pub aya_obj::KsymsError::IncompatibleFunctionSignature
+pub aya_obj::KsymsError::IncompatibleFunctionSignature::name: alloc::string::String
+pub aya_obj::KsymsError::IncompatibleVariableType
+pub aya_obj::KsymsError::IncompatibleVariableType::name: alloc::string::String
+pub aya_obj::KsymsError::InvalidExternType
+pub aya_obj::KsymsError::InvalidExternType::name: alloc::string::String
+pub aya_obj::KsymsError::KallsymsParseError(alloc::string::String)
+pub aya_obj::KsymsError::KallsymsReadError(std::io::error::Error)
+pub aya_obj::KsymsError::TypedKsymRequiresKernelBtf
+pub aya_obj::KsymsError::VariableNotFound
+pub aya_obj::KsymsError::VariableNotFound::name: alloc::string::String
+impl core::convert::From<aya_obj::btf::BtfError> for aya_obj::KsymsError
+pub fn aya_obj::KsymsError::from(aya_obj::btf::BtfError) -> Self
+impl core::convert::From<std::io::error::Error> for aya_obj::KsymsError
+pub fn aya_obj::KsymsError::from(std::io::error::Error) -> Self
+impl core::error::Error for aya_obj::KsymsError
+pub fn aya_obj::KsymsError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+impl core::fmt::Debug for aya_obj::KsymsError
+pub fn aya_obj::KsymsError::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::fmt::Display for aya_obj::KsymsError
+pub fn aya_obj::KsymsError::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for aya_obj::KsymsError
+impl core::marker::Send for aya_obj::KsymsError
+impl core::marker::Sync for aya_obj::KsymsError
+impl core::marker::Unpin for aya_obj::KsymsError
+impl core::marker::UnsafeUnpin for aya_obj::KsymsError
+impl !core::panic::unwind_safe::RefUnwindSafe for aya_obj::KsymsError
+impl !core::panic::unwind_safe::UnwindSafe for aya_obj::KsymsError
 pub enum aya_obj::Map
 pub aya_obj::Map::Btf(aya_obj::maps::BtfMap)
 pub aya_obj::Map::Legacy(aya_obj::maps::LegacyMap)
@@ -5450,7 +5495,10 @@ impl aya_obj::Object
 pub fn aya_obj::Object::relocate_btf(&mut self, &aya_obj::btf::Btf) -> core::result::Result<(), aya_obj::btf::BtfRelocationError>
 impl aya_obj::Object
 pub fn aya_obj::Object::relocate_calls(&mut self, &std::collections::hash::set::HashSet<usize>) -> core::result::Result<(), aya_obj::relocation::EbpfRelocationError>
+pub fn aya_obj::Object::relocate_externs(&mut self) -> core::result::Result<(), aya_obj::relocation::EbpfRelocationError>
 pub fn aya_obj::Object::relocate_maps<'a, I: core::iter::traits::iterator::Iterator<Item = (&'a str, std::os::fd::raw::RawFd, &'a aya_obj::maps::Map)>>(&mut self, I, &std::collections::hash::set::HashSet<usize>) -> core::result::Result<(), aya_obj::relocation::EbpfRelocationError>
+impl aya_obj::Object
+pub fn aya_obj::Object::resolve_externs(&mut self, core::option::Option<&aya_obj::btf::Btf>) -> core::result::Result<(), aya_obj::KsymsError>
 impl core::clone::Clone for aya_obj::Object
 pub fn aya_obj::Object::clone(&self) -> aya_obj::Object
 impl core::fmt::Debug for aya_obj::Object

--- a/xtask/public-api/aya-obj.txt
+++ b/xtask/public-api/aya-obj.txt
@@ -4815,6 +4815,8 @@ pub aya_obj::obj::Function::line_info_rec_size: usize
 pub aya_obj::obj::Function::name: alloc::string::String
 pub aya_obj::obj::Function::section_index: object::read::SectionIndex
 pub aya_obj::obj::Function::section_offset: usize
+impl aya_obj::Function
+pub fn aya_obj::Function::module_btf_load_requirements(&self) -> aya_obj::ModuleBtfLoadRequirements
 impl core::clone::Clone for aya_obj::Function
 pub fn aya_obj::Function::clone(&self) -> aya_obj::Function
 impl core::fmt::Debug for aya_obj::Function
@@ -4835,6 +4837,28 @@ impl<T> core::marker::Unpin for aya_obj::InvalidTypeBinding<T> where T: core::ma
 impl<T> core::marker::UnsafeUnpin for aya_obj::InvalidTypeBinding<T> where T: core::marker::UnsafeUnpin
 impl<T> core::panic::unwind_safe::RefUnwindSafe for aya_obj::InvalidTypeBinding<T> where T: core::panic::unwind_safe::RefUnwindSafe
 impl<T> core::panic::unwind_safe::UnwindSafe for aya_obj::InvalidTypeBinding<T> where T: core::panic::unwind_safe::UnwindSafe
+pub struct aya_obj::obj::ModuleBtfLoadRequirements
+impl aya_obj::ModuleBtfLoadRequirements
+pub const fn aya_obj::ModuleBtfLoadRequirements::needs_fd_array(self) -> bool
+pub const fn aya_obj::ModuleBtfLoadRequirements::needs_lifetime(self) -> bool
+impl core::clone::Clone for aya_obj::ModuleBtfLoadRequirements
+pub fn aya_obj::ModuleBtfLoadRequirements::clone(&self) -> aya_obj::ModuleBtfLoadRequirements
+impl core::cmp::Eq for aya_obj::ModuleBtfLoadRequirements
+impl core::cmp::PartialEq for aya_obj::ModuleBtfLoadRequirements
+pub fn aya_obj::ModuleBtfLoadRequirements::eq(&self, &aya_obj::ModuleBtfLoadRequirements) -> bool
+impl core::default::Default for aya_obj::ModuleBtfLoadRequirements
+pub fn aya_obj::ModuleBtfLoadRequirements::default() -> aya_obj::ModuleBtfLoadRequirements
+impl core::fmt::Debug for aya_obj::ModuleBtfLoadRequirements
+pub fn aya_obj::ModuleBtfLoadRequirements::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Copy for aya_obj::ModuleBtfLoadRequirements
+impl core::marker::StructuralPartialEq for aya_obj::ModuleBtfLoadRequirements
+impl core::marker::Freeze for aya_obj::ModuleBtfLoadRequirements
+impl core::marker::Send for aya_obj::ModuleBtfLoadRequirements
+impl core::marker::Sync for aya_obj::ModuleBtfLoadRequirements
+impl core::marker::Unpin for aya_obj::ModuleBtfLoadRequirements
+impl core::marker::UnsafeUnpin for aya_obj::ModuleBtfLoadRequirements
+impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::ModuleBtfLoadRequirements
+impl core::panic::unwind_safe::UnwindSafe for aya_obj::ModuleBtfLoadRequirements
 pub struct aya_obj::obj::Object
 pub aya_obj::obj::Object::btf: core::option::Option<aya_obj::btf::Btf>
 pub aya_obj::obj::Object::btf_ext: core::option::Option<aya_obj::btf::BtfExt>
@@ -4858,7 +4882,7 @@ pub fn aya_obj::Object::relocate_calls(&mut self, &std::collections::hash::set::
 pub fn aya_obj::Object::relocate_externs(&mut self) -> core::result::Result<(), aya_obj::relocation::EbpfRelocationError>
 pub fn aya_obj::Object::relocate_maps<'a, I: core::iter::traits::iterator::Iterator<Item = (&'a str, std::os::fd::raw::RawFd, &'a aya_obj::maps::Map)>>(&mut self, I, &std::collections::hash::set::HashSet<usize>) -> core::result::Result<(), aya_obj::relocation::EbpfRelocationError>
 impl aya_obj::Object
-pub fn aya_obj::Object::resolve_externs(&mut self, core::option::Option<&aya_obj::btf::Btf>) -> core::result::Result<(), aya_obj::KsymsError>
+pub fn aya_obj::Object::resolve_externs<P, F>(&mut self, core::option::Option<&aya_obj::btf::Btf>, F) -> core::result::Result<aya_obj::ResolvedExterns<P>, aya_obj::ResolveExternsError<<P as aya_obj::ExternModuleBtfProvider>::Error>> where P: aya_obj::ExternModuleBtfProvider, F: core::ops::function::FnOnce() -> core::result::Result<P, <P as aya_obj::ExternModuleBtfProvider>::Error>
 impl core::clone::Clone for aya_obj::Object
 pub fn aya_obj::Object::clone(&self) -> aya_obj::Object
 impl core::fmt::Debug for aya_obj::Object
@@ -5169,8 +5193,17 @@ impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::programs::xdp::XdpAtta
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::programs::xdp::XdpAttachType
 pub mod aya_obj::relocation
 pub enum aya_obj::relocation::RelocationError
+pub aya_obj::relocation::RelocationError::BtfFdIndexTooLarge
+pub aya_obj::relocation::RelocationError::BtfFdIndexTooLarge::index: u16
 pub aya_obj::relocation::RelocationError::ExternNotFound
 pub aya_obj::relocation::RelocationError::ExternNotFound::name: alloc::string::String
+pub aya_obj::relocation::RelocationError::InvalidExternRelocationInstruction
+pub aya_obj::relocation::RelocationError::InvalidExternRelocationInstruction::ins_index: usize
+pub aya_obj::relocation::RelocationError::InvalidExternRelocationInstruction::name: alloc::string::String
+pub aya_obj::relocation::RelocationError::InvalidLdImm64Relocation
+pub aya_obj::relocation::RelocationError::InvalidLdImm64Relocation::function_len: usize
+pub aya_obj::relocation::RelocationError::InvalidLdImm64Relocation::ins_index: usize
+pub aya_obj::relocation::RelocationError::InvalidLdImm64Relocation::name: alloc::string::String
 pub aya_obj::relocation::RelocationError::InvalidRelocationOffset
 pub aya_obj::relocation::RelocationError::InvalidRelocationOffset::offset: u64
 pub aya_obj::relocation::RelocationError::InvalidRelocationOffset::relocation_number: usize
@@ -5178,6 +5211,8 @@ pub aya_obj::relocation::RelocationError::SectionNotFound
 pub aya_obj::relocation::RelocationError::SectionNotFound::section_index: usize
 pub aya_obj::relocation::RelocationError::SectionNotFound::symbol_index: usize
 pub aya_obj::relocation::RelocationError::SectionNotFound::symbol_name: core::option::Option<alloc::string::String>
+pub aya_obj::relocation::RelocationError::StrongExternMissing
+pub aya_obj::relocation::RelocationError::StrongExternMissing::name: alloc::string::String
 pub aya_obj::relocation::RelocationError::UnknownFunction
 pub aya_obj::relocation::RelocationError::UnknownFunction::address: u64
 pub aya_obj::relocation::RelocationError::UnknownFunction::caller_name: alloc::string::String
@@ -5272,6 +5307,8 @@ impl core::fmt::Debug for aya_obj::KsymsError
 pub fn aya_obj::KsymsError::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::fmt::Display for aya_obj::KsymsError
 pub fn aya_obj::KsymsError::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl<E> core::convert::From<aya_obj::KsymsError> for aya_obj::ResolveExternsError<E>
+pub fn aya_obj::ResolveExternsError<E>::from(aya_obj::KsymsError) -> Self
 impl core::marker::Freeze for aya_obj::KsymsError
 impl core::marker::Send for aya_obj::KsymsError
 impl core::marker::Sync for aya_obj::KsymsError
@@ -5424,6 +5461,38 @@ impl core::marker::Unpin for aya_obj::ProgramSection
 impl core::marker::UnsafeUnpin for aya_obj::ProgramSection
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::ProgramSection
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::ProgramSection
+pub enum aya_obj::ResolveExternsError<E>
+pub aya_obj::ResolveExternsError::Ksyms(aya_obj::KsymsError)
+pub aya_obj::ResolveExternsError::ModuleBtf(E)
+impl<E: core::fmt::Debug> core::fmt::Debug for aya_obj::ResolveExternsError<E>
+pub fn aya_obj::ResolveExternsError<E>::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl<E> core::convert::From<aya_obj::KsymsError> for aya_obj::ResolveExternsError<E>
+pub fn aya_obj::ResolveExternsError<E>::from(aya_obj::KsymsError) -> Self
+impl<E> core::error::Error for aya_obj::ResolveExternsError<E> where Self: core::fmt::Debug + core::fmt::Display
+pub fn aya_obj::ResolveExternsError<E>::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+impl<E> core::fmt::Display for aya_obj::ResolveExternsError<E> where E: core::fmt::Display
+pub fn aya_obj::ResolveExternsError<E>::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl<E> core::marker::Freeze for aya_obj::ResolveExternsError<E> where E: core::marker::Freeze
+impl<E> core::marker::Send for aya_obj::ResolveExternsError<E> where E: core::marker::Send
+impl<E> core::marker::Sync for aya_obj::ResolveExternsError<E> where E: core::marker::Sync
+impl<E> core::marker::Unpin for aya_obj::ResolveExternsError<E> where E: core::marker::Unpin
+impl<E> core::marker::UnsafeUnpin for aya_obj::ResolveExternsError<E> where E: core::marker::UnsafeUnpin
+impl<E> !core::panic::unwind_safe::RefUnwindSafe for aya_obj::ResolveExternsError<E>
+impl<E> !core::panic::unwind_safe::UnwindSafe for aya_obj::ResolveExternsError<E>
+pub struct aya_obj::ExternResolverModule<'a>
+pub aya_obj::ExternResolverModule::btf: &'a aya_obj::btf::Btf
+pub aya_obj::ExternResolverModule::btf_obj_fd: std::os::fd::raw::RawFd
+pub aya_obj::ExternResolverModule::fd_idx: u16
+impl<'a> core::clone::Clone for aya_obj::ExternResolverModule<'a>
+pub fn aya_obj::ExternResolverModule<'a>::clone(&self) -> aya_obj::ExternResolverModule<'a>
+impl<'a> core::marker::Copy for aya_obj::ExternResolverModule<'a>
+impl<'a> core::marker::Freeze for aya_obj::ExternResolverModule<'a>
+impl<'a> core::marker::Send for aya_obj::ExternResolverModule<'a>
+impl<'a> core::marker::Sync for aya_obj::ExternResolverModule<'a>
+impl<'a> core::marker::Unpin for aya_obj::ExternResolverModule<'a>
+impl<'a> core::marker::UnsafeUnpin for aya_obj::ExternResolverModule<'a>
+impl<'a> core::panic::unwind_safe::RefUnwindSafe for aya_obj::ExternResolverModule<'a>
+impl<'a> core::panic::unwind_safe::UnwindSafe for aya_obj::ExternResolverModule<'a>
 pub struct aya_obj::Features
 impl aya_obj::Features
 pub const fn aya_obj::Features::bpf_cookie(&self) -> bool
@@ -5455,6 +5524,8 @@ pub aya_obj::Function::line_info_rec_size: usize
 pub aya_obj::Function::name: alloc::string::String
 pub aya_obj::Function::section_index: object::read::SectionIndex
 pub aya_obj::Function::section_offset: usize
+impl aya_obj::Function
+pub fn aya_obj::Function::module_btf_load_requirements(&self) -> aya_obj::ModuleBtfLoadRequirements
 impl core::clone::Clone for aya_obj::Function
 pub fn aya_obj::Function::clone(&self) -> aya_obj::Function
 impl core::fmt::Debug for aya_obj::Function
@@ -5475,6 +5546,28 @@ impl<T> core::marker::Unpin for aya_obj::InvalidTypeBinding<T> where T: core::ma
 impl<T> core::marker::UnsafeUnpin for aya_obj::InvalidTypeBinding<T> where T: core::marker::UnsafeUnpin
 impl<T> core::panic::unwind_safe::RefUnwindSafe for aya_obj::InvalidTypeBinding<T> where T: core::panic::unwind_safe::RefUnwindSafe
 impl<T> core::panic::unwind_safe::UnwindSafe for aya_obj::InvalidTypeBinding<T> where T: core::panic::unwind_safe::UnwindSafe
+pub struct aya_obj::ModuleBtfLoadRequirements
+impl aya_obj::ModuleBtfLoadRequirements
+pub const fn aya_obj::ModuleBtfLoadRequirements::needs_fd_array(self) -> bool
+pub const fn aya_obj::ModuleBtfLoadRequirements::needs_lifetime(self) -> bool
+impl core::clone::Clone for aya_obj::ModuleBtfLoadRequirements
+pub fn aya_obj::ModuleBtfLoadRequirements::clone(&self) -> aya_obj::ModuleBtfLoadRequirements
+impl core::cmp::Eq for aya_obj::ModuleBtfLoadRequirements
+impl core::cmp::PartialEq for aya_obj::ModuleBtfLoadRequirements
+pub fn aya_obj::ModuleBtfLoadRequirements::eq(&self, &aya_obj::ModuleBtfLoadRequirements) -> bool
+impl core::default::Default for aya_obj::ModuleBtfLoadRequirements
+pub fn aya_obj::ModuleBtfLoadRequirements::default() -> aya_obj::ModuleBtfLoadRequirements
+impl core::fmt::Debug for aya_obj::ModuleBtfLoadRequirements
+pub fn aya_obj::ModuleBtfLoadRequirements::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Copy for aya_obj::ModuleBtfLoadRequirements
+impl core::marker::StructuralPartialEq for aya_obj::ModuleBtfLoadRequirements
+impl core::marker::Freeze for aya_obj::ModuleBtfLoadRequirements
+impl core::marker::Send for aya_obj::ModuleBtfLoadRequirements
+impl core::marker::Sync for aya_obj::ModuleBtfLoadRequirements
+impl core::marker::Unpin for aya_obj::ModuleBtfLoadRequirements
+impl core::marker::UnsafeUnpin for aya_obj::ModuleBtfLoadRequirements
+impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::ModuleBtfLoadRequirements
+impl core::panic::unwind_safe::UnwindSafe for aya_obj::ModuleBtfLoadRequirements
 pub struct aya_obj::Object
 pub aya_obj::Object::btf: core::option::Option<aya_obj::btf::Btf>
 pub aya_obj::Object::btf_ext: core::option::Option<aya_obj::btf::BtfExt>
@@ -5498,7 +5591,7 @@ pub fn aya_obj::Object::relocate_calls(&mut self, &std::collections::hash::set::
 pub fn aya_obj::Object::relocate_externs(&mut self) -> core::result::Result<(), aya_obj::relocation::EbpfRelocationError>
 pub fn aya_obj::Object::relocate_maps<'a, I: core::iter::traits::iterator::Iterator<Item = (&'a str, std::os::fd::raw::RawFd, &'a aya_obj::maps::Map)>>(&mut self, I, &std::collections::hash::set::HashSet<usize>) -> core::result::Result<(), aya_obj::relocation::EbpfRelocationError>
 impl aya_obj::Object
-pub fn aya_obj::Object::resolve_externs(&mut self, core::option::Option<&aya_obj::btf::Btf>) -> core::result::Result<(), aya_obj::KsymsError>
+pub fn aya_obj::Object::resolve_externs<P, F>(&mut self, core::option::Option<&aya_obj::btf::Btf>, F) -> core::result::Result<aya_obj::ResolvedExterns<P>, aya_obj::ResolveExternsError<<P as aya_obj::ExternModuleBtfProvider>::Error>> where P: aya_obj::ExternModuleBtfProvider, F: core::ops::function::FnOnce() -> core::result::Result<P, <P as aya_obj::ExternModuleBtfProvider>::Error>
 impl core::clone::Clone for aya_obj::Object
 pub fn aya_obj::Object::clone(&self) -> aya_obj::Object
 impl core::fmt::Debug for aya_obj::Object
@@ -5529,6 +5622,18 @@ impl core::marker::Unpin for aya_obj::Program
 impl core::marker::UnsafeUnpin for aya_obj::Program
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::Program
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::Program
+pub struct aya_obj::ResolvedExterns<P>
+impl<P> aya_obj::ResolvedExterns<P>
+pub fn aya_obj::ResolvedExterns<P>::into_modules(self) -> core::option::Option<P>
+impl<P: core::fmt::Debug> core::fmt::Debug for aya_obj::ResolvedExterns<P>
+pub fn aya_obj::ResolvedExterns<P>::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl<P> core::marker::Freeze for aya_obj::ResolvedExterns<P> where P: core::marker::Freeze
+impl<P> core::marker::Send for aya_obj::ResolvedExterns<P> where P: core::marker::Send
+impl<P> core::marker::Sync for aya_obj::ResolvedExterns<P> where P: core::marker::Sync
+impl<P> core::marker::Unpin for aya_obj::ResolvedExterns<P> where P: core::marker::Unpin
+impl<P> core::marker::UnsafeUnpin for aya_obj::ResolvedExterns<P> where P: core::marker::UnsafeUnpin
+impl<P> core::panic::unwind_safe::RefUnwindSafe for aya_obj::ResolvedExterns<P> where P: core::panic::unwind_safe::RefUnwindSafe
+impl<P> core::panic::unwind_safe::UnwindSafe for aya_obj::ResolvedExterns<P> where P: core::panic::unwind_safe::UnwindSafe
 pub struct aya_obj::VerifierLog(_)
 impl aya_obj::VerifierLog
 pub const fn aya_obj::VerifierLog::new(alloc::string::String) -> Self
@@ -5543,5 +5648,8 @@ impl core::marker::Unpin for aya_obj::VerifierLog
 impl core::marker::UnsafeUnpin for aya_obj::VerifierLog
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::VerifierLog
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::VerifierLog
+pub trait aya_obj::ExternModuleBtfProvider
+pub type aya_obj::ExternModuleBtfProvider::Error
+pub fn aya_obj::ExternModuleBtfProvider::extern_resolution_modules(&self) -> core::result::Result<alloc::vec::Vec<aya_obj::ExternResolverModule<'_>>, Self::Error>
 pub fn aya_obj::copy_instructions(&[u8]) -> core::result::Result<alloc::vec::Vec<aya_obj::generated::bpf_insn>, aya_obj::ParseError>
 pub const fn aya_obj::parse_map_info(aya_obj::generated::bpf_map_info, aya_obj::maps::PinningType) -> aya_obj::maps::Map

--- a/xtask/public-api/aya.txt
+++ b/xtask/public-api/aya.txt
@@ -7735,6 +7735,7 @@ pub aya::EbpfError::BtfRelocationError(aya_obj::btf::relocation::BtfRelocationEr
 pub aya::EbpfError::FileError
 pub aya::EbpfError::FileError::error: std::io::error::Error
 pub aya::EbpfError::FileError::path: std::path::PathBuf
+pub aya::EbpfError::KsymsError(aya_obj::extern_types::KsymsError)
 pub aya::EbpfError::MapError(aya::maps::MapError)
 pub aya::EbpfError::NoBTF
 pub aya::EbpfError::ParseError(aya_obj::obj::ParseError)
@@ -7750,6 +7751,8 @@ impl core::convert::From<aya_obj::btf::btf::BtfError> for aya::EbpfError
 pub fn aya::EbpfError::from(aya_obj::btf::btf::BtfError) -> Self
 impl core::convert::From<aya_obj::btf::relocation::BtfRelocationError> for aya::EbpfError
 pub fn aya::EbpfError::from(aya_obj::btf::relocation::BtfRelocationError) -> Self
+impl core::convert::From<aya_obj::extern_types::KsymsError> for aya::EbpfError
+pub fn aya::EbpfError::from(aya_obj::extern_types::KsymsError) -> Self
 impl core::convert::From<aya_obj::obj::ParseError> for aya::EbpfError
 pub fn aya::EbpfError::from(aya_obj::obj::ParseError) -> Self
 impl core::convert::From<aya_obj::relocation::EbpfRelocationError> for aya::EbpfError

--- a/xtask/public-api/aya.txt
+++ b/xtask/public-api/aya.txt
@@ -7741,6 +7741,8 @@ pub aya::EbpfError::NoBTF
 pub aya::EbpfError::ParseError(aya_obj::obj::ParseError)
 pub aya::EbpfError::ProgramError(aya::programs::ProgramError)
 pub aya::EbpfError::RelocationError(aya_obj::relocation::EbpfRelocationError)
+pub aya::EbpfError::TooManyModuleBtfObjects
+pub aya::EbpfError::TooManyModuleBtfObjects::count: usize
 pub aya::EbpfError::UnexpectedPinningType
 pub aya::EbpfError::UnexpectedPinningType::name: u32
 impl core::convert::From<aya::maps::MapError> for aya::EbpfError

--- a/xtask/src/run.rs
+++ b/xtask/src/run.rs
@@ -44,7 +44,13 @@ enum Environment {
         #[clap(long)]
         github_api_token: Option<String>,
 
-        /// Debian kernel archives (.deb) to boot in the VM.
+        /// Integration-test kernel modules to build and inject into the VM.
+        ///
+        /// The module source is resolved from test/integration-test/kmod/<name>.
+        #[clap(long = "kmod")]
+        kmods: Vec<String>,
+
+        /// Kernel archives to boot in the VM.
         #[clap(required = true)]
         kernel_archives: Vec<PathBuf>,
     },
@@ -217,6 +223,490 @@ fn one<T: Debug>(slice: &[T]) -> Result<&T> {
     }
 }
 
+fn resolve_extracted_path(root: &Path, link: &Path) -> Result<PathBuf> {
+    let target = fs::read_link(link).with_context(|| format!("read_link({})", link.display()))?;
+    if target.is_absolute() {
+        Ok(root.join(
+            target
+                .strip_prefix("/")
+                .with_context(|| format!("strip absolute prefix from {}", target.display()))?,
+        ))
+    } else {
+        Ok(link
+            .parent()
+            .ok_or_else(|| anyhow!("{} has no parent", link.display()))?
+            .join(target))
+    }
+}
+
+struct KernelArtifacts {
+    image_root: PathBuf,
+    kernel_image: PathBuf,
+    config: PathBuf,
+    modules_dir: PathBuf,
+    system_map: PathBuf,
+    module_copy: ModuleCopy,
+}
+
+enum ModuleCopy {
+    FullTree,
+    TestDependencies,
+}
+
+const TEST_INITRAMFS_MODULES: &[&str] = &["cls_bpf", "sch_ingress"];
+
+fn module_release(modules_dir: &Path) -> Result<String> {
+    modules_dir
+        .file_name()
+        .ok_or_else(|| anyhow!("modules directory missing name: {}", modules_dir.display()))?
+        .to_str()
+        .ok_or_else(|| anyhow!("modules directory is not UTF-8: {}", modules_dir.display()))
+        .map(ToOwned::to_owned)
+}
+
+fn module_build_dir(image_root: &Path, modules_dir: &Path) -> Result<PathBuf> {
+    let build = modules_dir.join("build");
+    match fs::symlink_metadata(&build) {
+        Ok(metadata) if metadata.file_type().is_symlink() => {
+            resolve_extracted_path(image_root, &build)
+        }
+        Ok(_) => Ok(build),
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+            let release = module_release(modules_dir)?;
+            for usr_src in [image_root.join("usr/src"), image_root.join("image/usr/src")] {
+                let build_dir = usr_src.join(format!("linux-{release}"));
+                if build_dir.exists() {
+                    return Ok(build_dir);
+                }
+            }
+            Err(err).with_context(|| format!("metadata({})", build.display()))
+        }
+        Err(err) => Err(err).with_context(|| format!("metadata({})", build.display())),
+    }
+}
+
+fn is_gentoo_gpkg(archive: &Path) -> bool {
+    archive
+        .file_name()
+        .and_then(OsStr::to_str)
+        .is_some_and(|name| name.ends_with(".gpkg.tar"))
+}
+
+fn exists_nonempty(path: &Path) -> Result<bool> {
+    match fs::metadata(path) {
+        Ok(metadata) => Ok(metadata.len() != 0),
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(false),
+        Err(err) => Err(err).with_context(|| format!("metadata({})", path.display())),
+    }
+}
+
+fn gentoo_kernel_image(image_root: &Path, build_dir: &Path) -> Result<PathBuf> {
+    let arm64_image = build_dir.join("arch/arm64/boot/Image");
+    if exists_nonempty(&arm64_image)? {
+        return Ok(arm64_image);
+    }
+
+    let vmlinux = build_dir.join("vmlinux");
+    if build_dir.join("arch/arm64").exists() {
+        let image = image_root.join("gentoo-kernel-Image");
+        // Gentoo's arm64 package has a complete vmlinux, but not always a
+        // populated boot Image. QEMU needs the raw Image form.
+        let mut objcopy = Command::new("llvm-objcopy");
+        objcopy
+            .args(["-O", "binary"])
+            .args(["-R", ".note"])
+            .args(["-R", ".note.gnu.build-id"])
+            .args(["-R", ".comment"])
+            .arg("-S")
+            .arg(&vmlinux)
+            .arg(&image);
+        run_command(&mut objcopy)?;
+        return Ok(image);
+    }
+
+    let x86_image = build_dir.join("arch/x86/boot/bzImage");
+    if exists_nonempty(&x86_image)? {
+        return Ok(x86_image);
+    }
+
+    Ok(vmlinux)
+}
+
+fn extract_gentoo_gpkg(archive: &Path, dest: &Path) -> Result<()> {
+    fs::create_dir_all(dest).with_context(|| format!("failed to create {}", dest.display()))?;
+
+    let archive_reader = File::open(archive)
+        .with_context(|| format!("failed to open the gentoo package {}", archive.display()))?;
+    let mut archive_reader = tar::Archive::new(archive_reader);
+    let mut image_tar_xz_entries = 0;
+    let start = std::time::Instant::now();
+
+    for (outer_index, entry) in archive_reader.entries()?.enumerate() {
+        let entry =
+            entry.with_context(|| format!("({}).entries()[{outer_index}]", archive.display()))?;
+        let path = entry
+            .path()
+            .with_context(|| format!("({}).entries()[{outer_index}].path()", archive.display()))?;
+        if path.file_name() != Some(OsStr::new("image.tar.xz")) {
+            continue;
+        }
+
+        image_tar_xz_entries += 1;
+        let entry_reader = xz2::read::XzDecoder::new(entry);
+        let mut entry_reader = tar::Archive::new(entry_reader);
+        let entries = entry_reader
+            .entries()
+            .with_context(|| format!("({}/image.tar.xz).entries()", archive.display()))?;
+        for (i, entry) in entries.enumerate() {
+            let mut entry = entry
+                .with_context(|| format!("({}/image.tar.xz).entries()[{i}]", archive.display()))?;
+            let path = entry.path().with_context(|| {
+                format!("({}/image.tar.xz).entries()[{i}].path()", archive.display())
+            })?;
+            let path = path.into_owned();
+            if !path.starts_with("image/lib/modules") && !path.starts_with("image/usr/src") {
+                continue;
+            }
+
+            let entry_type = entry.header().entry_type();
+            if entry_type.is_symlink() && path.starts_with("image/lib/modules") {
+                continue;
+            }
+
+            let out_path = dest.join(&path);
+            if let Some(parent) = out_path.parent() {
+                fs::create_dir_all(parent)
+                    .with_context(|| format!("create_dir_all({})", parent.display()))?;
+            }
+            entry.unpack(&out_path).with_context(|| {
+                format!(
+                    "({}/image.tar.xz)[{i}].unpack({})",
+                    archive.display(),
+                    out_path.display(),
+                )
+            })?;
+        }
+    }
+
+    println!("{} in {:?}", archive.display(), start.elapsed());
+    anyhow::ensure!(
+        image_tar_xz_entries == 1,
+        "expected exactly one image.tar.xz in {}, found {image_tar_xz_entries}",
+        archive.display()
+    );
+    Ok(())
+}
+
+fn gentoo_kernel_artifacts(archive: &Path, image_root: PathBuf) -> Result<KernelArtifacts> {
+    extract_gentoo_gpkg(archive, &image_root)?;
+
+    let modules_root = image_root.join("image/lib/modules");
+    let modules_dirs = fs::read_dir(&modules_root)
+        .with_context(|| format!("read_dir({})", modules_root.display()))?
+        .map(|entry| {
+            let entry = entry.with_context(|| format!("read_dir({})", modules_root.display()))?;
+            let file_type = entry
+                .file_type()
+                .with_context(|| format!("file_type({})", entry.path().display()))?;
+            Ok(file_type.is_dir().then_some(entry.path()))
+        })
+        .collect::<Result<Vec<_>>>()?
+        .into_iter()
+        .flatten()
+        .collect::<Vec<_>>();
+    let modules_dir = one(modules_dirs.as_slice())
+        .with_context(|| format!("modules directory in {}", archive.display()))?
+        .to_owned();
+    let build_dir = module_build_dir(&image_root, &modules_dir)?;
+
+    let kernel_image = gentoo_kernel_image(&image_root, &build_dir)?;
+    let config = build_dir.join(".config");
+    let system_map = build_dir.join("System.map");
+    for path in [&kernel_image, &config, &system_map] {
+        anyhow::ensure!(path.exists(), "{} does not exist", path.display());
+    }
+
+    Ok(KernelArtifacts {
+        image_root,
+        kernel_image,
+        config,
+        modules_dir,
+        system_map,
+        module_copy: ModuleCopy::TestDependencies,
+    })
+}
+
+fn debian_kernel_artifacts(
+    kernel_archive: &Path,
+    debug_archive: &Path,
+    image_root: PathBuf,
+    debug_root: &Path,
+) -> Result<KernelArtifacts> {
+    let (kernel_images, configs, modules_dirs) = with_deb(
+        kernel_archive,
+        &image_root,
+        (Vec::new(), Vec::new(), Vec::new()),
+        |(kernel_images, configs, modules_dirs), path, entry_type| {
+            if let Some(path) = ["./lib/modules/", "./usr/lib/modules/"]
+                .into_iter()
+                .find_map(|modules_dir| {
+                    #[expect(clippy::manual_ok_err, reason = "type ascription")]
+                    match path.strip_prefix(modules_dir) {
+                        Ok(path) => Some(path),
+                        Err(path::StripPrefixError { .. }) => None,
+                    }
+                })
+            {
+                return Disposition::Unpack((
+                    (path.iter().count() == 1).then_some(modules_dirs),
+                    ControlFlow::Continue,
+                ));
+            }
+            if !entry_type.is_file() {
+                return Disposition::Skip;
+            }
+            let name = match path.strip_prefix("./boot/") {
+                Ok(path) => {
+                    if let Some(path::Component::Normal(name)) = path.components().next() {
+                        name
+                    } else {
+                        return Disposition::Skip;
+                    }
+                }
+                Err(path::StripPrefixError { .. }) => return Disposition::Skip,
+            };
+            let name = name.as_encoded_bytes();
+            if name.starts_with(b"vmlinuz-") {
+                Disposition::Unpack((Some(kernel_images), ControlFlow::Continue))
+            } else if name.starts_with(b"config-") {
+                Disposition::Unpack((Some(configs), ControlFlow::Continue))
+            } else {
+                Disposition::Skip
+            }
+        },
+    )?;
+    let kernel_image = one(kernel_images.as_slice())
+        .with_context(|| format!("kernel image in {}", kernel_archive.display()))?
+        .to_owned();
+    let config = one(configs.as_slice())
+        .with_context(|| format!("config in {}", kernel_archive.display()))?
+        .to_owned();
+    let modules_dir = one(modules_dirs.as_slice())
+        .with_context(|| format!("modules directory in {}", kernel_archive.display()))?
+        .to_owned();
+
+    let system_maps = with_deb(
+        debug_archive,
+        debug_root,
+        Vec::new(),
+        |system_maps: &mut Vec<PathBuf>, path, entry_type| {
+            if entry_type != tar::EntryType::Regular {
+                return Disposition::Skip;
+            }
+            let name = match path.strip_prefix("./usr/lib/debug/boot/") {
+                Ok(path) => {
+                    if let Some(path::Component::Normal(name)) = path.components().next() {
+                        name
+                    } else {
+                        return Disposition::Skip;
+                    }
+                }
+                Err(path::StripPrefixError { .. }) => return Disposition::Skip,
+            };
+            if name.as_encoded_bytes().starts_with(b"System.map-") {
+                Disposition::Unpack((Some(system_maps), ControlFlow::Break))
+            } else {
+                Disposition::Skip
+            }
+        },
+    )?;
+    let system_map = one(system_maps.as_slice())
+        .with_context(|| format!("System.map in {}", debug_archive.display()))?
+        .to_owned();
+
+    Ok(KernelArtifacts {
+        image_root,
+        kernel_image,
+        config,
+        modules_dir,
+        system_map,
+        module_copy: ModuleCopy::FullTree,
+    })
+}
+
+fn run_command(cmd: &mut Command) -> Result<()> {
+    let status = cmd
+        .status()
+        .with_context(|| format!("failed to run {cmd:?}"))?;
+    if status.code() == Some(0) {
+        Ok(())
+    } else {
+        bail!("{cmd:?} failed: {status:?}")
+    }
+}
+
+fn verify_ko_has_btf(ko: &Path) -> Result<()> {
+    let output = Command::new("llvm-readelf")
+        .arg("-S")
+        .arg(ko)
+        .output()
+        .with_context(|| format!("failed to run llvm-readelf -S {}", ko.display()))?;
+    if output.status.code() != Some(0) {
+        bail!("llvm-readelf -S {} failed: {output:?}", ko.display());
+    }
+
+    let stdout = String::from_utf8(output.stdout)
+        .with_context(|| format!("invalid UTF-8 from llvm-readelf -S {}", ko.display()))?;
+    anyhow::ensure!(
+        stdout.contains(".BTF"),
+        "{} does not contain a .BTF section",
+        ko.display()
+    );
+    Ok(())
+}
+
+fn find_kernel_module(modules_dir: &Path, name: &str) -> Result<Option<PathBuf>> {
+    let kernel_modules = modules_dir.join("kernel");
+    if !kernel_modules.exists() {
+        return Ok(None);
+    }
+
+    let module = format!("{name}.ko");
+    let compressed_module = format!("{module}.xz");
+    for entry in WalkDir::new(kernel_modules) {
+        let entry = entry.context("read_dir failed")?;
+        #[expect(
+            clippy::filetype_is_file,
+            reason = "we only want to match regular kernel module files"
+        )]
+        if !entry.file_type().is_file() {
+            continue;
+        }
+
+        let file_name = entry.file_name();
+        if file_name == OsStr::new(&module) || file_name == OsStr::new(&compressed_module) {
+            return Ok(Some(entry.into_path()));
+        }
+    }
+
+    Ok(None)
+}
+
+fn module_initramfs_inputs(
+    modules_dir: &Path,
+    module_copy: ModuleCopy,
+) -> Result<(Vec<PathBuf>, Vec<PathBuf>)> {
+    match module_copy {
+        ModuleCopy::FullTree => Ok((vec![modules_dir.to_owned()], Vec::new())),
+        ModuleCopy::TestDependencies => {
+            let mut module_roots = Vec::new();
+            let extra_modules = modules_dir.join("kernel/extra");
+            if extra_modules.exists() {
+                module_roots.push(extra_modules);
+            }
+
+            let mut module_files = Vec::new();
+            for module in TEST_INITRAMFS_MODULES {
+                let module_file = find_kernel_module(modules_dir, module)?.ok_or_else(|| {
+                    anyhow!(
+                        "kernel module {module}.ko not found under {}",
+                        modules_dir.display()
+                    )
+                })?;
+                module_files.push(module_file);
+            }
+
+            let modules_alias = modules_dir.join("modules.alias");
+            if modules_alias.exists() {
+                module_files.push(modules_alias);
+            }
+
+            Ok((module_roots, module_files))
+        }
+    }
+}
+
+fn build_test_kmod(
+    workspace_root: &Path,
+    image_root: &Path,
+    modules_dir: &Path,
+    name: &str,
+) -> Result<()> {
+    let build_dir = module_build_dir(image_root, modules_dir)?;
+    let build_vmlinux = build_dir.join("vmlinux");
+    anyhow::ensure!(
+        build_vmlinux.exists(),
+        "--kmod requires {} to generate module BTF",
+        build_vmlinux.display()
+    );
+
+    let work_dir = tempfile::tempdir().context("tempdir failed")?;
+    let src_dir = workspace_root.join("test/integration-test/kmod").join(name);
+    for entry in
+        fs::read_dir(&src_dir).with_context(|| format!("read_dir({})", src_dir.display()))?
+    {
+        let entry = entry.with_context(|| format!("read_dir({})", src_dir.display()))?;
+        let metadata = entry
+            .metadata()
+            .with_context(|| format!("metadata({})", entry.path().display()))?;
+        if metadata.is_file() {
+            let dst = work_dir.path().join(entry.file_name());
+            fs::copy(entry.path(), &dst)
+                .with_context(|| format!("copy({}, {})", entry.path().display(), dst.display()))?;
+        }
+    }
+
+    let mut make = Command::new("make");
+    make.arg("-C")
+        .arg(&build_dir)
+        .arg(format!("M={}", work_dir.path().display()))
+        .arg("PAHOLE_FLAGS=--btf_gen_all --btf_encode_force")
+        // Gentoo's prebuilt kernel tree can carry newer module pahole flags or
+        // compiler feature toggles than the local toolchain supports. Keep the
+        // build portable, then verify .BTF exists before using the module.
+        .arg("MODULE_PAHOLE_FLAGS=")
+        .arg("CONFIG_CC_HAS_MIN_FUNCTION_ALIGNMENT=")
+        .arg("modules");
+    run_command(&mut make)?;
+
+    let ko = work_dir.path().join(format!("{name}.ko"));
+    verify_ko_has_btf(&ko)?;
+
+    let dst_dir = modules_dir.join("kernel/extra");
+    fs::create_dir_all(&dst_dir)
+        .with_context(|| format!("create_dir_all({})", dst_dir.display()))?;
+    let dst = dst_dir.join(format!("{name}.ko"));
+    fs::copy(&ko, &dst).with_context(|| format!("copy({}, {})", ko.display(), dst.display()))?;
+
+    Ok(())
+}
+
+fn build_test_kmods(
+    workspace_root: &Path,
+    image_root: &Path,
+    modules_dir: &Path,
+    guest_arch: &str,
+    kmods: &[String],
+) -> Result<()> {
+    if kmods.is_empty() {
+        return Ok(());
+    }
+
+    let host_arch = env::consts::ARCH;
+    anyhow::ensure!(
+        guest_arch == host_arch,
+        "cannot build test kernel modules for guest architecture {guest_arch} on host architecture {host_arch}"
+    );
+
+    for kmod in kmods {
+        let name = kmod.replace('-', "_");
+        build_test_kmod(workspace_root, image_root, modules_dir, &name)
+            .with_context(|| format!("failed to build test kernel module {name}"))?;
+    }
+
+    Ok(())
+}
+
 /// Build and run the project.
 pub(crate) fn run(opts: Options, workspace_root: &Path) -> Result<()> {
     let Options {
@@ -297,6 +787,7 @@ pub(crate) fn run(opts: Options, workspace_root: &Path) -> Result<()> {
         Environment::VM {
             cache_dir,
             github_api_token,
+            kmods,
             kernel_archives,
         } => {
             // The user has asked us to run the tests on a VM. This is involved; strap in.
@@ -425,8 +916,55 @@ pub(crate) fn run(opts: Options, workspace_root: &Path) -> Result<()> {
                 debug: Vec<&'a Path>,
             }
 
+            enum KernelPackage<'a> {
+                Debian {
+                    base: &'a OsStr,
+                    kernel: &'a Path,
+                    debug: &'a Path,
+                },
+                Gentoo {
+                    archive: &'a Path,
+                },
+            }
+
+            impl KernelPackage<'_> {
+                fn artifacts(
+                    self,
+                    index: usize,
+                    extraction_root: &Path,
+                ) -> Result<KernelArtifacts> {
+                    let image_root = extraction_root.join(format!("kernel-archive-{index}-image"));
+                    match self {
+                        KernelPackage::Debian {
+                            base,
+                            kernel,
+                            debug,
+                        } => debian_kernel_artifacts(
+                            kernel,
+                            debug,
+                            image_root,
+                            &extraction_root.join(format!("kernel-archive-{index}-debug")),
+                        )
+                        .with_context(|| {
+                            format!("extracting Debian kernel package {}", base.display())
+                        }),
+                        KernelPackage::Gentoo { archive } => {
+                            gentoo_kernel_artifacts(archive, image_root).with_context(|| {
+                                format!("extracting Gentoo kernel package {}", archive.display())
+                            })
+                        }
+                    }
+                }
+            }
+
             let mut package_groups = BTreeMap::new();
+            let mut gentoo_archives = Vec::new();
             for archive in &kernel_archives {
+                if is_gentoo_gpkg(archive) {
+                    gentoo_archives.push(archive.as_path());
+                    continue;
+                }
+
                 let file_name = archive.file_name().ok_or_else(|| {
                     anyhow!("archive path missing filename: {}", archive.display())
                 })?;
@@ -451,120 +989,43 @@ pub(crate) fn run(opts: Options, workspace_root: &Path) -> Result<()> {
                 dst.push(archive.as_path());
             }
 
-            let mut errors = Vec::new();
-            for (index, (KernelPackageKey { base }, KernelPackageGroup { kernel, debug })) in
-                package_groups.into_iter().enumerate()
+            let mut kernel_packages = Vec::new();
+            for (KernelPackageKey { base }, KernelPackageGroup { kernel, debug }) in package_groups
             {
                 let base = {
                     use std::os::unix::ffi::OsStrExt as _;
                     OsStr::from_bytes(base)
                 };
+                kernel_packages.push(KernelPackage::Debian {
+                    base,
+                    kernel: one(kernel.as_slice())
+                        .with_context(|| format!("kernel archive for {}", base.display()))?,
+                    debug: one(debug.as_slice())
+                        .with_context(|| format!("debug archive for {}", base.display()))?,
+                });
+            }
+            kernel_packages.extend(
+                gentoo_archives
+                    .into_iter()
+                    .map(|archive| KernelPackage::Gentoo { archive }),
+            );
 
-                let kernel_archive = one(kernel.as_slice())
-                    .with_context(|| format!("kernel archive for {}", base.display()))?;
-                let debug_archive = one(debug.as_slice())
-                    .with_context(|| format!("debug archive for {}", base.display()))?;
-
-                let (kernel_images, configs, modules_dirs) = with_deb(
-                    kernel_archive,
-                    &extraction_root
-                        .path()
-                        .join(format!("kernel-archive-{index}-image")),
-                    (Vec::new(), Vec::new(), Vec::new()),
-                    |(kernel_images, configs, modules_dirs), path, entry_type| {
-                        if let Some(path) = ["./lib/modules/", "./usr/lib/modules/"]
-                            .into_iter()
-                            .find_map(|modules_dir| {
-                                // TODO(https://github.com/rust-lang/rust-clippy/issues/14112): Remove this
-                                // allowance when the lint behaves more sensibly.
-                                #[expect(clippy::manual_ok_err, reason = "type ascription")]
-                                match path.strip_prefix(modules_dir) {
-                                    Ok(path) => Some(path),
-                                    Err(path::StripPrefixError { .. }) => None,
-                                }
-                            })
-                        {
-                            return Disposition::Unpack((
-                                (path.iter().count() == 1).then_some(modules_dirs),
-                                ControlFlow::Continue,
-                            ));
-                        }
-                        if !entry_type.is_file() {
-                            return Disposition::Skip;
-                        }
-                        let name = match path.strip_prefix("./boot/") {
-                            Ok(path) => {
-                                if let Some(path::Component::Normal(name)) =
-                                    path.components().next()
-                                {
-                                    name
-                                } else {
-                                    return Disposition::Skip;
-                                }
-                            }
-                            Err(path::StripPrefixError { .. }) => return Disposition::Skip,
-                        };
-                        let name = name.as_encoded_bytes();
-                        if name.starts_with(b"vmlinuz-") {
-                            Disposition::Unpack((Some(kernel_images), ControlFlow::Continue))
-                        } else if name.starts_with(b"config-") {
-                            Disposition::Unpack((Some(configs), ControlFlow::Continue))
-                        } else {
-                            Disposition::Skip
-                        }
-                    },
-                )?;
-                let kernel_image = one(kernel_images.as_slice())
-                    .with_context(|| format!("kernel image in {}", kernel_archive.display()))?;
-                let config = one(configs.as_slice())
-                    .with_context(|| format!("config in {}", kernel_archive.display()))?;
-                let modules_dir = one(modules_dirs.as_slice()).with_context(|| {
-                    format!("modules directory in {}", kernel_archive.display())
-                })?;
-
-                let system_maps = with_deb(
-                    debug_archive,
-                    &extraction_root
-                        .path()
-                        .join(format!("kernel-archive-{index}-debug")),
-                    Vec::new(),
-                    |system_maps: &mut Vec<PathBuf>, path, entry_type| {
-                        if entry_type != tar::EntryType::Regular {
-                            return Disposition::Skip;
-                        }
-                        let name = match path.strip_prefix("./usr/lib/debug/boot/") {
-                            Ok(path) => {
-                                if let Some(path::Component::Normal(name)) =
-                                    path.components().next()
-                                {
-                                    name
-                                } else {
-                                    return Disposition::Skip;
-                                }
-                            }
-                            Err(path::StripPrefixError { .. }) => {
-                                return Disposition::Skip;
-                            }
-                        };
-                        if name.as_encoded_bytes().starts_with(b"System.map-") {
-                            // We only expect one System.map in the debug archive; ordinarily
-                            // we'd walk the whole archive to assert this fact but it turns out
-                            // that doing so takes around 10 seconds while stopping early takes
-                            // around 1ms.
-                            Disposition::Unpack((Some(system_maps), ControlFlow::Break))
-                        } else {
-                            Disposition::Skip
-                        }
-                    },
-                )?;
-                let system_map = one(system_maps.as_slice())
-                    .with_context(|| format!("System.map in {}", debug_archive.display()))?;
+            let mut errors = Vec::new();
+            for (index, kernel_package) in kernel_packages.into_iter().enumerate() {
+                let KernelArtifacts {
+                    image_root,
+                    kernel_image,
+                    config,
+                    modules_dir,
+                    system_map,
+                    module_copy,
+                } = kernel_package.artifacts(index, extraction_root.path())?;
 
                 // Guess the guest architecture.
                 let mut file = Command::new("file");
                 let output = file
                     .arg("--brief")
-                    .arg(kernel_image)
+                    .arg(&kernel_image)
                     .output()
                     .with_context(|| format!("failed to run {file:?}"))?;
                 let Output { status, .. } = &output;
@@ -578,16 +1039,23 @@ pub(crate) fn run(opts: Options, workspace_root: &Path) -> Result<()> {
                 // - Linux kernel ARM64 boot executable Image, little-endian, 4K pages
                 //
                 // - Linux kernel x86 boot executable bzImage, version 6.1.0-10-cloud-amd64 [..]
+                //
+                // Gentoo packages provide vmlinux directly, which file(1) reports as an ELF.
 
                 let stdout = String::from_utf8(stdout)
                     .with_context(|| format!("invalid UTF-8 in {file:?} stdout"))?;
-                let (_, stdout) = stdout
-                    .split_once("Linux kernel")
-                    .ok_or_else(|| anyhow!("failed to parse {file:?} stdout: {stdout}"))?;
-                let (guest_arch, _) = stdout
-                    .split_once("boot executable")
-                    .ok_or_else(|| anyhow!("failed to parse {file:?} stdout: {stdout}"))?;
-                let guest_arch = guest_arch.trim();
+                let guest_arch = if let Some((_, stdout)) = stdout.split_once("Linux kernel") {
+                    let (guest_arch, _) = stdout
+                        .split_once("boot executable")
+                        .ok_or_else(|| anyhow!("failed to parse {file:?} stdout: {stdout}"))?;
+                    guest_arch.trim()
+                } else if stdout.contains("ARM aarch64") {
+                    "ARM64"
+                } else if stdout.contains("x86-64") {
+                    "x86"
+                } else {
+                    bail!("failed to parse {file:?} stdout: {stdout}")
+                };
 
                 let (guest_arch, machine, cpu, console) = match guest_arch {
                     "ARM64" => (
@@ -711,14 +1179,14 @@ pub(crate) fn run(opts: Options, workspace_root: &Path) -> Result<()> {
                 write_dir(Path::new("/lib"));
                 write_dir(Path::new("/lib/modules"));
 
-                write_file(Path::new("/boot/config"), config, "644 0 0");
+                write_file(Path::new("/boot/config"), &config, "644 0 0");
                 if let Some(name) = config.file_name() {
-                    write_file(&Path::new("/boot").join(name), config, "644 0 0");
+                    write_file(&Path::new("/boot").join(name), &config, "644 0 0");
                 }
 
-                write_file(Path::new("/boot/System.map"), system_map, "644 0 0");
+                write_file(Path::new("/boot/System.map"), &system_map, "644 0 0");
                 if let Some(name) = system_map.file_name() {
-                    write_file(&Path::new("/boot").join(name), system_map, "644 0 0");
+                    write_file(&Path::new("/boot").join(name), &system_map, "644 0 0");
                 }
 
                 for (name, path) in &test_distro {
@@ -729,6 +1197,14 @@ pub(crate) fn run(opts: Options, workspace_root: &Path) -> Result<()> {
                     }
                 }
 
+                build_test_kmods(
+                    workspace_root,
+                    &image_root,
+                    &modules_dir,
+                    guest_arch,
+                    &kmods,
+                )?;
+
                 // At this point we need to make a slight detour!
                 // Preparing the `modules.alias` file inside the VM as part of
                 // `/init` is slow. It's faster to prepare it here.
@@ -737,7 +1213,7 @@ pub(crate) fn run(opts: Options, workspace_root: &Path) -> Result<()> {
                     .arg("run")
                     .args(test_distro_args)
                     .args(["--bin", "depmod", "--", "-b"])
-                    .arg(modules_dir)
+                    .arg(&modules_dir)
                     .output()
                     .with_context(|| format!("failed to run {cargo:?}"))?;
                 let Output { status, .. } = &output;
@@ -746,30 +1222,54 @@ pub(crate) fn run(opts: Options, workspace_root: &Path) -> Result<()> {
                 }
 
                 // Now our modules.alias file is built, we can recursively
-                // walk the modules directory and add all the files to the
-                // initramfs.
-                for entry in WalkDir::new(modules_dir) {
-                    let entry = entry.context("read_dir failed")?;
-                    let path = entry.path();
-                    let metadata = entry.metadata().context("metadata failed")?;
+                // walk the modules directory and add all the files to the initramfs.
+                let (module_roots, module_files) =
+                    module_initramfs_inputs(&modules_dir, module_copy)?;
+
+                for module_root in module_roots {
+                    for entry in WalkDir::new(&module_root) {
+                        let entry = entry.context("read_dir failed")?;
+                        let path = entry.path();
+                        let metadata = entry.metadata().context("metadata failed")?;
+                        let out_path = Path::new("/lib/modules").join(
+                            path.strip_prefix(&modules_dir).with_context(|| {
+                                format!(
+                                    "strip prefix {} failed for {}",
+                                    path.display(),
+                                    modules_dir.display()
+                                )
+                            })?,
+                        );
+                        #[expect(
+                            clippy::filetype_is_file,
+                            reason = "we only want to copy regular files"
+                        )]
+                        if metadata.file_type().is_dir() {
+                            write_dir(&out_path);
+                        } else if metadata.file_type().is_file() {
+                            write_file(&out_path, path, "644 0 0");
+                        }
+                    }
+                }
+
+                for module_file in module_files {
                     let out_path = Path::new("/lib/modules").join(
-                        path.strip_prefix(modules_dir).with_context(|| {
+                        module_file.strip_prefix(&modules_dir).with_context(|| {
                             format!(
                                 "strip prefix {} failed for {}",
-                                path.display(),
-                                modules_dir.display()
+                                modules_dir.display(),
+                                module_file.display()
                             )
                         })?,
                     );
-                    #[expect(
-                        clippy::filetype_is_file,
-                        reason = "we only want to copy regular files"
-                    )]
-                    if metadata.file_type().is_dir() {
-                        write_dir(&out_path);
-                    } else if metadata.file_type().is_file() {
-                        write_file(&out_path, path, "644 0 0");
+                    let mut parents = out_path.ancestors().skip(1).collect::<Vec<_>>();
+                    parents.reverse();
+                    for parent in parents {
+                        if parent != Path::new("/") {
+                            write_dir(parent);
+                        }
                     }
+                    write_file(&out_path, &module_file, "644 0 0");
                 }
 
                 for (profile, binaries) in binaries {
@@ -833,7 +1333,7 @@ pub(crate) fn run(opts: Options, workspace_root: &Path) -> Result<()> {
                     .arg("-append")
                     .arg(kernel_args)
                     .arg("-kernel")
-                    .arg(kernel_image)
+                    .arg(&kernel_image)
                     .arg("-initrd")
                     .arg(&initrd_image);
                 let mut qemu_child = qemu


### PR DESCRIPTION
Build on the typed ksym support in #1372 and the split-BTF view support in #1593 to resolve extern ksyms defined by kernel modules.

The ksyms PR resolves typed extern variables and kfuncs against vmlinux BTF. That is not enough for module-defined symbols, because module BTF is split BTF: it defines module-local symbols while referencing base vmlinux types. This PR discovers loaded module BTF objects lazily when vmlinux cannot resolve all typed externs, resolves those externs through `SplitBtf`, and keeps the module BTF FDs alive until program load.

Module-BTF relocations also need different kernel ABI encoding than vmlinux relocations. This PR tracks whether an extern resolved to vmlinux, module BTF, kallsyms, or weak-missing, then patches module kfunc calls with the module BTF fd-array index and module variable references with the module BTF object FD.

This also adds opt-in xtask support for building and injecting integration-test kernel modules, so module-BTF behavior can be tested in the VM integration flow.

  Added tests for:
  - typed extern variable and function resolution from module BTF
  - lazy module-BTF discovery only when vmlinux resolution is insufficient
  - module kfunc and module variable relocation encoding
  - invalid module-BTF relocation cases
  - module BTF fd-array indexing
  - integration coverage with a test kernel module exporting a typed ksym used by an eBPF program

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aya-rs/aya/1594)
<!-- Reviewable:end -->
