### PR TITLE
aya-ebpf: keep verifier-safe intrinsics

### DIFF
--- a/ebpf/aya-ebpf/build.rs
+++ b/ebpf/aya-ebpf/build.rs
@@ -1,5 +1,9 @@
 fn main() -> aya_build::Result<()> {
     println!("cargo::rustc-check-cfg=cfg(generic_const_exprs)");
+    println!("cargo::rustc-check-cfg=cfg(runtime_symbol_lint)");
+    if rustversion::cfg!(since(1.98)) {
+        println!("cargo:rustc-cfg=runtime_symbol_lint");
+    }
     check_rust_version();
 
     aya_build::emit_bpf_target_arch_cfg()

--- a/ebpf/aya-ebpf/src/lib.rs
+++ b/ebpf/aya-ebpf/src/lib.rs
@@ -84,6 +84,13 @@ pub trait EbpfContext {
     }
 }
 
+#[cfg_attr(
+    runtime_symbol_lint,
+    expect(
+        invalid_runtime_symbol_definitions,
+        reason = "BPF subprograms cannot return pointers into the caller's stack"
+    )
+)]
 mod intrinsics {
     use super::cty::c_int;
 


### PR DESCRIPTION
Nightly 1.98 now rejects Aya's void definitions of the standard library
runtime symbols.

Returning the destination pointer satisfies that lint but makes linked
eBPF subprograms return caller stack pointers, which the verifier
rejects. Keep the verifier-safe definitions and expect the lint only on
compilers that provide it.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aya-rs/aya/1614)
<!-- Reviewable:end -->