### PR TITLE
aya-ebpf: read first syscall arg from orig_x0 on arm64

### DIFF
--- a/ebpf/aya-ebpf/src/args.rs
+++ b/ebpf/aya-ebpf/src/args.rs
@@ -52,11 +52,15 @@ pub(crate) fn btf_arg<T: Argument>(ctx: &impl crate::EbpfContext, n: usize) -> T
     T::from_register(unsafe { *ptr as u64 })
 }
 
-trait PtRegsLayout {
+pub(crate) trait PtRegsLayout {
     type Reg;
 
     fn arg_reg(&self, index: usize) -> Option<&Self::Reg>;
     fn rc_reg(&self) -> &Self::Reg;
+
+    fn syscall_regs_ptr(&self) -> Option<*const pt_regs> {
+        None
+    }
 }
 
 #[cfg(bpf_target_arch = "aarch64")]
@@ -77,6 +81,11 @@ impl PtRegsLayout for pt_regs {
         // Return codes use libbpf's __PT_RC_REG (regs[0]/x0).
         // https://github.com/torvalds/linux/blob/v6.17/tools/lib/bpf/bpf_tracing.h#L248-L251
         &self.regs[0]
+    }
+
+    fn syscall_regs_ptr(&self) -> Option<*const pt_regs> {
+        // ARCH_HAS_SYSCALL_WRAPPER: the real pt_regs pointer is in x0.
+        self.arg_reg(0).map(|reg| *reg as *const pt_regs)
     }
 }
 
@@ -264,6 +273,33 @@ pub(crate) fn ret<T: Argument>(ctx: &pt_regs) -> T {
         reason = "architecture-specific"
     )]
     T::from_register((*reg) as u64)
+}
+
+/// Coerces a `T` from the `n`th syscall argument of the `pt_regs` pointed to
+/// by `regs`, where `n` starts at 0. Differs from [`arg`] in that on
+/// architectures like aarch64 the first syscall argument lives in
+/// `orig_x0` (outside `user_pt_regs`), not in `regs[0]`.
+pub(crate) fn syscall_read_arg<T: Argument>(regs: *const pt_regs, n: usize) -> Option<T> {
+    let layout = unsafe { &*regs };
+    #[cfg(bpf_target_arch = "aarch64")]
+    {
+        if n == 0 {
+            let orig_x0_addr =
+                unsafe { (regs as *const u8).add(size_of_val(layout)) };
+            let val =
+                unsafe { crate::helpers::bpf_probe_read_kernel(orig_x0_addr as *const u64) };
+            return val.ok().map(T::from_register);
+        }
+    }
+    let reg = layout.arg_reg(n)?;
+    #[expect(clippy::allow_attributes, reason = "architecture-specific")]
+    #[allow(
+        clippy::cast_sign_loss,
+        clippy::unnecessary_cast,
+        trivial_numeric_casts,
+        reason = "architecture-specific"
+    )]
+    Some(T::from_register((*reg) as u64))
 }
 
 /// Returns the n-th argument of the raw tracepoint.

--- a/ebpf/aya-ebpf/src/programs/mod.rs
+++ b/ebpf/aya-ebpf/src/programs/mod.rs
@@ -28,7 +28,7 @@ pub use fexit::FExitContext;
 pub use flow_dissector::FlowDissectorContext;
 pub use lsm::LsmContext;
 pub use perf_event::PerfEventContext;
-pub use probe::ProbeContext;
+pub use probe::{ProbeContext, syscall_arg};
 pub use raw_tracepoint::RawTracePointContext;
 pub use retprobe::RetProbeContext;
 pub use sk_buff::SkBuffContext;

--- a/ebpf/aya-ebpf/src/programs/probe.rs
+++ b/ebpf/aya-ebpf/src/programs/probe.rs
@@ -1,6 +1,10 @@
 use core::ffi::c_void;
 
-use crate::{Argument, EbpfContext, args::arg, bindings::pt_regs};
+use crate::{
+    Argument, EbpfContext,
+    args::{PtRegsLayout as _, arg, syscall_read_arg},
+    bindings::pt_regs,
+};
 
 pub struct ProbeContext {
     pub regs: *mut pt_regs,
@@ -37,6 +41,33 @@ impl ProbeContext {
     pub fn arg<T: Argument>(&self, n: usize) -> Option<T> {
         arg(unsafe { &*self.regs }, n)
     }
+
+    /// Returns the `n`th syscall argument, accounting for architecture-specific
+    /// conventions that differ from the function-call ABI.
+    ///
+    /// On architectures with `ARCH_HAS_SYSCALL_WRAPPER` (aarch64, s390x, x86_64),
+    /// the real `pt_regs` that holds the syscall arguments is obtained by
+    /// dereferencing the first function-call argument. On aarch64, the first
+    /// syscall argument is read from `orig_x0` (past `user_pt_regs`) rather
+    /// than `regs[0]`/`x0`.
+    ///
+    /// On architectures where the syscall and function-call conventions
+    /// coincide (arm, riscv64, mips, loongarch64), this is equivalent to
+    /// [`arg`](Self::arg).
+    pub fn syscall_arg<T: Argument>(&self, n: usize) -> Option<T> {
+        let layout = unsafe { &*self.regs };
+        let real_regs = layout.syscall_regs_ptr().unwrap_or(self.regs);
+        syscall_read_arg(real_regs, n)
+    }
+}
+
+/// Reads the `n`th syscall argument from the `pt_regs` pointed to by `regs`.
+///
+/// This is the building block for reading syscall arguments from contexts that
+/// provide a raw `pt_regs` pointer (for example, the `sys_enter` raw
+/// tracepoint passes a `struct pt_regs *` as its first argument).
+pub fn syscall_arg<T: Argument>(regs: *const pt_regs, n: usize) -> Option<T> {
+    syscall_read_arg(regs, n)
 }
 
 impl EbpfContext for ProbeContext {

--- a/test/integration-common/src/lib.rs
+++ b/test/integration-common/src/lib.rs
@@ -119,6 +119,7 @@ pub mod raw_tracepoint {
     pub struct SysEnterEvent {
         pub regs_addr: u64,
         pub syscall_id: i64,
+        pub first_syscall_arg: u64,
     }
 
     #[cfg(feature = "user")]

--- a/test/integration-ebpf/src/raw_tracepoint.rs
+++ b/test/integration-ebpf/src/raw_tracepoint.rs
@@ -4,9 +4,10 @@
 
 use aya_ebpf::{
     EbpfContext as _, Global,
+    bindings::pt_regs,
     macros::{map, raw_tracepoint},
     maps::Array,
-    programs::RawTracePointContext,
+    programs::{self, RawTracePointContext},
 };
 #[cfg(not(test))]
 extern crate ebpf_panic;
@@ -33,6 +34,12 @@ fn sys_enter(ctx: RawTracePointContext) -> i32 {
     let regs_addr: u64 = ctx.arg(0);
     let syscall_id: i64 = ctx.arg(1);
 
+    let first_arg = if regs_addr != 0 {
+        programs::syscall_arg::<u64>(regs_addr as *const pt_regs, 0).unwrap_or(0)
+    } else {
+        0
+    };
+
     if let Some(ptr) = RESULT.get_ptr_mut(0) {
         unsafe {
             if (*ptr).regs_addr != 0 {
@@ -40,6 +47,7 @@ fn sys_enter(ctx: RawTracePointContext) -> i32 {
             }
             (*ptr).regs_addr = regs_addr;
             (*ptr).syscall_id = syscall_id;
+            (*ptr).first_syscall_arg = first_arg;
         }
     }
 

--- a/test/integration-test/src/tests/raw_tracepoint.rs
+++ b/test/integration-test/src/tests/raw_tracepoint.rs
@@ -30,8 +30,14 @@ fn raw_tracepoint_sys_enter() {
     // Trigger a deterministic syscall after attaching the raw tracepoint.
     File::open("/dev/null").unwrap();
 
-    let SysEnterEvent { regs_addr, .. } = get_sys_enter_event(&mut bpf);
+    let SysEnterEvent {
+        regs_addr,
+        first_syscall_arg,
+        ..
+    } = get_sys_enter_event(&mut bpf);
     assert_ne!(regs_addr, 0);
+    // openat(AT_FDCWD, "/dev/null", O_RDONLY) has AT_FDCWD (-100) as the first arg.
+    assert_eq!(first_syscall_arg, (-100i64) as u64);
 }
 
 #[test_log::test]


### PR DESCRIPTION
Fixes #1146.

On arm64 the first syscall argument lives in `orig_x0`, which is in the kernel
`struct pt_regs` past the UAPI `user_pt_regs` that aya exposes as `pt_regs`.
`ProbeContext::arg(0)` reads `regs[0]`/x0, which is clobbered by the time a
syscall-entry probe fires (same issue libbpf fixed in 9f6e3a7).

This PR adds:

- `PtRegsLayout::syscall_regs_ptr()` -- returns the real syscall pt_regs
  pointer for `ARCH_HAS_SYSCALL_WRAPPER` arches (aarch64, s390x, x86_64).
  On aarch64 this dereferences arg(0) which holds the pointer.

- `ProbeContext::syscall_arg(n)` -- reads the nth syscall argument accounting
  for architecture-specific conventions. On aarch64, arg 0 is read from
  `orig_x0` via `bpf_probe_read_kernel` at offset `sizeof(user_pt_regs)`.

- `aya_ebpf::programs::syscall_arg(regs, n)` -- public free function for
  contexts that provide a raw `pt_regs` pointer (e.g. the `sys_enter` raw
  tracepoint passes a `struct pt_regs *` as its first argument).

- Integration test: extends the `sys_enter` raw tracepoint test to read the
  first syscall arg and assert it is `AT_FDCWD` (-100) from the triggered
  `openat(AT_FDCWD, "/dev/null", O_RDONLY)`.

Arm64 only for now -- arm/riscv/mips/loongarch already work since the
conventions coincide; s390x (`orig_gpr2`) and powerpc (`orig_gpr3`) are
follow-up material.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aya-rs/aya/1620)
<!-- Reviewable:end -->
