### PR TITLE
aya-ebpf: add ProbeContext::syscall_arg

### DIFF
--- a/ebpf/aya-ebpf/src/args.rs
+++ b/ebpf/aya-ebpf/src/args.rs
@@ -1,3 +1,6 @@
+#[cfg(any(bpf_target_arch = "aarch64", bpf_target_arch = "x86_64"))]
+use core::mem::offset_of;
+
 use crate::bindings::{bpf_raw_tracepoint_args, pt_regs};
 
 mod sealed {
@@ -57,6 +60,24 @@ trait PtRegsLayout {
 
     fn arg_reg(&self, index: usize) -> Option<&Self::Reg>;
     fn rc_reg(&self) -> &Self::Reg;
+
+    /// Returns the offset of the field holding the `index`th syscall argument
+    /// within the runtime [`pt_regs`] layout, or `None` if the index is out of
+    /// range. The offset may reference a field that is part of the kernel's
+    /// internal `struct pt_regs` but not of the ABI-stable `user_pt_regs`
+    /// exposed to userspace (e.g. `orig_x0` on `AArch64`).
+    ///
+    /// Callers are expected to read the value using a helper such as
+    /// [`bpf_probe_read_kernel`](crate::helpers::bpf_probe_read_kernel):
+    /// kprobes on syscall wrappers receive a `const struct pt_regs *` argument
+    /// that the verifier tracks as a scalar, so reinterpreting it as
+    /// `&pt_regs` and accessing fields directly is rejected.
+    fn syscall_arg_reg_offset(_index: usize) -> Option<usize>
+    where
+        Self: Sized,
+    {
+        None
+    }
 }
 
 #[cfg(bpf_target_arch = "aarch64")]
@@ -77,6 +98,25 @@ impl PtRegsLayout for pt_regs {
         // Return codes use libbpf's __PT_RC_REG (regs[0]/x0).
         // https://github.com/torvalds/linux/blob/v6.17/tools/lib/bpf/bpf_tracing.h#L248-L251
         &self.regs[0]
+    }
+
+    fn syscall_arg_reg_offset(index: usize) -> Option<usize> {
+        // `AArch64` syscall arguments differ from regular call arguments only in
+        // the first argument: it lives in `orig_x0`, which is part of the
+        // kernel's internal `struct pt_regs` but NOT of the ABI-stable
+        // `user_pt_regs` that `pt_regs` aliases here.
+        // https://github.com/torvalds/linux/blob/v6.17/arch/arm64/include/uapi/asm/ptrace.h#L88-L93
+        // https://github.com/torvalds/linux/blob/v6.17/arch/arm64/include/asm/ptrace.h#L59-L66
+        // https://github.com/torvalds/linux/blob/v6.17/tools/lib/bpf/bpf_tracing.h#L238-L246
+        let offset = match index {
+            // `orig_x0` immediately follows the `user_pt_regs` portion of the
+            // kernel's `struct pt_regs`.
+            0 => size_of::<Self>(),
+            // syscall args 1..5 live in `regs[1..5]`.
+            n @ 1..=5 => offset_of!(Self, regs) + n * size_of::<Self::Reg>(),
+            _ => return None,
+        };
+        Some(offset)
     }
 }
 
@@ -237,6 +277,25 @@ impl PtRegsLayout for pt_regs {
         // https://github.com/torvalds/linux/blob/v6.17/tools/lib/bpf/bpf_tracing.h#L148-L152
         &self.rax
     }
+
+    fn syscall_arg_reg_offset(index: usize) -> Option<usize> {
+        // x86-64 syscall arguments differ from regular call arguments only in
+        // the 4th argument (index 3): it is passed in `r10` instead of `rcx`
+        // because `rcx` is clobbered by the `syscall` instruction (it holds the
+        // return address).
+        // https://github.com/torvalds/linux/blob/v6.17/arch/x86/include/asm/ptrace.h#L103-L155
+        // https://github.com/torvalds/linux/blob/v6.17/tools/lib/bpf/bpf_tracing.h#L93-L102
+        let offset = match index {
+            0 => offset_of!(Self, rdi),
+            1 => offset_of!(Self, rsi),
+            2 => offset_of!(Self, rdx),
+            3 => offset_of!(Self, r10),
+            4 => offset_of!(Self, r8),
+            5 => offset_of!(Self, r9),
+            _ => return None,
+        };
+        Some(offset)
+    }
 }
 
 /// Coerces a `T` from the `n`th argument of a `pt_regs` context where `n` starts
@@ -251,6 +310,38 @@ pub(crate) fn arg<T: Argument>(ctx: &pt_regs, n: usize) -> Option<T> {
         reason = "architecture-specific"
     )]
     Some(T::from_register((*reg) as u64))
+}
+
+/// Coerces a `T` from the `n`th syscall argument of a `pt_regs` context where
+/// `n` starts at 0 and increases by 1 for each successive argument.
+///
+/// Unlike [`arg`], this uses the syscall calling convention rather than the
+/// regular call convention. On some architectures this differs from [`arg`]:
+///
+/// - `AArch64`: the first syscall argument lives in `orig_x0`, not `regs[0]`
+///   (which is overwritten with the return value).
+/// - `x86-64`: the 4th syscall argument (index 3) is passed in `r10` rather
+///   than `rcx` (which is clobbered by the `syscall` instruction).
+///
+/// Reads are performed with [`bpf_probe_read_kernel`] because `pt_regs`
+/// pointers obtained from a kprobe on a syscall wrapper are tracked by the
+/// verifier as scalars and cannot be dereferenced directly.
+///
+/// # Safety
+///
+/// `ctx` must point to a valid `pt_regs` value in kernel memory.
+pub(crate) unsafe fn syscall_arg<T: Argument>(ctx: *const pt_regs, n: usize) -> Option<T> {
+    let offset = pt_regs::syscall_arg_reg_offset(n)?;
+    let ptr = unsafe { ctx.byte_add(offset) }.cast::<u64>();
+    let reg = unsafe { crate::helpers::bpf_probe_read_kernel(ptr).ok() }?;
+    #[expect(clippy::allow_attributes, reason = "architecture-specific")]
+    #[allow(
+        clippy::cast_sign_loss,
+        clippy::unnecessary_cast,
+        trivial_numeric_casts,
+        reason = "architecture-specific"
+    )]
+    Some(T::from_register(reg as u64))
 }
 
 /// Coerces a `T` from the return value of a `pt_regs` context.

--- a/ebpf/aya-ebpf/src/programs/probe.rs
+++ b/ebpf/aya-ebpf/src/programs/probe.rs
@@ -1,6 +1,10 @@
 use core::ffi::c_void;
 
-use crate::{Argument, EbpfContext, args::arg, bindings::pt_regs};
+use crate::{
+    Argument, EbpfContext,
+    args::{arg, syscall_arg},
+    bindings::pt_regs,
+};
 
 pub struct ProbeContext {
     pub regs: *mut pt_regs,
@@ -36,6 +40,50 @@ impl ProbeContext {
     /// ```
     pub fn arg<T: Argument>(&self, n: usize) -> Option<T> {
         arg(unsafe { &*self.regs }, n)
+    }
+
+    /// Returns the `n`th syscall argument passed to the probed function,
+    /// starting from 0.
+    ///
+    /// This is intended for use with kprobes attached to syscall wrapper
+    /// functions (e.g., `__arm64_sys_*` on `AArch64` or `__x64_sys_*` on
+    /// `x86-64`), which are present on kernels built with
+    /// `CONFIG_ARCH_HAS_SYSCALL_WRAPPER`. Such wrappers take a single
+    /// `const struct pt_regs *` argument; retrieve that pointer with
+    /// [`Self::arg`] passing `0` as the index, then this method dereferences it
+    /// and extracts the syscall arguments using the syscall calling convention
+    /// rather than the regular call convention.
+    ///
+    /// On some architectures the syscall register layout differs from the
+    /// regular call convention; see the per-architecture details on the
+    /// `syscall_arg_reg_offset` impl in `aya_ebpf::args`.
+    ///
+    /// Currently this is implemented only for `AArch64` and `x86-64`; on other
+    /// architectures this method will return `None`.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use aya_ebpf::programs::ProbeContext;
+    /// unsafe fn try_kprobe_sys_kill(ctx: ProbeContext) -> Result<u32, u32> {
+    ///     // `__arm64_sys_kill` / `__x64_sys_kill` take a single
+    ///     // `const struct pt_regs *` argument.
+    ///     let pid: i32 = ctx.syscall_arg(0).ok_or(1u32)?;
+    ///     let sig: i32 = ctx.syscall_arg(1).ok_or(1u32)?;
+    ///     Ok(0)
+    /// }
+    /// ```
+    pub fn syscall_arg<T: Argument>(&self, n: usize) -> Option<T> {
+        // With CONFIG_ARCH_HAS_SYSCALL_WRAPPER, the probed function's only
+        // argument is `const struct pt_regs *regs`. On x86-64 and AArch64 the
+        // kernel selects this config automatically, but on other architectures
+        // (e.g. powerpc, s390) it is user-configurable; libbpf auto-detects the
+        // absence of a wrapper at runtime (see
+        // https://github.com/torvalds/linux/blob/e5f0a698b34ed76002dc5cff3804a61c80233a7a/tools/lib/bpf/bpf_tracing.h#L906).
+        // TODO: auto-detect non-wrapper kernels when support expands beyond
+        // x86-64 and AArch64.
+        let regs: *const pt_regs = self.arg(0)?;
+        unsafe { syscall_arg(regs, n) }
     }
 }
 

--- a/test/integration-common/src/lib.rs
+++ b/test/integration-common/src/lib.rs
@@ -286,3 +286,36 @@ pub mod test_run {
     pub const IF_INDEX: u32 = 1;
     pub const XDP_MODIFY_LEN: usize = 16;
 }
+
+pub mod syscall_args {
+    /// Index in the `RESULTS` map holding the single captured result.
+    pub const RESULT_INDEX: u32 = 0;
+
+    /// Marker written to [`TestResult::ran`] to distinguish a captured result
+    /// from an uninitialised slot.
+    pub const RAN: u32 = 1;
+
+    #[repr(C)]
+    #[derive(Clone, Copy, Default)]
+    pub struct TestResult {
+        /// Set to [`RAN`] once the kprobe has fired and overwritten the slot.
+        pub ran: u32,
+        /// `fd_in` (`splice` arg 0) as seen by the kprobe.
+        pub fd_in: u64,
+        /// `off_in` (`splice` arg 1) as seen by the kprobe.
+        pub off_in: u64,
+        /// `fd_out` (`splice` arg 2) as seen by the kprobe.
+        pub fd_out: u64,
+        /// `off_out` (`splice` arg 3) as seen by the kprobe.
+        /// On `x86-64` this is passed in `r10` (not `rcx`) for syscalls, so a
+        /// wrong value here indicates the regular calling convention was used.
+        pub off_out: u64,
+        /// `len` (`splice` arg 4) as seen by the kprobe.
+        pub len: u64,
+        /// `flags` (`splice` arg 5) as seen by the kprobe.
+        pub flags: u64,
+    }
+
+    #[cfg(feature = "user")]
+    unsafe impl aya::Pod for TestResult {}
+}

--- a/test/integration-ebpf/Cargo.toml
+++ b/test/integration-ebpf/Cargo.toml
@@ -207,3 +207,7 @@ path = "src/inode_storage.rs"
 [[bin]]
 name = "cgrp_storage"
 path = "src/cgrp_storage.rs"
+
+[[bin]]
+name = "syscall_args"
+path = "src/syscall_args.rs"

--- a/test/integration-ebpf/src/syscall_args.rs
+++ b/test/integration-ebpf/src/syscall_args.rs
@@ -1,0 +1,52 @@
+#![no_std]
+#![no_main]
+#![expect(unused_crate_dependencies, reason = "used in other bins")]
+
+use aya_ebpf::{
+    EbpfContext as _, Global,
+    macros::{kprobe, map},
+    maps::Array,
+    programs::ProbeContext,
+};
+use integration_common::syscall_args::{RAN, RESULT_INDEX, TestResult};
+#[cfg(not(test))]
+extern crate ebpf_panic;
+
+#[unsafe(no_mangle)]
+static TARGET_TGID: Global<u32> = Global::new(0);
+
+#[map]
+static RESULTS: Array<TestResult> = Array::with_max_entries(1, 0);
+
+// Kprobe on `__arm64_sys_splice` / `__x64_sys_splice` that captures all six
+// syscall arguments using `ProbeContext::syscall_arg`. The program filters by
+// `TARGET_TGID` (set from userspace) so only the test process's own `splice`
+// calls are recorded. See `integration_common::syscall_args` for the shared
+// protocol.
+#[kprobe]
+fn syscall_args_splice(ctx: ProbeContext) -> u32 {
+    if ctx.tgid() != TARGET_TGID.load() {
+        return 0;
+    }
+
+    let fd_in: u64 = ctx.syscall_arg(0).unwrap_or(0);
+    let off_in: u64 = ctx.syscall_arg(1).unwrap_or(0);
+    let fd_out: u64 = ctx.syscall_arg(2).unwrap_or(0);
+    let off_out: u64 = ctx.syscall_arg(3).unwrap_or(0);
+    let len: u64 = ctx.syscall_arg(4).unwrap_or(0);
+    let flags: u64 = ctx.syscall_arg(5).unwrap_or(0);
+    if let Some(result) = RESULTS.get_ptr_mut(RESULT_INDEX) {
+        unsafe {
+            *result = TestResult {
+                ran: RAN,
+                fd_in,
+                off_in,
+                fd_out,
+                off_out,
+                len,
+                flags,
+            };
+        }
+    }
+    0
+}

--- a/test/integration-test/src/lib.rs
+++ b/test/integration-test/src/lib.rs
@@ -85,6 +85,7 @@ bpf_file!(
     XSK_MAP => "xsk_map",
     INODE_STORAGE => "inode_storage",
     CGRP_STORAGE => "cgrp_storage",
+    SYSCALL_ARGS => "syscall_args",
 );
 
 #[cfg(test)]

--- a/test/integration-test/src/tests.rs
+++ b/test/integration-test/src/tests.rs
@@ -64,6 +64,7 @@ mod socket_filter;
 mod stack_trace;
 mod stack_trace_lsm;
 mod strncmp;
+mod syscall_args;
 mod tc_netlink;
 mod tcx;
 mod uprobe_cookie;

--- a/test/integration-test/src/tests/syscall_args.rs
+++ b/test/integration-test/src/tests/syscall_args.rs
@@ -1,0 +1,99 @@
+use aya::{
+    EbpfLoader,
+    maps::{Array, MapData},
+    programs::KProbe,
+};
+use integration_common::syscall_args::{RAN, RESULT_INDEX, TestResult};
+
+// Sentinel values passed as the six arguments of the `splice(2)` syscall.
+// The kprobe distinguishes each register slot round-trip through the syscall
+// wrapper. Mirrors the kernel selftest pattern in
+// <https://github.com/torvalds/linux/blob/e5f0a698b34ed76002dc5cff3804a61c80233a7a/tools/testing/selftests/bpf/progs/bpf_syscall_macro.c#L89-L103>.
+//
+// Positive `i32` values are used for `fd_in`/`fd_out` to avoid sign-extension
+// differences between architectures. The offset pointers are invalid non-null
+// sentinels; the kernel will fail with `EFAULT` but the kprobe fires first.
+const SPLICE_FD_IN: u64 = 0x0bad_f00d;
+const SPLICE_FD_OUT: u64 = 0x0f00_d0ad;
+const SPLICE_OFF_IN: u64 = 0x1234_5678_9abc_def0;
+const SPLICE_OFF_OUT: u64 = 0x0fed_cba9_8765_4321;
+const SPLICE_LEN: u64 = 0xcafe_babe_dad0_bad0;
+const SPLICE_FLAGS: u64 = 0x0edb_ab1e;
+
+// Returns the syscall wrapper symbol used by the host architecture, or `None`
+// if the architecture does not implement `CONFIG_ARCH_HAS_SYSCALL_WRAPPER`.
+fn splice_syscall_wrapper() -> Option<&'static str> {
+    if cfg!(target_arch = "x86_64") {
+        Some("__x64_sys_splice")
+    } else if cfg!(target_arch = "aarch64") {
+        Some("__arm64_sys_splice")
+    } else {
+        None
+    }
+}
+
+#[test_log::test]
+fn syscall_arg_splice() {
+    let Some(wrapper) = splice_syscall_wrapper() else {
+        eprintln!(
+            "skipping test - syscall wrappers unavailable on {}",
+            std::env::consts::ARCH
+        );
+        return;
+    };
+
+    let target_tgid = std::process::id();
+    let mut bpf = EbpfLoader::new()
+        .override_global("TARGET_TGID", &target_tgid, true)
+        .load(crate::SYSCALL_ARGS)
+        .unwrap();
+
+    let mut results: Array<MapData, TestResult> =
+        Array::try_from(bpf.take_map("RESULTS").unwrap()).unwrap();
+
+    let prog: &mut KProbe = bpf
+        .program_mut("syscall_args_splice")
+        .unwrap()
+        .try_into()
+        .unwrap();
+    prog.load().unwrap();
+    prog.attach(wrapper, 0).unwrap();
+
+    // For `off_in`/`off_out` (which are `loff_t *` pointers) we pass invalid
+    // non-null sentinel addresses; the kernel will fail with `EFAULT` when it
+    // tries to dereference them, but the kprobe fires first and captures the
+    // raw register value.
+    //
+    // On `x86-64` arg4 (`off_out`) is delivered in `r10` rather than `rcx`;
+    // a wrong `off_out` value in the captured result indicates the regular
+    // calling convention was used incorrectly.
+    let off_in_ptr = SPLICE_OFF_IN as *mut libc::loff_t;
+    let off_out_ptr = SPLICE_OFF_OUT as *mut libc::loff_t;
+
+    // Reset the result slot before triggering the kprobe.
+    results.set(RESULT_INDEX, TestResult::default(), 0).unwrap();
+
+    // Trigger the syscall. `splice` returns an error on these arguments
+    // (`EBADF` from the invalid fds or `EFAULT` from the invalid offset
+    // pointers), but the kprobe fires before the kernel validates them.
+    let rc = unsafe {
+        libc::splice(
+            SPLICE_FD_IN as i32,
+            off_in_ptr,
+            SPLICE_FD_OUT as i32,
+            off_out_ptr,
+            SPLICE_LEN as usize,
+            SPLICE_FLAGS as u32,
+        )
+    };
+    assert!(rc < 0, "splice unexpectedly succeeded");
+
+    let result = results.get(&RESULT_INDEX, 0).unwrap();
+    assert_eq!(result.ran, RAN, "kprobe did not fire");
+    assert_eq!(result.fd_in, SPLICE_FD_IN, "syscall arg 0 (fd_in)");
+    assert_eq!(result.off_in, SPLICE_OFF_IN, "syscall arg 1 (off_in)");
+    assert_eq!(result.fd_out, SPLICE_FD_OUT, "syscall arg 2 (fd_out)");
+    assert_eq!(result.off_out, SPLICE_OFF_OUT, "syscall arg 3 (off_out)");
+    assert_eq!(result.len, SPLICE_LEN, "syscall arg 4 (len)");
+    assert_eq!(result.flags, SPLICE_FLAGS, "syscall arg 5 (flags)");
+}

--- a/xtask/public-api/aya-ebpf.txt
+++ b/xtask/public-api/aya-ebpf.txt
@@ -1906,6 +1906,7 @@ pub aya_ebpf::programs::probe::ProbeContext::regs: *mut aya_ebpf_bindings::x86_6
 impl aya_ebpf::programs::probe::ProbeContext
 pub fn aya_ebpf::programs::probe::ProbeContext::arg<T: aya_ebpf::Argument>(&self, usize) -> core::option::Option<T>
 pub const fn aya_ebpf::programs::probe::ProbeContext::new(*mut core::ffi::c_void) -> Self
+pub fn aya_ebpf::programs::probe::ProbeContext::syscall_arg<T: aya_ebpf::Argument>(&self, usize) -> core::option::Option<T>
 impl aya_ebpf::EbpfContext for aya_ebpf::programs::probe::ProbeContext
 pub fn aya_ebpf::programs::probe::ProbeContext::as_ptr(&self) -> *mut core::ffi::c_void
 pub fn aya_ebpf::programs::probe::ProbeContext::command(&self) -> core::result::Result<[u8; 16], i32>
@@ -2449,6 +2450,7 @@ pub aya_ebpf::programs::ProbeContext::regs: *mut aya_ebpf_bindings::x86_64::bind
 impl aya_ebpf::programs::probe::ProbeContext
 pub fn aya_ebpf::programs::probe::ProbeContext::arg<T: aya_ebpf::Argument>(&self, usize) -> core::option::Option<T>
 pub const fn aya_ebpf::programs::probe::ProbeContext::new(*mut core::ffi::c_void) -> Self
+pub fn aya_ebpf::programs::probe::ProbeContext::syscall_arg<T: aya_ebpf::Argument>(&self, usize) -> core::option::Option<T>
 impl aya_ebpf::EbpfContext for aya_ebpf::programs::probe::ProbeContext
 pub fn aya_ebpf::programs::probe::ProbeContext::as_ptr(&self) -> *mut core::ffi::c_void
 pub fn aya_ebpf::programs::probe::ProbeContext::command(&self) -> core::result::Result<[u8; 16], i32>


### PR DESCRIPTION
Closes #1146.

## Background

On architectures with `CONFIG_ARCH_HAS_SYSCALL_WRAPPER` (arm64, x86-64,
s390, etc.), the kernel wraps each syscall in a function that takes a single
`const struct pt_regs *` argument. To obtain the actual syscall arguments
from a kprobe attached to such a wrapper, users must dereference that
pointer and read registers using the **syscall** calling convention, which
differs from the regular call convention on a few architectures:

| arch    | syscall arg 1    | regular arg 1    | syscall arg 4 | regular arg 4 |
|---------|--------------------------|--------------------------------------|---------------|--------------------------------|
| aarch64 | `orig_x0` (fixed-offset read) | `regs[0]` (overwritten with retval) | `regs[3]`     | `regs[3]` |
| x86-64  | `rdi`                    | `rdi`                                | `r10`         | `rcx` (clobbered by `syscall`) |

This mirrors what libbpf's `BPF_KSYSCALL` / `PT_REGS_PARMn_SYSCALL` macros
do in `bpf_tracing.h`. Only the native syscall ABI is supported; compat
wrappers (e.g. `__ia32_sys_*` on x86-64) pass arguments in a different
register set, matching libbpf's `BPF_KSYSCALL` limitation.

## Changes

* `PtRegsLayout::syscall_arg_reg_offset` — new trait method returning the
  field offset of the `n`th syscall argument; the default implementation
  returns `None` on architectures without syscall argument support.
* `aarch64` override — syscall arg 0 lives in `orig_x0`, which follows the
  ABI-stable `user_pt_regs` struct in the kernel's internal `pt_regs`; it
  is read with `bpf_probe_read_kernel` at a fixed offset.
* `x86_64` override — syscall arg 3 is read from `r10` instead of `rcx`.
* `ProbeContext::syscall_arg` — convenience method that reads the pt_regs
  pointer from `ctx.arg(0)` (the wrapper's only argument) and dispatches to
  the architecture-specific syscall register layout.
* Integration test: `tests::syscall_args::syscall_arg_splice` — a kprobe on
  `__arm64_sys_splice` / `__x64_sys_splice` that records all six syscall
  arguments (exercising the x86-64 `r10` difference) while userspace
  invokes `splice(2)` with sentinel values. The probe filters by
  `TARGET_TGID` so only the test process's calls are recorded. Skips on
  architectures that don't implement syscall wrappers.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aya-rs/aya/1621)
<!-- Reviewable:end -->
