### PR TITLE
aya, aya-ebpf: add UserRingBuf

### DIFF
--- a/aya/src/bpf.rs
+++ b/aya/src/bpf.rs
@@ -840,6 +840,7 @@ fn parse_map(
         bpf_map_type::BPF_MAP_TYPE_PERF_EVENT_ARRAY => Map::PerfEventArray(map),
         bpf_map_type::BPF_MAP_TYPE_REUSEPORT_SOCKARRAY => Map::ReusePortSockArray(map),
         bpf_map_type::BPF_MAP_TYPE_RINGBUF => Map::RingBuf(map),
+        bpf_map_type::BPF_MAP_TYPE_USER_RINGBUF => Map::UserRingBuf(map),
         bpf_map_type::BPF_MAP_TYPE_SOCKHASH => Map::SockHash(map),
         bpf_map_type::BPF_MAP_TYPE_SOCKMAP => Map::SockMap(map),
         bpf_map_type::BPF_MAP_TYPE_BLOOM_FILTER => Map::BloomFilter(map),
@@ -883,9 +884,11 @@ fn max_entries_override(
     let max_entries = || user_override.unwrap_or_else(&current_value);
     Ok(match map_type {
         bpf_map_type::BPF_MAP_TYPE_PERF_EVENT_ARRAY if max_entries() == 0 => Some(num_cpus()?),
-        bpf_map_type::BPF_MAP_TYPE_RINGBUF => Some(adjust_to_page_size(max_entries(), page_size()))
-            .filter(|adjusted| *adjusted != max_entries())
-            .or(user_override),
+        bpf_map_type::BPF_MAP_TYPE_RINGBUF | bpf_map_type::BPF_MAP_TYPE_USER_RINGBUF => {
+            Some(adjust_to_page_size(max_entries(), page_size()))
+                .filter(|adjusted| *adjusted != max_entries())
+                .or(user_override)
+        }
         _ => user_override,
     })
 }
@@ -898,7 +901,7 @@ fn value_size_override(map_type: bpf_map_type) -> Option<u32> {
         bpf_map_type::BPF_MAP_TYPE_DEVMAP | bpf_map_type::BPF_MAP_TYPE_DEVMAP_HASH => {
             Some(if FEATURES.devmap_prog_id() { 8 } else { 4 })
         }
-        bpf_map_type::BPF_MAP_TYPE_RINGBUF => Some(0),
+        bpf_map_type::BPF_MAP_TYPE_RINGBUF | bpf_map_type::BPF_MAP_TYPE_USER_RINGBUF => Some(0),
         _ => None,
     }
 }

--- a/aya/src/maps/mod.rs
+++ b/aya/src/maps/mod.rs
@@ -861,7 +861,7 @@ impl MapData {
 
     pub(crate) fn create_pinned_by_name<P: AsRef<Path>>(
         path: P,
-        obj: aya_obj::Map,
+        mut obj: aya_obj::Map,
         name: &str,
         btf_fd: Option<BorrowedFd<'_>>,
         inner_map_obj: Option<aya_obj::Map>,
@@ -883,6 +883,15 @@ impl MapData {
             }
         };
         if let Ok(fd) = bpf_get_object(&path_string) {
+            // The pinned map already exists, so its definition lives in the kernel rather than in
+            // `obj`. Ring buffers size their mmap from `max_entries`, but the ELF value is often
+            // zero (resolved at load time), so refresh it from the kernel for those map types.
+            let map_type = obj.map_type();
+            if map_type == bpf_map_type::BPF_MAP_TYPE_RINGBUF as u32
+                || map_type == bpf_map_type::BPF_MAP_TYPE_USER_RINGBUF as u32
+            {
+                obj.set_max_entries(MapInfo::new_from_fd(fd.as_fd())?.max_entries());
+            }
             Ok(Self {
                 obj,
                 fd: MapFd::from_fd(fd),

--- a/aya/src/maps/mod.rs
+++ b/aya/src/maps/mod.rs
@@ -87,6 +87,7 @@ pub mod sk_storage;
 pub mod sock;
 pub mod stack;
 pub mod stack_trace;
+pub mod user_ring_buf;
 pub mod xdp;
 
 pub use array::{Array, CgroupArray, PerCpuArray, ProgramArray};
@@ -109,6 +110,7 @@ pub use sk_storage::SkStorage;
 pub use sock::{ReusePortSockArray, SockHash, SockMap};
 pub use stack::Stack;
 pub use stack_trace::StackTraceMap;
+pub use user_ring_buf::UserRingBuf;
 pub use xdp::{CpuMap, DevMap, DevMapHash, XskMap};
 
 /// Trait for constructing a typed map from [`MapData`].
@@ -362,6 +364,8 @@ pub enum Map {
     StackTraceMap(MapData),
     /// An unsupported map type.
     Unsupported(MapData),
+    /// A [`UserRingBuf`] map.
+    UserRingBuf(MapData),
     /// A [`XskMap`] map.
     XskMap(MapData),
 }
@@ -399,6 +403,7 @@ impl Map {
             Self::Stack(map) => map.obj.map_type(),
             Self::StackTraceMap(map) => map.obj.map_type(),
             Self::Unsupported(map) => map.obj.map_type(),
+            Self::UserRingBuf(map) => map.obj.map_type(),
             Self::XskMap(map) => map.obj.map_type(),
         }
     }
@@ -438,6 +443,7 @@ impl Map {
             Self::Stack(map) => map.pin(path),
             Self::StackTraceMap(map) => map.pin(path),
             Self::Unsupported(map) => map.pin(path),
+            Self::UserRingBuf(map) => map.pin(path),
             Self::XskMap(map) => map.pin(path),
         }
     }
@@ -484,7 +490,7 @@ impl Map {
             bpf_map_type::BPF_MAP_TYPE_STRUCT_OPS => Self::Unsupported(map_data),
             bpf_map_type::BPF_MAP_TYPE_INODE_STORAGE => Self::InodeStorage(map_data),
             bpf_map_type::BPF_MAP_TYPE_TASK_STORAGE => Self::Unsupported(map_data),
-            bpf_map_type::BPF_MAP_TYPE_USER_RINGBUF => Self::Unsupported(map_data),
+            bpf_map_type::BPF_MAP_TYPE_USER_RINGBUF => Self::UserRingBuf(map_data),
             bpf_map_type::BPF_MAP_TYPE_CGRP_STORAGE => Self::CgrpStorage(map_data),
             bpf_map_type::BPF_MAP_TYPE_ARENA => Self::Unsupported(map_data),
             bpf_map_type::BPF_MAP_TYPE_PERCPU_CGROUP_STORAGE_DEPRECATED => {
@@ -623,6 +629,7 @@ impl_try_from_map!(() {
     RingBuf,
     SockMap,
     StackTraceMap,
+    UserRingBuf,
     XskMap,
 });
 
@@ -709,6 +716,7 @@ impl_from_map_data!(() {
 // PerfEventArray and RingBuf use map_data() instead of inner field.
 impl_from_map_data!(<()> PerfEventArray via map_data);
 impl_from_map_data!(<()> RingBuf via map_data);
+impl_from_map_data!(<()> UserRingBuf via map_data);
 
 impl_from_map_data!((V) {
     Array, BloomFilter, CgrpStorage, InodeStorage, PerCpuArray,

--- a/aya/src/maps/user_ring_buf.rs
+++ b/aya/src/maps/user_ring_buf.rs
@@ -1,0 +1,281 @@
+//! A user space ring buffer that eBPF programs drain.
+
+use std::{
+    borrow::Borrow,
+    mem::ManuallyDrop,
+    ops::{Deref, DerefMut},
+    os::fd::{AsFd, AsRawFd, BorrowedFd, RawFd},
+    slice,
+    sync::atomic::{AtomicU32, AtomicUsize, Ordering},
+};
+
+use aya_obj::generated::{BPF_RINGBUF_BUSY_BIT, BPF_RINGBUF_DISCARD_BIT, BPF_RINGBUF_HDR_SZ};
+use libc::{MAP_SHARED, PROT_READ, PROT_WRITE};
+
+use crate::{
+    maps::{MapData, MapError},
+    util::{MMap, page_size},
+};
+
+/// A ring buffer that user space publishes into and an eBPF program drains.
+///
+/// `UserRingBuf` is the user-space-to-kernel counterpart of [`RingBuf`]: user space reserves a
+/// sample with [`reserve`], writes into it, and submits it, then the eBPF program consumes the
+/// samples by calling `bpf_user_ringbuf_drain` (exposed as `UserRingBuf::drain` in `aya-ebpf`).
+///
+/// To publish events you need to:
+/// * Construct [`UserRingBuf`] using [`UserRingBuf::try_from`].
+/// * Call [`reserve`] to obtain an entry, write the payload into it, then call [`submit`].
+///
+/// To receive async notifications that space has become available, you may construct an
+/// [`tokio::io::unix::AsyncFd`] from the [`UserRingBuf`]'s file descriptor and poll it for
+/// writability.
+///
+/// # Minimum kernel version
+///
+/// The minimum kernel version required to use this feature is 6.1.
+///
+/// [`RingBuf`]: super::RingBuf
+/// [`reserve`]: UserRingBuf::reserve
+/// [`submit`]: UserRingBufEntry::submit
+/// [`tokio::io::unix::AsyncFd`]: https://docs.rs/tokio/latest/tokio/io/unix/struct.AsyncFd.html
+#[doc(alias = "BPF_MAP_TYPE_USER_RINGBUF")]
+pub struct UserRingBuf<T> {
+    map: T,
+    consumer: ConsumerPos,
+    producer: ProducerData,
+}
+
+impl<T: Borrow<MapData>> UserRingBuf<T> {
+    pub(crate) fn new(map: T) -> Result<Self, MapError> {
+        let data: &MapData = map.borrow();
+        let page_size = page_size();
+        let map_fd = data.fd().as_fd();
+        let byte_size = data.obj.max_entries();
+        let consumer = ConsumerPos::new(map_fd, page_size)?;
+        let producer = ProducerData::new(map_fd, page_size, byte_size)?;
+        Ok(Self {
+            map,
+            consumer,
+            producer,
+        })
+    }
+
+    pub(crate) fn map_data(&self) -> &MapData {
+        self.map.borrow()
+    }
+
+    /// Reserves a sample of `size` bytes in the ring buffer.
+    ///
+    /// Returns `None` if the ring buffer has no room for the sample, either because it is full or
+    /// because `size` exceeds its capacity. Write the payload into the returned entry, then call
+    /// [`UserRingBufEntry::submit`] to publish it; dropping the entry without submitting discards
+    /// it.
+    ///
+    /// Only one [`UserRingBufEntry`] may be outstanding at a time.
+    pub fn reserve(&mut self, size: usize) -> Option<UserRingBufEntry<'_>> {
+        let Self {
+            map: _,
+            consumer,
+            producer,
+        } = self;
+        producer.reserve(size, consumer)
+    }
+}
+
+impl<T: Borrow<MapData>> AsFd for UserRingBuf<T> {
+    fn as_fd(&self) -> BorrowedFd<'_> {
+        let Self {
+            map,
+            consumer: _,
+            producer: _,
+        } = self;
+        map.borrow().fd().as_fd()
+    }
+}
+
+impl<T: Borrow<MapData>> AsRawFd for UserRingBuf<T> {
+    fn as_raw_fd(&self) -> RawFd {
+        self.as_fd().as_raw_fd()
+    }
+}
+
+/// A reserved sample in a [`UserRingBuf`], obtained from [`UserRingBuf::reserve`].
+///
+/// Write the payload through the `[u8]` view, then call [`submit`] to publish it. Dropping the entry
+/// without submitting discards it.
+///
+/// [`submit`]: UserRingBufEntry::submit
+pub struct UserRingBufEntry<'a> {
+    payload: &'a mut [u8],
+    header: *const AtomicU32,
+}
+
+impl Deref for UserRingBufEntry<'_> {
+    type Target = [u8];
+
+    fn deref(&self) -> &Self::Target {
+        let Self { payload, header: _ } = self;
+        payload
+    }
+}
+
+impl DerefMut for UserRingBufEntry<'_> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        let Self { payload, header: _ } = self;
+        payload
+    }
+}
+
+impl UserRingBufEntry<'_> {
+    /// Submits the sample, making it available to the eBPF program draining the ring buffer.
+    pub fn submit(self) {
+        ManuallyDrop::new(self).commit(false);
+    }
+
+    /// Discards the sample; the eBPF program draining the ring buffer skips it.
+    pub fn discard(self) {
+        ManuallyDrop::new(self).commit(true);
+    }
+
+    fn commit(&self, discard: bool) {
+        let Self { payload, header } = self;
+        let mut len = payload.len() as u32;
+        if discard {
+            len |= BPF_RINGBUF_DISCARD_BIT;
+        }
+        // Clear the busy bit (and optionally set the discard bit). The release store pairs with the
+        // kernel's acquire load of the header in __bpf_user_ringbuf_peek, publishing the payload [0].
+        //
+        // [0]: https://github.com/torvalds/linux/blob/ffc253263a1375a65fa6c9f62a893e9767fbebfa/kernel/bpf/ringbuf.c#L675
+        unsafe { &**header }.store(len, Ordering::Release);
+    }
+}
+
+impl Drop for UserRingBufEntry<'_> {
+    fn drop(&mut self) {
+        // A reservation dropped without submitting is abandoned; discard it so the ring buffer is
+        // not blocked by a perpetually busy sample.
+        self.commit(true);
+    }
+}
+
+// A read-only view of the consumer position, which the kernel advances as it drains samples.
+struct ConsumerPos {
+    mmap: MMap,
+}
+
+impl ConsumerPos {
+    fn new(fd: BorrowedFd<'_>, page_size: usize) -> Result<Self, MapError> {
+        // The consumer position page is owned by the kernel; user space only reads it.
+        let mmap = MMap::new(fd, page_size, PROT_READ, MAP_SHARED, 0)?;
+        Ok(Self { mmap })
+    }
+
+    fn get(&self) -> usize {
+        // Pair the kernel's release store in __bpf_user_ringbuf_sample_release with an acquire load
+        // so that freed space becomes visible [0].
+        //
+        // [0]: https://github.com/torvalds/linux/blob/ffc253263a1375a65fa6c9f62a893e9767fbebfa/kernel/bpf/ringbuf.c#L723
+        unsafe { self.mmap.ptr().cast::<AtomicUsize>().as_ref() }.load(Ordering::Acquire)
+    }
+}
+
+// A writable view of the producer position and the data region, both owned by user space.
+struct ProducerData {
+    mmap: MMap,
+
+    // Offset in the mmap where the data region starts.
+    data_offset: usize,
+
+    // A bitmask which truncates positions to the domain of valid offsets in the ring buffer.
+    mask: usize,
+}
+
+impl ProducerData {
+    fn new(fd: BorrowedFd<'_>, page_size: usize, byte_size: u32) -> Result<Self, MapError> {
+        // The producer pages hold one metadata page followed by the data pages, mapped read-write
+        // because user space is the producer. The data pages are mapped twice consecutively so that
+        // a sample which wraps the end of the ring buffer remains contiguous [0].
+        //
+        // [0]: https://github.com/torvalds/linux/blob/ffc253263a1375a65fa6c9f62a893e9767fbebfa/kernel/bpf/ringbuf.c#L99-L114
+        let len = page_size + 2 * usize::try_from(byte_size).unwrap();
+        let mmap = MMap::new(
+            fd,
+            len,
+            PROT_READ | PROT_WRITE,
+            MAP_SHARED,
+            page_size.try_into().unwrap(),
+        )?;
+
+        // byte_size is a power of two, so subtracting one yields a mask for offsets less than it.
+        debug_assert!(byte_size.is_power_of_two());
+        let mask = usize::try_from(byte_size - 1).unwrap();
+        Ok(Self {
+            mmap,
+            data_offset: page_size,
+            mask,
+        })
+    }
+
+    fn reserve<'a>(
+        &'a mut self,
+        size: usize,
+        consumer: &ConsumerPos,
+    ) -> Option<UserRingBufEntry<'a>> {
+        let Self {
+            mmap,
+            data_offset,
+            mask,
+        } = self;
+
+        // The top two header bits encode the busy and discard flags, so a size that sets them would
+        // be misread by the kernel; reject it like libbpf does.
+        if size as u32 & (BPF_RINGBUF_BUSY_BIT | BPF_RINGBUF_DISCARD_BIT) != 0 {
+            return None;
+        }
+
+        let hdr_size = usize::try_from(BPF_RINGBUF_HDR_SZ).unwrap();
+        let max_size = *mask + 1;
+        let total = size
+            .checked_add(hdr_size)
+            .and_then(|total| total.checked_next_multiple_of(8))?;
+        if total > max_size {
+            return None;
+        }
+
+        // Read the producer position from the shared mapping on every reservation rather than
+        // caching it, so that a second handle over the same map (or a reopened pin) advancing the
+        // position cannot leave this one reserving a stale slot.
+        let producer_pos = unsafe { mmap.ptr().cast::<AtomicUsize>().as_ref() };
+        let pos = producer_pos.load(Ordering::Acquire);
+        let available = max_size - pos.wrapping_sub(consumer.get());
+        if available < total {
+            return None;
+        }
+
+        let data = unsafe { mmap.ptr().cast::<u8>().add(*data_offset) };
+
+        // Write the header with the busy bit set so the kernel skips the sample until it is
+        // submitted. The kernel only reads the first word of the header for user ring buffers, so
+        // the second word is left untouched. The data region is mapped twice, so the header and the
+        // payload are each contiguous across the wrap.
+        let header_offset = pos & *mask;
+        let header = unsafe { data.add(header_offset) }.cast::<AtomicU32>();
+        unsafe { header.as_ref() }.store(size as u32 | BPF_RINGBUF_BUSY_BIT, Ordering::Relaxed);
+
+        // Publish the advanced producer position. The release store pairs with the kernel's acquire
+        // load in __bpf_user_ringbuf_peek and makes the busy header visible [0].
+        //
+        // [0]: https://github.com/torvalds/linux/blob/ffc253263a1375a65fa6c9f62a893e9767fbebfa/kernel/bpf/ringbuf.c#L664
+        producer_pos.store(pos + total, Ordering::Release);
+
+        let payload = unsafe {
+            slice::from_raw_parts_mut(data.add((header_offset + hdr_size) & *mask).as_ptr(), size)
+        };
+        Some(UserRingBufEntry {
+            payload,
+            header: header.as_ptr().cast_const(),
+        })
+    }
+}

--- a/aya/src/sys/bpf.rs
+++ b/aya/src/sys/bpf.rs
@@ -91,7 +91,8 @@ pub(crate) fn bpf_create_map(
                 | bpf_map_type::BPF_MAP_TYPE_SOCKHASH
                 | bpf_map_type::BPF_MAP_TYPE_QUEUE
                 | bpf_map_type::BPF_MAP_TYPE_STACK
-                | bpf_map_type::BPF_MAP_TYPE_RINGBUF,
+                | bpf_map_type::BPF_MAP_TYPE_RINGBUF
+                | bpf_map_type::BPF_MAP_TYPE_USER_RINGBUF,
             ) => {
                 u.btf_key_type_id = 0;
                 u.btf_value_type_id = 0;
@@ -1614,6 +1615,7 @@ bpf_map_type::BPF_MAP_TYPE_DEVMAP_HASH`"]
     #[case::queue(bpf_map_type::BPF_MAP_TYPE_QUEUE)]
     #[case::stack(bpf_map_type::BPF_MAP_TYPE_STACK)]
     #[case::ringbuf(bpf_map_type::BPF_MAP_TYPE_RINGBUF)]
+    #[case::user_ringbuf(bpf_map_type::BPF_MAP_TYPE_USER_RINGBUF)]
     fn test_btf_blocklist_strips_type_ids(#[case] map_type: bpf_map_type) {
         const BTF_FD: i32 = 42;
 

--- a/ebpf/aya-ebpf/src/btf_maps/mod.rs
+++ b/ebpf/aya-ebpf/src/btf_maps/mod.rs
@@ -22,6 +22,7 @@ pub mod sock_hash;
 pub mod sock_map;
 pub mod stack;
 pub mod stack_trace;
+pub mod user_ring_buf;
 pub mod xsk_map;
 
 pub use array::Array;
@@ -52,6 +53,7 @@ pub use sock_hash::SockHash;
 pub use sock_map::SockMap;
 pub use stack::Stack;
 pub use stack_trace::StackTrace;
+pub use user_ring_buf::UserRingBuf;
 pub use xsk_map::XskMap;
 
 mod private {

--- a/ebpf/aya-ebpf/src/btf_maps/user_ring_buf.rs
+++ b/ebpf/aya-ebpf/src/btf_maps/user_ring_buf.rs
@@ -1,0 +1,33 @@
+use core::ops::ControlFlow;
+
+use crate::{
+    btf_maps::btf_map_def,
+    maps::user_ring_buf::{UserRingBufEntry, drain},
+};
+
+btf_map_def!(
+    /// A BTF-compatible BPF user ring buffer map.
+    ///
+    /// User ring buffers have a special `value_size` field set to 0.
+    ///
+    /// The minimum kernel version required to use this feature is 6.1.
+    pub struct UserRingBuf<T; const MAX_ENTRIES: usize, const FLAGS: usize = 0>,
+    map_type: BPF_MAP_TYPE_USER_RINGBUF,
+    max_entries: MAX_ENTRIES,
+    map_flags: FLAGS,
+    key_type: (),
+    value_type: T,
+    value_size: *const [i32; 0] = ::core::ptr::null(),
+);
+
+impl<T, const MAX_ENTRIES: usize, const FLAGS: usize> UserRingBuf<T, MAX_ENTRIES, FLAGS> {
+    /// Drains the samples published by user space, running `callback` over each one.
+    ///
+    /// See [`UserRingBuf::drain`](crate::maps::UserRingBuf::drain) for the full contract.
+    pub fn drain<F>(&self, callback: F, flags: u64) -> Result<u32, i32>
+    where
+        F: Fn(UserRingBufEntry<'_>) -> ControlFlow<()>,
+    {
+        drain(self.as_ptr().cast(), callback, flags)
+    }
+}

--- a/ebpf/aya-ebpf/src/maps/mod.rs
+++ b/ebpf/aya-ebpf/src/maps/mod.rs
@@ -92,6 +92,7 @@ pub mod sock_hash;
 pub mod sock_map;
 pub mod stack;
 pub mod stack_trace;
+pub mod user_ring_buf;
 pub mod xdp;
 
 pub use array::Array;
@@ -114,6 +115,7 @@ pub use sock_hash::SockHash;
 pub use sock_map::SockMap;
 pub use stack::Stack;
 pub use stack_trace::StackTrace;
+pub use user_ring_buf::UserRingBuf;
 pub use xdp::{CpuMap, DevMap, DevMapHash, XskMap};
 
 mod private {

--- a/ebpf/aya-ebpf/src/maps/user_ring_buf.rs
+++ b/ebpf/aya-ebpf/src/maps/user_ring_buf.rs
@@ -1,0 +1,159 @@
+use core::{
+    marker::PhantomData,
+    mem::{self, MaybeUninit},
+    ops::ControlFlow,
+    ptr,
+};
+
+use aya_ebpf_cty::{c_long, c_void};
+
+use crate::{
+    bindings::{bpf_dynptr, bpf_map_type::BPF_MAP_TYPE_USER_RINGBUF},
+    helpers::{bpf_dynptr_read, bpf_user_ringbuf_drain},
+    maps::{MapDef, PinningType},
+};
+
+/// A ring buffer map that user space publishes into and an eBPF program drains.
+///
+/// `UserRingBuf` is the user-space-to-kernel counterpart of [`RingBuf`]: user space
+/// reserves and submits samples into the ring, and the eBPF program consumes them by
+/// calling [`UserRingBuf::drain`], which runs a callback over each pending sample.
+///
+/// # Minimum kernel version
+///
+/// The minimum kernel version required to use this feature is 6.1.
+///
+/// [`RingBuf`]: super::RingBuf
+#[repr(transparent)]
+pub struct UserRingBuf {
+    def: MapDef,
+}
+
+impl super::private::Map for UserRingBuf {
+    type Key = ();
+    type Value = ();
+}
+
+impl UserRingBuf {
+    /// Declares an eBPF user ring buffer.
+    ///
+    /// The Linux kernel requires that `byte_size` be a power-of-2 multiple of the page
+    /// size. The loading program may coerce the size when loading the map.
+    pub const fn with_byte_size(byte_size: u32, flags: u32) -> Self {
+        Self::new(byte_size, flags, PinningType::None)
+    }
+
+    /// Declares a pinned eBPF user ring buffer.
+    ///
+    /// The Linux kernel requires that `byte_size` be a power-of-2 multiple of the page
+    /// size. The loading program may coerce the size when loading the map.
+    pub const fn pinned(byte_size: u32, flags: u32) -> Self {
+        Self::new(byte_size, flags, PinningType::ByName)
+    }
+
+    const fn new(byte_size: u32, flags: u32, pinning_type: PinningType) -> Self {
+        Self {
+            def: MapDef::new::<(), ()>(BPF_MAP_TYPE_USER_RINGBUF, byte_size, flags, pinning_type),
+        }
+    }
+
+    /// Drains the samples published by user space, running `callback` over each one.
+    ///
+    /// The callback returns [`ControlFlow::Continue`] to consume the next sample, or
+    /// [`ControlFlow::Break`] to stop early. It must not capture any state, because the
+    /// kernel verifier requires it to be a standalone program; communicate through other
+    /// maps instead.
+    ///
+    /// Returns the number of samples drained.
+    ///
+    /// # Errors
+    ///
+    /// Returns a negative errno on failure: `-EBUSY` if another context is already
+    /// draining the ring, `-EINVAL` for invalid `flags`, or `-E2BIG` for an oversized
+    /// sample.
+    pub fn drain<F>(&self, callback: F, flags: u64) -> Result<u32, i32>
+    where
+        F: Fn(UserRingBufEntry<'_>) -> ControlFlow<()>,
+    {
+        drain(self.def.as_ptr(), callback, flags)
+    }
+}
+
+/// A read-only sample drained from a [`UserRingBuf`].
+///
+/// The sample's backing memory is owned by user space, so an eBPF program may only read
+/// it. The entry must not outlive the drain callback.
+pub struct UserRingBufEntry<'a> {
+    dynptr: *mut bpf_dynptr,
+    _marker: PhantomData<&'a [u8]>,
+}
+
+impl UserRingBufEntry<'_> {
+    /// Reads the sample, interpreting its bytes as `T`.
+    ///
+    /// Returns `None` if the sample is shorter than `size_of::<T>()`.
+    ///
+    /// # Safety
+    ///
+    /// The sample bytes are published by user space and are not validated, so the caller must
+    /// ensure they form a valid bit pattern for `T`. Reading a type that has invalid bit patterns
+    /// (`bool`, `char`, enums, `NonZero` integers, references, or any aggregate containing them)
+    /// from untrusted bytes is undefined behavior.
+    pub unsafe fn read<T>(&self) -> Option<T> {
+        let mut value = MaybeUninit::<T>::uninit();
+        let ret = unsafe {
+            bpf_dynptr_read(
+                value.as_mut_ptr().cast(),
+                size_of::<T>() as u32,
+                self.dynptr,
+                0,
+                0,
+            )
+        };
+        // SAFETY: a return value of 0 means `size_of::<T>()` bytes were written to `value`.
+        (ret == 0).then(|| unsafe { value.assume_init() })
+    }
+}
+
+/// Drains a user ring buffer identified by `map`, shared by the legacy and BTF
+/// [`UserRingBuf`] wrappers.
+pub(crate) fn drain<F>(map: *mut c_void, _callback: F, flags: u64) -> Result<u32, i32>
+where
+    F: Fn(UserRingBufEntry<'_>) -> ControlFlow<()>,
+{
+    // The kernel requires the callback to be a standalone BPF program (ARG_PTR_TO_FUNC),
+    // so it cannot capture state.
+    const {
+        assert!(
+            size_of::<F>() == 0,
+            "user ring buffer drain callback must not capture state"
+        )
+    };
+
+    unsafe extern "C" fn trampoline<F>(dynptr: *mut bpf_dynptr, _ctx: *mut c_void) -> c_long
+    where
+        F: Fn(UserRingBufEntry<'_>) -> ControlFlow<()>,
+    {
+        // SAFETY: `F` is zero-sized (asserted in `drain`), so a value can be produced
+        // without reading any memory.
+        let callback = unsafe { mem::zeroed::<F>() };
+        let entry = UserRingBufEntry {
+            dynptr,
+            _marker: PhantomData,
+        };
+        match callback(entry) {
+            ControlFlow::Continue(()) => 0,
+            ControlFlow::Break(()) => 1,
+        }
+    }
+
+    let ret = unsafe {
+        bpf_user_ringbuf_drain(
+            map,
+            trampoline::<F> as *const () as *mut c_void,
+            ptr::null_mut(),
+            flags,
+        )
+    };
+    u32::try_from(ret).map_err(|_err| ret as i32)
+}

--- a/test/integration-ebpf/Cargo.toml
+++ b/test/integration-ebpf/Cargo.toml
@@ -207,3 +207,7 @@ path = "src/inode_storage.rs"
 [[bin]]
 name = "cgrp_storage"
 path = "src/cgrp_storage.rs"
+
+[[bin]]
+name = "user_ring_buf"
+path = "src/user_ring_buf.rs"

--- a/test/integration-ebpf/src/user_ring_buf.rs
+++ b/test/integration-ebpf/src/user_ring_buf.rs
@@ -1,0 +1,73 @@
+#![no_std]
+#![no_main]
+#![expect(unused_crate_dependencies, reason = "used in other bins")]
+
+use core::ops::ControlFlow;
+
+use aya_ebpf::{
+    btf_maps::{RingBuf, UserRingBuf as BtfUserRingBuf},
+    macros::{btf_map, map, uprobe},
+    maps::{Array, UserRingBuf as LegacyUserRingBuf, user_ring_buf::UserRingBufEntry},
+    programs::ProbeContext,
+};
+#[cfg(not(test))]
+extern crate ebpf_panic;
+
+#[btf_map]
+static USER_RING_BUF: BtfUserRingBuf<u64, 0, 0> = BtfUserRingBuf::new();
+
+#[map]
+static USER_RING_BUF_LEGACY: LegacyUserRingBuf = LegacyUserRingBuf::with_byte_size(0, 0);
+
+// Each drained sample is echoed back to user space through this ring buffer so the test can assert
+// on the values the kernel observed.
+#[btf_map]
+static RESULT: RingBuf<u64, 0, 0> = RingBuf::new();
+
+// The number of samples the last drain reported, so the test can assert on the drain return value.
+#[map]
+static DRAIN_COUNT: Array<u64> = Array::with_max_entries(1, 0);
+
+fn echo_sample(entry: UserRingBufEntry<'_>) {
+    // SAFETY: the test publishes `u64` samples, and `u64` is valid for any bit pattern. A sample
+    // too short to hold a `u64` yields `None` and is skipped.
+    if let Some(value) = unsafe { entry.read::<u64>() } {
+        let _result = RESULT.output(value, 0);
+    }
+}
+
+// Echoes every sample, draining the whole ring buffer.
+fn echo(entry: UserRingBufEntry<'_>) -> ControlFlow<()> {
+    echo_sample(entry);
+    ControlFlow::Continue(())
+}
+
+// Echoes a single sample and then stops, leaving the rest of the ring buffer undrained.
+fn echo_once(entry: UserRingBufEntry<'_>) -> ControlFlow<()> {
+    echo_sample(entry);
+    ControlFlow::Break(())
+}
+
+macro_rules! define_user_ring_buf_drain {
+    ($name:ident, $map:expr, $callback:expr) => {
+        #[uprobe]
+        fn $name(_ctx: ProbeContext) {
+            if let Ok(drained) = $map.drain($callback, 0) {
+                if let Some(count) = DRAIN_COUNT.get_ptr_mut(0) {
+                    // SAFETY: the integration tests run single-threaded, so this is the only writer
+                    // of slot 0.
+                    unsafe { *count = drained.into() };
+                }
+            }
+        }
+    };
+}
+
+define_user_ring_buf_drain!(user_ring_buf_test, USER_RING_BUF, echo);
+define_user_ring_buf_drain!(user_ring_buf_test_legacy, USER_RING_BUF_LEGACY, echo);
+define_user_ring_buf_drain!(user_ring_buf_test_break, USER_RING_BUF, echo_once);
+define_user_ring_buf_drain!(
+    user_ring_buf_test_break_legacy,
+    USER_RING_BUF_LEGACY,
+    echo_once
+);

--- a/test/integration-test/src/lib.rs
+++ b/test/integration-test/src/lib.rs
@@ -90,6 +90,7 @@ bpf_file!(
     XSK_MAP => "xsk_map",
     INODE_STORAGE => "inode_storage",
     CGRP_STORAGE => "cgrp_storage",
+    USER_RING_BUF => "user_ring_buf",
 );
 
 #[cfg(test)]

--- a/test/integration-test/src/tests.rs
+++ b/test/integration-test/src/tests.rs
@@ -68,4 +68,5 @@ mod strncmp;
 mod tc_netlink;
 mod tcx;
 mod uprobe_cookie;
+mod user_ring_buf;
 mod xdp;

--- a/test/integration-test/src/tests/user_ring_buf.rs
+++ b/test/integration-test/src/tests/user_ring_buf.rs
@@ -1,0 +1,666 @@
+use std::{
+    os::fd::AsRawFd as _,
+    path::Path,
+    sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    },
+    thread,
+};
+
+use assert_matches::assert_matches;
+use aya::{
+    Ebpf, EbpfLoader,
+    maps::{Array, MapData, MapType, ring_buf::RingBuf, user_ring_buf::UserRingBuf},
+    programs::{UProbe, uprobe::UProbeScope},
+    sys::is_map_supported,
+};
+use aya_obj::generated::BPF_RINGBUF_HDR_SZ;
+use rand::RngExt as _;
+use rstest::rstest;
+use scopeguard::defer;
+use tokio::io::{Interest, unix::AsyncFd};
+
+// The producer ring buffer size. The loader rounds a ring buffer up to a power-of-2 multiple of the
+// page size, so this must already be one for every page size CI runs on, otherwise CAPACITY would
+// understate the real ring and the capacity-exact assertions would fail. 64 KiB satisfies that on
+// 4 KiB, 16 KiB, and 64 KiB page kernels (16 * 4 KiB = 4 * 16 KiB = 1 * 64 KiB).
+const BYTE_SIZE: u32 = 64 * 1024;
+
+// The size, in bytes, that a published `u64` sample occupies in the ring (header plus payload,
+// rounded up to 8). This is the kernel's per-sample stride.
+const SAMPLE_SIZE: usize = (size_of::<u64>() + BPF_RINGBUF_HDR_SZ as usize).next_multiple_of(8);
+
+// The number of `u64` samples the ring can hold at once.
+const CAPACITY: usize = BYTE_SIZE as usize / SAMPLE_SIZE;
+
+// The most samples any test echoes through RESULT before reading them back. The async no-drop test
+// publishes this many, several times the producer ring capacity, so the producer must wait for the
+// drainer to free space repeatedly.
+const MAX_ECHOED_SAMPLES: usize = 3 * CAPACITY;
+
+// RESULT must hold every echoed sample at once: the drainer can fill it before the reader runs, and
+// the eBPF echo silently drops samples once RESULT is full. Size it to the next power-of-2 byte
+// count (the kernel requires that for ring buffers) that fits the largest echo batch.
+const RESULT_BYTE_SIZE: u32 = (MAX_ECHOED_SAMPLES * SAMPLE_SIZE).next_power_of_two() as u32;
+
+// The trigger function the drain programs are attached to. The integration tests run
+// single-threaded and each test loads its own maps, so a single shared trigger cannot cross-drain
+// another test's ring buffer.
+const TRIGGER: &str = "user_ring_buf_trigger_ebpf_program";
+
+#[unsafe(no_mangle)]
+#[inline(never)]
+extern "C" fn user_ring_buf_trigger_ebpf_program() {
+    core::hint::black_box(());
+}
+
+// The (map, program) pairs the asynchronous tests run against. They iterate the variants internally
+// rather than via rstest cases, mirroring ring_buf's async tests.
+const VARIANTS: &[(&str, &str)] = &[
+    ("USER_RING_BUF_LEGACY", "user_ring_buf_test_legacy"),
+    ("USER_RING_BUF", "user_ring_buf_test"),
+];
+
+// The number of samples the writability tests publish. Far larger than the ring capacity so the
+// producer has to wait for the drainer to free space many times over.
+const NUM_MESSAGES: u64 = 20_000;
+
+// Drains the user ring buffer continuously from another thread by hammering the trigger function,
+// the inverse of ring_buf's WriterThread. Each call fires the process-wide uprobe, draining the
+// pending samples and freeing space for the producer.
+struct DrainerThread {
+    thread: thread::JoinHandle<()>,
+    done: Arc<AtomicBool>,
+}
+
+impl DrainerThread {
+    fn spawn() -> Self {
+        let done = Arc::new(AtomicBool::new(false));
+        Self {
+            thread: {
+                let done = Arc::clone(&done);
+                thread::spawn(move || {
+                    while !done.load(Ordering::Relaxed) {
+                        user_ring_buf_trigger_ebpf_program();
+                    }
+                })
+            },
+            done,
+        }
+    }
+
+    fn join(self) {
+        let Self { thread, done } = self;
+        done.store(true, Ordering::Relaxed);
+        thread.join().unwrap();
+    }
+}
+
+struct UserRingBufTest {
+    bpf: Ebpf,
+    result: RingBuf<MapData>,
+    user_ring_buf: UserRingBuf<MapData>,
+    drain_count: Array<MapData, u64>,
+}
+
+// Returns `false` and prints a skip notice when the running kernel lacks user ring buffer support.
+fn user_ring_buf_supported() -> bool {
+    if is_map_supported(MapType::UserRingBuf).unwrap() {
+        return true;
+    }
+    eprintln!("skipping test - user ring buffer maps not supported");
+    false
+}
+
+// Sizes both producer rings and the `RESULT` echo ring on the loader.
+fn size_maps(loader: &mut EbpfLoader<'_>) {
+    for map in ["USER_RING_BUF", "USER_RING_BUF_LEGACY"] {
+        loader.map_max_entries(map, BYTE_SIZE);
+    }
+    loader.map_max_entries("RESULT", RESULT_BYTE_SIZE);
+}
+
+// Loads the user ring buffer object, takes `map` as the producer plus the `RESULT` echo ring buffer
+// and the `DRAIN_COUNT` array, and attaches `prog` to the trigger. Returns `None` when the running
+// kernel lacks user ring buffer support.
+fn load(map: &str, prog: &str) -> Option<UserRingBufTest> {
+    load_with_mutators(map, prog, |_loader| {}, |_bpf| {})
+}
+
+// Like [`load`], but lets a test mutate the `EbpfLoader` before the object is loaded from disk (for
+// example to set a pin path) and the loaded `Ebpf` before its program is attached (for example to
+// pin a map), mirroring ring_buf's `RingBufTest::new_with_mutators`.
+fn load_with_mutators<'loader>(
+    map: &'loader str,
+    prog: &str,
+    loader_fn: impl FnOnce(&mut EbpfLoader<'loader>),
+    bpf_fn: impl FnOnce(&mut Ebpf),
+) -> Option<UserRingBufTest> {
+    if !user_ring_buf_supported() {
+        return None;
+    }
+
+    let mut loader = EbpfLoader::new();
+    size_maps(&mut loader);
+    loader_fn(&mut loader);
+    let mut bpf = loader.load(crate::USER_RING_BUF).unwrap();
+    bpf_fn(&mut bpf);
+
+    let result = RingBuf::try_from(bpf.take_map("RESULT").unwrap()).unwrap();
+    let user_ring_buf = UserRingBuf::try_from(bpf.take_map(map).unwrap()).unwrap();
+    let drain_count = Array::try_from(bpf.take_map("DRAIN_COUNT").unwrap()).unwrap();
+
+    let prog: &mut UProbe = bpf.program_mut(prog).unwrap().try_into().unwrap();
+    prog.load().unwrap();
+    prog.attach(TRIGGER, "/proc/self/exe", UProbeScope::AllProcesses)
+        .unwrap();
+
+    Some(UserRingBufTest {
+        bpf,
+        result,
+        user_ring_buf,
+        drain_count,
+    })
+}
+
+// Reserves a `u64` sample, writes `value` into it, and submits it.
+fn submit(user_ring_buf: &mut UserRingBuf<MapData>, value: u64) {
+    let mut entry = user_ring_buf.reserve(size_of::<u64>()).unwrap();
+    entry.copy_from_slice(&value.to_ne_bytes());
+    entry.submit();
+}
+
+// Drains `n` echoed `u64` values out of the result ring buffer, busy-waiting until they arrive.
+fn collect(result: &mut RingBuf<MapData>, n: usize) -> Vec<u64> {
+    let mut seen = Vec::with_capacity(n);
+    while seen.len() < n {
+        if let Some(read) = result.next() {
+            let read: [u8; 8] = (*read).try_into().unwrap();
+            seen.push(u64::from_ne_bytes(read));
+        }
+    }
+    seen
+}
+
+// Returns the sample count reported by the last drain.
+fn drained(drain_count: &Array<MapData, u64>) -> u64 {
+    drain_count.get(&0, 0).unwrap()
+}
+
+#[rstest]
+#[case::legacy("USER_RING_BUF_LEGACY", "user_ring_buf_test_legacy")]
+#[case::btf("USER_RING_BUF", "user_ring_buf_test")]
+#[test_attr(test_log::test)]
+fn user_ring_buf(#[case] map: &str, #[case] prog: &str) {
+    let Some(UserRingBufTest {
+        bpf: _bpf,
+        mut result,
+        mut user_ring_buf,
+        drain_count,
+    }) = load(map, prog)
+    else {
+        return;
+    };
+
+    // An oversized reservation is rejected rather than overflowing.
+    assert!(user_ring_buf.reserve(usize::MAX).is_none());
+
+    // Publish a batch of samples, submitting even values and discarding odd ones, so the test
+    // exercises both the submit and discard paths.
+    let mut rng = rand::rng();
+    let mut expected = Vec::new();
+    for value in std::iter::repeat_with(|| rng.random::<u64>()).take(64) {
+        let mut entry = user_ring_buf.reserve(size_of::<u64>()).unwrap();
+        entry.copy_from_slice(&value.to_ne_bytes());
+        if value.is_multiple_of(2) {
+            entry.submit();
+            expected.push(value);
+        } else {
+            entry.discard();
+        }
+    }
+
+    user_ring_buf_trigger_ebpf_program();
+
+    let seen = collect(&mut result, expected.len());
+    assert_matches!(result.next(), None);
+    assert_eq!(seen, expected);
+    // The drain reports only the submitted samples; discarded ones are skipped by the kernel.
+    assert_eq!(drained(&drain_count), expected.len() as u64);
+}
+
+#[rstest]
+#[case::legacy("USER_RING_BUF_LEGACY", "user_ring_buf_test_legacy")]
+#[case::btf("USER_RING_BUF", "user_ring_buf_test")]
+#[test_attr(test_log::test)]
+fn user_ring_buf_drop_discards(#[case] map: &str, #[case] prog: &str) {
+    let Some(UserRingBufTest {
+        bpf: _bpf,
+        mut result,
+        mut user_ring_buf,
+        drain_count,
+    }) = load(map, prog)
+    else {
+        return;
+    };
+
+    // Reserve an entry and drop it without submitting; the kernel must skip it.
+    drop(user_ring_buf.reserve(size_of::<u64>()).unwrap());
+
+    // Submit a sentinel after the dropped entry. Only the sentinel must reach the drain callback.
+    let sentinel = rand::rng().random::<u64>();
+    submit(&mut user_ring_buf, sentinel);
+
+    user_ring_buf_trigger_ebpf_program();
+
+    let seen = collect(&mut result, 1);
+    assert_matches!(result.next(), None);
+    assert_eq!(seen, [sentinel]);
+    // Only the sentinel is drained; the dropped entry is discarded.
+    assert_eq!(drained(&drain_count), 1);
+}
+
+#[rstest]
+#[case::legacy("USER_RING_BUF_LEGACY", "user_ring_buf_test_break_legacy")]
+#[case::btf("USER_RING_BUF", "user_ring_buf_test_break")]
+#[test_attr(test_log::test)]
+fn user_ring_buf_break(#[case] map: &str, #[case] prog: &str) {
+    let Some(UserRingBufTest {
+        bpf: _bpf,
+        mut result,
+        mut user_ring_buf,
+        drain_count,
+    }) = load(map, prog)
+    else {
+        return;
+    };
+
+    // Submit two samples; the callback breaks after echoing the first.
+    let mut rng = rand::rng();
+    let values: [u64; 2] = [rng.random(), rng.random()];
+    for value in values {
+        submit(&mut user_ring_buf, value);
+    }
+
+    user_ring_buf_trigger_ebpf_program();
+
+    // Only the first sample is echoed; the second is left in the ring buffer.
+    let seen = collect(&mut result, 1);
+    assert_matches!(result.next(), None);
+    assert_eq!(seen, [values[0]]);
+    assert_eq!(drained(&drain_count), 1);
+}
+
+#[rstest]
+#[case::legacy("USER_RING_BUF_LEGACY", "user_ring_buf_test_legacy")]
+#[case::btf("USER_RING_BUF", "user_ring_buf_test")]
+#[test_attr(test_log::test)]
+fn user_ring_buf_full(#[case] map: &str, #[case] prog: &str) {
+    let Some(UserRingBufTest {
+        bpf: _bpf,
+        mut result,
+        mut user_ring_buf,
+        drain_count,
+    }) = load(map, prog)
+    else {
+        return;
+    };
+
+    // Fill the ring buffer until a reservation fails, exercising the full-ring back pressure path.
+    let mut published = Vec::new();
+    let mut value: u64 = 0;
+    while let Some(mut entry) = user_ring_buf.reserve(size_of::<u64>()) {
+        entry.copy_from_slice(&value.to_ne_bytes());
+        entry.submit();
+        published.push(value);
+        value += 1;
+    }
+    assert_eq!(published.len(), CAPACITY);
+
+    user_ring_buf_trigger_ebpf_program();
+
+    let seen = collect(&mut result, published.len());
+    assert_matches!(result.next(), None);
+    assert_eq!(seen, published);
+    assert_eq!(drained(&drain_count), CAPACITY as u64);
+
+    // Draining freed the ring, so a reservation succeeds again.
+    let sentinel = value;
+    submit(&mut user_ring_buf, sentinel);
+    user_ring_buf_trigger_ebpf_program();
+    let seen = collect(&mut result, 1);
+    assert_matches!(result.next(), None);
+    assert_eq!(seen, [sentinel]);
+}
+
+#[rstest]
+#[case::legacy("USER_RING_BUF_LEGACY", "user_ring_buf_test_legacy")]
+#[case::btf("USER_RING_BUF", "user_ring_buf_test")]
+#[test_attr(test_log::test)]
+fn user_ring_buf_wrap(#[case] map: &str, #[case] prog: &str) {
+    let Some(UserRingBufTest {
+        bpf: _bpf,
+        mut result,
+        mut user_ring_buf,
+        drain_count,
+    }) = load(map, prog)
+    else {
+        return;
+    };
+
+    // Reserve and drain in rounds smaller than the capacity, so each round leaves room. Enough
+    // rounds to push the producer position past twice the ring size, exercising the wrap of the
+    // double-mapped data region.
+    const PER_ROUND: usize = CAPACITY / 2;
+    const ROUNDS: usize = 2 * CAPACITY / PER_ROUND + 1;
+
+    let mut value = 0;
+    for _ in 0..ROUNDS {
+        let mut published = Vec::with_capacity(PER_ROUND);
+        for _ in 0..PER_ROUND {
+            submit(&mut user_ring_buf, value);
+            published.push(value);
+            value += 1;
+        }
+
+        user_ring_buf_trigger_ebpf_program();
+
+        let seen = collect(&mut result, published.len());
+        assert_matches!(result.next(), None);
+        assert_eq!(seen, published);
+        assert_eq!(drained(&drain_count), PER_ROUND as u64);
+    }
+}
+
+#[rstest]
+#[case::legacy("USER_RING_BUF_LEGACY", "user_ring_buf_test_legacy")]
+#[case::btf("USER_RING_BUF", "user_ring_buf_test")]
+#[test_attr(test_log::test)]
+fn user_ring_buf_short_sample(#[case] map: &str, #[case] prog: &str) {
+    let Some(UserRingBufTest {
+        bpf: _bpf,
+        mut result,
+        mut user_ring_buf,
+        drain_count,
+    }) = load(map, prog)
+    else {
+        return;
+    };
+
+    // Publish a sample too short to read as a `u64`; the drain callback's read returns `None` and
+    // skips it without echoing.
+    let mut rng = rand::rng();
+    let mut short = user_ring_buf.reserve(size_of::<u32>()).unwrap();
+    short.copy_from_slice(&rng.random::<u32>().to_ne_bytes());
+    short.submit();
+
+    let sentinel = rng.random::<u64>();
+    submit(&mut user_ring_buf, sentinel);
+
+    user_ring_buf_trigger_ebpf_program();
+
+    let seen = collect(&mut result, 1);
+    assert_matches!(result.next(), None);
+    assert_eq!(seen, [sentinel]);
+    // Both samples are drained even though only the sentinel is echoed.
+    assert_eq!(drained(&drain_count), 2);
+}
+
+#[rstest]
+#[case::legacy("USER_RING_BUF_LEGACY", "user_ring_buf_test_legacy")]
+#[case::btf("USER_RING_BUF", "user_ring_buf_test")]
+#[test_attr(test_log::test)]
+fn user_ring_buf_pinned(#[case] map: &str, #[case] prog: &str) {
+    let pin_path =
+        Path::new("/sys/fs/bpf/").join(format!("user_ring_buf_{}", rand::rng().random::<u64>()));
+
+    let mut rng = rand::rng();
+    let before: [u64; 2] = [rng.random(), rng.random()];
+    let after: [u64; 2] = [rng.random(), rng.random()];
+
+    // Publish two samples into a pinned producer ring without draining them, then drop the handle.
+    {
+        let Some(UserRingBufTest {
+            mut user_ring_buf, ..
+        }) = load_with_mutators(
+            map,
+            prog,
+            |_loader| {},
+            |bpf| {
+                bpf.map_mut(map).unwrap().pin(&pin_path).unwrap();
+            },
+        )
+        else {
+            return;
+        };
+        for value in before {
+            submit(&mut user_ring_buf, value);
+        }
+    }
+    defer! { std::fs::remove_file(&pin_path).unwrap() }
+
+    // Reopen the pinned ring, publish two more samples, then drain everything. The samples written
+    // before the reopen must still be present and ordered ahead of the new ones, which only holds if
+    // the producer position survived the reopen.
+    let Some(UserRingBufTest {
+        bpf: _bpf,
+        mut result,
+        mut user_ring_buf,
+        ..
+    }) = load_with_mutators(
+        map,
+        prog,
+        |loader| {
+            loader.map_pin_path(map, &pin_path);
+        },
+        |_bpf| {},
+    )
+    else {
+        return;
+    };
+
+    for value in after {
+        submit(&mut user_ring_buf, value);
+    }
+
+    user_ring_buf_trigger_ebpf_program();
+
+    let expected: Vec<u64> = before.into_iter().chain(after).collect();
+    let seen = collect(&mut result, expected.len());
+    assert_matches!(result.next(), None);
+    assert_eq!(seen, expected);
+}
+
+#[rstest]
+#[case::legacy("USER_RING_BUF_LEGACY")]
+#[case::btf("USER_RING_BUF")]
+#[test_attr(test_log::test)]
+fn user_ring_buf_pinned_reopen_keeps_size(#[case] map: &str) {
+    if !user_ring_buf_supported() {
+        return;
+    }
+
+    let pin_path = Path::new("/sys/fs/bpf/").join(format!(
+        "user_ring_buf_reopen_{}",
+        rand::rng().random::<u64>()
+    ));
+
+    // Pin a sized ring, then drop the handle.
+    {
+        let mut loader = EbpfLoader::new();
+        size_maps(&mut loader);
+        let mut bpf = loader.load(crate::USER_RING_BUF).unwrap();
+        bpf.map_mut(map).unwrap().pin(&pin_path).unwrap();
+    }
+    defer! { std::fs::remove_file(&pin_path).unwrap() }
+
+    // Reopen the pinned ring without setting its max_entries. The size must come from the kernel,
+    // not the zero declared in the object, otherwise the mmap is empty and reserve fails. This is
+    // why the reopen loader is built by hand rather than through `size_maps`: only the other,
+    // non-pinned producer is sized.
+    let mut loader = EbpfLoader::new();
+    loader.map_pin_path(map, &pin_path);
+    for other in ["USER_RING_BUF", "USER_RING_BUF_LEGACY"] {
+        if other != map {
+            loader.map_max_entries(other, BYTE_SIZE);
+        }
+    }
+    loader.map_max_entries("RESULT", RESULT_BYTE_SIZE);
+    let mut bpf = loader.load(crate::USER_RING_BUF).unwrap();
+
+    let mut user_ring_buf = UserRingBuf::try_from(bpf.take_map(map).unwrap()).unwrap();
+    assert!(user_ring_buf.reserve(size_of::<u64>()).is_some());
+}
+
+// The inverse of ring_buf_asyncfd_events: the producer waits for writability through an AsyncFd
+// while a background thread drains the ring, and must publish every sample without hanging.
+#[tokio::test(flavor = "multi_thread")]
+#[test_log::test]
+async fn user_ring_buf_asyncfd_writable() {
+    for &(map, prog) in VARIANTS {
+        let Some(UserRingBufTest {
+            bpf: _bpf,
+            result: _result,
+            user_ring_buf,
+            drain_count: _drain_count,
+        }) = load(map, prog)
+        else {
+            return;
+        };
+
+        // RESULT is not consumed here; the drain only needs to free space for the producer.
+        let mut async_fd = AsyncFd::with_interest(user_ring_buf, Interest::WRITABLE).unwrap();
+        let drainer = DrainerThread::spawn();
+        let mut written: u64 = 0;
+        while written < NUM_MESSAGES {
+            let mut guard = async_fd.writable_mut().await.unwrap();
+            let user_ring_buf = guard.get_inner_mut();
+            loop {
+                let Some(mut entry) = user_ring_buf.reserve(size_of::<u64>()) else {
+                    // The ring is full; clear readiness so the next wait blocks until the drainer
+                    // frees space.
+                    guard.clear_ready();
+                    break;
+                };
+                entry.copy_from_slice(&written.to_ne_bytes());
+                entry.submit();
+                written += 1;
+                if written >= NUM_MESSAGES {
+                    break;
+                }
+            }
+        }
+        drainer.join();
+    }
+}
+
+// The inverse of ring_buf_epoll_wakeup: an edge-triggered EPOLLOUT registration must wake the
+// producer each time the drainer frees space, so a full ring does not stall the producer forever.
+#[test_log::test]
+fn user_ring_buf_epoll_writable() {
+    for &(map, prog) in VARIANTS {
+        let Some(UserRingBufTest {
+            bpf: _bpf,
+            result: _result,
+            mut user_ring_buf,
+            drain_count: _drain_count,
+        }) = load(map, prog)
+        else {
+            return;
+        };
+
+        let epoll_fd = epoll::create(false).unwrap();
+        epoll::ctl(
+            epoll_fd,
+            epoll::ControlOptions::EPOLL_CTL_ADD,
+            user_ring_buf.as_raw_fd(),
+            // EPOLLET mirrors tokio's AsyncFd and verifies the producer is woken on the
+            // not-writable to writable transition rather than relying on level-triggering.
+            epoll::Event::new(epoll::Events::EPOLLOUT | epoll::Events::EPOLLET, 0),
+        )
+        .unwrap();
+        let mut epoll_event_buf = [epoll::Event::new(epoll::Events::EPOLLOUT, 0); 1];
+        let drainer = DrainerThread::spawn();
+        let mut written: u64 = 0;
+        while written < NUM_MESSAGES {
+            while let Some(mut entry) = user_ring_buf.reserve(size_of::<u64>()) {
+                entry.copy_from_slice(&written.to_ne_bytes());
+                entry.submit();
+                written += 1;
+                if written >= NUM_MESSAGES {
+                    break;
+                }
+            }
+            if written < NUM_MESSAGES {
+                epoll::wait(epoll_fd, -1, &mut epoll_event_buf).unwrap();
+            }
+        }
+        drainer.join();
+    }
+}
+
+// The inverse of ring_buf_async_no_drop: the producer publishes a sequence larger than the ring
+// while the drained samples are read back from RESULT concurrently, so nothing is dropped or
+// reordered.
+#[tokio::test(flavor = "multi_thread")]
+#[test_log::test]
+async fn user_ring_buf_async_no_drop() {
+    for &(map, prog) in VARIANTS {
+        let Some(UserRingBufTest {
+            bpf: _bpf,
+            result,
+            user_ring_buf,
+            drain_count: _drain_count,
+        }) = load(map, prog)
+        else {
+            return;
+        };
+
+        const N: u64 = MAX_ECHOED_SAMPLES as u64;
+
+        let mut producer_fd = AsyncFd::with_interest(user_ring_buf, Interest::WRITABLE).unwrap();
+        let mut result_fd = AsyncFd::with_interest(result, Interest::READABLE).unwrap();
+        let drainer = DrainerThread::spawn();
+
+        let producer = async {
+            let mut value: u64 = 0;
+            while value < N {
+                let mut guard = producer_fd.writable_mut().await.unwrap();
+                let user_ring_buf = guard.get_inner_mut();
+                loop {
+                    let Some(mut entry) = user_ring_buf.reserve(size_of::<u64>()) else {
+                        guard.clear_ready();
+                        break;
+                    };
+                    entry.copy_from_slice(&value.to_ne_bytes());
+                    entry.submit();
+                    value += 1;
+                    if value >= N {
+                        break;
+                    }
+                }
+            }
+        };
+
+        let reader = async {
+            let mut seen = Vec::with_capacity(N as usize);
+            while (seen.len() as u64) < N {
+                let mut guard = result_fd.readable_mut().await.unwrap();
+                let result = guard.get_inner_mut();
+                while let Some(read) = result.next() {
+                    let read: [u8; 8] = (*read).try_into().unwrap();
+                    seen.push(u64::from_ne_bytes(read));
+                }
+                guard.clear_ready();
+            }
+            seen
+        };
+
+        let ((), seen) = tokio::join!(producer, reader);
+        drainer.join();
+
+        let expected: Vec<u64> = (0..N).collect();
+        assert_eq!(seen, expected);
+    }
+}

--- a/xtask/public-api/aya-ebpf.txt
+++ b/xtask/public-api/aya-ebpf.txt
@@ -504,6 +504,21 @@ impl<const MAX_ENTRIES: usize, const FLAGS: usize, const DEPTH: usize> core::mar
 impl<const MAX_ENTRIES: usize, const FLAGS: usize, const DEPTH: usize> core::marker::UnsafeUnpin for aya_ebpf::btf_maps::stack_trace::StackTrace<MAX_ENTRIES, FLAGS, DEPTH>
 impl<const MAX_ENTRIES: usize, const FLAGS: usize, const DEPTH: usize> core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::btf_maps::stack_trace::StackTrace<MAX_ENTRIES, FLAGS, DEPTH>
 impl<const MAX_ENTRIES: usize, const FLAGS: usize, const DEPTH: usize> core::panic::unwind_safe::UnwindSafe for aya_ebpf::btf_maps::stack_trace::StackTrace<MAX_ENTRIES, FLAGS, DEPTH>
+pub mod aya_ebpf::btf_maps::user_ring_buf
+#[repr(C)] pub struct aya_ebpf::btf_maps::user_ring_buf::UserRingBuf<T, const MAX_ENTRIES: usize, const FLAGS: usize>
+impl<T, const MAX_ENTRIES: usize, const FLAGS: usize> aya_ebpf::btf_maps::user_ring_buf::UserRingBuf<T, MAX_ENTRIES, FLAGS>
+pub fn aya_ebpf::btf_maps::user_ring_buf::UserRingBuf<T, MAX_ENTRIES, FLAGS>::drain<F>(&self, F, u64) -> core::result::Result<u32, i32> where F: core::ops::function::Fn(aya_ebpf::maps::user_ring_buf::UserRingBufEntry<'_>) -> core::ops::control_flow::ControlFlow<()>
+impl<T, const MAX_ENTRIES: usize, const FLAGS: usize> aya_ebpf::btf_maps::user_ring_buf::UserRingBuf<T, MAX_ENTRIES, FLAGS>
+pub const fn aya_ebpf::btf_maps::user_ring_buf::UserRingBuf<T, MAX_ENTRIES, FLAGS>::new() -> Self
+impl<T, const MAX_ENTRIES: usize, const FLAGS: usize> core::default::Default for aya_ebpf::btf_maps::user_ring_buf::UserRingBuf<T, MAX_ENTRIES, FLAGS>
+pub fn aya_ebpf::btf_maps::user_ring_buf::UserRingBuf<T, MAX_ENTRIES, FLAGS>::default() -> Self
+impl<T, const MAX_ENTRIES: usize, const FLAGS: usize> core::marker::Sync for aya_ebpf::btf_maps::user_ring_buf::UserRingBuf<T, MAX_ENTRIES, FLAGS>
+impl<T, const MAX_ENTRIES: usize, const FLAGS: usize> core::marker::Freeze for aya_ebpf::btf_maps::user_ring_buf::UserRingBuf<T, MAX_ENTRIES, FLAGS>
+impl<T, const MAX_ENTRIES: usize, const FLAGS: usize> !core::marker::Send for aya_ebpf::btf_maps::user_ring_buf::UserRingBuf<T, MAX_ENTRIES, FLAGS>
+impl<T, const MAX_ENTRIES: usize, const FLAGS: usize> core::marker::Unpin for aya_ebpf::btf_maps::user_ring_buf::UserRingBuf<T, MAX_ENTRIES, FLAGS>
+impl<T, const MAX_ENTRIES: usize, const FLAGS: usize> core::marker::UnsafeUnpin for aya_ebpf::btf_maps::user_ring_buf::UserRingBuf<T, MAX_ENTRIES, FLAGS>
+impl<T, const MAX_ENTRIES: usize, const FLAGS: usize> core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::btf_maps::user_ring_buf::UserRingBuf<T, MAX_ENTRIES, FLAGS> where T: core::panic::unwind_safe::RefUnwindSafe
+impl<T, const MAX_ENTRIES: usize, const FLAGS: usize> core::panic::unwind_safe::UnwindSafe for aya_ebpf::btf_maps::user_ring_buf::UserRingBuf<T, MAX_ENTRIES, FLAGS> where T: core::panic::unwind_safe::RefUnwindSafe
 pub mod aya_ebpf::btf_maps::xsk_map
 #[repr(C)] pub struct aya_ebpf::btf_maps::xsk_map::XskMap<const MAX_ENTRIES: usize, const FLAGS: usize>
 impl<const MAX_ENTRIES: usize, const FLAGS: usize> aya_ebpf::btf_maps::xsk_map::XskMap<MAX_ENTRIES, FLAGS>
@@ -968,6 +983,20 @@ impl<const MAX_ENTRIES: usize, const FLAGS: usize, const DEPTH: usize> core::mar
 impl<const MAX_ENTRIES: usize, const FLAGS: usize, const DEPTH: usize> core::marker::UnsafeUnpin for aya_ebpf::btf_maps::stack_trace::StackTrace<MAX_ENTRIES, FLAGS, DEPTH>
 impl<const MAX_ENTRIES: usize, const FLAGS: usize, const DEPTH: usize> core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::btf_maps::stack_trace::StackTrace<MAX_ENTRIES, FLAGS, DEPTH>
 impl<const MAX_ENTRIES: usize, const FLAGS: usize, const DEPTH: usize> core::panic::unwind_safe::UnwindSafe for aya_ebpf::btf_maps::stack_trace::StackTrace<MAX_ENTRIES, FLAGS, DEPTH>
+#[repr(C)] pub struct aya_ebpf::btf_maps::UserRingBuf<T, const MAX_ENTRIES: usize, const FLAGS: usize>
+impl<T, const MAX_ENTRIES: usize, const FLAGS: usize> aya_ebpf::btf_maps::user_ring_buf::UserRingBuf<T, MAX_ENTRIES, FLAGS>
+pub fn aya_ebpf::btf_maps::user_ring_buf::UserRingBuf<T, MAX_ENTRIES, FLAGS>::drain<F>(&self, F, u64) -> core::result::Result<u32, i32> where F: core::ops::function::Fn(aya_ebpf::maps::user_ring_buf::UserRingBufEntry<'_>) -> core::ops::control_flow::ControlFlow<()>
+impl<T, const MAX_ENTRIES: usize, const FLAGS: usize> aya_ebpf::btf_maps::user_ring_buf::UserRingBuf<T, MAX_ENTRIES, FLAGS>
+pub const fn aya_ebpf::btf_maps::user_ring_buf::UserRingBuf<T, MAX_ENTRIES, FLAGS>::new() -> Self
+impl<T, const MAX_ENTRIES: usize, const FLAGS: usize> core::default::Default for aya_ebpf::btf_maps::user_ring_buf::UserRingBuf<T, MAX_ENTRIES, FLAGS>
+pub fn aya_ebpf::btf_maps::user_ring_buf::UserRingBuf<T, MAX_ENTRIES, FLAGS>::default() -> Self
+impl<T, const MAX_ENTRIES: usize, const FLAGS: usize> core::marker::Sync for aya_ebpf::btf_maps::user_ring_buf::UserRingBuf<T, MAX_ENTRIES, FLAGS>
+impl<T, const MAX_ENTRIES: usize, const FLAGS: usize> core::marker::Freeze for aya_ebpf::btf_maps::user_ring_buf::UserRingBuf<T, MAX_ENTRIES, FLAGS>
+impl<T, const MAX_ENTRIES: usize, const FLAGS: usize> !core::marker::Send for aya_ebpf::btf_maps::user_ring_buf::UserRingBuf<T, MAX_ENTRIES, FLAGS>
+impl<T, const MAX_ENTRIES: usize, const FLAGS: usize> core::marker::Unpin for aya_ebpf::btf_maps::user_ring_buf::UserRingBuf<T, MAX_ENTRIES, FLAGS>
+impl<T, const MAX_ENTRIES: usize, const FLAGS: usize> core::marker::UnsafeUnpin for aya_ebpf::btf_maps::user_ring_buf::UserRingBuf<T, MAX_ENTRIES, FLAGS>
+impl<T, const MAX_ENTRIES: usize, const FLAGS: usize> core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::btf_maps::user_ring_buf::UserRingBuf<T, MAX_ENTRIES, FLAGS> where T: core::panic::unwind_safe::RefUnwindSafe
+impl<T, const MAX_ENTRIES: usize, const FLAGS: usize> core::panic::unwind_safe::UnwindSafe for aya_ebpf::btf_maps::user_ring_buf::UserRingBuf<T, MAX_ENTRIES, FLAGS> where T: core::panic::unwind_safe::RefUnwindSafe
 #[repr(C)] pub struct aya_ebpf::btf_maps::XskMap<const MAX_ENTRIES: usize, const FLAGS: usize>
 impl<const MAX_ENTRIES: usize, const FLAGS: usize> aya_ebpf::btf_maps::xsk_map::XskMap<MAX_ENTRIES, FLAGS>
 pub fn aya_ebpf::btf_maps::xsk_map::XskMap<MAX_ENTRIES, FLAGS>::get(&self, u32) -> core::option::Option<u32>
@@ -1364,6 +1393,29 @@ impl core::marker::Unpin for aya_ebpf::maps::stack_trace::StackTrace
 impl core::marker::UnsafeUnpin for aya_ebpf::maps::stack_trace::StackTrace
 impl !core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::maps::stack_trace::StackTrace
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf::maps::stack_trace::StackTrace
+pub mod aya_ebpf::maps::user_ring_buf
+#[repr(transparent)] pub struct aya_ebpf::maps::user_ring_buf::UserRingBuf
+impl aya_ebpf::maps::user_ring_buf::UserRingBuf
+pub fn aya_ebpf::maps::user_ring_buf::UserRingBuf::drain<F>(&self, F, u64) -> core::result::Result<u32, i32> where F: core::ops::function::Fn(aya_ebpf::maps::user_ring_buf::UserRingBufEntry<'_>) -> core::ops::control_flow::ControlFlow<()>
+pub const fn aya_ebpf::maps::user_ring_buf::UserRingBuf::pinned(u32, u32) -> Self
+pub const fn aya_ebpf::maps::user_ring_buf::UserRingBuf::with_byte_size(u32, u32) -> Self
+impl !core::marker::Freeze for aya_ebpf::maps::user_ring_buf::UserRingBuf
+impl core::marker::Send for aya_ebpf::maps::user_ring_buf::UserRingBuf
+impl core::marker::Sync for aya_ebpf::maps::user_ring_buf::UserRingBuf
+impl core::marker::Unpin for aya_ebpf::maps::user_ring_buf::UserRingBuf
+impl core::marker::UnsafeUnpin for aya_ebpf::maps::user_ring_buf::UserRingBuf
+impl !core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::maps::user_ring_buf::UserRingBuf
+impl core::panic::unwind_safe::UnwindSafe for aya_ebpf::maps::user_ring_buf::UserRingBuf
+pub struct aya_ebpf::maps::user_ring_buf::UserRingBufEntry<'a>
+impl aya_ebpf::maps::user_ring_buf::UserRingBufEntry<'_>
+pub unsafe fn aya_ebpf::maps::user_ring_buf::UserRingBufEntry<'_>::read<T>(&self) -> core::option::Option<T>
+impl<'a> core::marker::Freeze for aya_ebpf::maps::user_ring_buf::UserRingBufEntry<'a>
+impl<'a> !core::marker::Send for aya_ebpf::maps::user_ring_buf::UserRingBufEntry<'a>
+impl<'a> !core::marker::Sync for aya_ebpf::maps::user_ring_buf::UserRingBufEntry<'a>
+impl<'a> core::marker::Unpin for aya_ebpf::maps::user_ring_buf::UserRingBufEntry<'a>
+impl<'a> core::marker::UnsafeUnpin for aya_ebpf::maps::user_ring_buf::UserRingBufEntry<'a>
+impl<'a> core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::maps::user_ring_buf::UserRingBufEntry<'a>
+impl<'a> core::panic::unwind_safe::UnwindSafe for aya_ebpf::maps::user_ring_buf::UserRingBufEntry<'a>
 pub mod aya_ebpf::maps::xdp
 #[repr(transparent)] pub struct aya_ebpf::maps::xdp::CpuMap
 impl aya_ebpf::maps::CpuMap
@@ -1766,6 +1818,18 @@ impl core::marker::Unpin for aya_ebpf::maps::stack_trace::StackTrace
 impl core::marker::UnsafeUnpin for aya_ebpf::maps::stack_trace::StackTrace
 impl !core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::maps::stack_trace::StackTrace
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf::maps::stack_trace::StackTrace
+#[repr(transparent)] pub struct aya_ebpf::maps::UserRingBuf
+impl aya_ebpf::maps::user_ring_buf::UserRingBuf
+pub fn aya_ebpf::maps::user_ring_buf::UserRingBuf::drain<F>(&self, F, u64) -> core::result::Result<u32, i32> where F: core::ops::function::Fn(aya_ebpf::maps::user_ring_buf::UserRingBufEntry<'_>) -> core::ops::control_flow::ControlFlow<()>
+pub const fn aya_ebpf::maps::user_ring_buf::UserRingBuf::pinned(u32, u32) -> Self
+pub const fn aya_ebpf::maps::user_ring_buf::UserRingBuf::with_byte_size(u32, u32) -> Self
+impl !core::marker::Freeze for aya_ebpf::maps::user_ring_buf::UserRingBuf
+impl core::marker::Send for aya_ebpf::maps::user_ring_buf::UserRingBuf
+impl core::marker::Sync for aya_ebpf::maps::user_ring_buf::UserRingBuf
+impl core::marker::Unpin for aya_ebpf::maps::user_ring_buf::UserRingBuf
+impl core::marker::UnsafeUnpin for aya_ebpf::maps::user_ring_buf::UserRingBuf
+impl !core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::maps::user_ring_buf::UserRingBuf
+impl core::panic::unwind_safe::UnwindSafe for aya_ebpf::maps::user_ring_buf::UserRingBuf
 #[repr(transparent)] pub struct aya_ebpf::maps::XskMap
 impl aya_ebpf::maps::XskMap
 pub fn aya_ebpf::maps::XskMap::get(&self, u32) -> core::option::Option<u32>

--- a/xtask/public-api/aya.txt
+++ b/xtask/public-api/aya.txt
@@ -803,6 +803,48 @@ impl<T> core::marker::Unpin for aya::maps::stack_trace::StackTraceMap<T> where T
 impl<T> core::marker::UnsafeUnpin for aya::maps::stack_trace::StackTraceMap<T> where T: core::marker::UnsafeUnpin
 impl<T> core::panic::unwind_safe::RefUnwindSafe for aya::maps::stack_trace::StackTraceMap<T> where T: core::panic::unwind_safe::RefUnwindSafe
 impl<T> core::panic::unwind_safe::UnwindSafe for aya::maps::stack_trace::StackTraceMap<T> where T: core::panic::unwind_safe::UnwindSafe
+pub mod aya::maps::user_ring_buf
+pub struct aya::maps::user_ring_buf::UserRingBuf<T>
+impl<T: core::borrow::Borrow<aya::maps::MapData>> aya::maps::user_ring_buf::UserRingBuf<T>
+pub fn aya::maps::user_ring_buf::UserRingBuf<T>::reserve(&mut self, usize) -> core::option::Option<aya::maps::user_ring_buf::UserRingBufEntry<'_>>
+impl core::convert::TryFrom<aya::maps::Map> for aya::maps::user_ring_buf::UserRingBuf<aya::maps::MapData>
+pub type aya::maps::user_ring_buf::UserRingBuf<aya::maps::MapData>::Error = aya::maps::MapError
+pub fn aya::maps::user_ring_buf::UserRingBuf<aya::maps::MapData>::try_from(aya::maps::Map) -> core::result::Result<Self, Self::Error>
+impl<'a> core::convert::TryFrom<&'a aya::maps::Map> for aya::maps::user_ring_buf::UserRingBuf<&'a aya::maps::MapData>
+pub type aya::maps::user_ring_buf::UserRingBuf<&'a aya::maps::MapData>::Error = aya::maps::MapError
+pub fn aya::maps::user_ring_buf::UserRingBuf<&'a aya::maps::MapData>::try_from(&'a aya::maps::Map) -> core::result::Result<Self, Self::Error>
+impl<'a> core::convert::TryFrom<&'a mut aya::maps::Map> for aya::maps::user_ring_buf::UserRingBuf<&'a mut aya::maps::MapData>
+pub type aya::maps::user_ring_buf::UserRingBuf<&'a mut aya::maps::MapData>::Error = aya::maps::MapError
+pub fn aya::maps::user_ring_buf::UserRingBuf<&'a mut aya::maps::MapData>::try_from(&'a mut aya::maps::Map) -> core::result::Result<Self, Self::Error>
+impl<T: core::borrow::Borrow<aya::maps::MapData>> std::os::fd::owned::AsFd for aya::maps::user_ring_buf::UserRingBuf<T>
+pub fn aya::maps::user_ring_buf::UserRingBuf<T>::as_fd(&self) -> std::os::fd::owned::BorrowedFd<'_>
+impl<T: core::borrow::Borrow<aya::maps::MapData>> std::os::fd::raw::AsRawFd for aya::maps::user_ring_buf::UserRingBuf<T>
+pub fn aya::maps::user_ring_buf::UserRingBuf<T>::as_raw_fd(&self) -> std::os::fd::raw::RawFd
+impl<T> core::marker::Freeze for aya::maps::user_ring_buf::UserRingBuf<T> where T: core::marker::Freeze
+impl<T> core::marker::Send for aya::maps::user_ring_buf::UserRingBuf<T> where T: core::marker::Send
+impl<T> core::marker::Sync for aya::maps::user_ring_buf::UserRingBuf<T> where T: core::marker::Sync
+impl<T> core::marker::Unpin for aya::maps::user_ring_buf::UserRingBuf<T> where T: core::marker::Unpin
+impl<T> core::marker::UnsafeUnpin for aya::maps::user_ring_buf::UserRingBuf<T> where T: core::marker::UnsafeUnpin
+impl<T> core::panic::unwind_safe::RefUnwindSafe for aya::maps::user_ring_buf::UserRingBuf<T> where T: core::panic::unwind_safe::RefUnwindSafe
+impl<T> core::panic::unwind_safe::UnwindSafe for aya::maps::user_ring_buf::UserRingBuf<T> where T: core::panic::unwind_safe::UnwindSafe
+pub struct aya::maps::user_ring_buf::UserRingBufEntry<'a>
+impl aya::maps::user_ring_buf::UserRingBufEntry<'_>
+pub fn aya::maps::user_ring_buf::UserRingBufEntry<'_>::discard(self)
+pub fn aya::maps::user_ring_buf::UserRingBufEntry<'_>::submit(self)
+impl core::ops::deref::Deref for aya::maps::user_ring_buf::UserRingBufEntry<'_>
+pub type aya::maps::user_ring_buf::UserRingBufEntry<'_>::Target = [u8]
+pub fn aya::maps::user_ring_buf::UserRingBufEntry<'_>::deref(&self) -> &Self::Target
+impl core::ops::deref::DerefMut for aya::maps::user_ring_buf::UserRingBufEntry<'_>
+pub fn aya::maps::user_ring_buf::UserRingBufEntry<'_>::deref_mut(&mut self) -> &mut Self::Target
+impl core::ops::drop::Drop for aya::maps::user_ring_buf::UserRingBufEntry<'_>
+pub fn aya::maps::user_ring_buf::UserRingBufEntry<'_>::drop(&mut self)
+impl<'a> core::marker::Freeze for aya::maps::user_ring_buf::UserRingBufEntry<'a>
+impl<'a> !core::marker::Send for aya::maps::user_ring_buf::UserRingBufEntry<'a>
+impl<'a> !core::marker::Sync for aya::maps::user_ring_buf::UserRingBufEntry<'a>
+impl<'a> core::marker::Unpin for aya::maps::user_ring_buf::UserRingBufEntry<'a>
+impl<'a> core::marker::UnsafeUnpin for aya::maps::user_ring_buf::UserRingBufEntry<'a>
+impl<'a> core::panic::unwind_safe::RefUnwindSafe for aya::maps::user_ring_buf::UserRingBufEntry<'a>
+impl<'a> !core::panic::unwind_safe::UnwindSafe for aya::maps::user_ring_buf::UserRingBufEntry<'a>
 pub mod aya::maps::xdp
 pub enum aya::maps::xdp::XdpMapError
 pub aya::maps::xdp::XdpMapError::ChainedProgramNotSupported
@@ -956,6 +998,7 @@ pub aya::maps::Map::SockMap(aya::maps::MapData)
 pub aya::maps::Map::Stack(aya::maps::MapData)
 pub aya::maps::Map::StackTraceMap(aya::maps::MapData)
 pub aya::maps::Map::Unsupported(aya::maps::MapData)
+pub aya::maps::Map::UserRingBuf(aya::maps::MapData)
 pub aya::maps::Map::XskMap(aya::maps::MapData)
 impl aya::maps::Map
 pub fn aya::maps::Map::from_map_data(aya::maps::MapData) -> core::result::Result<Self, aya::maps::MapError>
@@ -993,6 +1036,9 @@ pub fn aya::maps::ring_buf::RingBuf<aya::maps::MapData>::try_from(aya::maps::Map
 impl core::convert::TryFrom<aya::maps::Map> for aya::maps::stack_trace::StackTraceMap<aya::maps::MapData>
 pub type aya::maps::stack_trace::StackTraceMap<aya::maps::MapData>::Error = aya::maps::MapError
 pub fn aya::maps::stack_trace::StackTraceMap<aya::maps::MapData>::try_from(aya::maps::Map) -> core::result::Result<Self, Self::Error>
+impl core::convert::TryFrom<aya::maps::Map> for aya::maps::user_ring_buf::UserRingBuf<aya::maps::MapData>
+pub type aya::maps::user_ring_buf::UserRingBuf<aya::maps::MapData>::Error = aya::maps::MapError
+pub fn aya::maps::user_ring_buf::UserRingBuf<aya::maps::MapData>::try_from(aya::maps::Map) -> core::result::Result<Self, Self::Error>
 impl core::fmt::Debug for aya::maps::Map
 pub fn aya::maps::Map::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl<'a, K: aya::Pod, V: aya::Pod> core::convert::TryFrom<&'a aya::maps::Map> for aya::maps::hash_map::HashMap<&'a aya::maps::MapData, K, V>
@@ -1124,6 +1170,9 @@ pub fn aya::maps::ring_buf::RingBuf<&'a aya::maps::MapData>::try_from(&'a aya::m
 impl<'a> core::convert::TryFrom<&'a aya::maps::Map> for aya::maps::stack_trace::StackTraceMap<&'a aya::maps::MapData>
 pub type aya::maps::stack_trace::StackTraceMap<&'a aya::maps::MapData>::Error = aya::maps::MapError
 pub fn aya::maps::stack_trace::StackTraceMap<&'a aya::maps::MapData>::try_from(&'a aya::maps::Map) -> core::result::Result<Self, Self::Error>
+impl<'a> core::convert::TryFrom<&'a aya::maps::Map> for aya::maps::user_ring_buf::UserRingBuf<&'a aya::maps::MapData>
+pub type aya::maps::user_ring_buf::UserRingBuf<&'a aya::maps::MapData>::Error = aya::maps::MapError
+pub fn aya::maps::user_ring_buf::UserRingBuf<&'a aya::maps::MapData>::try_from(&'a aya::maps::Map) -> core::result::Result<Self, Self::Error>
 impl<'a> core::convert::TryFrom<&'a mut aya::maps::Map> for aya::maps::CgroupArray<&'a mut aya::maps::MapData>
 pub type aya::maps::CgroupArray<&'a mut aya::maps::MapData>::Error = aya::maps::MapError
 pub fn aya::maps::CgroupArray<&'a mut aya::maps::MapData>::try_from(&'a mut aya::maps::Map) -> core::result::Result<Self, Self::Error>
@@ -1157,6 +1206,9 @@ pub fn aya::maps::ring_buf::RingBuf<&'a mut aya::maps::MapData>::try_from(&'a mu
 impl<'a> core::convert::TryFrom<&'a mut aya::maps::Map> for aya::maps::stack_trace::StackTraceMap<&'a mut aya::maps::MapData>
 pub type aya::maps::stack_trace::StackTraceMap<&'a mut aya::maps::MapData>::Error = aya::maps::MapError
 pub fn aya::maps::stack_trace::StackTraceMap<&'a mut aya::maps::MapData>::try_from(&'a mut aya::maps::Map) -> core::result::Result<Self, Self::Error>
+impl<'a> core::convert::TryFrom<&'a mut aya::maps::Map> for aya::maps::user_ring_buf::UserRingBuf<&'a mut aya::maps::MapData>
+pub type aya::maps::user_ring_buf::UserRingBuf<&'a mut aya::maps::MapData>::Error = aya::maps::MapError
+pub fn aya::maps::user_ring_buf::UserRingBuf<&'a mut aya::maps::MapData>::try_from(&'a mut aya::maps::Map) -> core::result::Result<Self, Self::Error>
 impl<K: aya::Pod, V: aya::Pod> core::convert::TryFrom<aya::maps::Map> for aya::maps::hash_map::HashMap<aya::maps::MapData, K, V>
 pub type aya::maps::hash_map::HashMap<aya::maps::MapData, K, V>::Error = aya::maps::MapError
 pub fn aya::maps::hash_map::HashMap<aya::maps::MapData, K, V>::try_from(aya::maps::Map) -> core::result::Result<Self, Self::Error>
@@ -2160,6 +2212,29 @@ impl<T> core::marker::Unpin for aya::maps::stack_trace::StackTraceMap<T> where T
 impl<T> core::marker::UnsafeUnpin for aya::maps::stack_trace::StackTraceMap<T> where T: core::marker::UnsafeUnpin
 impl<T> core::panic::unwind_safe::RefUnwindSafe for aya::maps::stack_trace::StackTraceMap<T> where T: core::panic::unwind_safe::RefUnwindSafe
 impl<T> core::panic::unwind_safe::UnwindSafe for aya::maps::stack_trace::StackTraceMap<T> where T: core::panic::unwind_safe::UnwindSafe
+pub struct aya::maps::UserRingBuf<T>
+impl<T: core::borrow::Borrow<aya::maps::MapData>> aya::maps::user_ring_buf::UserRingBuf<T>
+pub fn aya::maps::user_ring_buf::UserRingBuf<T>::reserve(&mut self, usize) -> core::option::Option<aya::maps::user_ring_buf::UserRingBufEntry<'_>>
+impl core::convert::TryFrom<aya::maps::Map> for aya::maps::user_ring_buf::UserRingBuf<aya::maps::MapData>
+pub type aya::maps::user_ring_buf::UserRingBuf<aya::maps::MapData>::Error = aya::maps::MapError
+pub fn aya::maps::user_ring_buf::UserRingBuf<aya::maps::MapData>::try_from(aya::maps::Map) -> core::result::Result<Self, Self::Error>
+impl<'a> core::convert::TryFrom<&'a aya::maps::Map> for aya::maps::user_ring_buf::UserRingBuf<&'a aya::maps::MapData>
+pub type aya::maps::user_ring_buf::UserRingBuf<&'a aya::maps::MapData>::Error = aya::maps::MapError
+pub fn aya::maps::user_ring_buf::UserRingBuf<&'a aya::maps::MapData>::try_from(&'a aya::maps::Map) -> core::result::Result<Self, Self::Error>
+impl<'a> core::convert::TryFrom<&'a mut aya::maps::Map> for aya::maps::user_ring_buf::UserRingBuf<&'a mut aya::maps::MapData>
+pub type aya::maps::user_ring_buf::UserRingBuf<&'a mut aya::maps::MapData>::Error = aya::maps::MapError
+pub fn aya::maps::user_ring_buf::UserRingBuf<&'a mut aya::maps::MapData>::try_from(&'a mut aya::maps::Map) -> core::result::Result<Self, Self::Error>
+impl<T: core::borrow::Borrow<aya::maps::MapData>> std::os::fd::owned::AsFd for aya::maps::user_ring_buf::UserRingBuf<T>
+pub fn aya::maps::user_ring_buf::UserRingBuf<T>::as_fd(&self) -> std::os::fd::owned::BorrowedFd<'_>
+impl<T: core::borrow::Borrow<aya::maps::MapData>> std::os::fd::raw::AsRawFd for aya::maps::user_ring_buf::UserRingBuf<T>
+pub fn aya::maps::user_ring_buf::UserRingBuf<T>::as_raw_fd(&self) -> std::os::fd::raw::RawFd
+impl<T> core::marker::Freeze for aya::maps::user_ring_buf::UserRingBuf<T> where T: core::marker::Freeze
+impl<T> core::marker::Send for aya::maps::user_ring_buf::UserRingBuf<T> where T: core::marker::Send
+impl<T> core::marker::Sync for aya::maps::user_ring_buf::UserRingBuf<T> where T: core::marker::Sync
+impl<T> core::marker::Unpin for aya::maps::user_ring_buf::UserRingBuf<T> where T: core::marker::Unpin
+impl<T> core::marker::UnsafeUnpin for aya::maps::user_ring_buf::UserRingBuf<T> where T: core::marker::UnsafeUnpin
+impl<T> core::panic::unwind_safe::RefUnwindSafe for aya::maps::user_ring_buf::UserRingBuf<T> where T: core::panic::unwind_safe::RefUnwindSafe
+impl<T> core::panic::unwind_safe::UnwindSafe for aya::maps::user_ring_buf::UserRingBuf<T> where T: core::panic::unwind_safe::UnwindSafe
 pub struct aya::maps::XskMap<T>
 impl<T: core::borrow::Borrow<aya::maps::MapData>> aya::maps::XskMap<T>
 pub fn aya::maps::XskMap<T>::len(&self) -> u32


### PR DESCRIPTION
Adds `UserRingBuf` to `aya::maps`, `aya_ebpf::maps`, and
`aya_ebpf::btf_maps`, so `BPF_MAP_TYPE_USER_RINGBUF` is no longer routed to
`Map::Unsupported`. It is the user-space-to-kernel counterpart of `RingBuf`:
user space produces samples and an eBPF program drains them.

Userspace `reserve` returns an entry that derefs to `[u8]`; writing the
payload and calling `submit` publishes it, while dropping it discards. The
map implements `AsFd`/`AsRawFd` so it can be polled for writability, and its
producer mapping is sized from `max_entries`.

The eBPF maps expose `drain`, wrapping `bpf_user_ringbuf_drain`, which runs a
callback per sample and stops early on `ControlFlow::Break`, and
`UserRingBufEntry::read`, which copies a value out of a sample. The legacy
and BTF forms share a single drain implementation.

A separate commit fixes reopening a pinned ring buffer: the loader now
refreshes `max_entries` from the kernel rather than the zero declared in the
ELF, without which the producer mapping would be empty. This corrects the
same latent case for `RingBuf`.

Integration tests parametrize over the legacy and BTF variants and cover
submit and discard, drop-discard, callback break, a full ring, wraparound,
short samples, and pinning across a reopen, plus asynchronous writability
through `AsyncFd` and `epoll`. They skip on kernels without user ring buffer
support.

### Added/updated tests?

- [x] Yes

### Checklist

- [x] Rust code has been formatted with `cargo +nightly fmt`.
- [x] All clippy lints have been fixed.
      You can find failing lints with `cargo xtask clippy`.
- [x] Unit tests are passing locally with `cargo test`.
- [x] The integration tests are passing locally.
- [x] I have blessed any API changes with `cargo xtask public-api --bless`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aya-rs/aya/1599)
<!-- Reviewable:end -->
