### PR TITLE
xtask: Add `Architecture::sysroot` method

### DIFF
--- a/xtask/src/codegen/aya.rs
+++ b/xtask/src/codegen/aya.rs
@@ -35,17 +35,6 @@ fn codegen_internal_btf_bindings(libbpf_dir: &Path) -> Result<()> {
 }
 
 fn codegen_bindings(opts: &SysrootOptions, libbpf_dir: &Path) -> Result<()> {
-    let SysrootOptions {
-        aarch64_sysroot,
-        armv7_sysroot,
-        loongarch64_sysroot,
-        mips_sysroot,
-        mips64_sysroot,
-        powerpc64_sysroot,
-        riscv64_sysroot,
-        s390x_sysroot,
-        x86_64_sysroot,
-    } = opts;
     let dir = Path::new("aya-obj");
     let generated = dir.join("src/generated");
     create_dir_all(&generated)?;
@@ -189,17 +178,7 @@ fn codegen_bindings(opts: &SysrootOptions, libbpf_dir: &Path) -> Result<()> {
 
         // Set the sysroot. This is needed to ensure that the correct arch
         // specific headers are imported.
-        let sysroot = match arch {
-            Architecture::AArch64 => aarch64_sysroot,
-            Architecture::ARMv7 => armv7_sysroot,
-            Architecture::LoongArch64 => loongarch64_sysroot,
-            Architecture::Mips => mips_sysroot,
-            Architecture::Mips64 => mips64_sysroot,
-            Architecture::PowerPC64 => powerpc64_sysroot,
-            Architecture::RISCV64 => riscv64_sysroot,
-            Architecture::S390X => s390x_sysroot,
-            Architecture::X86_64 => x86_64_sysroot,
-        };
+        let sysroot = arch.sysroot(opts);
         bindgen = bindgen.clang_args(["-I", sysroot.to_str().unwrap()]);
 
         let bindings = bindgen.generate().context("bindgen failed")?;

--- a/xtask/src/codegen/aya_ebpf_bindings.rs
+++ b/xtask/src/codegen/aya_ebpf_bindings.rs
@@ -16,18 +16,6 @@ use crate::codegen::{
 };
 
 pub(crate) fn codegen(opts: &SysrootOptions, libbpf_dir: &Path) -> Result<()> {
-    let SysrootOptions {
-        aarch64_sysroot,
-        armv7_sysroot,
-        loongarch64_sysroot,
-        mips_sysroot,
-        mips64_sysroot,
-        powerpc64_sysroot,
-        riscv64_sysroot,
-        s390x_sysroot,
-        x86_64_sysroot,
-    } = opts;
-
     let tmp_dir = tempfile::tempdir().context("tempdir failed")?;
     let libbpf_headers_dir = tmp_dir.path().join("libbpf_headers");
 
@@ -106,17 +94,7 @@ pub(crate) fn codegen(opts: &SysrootOptions, libbpf_dir: &Path) -> Result<()> {
 
         // Set the sysroot. This is needed to ensure that the correct arch
         // specific headers are imported.
-        let sysroot = match arch {
-            Architecture::AArch64 => aarch64_sysroot,
-            Architecture::ARMv7 => armv7_sysroot,
-            Architecture::LoongArch64 => loongarch64_sysroot,
-            Architecture::Mips => mips_sysroot,
-            Architecture::Mips64 => mips64_sysroot,
-            Architecture::PowerPC64 => powerpc64_sysroot,
-            Architecture::RISCV64 => riscv64_sysroot,
-            Architecture::S390X => s390x_sysroot,
-            Architecture::X86_64 => x86_64_sysroot,
-        };
+        let sysroot = arch.sysroot(opts);
         bindgen = bindgen.clang_args(["-I", sysroot.to_str().unwrap()]);
 
         let bindings = bindgen.generate().context("bindgen failed")?;

--- a/xtask/src/codegen/mod.rs
+++ b/xtask/src/codegen/mod.rs
@@ -50,6 +50,31 @@ impl Architecture {
             Self::X86_64 => "x86_64-unknown-linux-gnu",
         }
     }
+
+    pub(crate) fn sysroot(self, opts: &SysrootOptions) -> &Path {
+        let SysrootOptions {
+            aarch64_sysroot,
+            armv7_sysroot,
+            loongarch64_sysroot,
+            mips_sysroot,
+            mips64_sysroot,
+            powerpc64_sysroot,
+            riscv64_sysroot,
+            s390x_sysroot,
+            x86_64_sysroot,
+        } = opts;
+        match self {
+            Self::AArch64 => aarch64_sysroot,
+            Self::ARMv7 => armv7_sysroot,
+            Self::LoongArch64 => loongarch64_sysroot,
+            Self::Mips => mips_sysroot,
+            Self::Mips64 => mips64_sysroot,
+            Self::PowerPC64 => powerpc64_sysroot,
+            Self::RISCV64 => riscv64_sysroot,
+            Self::S390X => s390x_sysroot,
+            Self::X86_64 => x86_64_sysroot,
+        }
+    }
 }
 
 impl std::str::FromStr for Architecture {


### PR DESCRIPTION
Each subcommand of `xtask codegen` uses the same boilerplate match statement for figuring out the sysroot. Move it to a common method.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aya-rs/aya/1597)
<!-- Reviewable:end -->
