### PR TITLE
aya: add Ebpf::take_program

### DIFF
--- a/aya/src/bpf.rs
+++ b/aya/src/bpf.rs
@@ -1169,6 +1169,29 @@ impl Ebpf {
         self.programs.get_mut(name)
     }
 
+    /// Takes ownership of the program with the given name.
+    ///
+    /// Use this when borrowing with [`program`](crate::Ebpf::program) or
+    /// [`program_mut`](crate::Ebpf::program_mut) is not possible (e.g. when using the
+    /// program from an async task). The caller then owns the returned program and is
+    /// responsible for managing its lifetime; like any [`Program`](crate::programs::Program),
+    /// it is unloaded on `Drop`.
+    ///
+    /// For more details on programs and their usage, see the
+    /// [programs module documentation](crate::programs).
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # let mut bpf = aya::Ebpf::load(&[])?;
+    /// let program = bpf.take_program("SSL_read").unwrap();
+    /// println!("took program SSL_read, type {:?}", program.prog_type());
+    /// # Ok::<(), aya::EbpfError>(())
+    /// ```
+    pub fn take_program(&mut self, name: &str) -> Option<Program> {
+        self.programs.remove(name)
+    }
+
     /// An iterator over all the programs.
     ///
     /// # Examples

--- a/xtask/public-api/aya.txt
+++ b/xtask/public-api/aya.txt
@@ -7889,6 +7889,7 @@ pub fn aya::Ebpf::program_mut(&mut self, &str) -> core::option::Option<&mut aya:
 pub fn aya::Ebpf::programs(&self) -> impl core::iter::traits::iterator::Iterator<Item = (&str, &aya::programs::Program)>
 pub fn aya::Ebpf::programs_mut(&mut self) -> impl core::iter::traits::iterator::Iterator<Item = (&str, &mut aya::programs::Program)>
 pub fn aya::Ebpf::take_map(&mut self, &str) -> core::option::Option<aya::maps::Map>
+pub fn aya::Ebpf::take_program(&mut self, &str) -> core::option::Option<aya::programs::Program>
 impl core::fmt::Debug for aya::Ebpf
 pub fn aya::Ebpf::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Freeze for aya::Ebpf


### PR DESCRIPTION
Adds `Ebpf::take_program`, the program-side counterpart of the existing `Ebpf::take_map`.

It moves a program out of the `Ebpf` instance and hands ownership to the caller — useful when a `&`/`&mut` borrow is not enough, e.g. moving a program into an async task. Implementation and docs mirror `take_map` (`self.programs.remove(name)`).

Also updates the `aya` public-API snapshot (`xtask/public-api/aya.txt`).

Closes #809


<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aya-rs/aya/1616)
<!-- Reviewable:end -->
