### PR TITLE
build: pin @llvm-project to rustc's LLVM commit

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -41,6 +41,15 @@ archive_override(
     urls = ["https://github.com/hermeticbuild/linux.bzl/archive/e18628f3e177022c2ff0cf93a2e5f2d408f7d2fc.tar.gz"],
 )
 
+# Use the rust-lang/llvm-project commit referenced by nightly/2026-06-24 rustc.
+llvm_source = use_extension("@llvm//extensions:llvm_source.bzl", "llvm_source")
+llvm_source.from_archive(
+    integrity = "sha256-oiZ9KV9pqEUMrkYhWNV/VZm+95tMKUARHJOQ1HZg1P0=",
+    strip_prefix = "llvm-project-ec9ab9d68bf7a0e86b2ddf3c0e6e3c4620e02961",
+    urls = ["https://github.com/rust-lang/llvm-project/archive/ec9ab9d68bf7a0e86b2ddf3c0e6e3c4620e02961.tar.gz"],
+)
+use_repo(llvm_source, "llvm-raw", "llvm_config", "llvm_zlib", "llvm_zstd")
+
 # @rules_rs creates @rules_rust here; generated BUILD files and .bazelrc labels
 # reference @rules_rust directly.
 rules_rust = use_extension("@rules_rs//rs:rules_rust.bzl", "rules_rust")


### PR DESCRIPTION
By Codex

## Summary

- Configure `llvm_source.from_archive` so source-backed `@llvm-project` targets use the `rust-lang/llvm-project` commit referenced by the pinned `nightly/2026-06-24` rustc.
- Verify the GitHub archive with an integrity hash and import the repositories declared by `llvm_source`.
- Keep hermetic-llvm's prebuilt LLVM 22.1.7 compiler selected.

The default hermetic-llvm source archive uses the upstream LLVM release. This change aligns `@llvm-project` with rustc's LLVM 22.1.7 fork without rebuilding the compiler.

## Validation

- `buildifier -mode=check MODULE.bazel`
- `git diff --check`
- Verified the archive SHA-256 as `a2267d295f69a8450cae462158d57f5599bef79b4c2940111c9390d47660d4fd`.

The full `@llvm-project` source graph was not materialized locally because the machine did not have enough free disk space.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aya-rs/aya/1634)
<!-- Reviewable:end -->
