### PR TITLE
refactor(test): Move `utils.rs` from the `integration-test` crate to `aya`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -95,6 +95,7 @@ checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 name = "aya"
 version = "0.13.2"
 dependencies = [
+ "anyhow",
  "assert_matches",
  "aya-obj",
  "bitflags",

--- a/aya/Cargo.toml
+++ b/aya/Cargo.toml
@@ -17,6 +17,7 @@ rust-version.workspace = true
 workspace = true
 
 [dependencies]
+anyhow = { workspace = true, optional = true }
 assert_matches = { workspace = true }
 aya-obj = { path = "../aya-obj", version = "^0.2.2" }
 bitflags = { workspace = true }
@@ -25,6 +26,7 @@ bitflags = { workspace = true }
 hashbrown = { workspace = true, features = ["default-hasher", "equivalent"] }
 libc = { workspace = true }
 log = { workspace = true }
+nix = { workspace = true, features = ["mount", "sched"], optional = true }
 object = { workspace = true, features = ["elf", "read_core", "std", "write"] }
 once_cell = { workspace = true }
 scopeguard = { workspace = true }
@@ -34,6 +36,9 @@ thiserror = { workspace = true }
 nix = { workspace = true, features = ["net", "socket"] }
 rstest = { workspace = true }
 tempfile = { workspace = true }
+
+[features]
+test-helpers = ["dep:anyhow", "dep:nix"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/aya/src/lib.rs
+++ b/aya/src/lib.rs
@@ -38,13 +38,18 @@
 )]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![deny(missing_docs)]
-#![cfg_attr(test, expect(unused_crate_dependencies, reason = "used in doctests"))]
+#![cfg_attr(
+    all(test, not(feature = "test-helpers")),
+    expect(unused_crate_dependencies, reason = "used in doctests")
+)]
 
 mod bpf;
 pub mod maps;
 pub mod pin;
 pub mod programs;
 pub mod sys;
+#[cfg(feature = "test-helpers")]
+pub mod test_helpers;
 pub mod util;
 
 use std::os::fd::{AsFd, AsRawFd, BorrowedFd, FromRawFd, OwnedFd, RawFd};

--- a/aya/src/sys/mod.rs
+++ b/aya/src/sys/mod.rs
@@ -19,6 +19,7 @@ pub(crate) use bpf::*;
 #[cfg(test)]
 pub(crate) use fake::*;
 pub use feature_probe::{BpfHelper, is_helper_supported, is_map_supported, is_program_supported};
+pub use netlink::NetlinkError;
 #[doc(hidden)]
 pub use netlink::netlink_set_link_up;
 pub(crate) use netlink::*;

--- a/aya/src/sys/netlink.rs
+++ b/aya/src/sys/netlink.rs
@@ -90,6 +90,10 @@ pub(crate) enum NetlinkErrorInternal {
 pub struct NetlinkError(#[from] NetlinkErrorInternal);
 
 impl NetlinkError {
+    /// Returns the raw OS error code, if one is available.
+    ///
+    /// Returns `None` if the error does not wrap an OS error (e.g. buffer
+    /// length or header length errors from the netlink attribute parser).
     pub fn raw_os_error(&self) -> Option<i32> {
         let Self(inner) = self;
         match inner {

--- a/aya/src/sys/netlink.rs
+++ b/aya/src/sys/netlink.rs
@@ -83,10 +83,6 @@ pub(crate) enum NetlinkErrorInternal {
 /// An error occurred during a netlink operation.
 #[derive(Error, Debug)]
 #[error(transparent)]
-#[expect(
-    unnameable_types,
-    reason = "the internal error is crate-private but transparently wrapped"
-)]
 pub struct NetlinkError(#[from] NetlinkErrorInternal);
 
 impl NetlinkError {

--- a/aya/src/test_helpers.rs
+++ b/aya/src/test_helpers.rs
@@ -4,6 +4,7 @@ use std::{
     borrow::Cow,
     fs,
     io::{self, BufRead as _, BufReader, Write as _},
+    marker::PhantomData,
     os::fd::{AsFd, BorrowedFd},
     path::{Path, PathBuf},
     process,
@@ -277,6 +278,10 @@ pub struct NetNsGuard {
     old_ns: fs::File,
     /// File handle to the newly created network namespace.
     new_ns: fs::File,
+    /// Prevents moving the guard to another thread (makes it `!Send`).
+    // TODO(https://github.com/rust-lang/rust/issues/68318): Replace with a
+    // negative `impl` when possible.
+    _not_send: PhantomData<*mut ()>,
 }
 
 impl NetNsGuard {
@@ -399,6 +404,7 @@ impl NetNsGuard {
             name,
             old_ns,
             new_ns,
+            _not_send: PhantomData,
         };
 
         // By default, the loopback in a new netns is down. Set it up.
@@ -447,6 +453,7 @@ impl Drop for NetNsGuard {
             old_ns,
             name,
             new_ns: _,
+            _not_send: _,
         } = self;
         match (|| -> Result<()> {
             nix::sched::setns(old_ns, nix::sched::CloneFlags::CLONE_NEWNET)

--- a/aya/src/test_helpers.rs
+++ b/aya/src/test_helpers.rs
@@ -72,6 +72,10 @@ pub enum AyaTestError {
         source: nix::errno::Errno,
     },
 
+    /// Multiple errors.
+    #[error("errors: {0:?}")]
+    Multi(Vec<Self>),
+
     /// An error occurred during a netlink operation.
     #[error(transparent)]
     Netlink(#[from] NetlinkError),
@@ -291,7 +295,7 @@ impl NetNsGuard {
         clippy::print_stdout,
         reason = "integration tests print namespace transitions for diagnostics"
     )]
-    pub fn new() -> AyaTestResult<Self> {
+    pub fn new() -> Result<Self, AyaTestError> {
         // `/proc/thread-self/ns/net` resolves to the calling thread's netns
         // (`/proc/self/ns/net` would always pin to the main thread's).
         let old_ns = fs::File::open(Self::THREAD_NETNS).map_err(|source| AyaTestError::Io {
@@ -316,18 +320,45 @@ impl NetNsGuard {
             source,
         })?;
         nix::sched::unshare(nix::sched::CloneFlags::CLONE_NEWNET).map_err(|source| {
-            AyaTestError::Syscall {
+            let mut errs = vec![AyaTestError::Syscall {
                 syscall: "unshare",
                 path: None,
                 source,
-            }
+            }];
+            fs::remove_file(&ns_path).unwrap_or_else(|source| {
+                errs.push(AyaTestError::Io {
+                    op: "remove file",
+                    path: ns_path.clone(),
+                    source,
+                })
+            });
+            AyaTestError::Multi(errs)
         })?;
 
         // Re-open after unshare to capture the freshly entered namespace.
-        let new_ns = fs::File::open(Self::THREAD_NETNS).map_err(|source| AyaTestError::Io {
-            op: "open",
-            path: PathBuf::from(Self::THREAD_NETNS),
-            source,
+        let new_ns = fs::File::open(Self::THREAD_NETNS).map_err(|source| {
+            let mut errs = vec![AyaTestError::Io {
+                op: "open",
+                path: PathBuf::from(Self::THREAD_NETNS),
+                source,
+            }];
+            nix::sched::setns(&old_ns, nix::sched::CloneFlags::CLONE_NEWNET).unwrap_or_else(
+                |source| {
+                    errs.push(AyaTestError::Syscall {
+                        syscall: "setns",
+                        path: Some(PathBuf::from(Self::THREAD_NETNS)),
+                        source,
+                    });
+                },
+            );
+            fs::remove_file(&ns_path).unwrap_or_else(|source| {
+                errs.push(AyaTestError::Io {
+                    op: "remove file",
+                    path: ns_path.clone(),
+                    source,
+                })
+            });
+            AyaTestError::Multi(errs)
         })?;
 
         nix::mount::mount(
@@ -337,10 +368,29 @@ impl NetNsGuard {
             nix::mount::MsFlags::MS_BIND,
             None::<&str>,
         )
-        .map_err(|source| AyaTestError::Syscall {
-            syscall: "mount",
-            path: Some(ns_path.clone()),
-            source,
+        .map_err(|source| {
+            let mut errs = vec![AyaTestError::Syscall {
+                syscall: "mount",
+                path: Some(ns_path.clone()),
+                source,
+            }];
+            nix::sched::setns(&old_ns, nix::sched::CloneFlags::CLONE_NEWNET).unwrap_or_else(
+                |source| {
+                    errs.push(AyaTestError::Syscall {
+                        syscall: "setns",
+                        path: Some(PathBuf::from(Self::THREAD_NETNS)),
+                        source,
+                    })
+                },
+            );
+            fs::remove_file(&ns_path).unwrap_or_else(|source| {
+                errs.push(AyaTestError::Io {
+                    op: "remove file",
+                    path: ns_path,
+                    source,
+                })
+            });
+            AyaTestError::Multi(errs)
         })?;
 
         println!("entered network namespace {name}");

--- a/aya/src/test_helpers.rs
+++ b/aya/src/test_helpers.rs
@@ -2,7 +2,6 @@
 
 use std::{
     borrow::Cow,
-    ffi::CString,
     fs,
     io::{self, BufRead as _, BufReader, Write as _},
     os::fd::{AsFd, BorrowedFd},
@@ -11,14 +10,75 @@ use std::{
     sync::atomic::{AtomicU64, Ordering},
 };
 
-use anyhow::{Context as _, Result};
 use libc::if_nametoindex;
 
-use crate::netlink_set_link_up;
+use crate::{netlink_set_link_up, sys::NetlinkError};
 
 /// The cgroup-relative name of the file to which a PID is written to assign
 /// that process to the cgroup.
 const CGROUP_PROCS: &str = "cgroup.procs";
+
+/// The path to the per-process mount table, used to locate cgroup2 mounts.
+const PROC_MOUNTS: &str = "/proc/self/mounts";
+
+/// An error type for test helpers.
+///
+/// This enum covers all failures that can occur during cgroup setup,
+/// network namespace creation, and link manipulation in integration tests.
+#[derive(Debug, thiserror::Error)]
+pub enum AyaTestError {
+    /// A filesystem operation failed (open, create, write, remove, etc.).
+    #[error("failed to {op}: {path}: {source}")]
+    Io {
+        /// The operation that failed (e.g. `"create dir"`).
+        op: &'static str,
+        /// The path involved in the operation.
+        path: PathBuf,
+        /// Source error.
+        #[source]
+        source: io::Error,
+    },
+
+    /// A mount entry is missing a required field (e.g. device, mountpoint,
+    /// or fstype).
+    #[error("mount entry from {PROC_MOUNTS} has no {field} field: {mount_entry}")]
+    MissingMountEntryField {
+        /// The name of the missing field (e.g. `"device"`, `"mountpoint"`, `"fstype"`).
+        field: &'static str,
+        /// The full mount entry line that is missing the field.
+        mount_entry: String,
+    },
+
+    /// No cgroup2 mount entry was found.
+    #[error("could not find a cgroup2 mount entry in {PROC_MOUNTS}")]
+    Cgroup2NotFound,
+
+    /// A syscall failed.
+    #[error(
+        "syscall {syscall} failed{}: {source}",
+        if let Some(path) = &.path {
+            format!(": {}", path.display())
+        } else {
+            String::new()
+        }
+    )]
+    Syscall {
+        /// The syscall that failed (e.g. `"nix::sched::unshare"`).
+        syscall: &'static str,
+        /// The path involved in the syscall, if any.
+        path: Option<PathBuf>,
+        /// Source error.
+        #[source]
+        source: nix::errno::Errno,
+    },
+
+    /// An error occurred during a netlink operation.
+    #[error(transparent)]
+    Netlink(#[from] NetlinkError),
+}
+
+/// A result type for test helpers.
+pub type AyaTestResult<T> = Result<T, AyaTestError>;
 
 /// A handle to a child cgroup created under a [`Cgroup`].
 ///
@@ -44,32 +104,46 @@ pub enum Cgroup<'a> {
 
 impl Cgroup<'static> {
     /// Returns a handle to the root cgroup.
-    pub fn root() -> Self {
-        const PROC_MOUNTS: &str = "/proc/self/mounts";
+    pub fn root() -> AyaTestResult<Self> {
         const CGROUP2: &str = "cgroup2";
         {
-            let mounts = fs::File::open(PROC_MOUNTS)
-                .unwrap_or_else(|err| panic!("fs::File::open(\"{PROC_MOUNTS}\"): {err}"));
-            for line in BufReader::new(mounts).lines() {
-                let line = line.unwrap_or_else(|err| {
-                    panic!("line yielded by io::BufReader::new(mounts): {err}")
-                });
-                let mut parts = line.split_whitespace();
-                let device = parts.next().unwrap_or_else(|| {
-                    panic!("mount entry from {PROC_MOUNTS} has no device field: {line}")
-                });
-                let mountpoint = parts.next().unwrap_or_else(|| {
-                    panic!("mount entry from {PROC_MOUNTS} has no mountpoint field: {line}")
-                });
-                let fstype = parts.next().unwrap_or_else(|| {
-                    panic!("mount entry from {PROC_MOUNTS} has no fstype field: {line}")
-                });
+            let mounts = fs::File::open(PROC_MOUNTS).map_err(|source| AyaTestError::Io {
+                op: "open",
+                path: PathBuf::from(PROC_MOUNTS),
+                source,
+            })?;
+            for mount_entry in BufReader::new(mounts).lines() {
+                let mount_entry = mount_entry.map_err(|source| AyaTestError::Io {
+                    op: "retrieve a line",
+                    path: PathBuf::from(PROC_MOUNTS),
+                    source,
+                })?;
+                let mut parts = mount_entry.split_whitespace();
+                let device = parts
+                    .next()
+                    .ok_or_else(|| AyaTestError::MissingMountEntryField {
+                        field: "device",
+                        mount_entry: mount_entry.clone(),
+                    })?;
+                let mountpoint =
+                    parts
+                        .next()
+                        .ok_or_else(|| AyaTestError::MissingMountEntryField {
+                            field: "mountpoint",
+                            mount_entry: mount_entry.clone(),
+                        })?;
+                let fstype = parts
+                    .next()
+                    .ok_or_else(|| AyaTestError::MissingMountEntryField {
+                        field: "fstype",
+                        mount_entry: mount_entry.clone(),
+                    })?;
                 if device == CGROUP2 && fstype == CGROUP2 {
-                    return Self::Root(PathBuf::from(mountpoint));
+                    return Ok(Self::Root(PathBuf::from(mountpoint)));
                 }
             }
         }
-        panic!("could not find a cgroup2 mount entry in {PROC_MOUNTS}");
+        Err(AyaTestError::Cgroup2NotFound)
     }
 }
 
@@ -84,31 +158,44 @@ impl<'a> Cgroup<'a> {
 
     /// Creates a child cgroup with the given name under this cgroup and returns
     /// a [`ChildCgroup`] handle to it.
-    pub fn create_child(&'a self, name: &str) -> ChildCgroup<'a> {
+    pub fn create_child(&'a self, name: &str) -> AyaTestResult<ChildCgroup<'a>> {
         let path = self.path().join(name);
-        fs::create_dir(&path).unwrap();
+        fs::create_dir(&path).map_err(|source| AyaTestError::Io {
+            op: "create directory",
+            path: path.clone(),
+            source,
+        })?;
 
-        ChildCgroup {
+        Ok(ChildCgroup {
             parent: self,
             path: path.into(),
-        }
+        })
     }
 
     /// Writes the given PID to this cgroup's `cgroup.procs` file, thereby
     /// moving that process into this cgroup.
-    pub fn write_pid(&self, pid: u32) {
-        fs::write(self.path().join(CGROUP_PROCS), format!("{pid}\n")).unwrap();
+    pub fn write_pid(&self, pid: u32) -> AyaTestResult<()> {
+        let cgroup_procs = self.path().join(CGROUP_PROCS);
+        fs::write(&cgroup_procs, format!("{pid}\n")).map_err(move |source| AyaTestError::Io {
+            op: "write",
+            path: cgroup_procs,
+            source,
+        })
     }
 }
 
 impl<'a> ChildCgroup<'a> {
     /// Opens the cgroup directory and returns its file descriptor.
-    pub fn fd(&self) -> fs::File {
+    pub fn fd(&self) -> AyaTestResult<fs::File> {
         let Self { parent: _, path } = self;
         fs::OpenOptions::new()
             .read(true)
             .open(path.as_ref())
-            .unwrap()
+            .map_err(|source| AyaTestError::Io {
+                op: "open",
+                path: path.to_path_buf(),
+                source,
+            })
     }
 
     /// Consumes `self` and returns a [`Cgroup::Child`] variant.
@@ -134,6 +221,8 @@ impl Drop for ChildCgroup<'_> {
     )]
     #[expect(clippy::panic, reason = "drop handlers can't return a result")]
     fn drop(&mut self) {
+        use anyhow::{Context as _, Result};
+
         let Self { parent, path } = self;
 
         match (|| -> Result<()> {
@@ -202,27 +291,44 @@ impl NetNsGuard {
         clippy::print_stdout,
         reason = "integration tests print namespace transitions for diagnostics"
     )]
-    pub fn new() -> Self {
+    pub fn new() -> AyaTestResult<Self> {
         // `/proc/thread-self/ns/net` resolves to the calling thread's netns
         // (`/proc/self/ns/net` would always pin to the main thread's).
-        let old_ns = fs::File::open(Self::THREAD_NETNS)
-            .unwrap_or_else(|err| panic!("fs::File::open(\"{}\"): {err:?}", Self::THREAD_NETNS));
+        let old_ns = fs::File::open(Self::THREAD_NETNS).map_err(|source| AyaTestError::Io {
+            op: "open",
+            path: PathBuf::from(Self::THREAD_NETNS),
+            source,
+        })?;
 
         static COUNTER: AtomicU64 = AtomicU64::new(0);
         let pid = process::id();
         let name = format!("aya-test-{pid}-{}", COUNTER.fetch_add(1, Ordering::Relaxed));
 
-        fs::create_dir_all(Self::PERSIST_DIR)
-            .unwrap_or_else(|err| panic!("fs::create_dir_all(\"{}\"): {err:?}", Self::PERSIST_DIR));
+        fs::create_dir_all(Self::PERSIST_DIR).map_err(|source| AyaTestError::Io {
+            op: "create directory",
+            path: PathBuf::from(Self::PERSIST_DIR),
+            source,
+        })?;
         let ns_path = Path::new(Self::PERSIST_DIR).join(&name);
-        let _unused: fs::File = fs::File::create(&ns_path)
-            .unwrap_or_else(|err| panic!("fs::File::create(\"{}\"): {err:?}", ns_path.display()));
-        nix::sched::unshare(nix::sched::CloneFlags::CLONE_NEWNET)
-            .expect("nix::sched::unshare(CLONE_NEWNET)");
+        let _unused: fs::File = fs::File::create(&ns_path).map_err(|source| AyaTestError::Io {
+            op: "create file",
+            path: ns_path.clone(),
+            source,
+        })?;
+        nix::sched::unshare(nix::sched::CloneFlags::CLONE_NEWNET).map_err(|source| {
+            AyaTestError::Syscall {
+                syscall: "unshare",
+                path: None,
+                source,
+            }
+        })?;
 
         // Re-open after unshare to capture the freshly entered namespace.
-        let new_ns = fs::File::open(Self::THREAD_NETNS)
-            .unwrap_or_else(|err| panic!("fs::File::open(\"{}\"): {err:?}", Self::THREAD_NETNS));
+        let new_ns = fs::File::open(Self::THREAD_NETNS).map_err(|source| AyaTestError::Io {
+            op: "open",
+            path: PathBuf::from(Self::THREAD_NETNS),
+            source,
+        })?;
 
         nix::mount::mount(
             Some(Self::THREAD_NETNS),
@@ -231,7 +337,11 @@ impl NetNsGuard {
             nix::mount::MsFlags::MS_BIND,
             None::<&str>,
         )
-        .expect("nix::mount::mount");
+        .map_err(|source| AyaTestError::Syscall {
+            syscall: "mount",
+            path: Some(ns_path.clone()),
+            source,
+        })?;
 
         println!("entered network namespace {name}");
 
@@ -242,20 +352,20 @@ impl NetNsGuard {
         };
 
         // By default, the loopback in a new netns is down. Set it up.
-        let lo = CString::new("lo").unwrap();
+        let lo = c"lo";
         unsafe {
             let idx = if_nametoindex(lo.as_ptr());
-            assert!(
-                idx != 0,
-                "interface `lo` not found in netns {}: {}",
-                ns.name,
-                io::Error::last_os_error()
-            );
-            netlink_set_link_up(idx as i32)
-                .unwrap_or_else(|e| panic!("failed to set `lo` up in netns {}: {e}", ns.name));
+            if idx == 0 {
+                return Err(AyaTestError::Io {
+                    op: "lookup interface index",
+                    path: PathBuf::from("lo"),
+                    source: io::Error::last_os_error(),
+                });
+            }
+            netlink_set_link_up(idx as i32)?;
         }
 
-        ns
+        Ok(ns)
     }
 }
 
@@ -281,6 +391,8 @@ impl Drop for NetNsGuard {
     )]
     #[expect(clippy::panic, reason = "drop handlers can't return a result")]
     fn drop(&mut self) {
+        use anyhow::{Context as _, Result};
+
         let Self {
             old_ns,
             name,

--- a/aya/src/test_helpers.rs
+++ b/aya/src/test_helpers.rs
@@ -12,8 +12,9 @@ use std::{
 };
 
 use anyhow::{Context as _, Result};
-use aya::netlink_set_link_up;
 use libc::if_nametoindex;
+
+use crate::netlink_set_link_up;
 
 /// The cgroup-relative name of the file to which a PID is written to assign
 /// that process to the cgroup.
@@ -23,7 +24,7 @@ const CGROUP_PROCS: &str = "cgroup.procs";
 ///
 /// On drop, the PIDs in this cgroup's `cgroup.procs` are moved back to the
 /// parent cgroup and the directory is removed.
-pub(crate) struct ChildCgroup<'a> {
+pub struct ChildCgroup<'a> {
     /// The parent cgroup under which this child was created.
     parent: &'a Cgroup<'a>,
     /// The filesystem path of this cgroup directory.
@@ -34,7 +35,7 @@ pub(crate) struct ChildCgroup<'a> {
 ///
 /// This enum is used to avoid unnecessary reference counting when the root
 /// cgroup is the only handle needed.
-pub(crate) enum Cgroup<'a> {
+pub enum Cgroup<'a> {
     /// The root cgroup.
     Root(PathBuf),
     /// A child cgroup created via [`Cgroup::create_child`].
@@ -43,7 +44,7 @@ pub(crate) enum Cgroup<'a> {
 
 impl Cgroup<'static> {
     /// Returns a handle to the root cgroup.
-    pub(crate) fn root() -> Self {
+    pub fn root() -> Self {
         const PROC_MOUNTS: &str = "/proc/self/mounts";
         const CGROUP2: &str = "cgroup2";
         {
@@ -83,7 +84,7 @@ impl<'a> Cgroup<'a> {
 
     /// Creates a child cgroup with the given name under this cgroup and returns
     /// a [`ChildCgroup`] handle to it.
-    pub(crate) fn create_child(&'a self, name: &str) -> ChildCgroup<'a> {
+    pub fn create_child(&'a self, name: &str) -> ChildCgroup<'a> {
         let path = self.path().join(name);
         fs::create_dir(&path).unwrap();
 
@@ -95,14 +96,14 @@ impl<'a> Cgroup<'a> {
 
     /// Writes the given PID to this cgroup's `cgroup.procs` file, thereby
     /// moving that process into this cgroup.
-    pub(crate) fn write_pid(&self, pid: u32) {
+    pub fn write_pid(&self, pid: u32) {
         fs::write(self.path().join(CGROUP_PROCS), format!("{pid}\n")).unwrap();
     }
 }
 
 impl<'a> ChildCgroup<'a> {
     /// Opens the cgroup directory and returns its file descriptor.
-    pub(crate) fn fd(&self) -> fs::File {
+    pub fn fd(&self) -> fs::File {
         let Self { parent: _, path } = self;
         fs::OpenOptions::new()
             .read(true)
@@ -111,7 +112,7 @@ impl<'a> ChildCgroup<'a> {
     }
 
     /// Consumes `self` and returns a [`Cgroup::Child`] variant.
-    pub(crate) fn into_cgroup(self) -> Cgroup<'a> {
+    pub const fn into_cgroup(self) -> Cgroup<'a> {
         Cgroup::Child(self)
     }
 }
@@ -131,6 +132,7 @@ impl Drop for ChildCgroup<'_> {
         clippy::use_debug,
         reason = "debug formatting preserves error context in drop"
     )]
+    #[expect(clippy::panic, reason = "drop handlers can't return a result")]
     fn drop(&mut self) {
         let Self { parent, path } = self;
 
@@ -175,7 +177,7 @@ impl Drop for ChildCgroup<'_> {
 ///
 /// The guard also brings up the `lo` (loopback) interface in the new
 /// namespace by default, since it is down in freshly created namespaces.
-pub(crate) struct NetNsGuard {
+pub struct NetNsGuard {
     /// The name of the persisted network namespace.
     name: String,
     /// File handle to the original network namespace, used for restoration on drop.
@@ -200,7 +202,7 @@ impl NetNsGuard {
         clippy::print_stdout,
         reason = "integration tests print namespace transitions for diagnostics"
     )]
-    pub(crate) fn new() -> Self {
+    pub fn new() -> Self {
         // `/proc/thread-self/ns/net` resolves to the calling thread's netns
         // (`/proc/self/ns/net` would always pin to the main thread's).
         let old_ns = fs::File::open(Self::THREAD_NETNS)
@@ -277,6 +279,7 @@ impl Drop for NetNsGuard {
         clippy::use_debug,
         reason = "debug formatting preserves error context in drop"
     )]
+    #[expect(clippy::panic, reason = "drop handlers can't return a result")]
     fn drop(&mut self) {
         let Self {
             old_ns,
@@ -313,10 +316,12 @@ impl Drop for NetNsGuard {
 /// Otherwise, evaluates to `assert!(!$cond)`.
 ///
 /// This is useful for tests that behave differently across kernel versions.
-macro_rules! kernel_assert {
+#[doc(hidden)]
+#[macro_export]
+macro_rules! __aya_kernel_assert {
     ($cond:expr, $version:expr $(,)?) => {
-        let current = aya::util::KernelVersion::current().unwrap();
-        let required: aya::util::KernelVersion = $version;
+        let current = $crate::util::KernelVersion::current().unwrap();
+        let required: $crate::util::KernelVersion = $version;
         if current >= required {
             assert!($cond, "{current} >= {required}");
         } else {
@@ -325,8 +330,6 @@ macro_rules! kernel_assert {
     };
 }
 
-pub(crate) use kernel_assert;
-
 /// Asserts equality based on the running kernel version.
 ///
 /// If `KernelVersion::current >= $version`, evaluates to `assert_eq!($left, $right)`.
@@ -334,10 +337,12 @@ pub(crate) use kernel_assert;
 ///
 /// This is useful for tests that check for behavioral changes introduced in
 /// specific kernel versions.
-macro_rules! kernel_assert_eq {
+#[doc(hidden)]
+#[macro_export]
+macro_rules! __aya_kernel_assert_eq {
     ($left:expr, $right:expr, $version:expr $(,)?) => {
-        let current = aya::util::KernelVersion::current().unwrap();
-        let required: aya::util::KernelVersion = $version;
+        let current = $crate::util::KernelVersion::current().unwrap();
+        let required: $crate::util::KernelVersion = $version;
         if current >= required {
             assert_eq!($left, $right, "{current} >= {required}");
         } else {
@@ -346,4 +351,7 @@ macro_rules! kernel_assert_eq {
     };
 }
 
-pub(crate) use kernel_assert_eq;
+/// Asserts a condition based on the running kernel version.
+pub use crate::__aya_kernel_assert as kernel_assert;
+/// Asserts equality based on the running kernel version.
+pub use crate::__aya_kernel_assert_eq as kernel_assert_eq;

--- a/test/integration-test/Cargo.toml
+++ b/test/integration-test/Cargo.toml
@@ -14,7 +14,9 @@ rust-version.workspace = true
 workspace = true
 
 [dependencies]
-aya = { path = "../../aya", version = "^0.13.2", default-features = false }
+aya = { path = "../../aya", version = "^0.13.2", default-features = false, features = [
+    "test-helpers",
+] }
 
 [dev-dependencies]
 anyhow = { workspace = true, features = ["std"] }

--- a/test/integration-test/src/lib.rs
+++ b/test/integration-test/src/lib.rs
@@ -89,5 +89,3 @@ bpf_file!(
 
 #[cfg(test)]
 mod tests;
-#[cfg(test)]
-mod utils;

--- a/test/integration-test/src/tests.rs
+++ b/test/integration-test/src/tests.rs
@@ -8,6 +8,20 @@
     reason = "debug formatting aids diagnostics in tests"
 )]
 
+fn run_netns_tokio<F, Fut, T>(test: F) -> T
+where
+    F: FnOnce() -> Fut,
+    Fut: Future<Output = T>,
+{
+    let _netns = aya::test_helpers::NetNsGuard::new().unwrap();
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+
+    runtime.block_on(test())
+}
+
 mod array;
 mod bloom_filter;
 mod bpf_probe_read;

--- a/test/integration-test/src/tests/cgroup_array.rs
+++ b/test/integration-test/src/tests/cgroup_array.rs
@@ -65,8 +65,8 @@ fn current_task_under_cgroup(
 
     // The cgroup root is an ancestor of every task; a fresh child cgroup that
     // the test process is not moved into is not.
-    let root = Cgroup::root();
-    let not_under = root.create_child(prog);
+    let root = Cgroup::root().unwrap();
+    let not_under = root.create_child(prog).unwrap();
     let under = File::open("/sys/fs/cgroup").expect("open cgroup root");
 
     let mut cgroups: CgroupArray<_> = bpf.take_map(cgroups_map).unwrap().try_into().unwrap();
@@ -74,7 +74,7 @@ fn current_task_under_cgroup(
         .set(UNDER_INDEX, under.as_raw_fd(), 0)
         .expect("set UNDER_INDEX");
     cgroups
-        .set(NOT_UNDER_INDEX, not_under.fd().as_raw_fd(), 0)
+        .set(NOT_UNDER_INDEX, not_under.fd().unwrap().as_raw_fd(), 0)
         .expect("set NOT_UNDER_INDEX");
 
     let result = Array::<_, TestResult>::try_from(bpf.map(result_map).unwrap()).unwrap();

--- a/test/integration-test/src/tests/cgroup_array.rs
+++ b/test/integration-test/src/tests/cgroup_array.rs
@@ -5,12 +5,11 @@ use aya::{
     maps::{Array, CgroupArray, MapType},
     programs::{SchedClassifier, UProbe, uprobe::UProbeScope},
     sys::is_map_supported,
+    test_helpers::Cgroup,
     util::KernelVersion,
 };
 use integration_common::cgroup_array::{NOT_UNDER_INDEX, TestResult, UNDER_INDEX};
 use rstest::rstest;
-
-use crate::utils::Cgroup;
 
 #[unsafe(no_mangle)]
 #[inline(never)]

--- a/test/integration-test/src/tests/cgroup_array.rs
+++ b/test/integration-test/src/tests/cgroup_array.rs
@@ -10,7 +10,7 @@ use aya::{
 use integration_common::cgroup_array::{NOT_UNDER_INDEX, TestResult, UNDER_INDEX};
 use rstest::rstest;
 
-use crate::utils::{Cgroup, is_cgroup2};
+use crate::utils::Cgroup;
 
 #[unsafe(no_mangle)]
 #[inline(never)]
@@ -29,11 +29,6 @@ fn current_task_under_cgroup(
 ) {
     if !is_map_supported(MapType::CgroupArray).unwrap() {
         eprintln!("skipping test - cgroup array map not supported");
-        return;
-    }
-
-    if !is_cgroup2() {
-        eprintln!("skipping test - /sys/fs/cgroup is not cgroup2");
         return;
     }
 

--- a/test/integration-test/src/tests/cgroup_storage.rs
+++ b/test/integration-test/src/tests/cgroup_storage.rs
@@ -19,7 +19,7 @@ use aya::{
 use aya_obj::generated::bpf_attach_type::BPF_CGROUP_INET4_CONNECT;
 use rstest::rstest;
 
-use crate::utils::{Cgroup, NetNsGuard, is_cgroup2};
+use crate::utils::{Cgroup, NetNsGuard};
 
 #[rstest]
 #[case::legacy("STORAGE_LEGACY", "PERCPU_LEGACY", "connect4_legacy")]
@@ -30,11 +30,6 @@ fn cgroup_storage(#[case] storage_map: &str, #[case] percpu_map: &str, #[case] p
         || !is_map_supported(MapType::PerCpuCgroupStorage).unwrap()
     {
         eprintln!("skipping test - cgroup storage maps not supported");
-        return;
-    }
-
-    if !is_cgroup2() {
-        eprintln!("skipping test - /sys/fs/cgroup is not cgroup2");
         return;
     }
 

--- a/test/integration-test/src/tests/cgroup_storage.rs
+++ b/test/integration-test/src/tests/cgroup_storage.rs
@@ -14,12 +14,11 @@ use aya::{
     maps::{CgroupStorage, CgroupStorageKey, MapType, PerCpuCgroupStorage},
     programs::{CgroupAttachMode, CgroupSockAddr},
     sys::is_map_supported,
+    test_helpers::{Cgroup, NetNsGuard},
     util::KernelVersion,
 };
 use aya_obj::generated::bpf_attach_type::BPF_CGROUP_INET4_CONNECT;
 use rstest::rstest;
-
-use crate::utils::{Cgroup, NetNsGuard};
 
 #[rstest]
 #[case::legacy("STORAGE_LEGACY", "PERCPU_LEGACY", "connect4_legacy")]

--- a/test/integration-test/src/tests/cgroup_storage.rs
+++ b/test/integration-test/src/tests/cgroup_storage.rs
@@ -44,10 +44,10 @@ fn cgroup_storage(#[case] storage_map: &str, #[case] percpu_map: &str, #[case] p
         .load(crate::CGROUP_STORAGE)
         .expect("load cgroup_storage program");
 
-    let _netns = NetNsGuard::new();
-    let root = Cgroup::root();
-    let cgroup = root.create_child(prog);
-    let cgroup_fd = cgroup.fd();
+    let _netns = NetNsGuard::new().unwrap();
+    let root = Cgroup::root().unwrap();
+    let cgroup = root.create_child(prog).unwrap();
+    let cgroup_fd = cgroup.fd().unwrap();
     let cgroup_inode_id = cgroup_fd.metadata().expect("cgroup metadata").ino();
 
     {
@@ -65,7 +65,7 @@ fn cgroup_storage(#[case] storage_map: &str, #[case] percpu_map: &str, #[case] p
     }
 
     let cgroup = cgroup.into_cgroup();
-    cgroup.write_pid(process::id());
+    cgroup.write_pid(process::id()).unwrap();
 
     // A single connect over loopback fires the connect4 program exactly once.
     let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).unwrap();

--- a/test/integration-test/src/tests/cgroup_storage.rs
+++ b/test/integration-test/src/tests/cgroup_storage.rs
@@ -53,7 +53,8 @@ fn cgroup_storage(#[case] storage_map: &str, #[case] percpu_map: &str, #[case] p
     let _netns = NetNsGuard::new();
     let root = Cgroup::root();
     let cgroup = root.create_child(prog);
-    let cgroup_inode_id = cgroup.fd().metadata().expect("cgroup metadata").ino();
+    let cgroup_fd = cgroup.fd();
+    let cgroup_inode_id = cgroup_fd.metadata().expect("cgroup metadata").ino();
 
     {
         let program: &mut CgroupSockAddr = bpf
@@ -65,7 +66,7 @@ fn cgroup_storage(#[case] storage_map: &str, #[case] percpu_map: &str, #[case] p
             .load()
             .unwrap_or_else(|err| panic!("load {prog}: {err}"));
         program
-            .attach(cgroup.fd(), CgroupAttachMode::Single)
+            .attach(cgroup_fd, CgroupAttachMode::Single)
             .unwrap_or_else(|err| panic!("attach {prog}: {err}"));
     }
 

--- a/test/integration-test/src/tests/cgrp_storage.rs
+++ b/test/integration-test/src/tests/cgrp_storage.rs
@@ -4,11 +4,10 @@ use aya::{
     maps::{CgrpStorage, MapError, MapType},
     programs::{BtfTracePoint, ProgramType},
     sys::{is_map_supported, is_program_supported},
+    test_helpers::Cgroup,
 };
 use integration_common::local_storage::SENTINEL;
 use test_log::test;
-
-use crate::utils::Cgroup;
 
 #[test]
 fn cgrp_storage() {

--- a/test/integration-test/src/tests/cgrp_storage.rs
+++ b/test/integration-test/src/tests/cgrp_storage.rs
@@ -33,9 +33,9 @@ fn cgrp_storage() {
     prog.attach().unwrap();
 
     // Creating a cgroup fires `cgroup_mkdir`, populating its storage.
-    let root = Cgroup::root();
-    let cgroup = root.create_child("aya-test-cgrp-storage");
-    let cgroup_fd = cgroup.fd();
+    let root = Cgroup::root().unwrap();
+    let cgroup = root.create_child("aya-test-cgrp-storage").unwrap();
+    let cgroup_fd = cgroup.fd().unwrap();
 
     let mut storage =
         CgrpStorage::<_, u64>::try_from(bpf.map_mut("CGRP_STORAGE").unwrap()).unwrap();

--- a/test/integration-test/src/tests/cgrp_storage.rs
+++ b/test/integration-test/src/tests/cgrp_storage.rs
@@ -8,7 +8,7 @@ use aya::{
 use integration_common::local_storage::SENTINEL;
 use test_log::test;
 
-use crate::utils::{Cgroup, is_cgroup2};
+use crate::utils::Cgroup;
 
 #[test]
 fn cgrp_storage() {
@@ -19,11 +19,6 @@ fn cgrp_storage() {
 
     if !is_program_supported(ProgramType::Tracing).unwrap() {
         eprintln!("skipping test - tracing programs not supported");
-        return;
-    }
-
-    if !is_cgroup2() {
-        eprintln!("skipping test - /sys/fs/cgroup is not cgroup2");
         return;
     }
 

--- a/test/integration-test/src/tests/cgrp_storage.rs
+++ b/test/integration-test/src/tests/cgrp_storage.rs
@@ -41,12 +41,13 @@ fn cgrp_storage() {
     // Creating a cgroup fires `cgroup_mkdir`, populating its storage.
     let root = Cgroup::root();
     let cgroup = root.create_child("aya-test-cgrp-storage");
+    let cgroup_fd = cgroup.fd();
 
     let mut storage =
         CgrpStorage::<_, u64>::try_from(bpf.map_mut("CGRP_STORAGE").unwrap()).unwrap();
-    assert_matches!(storage.get(cgroup.fd(), 0), Ok(value) => {
+    assert_matches!(storage.get(&cgroup_fd, 0), Ok(value) => {
         assert_eq!(value, SENTINEL);
     });
-    storage.remove(cgroup.fd()).unwrap();
-    assert_matches!(storage.get(cgroup.fd(), 0), Err(MapError::KeyNotFound));
+    storage.remove(&cgroup_fd).unwrap();
+    assert_matches!(storage.get(&cgroup_fd, 0), Err(MapError::KeyNotFound));
 }

--- a/test/integration-test/src/tests/feature_probe.rs
+++ b/test/integration-test/src/tests/feature_probe.rs
@@ -8,11 +8,10 @@ use aya::{
     maps::MapType,
     programs::{LsmAttachType, ProgramError, ProgramType},
     sys::{BpfHelper, is_helper_supported, is_map_supported, is_program_supported},
+    test_helpers::kernel_assert,
     util::KernelVersion,
 };
 use procfs::kernel_config;
-
-use crate::utils::kernel_assert;
 
 #[test_log::test]
 fn probe_supported_programs() {

--- a/test/integration-test/src/tests/info.rs
+++ b/test/integration-test/src/tests/info.rs
@@ -16,12 +16,11 @@ use aya::{
         uprobe::UProbeScope,
     },
     sys::{is_map_supported, is_program_supported},
+    test_helpers::{kernel_assert, kernel_assert_eq},
     util::KernelVersion,
 };
 use aya_obj::generated::bpf_prog_type;
 use libc::EINVAL;
-
-use crate::utils::{kernel_assert, kernel_assert_eq};
 
 #[test_log::test]
 fn test_loaded_programs() {

--- a/test/integration-test/src/tests/load.rs
+++ b/test/integration-test/src/tests/load.rs
@@ -447,7 +447,7 @@ fn pin_tcx_link() {
     }
 
     use aya::test_helpers::NetNsGuard;
-    let _netns = NetNsGuard::new();
+    let _netns = NetNsGuard::new().unwrap();
 
     let program_name = "tcx_next";
     let pin_path = "/sys/fs/bpf/aya-tcx-test-lo";

--- a/test/integration-test/src/tests/load.rs
+++ b/test/integration-test/src/tests/load.rs
@@ -446,7 +446,7 @@ fn pin_tcx_link() {
         return;
     }
 
-    use crate::utils::NetNsGuard;
+    use aya::test_helpers::NetNsGuard;
     let _netns = NetNsGuard::new();
 
     let program_name = "tcx_next";

--- a/test/integration-test/src/tests/lsm.rs
+++ b/test/integration-test/src/tests/lsm.rs
@@ -3,10 +3,9 @@ use aya::{
     Btf, Ebpf,
     programs::{Lsm, LsmAttachType, LsmCgroup, ProgramError, ProgramType},
     sys::{SyscallError, is_program_supported},
+    test_helpers::Cgroup,
     util::KernelVersion,
 };
-
-use crate::utils::Cgroup;
 
 macro_rules! expect_permission_denied {
     ($result:expr) => {

--- a/test/integration-test/src/tests/lsm.rs
+++ b/test/integration-test/src/tests/lsm.rs
@@ -74,11 +74,11 @@ fn lsm_cgroup() {
     assert_matches!(std::net::TcpListener::bind("127.0.0.1:0"), Ok(_));
 
     let pid = std::process::id();
-    let root = Cgroup::root();
-    let cgroup = root.create_child("aya-test-lsm-cgroup");
+    let root = Cgroup::root().unwrap();
+    let cgroup = root.create_child("aya-test-lsm-cgroup").unwrap();
 
     let link_id = {
-        let result = prog.attach(cgroup.fd());
+        let result = prog.attach(cgroup.fd().unwrap());
 
         // See https://www.exein.io/blog/exploring-bpf-lsm-support-on-aarch64-with-ftrace.
         if cfg!(target_arch = "aarch64")
@@ -96,15 +96,15 @@ fn lsm_cgroup() {
 
     let cgroup = cgroup.into_cgroup();
 
-    cgroup.write_pid(pid);
+    cgroup.write_pid(pid).unwrap();
 
     expect_permission_denied!(std::net::TcpListener::bind("127.0.0.1:0"));
 
-    root.write_pid(pid);
+    root.write_pid(pid).unwrap();
 
     assert_matches!(std::net::TcpListener::bind("127.0.0.1:0"), Ok(_));
 
-    cgroup.write_pid(pid);
+    cgroup.write_pid(pid).unwrap();
 
     expect_permission_denied!(std::net::TcpListener::bind("127.0.0.1:0"));
 

--- a/test/integration-test/src/tests/sk_lookup.rs
+++ b/test/integration-test/src/tests/sk_lookup.rs
@@ -76,7 +76,7 @@ fn redirect_sk_lookup(
         return;
     }
 
-    let netns = NetNsGuard::new();
+    let netns = NetNsGuard::new().unwrap();
 
     let canary = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).expect("bind canary listener");
 
@@ -129,7 +129,7 @@ fn redirect_sk_lookup_miss_propagates_enoent(
         return;
     }
 
-    let netns = NetNsGuard::new();
+    let netns = NetNsGuard::new().unwrap();
 
     // Empty map: `redirect_sk_lookup` must return `Err(-ENOENT)` and the BPF
     // program records it in LAST_ERRNO before returning SK_DROP.

--- a/test/integration-test/src/tests/sk_lookup.rs
+++ b/test/integration-test/src/tests/sk_lookup.rs
@@ -10,11 +10,10 @@ use aya::{
     maps::{Array, MapType, SockHash, SockMap},
     programs::{ProgramType, SkLookup},
     sys::{is_map_supported, is_program_supported},
+    test_helpers::NetNsGuard,
 };
 use libc::ENOENT;
 use rstest::rstest;
-
-use crate::utils::NetNsGuard;
 
 const CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
 const MISS_TIMEOUT: Duration = Duration::from_millis(200);

--- a/test/integration-test/src/tests/sk_reuseport.rs
+++ b/test/integration-test/src/tests/sk_reuseport.rs
@@ -154,7 +154,7 @@ async fn sk_reuseport_selects_expected_listener(
     #[case] select_prog: &str,
 ) {
     // Aya's CI VM init may leave `lo` down; NetNsGuard brings it up.
-    let _netns = NetNsGuard::new();
+    let _netns = NetNsGuard::new().unwrap();
 
     let mut ebpf = Ebpf::load(crate::SK_REUSEPORT).unwrap();
     let mut socket_array: ReusePortSockArray<_> =
@@ -216,7 +216,7 @@ async fn sk_reuseport_clear_index_changes_selection(
     #[case] clear_prog: &str,
 ) {
     // Aya's CI VM init may leave `lo` down; NetNsGuard brings it up.
-    let _netns = NetNsGuard::new();
+    let _netns = NetNsGuard::new().unwrap();
 
     let mut ebpf = Ebpf::load(crate::SK_REUSEPORT).unwrap();
     let mut socket_array: ReusePortSockArray<_> =
@@ -277,7 +277,7 @@ async fn sk_reuseport_clear_index_changes_selection(
 #[test_attr(test_log::test(tokio::test))]
 async fn sk_reuseport_stays_attached_until_explicit_detach(#[case] select_prog: &str) {
     // Aya's CI VM init may leave `lo` down; NetNsGuard brings it up.
-    let _netns = NetNsGuard::new();
+    let _netns = NetNsGuard::new().unwrap();
 
     let mut ebpf = Ebpf::load(crate::SK_REUSEPORT).unwrap();
     let [first, second] = reuseport_listeners();
@@ -317,7 +317,7 @@ async fn sk_reuseport_migrates_to_expected_listener(
     }
 
     // Aya's CI VM init may leave `lo` down; NetNsGuard brings it up.
-    let _netns = NetNsGuard::new();
+    let _netns = NetNsGuard::new().unwrap();
     match std::fs::write("/proc/sys/net/ipv4/tcp_migrate_req", "1") {
         Ok(()) => {}
         Err(err)

--- a/test/integration-test/src/tests/sk_reuseport.rs
+++ b/test/integration-test/src/tests/sk_reuseport.rs
@@ -10,7 +10,6 @@ use aya::{
     Ebpf,
     maps::{Array, MapData, ReusePortSockArray},
     programs::{ProgramError, SkReuseport, SkReuseportError},
-    test_helpers::NetNsGuard,
     util::KernelVersion,
 };
 use futures::future::select_all;
@@ -25,6 +24,8 @@ use tokio::{
     net::{TcpListener as TokioTcpListener, TcpSocket, TcpStream as TokioTcpStream},
     time::{sleep, timeout},
 };
+
+use super::run_netns_tokio;
 
 const RETRY_DURATION: Duration = Duration::from_millis(10);
 const ACCEPT_TIMEOUT: Duration = Duration::from_secs(10);
@@ -148,165 +149,156 @@ async fn assert_connection_works(mut client: TokioTcpStream, mut server: TokioTc
 #[rstest]
 #[case::legacy("socket_map", "select_socket")]
 #[case::btf("socket_map_btf", "select_socket_btf")]
-#[test_attr(test_log::test(tokio::test))]
-async fn sk_reuseport_selects_expected_listener(
-    #[case] socket_map: &str,
-    #[case] select_prog: &str,
-) {
-    // Aya's CI VM init may leave `lo` down; NetNsGuard brings it up.
-    let _netns = NetNsGuard::new().unwrap();
+#[test_attr(test_log::test)]
+fn sk_reuseport_selects_expected_listener(#[case] socket_map: &str, #[case] select_prog: &str) {
+    run_netns_tokio(async || {
+        let mut ebpf = Ebpf::load(crate::SK_REUSEPORT).unwrap();
+        let mut socket_array: ReusePortSockArray<_> =
+            ebpf.take_map(socket_map).unwrap().try_into().unwrap();
+        let path_hits: Array<_, u64> = ebpf.take_map("path_hits").unwrap().try_into().unwrap();
+        let [first, second, third] = reuseport_listeners();
+        let addr = first.local_addr().unwrap();
 
-    let mut ebpf = Ebpf::load(crate::SK_REUSEPORT).unwrap();
-    let mut socket_array: ReusePortSockArray<_> =
-        ebpf.take_map(socket_map).unwrap().try_into().unwrap();
-    let path_hits: Array<_, u64> = ebpf.take_map("path_hits").unwrap().try_into().unwrap();
-    let [first, second, third] = reuseport_listeners();
-    let addr = first.local_addr().unwrap();
+        for (index, listener) in [&first, &second, &third].into_iter().enumerate() {
+            socket_array.set(index as u32, listener, 0).unwrap();
+        }
 
-    for (index, listener) in [&first, &second, &third].into_iter().enumerate() {
-        socket_array.set(index as u32, listener, 0).unwrap();
-    }
+        {
+            // Limit the mutable borrow of `ebpf` from `program_mut()` to this block.
+            let prog: &mut SkReuseport = ebpf.program_mut(select_prog).unwrap().try_into().unwrap();
+            prog.load().unwrap();
+            prog.attach(&first).unwrap();
+        }
 
-    {
-        // Limit the mutable borrow of `ebpf` from `program_mut()` to this block.
-        let prog: &mut SkReuseport = ebpf.program_mut(select_prog).unwrap().try_into().unwrap();
-        prog.load().unwrap();
-        prog.attach(&first).unwrap();
-    }
+        let client = connect(addr).await.unwrap();
+        let (accepted_idx, server) = wait_for_accept_tokio(&[&first, &second, &third]).await;
+        assert_eq!(
+            accepted_idx, SELECT_SOCKET_INDEX as usize,
+            "connection should be steered to listener A",
+        );
 
-    let client = connect(addr).await.unwrap();
-    let (accepted_idx, server) = wait_for_accept_tokio(&[&first, &second, &third]).await;
-    assert_eq!(
-        accepted_idx, SELECT_SOCKET_INDEX as usize,
-        "connection should be steered to listener A",
-    );
+        // Confirm that the BPF select path ran, not just the kernel's default
+        // SO_REUSEPORT selection logic landing on listener A by chance.
+        assert!(
+            read_hits(&path_hits, SELECT_HITS_INDEX) > 0,
+            "select path did not run",
+        );
+        assert_eq!(read_hits(&path_hits, MIGRATE_HITS_INDEX), 0);
+        assert_eq!(read_hits(&path_hits, CLEAR_FALLBACK_HITS_INDEX), 0);
+        assert_connection_works(client, server).await;
 
-    // Confirm that the BPF select path ran, not just the kernel's default
-    // SO_REUSEPORT selection logic landing on listener A by chance.
-    assert!(
-        read_hits(&path_hits, SELECT_HITS_INDEX) > 0,
-        "select path did not run",
-    );
-    assert_eq!(read_hits(&path_hits, MIGRATE_HITS_INDEX), 0);
-    assert_eq!(read_hits(&path_hits, CLEAR_FALLBACK_HITS_INDEX), 0);
-    assert_connection_works(client, server).await;
+        // `SkReuseport` attachments are group-scoped: detaching through any socket in
+        // the reuseport group removes the program from the whole group, even if that
+        // socket was not used for attach, so a second detach through listener A yields
+        // ENOENT.
+        SkReuseport::detach(&second).unwrap();
 
-    // `SkReuseport` attachments are group-scoped: detaching through any socket in
-    // the reuseport group removes the program from the whole group, even if that
-    // socket was not used for attach, so a second detach through listener A yields
-    // ENOENT.
-    SkReuseport::detach(&second).unwrap();
-
-    let err = SkReuseport::detach(&first).unwrap_err();
-    assert_matches!(
-        err,
-        ProgramError::SkReuseportError(SkReuseportError::SetsockoptError {
-            option: "SO_DETACH_REUSEPORT_BPF",
-            io_error,
-        }) if io_error.raw_os_error() == Some(ENOENT)
-    );
+        let err = SkReuseport::detach(&first).unwrap_err();
+        assert_matches!(
+            err,
+            ProgramError::SkReuseportError(SkReuseportError::SetsockoptError {
+                option: "SO_DETACH_REUSEPORT_BPF",
+                io_error,
+            }) if io_error.raw_os_error() == Some(ENOENT)
+        );
+    });
 }
 
 #[rstest]
 #[case::legacy("socket_map", "select_socket_after_clear")]
 #[case::btf("socket_map_btf", "select_socket_after_clear_btf")]
-#[test_attr(test_log::test(tokio::test))]
-async fn sk_reuseport_clear_index_changes_selection(
-    #[case] socket_map: &str,
-    #[case] clear_prog: &str,
-) {
-    // Aya's CI VM init may leave `lo` down; NetNsGuard brings it up.
-    let _netns = NetNsGuard::new().unwrap();
+#[test_attr(test_log::test)]
+fn sk_reuseport_clear_index_changes_selection(#[case] socket_map: &str, #[case] clear_prog: &str) {
+    run_netns_tokio(async || {
+        let mut ebpf = Ebpf::load(crate::SK_REUSEPORT).unwrap();
+        let mut socket_array: ReusePortSockArray<_> =
+            ebpf.take_map(socket_map).unwrap().try_into().unwrap();
+        let path_hits: Array<_, u64> = ebpf.take_map("path_hits").unwrap().try_into().unwrap();
+        let [first, second, third] = reuseport_listeners();
+        let addr = first.local_addr().unwrap();
 
-    let mut ebpf = Ebpf::load(crate::SK_REUSEPORT).unwrap();
-    let mut socket_array: ReusePortSockArray<_> =
-        ebpf.take_map(socket_map).unwrap().try_into().unwrap();
-    let path_hits: Array<_, u64> = ebpf.take_map("path_hits").unwrap().try_into().unwrap();
-    let [first, second, third] = reuseport_listeners();
-    let addr = first.local_addr().unwrap();
+        for (index, listener) in [&first, &second, &third].into_iter().enumerate() {
+            socket_array.set(index as u32, listener, 0).unwrap();
+        }
 
-    for (index, listener) in [&first, &second, &third].into_iter().enumerate() {
-        socket_array.set(index as u32, listener, 0).unwrap();
-    }
+        {
+            // Limit the mutable borrow of `ebpf` from `program_mut()` to this block.
+            let prog: &mut SkReuseport = ebpf.program_mut(clear_prog).unwrap().try_into().unwrap();
+            prog.load().unwrap();
+            prog.attach(&first).unwrap();
+        }
 
-    {
-        // Limit the mutable borrow of `ebpf` from `program_mut()` to this block.
-        let prog: &mut SkReuseport = ebpf.program_mut(clear_prog).unwrap().try_into().unwrap();
-        prog.load().unwrap();
-        prog.attach(&first).unwrap();
-    }
+        let first_client = connect(addr).await.unwrap();
+        let (first_accepted_idx, first_server) =
+            wait_for_accept_tokio(&[&first, &second, &third]).await;
+        assert_eq!(
+            first_accepted_idx, SELECT_SOCKET_INDEX as usize,
+            "before clearing key 0, the program should steer to listener A",
+        );
+        assert!(
+            read_hits(&path_hits, SELECT_HITS_INDEX) > 0,
+            "select path did not run before clear",
+        );
+        assert_eq!(read_hits(&path_hits, MIGRATE_HITS_INDEX), 0);
+        assert_eq!(read_hits(&path_hits, CLEAR_FALLBACK_HITS_INDEX), 0);
+        assert_connection_works(first_client, first_server).await;
 
-    let first_client = connect(addr).await.unwrap();
-    let (first_accepted_idx, first_server) =
-        wait_for_accept_tokio(&[&first, &second, &third]).await;
-    assert_eq!(
-        first_accepted_idx, SELECT_SOCKET_INDEX as usize,
-        "before clearing key 0, the program should steer to listener A",
-    );
-    assert!(
-        read_hits(&path_hits, SELECT_HITS_INDEX) > 0,
-        "select path did not run before clear",
-    );
-    assert_eq!(read_hits(&path_hits, MIGRATE_HITS_INDEX), 0);
-    assert_eq!(read_hits(&path_hits, CLEAR_FALLBACK_HITS_INDEX), 0);
-    assert_connection_works(first_client, first_server).await;
+        socket_array.clear_index(&SELECT_SOCKET_INDEX).unwrap();
 
-    socket_array.clear_index(&SELECT_SOCKET_INDEX).unwrap();
-
-    let second_client = connect(addr).await.unwrap();
-    let (second_accepted_idx, second_server) =
-        wait_for_accept_tokio(&[&first, &second, &third]).await;
-    assert_eq!(
-        second_accepted_idx, MIGRATE_SOCKET_INDEX as usize,
-        "after clearing key 0, the program should fall back to listener C",
-    );
-    assert_eq!(read_hits(&path_hits, MIGRATE_HITS_INDEX), 0);
-    // Confirm that the test program observed the missing primary key and
-    // explicitly selected listener C, rather than relying on the kernel's
-    // default SO_REUSEPORT selection logic.
-    assert!(
-        read_hits(&path_hits, CLEAR_FALLBACK_HITS_INDEX) > 0,
-        "clear fallback path did not run",
-    );
-    assert_connection_works(second_client, second_server).await;
+        let second_client = connect(addr).await.unwrap();
+        let (second_accepted_idx, second_server) =
+            wait_for_accept_tokio(&[&first, &second, &third]).await;
+        assert_eq!(
+            second_accepted_idx, MIGRATE_SOCKET_INDEX as usize,
+            "after clearing key 0, the program should fall back to listener C",
+        );
+        assert_eq!(read_hits(&path_hits, MIGRATE_HITS_INDEX), 0);
+        // Confirm that the test program observed the missing primary key and
+        // explicitly selected listener C, rather than relying on the kernel's
+        // default SO_REUSEPORT selection logic.
+        assert!(
+            read_hits(&path_hits, CLEAR_FALLBACK_HITS_INDEX) > 0,
+            "clear fallback path did not run",
+        );
+        assert_connection_works(second_client, second_server).await;
+    });
 }
 
 #[rstest]
 #[case::legacy("select_socket")]
 #[case::btf("select_socket_btf")]
-#[test_attr(test_log::test(tokio::test))]
-async fn sk_reuseport_stays_attached_until_explicit_detach(#[case] select_prog: &str) {
-    // Aya's CI VM init may leave `lo` down; NetNsGuard brings it up.
-    let _netns = NetNsGuard::new().unwrap();
+#[test_attr(test_log::test)]
+fn sk_reuseport_stays_attached_until_explicit_detach(#[case] select_prog: &str) {
+    run_netns_tokio(async || {
+        let mut ebpf = Ebpf::load(crate::SK_REUSEPORT).unwrap();
+        let [first, second] = reuseport_listeners();
 
-    let mut ebpf = Ebpf::load(crate::SK_REUSEPORT).unwrap();
-    let [first, second] = reuseport_listeners();
+        let prog: &mut SkReuseport = ebpf.program_mut(select_prog).unwrap().try_into().unwrap();
+        prog.load().unwrap();
+        prog.attach(&first).unwrap();
+        drop(ebpf);
 
-    let prog: &mut SkReuseport = ebpf.program_mut(select_prog).unwrap().try_into().unwrap();
-    prog.load().unwrap();
-    prog.attach(&first).unwrap();
-    drop(ebpf);
+        // `SO_DETACH_REUSEPORT_BPF` identifies the group solely from the
+        // socket, so detaching should still succeed after the local program has
+        // been unloaded.
+        SkReuseport::detach(&second).unwrap();
 
-    // `SO_DETACH_REUSEPORT_BPF` identifies the group solely from the
-    // socket, so detaching should still succeed after the local program has
-    // been unloaded.
-    SkReuseport::detach(&second).unwrap();
-
-    let err = SkReuseport::detach(&first).unwrap_err();
-    assert_matches!(
-        err,
-        ProgramError::SkReuseportError(SkReuseportError::SetsockoptError {
-            option: "SO_DETACH_REUSEPORT_BPF",
-            io_error,
-        }) if io_error.raw_os_error() == Some(ENOENT)
-    );
+        let err = SkReuseport::detach(&first).unwrap_err();
+        assert_matches!(
+            err,
+            ProgramError::SkReuseportError(SkReuseportError::SetsockoptError {
+                option: "SO_DETACH_REUSEPORT_BPF",
+                io_error,
+            }) if io_error.raw_os_error() == Some(ENOENT)
+        );
+    });
 }
 
 #[rstest]
 #[case::legacy("socket_map", "select_or_migrate_socket")]
 #[case::btf("socket_map_btf", "select_or_migrate_socket_btf")]
-#[test_attr(test_log::test(tokio::test))]
-async fn sk_reuseport_migrates_to_expected_listener(
+#[test_attr(test_log::test)]
+fn sk_reuseport_migrates_to_expected_listener(
     #[case] socket_map: &str,
     #[case] migrate_prog: &str,
 ) {
@@ -316,84 +308,89 @@ async fn sk_reuseport_migrates_to_expected_listener(
         return;
     }
 
-    // Aya's CI VM init may leave `lo` down; NetNsGuard brings it up.
-    let _netns = NetNsGuard::new().unwrap();
-    match std::fs::write("/proc/sys/net/ipv4/tcp_migrate_req", "1") {
-        Ok(()) => {}
-        Err(err)
-            if matches!(
-                err.kind(),
-                ErrorKind::NotFound | ErrorKind::PermissionDenied | ErrorKind::ReadOnlyFilesystem
-            ) =>
+    run_netns_tokio(async || {
+        match std::fs::write("/proc/sys/net/ipv4/tcp_migrate_req", "1") {
+            Ok(()) => {}
+            Err(err)
+                if matches!(
+                    err.kind(),
+                    ErrorKind::NotFound
+                        | ErrorKind::PermissionDenied
+                        | ErrorKind::ReadOnlyFilesystem
+                ) =>
+            {
+                eprintln!("skipping test - tcp_migrate_req not configurable in test netns: {err}");
+                return;
+            }
+            Err(err) => panic!("unexpected error configuring tcp_migrate_req: {err}"),
+        }
+
+        let mut ebpf = Ebpf::load(crate::SK_REUSEPORT).unwrap();
+        let mut socket_array: ReusePortSockArray<_> =
+            ebpf.take_map(socket_map).unwrap().try_into().unwrap();
+        let path_hits: Array<_, u64> = ebpf.take_map("path_hits").unwrap().try_into().unwrap();
+        let [listener_a, listener_b, listener_c] = reuseport_listeners();
+
+        for (index, listener) in [&listener_a, &listener_b, &listener_c]
+            .into_iter()
+            .enumerate()
         {
-            eprintln!("skipping test - tcp_migrate_req not configurable in test netns: {err}");
-            return;
+            socket_array.set(index as u32, listener, 0).unwrap();
         }
-        Err(err) => panic!("unexpected error configuring tcp_migrate_req: {err}"),
-    }
 
-    let mut ebpf = Ebpf::load(crate::SK_REUSEPORT).unwrap();
-    let mut socket_array: ReusePortSockArray<_> =
-        ebpf.take_map(socket_map).unwrap().try_into().unwrap();
-    let path_hits: Array<_, u64> = ebpf.take_map("path_hits").unwrap().try_into().unwrap();
-    let [listener_a, listener_b, listener_c] = reuseport_listeners();
-
-    for (index, listener) in [&listener_a, &listener_b, &listener_c]
-        .into_iter()
-        .enumerate()
-    {
-        socket_array.set(index as u32, listener, 0).unwrap();
-    }
-
-    let prog: &mut SkReuseport = ebpf.program_mut(migrate_prog).unwrap().try_into().unwrap();
-    match prog.load() {
-        Ok(()) => {}
-        Err(ProgramError::LoadError { io_error, .. })
-            if io_error.raw_os_error() == Some(EINVAL) =>
-        {
-            eprintln!("skipping test - kernel rejected BPF_SK_REUSEPORT_SELECT_OR_MIGRATE at load");
-            return;
-        }
-        Err(err) => {
-            panic!("unexpected error loading sk_reuseport/migrate program: {err}")
-        }
-    }
-
-    {
-        // Limit the mutable borrow of `ebpf` from `program_mut()` to this block.
         let prog: &mut SkReuseport = ebpf.program_mut(migrate_prog).unwrap().try_into().unwrap();
-        prog.attach(&listener_a).unwrap();
-    }
+        match prog.load() {
+            Ok(()) => {}
+            Err(ProgramError::LoadError { io_error, .. })
+                if io_error.raw_os_error() == Some(EINVAL) =>
+            {
+                eprintln!(
+                    "skipping test - kernel rejected BPF_SK_REUSEPORT_SELECT_OR_MIGRATE at load"
+                );
+                return;
+            }
+            Err(err) => {
+                panic!("unexpected error loading sk_reuseport/migrate program: {err}")
+            }
+        }
 
-    let addr = listener_b.local_addr().unwrap();
-    // Leave the connection pending on the listener side so dropping the
-    // selected listener exercises the kernel's reuseport migration path
-    // instead of handing an already-accepted socket to userspace.
-    let client = connect(addr).await.unwrap();
-    assert!(
-        read_hits(&path_hits, SELECT_HITS_INDEX) > 0,
-        "initial selection path did not run",
-    );
+        {
+            // Limit the mutable borrow of `ebpf` from `program_mut()` to this block.
+            let prog: &mut SkReuseport =
+                ebpf.program_mut(migrate_prog).unwrap().try_into().unwrap();
+            prog.attach(&listener_a).unwrap();
+        }
 
-    drop(listener_a);
+        let addr = listener_b.local_addr().unwrap();
+        // Leave the connection pending on the listener side so dropping the
+        // selected listener exercises the kernel's reuseport migration path
+        // instead of handing an already-accepted socket to userspace.
+        let client = connect(addr).await.unwrap();
+        assert!(
+            read_hits(&path_hits, SELECT_HITS_INDEX) > 0,
+            "initial selection path did not run",
+        );
 
-    // Confirm that the migrate-capable BPF path ran, not just the kernel's
-    // default SO_REUSEPORT selection logic choosing a surviving listener.
-    assert!(
-        read_hits(&path_hits, MIGRATE_HITS_INDEX) > 0,
-        "migration path did not run",
-    );
-    assert_eq!(read_hits(&path_hits, CLEAR_FALLBACK_HITS_INDEX), 0);
-    let surviving_group_indices = [1u32, MIGRATE_SOCKET_INDEX];
-    // Switch to polling on the underlying std listeners here: the
-    // migration path can make a connection accept-ready on the surviving
-    // listener without a fresh tokio readiness event.
-    let listener_b = listener_b.into_std().unwrap();
-    let listener_c = listener_c.into_std().unwrap();
-    let (accepted_idx, server) = wait_for_accept_polling([&listener_b, &listener_c]).await;
-    assert_eq!(
-        surviving_group_indices[accepted_idx], MIGRATE_SOCKET_INDEX,
-        "migration should steer the connection to listener C",
-    );
-    assert_connection_works(client, server).await;
+        drop(listener_a);
+
+        // Confirm that the migrate-capable BPF path ran, not just the kernel's
+        // default SO_REUSEPORT selection logic choosing a surviving listener.
+        assert!(
+            read_hits(&path_hits, MIGRATE_HITS_INDEX) > 0,
+            "migration path did not run",
+        );
+        assert_eq!(read_hits(&path_hits, CLEAR_FALLBACK_HITS_INDEX), 0);
+        let surviving_group_indices = [1u32, MIGRATE_SOCKET_INDEX];
+        // Switch to polling on the underlying std listeners here: the
+        // migration path can make a connection accept-ready on the surviving
+        // listener without a fresh tokio readiness event.
+        let listener_b = listener_b.into_std().unwrap();
+        let listener_c = listener_c.into_std().unwrap();
+        let (accepted_idx, server) = wait_for_accept_polling([&listener_b, &listener_c]).await;
+        assert_eq!(
+            surviving_group_indices[accepted_idx], MIGRATE_SOCKET_INDEX,
+            "migration should steer the connection to listener C",
+        );
+        assert_connection_works(client, server).await;
+    });
 }

--- a/test/integration-test/src/tests/sk_reuseport.rs
+++ b/test/integration-test/src/tests/sk_reuseport.rs
@@ -10,6 +10,7 @@ use aya::{
     Ebpf,
     maps::{Array, MapData, ReusePortSockArray},
     programs::{ProgramError, SkReuseport, SkReuseportError},
+    test_helpers::NetNsGuard,
     util::KernelVersion,
 };
 use futures::future::select_all;
@@ -24,8 +25,6 @@ use tokio::{
     net::{TcpListener as TokioTcpListener, TcpSocket, TcpStream as TokioTcpStream},
     time::{sleep, timeout},
 };
-
-use crate::utils::NetNsGuard;
 
 const RETRY_DURATION: Duration = Duration::from_millis(10);
 const ACCEPT_TIMEOUT: Duration = Duration::from_secs(10);

--- a/test/integration-test/src/tests/sk_storage.rs
+++ b/test/integration-test/src/tests/sk_storage.rs
@@ -29,7 +29,7 @@ fn sk_storage_connect() {
             let prog: &mut CgroupSockAddr = prog.try_into().expect(name);
             prog.load().expect(name);
             let link_id = prog
-                .attach(cgroup_fd, CgroupAttachMode::Single)
+                .attach(&cgroup_fd, CgroupAttachMode::Single)
                 .expect(name);
             scopeguard::guard((), |()| {
                 prog.detach(link_id).expect(name);

--- a/test/integration-test/src/tests/sk_storage.rs
+++ b/test/integration-test/src/tests/sk_storage.rs
@@ -17,10 +17,10 @@ fn sk_storage_connect() {
     let storage = ebpf.take_map("SOCKET_STORAGE").unwrap();
     let mut storage = SkStorage::<_, Value>::try_from(storage).unwrap();
 
-    let _netns = NetNsGuard::new();
-    let root_cgroup = Cgroup::root();
-    let cgroup = root_cgroup.create_child("aya-test-sk-storage");
-    let cgroup_fd = cgroup.fd();
+    let _netns = NetNsGuard::new().unwrap();
+    let root_cgroup = Cgroup::root().unwrap();
+    let cgroup = root_cgroup.create_child("aya-test-sk-storage").unwrap();
+    let cgroup_fd = cgroup.fd().unwrap();
 
     let guards = ebpf
         .programs_mut()
@@ -37,7 +37,7 @@ fn sk_storage_connect() {
         .collect::<Vec<_>>();
 
     let cgroup = cgroup.into_cgroup();
-    cgroup.write_pid(std::process::id());
+    cgroup.write_pid(std::process::id()).unwrap();
 
     let listener4 = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).unwrap();
     let addr4 = listener4.local_addr().unwrap();

--- a/test/integration-test/src/tests/sk_storage.rs
+++ b/test/integration-test/src/tests/sk_storage.rs
@@ -5,11 +5,10 @@ use aya::{
     EbpfLoader,
     maps::{MapError, SkStorage},
     programs::{CgroupAttachMode, CgroupSockAddr},
+    test_helpers::{Cgroup, NetNsGuard},
 };
 use integration_common::sk_storage::{Ip, Value};
 use test_log::test;
-
-use crate::utils::{Cgroup, NetNsGuard};
 
 #[test]
 fn sk_storage_connect() {

--- a/test/integration-test/src/tests/smoke.rs
+++ b/test/integration-test/src/tests/smoke.rs
@@ -13,7 +13,7 @@ fn modprobe() {
     // `/sbin/modprobe` to load the required kernel module.
     // In order for this test to pass, all of that machinery must work
     // correctly within the test environment.
-    let _netns = NetNsGuard::new();
+    let _netns = NetNsGuard::new().unwrap();
 
     tc::qdisc_add_clsact("lo").unwrap();
 }
@@ -28,7 +28,7 @@ fn xdp() {
         return;
     }
 
-    let _netns = NetNsGuard::new();
+    let _netns = NetNsGuard::new().unwrap();
 
     let mut bpf = Ebpf::load(crate::PASS).unwrap();
     let dispatcher: &mut Xdp = bpf.program_mut("pass").unwrap().try_into().unwrap();
@@ -66,7 +66,7 @@ fn extension() {
         return;
     }
 
-    let _netns = NetNsGuard::new();
+    let _netns = NetNsGuard::new().unwrap();
 
     let mut bpf = Ebpf::load(crate::MAIN).unwrap();
     let pass: &mut Xdp = bpf.program_mut("xdp_pass").unwrap().try_into().unwrap();

--- a/test/integration-test/src/tests/smoke.rs
+++ b/test/integration-test/src/tests/smoke.rs
@@ -1,10 +1,9 @@
 use aya::{
     Ebpf, EbpfLoader,
     programs::{Extension, TracePoint, Xdp, XdpMode, tc},
+    test_helpers::NetNsGuard,
     util::KernelVersion,
 };
-
-use crate::utils::NetNsGuard;
 
 #[test_log::test]
 fn modprobe() {

--- a/test/integration-test/src/tests/socket_filter.rs
+++ b/test/integration-test/src/tests/socket_filter.rs
@@ -182,7 +182,7 @@ async fn socket_filter_attach_types_use_separate_slots() {
     }
 
     // Aya's CI VM init may leave `lo` down; NetNsGuard brings it up.
-    let _netns = NetNsGuard::new();
+    let _netns = NetNsGuard::new().unwrap();
     let listener = reuseport_listener(0).expect("failed to create reuseport listener");
 
     let mut ebpf = Ebpf::load(crate::SOCKET_FILTER).unwrap();
@@ -282,7 +282,7 @@ async fn socket_filter_reuseport_selects_listener_and_detaches() {
     }
 
     // Aya's CI VM init may leave `lo` down; NetNsGuard brings it up.
-    let _netns = NetNsGuard::new();
+    let _netns = NetNsGuard::new().unwrap();
     let [first, second] = reuseport_listeners();
     let addr = first.local_addr().unwrap();
 
@@ -342,7 +342,7 @@ async fn socket_filter_reuseport_stays_attached_after_ebpf_drop() {
     }
 
     // Aya's CI VM init may leave `lo` down; NetNsGuard brings it up.
-    let _netns = NetNsGuard::new();
+    let _netns = NetNsGuard::new().unwrap();
     let [first, second] = reuseport_listeners();
     let addr = first.local_addr().unwrap();
 
@@ -396,7 +396,7 @@ async fn socket_filter_reuseport_replacement_uses_latest_program() {
     }
 
     // Aya's CI VM init may leave `lo` down; NetNsGuard brings it up.
-    let _netns = NetNsGuard::new();
+    let _netns = NetNsGuard::new().unwrap();
     let [first, second] = reuseport_listeners();
     let addr = first.local_addr().unwrap();
 

--- a/test/integration-test/src/tests/socket_filter.rs
+++ b/test/integration-test/src/tests/socket_filter.rs
@@ -10,6 +10,7 @@ use aya::{
     maps::{Array, MapData},
     programs::{ProgramError, ProgramType, ReusePortSocketFilter, SocketFilter, SocketFilterError},
     sys::is_program_supported,
+    test_helpers::NetNsGuard,
     util::KernelVersion,
 };
 use integration_common::socket_filter::{
@@ -22,8 +23,6 @@ use tokio::{
     net::{TcpListener, TcpSocket, TcpStream, UnixDatagram},
     time::timeout,
 };
-
-use crate::utils::NetNsGuard;
 
 const IO_TIMEOUT: Duration = Duration::from_secs(10);
 const ACCEPT_TIMEOUT: Duration = Duration::from_secs(10);

--- a/test/integration-test/src/tests/socket_filter.rs
+++ b/test/integration-test/src/tests/socket_filter.rs
@@ -10,7 +10,6 @@ use aya::{
     maps::{Array, MapData},
     programs::{ProgramError, ProgramType, ReusePortSocketFilter, SocketFilter, SocketFilterError},
     sys::is_program_supported,
-    test_helpers::NetNsGuard,
     util::KernelVersion,
 };
 use integration_common::socket_filter::{
@@ -23,6 +22,8 @@ use tokio::{
     net::{TcpListener, TcpSocket, TcpStream, UnixDatagram},
     time::timeout,
 };
+
+use super::run_netns_tokio;
 
 const IO_TIMEOUT: Duration = Duration::from_secs(10);
 const ACCEPT_TIMEOUT: Duration = Duration::from_secs(10);
@@ -170,8 +171,8 @@ async fn socket_filter_program_can_trim_packets_and_detach() {
     );
 }
 
-#[test_log::test(tokio::test)]
-async fn socket_filter_attach_types_use_separate_slots() {
+#[test_log::test]
+fn socket_filter_attach_types_use_separate_slots() {
     if !is_program_supported(ProgramType::SocketFilter).unwrap() {
         eprintln!("skipping test - socket_filter program not supported");
         return;
@@ -181,97 +182,98 @@ async fn socket_filter_attach_types_use_separate_slots() {
         return;
     }
 
-    // Aya's CI VM init may leave `lo` down; NetNsGuard brings it up.
-    let _netns = NetNsGuard::new().unwrap();
-    let listener = reuseport_listener(0).expect("failed to create reuseport listener");
+    run_netns_tokio(async || {
+        let listener = reuseport_listener(0).expect("failed to create reuseport listener");
 
-    let mut ebpf = Ebpf::load(crate::SOCKET_FILTER).unwrap();
-    let path_hits: Array<_, u64> = ebpf.take_map("path_hits").unwrap().try_into().unwrap();
+        let mut ebpf = Ebpf::load(crate::SOCKET_FILTER).unwrap();
+        let path_hits: Array<_, u64> = ebpf.take_map("path_hits").unwrap().try_into().unwrap();
 
-    {
-        let prog: &mut SocketFilter = ebpf
-            .program_mut("pass_packets")
-            .unwrap()
-            .try_into()
+        {
+            let prog: &mut SocketFilter = ebpf
+                .program_mut("pass_packets")
+                .unwrap()
+                .try_into()
+                .unwrap();
+            prog.load().unwrap();
+            prog.attach(&listener).unwrap();
+        }
+
+        // Attaching a regular socket filter must not populate the reuseport
+        // selector slot.
+        let err = ReusePortSocketFilter::detach(&listener).unwrap_err();
+        assert_matches!(
+            err,
+            ProgramError::SocketFilterError(SocketFilterError::SetsockoptError {
+                option: "SO_DETACH_REUSEPORT_BPF",
+                io_error,
+            }) if io_error.raw_os_error() == Some(ENOENT)
+        );
+        SocketFilter::detach(&listener).expect("regular socket filter should still be attached");
+
+        {
+            let prog: &mut ReusePortSocketFilter = ebpf
+                .program_mut("select_first")
+                .unwrap()
+                .try_into()
+                .unwrap();
+            prog.load().unwrap();
+            prog.attach(&listener).unwrap();
+        }
+
+        // A TCP listener is awkward for a regular socket filter path assertion, so
+        // only smoke-test that the reuseport selector actually runs.
+        let _client = TcpStream::connect(listener.local_addr().unwrap())
+            .await
             .unwrap();
-        prog.load().unwrap();
-        prog.attach(&listener).unwrap();
-    }
-
-    // Attaching a regular socket filter must not populate the reuseport
-    // selector slot.
-    let err = ReusePortSocketFilter::detach(&listener).unwrap_err();
-    assert_matches!(
-        err,
-        ProgramError::SocketFilterError(SocketFilterError::SetsockoptError {
-            option: "SO_DETACH_REUSEPORT_BPF",
-            io_error,
-        }) if io_error.raw_os_error() == Some(ENOENT)
-    );
-    SocketFilter::detach(&listener).expect("regular socket filter should still be attached");
-
-    {
-        let prog: &mut ReusePortSocketFilter = ebpf
-            .program_mut("select_first")
+        timeout(ACCEPT_TIMEOUT, listener.accept())
+            .await
             .unwrap()
-            .try_into()
             .unwrap();
-        prog.load().unwrap();
-        prog.attach(&listener).unwrap();
-    }
+        assert!(
+            read_hits(&path_hits, REUSEPORT_SELECT_FIRST_HITS_INDEX) > 0,
+            "reuseport path did not run",
+        );
 
-    // A TCP listener is awkward for a regular socket filter path assertion, so
-    // only smoke-test that the reuseport selector actually runs.
-    let _client = TcpStream::connect(listener.local_addr().unwrap())
-        .await
-        .unwrap();
-    timeout(ACCEPT_TIMEOUT, listener.accept())
-        .await
-        .unwrap()
-        .unwrap();
-    assert!(
-        read_hits(&path_hits, REUSEPORT_SELECT_FIRST_HITS_INDEX) > 0,
-        "reuseport path did not run",
-    );
+        // Conversely, attaching a reuseport selector must not populate the
+        // socket's regular filter slot.
+        let err = SocketFilter::detach(&listener).unwrap_err();
+        assert_matches!(
+            err,
+            ProgramError::SocketFilterError(SocketFilterError::SetsockoptError {
+                option: "SO_DETACH_BPF",
+                io_error,
+            }) if io_error.raw_os_error() == Some(ENOENT)
+        );
+        // The reuseport selector should still be attached after the wrong detach
+        // type above.
+        ReusePortSocketFilter::detach(&listener)
+            .expect("reuseport selector should still be attached");
 
-    // Conversely, attaching a reuseport selector must not populate the
-    // socket's regular filter slot.
-    let err = SocketFilter::detach(&listener).unwrap_err();
-    assert_matches!(
-        err,
-        ProgramError::SocketFilterError(SocketFilterError::SetsockoptError {
-            option: "SO_DETACH_BPF",
-            io_error,
-        }) if io_error.raw_os_error() == Some(ENOENT)
-    );
-    // The reuseport selector should still be attached after the wrong detach
-    // type above.
-    ReusePortSocketFilter::detach(&listener).expect("reuseport selector should still be attached");
+        {
+            let prog: &mut SocketFilter = ebpf
+                .program_mut("pass_packets")
+                .unwrap()
+                .try_into()
+                .unwrap();
+            prog.attach(&listener).unwrap();
+        }
+        {
+            let prog: &mut ReusePortSocketFilter = ebpf
+                .program_mut("select_first")
+                .unwrap()
+                .try_into()
+                .unwrap();
+            prog.attach(&listener).unwrap();
+        }
 
-    {
-        let prog: &mut SocketFilter = ebpf
-            .program_mut("pass_packets")
-            .unwrap()
-            .try_into()
-            .unwrap();
-        prog.attach(&listener).unwrap();
-    }
-    {
-        let prog: &mut ReusePortSocketFilter = ebpf
-            .program_mut("select_first")
-            .unwrap()
-            .try_into()
-            .unwrap();
-        prog.attach(&listener).unwrap();
-    }
-
-    // Both slots can be populated on the same socket at the same time.
-    ReusePortSocketFilter::detach(&listener).expect("failed to detach reuseport selector");
-    SocketFilter::detach(&listener).expect("failed to detach regular socket filter");
+        // Both slots can be populated on the same socket at the same time.
+        ReusePortSocketFilter::detach(&listener).expect("failed to detach reuseport selector");
+        SocketFilter::detach(&listener).expect("failed to detach regular socket filter");
+    });
 }
 
-#[test_log::test(tokio::test)]
-async fn socket_filter_reuseport_selects_listener_and_detaches() {
+#[test_log::test]
+fn socket_filter_reuseport_selects_listener_and_detaches() {
     if !is_program_supported(ProgramType::SocketFilter).unwrap() {
         eprintln!("skipping test - socket_filter program not supported");
         return;
@@ -281,74 +283,10 @@ async fn socket_filter_reuseport_selects_listener_and_detaches() {
         return;
     }
 
-    // Aya's CI VM init may leave `lo` down; NetNsGuard brings it up.
-    let _netns = NetNsGuard::new().unwrap();
-    let [first, second] = reuseport_listeners();
-    let addr = first.local_addr().unwrap();
+    run_netns_tokio(async || {
+        let [first, second] = reuseport_listeners();
+        let addr = first.local_addr().unwrap();
 
-    let mut ebpf = Ebpf::load(crate::SOCKET_FILTER).unwrap();
-    let path_hits: Array<_, u64> = ebpf.take_map("path_hits").unwrap().try_into().unwrap();
-    let prog: &mut ReusePortSocketFilter = ebpf
-        .program_mut("select_second")
-        .unwrap()
-        .try_into()
-        .unwrap();
-    prog.load().unwrap();
-    prog.attach(&first).unwrap();
-
-    let _client = TcpStream::connect(addr).await.unwrap();
-    assert_eq!(
-        accept_from_either(&first, &second).await,
-        REUSEPORT_SECOND_LISTENER_INDEX,
-        "reuseport socket filter did not select the second listener",
-    );
-    assert!(
-        read_hits(&path_hits, REUSEPORT_SELECT_SECOND_HITS_INDEX) > 0,
-        "reuseport path did not run",
-    );
-    let hits_before_detach = read_hits(&path_hits, REUSEPORT_SELECT_SECOND_HITS_INDEX);
-
-    // Reuseport detach is group-scoped: detaching through `second` clears the
-    // selector for the whole group, including `first`.
-    ReusePortSocketFilter::detach(&second).unwrap();
-
-    let err = ReusePortSocketFilter::detach(&first).unwrap_err();
-    assert_matches!(
-        err,
-        ProgramError::SocketFilterError(SocketFilterError::SetsockoptError {
-            option: "SO_DETACH_REUSEPORT_BPF",
-            io_error,
-        }) if io_error.raw_os_error() == Some(ENOENT)
-    );
-
-    let _client = TcpStream::connect(addr).await.unwrap();
-    accept_from_either(&first, &second).await;
-    assert_eq!(
-        read_hits(&path_hits, REUSEPORT_SELECT_SECOND_HITS_INDEX),
-        hits_before_detach,
-        "reuseport path ran after detach",
-    );
-}
-
-#[test_log::test(tokio::test)]
-async fn socket_filter_reuseport_stays_attached_after_ebpf_drop() {
-    if !is_program_supported(ProgramType::SocketFilter).unwrap() {
-        eprintln!("skipping test - socket_filter program not supported");
-        return;
-    }
-
-    if !reuseport_detach_supported() {
-        return;
-    }
-
-    // Aya's CI VM init may leave `lo` down; NetNsGuard brings it up.
-    let _netns = NetNsGuard::new().unwrap();
-    let [first, second] = reuseport_listeners();
-    let addr = first.local_addr().unwrap();
-
-    // Dropping `Ebpf` at the end of this scope releases local program FDs, but
-    // the reuseport group slot owns the attachment and must keep it active.
-    let path_hits: Array<_, u64> = {
         let mut ebpf = Ebpf::load(crate::SOCKET_FILTER).unwrap();
         let path_hits: Array<_, u64> = ebpf.take_map("path_hits").unwrap().try_into().unwrap();
         let prog: &mut ReusePortSocketFilter = ebpf
@@ -358,34 +296,44 @@ async fn socket_filter_reuseport_stays_attached_after_ebpf_drop() {
             .unwrap();
         prog.load().unwrap();
         prog.attach(&first).unwrap();
-        path_hits
-    };
 
-    let _client = TcpStream::connect(addr).await.unwrap();
-    assert_eq!(
-        accept_from_either(&first, &second).await,
-        REUSEPORT_SECOND_LISTENER_INDEX,
-        "dropping Ebpf detached the reuseport socket filter",
-    );
-    let hits_before_detach = read_hits(&path_hits, REUSEPORT_SELECT_SECOND_HITS_INDEX);
-    assert!(
-        hits_before_detach > 0,
-        "reuseport path did not run after Ebpf drop",
-    );
+        let _client = TcpStream::connect(addr).await.unwrap();
+        assert_eq!(
+            accept_from_either(&first, &second).await,
+            REUSEPORT_SECOND_LISTENER_INDEX,
+            "reuseport socket filter did not select the second listener",
+        );
+        assert!(
+            read_hits(&path_hits, REUSEPORT_SELECT_SECOND_HITS_INDEX) > 0,
+            "reuseport path did not run",
+        );
+        let hits_before_detach = read_hits(&path_hits, REUSEPORT_SELECT_SECOND_HITS_INDEX);
 
-    ReusePortSocketFilter::detach(&first).unwrap();
+        // Reuseport detach is group-scoped: detaching through `second` clears the
+        // selector for the whole group, including `first`.
+        ReusePortSocketFilter::detach(&second).unwrap();
 
-    let _client = TcpStream::connect(addr).await.unwrap();
-    accept_from_either(&first, &second).await;
-    assert_eq!(
-        read_hits(&path_hits, REUSEPORT_SELECT_SECOND_HITS_INDEX),
-        hits_before_detach,
-        "reuseport path ran after detach",
-    );
+        let err = ReusePortSocketFilter::detach(&first).unwrap_err();
+        assert_matches!(
+            err,
+            ProgramError::SocketFilterError(SocketFilterError::SetsockoptError {
+                option: "SO_DETACH_REUSEPORT_BPF",
+                io_error,
+            }) if io_error.raw_os_error() == Some(ENOENT)
+        );
+
+        let _client = TcpStream::connect(addr).await.unwrap();
+        accept_from_either(&first, &second).await;
+        assert_eq!(
+            read_hits(&path_hits, REUSEPORT_SELECT_SECOND_HITS_INDEX),
+            hits_before_detach,
+            "reuseport path ran after detach",
+        );
+    });
 }
 
-#[test_log::test(tokio::test)]
-async fn socket_filter_reuseport_replacement_uses_latest_program() {
+#[test_log::test]
+fn socket_filter_reuseport_stays_attached_after_ebpf_drop() {
     if !is_program_supported(ProgramType::SocketFilter).unwrap() {
         eprintln!("skipping test - socket_filter program not supported");
         return;
@@ -395,69 +343,124 @@ async fn socket_filter_reuseport_replacement_uses_latest_program() {
         return;
     }
 
-    // Aya's CI VM init may leave `lo` down; NetNsGuard brings it up.
-    let _netns = NetNsGuard::new().unwrap();
-    let [first, second] = reuseport_listeners();
-    let addr = first.local_addr().unwrap();
+    run_netns_tokio(async || {
+        let [first, second] = reuseport_listeners();
+        let addr = first.local_addr().unwrap();
 
-    let mut ebpf = Ebpf::load(crate::SOCKET_FILTER).unwrap();
-    let path_hits: Array<_, u64> = ebpf.take_map("path_hits").unwrap().try_into().unwrap();
+        // Dropping `Ebpf` at the end of this scope releases local program FDs, but
+        // the reuseport group slot owns the attachment and must keep it active.
+        let path_hits: Array<_, u64> = {
+            let mut ebpf = Ebpf::load(crate::SOCKET_FILTER).unwrap();
+            let path_hits: Array<_, u64> = ebpf.take_map("path_hits").unwrap().try_into().unwrap();
+            let prog: &mut ReusePortSocketFilter = ebpf
+                .program_mut("select_second")
+                .unwrap()
+                .try_into()
+                .unwrap();
+            prog.load().unwrap();
+            prog.attach(&first).unwrap();
+            path_hits
+        };
 
-    // Drop the mutable program reference before exercising the attachment. The
-    // kernel slot, not a link handle, owns the attachment, so ending this scope
-    // must not detach it.
-    {
-        let first_prog: &mut ReusePortSocketFilter = ebpf
-            .program_mut("select_first")
-            .unwrap()
-            .try_into()
-            .unwrap();
-        first_prog.load().unwrap();
-        first_prog.attach(&first).unwrap();
+        let _client = TcpStream::connect(addr).await.unwrap();
+        assert_eq!(
+            accept_from_either(&first, &second).await,
+            REUSEPORT_SECOND_LISTENER_INDEX,
+            "dropping Ebpf detached the reuseport socket filter",
+        );
+        let hits_before_detach = read_hits(&path_hits, REUSEPORT_SELECT_SECOND_HITS_INDEX);
+        assert!(
+            hits_before_detach > 0,
+            "reuseport path did not run after Ebpf drop",
+        );
+
+        ReusePortSocketFilter::detach(&first).unwrap();
+
+        let _client = TcpStream::connect(addr).await.unwrap();
+        accept_from_either(&first, &second).await;
+        assert_eq!(
+            read_hits(&path_hits, REUSEPORT_SELECT_SECOND_HITS_INDEX),
+            hits_before_detach,
+            "reuseport path ran after detach",
+        );
+    });
+}
+
+#[test_log::test]
+fn socket_filter_reuseport_replacement_uses_latest_program() {
+    if !is_program_supported(ProgramType::SocketFilter).unwrap() {
+        eprintln!("skipping test - socket_filter program not supported");
+        return;
     }
 
-    let _client = TcpStream::connect(addr).await.unwrap();
-    assert_eq!(
-        accept_from_either(&first, &second).await,
-        REUSEPORT_FIRST_LISTENER_INDEX,
-        "first reuseport socket filter did not select the first listener",
-    );
-    let first_hits_before_replacement = read_hits(&path_hits, REUSEPORT_SELECT_FIRST_HITS_INDEX);
-    assert!(
-        first_hits_before_replacement > 0,
-        "first reuseport path did not run",
-    );
-
-    // A second attach through the same reuseport group replaces `reuse->prog`;
-    // it does not create a second attachment or change the socket indexes:
-    // https://github.com/torvalds/linux/blob/v6.9/net/core/sock_reuseport.c#L684-L712
-    {
-        let second_prog: &mut ReusePortSocketFilter = ebpf
-            .program_mut("select_second")
-            .unwrap()
-            .try_into()
-            .unwrap();
-        second_prog.load().unwrap();
-        second_prog.attach(&first).unwrap();
+    if !reuseport_detach_supported() {
+        return;
     }
 
-    let _client = TcpStream::connect(addr).await.unwrap();
-    assert_eq!(
-        accept_from_either(&first, &second).await,
-        REUSEPORT_SECOND_LISTENER_INDEX,
-        "replacement reuseport socket filter did not select the second listener",
-    );
-    assert_eq!(
-        read_hits(&path_hits, REUSEPORT_SELECT_FIRST_HITS_INDEX),
-        first_hits_before_replacement,
-        "replaced reuseport path ran after replacement",
-    );
-    assert!(
-        read_hits(&path_hits, REUSEPORT_SELECT_SECOND_HITS_INDEX) > 0,
-        "replacement reuseport path did not run",
-    );
+    run_netns_tokio(async || {
+        let [first, second] = reuseport_listeners();
+        let addr = first.local_addr().unwrap();
 
-    ReusePortSocketFilter::detach(&second).unwrap();
+        let mut ebpf = Ebpf::load(crate::SOCKET_FILTER).unwrap();
+        let path_hits: Array<_, u64> = ebpf.take_map("path_hits").unwrap().try_into().unwrap();
+
+        // Drop the mutable program reference before exercising the attachment. The
+        // kernel slot, not a link handle, owns the attachment, so ending this scope
+        // must not detach it.
+        {
+            let first_prog: &mut ReusePortSocketFilter = ebpf
+                .program_mut("select_first")
+                .unwrap()
+                .try_into()
+                .unwrap();
+            first_prog.load().unwrap();
+            first_prog.attach(&first).unwrap();
+        }
+
+        let _client = TcpStream::connect(addr).await.unwrap();
+        assert_eq!(
+            accept_from_either(&first, &second).await,
+            REUSEPORT_FIRST_LISTENER_INDEX,
+            "first reuseport socket filter did not select the first listener",
+        );
+        let first_hits_before_replacement =
+            read_hits(&path_hits, REUSEPORT_SELECT_FIRST_HITS_INDEX);
+        assert!(
+            first_hits_before_replacement > 0,
+            "first reuseport path did not run",
+        );
+
+        // A second attach through the same reuseport group replaces `reuse->prog`;
+        // it does not create a second attachment or change the socket indexes:
+        // https://github.com/torvalds/linux/blob/v6.9/net/core/sock_reuseport.c#L684-L712
+        {
+            let second_prog: &mut ReusePortSocketFilter = ebpf
+                .program_mut("select_second")
+                .unwrap()
+                .try_into()
+                .unwrap();
+            second_prog.load().unwrap();
+            second_prog.attach(&first).unwrap();
+        }
+
+        let _client = TcpStream::connect(addr).await.unwrap();
+        assert_eq!(
+            accept_from_either(&first, &second).await,
+            REUSEPORT_SECOND_LISTENER_INDEX,
+            "replacement reuseport socket filter did not select the second listener",
+        );
+        assert_eq!(
+            read_hits(&path_hits, REUSEPORT_SELECT_FIRST_HITS_INDEX),
+            first_hits_before_replacement,
+            "replaced reuseport path ran after replacement",
+        );
+        assert!(
+            read_hits(&path_hits, REUSEPORT_SELECT_SECOND_HITS_INDEX) > 0,
+            "replacement reuseport path did not run",
+        );
+
+        ReusePortSocketFilter::detach(&second).unwrap();
+    });
 }
 
 #[test_log::test(tokio::test)]

--- a/test/integration-test/src/tests/tc_netlink.rs
+++ b/test/integration-test/src/tests/tc_netlink.rs
@@ -44,7 +44,7 @@ fn netlink_attach_to_link_preserves_classid() {
         return;
     }
 
-    let _netns = NetNsGuard::new();
+    let _netns = NetNsGuard::new().unwrap();
 
     qdisc_add_clsact("lo").unwrap();
 
@@ -81,7 +81,7 @@ fn netlink_attach_auto_assigns_handle() {
         return;
     }
 
-    let _netns = NetNsGuard::new();
+    let _netns = NetNsGuard::new().unwrap();
 
     qdisc_add_clsact("lo").unwrap();
 
@@ -108,7 +108,7 @@ fn netlink_attach_preserves_explicit_handle() {
         return;
     }
 
-    let _netns = NetNsGuard::new();
+    let _netns = NetNsGuard::new().unwrap();
 
     qdisc_add_clsact("lo").unwrap();
 

--- a/test/integration-test/src/tests/tc_netlink.rs
+++ b/test/integration-test/src/tests/tc_netlink.rs
@@ -4,10 +4,11 @@ use aya::{
         SchedClassifier, TcAttachType,
         tc::{NlOptions, TcAttachOptions, TcHandle, qdisc_add_clsact},
     },
+    test_helpers::NetNsGuard,
     util::KernelVersion,
 };
 
-use crate::{TCX, utils::NetNsGuard};
+use crate::TCX;
 
 /// Returns true if the kernel autoloads `cls_bpf` on netlink attach.
 ///

--- a/test/integration-test/src/tests/tcx.rs
+++ b/test/integration-test/src/tests/tcx.rs
@@ -13,7 +13,7 @@ fn tcx() {
         return;
     }
 
-    let _netns = NetNsGuard::new();
+    let _netns = NetNsGuard::new().unwrap();
 
     // We need a dedicated `Ebpf` instance for each program that we load
     // since TCX does not allow the same program ID to be attached multiple

--- a/test/integration-test/src/tests/tcx.rs
+++ b/test/integration-test/src/tests/tcx.rs
@@ -1,10 +1,9 @@
 use aya::{
     Ebpf,
     programs::{LinkOrder, ProgramId, SchedClassifier, TcAttachType, tc::TcAttachOptions},
+    test_helpers::NetNsGuard,
     util::KernelVersion,
 };
-
-use crate::utils::NetNsGuard;
 
 #[test_log::test]
 fn tcx() {

--- a/test/integration-test/src/tests/xdp.rs
+++ b/test/integration-test/src/tests/xdp.rs
@@ -17,7 +17,7 @@ use xdpilone::{BufIdx, IfInfo, Socket, SocketConfig, Umem, UmemConfig};
 #[case::btf("SOCKS_BTF", "redirect_sock_btf")]
 #[test_attr(test_log::test)]
 fn af_xdp(#[case] socks_name: &str, #[case] prog_name: &str) {
-    let _netns = NetNsGuard::new();
+    let _netns = NetNsGuard::new().unwrap();
 
     let mut bpf = Ebpf::load(crate::XSK_MAP).unwrap();
     let mut socks: XskMap<_> = bpf.take_map(socks_name).unwrap().try_into().unwrap();
@@ -165,7 +165,7 @@ fn map_load() {
 #[case::btf("CPUS_BTF", "redirect_cpu_btf")]
 #[test_attr(test_log::test)]
 fn cpumap_chain(#[case] cpus_name: &str, #[case] prog_name: &str) {
-    let _netns = NetNsGuard::new();
+    let _netns = NetNsGuard::new().unwrap();
 
     let mut bpf = Ebpf::load(crate::CPU_MAP).unwrap();
 
@@ -247,7 +247,7 @@ fn devmap_set(
     #[case] dev_get_prog: &str,
     #[case] dev_hash_get_prog: &str,
 ) {
-    let _netns = NetNsGuard::new();
+    let _netns = NetNsGuard::new().unwrap();
 
     let mut bpf = Ebpf::load(crate::DEV_MAP).unwrap();
     let mut devs: DevMap<_> = bpf.take_map(devs_name).unwrap().try_into().unwrap();
@@ -289,7 +289,7 @@ fn devmap_set(
 #[case::btf_hash("get_ifindex_dev_hash_btf")]
 #[test_attr(test_log::test)]
 fn devmap_get_ifindex(#[case] prog_name: &str) {
-    let _netns = NetNsGuard::new();
+    let _netns = NetNsGuard::new().unwrap();
     let mut bpf = Ebpf::load(crate::DEV_MAP).unwrap();
     let xdp: &mut Xdp = bpf.program_mut(prog_name).unwrap().try_into().unwrap();
     xdp.load().unwrap();

--- a/test/integration-test/src/tests/xdp.rs
+++ b/test/integration-test/src/tests/xdp.rs
@@ -5,13 +5,12 @@ use aya::{
     Ebpf,
     maps::{Array, CpuMap, DevMap, DevMapHash, XskMap},
     programs::{ProgramError, Xdp, XdpError, XdpMode, xdp::XdpLinkId},
+    test_helpers::NetNsGuard,
     util::KernelVersion,
 };
 use object::{Object as _, ObjectSection as _, ObjectSymbol as _, SymbolSection};
 use rstest::rstest;
 use xdpilone::{BufIdx, IfInfo, Socket, SocketConfig, Umem, UmemConfig};
-
-use crate::utils::NetNsGuard;
 
 #[rstest]
 #[case::legacy("SOCKS", "redirect_sock")]

--- a/test/integration-test/src/utils.rs
+++ b/test/integration-test/src/utils.rs
@@ -4,9 +4,9 @@ use std::{
     borrow::Cow,
     ffi::CString,
     fs,
-    io::{self, Write as _},
+    io::{self, BufRead as _, BufReader, Write as _},
     os::fd::{AsFd, BorrowedFd},
-    path::Path,
+    path::{Path, PathBuf},
     process,
     sync::atomic::{AtomicU64, Ordering},
 };
@@ -15,13 +15,7 @@ use anyhow::{Context as _, Result};
 use aya::netlink_set_link_up;
 use libc::if_nametoindex;
 
-const CGROUP_ROOT: &str = "/sys/fs/cgroup";
 const CGROUP_PROCS: &str = "cgroup.procs";
-
-pub(crate) fn is_cgroup2() -> bool {
-    // `cgroup.controllers` exists only at the root of a cgroup2 mount.
-    Path::new(CGROUP_ROOT).join("cgroup.controllers").exists()
-}
 
 pub(crate) struct ChildCgroup<'a> {
     parent: &'a Cgroup<'a>,
@@ -29,20 +23,44 @@ pub(crate) struct ChildCgroup<'a> {
 }
 
 pub(crate) enum Cgroup<'a> {
-    Root,
+    Root(PathBuf),
     Child(ChildCgroup<'a>),
 }
 
 impl Cgroup<'static> {
     pub(crate) fn root() -> Self {
-        Self::Root
+        const PROC_MOUNTS: &str = "/proc/self/mounts";
+        const CGROUP2: &str = "cgroup2";
+        {
+            let mounts = fs::File::open(PROC_MOUNTS)
+                .unwrap_or_else(|err| panic!("fs::File::open(\"{PROC_MOUNTS}\"): {err}"));
+            for line in BufReader::new(mounts).lines() {
+                let line = line.unwrap_or_else(|err| {
+                    panic!("line yielded by io::BufReader::new(mounts): {err}")
+                });
+                let mut parts = line.split_whitespace();
+                let device = parts.next().unwrap_or_else(|| {
+                    panic!("mount entry from {PROC_MOUNTS} has no device field: {line}")
+                });
+                let mountpoint = parts.next().unwrap_or_else(|| {
+                    panic!("mount entry from {PROC_MOUNTS} has no mountpoint field: {line}")
+                });
+                let fstype = parts.next().unwrap_or_else(|| {
+                    panic!("mount entry from {PROC_MOUNTS} has no fstype field: {line}")
+                });
+                if device == CGROUP2 && fstype == CGROUP2 {
+                    return Self::Root(PathBuf::from(mountpoint));
+                }
+            }
+        }
+        panic!("could not find a cgroup2 mount entry in {PROC_MOUNTS}");
     }
 }
 
 impl<'a> Cgroup<'a> {
     fn path(&self) -> &Path {
         match self {
-            Self::Root => Path::new(CGROUP_ROOT),
+            Self::Root(path) => path,
             Self::Child(ChildCgroup { parent: _, path }) => path,
         }
     }

--- a/test/integration-test/src/utils.rs
+++ b/test/integration-test/src/utils.rs
@@ -2,7 +2,6 @@
 
 use std::{
     borrow::Cow,
-    cell::OnceCell,
     ffi::CString,
     fs,
     io::{self, Write as _},
@@ -27,7 +26,6 @@ pub(crate) fn is_cgroup2() -> bool {
 pub(crate) struct ChildCgroup<'a> {
     parent: &'a Cgroup<'a>,
     path: Cow<'a, Path>,
-    fd: OnceCell<fs::File>,
 }
 
 pub(crate) enum Cgroup<'a> {
@@ -45,11 +43,7 @@ impl<'a> Cgroup<'a> {
     fn path(&self) -> &Path {
         match self {
             Self::Root => Path::new(CGROUP_ROOT),
-            Self::Child(ChildCgroup {
-                parent: _,
-                path,
-                fd: _,
-            }) => path,
+            Self::Child(ChildCgroup { parent: _, path }) => path,
         }
     }
 
@@ -60,7 +54,6 @@ impl<'a> Cgroup<'a> {
         ChildCgroup {
             parent: self,
             path: path.into(),
-            fd: OnceCell::new(),
         }
     }
 
@@ -70,18 +63,12 @@ impl<'a> Cgroup<'a> {
 }
 
 impl<'a> ChildCgroup<'a> {
-    pub(crate) fn fd(&self) -> &fs::File {
-        let Self {
-            parent: _,
-            path,
-            fd,
-        } = self;
-        fd.get_or_init(|| {
-            fs::OpenOptions::new()
-                .read(true)
-                .open(path.as_ref())
-                .unwrap()
-        })
+    pub(crate) fn fd(&self) -> fs::File {
+        let Self { parent: _, path } = self;
+        fs::OpenOptions::new()
+            .read(true)
+            .open(path.as_ref())
+            .unwrap()
     }
 
     pub(crate) fn into_cgroup(self) -> Cgroup<'a> {
@@ -99,11 +86,7 @@ impl Drop for ChildCgroup<'_> {
         reason = "debug formatting preserves error context in drop"
     )]
     fn drop(&mut self) {
-        let Self {
-            parent,
-            path,
-            fd: _,
-        } = self;
+        let Self { parent, path } = self;
 
         match (|| -> Result<()> {
             let dst = parent.path().join(CGROUP_PROCS);

--- a/test/integration-test/src/utils.rs
+++ b/test/integration-test/src/utils.rs
@@ -15,19 +15,34 @@ use anyhow::{Context as _, Result};
 use aya::netlink_set_link_up;
 use libc::if_nametoindex;
 
+/// The cgroup-relative name of the file to which a PID is written to assign
+/// that process to the cgroup.
 const CGROUP_PROCS: &str = "cgroup.procs";
 
+/// A handle to a child cgroup created under a [`Cgroup`].
+///
+/// On drop, the PIDs in this cgroup's `cgroup.procs` are moved back to the
+/// parent cgroup and the directory is removed.
 pub(crate) struct ChildCgroup<'a> {
+    /// The parent cgroup under which this child was created.
     parent: &'a Cgroup<'a>,
+    /// The filesystem path of this cgroup directory.
     path: Cow<'a, Path>,
 }
 
+/// A handle representing either the root cgroup or a child cgroup.
+///
+/// This enum is used to avoid unnecessary reference counting when the root
+/// cgroup is the only handle needed.
 pub(crate) enum Cgroup<'a> {
+    /// The root cgroup.
     Root(PathBuf),
+    /// A child cgroup created via [`Cgroup::create_child`].
     Child(ChildCgroup<'a>),
 }
 
 impl Cgroup<'static> {
+    /// Returns a handle to the root cgroup.
     pub(crate) fn root() -> Self {
         const PROC_MOUNTS: &str = "/proc/self/mounts";
         const CGROUP2: &str = "cgroup2";
@@ -58,6 +73,7 @@ impl Cgroup<'static> {
 }
 
 impl<'a> Cgroup<'a> {
+    /// Returns the filesystem path for this cgroup.
     fn path(&self) -> &Path {
         match self {
             Self::Root(path) => path,
@@ -65,6 +81,8 @@ impl<'a> Cgroup<'a> {
         }
     }
 
+    /// Creates a child cgroup with the given name under this cgroup and returns
+    /// a [`ChildCgroup`] handle to it.
     pub(crate) fn create_child(&'a self, name: &str) -> ChildCgroup<'a> {
         let path = self.path().join(name);
         fs::create_dir(&path).unwrap();
@@ -75,12 +93,15 @@ impl<'a> Cgroup<'a> {
         }
     }
 
+    /// Writes the given PID to this cgroup's `cgroup.procs` file, thereby
+    /// moving that process into this cgroup.
     pub(crate) fn write_pid(&self, pid: u32) {
         fs::write(self.path().join(CGROUP_PROCS), format!("{pid}\n")).unwrap();
     }
 }
 
 impl<'a> ChildCgroup<'a> {
+    /// Opens the cgroup directory and returns its file descriptor.
     pub(crate) fn fd(&self) -> fs::File {
         let Self { parent: _, path } = self;
         fs::OpenOptions::new()
@@ -89,12 +110,19 @@ impl<'a> ChildCgroup<'a> {
             .unwrap()
     }
 
+    /// Consumes `self` and returns a [`Cgroup::Child`] variant.
     pub(crate) fn into_cgroup(self) -> Cgroup<'a> {
         Cgroup::Child(self)
     }
 }
 
 impl Drop for ChildCgroup<'_> {
+    /// Moves all PIDs from this child cgroup back to the parent cgroup's
+    /// `cgroup.procs`, then removes this cgroup's directory.
+    ///
+    /// If this cgroup is empty, the directory is simply removed. Errors
+    /// cause a panic unless the runtime is already unwinding, in which case
+    /// they are logged to avoid a double-panic.
     #[expect(
         clippy::print_stderr,
         reason = "drop handlers avoid panic-in-panic by logging errors"
@@ -142,16 +170,32 @@ impl Drop for ChildCgroup<'_> {
     }
 }
 
+/// A guard that creates and enters a new network namespace, restoring the
+/// previous namespace on drop.
+///
+/// The guard also brings up the `lo` (loopback) interface in the new
+/// namespace by default, since it is down in freshly created namespaces.
 pub(crate) struct NetNsGuard {
+    /// The name of the persisted network namespace.
     name: String,
+    /// File handle to the original network namespace, used for restoration on drop.
     old_ns: fs::File,
+    /// File handle to the newly created network namespace.
     new_ns: fs::File,
 }
 
 impl NetNsGuard {
+    /// The directory where network namespaces are persisted for user-space access.
     const PERSIST_DIR: &str = "/var/run/netns/";
+
+    /// The path to the calling thread's network namespace file.
     const THREAD_NETNS: &str = "/proc/thread-self/ns/net";
 
+    /// Creates a new network namespace guard.
+    ///
+    /// This creates a new network namespace, persists it under `/var/run/netns/`,
+    /// enters it, and brings up the `lo` interface. On drop, the guard restores
+    /// the previous namespace and cleans up the persisted namespace entry.
     #[expect(
         clippy::print_stdout,
         reason = "integration tests print namespace transitions for diagnostics"
@@ -220,6 +264,11 @@ impl AsFd for NetNsGuard {
 }
 
 impl Drop for NetNsGuard {
+    /// Restores the original network namespace and cleans up the persisted
+    /// namespace entry under `/var/run/netns/`.
+    ///
+    /// Errors cause a panic unless the runtime is already unwinding, in which
+    /// case they are logged to avoid a double-panic.
     #[expect(
         clippy::print_stderr,
         reason = "drop handlers avoid panic-in-panic by logging errors"
@@ -258,7 +307,12 @@ impl Drop for NetNsGuard {
     }
 }
 
-/// If the `KernelVersion::current >= $version`, `assert!($cond)`, else `assert!(!$cond)`.
+/// Asserts a condition based on the running kernel version.
+///
+/// If `KernelVersion::current >= $version`, evaluates to `assert!($cond)`.
+/// Otherwise, evaluates to `assert!(!$cond)`.
+///
+/// This is useful for tests that behave differently across kernel versions.
 macro_rules! kernel_assert {
     ($cond:expr, $version:expr $(,)?) => {
         let current = aya::util::KernelVersion::current().unwrap();
@@ -273,8 +327,13 @@ macro_rules! kernel_assert {
 
 pub(crate) use kernel_assert;
 
-/// If the `KernelVersion::current >= $version`, `assert_eq!($left, $right)`, else
-/// `assert_ne!($left, $right)`.
+/// Asserts equality based on the running kernel version.
+///
+/// If `KernelVersion::current >= $version`, evaluates to `assert_eq!($left, $right)`.
+/// Otherwise, evaluates to `assert_ne!($left, $right)`.
+///
+/// This is useful for tests that check for behavioral changes introduced in
+/// specific kernel versions.
 macro_rules! kernel_assert_eq {
     ($left:expr, $right:expr, $version:expr $(,)?) => {
         let current = aya::util::KernelVersion::current().unwrap();

--- a/xtask/public-api/aya.txt
+++ b/xtask/public-api/aya.txt
@@ -4894,12 +4894,14 @@ pub aya::programs::tc::TcError::AlreadyAttached
 pub aya::programs::tc::TcError::InvalidLinkOperation
 pub aya::programs::tc::TcError::InvalidTcxAttach(u32)
 pub aya::programs::tc::TcError::IoError(std::io::error::Error)
-pub aya::programs::tc::TcError::NetlinkError(aya::sys::netlink::NetlinkError)
+pub aya::programs::tc::TcError::NetlinkError(aya::sys::NetlinkError)
 pub aya::programs::tc::TcError::NulError(alloc::ffi::c_str::NulError)
 impl core::convert::From<alloc::ffi::c_str::NulError> for aya::programs::tc::TcError
 pub fn aya::programs::tc::TcError::from(alloc::ffi::c_str::NulError) -> Self
 impl core::convert::From<aya::programs::tc::TcError> for aya::programs::ProgramError
 pub fn aya::programs::ProgramError::from(aya::programs::tc::TcError) -> Self
+impl core::convert::From<aya::sys::NetlinkError> for aya::programs::tc::TcError
+pub fn aya::programs::tc::TcError::from(aya::sys::NetlinkError) -> Self
 impl core::convert::From<std::io::error::Error> for aya::programs::tc::TcError
 pub fn aya::programs::tc::TcError::from(std::io::error::Error) -> Self
 impl core::error::Error for aya::programs::tc::TcError
@@ -5462,9 +5464,11 @@ impl core::panic::unwind_safe::RefUnwindSafe for aya::programs::uprobe::UProbeLi
 impl core::panic::unwind_safe::UnwindSafe for aya::programs::uprobe::UProbeLinkId
 pub mod aya::programs::xdp
 pub enum aya::programs::xdp::XdpError
-pub aya::programs::xdp::XdpError::NetlinkError(aya::sys::netlink::NetlinkError)
+pub aya::programs::xdp::XdpError::NetlinkError(aya::sys::NetlinkError)
 impl core::convert::From<aya::programs::xdp::XdpError> for aya::programs::ProgramError
 pub fn aya::programs::ProgramError::from(aya::programs::xdp::XdpError) -> Self
+impl core::convert::From<aya::sys::NetlinkError> for aya::programs::xdp::XdpError
+pub fn aya::programs::xdp::XdpError::from(aya::sys::NetlinkError) -> Self
 impl core::error::Error for aya::programs::xdp::XdpError
 pub fn aya::programs::xdp::XdpError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
 impl core::fmt::Debug for aya::programs::xdp::XdpError
@@ -5915,7 +5919,7 @@ pub aya::programs::ProgramError::LoadError
 pub aya::programs::ProgramError::LoadError::io_error: std::io::error::Error
 pub aya::programs::ProgramError::LoadError::verifier_log: aya_obj::VerifierLog
 pub aya::programs::ProgramError::MapError(aya::maps::MapError)
-pub aya::programs::ProgramError::NetlinkError(aya::sys::netlink::NetlinkError)
+pub aya::programs::ProgramError::NetlinkError(aya::sys::NetlinkError)
 pub aya::programs::ProgramError::NotAttached
 pub aya::programs::ProgramError::NotLoaded
 pub aya::programs::ProgramError::SkReuseportError(aya::programs::sk_reuseport::SkReuseportError)
@@ -5948,6 +5952,8 @@ impl core::convert::From<aya::programs::uprobe::UProbeError> for aya::programs::
 pub fn aya::programs::ProgramError::from(aya::programs::uprobe::UProbeError) -> Self
 impl core::convert::From<aya::programs::xdp::XdpError> for aya::programs::ProgramError
 pub fn aya::programs::ProgramError::from(aya::programs::xdp::XdpError) -> Self
+impl core::convert::From<aya::sys::NetlinkError> for aya::programs::ProgramError
+pub fn aya::programs::ProgramError::from(aya::sys::NetlinkError) -> Self
 impl core::convert::From<aya::sys::SyscallError> for aya::programs::ProgramError
 pub fn aya::programs::ProgramError::from(aya::sys::SyscallError) -> Self
 impl core::convert::From<aya_obj::btf::btf::BtfError> for aya::programs::ProgramError
@@ -6083,12 +6089,14 @@ pub aya::programs::TcError::AlreadyAttached
 pub aya::programs::TcError::InvalidLinkOperation
 pub aya::programs::TcError::InvalidTcxAttach(u32)
 pub aya::programs::TcError::IoError(std::io::error::Error)
-pub aya::programs::TcError::NetlinkError(aya::sys::netlink::NetlinkError)
+pub aya::programs::TcError::NetlinkError(aya::sys::NetlinkError)
 pub aya::programs::TcError::NulError(alloc::ffi::c_str::NulError)
 impl core::convert::From<alloc::ffi::c_str::NulError> for aya::programs::tc::TcError
 pub fn aya::programs::tc::TcError::from(alloc::ffi::c_str::NulError) -> Self
 impl core::convert::From<aya::programs::tc::TcError> for aya::programs::ProgramError
 pub fn aya::programs::ProgramError::from(aya::programs::tc::TcError) -> Self
+impl core::convert::From<aya::sys::NetlinkError> for aya::programs::tc::TcError
+pub fn aya::programs::tc::TcError::from(aya::sys::NetlinkError) -> Self
 impl core::convert::From<std::io::error::Error> for aya::programs::tc::TcError
 pub fn aya::programs::tc::TcError::from(std::io::error::Error) -> Self
 impl core::error::Error for aya::programs::tc::TcError
@@ -6153,9 +6161,11 @@ impl core::marker::UnsafeUnpin for aya::programs::uprobe::UProbeError
 impl !core::panic::unwind_safe::RefUnwindSafe for aya::programs::uprobe::UProbeError
 impl !core::panic::unwind_safe::UnwindSafe for aya::programs::uprobe::UProbeError
 pub enum aya::programs::XdpError
-pub aya::programs::XdpError::NetlinkError(aya::sys::netlink::NetlinkError)
+pub aya::programs::XdpError::NetlinkError(aya::sys::NetlinkError)
 impl core::convert::From<aya::programs::xdp::XdpError> for aya::programs::ProgramError
 pub fn aya::programs::ProgramError::from(aya::programs::xdp::XdpError) -> Self
+impl core::convert::From<aya::sys::NetlinkError> for aya::programs::xdp::XdpError
+pub fn aya::programs::xdp::XdpError::from(aya::sys::NetlinkError) -> Self
 impl core::error::Error for aya::programs::xdp::XdpError
 pub fn aya::programs::xdp::XdpError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
 impl core::fmt::Debug for aya::programs::xdp::XdpError
@@ -7669,6 +7679,30 @@ impl core::marker::Unpin for aya::sys::Stats
 impl core::marker::UnsafeUnpin for aya::sys::Stats
 impl core::panic::unwind_safe::RefUnwindSafe for aya::sys::Stats
 impl core::panic::unwind_safe::UnwindSafe for aya::sys::Stats
+pub struct aya::sys::NetlinkError(_)
+impl aya::sys::NetlinkError
+pub fn aya::sys::NetlinkError::raw_os_error(&self) -> core::option::Option<i32>
+impl core::convert::From<aya::sys::NetlinkError> for aya::programs::ProgramError
+pub fn aya::programs::ProgramError::from(aya::sys::NetlinkError) -> Self
+impl core::convert::From<aya::sys::NetlinkError> for aya::programs::tc::TcError
+pub fn aya::programs::tc::TcError::from(aya::sys::NetlinkError) -> Self
+impl core::convert::From<aya::sys::NetlinkError> for aya::programs::xdp::XdpError
+pub fn aya::programs::xdp::XdpError::from(aya::sys::NetlinkError) -> Self
+impl core::convert::From<aya::sys::NetlinkError> for aya::test_helpers::AyaTestError
+pub fn aya::test_helpers::AyaTestError::from(aya::sys::NetlinkError) -> Self
+impl core::error::Error for aya::sys::NetlinkError
+pub fn aya::sys::NetlinkError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+impl core::fmt::Debug for aya::sys::NetlinkError
+pub fn aya::sys::NetlinkError::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::fmt::Display for aya::sys::NetlinkError
+pub fn aya::sys::NetlinkError::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for aya::sys::NetlinkError
+impl core::marker::Send for aya::sys::NetlinkError
+impl core::marker::Sync for aya::sys::NetlinkError
+impl core::marker::Unpin for aya::sys::NetlinkError
+impl core::marker::UnsafeUnpin for aya::sys::NetlinkError
+impl !core::panic::unwind_safe::RefUnwindSafe for aya::sys::NetlinkError
+impl !core::panic::unwind_safe::UnwindSafe for aya::sys::NetlinkError
 pub struct aya::sys::SyscallError
 pub aya::sys::SyscallError::call: &'static str
 pub aya::sys::SyscallError::io_error: std::io::error::Error
@@ -7698,6 +7732,80 @@ pub fn aya::sys::is_helper_supported(aya::programs::ProgramType, aya::sys::BpfHe
 pub fn aya::sys::is_map_supported(aya::maps::MapType) -> core::result::Result<bool, aya::sys::SyscallError>
 pub fn aya::sys::is_program_supported(aya::programs::ProgramType) -> core::result::Result<bool, aya::programs::ProgramError>
 pub type aya::sys::BpfHelper = aya_obj::generated::linux_bindings_x86_64::bpf_func_id
+pub mod aya::test_helpers
+pub enum aya::test_helpers::AyaTestError
+pub aya::test_helpers::AyaTestError::Cgroup2NotFound
+pub aya::test_helpers::AyaTestError::Io
+pub aya::test_helpers::AyaTestError::Io::op: &'static str
+pub aya::test_helpers::AyaTestError::Io::path: std::path::PathBuf
+pub aya::test_helpers::AyaTestError::Io::source: std::io::error::Error
+pub aya::test_helpers::AyaTestError::MissingMountEntryField
+pub aya::test_helpers::AyaTestError::MissingMountEntryField::field: &'static str
+pub aya::test_helpers::AyaTestError::MissingMountEntryField::mount_entry: alloc::string::String
+pub aya::test_helpers::AyaTestError::Multi(alloc::vec::Vec<Self>)
+pub aya::test_helpers::AyaTestError::Netlink(aya::sys::NetlinkError)
+pub aya::test_helpers::AyaTestError::Syscall
+pub aya::test_helpers::AyaTestError::Syscall::path: core::option::Option<std::path::PathBuf>
+pub aya::test_helpers::AyaTestError::Syscall::source: nix::errno::consts::Errno
+pub aya::test_helpers::AyaTestError::Syscall::syscall: &'static str
+impl core::convert::From<aya::sys::NetlinkError> for aya::test_helpers::AyaTestError
+pub fn aya::test_helpers::AyaTestError::from(aya::sys::NetlinkError) -> Self
+impl core::error::Error for aya::test_helpers::AyaTestError
+pub fn aya::test_helpers::AyaTestError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+impl core::fmt::Debug for aya::test_helpers::AyaTestError
+pub fn aya::test_helpers::AyaTestError::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::fmt::Display for aya::test_helpers::AyaTestError
+pub fn aya::test_helpers::AyaTestError::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for aya::test_helpers::AyaTestError
+impl core::marker::Send for aya::test_helpers::AyaTestError
+impl core::marker::Sync for aya::test_helpers::AyaTestError
+impl core::marker::Unpin for aya::test_helpers::AyaTestError
+impl core::marker::UnsafeUnpin for aya::test_helpers::AyaTestError
+impl !core::panic::unwind_safe::RefUnwindSafe for aya::test_helpers::AyaTestError
+impl !core::panic::unwind_safe::UnwindSafe for aya::test_helpers::AyaTestError
+pub enum aya::test_helpers::Cgroup<'a>
+pub aya::test_helpers::Cgroup::Child(aya::test_helpers::ChildCgroup<'a>)
+pub aya::test_helpers::Cgroup::Root(std::path::PathBuf)
+impl aya::test_helpers::Cgroup<'static>
+pub fn aya::test_helpers::Cgroup<'static>::root() -> aya::test_helpers::AyaTestResult<Self>
+impl<'a> aya::test_helpers::Cgroup<'a>
+pub fn aya::test_helpers::Cgroup<'a>::create_child(&'a self, &str) -> aya::test_helpers::AyaTestResult<aya::test_helpers::ChildCgroup<'a>>
+pub fn aya::test_helpers::Cgroup<'a>::write_pid(&self, u32) -> aya::test_helpers::AyaTestResult<()>
+impl<'a> core::marker::Freeze for aya::test_helpers::Cgroup<'a>
+impl<'a> core::marker::Send for aya::test_helpers::Cgroup<'a>
+impl<'a> core::marker::Sync for aya::test_helpers::Cgroup<'a>
+impl<'a> core::marker::Unpin for aya::test_helpers::Cgroup<'a>
+impl<'a> core::marker::UnsafeUnpin for aya::test_helpers::Cgroup<'a>
+impl<'a> core::panic::unwind_safe::RefUnwindSafe for aya::test_helpers::Cgroup<'a>
+impl<'a> core::panic::unwind_safe::UnwindSafe for aya::test_helpers::Cgroup<'a>
+pub struct aya::test_helpers::ChildCgroup<'a>
+impl<'a> aya::test_helpers::ChildCgroup<'a>
+pub fn aya::test_helpers::ChildCgroup<'a>::fd(&self) -> aya::test_helpers::AyaTestResult<std::fs::File>
+pub const fn aya::test_helpers::ChildCgroup<'a>::into_cgroup(self) -> aya::test_helpers::Cgroup<'a>
+impl core::ops::drop::Drop for aya::test_helpers::ChildCgroup<'_>
+pub fn aya::test_helpers::ChildCgroup<'_>::drop(&mut self)
+impl<'a> core::marker::Freeze for aya::test_helpers::ChildCgroup<'a>
+impl<'a> core::marker::Send for aya::test_helpers::ChildCgroup<'a>
+impl<'a> core::marker::Sync for aya::test_helpers::ChildCgroup<'a>
+impl<'a> core::marker::Unpin for aya::test_helpers::ChildCgroup<'a>
+impl<'a> core::marker::UnsafeUnpin for aya::test_helpers::ChildCgroup<'a>
+impl<'a> core::panic::unwind_safe::RefUnwindSafe for aya::test_helpers::ChildCgroup<'a>
+impl<'a> core::panic::unwind_safe::UnwindSafe for aya::test_helpers::ChildCgroup<'a>
+pub struct aya::test_helpers::NetNsGuard
+impl aya::test_helpers::NetNsGuard
+pub fn aya::test_helpers::NetNsGuard::new() -> core::result::Result<Self, aya::test_helpers::AyaTestError>
+impl core::ops::drop::Drop for aya::test_helpers::NetNsGuard
+pub fn aya::test_helpers::NetNsGuard::drop(&mut self)
+impl std::os::fd::owned::AsFd for aya::test_helpers::NetNsGuard
+pub fn aya::test_helpers::NetNsGuard::as_fd(&self) -> std::os::fd::owned::BorrowedFd<'_>
+impl core::marker::Freeze for aya::test_helpers::NetNsGuard
+impl !core::marker::Send for aya::test_helpers::NetNsGuard
+impl !core::marker::Sync for aya::test_helpers::NetNsGuard
+impl core::marker::Unpin for aya::test_helpers::NetNsGuard
+impl core::marker::UnsafeUnpin for aya::test_helpers::NetNsGuard
+impl core::panic::unwind_safe::RefUnwindSafe for aya::test_helpers::NetNsGuard
+impl core::panic::unwind_safe::UnwindSafe for aya::test_helpers::NetNsGuard
+pub type aya::test_helpers::AyaTestResult<T> = core::result::Result<T, aya::test_helpers::AyaTestError>
 pub mod aya::util
 pub struct aya::util::KernelVersion
 impl aya::util::KernelVersion


### PR DESCRIPTION
There is demand for using these test helpers outside of Aya monorepo for developers to test their programs. Move `utils.rs` from the `integration-test` crate to `test_helpers.rs` in the aya crate.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aya-rs/aya/1596)
<!-- Reviewable:end -->
