### PR TITLE
fix(maps): propagate correct PinningType in map initialization from FD

### DIFF
--- a/aya/src/maps/mod.rs
+++ b/aya/src/maps/mod.rs
@@ -944,19 +944,19 @@ impl MapData {
             io_error,
         })?;
 
-        Self::from_fd_inner(fd)
+        Self::from_fd_inner(fd, PinningType::ByName)
     }
 
     /// Loads a map from a map id.
     pub fn from_id(id: u32) -> Result<Self, MapError> {
         let fd = bpf_map_get_fd_by_id(id)?;
-        Self::from_fd_inner(fd)
+        Self::from_fd_inner(fd, PinningType::None)
     }
 
-    fn from_fd_inner(fd: crate::MockableFd) -> Result<Self, MapError> {
+    fn from_fd_inner(fd: crate::MockableFd, pinning: PinningType) -> Result<Self, MapError> {
         let MapInfo(info) = MapInfo::new_from_fd(fd.as_fd())?;
         Ok(Self {
-            obj: parse_map_info(info, PinningType::None),
+            obj: parse_map_info(info, pinning),
             fd: MapFd::from_fd(fd),
         })
     }
@@ -968,7 +968,7 @@ impl MapData {
     /// For example, you received an FD over Unix Domain Socket.
     pub fn from_fd(fd: OwnedFd) -> Result<Self, MapError> {
         let fd = crate::MockableFd::from_fd(fd);
-        Self::from_fd_inner(fd)
+        Self::from_fd_inner(fd, PinningType::None)
     }
 
     /// Allows the map to be pinned to the provided path.

--- a/test/integration-test/src/tests/map_pin.rs
+++ b/test/integration-test/src/tests/map_pin.rs
@@ -58,3 +58,31 @@ fn pin_and_reopen_hashmap() {
     assert_eq!(hash_from_bpf.get(&0, 0).unwrap(), 2);
     assert_eq!(hash_from_pin.get(&0, 0).unwrap(), 2);
 }
+
+#[test_log::test]
+fn pin_type_preserved_after_from_pin() {
+    if !is_program_supported(ProgramType::SocketFilter).unwrap() {
+        return;
+    }
+
+    let mut bpf: Ebpf = Ebpf::load(crate::MAP_TEST).unwrap();
+
+    let hash_to_pin: HashMap<_, u32, u8> = HashMap::try_from(bpf.map_mut("BAR").unwrap()).unwrap();
+
+    let mut rng = rand::rng();
+    let pin_path = Path::new("/sys/fs/bpf/")
+        .join(format!("test_pin_type_preserved_{:x}", rng.random::<u64>()));
+    hash_to_pin.pin(&pin_path).unwrap();
+
+    defer! {
+        drop(std::fs::remove_file(&pin_path));
+    }
+
+    let reopened_map_data = MapData::from_pin(&pin_path).unwrap();
+    let reopened_map = Map::from_map_data(reopened_map_data).unwrap();
+
+    assert!(
+        matches!(reopened_map, Map::HashMap(_)),
+        "Expected map to be reconstructed as Map::HashMap"
+    );
+}


### PR DESCRIPTION
When initializing maps via `MapData::from_pin`, the internal routine `from_fd_inner` hardcoded `PinningType::None` when rebuilding the underlying `Map` structure through `parse_map_info`.

This erasure of the pinning context led to critical failures during program relocation (e.g., inside `program.load()`). Because the engine treated the map as an unpinned, newly managed userspace entity rather than a persistent object inherited from bpffs, the internal file descriptor state became desynchronized. This ultimately resulted in premature drops or malformed relocation inputs, causing the kernel verifier to reject the load with:
`fd X is not pointing to valid bpf_map`

Fix this by refactoring `from_fd_inner` to accept an explicit `PinningType`. This allows `from_pin` to correctly propagate `PinningType::ByName`, while preserving the default `PinningType::None` behavior for generic ID and raw FD lookups (`from_id` / `from_fd`).

### Added/updated tests?

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

Added an integration test (`pin_type_preserved_after_from_pin`) that verifies the end-to-end pinning context lifecycle. It ensures that a map serialized to `bpffs` preserves its structural identity and state upon subsequent retrieval via `MapData::from_pin` instead of degenerating into fallback or unsupported typings.

### Checklist

- [x] Rust code has been formatted with `cargo +nightly fmt`.
- [x] All clippy lints have been fixed.
      You can find failing lints with `cargo xtask clippy`.
- [x] Unit tests are passing locally with `cargo test`.
- [x] The [Integration tests] are passing locally.
           *Verified locally using `cargo xtask integration-test`. All relevant core subsystems passed successfully.* 
- [x] I have blessed any API changes with `cargo xtask public-api --bless`.

[Integration tests]: https://github.com/aya-rs/aya/blob/main/test/README.md

### (Optional) What GIF best describes this PR or how it makes you feel?

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aya-rs/aya/1631)
<!-- Reviewable:end -->
