### PR TITLE
aya-ebpf: check map layouts are FFI-safe

### DIFF
--- a/aya-ebpf-macros/src/btf_map.rs
+++ b/aya-ebpf-macros/src/btf_map.rs
@@ -4,7 +4,7 @@ use proc_macro2::TokenStream;
 use quote::quote;
 use syn::{ItemStatic, Result};
 
-use crate::args::Args;
+use crate::{args::Args, map_layout};
 
 pub(crate) struct BtfMap {
     item: ItemStatic,
@@ -24,10 +24,14 @@ impl BtfMap {
         let section_name: Cow<'_, _> = ".maps".into();
         let name = &self.name;
         let item = &self.item;
+        let map_ty = &self.item.ty;
+        let layout_check = map_layout::btf_map(map_ty);
         quote! {
             #[unsafe(link_section = #section_name)]
             #[unsafe(export_name = #name)]
             #item
+
+            #layout_check
         }
     }
 }
@@ -48,10 +52,13 @@ mod tests {
         )
         .unwrap();
         let expanded = map.expand();
+        let layout_check = map_layout::btf_map(&parse_quote!(HashMap<&'static str, u32>));
         let expected = quote!(
             #[unsafe(link_section = ".maps")]
             #[unsafe(export_name = "foo")]
             static BAR: HashMap<&'static str, u32> = HashMap::new();
+
+            #layout_check
         );
         assert_eq!(expected.to_string(), expanded.to_string());
     }
@@ -66,10 +73,13 @@ mod tests {
         )
         .unwrap();
         let expanded = map.expand();
+        let layout_check = map_layout::btf_map(&parse_quote!(HashMap<&'static str, u32>));
         let expected = quote!(
             #[unsafe(link_section = ".maps")]
             #[unsafe(export_name = "BAR")]
             static BAR: HashMap<&'static str, u32> = HashMap::new();
+
+            #layout_check
         );
         assert_eq!(expected.to_string(), expanded.to_string());
     }

--- a/aya-ebpf-macros/src/lib.rs
+++ b/aya-ebpf-macros/src/lib.rs
@@ -16,6 +16,7 @@ mod kprobe;
 mod lsm;
 mod lsm_cgroup;
 mod map;
+mod map_layout;
 mod perf_event;
 mod raw_tracepoint;
 mod sk_lookup;
@@ -58,6 +59,52 @@ use tracepoint::TracePoint;
 use uprobe::{UProbe, UProbeKind};
 use xdp::Xdp;
 
+/// Marks a static as an eBPF BTF map definition.
+///
+/// Map keys and values must have an FFI-safe layout. Rust-native enums without
+/// a guaranteed representation, such as `Option<State>` below, are not
+/// FFI-safe even when nested in a `#[repr(C)]` type.
+///
+/// ```compile_fail
+/// use aya_ebpf::{btf_maps::HashMap, macros::btf_map};
+///
+/// #[repr(u32)]
+/// enum State {
+///     Started,
+///     Stopped,
+/// }
+///
+/// #[repr(C)]
+/// struct Value {
+///     state: Option<State>,
+/// }
+///
+/// #[btf_map]
+/// static VALUES: HashMap<u32, Value, 16> = HashMap::new();
+/// ```
+///
+/// Inner map keys and values in maps of maps are checked as well.
+///
+/// ```compile_fail
+/// use aya_ebpf::{
+///     btf_maps::{Array, ArrayOfMaps},
+///     macros::btf_map,
+/// };
+///
+/// #[repr(u32)]
+/// enum State {
+///     Started,
+///     Stopped,
+/// }
+///
+/// #[repr(C)]
+/// struct Value {
+///     state: Option<State>,
+/// }
+///
+/// #[btf_map]
+/// static VALUES: ArrayOfMaps<Array<Value, 16>, 4> = ArrayOfMaps::new();
+/// ```
 #[proc_macro_attribute]
 pub fn btf_map(attrs: TokenStream, item: TokenStream) -> TokenStream {
     match BtfMap::parse(attrs.into(), item.into()) {
@@ -67,6 +114,29 @@ pub fn btf_map(attrs: TokenStream, item: TokenStream) -> TokenStream {
     .into()
 }
 
+/// Marks a static as an eBPF map definition.
+///
+/// Map keys and values must have an FFI-safe layout. Rust-native enums without
+/// a guaranteed representation, such as `Option<State>` below, are not
+/// FFI-safe even when nested in a `#[repr(C)]` type.
+///
+/// ```compile_fail
+/// use aya_ebpf::{macros::map, maps::HashMap};
+///
+/// #[repr(u32)]
+/// enum State {
+///     Started,
+///     Stopped,
+/// }
+///
+/// #[repr(C)]
+/// struct Value {
+///     state: Option<State>,
+/// }
+///
+/// #[map]
+/// static VALUES: HashMap<Value, u32> = HashMap::with_max_entries(16, 0);
+/// ```
 #[proc_macro_attribute]
 pub fn map(attrs: TokenStream, item: TokenStream) -> TokenStream {
     match Map::parse(attrs.into(), item.into()) {

--- a/aya-ebpf-macros/src/map.rs
+++ b/aya-ebpf-macros/src/map.rs
@@ -4,7 +4,7 @@ use proc_macro2::TokenStream;
 use quote::quote;
 use syn::{ItemStatic, Result};
 
-use crate::args::Args;
+use crate::{args::Args, map_layout};
 pub(crate) struct Map {
     item: ItemStatic,
     name: String,
@@ -23,10 +23,14 @@ impl Map {
         let section_name: Cow<'_, _> = "maps".into();
         let name = &self.name;
         let item = &self.item;
+        let map_ty = &self.item.ty;
+        let layout_check = map_layout::map(map_ty);
         quote! {
             #[unsafe(link_section = #section_name)]
             #[unsafe(export_name = #name)]
             #item
+
+            #layout_check
         }
     }
 }
@@ -47,10 +51,13 @@ mod tests {
         )
         .unwrap();
         let expanded = map.expand();
+        let layout_check = map_layout::map(&parse_quote!(HashMap<&'static str, u32>));
         let expected = quote!(
             #[unsafe(link_section = "maps")]
             #[unsafe(export_name = "foo")]
             static BAR: HashMap<&'static str, u32> = HashMap::new();
+
+            #layout_check
         );
         assert_eq!(expected.to_string(), expanded.to_string());
     }
@@ -65,10 +72,13 @@ mod tests {
         )
         .unwrap();
         let expanded = map.expand();
+        let layout_check = map_layout::map(&parse_quote!(HashMap<&'static str, u32>));
         let expected = quote!(
             #[unsafe(link_section = "maps")]
             #[unsafe(export_name = "BAR")]
             static BAR: HashMap<&'static str, u32> = HashMap::new();
+
+            #layout_check
         );
         assert_eq!(expected.to_string(), expanded.to_string());
     }

--- a/aya-ebpf-macros/src/map_layout.rs
+++ b/aya-ebpf-macros/src/map_layout.rs
@@ -1,0 +1,154 @@
+use proc_macro2::TokenStream;
+use quote::{format_ident, quote_spanned};
+use syn::{Type, spanned::Spanned as _};
+
+pub(crate) fn map(map_ty: &Type) -> TokenStream {
+    let layout_trait = quote_spanned!(map_ty.span() => ::aya_ebpf::maps::__MapLayout);
+    ffi_safety_checks(map_ty, layout_trait, "__aya_map", false)
+}
+
+pub(crate) fn btf_map(map_ty: &Type) -> TokenStream {
+    let layout_trait = quote_spanned!(map_ty.span() => ::aya_ebpf::btf_maps::__MapLayout);
+    ffi_safety_checks(map_ty, layout_trait, "__aya_btf_map", true)
+}
+
+fn ffi_safety_checks(
+    map_ty: &Type,
+    layout_trait: TokenStream,
+    prefix: &str,
+    check_inner_map: bool,
+) -> TokenStream {
+    let key_check = format_ident!("{prefix}_key_must_be_ffi_safe");
+    let value_check = format_ident!("{prefix}_value_must_be_ffi_safe");
+    // The kernel rejects map-in-map nesting deeper than one level.
+    // https://github.com/torvalds/linux/blob/v6.17/kernel/bpf/map_in_map.c#L20-L22
+    let inner_checks = check_inner_map.then(|| {
+        let key_check = format_ident!("{prefix}_inner_key_must_be_ffi_safe");
+        let value_check = format_ident!("{prefix}_inner_value_must_be_ffi_safe");
+        quote_spanned! {map_ty.span() =>
+            #[deny(improper_ctypes_definitions)]
+            #[allow(dead_code)]
+            extern "C" fn #key_check(
+                _: ::aya_ebpf::__LayoutCheck<
+                    <<#map_ty as #layout_trait>::Inner as #layout_trait>::Key,
+                >,
+            ) {
+            }
+
+            #[deny(improper_ctypes_definitions)]
+            #[allow(dead_code)]
+            extern "C" fn #value_check(
+                _: ::aya_ebpf::__LayoutCheck<
+                    <<#map_ty as #layout_trait>::Inner as #layout_trait>::Value,
+                >,
+            ) {
+            }
+        }
+    });
+
+    // quote_spanned! rather than quote!: rustc suppresses
+    // `improper_ctypes_definitions` (like most lints) in code carrying an
+    // external macro expansion context, which call-site spans do. Spanning the
+    // generated tokens onto the user's map type keeps the lint active and
+    // points its diagnostics at the map definition.
+    //
+    // The parameters are wrapped in `__LayoutCheck` (a `repr(C)` struct)
+    // because the lint's predicate for bare parameters is stricter than what a
+    // map layout requires: arrays decay to pointers in C calls and `()` is
+    // rejected as an argument, yet both are valid map key/value layouts (e.g.
+    // `HashMap<[u8; 16], _>` keys, ring buffer `()` keys). As a `repr(C)`
+    // field the same types are checked for layout stability only.
+    quote_spanned! {map_ty.span() =>
+        const _: () = {
+            #[deny(improper_ctypes_definitions)]
+            #[allow(dead_code)]
+            extern "C" fn #key_check(
+                _: ::aya_ebpf::__LayoutCheck<<#map_ty as #layout_trait>::Key>,
+            ) {
+            }
+
+            #[deny(improper_ctypes_definitions)]
+            #[allow(dead_code)]
+            extern "C" fn #value_check(
+                _: ::aya_ebpf::__LayoutCheck<<#map_ty as #layout_trait>::Value>,
+            ) {
+            }
+
+            #inner_checks
+        };
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use quote::quote;
+    use syn::parse_quote;
+
+    use super::*;
+
+    #[test]
+    #[rustfmt::skip]
+    fn test_map_layout_checks() {
+        let expected = quote!(
+            const _: () = {
+                #[deny(improper_ctypes_definitions)]
+                #[allow(dead_code)]
+                extern "C" fn __aya_map_key_must_be_ffi_safe(
+                    _: ::aya_ebpf::__LayoutCheck<<HashMap<&'static str, u32> as ::aya_ebpf::maps::__MapLayout>::Key>,
+                ) {
+                }
+
+                #[deny(improper_ctypes_definitions)]
+                #[allow(dead_code)]
+                extern "C" fn __aya_map_value_must_be_ffi_safe(
+                    _: ::aya_ebpf::__LayoutCheck<<HashMap<&'static str, u32> as ::aya_ebpf::maps::__MapLayout>::Value>,
+                ) {
+                }
+            };
+        );
+        let expanded = map(&parse_quote!(HashMap<&'static str, u32>));
+        assert_eq!(expected.to_string(), expanded.to_string());
+    }
+
+    #[test]
+    #[rustfmt::skip]
+    fn test_btf_map_layout_checks() {
+        let expected = quote!(
+            const _: () = {
+                #[deny(improper_ctypes_definitions)]
+                #[allow(dead_code)]
+                extern "C" fn __aya_btf_map_key_must_be_ffi_safe(
+                    _: ::aya_ebpf::__LayoutCheck<<Array<u32, 4> as ::aya_ebpf::btf_maps::__MapLayout>::Key>,
+                ) {
+                }
+
+                #[deny(improper_ctypes_definitions)]
+                #[allow(dead_code)]
+                extern "C" fn __aya_btf_map_value_must_be_ffi_safe(
+                    _: ::aya_ebpf::__LayoutCheck<<Array<u32, 4> as ::aya_ebpf::btf_maps::__MapLayout>::Value>,
+                ) {
+                }
+
+                #[deny(improper_ctypes_definitions)]
+                #[allow(dead_code)]
+                extern "C" fn __aya_btf_map_inner_key_must_be_ffi_safe(
+                    _: ::aya_ebpf::__LayoutCheck<
+                        <<Array<u32, 4> as ::aya_ebpf::btf_maps::__MapLayout>::Inner as ::aya_ebpf::btf_maps::__MapLayout>::Key,
+                    >,
+                ) {
+                }
+
+                #[deny(improper_ctypes_definitions)]
+                #[allow(dead_code)]
+                extern "C" fn __aya_btf_map_inner_value_must_be_ffi_safe(
+                    _: ::aya_ebpf::__LayoutCheck<
+                        <<Array<u32, 4> as ::aya_ebpf::btf_maps::__MapLayout>::Inner as ::aya_ebpf::btf_maps::__MapLayout>::Value,
+                    >,
+                ) {
+                }
+            };
+        );
+        let expanded = btf_map(&parse_quote!(Array<u32, 4>));
+        assert_eq!(expected.to_string(), expanded.to_string());
+    }
+}

--- a/ebpf/aya-ebpf/src/btf_maps/mod.rs
+++ b/ebpf/aya-ebpf/src/btf_maps/mod.rs
@@ -65,6 +65,8 @@ mod private {
         type Key;
         /// The value type of this map.
         type Value;
+        /// The inner map type, or `()` if this is not a map of maps.
+        type Inner;
     }
 
     /// Sealed marker for inner-map types whose `bpf_map_lookup_elem` returns
@@ -89,6 +91,29 @@ mod private {
 pub trait MapDef: private::MapDef {}
 
 impl<T: private::MapDef> MapDef for T {}
+
+#[doc(hidden)]
+pub trait __MapLayout {
+    type Key;
+    type Value;
+    type Inner: __MapLayout;
+}
+
+impl<T> __MapLayout for T
+where
+    T: private::MapDef,
+    T::Inner: __MapLayout,
+{
+    type Key = T::Key;
+    type Value = T::Value;
+    type Inner = T::Inner;
+}
+
+impl __MapLayout for () {
+    type Key = ();
+    type Value = ();
+    type Inner = ();
+}
 
 /// Marks a BTF map type whose fused inner lookup via [`ArrayOfMaps::get_value`]
 /// is safe without an additional `unsafe` contract from the caller.
@@ -179,8 +204,8 @@ pub(crate) fn lookup_inner_ptr_mut<M: private::MapDef>(
 /// map type `V` is encoded in BTF so that loaders can resolve the inner map
 /// template.
 macro_rules! btf_map_def {
-    // Map-of-maps (with inner_map) - rewrites into the regular arm with a
-    // `values` extra field whose initializer is `[]` (a zero-length array).
+    // Map-of-maps (with inner_map) - rewrites into the implementation arm with
+    // a `values` extra field whose initializer is `[]` (a zero-length array).
     (
         $(#[$attr:meta])*
         $vis:vis struct $name:ident<
@@ -197,6 +222,7 @@ macro_rules! btf_map_def {
         $(,)?
     ) => {
         $crate::btf_maps::btf_map_def!(
+            @impl
             $(#[$attr])*
             $vis struct $name<
                 $($ty_gen $(= $ty_default)?),+
@@ -207,7 +233,8 @@ macro_rules! btf_map_def {
             map_flags: $map_flags,
             key_type: $key_ty,
             value_type: $value_ty,
-            values: [*const $inner_ty; 0] = []
+            inner_type: $inner_ty,
+            values: [*const $inner_ty; 0] = [],
         );
     };
 
@@ -226,6 +253,39 @@ macro_rules! btf_map_def {
         value_type: $value_ty:ty
         $(, $extra_field:ident : $extra_ty:ty = $extra_init:expr)*
         $(,)?
+    ) => {
+        $crate::btf_maps::btf_map_def!(
+            @impl
+            $(#[$attr])*
+            $vis struct $name<
+                $($ty_gen $(= $ty_default)?),*
+                $(; $(const $const_gen : $const_ty $(= $const_default)?),+)?
+            >,
+            map_type: $map_type,
+            max_entries: $max_entries,
+            map_flags: $map_flags,
+            key_type: $key_ty,
+            value_type: $value_ty,
+            inner_type: (),
+            $($extra_field: $extra_ty = $extra_init,)*
+        );
+    };
+
+    (
+        @impl
+        $(#[$attr:meta])*
+        $vis:vis struct $name:ident<
+            $($ty_gen:ident $(= $ty_default:ty)?),*
+            $(; $(const $const_gen:ident : $const_ty:ty $(= $const_default:tt)?),+)?
+            $(,)?
+        >,
+        map_type: $map_type:ident,
+        max_entries: $max_entries:expr,
+        map_flags: $map_flags:expr,
+        key_type: $key_ty:ty,
+        value_type: $value_ty:ty,
+        inner_type: $inner_ty:ty,
+        $($extra_field:ident : $extra_ty:ty = $extra_init:expr,)*
     ) => {
         $(#[$attr])*
         // repr(C) is required to ensure fields maintain their declared order in BTF.
@@ -308,6 +368,7 @@ macro_rules! btf_map_def {
         > {
             type Key = $key_ty;
             type Value = $value_ty;
+            type Inner = $inner_ty;
         }
     };
 }

--- a/ebpf/aya-ebpf/src/lib.rs
+++ b/ebpf/aya-ebpf/src/lib.rs
@@ -254,3 +254,13 @@ where
         unsafe { ptr::read_volatile(self.value.as_ptr()) }
     }
 }
+
+/// Wrapper used by the layout checks emitted by `#[map]` and `#[btf_map]`.
+///
+/// `improper_ctypes_definitions` rejects bare array and `()` function
+/// parameters even though both are valid map key/value layouts; as fields of a
+/// `repr(C)` struct the same types are checked for layout stability only. The
+/// trailing `u8` keeps the struct from becoming zero-sized when `T` is `()`.
+#[doc(hidden)]
+#[repr(C)]
+pub struct __LayoutCheck<T>(T, u8);

--- a/ebpf/aya-ebpf/src/maps/cgroup_array.rs
+++ b/ebpf/aya-ebpf/src/maps/cgroup_array.rs
@@ -37,6 +37,11 @@ pub struct CgroupArray {
     def: MapDef,
 }
 
+impl super::__MapLayout for CgroupArray {
+    type Key = u32;
+    type Value = u32;
+}
+
 impl CgroupArray {
     map_constructors!(u32, u32, BPF_MAP_TYPE_CGROUP_ARRAY);
 

--- a/ebpf/aya-ebpf/src/maps/cgroup_storage.rs
+++ b/ebpf/aya-ebpf/src/maps/cgroup_storage.rs
@@ -21,6 +21,11 @@ macro_rules! define_cgroup_storage {
             _v: PhantomData<V>,
         }
 
+        impl<V> super::__MapLayout for $name<V> {
+            type Key = bpf_cgroup_storage_key;
+            type Value = V;
+        }
+
         impl<V> $name<V> {
             /// Creates the map definition. Cgroup storage maps have no capacity
             /// of their own; the kernel allocates one entry per cgroup the

--- a/ebpf/aya-ebpf/src/maps/mod.rs
+++ b/ebpf/aya-ebpf/src/maps/mod.rs
@@ -136,3 +136,14 @@ mod private {
 pub trait Map: private::Map {}
 
 impl<T: private::Map> Map for T {}
+
+#[doc(hidden)]
+pub trait __MapLayout {
+    type Key;
+    type Value;
+}
+
+impl<T: private::Map> __MapLayout for T {
+    type Key = T::Key;
+    type Value = T::Value;
+}

--- a/ebpf/aya-ebpf/src/maps/perf/perf_event_array.rs
+++ b/ebpf/aya-ebpf/src/maps/perf/perf_event_array.rs
@@ -13,6 +13,11 @@ pub struct PerfEventArray<T> {
     _t: PhantomData<T>,
 }
 
+impl<T> super::super::__MapLayout for PerfEventArray<T> {
+    type Key = u32;
+    type Value = u32;
+}
+
 impl<T> PerfEventArray<T> {
     pub const fn new(flags: u32) -> Self {
         Self::new_with_pinning(flags, PinningType::None)

--- a/ebpf/aya-ebpf/src/maps/perf/perf_event_byte_array.rs
+++ b/ebpf/aya-ebpf/src/maps/perf/perf_event_byte_array.rs
@@ -10,6 +10,11 @@ pub struct PerfEventByteArray {
     def: MapDef,
 }
 
+impl super::super::__MapLayout for PerfEventByteArray {
+    type Key = u32;
+    type Value = u32;
+}
+
 impl PerfEventByteArray {
     pub const fn new(flags: u32) -> Self {
         Self::new_with_pinning(flags, PinningType::None)

--- a/ebpf/aya-ebpf/src/maps/program_array.rs
+++ b/ebpf/aya-ebpf/src/maps/program_array.rs
@@ -29,6 +29,11 @@ pub struct ProgramArray {
     def: MapDef,
 }
 
+impl super::__MapLayout for ProgramArray {
+    type Key = u32;
+    type Value = u32;
+}
+
 impl ProgramArray {
     map_constructors!(u32, u32, BPF_MAP_TYPE_PROG_ARRAY);
 

--- a/ebpf/aya-ebpf/src/maps/reuseport_sock_array.rs
+++ b/ebpf/aya-ebpf/src/maps/reuseport_sock_array.rs
@@ -21,6 +21,11 @@ pub struct ReusePortSockArray {
     def: MapDef,
 }
 
+impl super::__MapLayout for ReusePortSockArray {
+    type Key = u32;
+    type Value = u32;
+}
+
 impl ReusePortSockArray {
     map_constructors!(u32, u32, BPF_MAP_TYPE_REUSEPORT_SOCKARRAY);
 

--- a/test/integration-common/src/lib.rs
+++ b/test/integration-common/src/lib.rs
@@ -67,11 +67,16 @@ pub mod fexit {
 pub mod bpf_probe_read {
     pub const RESULT_BUF_LEN: usize = 1024;
 
+    /// Sentinel stored in [`TestResult::len`] when the probe did not run to
+    /// completion. Negative values are helper errors; non-negative values are
+    /// the length read.
+    pub const LEN_UNSET: i64 = i64::MIN;
+
     #[derive(Copy, Clone)]
     #[repr(C)]
     pub struct TestResult {
         pub buf: [u8; RESULT_BUF_LEN],
-        pub len: Option<Result<usize, i32>>,
+        pub len: i64,
     }
 
     #[cfg(feature = "user")]

--- a/test/integration-ebpf/src/bpf_probe_read.rs
+++ b/test/integration-ebpf/src/bpf_probe_read.rs
@@ -8,7 +8,7 @@ use aya_ebpf::{
     maps::Array,
     programs::ProbeContext,
 };
-use integration_common::bpf_probe_read::{RESULT_BUF_LEN, TestResult};
+use integration_common::bpf_probe_read::{LEN_UNSET, RESULT_BUF_LEN, TestResult};
 #[cfg(not(test))]
 extern crate ebpf_panic;
 
@@ -30,7 +30,7 @@ fn read_str_bytes(
     let Some(TestResult { buf, len }) = dst else {
         return;
     };
-    *len = None;
+    *len = LEN_UNSET;
 
     // len comes from ctx.arg(1) so it's dynamic and the verifier doesn't see any bounds. We slice
     // here to ensure that the verifier can see the upper bound, or you get:
@@ -45,7 +45,10 @@ fn read_str_bytes(
         return;
     };
 
-    *len = Some(unsafe { fun(iptr, buf) }.map(<[_]>::len));
+    *len = match unsafe { fun(iptr, buf) } {
+        Ok(s) => s.len() as i64,
+        Err(e) => e.into(),
+    };
 }
 
 #[map]

--- a/test/integration-ebpf/src/memmove_test.rs
+++ b/test/integration-ebpf/src/memmove_test.rs
@@ -30,6 +30,7 @@ fn ptr_at<T>(ctx: &XdpContext, offset: usize) -> Result<*const T, ()> {
     Ok((start + offset) as *const T)
 }
 
+#[repr(C)]
 struct Value {
     pub orig_ip: [u8; 16],
 }

--- a/test/integration-test/src/tests/bpf_probe_read.rs
+++ b/test/integration-test/src/tests/bpf_probe_read.rs
@@ -90,8 +90,8 @@ fn set_kernel_buffer_element(bpf: &mut Ebpf, bytes: &[u8]) {
 fn result_bytes(bpf: &Ebpf) -> Vec<u8> {
     let m = Array::<_, TestResult>::try_from(bpf.map("RESULT").unwrap()).unwrap();
     let TestResult { buf, len } = m.get(&0, 0).unwrap();
-    let len = len.unwrap();
-    let len = len.unwrap();
+    // Negative values are helper errors, i64::MIN means the probe bailed out.
+    let len = usize::try_from(len).unwrap();
     // assert that the buffer is always null terminated
     assert_eq!(buf[len], 0);
     buf[..len].to_vec()


### PR DESCRIPTION
Map bytes are shared between BPF and userspace targets, but Rust-native layouts are not necessarily stable across them. For example, `Option<MyEnum>::None` may have different representations, and `#[repr(C)]` on an outer struct does not stabilize nested fields.

This makes `#[map]` and `#[btf_map]` emit `improper_ctypes_definitions` checks for their key and value types. BTF maps of maps also validate the inner map's key and value.

Doc-hidden traits expose the relevant layout metadata to the proc macros. A `#[repr(C)]` wrapper avoids false positives for valid array and `()` layouts.

This checks FFI safety, not universal cross-target ABI equality. Existing map-size validation continues to catch target-size mismatches.

 ### Testing
  - Macro unit tests verify the generated checks.
  - Compile-fail doctests verify that invalid legacy, BTF, and inner-map layouts are rejected.
  - The integration eBPF build exercises valid existing map layouts.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aya-rs/aya/1636)
<!-- Reviewable:end -->
