### PR TITLE
aya-ebpf: expose addrs and ports on SkMsgContext

### DIFF
--- a/ebpf/aya-ebpf/src/programs/sk_msg.rs
+++ b/ebpf/aya-ebpf/src/programs/sk_msg.rs
@@ -19,6 +19,34 @@ impl SkMsgContext {
         unsafe { (*self.msg).size }
     }
 
+    pub fn family(&self) -> u32 {
+        unsafe { (*self.msg).family }
+    }
+
+    pub fn remote_ip4(&self) -> u32 {
+        unsafe { (*self.msg).remote_ip4 }
+    }
+
+    pub fn local_ip4(&self) -> u32 {
+        unsafe { (*self.msg).local_ip4 }
+    }
+
+    pub fn remote_ip6(&self) -> [u32; 4] {
+        unsafe { (*self.msg).remote_ip6 }
+    }
+
+    pub fn local_ip6(&self) -> [u32; 4] {
+        unsafe { (*self.msg).local_ip6 }
+    }
+
+    pub fn local_port(&self) -> u32 {
+        unsafe { (*self.msg).local_port }
+    }
+
+    pub fn remote_port(&self) -> u32 {
+        unsafe { (*self.msg).remote_port }
+    }
+
     pub fn data(&self) -> usize {
         unsafe { (*self.msg).__bindgen_anon_1.data as usize }
     }

--- a/xtask/public-api/aya-ebpf.txt
+++ b/xtask/public-api/aya-ebpf.txt
@@ -2051,9 +2051,16 @@ pub aya_ebpf::programs::sk_msg::SkMsgContext::msg: *mut aya_ebpf_bindings::x86_6
 impl aya_ebpf::programs::sk_msg::SkMsgContext
 pub fn aya_ebpf::programs::sk_msg::SkMsgContext::data(&self) -> usize
 pub fn aya_ebpf::programs::sk_msg::SkMsgContext::data_end(&self) -> usize
+pub fn aya_ebpf::programs::sk_msg::SkMsgContext::family(&self) -> u32
+pub fn aya_ebpf::programs::sk_msg::SkMsgContext::local_ip4(&self) -> u32
+pub fn aya_ebpf::programs::sk_msg::SkMsgContext::local_ip6(&self) -> [u32; 4]
+pub fn aya_ebpf::programs::sk_msg::SkMsgContext::local_port(&self) -> u32
 pub const fn aya_ebpf::programs::sk_msg::SkMsgContext::new(*mut aya_ebpf_bindings::x86_64::bindings::sk_msg_md) -> Self
 pub fn aya_ebpf::programs::sk_msg::SkMsgContext::pop_data(&self, u32, u32, u64) -> core::result::Result<(), i32>
 pub fn aya_ebpf::programs::sk_msg::SkMsgContext::push_data(&self, u32, u32, u64) -> core::result::Result<(), i32>
+pub fn aya_ebpf::programs::sk_msg::SkMsgContext::remote_ip4(&self) -> u32
+pub fn aya_ebpf::programs::sk_msg::SkMsgContext::remote_ip6(&self) -> [u32; 4]
+pub fn aya_ebpf::programs::sk_msg::SkMsgContext::remote_port(&self) -> u32
 pub fn aya_ebpf::programs::sk_msg::SkMsgContext::size(&self) -> u32
 impl aya_ebpf::EbpfContext for aya_ebpf::programs::sk_msg::SkMsgContext
 pub fn aya_ebpf::programs::sk_msg::SkMsgContext::as_ptr(&self) -> *mut core::ffi::c_void
@@ -2555,9 +2562,16 @@ pub aya_ebpf::programs::SkMsgContext::msg: *mut aya_ebpf_bindings::x86_64::bindi
 impl aya_ebpf::programs::sk_msg::SkMsgContext
 pub fn aya_ebpf::programs::sk_msg::SkMsgContext::data(&self) -> usize
 pub fn aya_ebpf::programs::sk_msg::SkMsgContext::data_end(&self) -> usize
+pub fn aya_ebpf::programs::sk_msg::SkMsgContext::family(&self) -> u32
+pub fn aya_ebpf::programs::sk_msg::SkMsgContext::local_ip4(&self) -> u32
+pub fn aya_ebpf::programs::sk_msg::SkMsgContext::local_ip6(&self) -> [u32; 4]
+pub fn aya_ebpf::programs::sk_msg::SkMsgContext::local_port(&self) -> u32
 pub const fn aya_ebpf::programs::sk_msg::SkMsgContext::new(*mut aya_ebpf_bindings::x86_64::bindings::sk_msg_md) -> Self
 pub fn aya_ebpf::programs::sk_msg::SkMsgContext::pop_data(&self, u32, u32, u64) -> core::result::Result<(), i32>
 pub fn aya_ebpf::programs::sk_msg::SkMsgContext::push_data(&self, u32, u32, u64) -> core::result::Result<(), i32>
+pub fn aya_ebpf::programs::sk_msg::SkMsgContext::remote_ip4(&self) -> u32
+pub fn aya_ebpf::programs::sk_msg::SkMsgContext::remote_ip6(&self) -> [u32; 4]
+pub fn aya_ebpf::programs::sk_msg::SkMsgContext::remote_port(&self) -> u32
 pub fn aya_ebpf::programs::sk_msg::SkMsgContext::size(&self) -> u32
 impl aya_ebpf::EbpfContext for aya_ebpf::programs::sk_msg::SkMsgContext
 pub fn aya_ebpf::programs::sk_msg::SkMsgContext::as_ptr(&self) -> *mut core::ffi::c_void


### PR DESCRIPTION
Closes #1410.

`SockOpsContext` exposes the network 4-tuple from `bpf_sock_ops`, but
`SkMsgContext` didn't expose the equivalent fields from `sk_msg_md`,
forcing users to read the raw pointer themselves. This mirrors
`SockOpsContext`: `family`, `remote_ip4`, `local_ip4`, `remote_ip6`,
`local_ip6`, `local_port`, `remote_port`.

The fields are plain `__u32` in `sk_msg_md` (outside the bindgen
unions), so the accessors are the same shape as the existing ones.
Values are returned raw, in the kernel's byte order: network byte order
for everything except `local_port`, which is host byte order (per the
UAPI).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aya-rs/aya/1609)
<!-- Reviewable:end -->
