### PR TITLE
fix(aya-ebpf-macros): use NonNull for SkBuffContext in cgroup_skb

### DIFF
--- a/aya-ebpf-macros/src/cgroup_skb.rs
+++ b/aya-ebpf-macros/src/cgroup_skb.rs
@@ -42,6 +42,8 @@ impl CgroupSkb {
             #[unsafe(no_mangle)]
             #[unsafe(link_section = #section_name)]
             #vis fn #fn_name(ctx: *mut ::aya_ebpf::bindings::__sk_buff) -> i32 {
+                // SAFETY: The `ctx` pointer provided by the kernel should be valid.
+                let ctx = unsafe { ::core::ptr::NonNull::new_unchecked(ctx) };
                 return #fn_name(::aya_ebpf::programs::SkBuffContext::new(ctx));
 
                 #item
@@ -72,6 +74,8 @@ mod tests {
             #[unsafe(no_mangle)]
             #[unsafe(link_section = "cgroup/skb")]
             fn foo(ctx: *mut ::aya_ebpf::bindings::__sk_buff) -> i32 {
+                // SAFETY: The `ctx` pointer provided by the kernel should be valid.
+                let ctx = unsafe { ::core::ptr::NonNull::new_unchecked(ctx) };
                 return foo(::aya_ebpf::programs::SkBuffContext::new(ctx));
 
                 fn foo(ctx: SkBuffContext) -> i32 {
@@ -98,6 +102,8 @@ mod tests {
             #[unsafe(no_mangle)]
             #[unsafe(link_section = "cgroup_skb/egress")]
             fn foo(ctx: *mut ::aya_ebpf::bindings::__sk_buff) -> i32 {
+                // SAFETY: The `ctx` pointer provided by the kernel should be valid.
+                let ctx = unsafe { ::core::ptr::NonNull::new_unchecked(ctx) };
                 return foo(::aya_ebpf::programs::SkBuffContext::new(ctx));
 
                 fn foo(ctx: SkBuffContext) -> i32 {
@@ -124,6 +130,8 @@ mod tests {
             #[unsafe(no_mangle)]
             #[unsafe(link_section = "cgroup_skb/ingress")]
             fn foo(ctx: *mut ::aya_ebpf::bindings::__sk_buff) -> i32 {
+                // SAFETY: The `ctx` pointer provided by the kernel should be valid.
+                let ctx = unsafe { ::core::ptr::NonNull::new_unchecked(ctx) };
                 return foo(::aya_ebpf::programs::SkBuffContext::new(ctx));
 
                 fn foo(ctx: SkBuffContext) -> i32 {
@@ -150,6 +158,8 @@ mod tests {
             #[unsafe(no_mangle)]
             #[unsafe(link_section = "cgroup_skb/egress")]
             fn foo(ctx: *mut ::aya_ebpf::bindings::__sk_buff) -> i32 {
+                // SAFETY: The `ctx` pointer provided by the kernel should be valid.
+                let ctx = unsafe { ::core::ptr::NonNull::new_unchecked(ctx) };
                 return foo(::aya_ebpf::programs::SkBuffContext::new(ctx));
 
                 fn foo(ctx: SkBuffContext) -> i32 {
@@ -176,6 +186,8 @@ mod tests {
             #[unsafe(no_mangle)]
             #[unsafe(link_section = "cgroup_skb/egress")]
             pub fn foo(ctx: *mut ::aya_ebpf::bindings::__sk_buff) -> i32 {
+                // SAFETY: The `ctx` pointer provided by the kernel should be valid.
+                let ctx = unsafe { ::core::ptr::NonNull::new_unchecked(ctx) };
                 return foo(::aya_ebpf::programs::SkBuffContext::new(ctx));
 
                 pub fn foo(ctx: SkBuffContext) -> i32 {
@@ -202,6 +214,8 @@ mod tests {
             #[unsafe(no_mangle)]
             #[unsafe(link_section = "cgroup_skb/egress")]
             pub(crate) fn foo(ctx: *mut ::aya_ebpf::bindings::__sk_buff) -> i32 {
+                // SAFETY: The `ctx` pointer provided by the kernel should be valid.
+                let ctx = unsafe { ::core::ptr::NonNull::new_unchecked(ctx) };
                 return foo(::aya_ebpf::programs::SkBuffContext::new(ctx));
 
                 pub(crate) fn foo(ctx: SkBuffContext) -> i32 {

--- a/test/integration-ebpf/src/test.rs
+++ b/test/integration-ebpf/src/test.rs
@@ -5,11 +5,12 @@
 use aya_ebpf::{
     bindings::{bpf_ret_code, xdp_action},
     macros::{
-        flow_dissector, kprobe, kretprobe, lsm, lsm_cgroup, tracepoint, uprobe, uretprobe, xdp,
+        cgroup_skb, flow_dissector, kprobe, kretprobe, lsm, lsm_cgroup, tracepoint, uprobe,
+        uretprobe, xdp,
     },
     programs::{
-        FlowDissectorContext, LsmContext, ProbeContext, RetProbeContext, TracePointContext,
-        XdpContext,
+        FlowDissectorContext, LsmContext, ProbeContext, RetProbeContext, SkBuffContext,
+        TracePointContext, XdpContext,
     },
 };
 #[cfg(not(test))]
@@ -60,4 +61,9 @@ const fn test_lsm(_ctx: LsmContext) -> i32 {
 #[lsm_cgroup(hook = "socket_bind")]
 const fn test_lsm_cgroup(_ctx: LsmContext) -> i32 {
     0 // Disallow.
+}
+
+#[cgroup_skb(egress)]
+const fn test_cgroup_skb(_ctx: SkBuffContext) -> i32 {
+    1
 }


### PR DESCRIPTION
SkBuffContext::new takes NonNull<__sk_buff>, but the cgroup_skb macro
still passed the raw kernel context directly. That made #[cgroup_skb]
programs fail to compile after the context API change.

Wrap the pointer at the generated kernel boundary, matching the other
SkBuffContext macros. Add a cgroup_skb program to the integration eBPF
compilation corpus so the real macro expansion is type-checked.

Fixes: aya-rs/book#280

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aya-rs/aya/1627)
<!-- Reviewable:end -->