### PR TITLE
fix(ci): Use upstream debian URL

### DIFF
--- a/.github/scripts/download_kernel_images.sh
+++ b/.github/scripts/download_kernel_images.sh
@@ -19,7 +19,7 @@ ARCHITECTURE=$2
 shift 2
 VERSIONS=("$@")
 
-URLS=$(lynx -dump -listonly -nonumbers https://mirrors.wikimedia.org/debian/pool/main/l/linux/)
+URLS=$(lynx -dump -listonly -nonumbers -stderr https://deb.debian.org/debian/pool/main/l/linux/)
 readonly URLS
 
 # Find the latest revision of each kernel version.


### PR DESCRIPTION
The Wikipedia one became flake'y recently, leading to CI job failures.

Add `-stderr` so lynx failures aren't silent.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aya-rs/aya/1607)
<!-- Reviewable:end -->
