### PR TITLE
aya-ebpf: TcContext, SkBuff: add set_tc_classid

### DIFF
--- a/ebpf/aya-ebpf/src/programs/sk_buff.rs
+++ b/ebpf/aya-ebpf/src/programs/sk_buff.rs
@@ -48,6 +48,19 @@ impl SkBuff {
         unsafe { (*self.as_raw_ptr()).mark = mark }
     }
 
+    // Not public: writes to `tc_classid` are only accepted from sched_cls and
+    // sched_act programs, so this is exposed publicly on `TcContext` only.
+    // https://github.com/torvalds/linux/blob/e5f0a698b/net/core/filter.c#L9032-L9050
+    // The other program types built on `SkBuff` reject the field outright:
+    // socket_filter, cgroup_skb, and sk_skb.
+    // https://github.com/torvalds/linux/blob/e5f0a698b/net/core/filter.c#L8727-L8741
+    // https://github.com/torvalds/linux/blob/e5f0a698b/net/core/filter.c#L8756-L8765
+    // https://github.com/torvalds/linux/blob/e5f0a698b/net/core/filter.c#L9369-L9380
+    #[inline]
+    pub(crate) fn set_tc_classid(&self, classid: u16) {
+        unsafe { (*self.as_raw_ptr()).tc_classid = u32::from(classid) }
+    }
+
     #[inline]
     pub fn cb(&self) -> &[u32] {
         unsafe { &(*self.as_raw_ptr()).cb }

--- a/ebpf/aya-ebpf/src/programs/sk_buff.rs
+++ b/ebpf/aya-ebpf/src/programs/sk_buff.rs
@@ -48,6 +48,13 @@ impl SkBuff {
         unsafe { (*self.as_raw_ptr()).mark = mark }
     }
 
+    // Not public: the verifier only accepts writes to `tc_classid` from
+    // sched_cls/sched_act, so this is exposed publicly on `TcContext` only.
+    #[inline]
+    pub(crate) fn set_tc_classid(&self, classid: u32) {
+        unsafe { (*self.as_raw_ptr()).tc_classid = classid }
+    }
+
     #[inline]
     pub fn cb(&self) -> &[u32] {
         unsafe { &(*self.as_raw_ptr()).cb }

--- a/ebpf/aya-ebpf/src/programs/tc.rs
+++ b/ebpf/aya-ebpf/src/programs/tc.rs
@@ -52,6 +52,13 @@ impl TcContext {
         self.skb.set_mark(mark);
     }
 
+    /// Sets `__sk_buff::tc_classid`, steering the packet to a traffic-control
+    /// (e.g. HTB) class. Write-only, and only valid for TC classifier programs.
+    #[inline]
+    pub fn set_tc_classid(&self, classid: u32) {
+        self.skb.set_tc_classid(classid);
+    }
+
     #[inline]
     pub fn cb(&self) -> &[u32] {
         self.skb.cb()

--- a/ebpf/aya-ebpf/src/programs/tc.rs
+++ b/ebpf/aya-ebpf/src/programs/tc.rs
@@ -52,6 +52,31 @@ impl TcContext {
         self.skb.set_mark(mark);
     }
 
+    /// Sets `__sk_buff::tc_classid`.
+    ///
+    /// The kernel [stores this field as 16 bits][store], so writes are
+    /// truncated to the minor id.
+    ///
+    /// Class routing and pre-population require a netlink `cls_bpf` filter.
+    /// Attach with `aya::programs::tc::SchedClassifier::attach_with_options`
+    /// and `TcAttachOptions::Netlink`, setting `NlOptions::classid` to the
+    /// intended class.
+    ///
+    /// In direct-action mode this provides the minor 16 bits of the
+    /// resulting class id; [the major 16 bits come from the `classid`
+    /// configured on the attached filter][major].
+    ///
+    /// Before the program runs, [`cls_bpf`][cls_bpf] pre-populates this
+    /// field with that same `classid`.
+    ///
+    /// [store]: https://github.com/torvalds/linux/blob/e5f0a698b/net/core/filter.c#L9768-L9781
+    /// [major]: https://github.com/torvalds/linux/blob/e5f0a698b/net/sched/cls_bpf.c#L110-L118
+    /// [cls_bpf]: https://github.com/torvalds/linux/blob/e5f0a698b/net/sched/cls_bpf.c#L90-L105
+    #[inline]
+    pub fn set_tc_classid(&self, classid: u16) {
+        self.skb.set_tc_classid(classid);
+    }
+
     #[inline]
     pub fn cb(&self) -> &[u32] {
         self.skb.cb()

--- a/test/integration-common/src/lib.rs
+++ b/test/integration-common/src/lib.rs
@@ -281,6 +281,10 @@ pub mod stack_trace {
     unsafe impl aya::Pod for TestResult {}
 }
 
+pub mod tc_classid {
+    pub const EXPECTED_CLASSID: u32 = 0x0001_0001;
+}
+
 pub mod test_run {
     pub const XDP_MODIFY_VAL: u8 = 0xAA;
     pub const IF_INDEX: u32 = 1;

--- a/test/integration-common/src/lib.rs
+++ b/test/integration-common/src/lib.rs
@@ -281,6 +281,10 @@ pub mod stack_trace {
     unsafe impl aya::Pod for TestResult {}
 }
 
+pub mod tc_classid {
+    pub const EXPECTED_CLASSID: u16 = 0xbeef;
+}
+
 pub mod test_run {
     pub const XDP_MODIFY_VAL: u8 = 0xAA;
     pub const IF_INDEX: u32 = 1;

--- a/test/integration-ebpf/Cargo.toml
+++ b/test/integration-ebpf/Cargo.toml
@@ -141,6 +141,10 @@ name = "strncmp"
 path = "src/strncmp.rs"
 
 [[bin]]
+name = "tc_classid"
+path = "src/tc_classid.rs"
+
+[[bin]]
 name = "tcx"
 path = "src/tcx.rs"
 

--- a/test/integration-ebpf/src/tc_classid.rs
+++ b/test/integration-ebpf/src/tc_classid.rs
@@ -1,0 +1,14 @@
+#![no_std]
+#![no_main]
+#![expect(unused_crate_dependencies, reason = "used in other bins")]
+
+use aya_ebpf::{bindings::TC_ACT_OK, macros::classifier, programs::TcContext};
+use integration_common::tc_classid::EXPECTED_CLASSID;
+#[cfg(not(test))]
+extern crate ebpf_panic;
+
+#[classifier]
+fn set_classid(ctx: TcContext) -> i32 {
+    ctx.set_tc_classid(EXPECTED_CLASSID);
+    TC_ACT_OK
+}

--- a/test/integration-ebpf/src/tc_classid.rs
+++ b/test/integration-ebpf/src/tc_classid.rs
@@ -1,0 +1,19 @@
+#![no_std]
+#![no_main]
+
+use aya_ebpf::{EbpfContext as _, bindings::__sk_buff, macros::classifier, programs::TcContext};
+use integration_common::tc_classid::EXPECTED_CLASSID;
+#[cfg(not(test))]
+extern crate ebpf_panic;
+
+#[classifier]
+fn set_classid(ctx: TcContext) -> i32 {
+    ctx.set_tc_classid(EXPECTED_CLASSID);
+
+    // Read the field back and return it so the test can assert the store
+    // happened. Volatile so the compiler emits the BPF load instead of
+    // forwarding the store above.
+    let skb = ctx.as_ptr().cast::<__sk_buff>();
+    let read_back = unsafe { core::ptr::read_volatile(&raw const (*skb).tc_classid) };
+    read_back as i32
+}

--- a/test/integration-test/src/lib.rs
+++ b/test/integration-test/src/lib.rs
@@ -76,6 +76,7 @@ bpf_file!(
     SOCK_HASH => "sock_hash",
     SOCK_MAP => "sock_map",
     STRNCMP => "strncmp",
+    TC_CLASSID => "tc_classid",
     TCX => "tcx",
     TEST => "test",
     TEST_RUN => "test_run",

--- a/test/integration-test/src/lib.rs
+++ b/test/integration-test/src/lib.rs
@@ -77,6 +77,7 @@ bpf_file!(
     SOCK_HASH => "sock_hash",
     SOCK_MAP => "sock_map",
     STRNCMP => "strncmp",
+    TC_CLASSID => "tc_classid",
     TCX => "tcx",
     TEST => "test",
     TEST_RUN => "test_run",

--- a/test/integration-test/src/tests.rs
+++ b/test/integration-test/src/tests.rs
@@ -65,6 +65,7 @@ mod socket_filter;
 mod stack_trace;
 mod stack_trace_lsm;
 mod strncmp;
+mod tc_classid;
 mod tc_netlink;
 mod tcx;
 mod uprobe_cookie;

--- a/test/integration-test/src/tests/tc_classid.rs
+++ b/test/integration-test/src/tests/tc_classid.rs
@@ -1,0 +1,40 @@
+use aya::{
+    Ebpf, TestRunOptions, TestRunResult,
+    programs::{SchedClassifier, TestRun as _},
+};
+
+// `sizeof(pkt_v4)` = Size(Ethernet) + Size(IPv4) + Size(TCP) = 14 + 20 + 20
+const PKT_V4_SIZE: usize = 14 + 20 + 20;
+
+// Scope: proves only that the verifier loads a sched_cls program writing
+// `tc_classid`. The written value can't be observed here (BPF_PROG_TEST_RUN
+// leaves ctx_out empty for sched_cls, and the qdisc consumes the field), and
+// checking real routing needs HTB-qdisc infra the suite lacks; that path was
+// verified manually.
+#[test_log::test]
+fn tc_classid_set() {
+    let kernel_version = aya::util::KernelVersion::current().unwrap();
+    // BPF_PROG_TEST_RUN was introduced in v4.12 (1cf1cae963c2, "bpf: introduce
+    // BPF_PROG_TEST_RUN command") with support for sched_cls (used here) and
+    // sched_act program types. On kernels before v4.12 the syscall command does
+    // not exist and the bpf(2) call returns EINVAL.
+    if kernel_version < aya::util::KernelVersion::new(4, 12, 0) {
+        return;
+    }
+
+    let mut bpf = Ebpf::load(crate::TC_CLASSID).unwrap();
+    let prog: &mut SchedClassifier = bpf.program_mut("set_classid").unwrap().try_into().unwrap();
+    prog.load().unwrap();
+
+    let data_in = vec![0u8; PKT_V4_SIZE];
+    let mut data_out = vec![0u8; PKT_V4_SIZE];
+
+    let opts = TestRunOptions {
+        data_in: Some(&data_in),
+        data_out: Some(&mut data_out),
+        ..TestRunOptions::default()
+    };
+
+    let TestRunResult { return_value, .. } = prog.test_run(opts).unwrap();
+    assert_eq!(return_value, 0, "Expected TC_ACT_OK(0)");
+}

--- a/test/integration-test/src/tests/tc_classid.rs
+++ b/test/integration-test/src/tests/tc_classid.rs
@@ -1,0 +1,46 @@
+use aya::{
+    Ebpf, TestRunOptions, TestRunResult,
+    programs::{SchedClassifier, TestRun as _},
+};
+use integration_common::tc_classid::EXPECTED_CLASSID;
+
+// `sizeof(pkt_v4)` = Size(Ethernet) + Size(IPv4) + Size(TCP) = 14 + 20 + 20
+const PKT_V4_SIZE: usize = 14 + 20 + 20;
+
+// The program writes `tc_classid` and returns what a subsequent read observes,
+// so this asserts the store reached the field.
+#[test_log::test]
+fn tc_classid_set() {
+    let kernel_version = aya::util::KernelVersion::current().unwrap();
+    // BPF_PROG_TEST_RUN was introduced in v4.12 (1cf1cae963c2, "bpf: introduce
+    // BPF_PROG_TEST_RUN command") with support for sched_cls (used here) and
+    // sched_act program types. On kernels before v4.12 the syscall command does
+    // not exist and the bpf(2) call returns EINVAL.
+    if kernel_version < aya::util::KernelVersion::new(4, 12, 0) {
+        return;
+    }
+
+    let mut bpf = Ebpf::load(crate::TC_CLASSID).unwrap();
+    let prog: &mut SchedClassifier = bpf.program_mut("set_classid").unwrap().try_into().unwrap();
+    prog.load().unwrap();
+
+    // The program never reads the packet, but the kernel refuses to build the
+    // skb from fewer than ETH_HLEN bytes.
+    // https://github.com/torvalds/linux/blob/e5f0a698b/net/bpf/test_run.c#L662-L669
+    let data_in = vec![0u8; PKT_V4_SIZE];
+
+    let opts = TestRunOptions {
+        data_in: Some(&data_in),
+        ..TestRunOptions::default()
+    };
+
+    let TestRunResult {
+        return_value,
+        duration,
+        data_size_out: _,
+        ctx_size_out: _,
+    } = prog.test_run(opts).unwrap();
+
+    assert_eq!(return_value, u32::from(EXPECTED_CLASSID));
+    assert!(!duration.is_zero());
+}

--- a/xtask/public-api/aya-ebpf.txt
+++ b/xtask/public-api/aya-ebpf.txt
@@ -2227,6 +2227,7 @@ pub fn aya_ebpf::programs::tc::TcContext::load_bytes(&self, usize, &mut [u8]) ->
 pub const fn aya_ebpf::programs::tc::TcContext::new(core::ptr::non_null::NonNull<aya_ebpf_bindings::x86_64::bindings::__sk_buff>) -> Self
 pub fn aya_ebpf::programs::tc::TcContext::pull_data(&self, u32) -> core::result::Result<(), aya_ebpf_cty::od::c_long>
 pub fn aya_ebpf::programs::tc::TcContext::set_mark(&self, u32)
+pub fn aya_ebpf::programs::tc::TcContext::set_tc_classid(&self, u32)
 pub fn aya_ebpf::programs::tc::TcContext::skb_under_cgroup<M: aya_ebpf::programs::tc::CgroupArrayMap>(&self, &M, u32) -> core::result::Result<bool, aya_ebpf_cty::od::c_long>
 pub fn aya_ebpf::programs::tc::TcContext::store<T>(&self, usize, &T, u64) -> core::result::Result<(), aya_ebpf_cty::od::c_long>
 impl aya_ebpf::EbpfContext for aya_ebpf::programs::tc::TcContext
@@ -2726,6 +2727,7 @@ pub fn aya_ebpf::programs::tc::TcContext::load_bytes(&self, usize, &mut [u8]) ->
 pub const fn aya_ebpf::programs::tc::TcContext::new(core::ptr::non_null::NonNull<aya_ebpf_bindings::x86_64::bindings::__sk_buff>) -> Self
 pub fn aya_ebpf::programs::tc::TcContext::pull_data(&self, u32) -> core::result::Result<(), aya_ebpf_cty::od::c_long>
 pub fn aya_ebpf::programs::tc::TcContext::set_mark(&self, u32)
+pub fn aya_ebpf::programs::tc::TcContext::set_tc_classid(&self, u32)
 pub fn aya_ebpf::programs::tc::TcContext::skb_under_cgroup<M: aya_ebpf::programs::tc::CgroupArrayMap>(&self, &M, u32) -> core::result::Result<bool, aya_ebpf_cty::od::c_long>
 pub fn aya_ebpf::programs::tc::TcContext::store<T>(&self, usize, &T, u64) -> core::result::Result<(), aya_ebpf_cty::od::c_long>
 impl aya_ebpf::EbpfContext for aya_ebpf::programs::tc::TcContext

--- a/xtask/public-api/aya-ebpf.txt
+++ b/xtask/public-api/aya-ebpf.txt
@@ -2227,6 +2227,7 @@ pub fn aya_ebpf::programs::tc::TcContext::load_bytes(&self, usize, &mut [u8]) ->
 pub const fn aya_ebpf::programs::tc::TcContext::new(core::ptr::non_null::NonNull<aya_ebpf_bindings::x86_64::bindings::__sk_buff>) -> Self
 pub fn aya_ebpf::programs::tc::TcContext::pull_data(&self, u32) -> core::result::Result<(), aya_ebpf_cty::od::c_long>
 pub fn aya_ebpf::programs::tc::TcContext::set_mark(&self, u32)
+pub fn aya_ebpf::programs::tc::TcContext::set_tc_classid(&self, u16)
 pub fn aya_ebpf::programs::tc::TcContext::skb_under_cgroup<M: aya_ebpf::programs::tc::CgroupArrayMap>(&self, &M, u32) -> core::result::Result<bool, aya_ebpf_cty::od::c_long>
 pub fn aya_ebpf::programs::tc::TcContext::store<T>(&self, usize, &T, u64) -> core::result::Result<(), aya_ebpf_cty::od::c_long>
 impl aya_ebpf::EbpfContext for aya_ebpf::programs::tc::TcContext
@@ -2726,6 +2727,7 @@ pub fn aya_ebpf::programs::tc::TcContext::load_bytes(&self, usize, &mut [u8]) ->
 pub const fn aya_ebpf::programs::tc::TcContext::new(core::ptr::non_null::NonNull<aya_ebpf_bindings::x86_64::bindings::__sk_buff>) -> Self
 pub fn aya_ebpf::programs::tc::TcContext::pull_data(&self, u32) -> core::result::Result<(), aya_ebpf_cty::od::c_long>
 pub fn aya_ebpf::programs::tc::TcContext::set_mark(&self, u32)
+pub fn aya_ebpf::programs::tc::TcContext::set_tc_classid(&self, u16)
 pub fn aya_ebpf::programs::tc::TcContext::skb_under_cgroup<M: aya_ebpf::programs::tc::CgroupArrayMap>(&self, &M, u32) -> core::result::Result<bool, aya_ebpf_cty::od::c_long>
 pub fn aya_ebpf::programs::tc::TcContext::store<T>(&self, usize, &T, u64) -> core::result::Result<(), aya_ebpf_cty::od::c_long>
 impl aya_ebpf::EbpfContext for aya_ebpf::programs::tc::TcContext


### PR DESCRIPTION
Follow-up to #1571, which added `classid` to `SchedClassifier` netlink
attach, setting `TCA_BPF_CLASSID` (the upper 16 bits of the class a
direct-action program routes to). The lower 16 bits are written by the
program into `__sk_buff::tc_classid`, but there was no safe way to write
that field from aya-ebpf, so a classifier had to go through a raw pointer
to the skb. This adds `set_tc_classid` on `TcContext`.

The setter is only exposed on `TcContext`. The verifier rejects writes
to `__sk_buff::tc_classid` from the program types behind `SkBuffContext`
(`cgroup_skb`, `socket_filter`, `sk_skb`), so the setter would compile
but fail to load there.

The integration test runs a classifier through `BPF_PROG_TEST_RUN` to
write the field and read it back with a volatile load, asserting
against the value observed. It can't exercise actual qdisc routing,
which needs an HTB class hierarchy; that part was verified manually by
attaching a classifier on `lo` under an HTB qdisc and confirming
packets are routed to the class the program writes.

Refs: #886, #1571

### Added/updated tests?

- [x] Yes

### Checklist

- [x] Rust code has been formatted with `cargo +nightly fmt`.
- [x] All clippy lints have been fixed.
- [x] Unit tests are passing locally with `cargo test`.
- [x] The integration tests are passing locally.
- [x] I have blessed any API changes with `cargo xtask public-api --bless`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aya-rs/aya/1595)
<!-- Reviewable:end -->
