### PR TITLE
fix(aya): avoid loading kernel BTF twice

### DIFF
--- a/aya-obj/src/extern_types.rs
+++ b/aya-obj/src/extern_types.rs
@@ -6,6 +6,13 @@ use crate::{
 };
 
 impl Object {
+    /// Returns true if this object contains typed kernel symbols.
+    pub fn has_typed_ksyms(&self) -> bool {
+        self.btf
+            .as_ref()
+            .is_some_and(|btf| btf.externs.has_typed_ksyms())
+    }
+
     /// Resolves extern kernel symbols through kernel `BTF` and `kallsyms`.
     pub fn resolve_externs(&mut self, kernel_btf: Option<&Btf>) -> Result<(), KsymsError> {
         if self.btf.is_none() {
@@ -24,12 +31,10 @@ impl Object {
     }
 
     /// Returns whether the object contains strong typed ksyms that require kernel `BTF`.
-    pub(crate) fn has_strong_typed_ksyms(&self) -> bool {
-        self.btf.as_ref().is_some_and(|btf| {
-            btf.externs.iter().any(|(_, ext)| {
-                ext.extern_type == ExternType::Ksym && ext.type_id.is_some() && !ext.is_weak
-            })
-        })
+    pub fn has_strong_typed_ksyms(&self) -> bool {
+        self.btf
+            .as_ref()
+            .is_some_and(|btf| btf.externs.has_strong_typed_ksyms())
     }
 
     /// Resolves typed externs through kernel `BTF`.
@@ -421,6 +426,12 @@ pub(crate) struct ExternCollection {
 
     /// Index ID of `.ksyms` datasec entry in BTF types.
     pub(crate) datasec_id: Option<u32>,
+
+    /// Whether the collection contains any typed ksyms.
+    has_typed_ksyms: bool,
+
+    /// Whether the collection contains any strong typed ksyms.
+    has_strong_typed_ksyms: bool,
 }
 
 impl ExternCollection {
@@ -429,7 +440,21 @@ impl ExternCollection {
     }
 
     pub(crate) fn insert(&mut self, name: String, desc: ExternDesc) {
+        if desc.extern_type == ExternType::Ksym && desc.type_id.is_some() {
+            self.has_typed_ksyms = true;
+            if !desc.is_weak {
+                self.has_strong_typed_ksyms = true;
+            }
+        }
         self.externs.insert(name, desc);
+    }
+
+    pub(crate) const fn has_typed_ksyms(&self) -> bool {
+        self.has_typed_ksyms
+    }
+
+    pub(crate) const fn has_strong_typed_ksyms(&self) -> bool {
+        self.has_strong_typed_ksyms
     }
 
     pub(crate) fn get_mut(&mut self, name: &str) -> Option<&mut ExternDesc> {
@@ -547,6 +572,9 @@ mod tests {
 
         let mut object = object_with_externs(externs);
 
+        assert!(object.has_typed_ksyms());
+        assert!(object.has_strong_typed_ksyms());
+
         let err = object.resolve_externs(None).unwrap_err();
         assert!(matches!(err, KsymsError::TypedKsymRequiresKernelBtf));
     }
@@ -561,11 +589,25 @@ mod tests {
 
         let mut object = object_with_externs(externs);
 
+        assert!(object.has_typed_ksyms());
+        assert!(!object.has_strong_typed_ksyms());
+
         object.resolve_externs(None).unwrap();
 
         let ext = &object.btf.as_ref().unwrap().externs.externs["typed"];
         assert!(!ext.is_resolved);
         assert_eq!(ext.ksym_addr, Some(0));
+    }
+
+    #[test]
+    fn has_typed_ksyms_ignores_typeless_ksyms() {
+        let mut externs = ExternCollection::new();
+        let typeless = ExternDesc::new("typeless".into(), ExternType::Ksym, 1, false);
+        externs.insert(typeless.name.clone(), typeless);
+
+        let object = object_with_externs(externs);
+
+        assert!(!object.has_typed_ksyms());
     }
 
     #[test]

--- a/aya/src/bpf.rs
+++ b/aya/src/bpf.rs
@@ -102,12 +102,9 @@ pub fn features() -> &'static Features {
 /// # Examples
 ///
 /// ```no_run
-/// use aya::{EbpfLoader, Btf};
-/// use std::fs;
+/// use aya::EbpfLoader;
 ///
 /// let bpf = EbpfLoader::new()
-///     // load the BTF data from /sys/kernel/btf/vmlinux
-///     .btf(Btf::from_sys_fs().ok().as_ref())
 ///     // load pinned maps from /sys/fs/bpf/my-program
 ///     .default_map_pin_directory("/sys/fs/bpf/my-program")
 ///     // finally load the code
@@ -160,7 +157,7 @@ impl<'a> EbpfLoader<'a> {
     /// Creates a new loader instance.
     pub fn new() -> Self {
         Self {
-            btf: Btf::from_sys_fs().ok().map(Cow::Owned),
+            btf: None,
             default_map_pin_directory: None,
             globals: HashMap::new(),
             max_entries: HashMap::new(),
@@ -173,9 +170,10 @@ impl<'a> EbpfLoader<'a> {
 
     /// Sets the target [BTF](Btf) info.
     ///
-    /// The loader defaults to loading `BTF` info using [`Btf::from_sys_fs`].
-    /// Use this method if you want to load `BTF` from a custom location or
-    /// pass `None` to disable `BTF` relocations entirely.
+    /// By default, the loader reads target `BTF` using [`Btf::from_sys_fs`] when
+    /// the object contains CO-RE relocations or typed kernel symbols. Use this
+    /// method to load `BTF` from a custom location.
+    ///
     /// # Example
     ///
     /// ```no_run
@@ -183,13 +181,16 @@ impl<'a> EbpfLoader<'a> {
     ///
     /// let bpf = EbpfLoader::new()
     ///     // load the BTF data from a custom location
-    ///     .btf(Btf::parse_file("/custom_btf_file", Endianness::default()).ok().as_ref())
+    ///     .btf(&Btf::parse_file(
+    ///         "/custom_btf_file",
+    ///         Endianness::default(),
+    ///     )?)
     ///     .load_file("file.o")?;
     ///
     /// # Ok::<(), aya::EbpfError>(())
     /// ```
-    pub fn btf(&mut self, btf: Option<&'a Btf>) -> &mut Self {
-        self.btf = btf.map(Cow::Borrowed);
+    pub fn btf(&mut self, btf: &'a Btf) -> &mut Self {
+        self.btf = Some(Cow::Borrowed(btf));
         self
     }
 
@@ -492,11 +493,29 @@ impl<'a> EbpfLoader<'a> {
             None
         };
 
-        if let Some(btf) = &btf {
+        if btf.is_none() && (obj.has_btf_relocations() || obj.has_typed_ksyms()) {
+            match Btf::from_sys_fs() {
+                Ok(kernel_btf) => *btf = Some(Cow::Owned(kernel_btf)),
+                Err(err) => {
+                    // CO-RE relocations and strong typed ksyms cannot be resolved without kernel
+                    // BTF, so preserve the original loading error.
+                    if obj.has_btf_relocations() || obj.has_strong_typed_ksyms() {
+                        return Err(err.into());
+                    }
+
+                    // Unresolved weak typed ksyms are allowed and handled during extern
+                    // relocation.
+                    warn!("kernel BTF is unavailable; weak typed ksyms will be unresolved: {err}")
+                }
+            }
+        }
+
+        let btf = btf.as_deref();
+        if let Some(btf) = btf {
             obj.relocate_btf(btf)?;
         }
 
-        obj.resolve_externs(btf.as_deref())?;
+        obj.resolve_externs(btf)?;
 
         const fn is_map_of_maps(map_type: bpf_map_type) -> bool {
             matches!(
@@ -993,9 +1012,7 @@ impl Ebpf {
     /// # Ok::<(), aya::EbpfError>(())
     /// ```
     pub fn load_file<P: AsRef<Path>>(path: P) -> Result<Self, EbpfError> {
-        EbpfLoader::new()
-            .btf(Btf::from_sys_fs().ok().as_ref())
-            .load_file(path)
+        EbpfLoader::new().load_file(path)
     }
 
     /// Loads eBPF bytecode from a buffer.
@@ -1022,9 +1039,7 @@ impl Ebpf {
     /// # Ok::<(), aya::EbpfError>(())
     /// ```
     pub fn load(data: &[u8]) -> Result<Self, EbpfError> {
-        EbpfLoader::new()
-            .btf(Btf::from_sys_fs().ok().as_ref())
-            .load(data)
+        EbpfLoader::new().load(data)
     }
 
     /// Returns a reference to the map with the given name.

--- a/aya/src/sys/bpf.rs
+++ b/aya/src/sys/bpf.rs
@@ -24,7 +24,7 @@ use aya_obj::{
     maps::{LegacyMap, bpf_map_def},
 };
 use libc::{
-    EBADF, ENOENT, ENOSPC, EPERM, RLIM_INFINITY, RLIMIT_MEMLOCK, getrlimit, rlim_t, rlimit,
+    EBADF, ENOENT, ENOMEM, ENOSPC, EPERM, RLIM_INFINITY, RLIMIT_MEMLOCK, getrlimit, rlim_t, rlimit,
     setrlimit,
 };
 use log::warn;
@@ -490,8 +490,14 @@ pub(crate) fn bpf_link_create(
         }
     }
 
-    // BPF_LINK_CREATE returns a new file descriptor.
-    unsafe { fd_sys_bpf(bpf_cmd::BPF_LINK_CREATE, &mut attr) }
+    // Cgroup storage allocation can report memlock failures as ENOMEM:
+    // https://github.com/torvalds/linux/blob/b15dc417/kernel/bpf/cgroup.c#L475-L477
+    //
+    // SAFETY: BPF_LINK_CREATE returns a new file descriptor.
+    with_raised_rlimit_retry(
+        || unsafe { fd_sys_bpf(bpf_cmd::BPF_LINK_CREATE, &mut attr) },
+        &[EPERM, ENOMEM],
+    )
 }
 
 // since kernel 5.7
@@ -528,7 +534,13 @@ pub(crate) fn bpf_prog_attach(
     attr.__bindgen_anon_5.attach_type = attach_type.into() as u32;
     attr.__bindgen_anon_5.attach_flags = flags;
 
-    unit_sys_bpf(bpf_cmd::BPF_PROG_ATTACH, &mut attr).map_err(|io_error| SyscallError {
+    // Cgroup storage allocation can report memlock failures as ENOMEM:
+    // https://github.com/torvalds/linux/blob/b15dc417/kernel/bpf/cgroup.c#L475-L477
+    with_raised_rlimit_retry(
+        || unit_sys_bpf(bpf_cmd::BPF_PROG_ATTACH, &mut attr),
+        &[EPERM, ENOMEM],
+    )
+    .map_err(|io_error| SyscallError {
         call: "bpf_prog_attach",
         io_error,
     })
@@ -858,13 +870,23 @@ pub(super) unsafe fn fd_sys_bpf(
 }
 
 static RAISE_MEMLIMIT: std::sync::Once = std::sync::Once::new();
-fn with_raised_rlimit_retry<T, F: FnMut() -> io::Result<T>>(mut op: F) -> io::Result<T> {
+
+fn with_raised_rlimit_retry<T, F: FnMut() -> io::Result<T>>(
+    mut op: F,
+    memlock_errnos: &[i32],
+) -> io::Result<T> {
     let mut result = op();
-    if matches!(result.as_ref(), Err(err) if err.raw_os_error() == Some(EPERM)) {
+    // Linux 5.11 stopped accounting BPF allocations against RLIMIT_MEMLOCK.
+    if !KernelVersion::at_least(5, 11, 0)
+        && matches!(
+            result.as_ref(),
+            Err(err)
+                if err
+                    .raw_os_error()
+                    .is_some_and(|errno| memlock_errnos.contains(&errno))
+        )
+    {
         RAISE_MEMLIMIT.call_once(|| {
-            if KernelVersion::at_least(5, 11, 0) {
-                return;
-            }
             let mut limit = MaybeUninit::<rlimit>::uninit();
             let ret = unsafe { getrlimit(RLIMIT_MEMLOCK, limit.as_mut_ptr()) };
             if ret != 0 {
@@ -913,7 +935,10 @@ fn with_raised_rlimit_retry<T, F: FnMut() -> io::Result<T>>(mut op: F) -> io::Re
 
 pub(super) fn bpf_map_create(attr: &mut bpf_attr) -> io::Result<crate::MockableFd> {
     // SAFETY: BPF_MAP_CREATE returns a new file descriptor.
-    with_raised_rlimit_retry(|| unsafe { fd_sys_bpf(bpf_cmd::BPF_MAP_CREATE, attr) })
+    with_raised_rlimit_retry(
+        || unsafe { fd_sys_bpf(bpf_cmd::BPF_MAP_CREATE, attr) },
+        &[EPERM],
+    )
 }
 
 pub(crate) fn bpf_btf_get_fd_by_id(id: u32) -> Result<crate::MockableFd, SyscallError> {
@@ -1318,7 +1343,10 @@ pub(crate) fn is_btf_type_tag_supported() -> bool {
 
 pub(super) fn bpf_prog_load(attr: &mut bpf_attr) -> io::Result<crate::MockableFd> {
     // SAFETY: BPF_PROG_LOAD returns a new file descriptor.
-    with_raised_rlimit_retry(|| unsafe { fd_sys_bpf(bpf_cmd::BPF_PROG_LOAD, attr) })
+    with_raised_rlimit_retry(
+        || unsafe { fd_sys_bpf(bpf_cmd::BPF_PROG_LOAD, attr) },
+        &[EPERM],
+    )
 }
 
 fn sys_bpf(cmd: bpf_cmd, attr: &mut bpf_attr) -> io::Result<i64> {

--- a/test/integration-test/src/tests/btf_relocations.rs
+++ b/test/integration-test/src/tests/btf_relocations.rs
@@ -6,91 +6,55 @@ use aya::{
 use aya_obj::btf::Btf;
 use rstest::rstest;
 
-#[derive(Debug)]
-enum Requirements {}
-
 #[rstest]
-#[case(crate::ENUM_SIGNED_32_RELOC_BPF, None, None,-0x7AAAAAAAi32 as u64)]
-#[case(crate::ENUM_SIGNED_32_RELOC_BPF, Some(crate::ENUM_SIGNED_32_RELOC_BTF),  None, -0x7BBBBBBBi32 as u64)]
-#[case(crate::ENUM_SIGNED_32_CHECKED_VARIANTS_RELOC_BPF, None, None,-0x7AAAAAAAi32 as u64)]
-#[case(crate::ENUM_SIGNED_32_CHECKED_VARIANTS_RELOC_BPF, Some(crate::ENUM_SIGNED_32_CHECKED_VARIANTS_RELOC_BTF),  None, -0x7BBBBBBBi32 as u64)]
-#[case(crate::ENUM_SIGNED_64_RELOC_BPF, None, None,-0xAAAAAAABBBBBBBBi64 as u64)]
-#[case(crate::ENUM_SIGNED_64_RELOC_BPF, Some(crate::ENUM_SIGNED_64_RELOC_BTF),  None, -0xCCCCCCCDDDDDDDDi64 as u64)]
-#[case(crate::ENUM_SIGNED_64_CHECKED_VARIANTS_RELOC_BPF, None, None,-0xAAAAAAABBBBBBBi64 as u64)]
-#[case(crate::ENUM_SIGNED_64_CHECKED_VARIANTS_RELOC_BPF, Some(crate::ENUM_SIGNED_64_CHECKED_VARIANTS_RELOC_BTF),  None, -0xCCCCCCCDDDDDDDi64 as u64)]
-#[case(crate::ENUM_UNSIGNED_32_RELOC_BPF, None, None, 0xAAAAAAAA)]
+#[case(
+    crate::ENUM_SIGNED_32_RELOC_BPF,
+    crate::ENUM_SIGNED_32_RELOC_BTF,
+    -0x7BBBBBBBi32 as u64
+)]
+#[case(
+    crate::ENUM_SIGNED_32_CHECKED_VARIANTS_RELOC_BPF,
+    crate::ENUM_SIGNED_32_CHECKED_VARIANTS_RELOC_BTF,
+    -0x7BBBBBBBi32 as u64
+)]
+#[case(
+    crate::ENUM_SIGNED_64_RELOC_BPF,
+    crate::ENUM_SIGNED_64_RELOC_BTF,
+    -0xCCCCCCCDDDDDDDDi64 as u64
+)]
+#[case(
+    crate::ENUM_SIGNED_64_CHECKED_VARIANTS_RELOC_BPF,
+    crate::ENUM_SIGNED_64_CHECKED_VARIANTS_RELOC_BTF,
+    -0xCCCCCCCDDDDDDDi64 as u64
+)]
 #[case(
     crate::ENUM_UNSIGNED_32_RELOC_BPF,
-    Some(crate::ENUM_UNSIGNED_32_RELOC_BTF),
-    None,
+    crate::ENUM_UNSIGNED_32_RELOC_BTF,
     0xBBBBBBBB
 )]
 #[case(
     crate::ENUM_UNSIGNED_32_CHECKED_VARIANTS_RELOC_BPF,
-    None,
-    None,
-    0xAAAAAAAA
-)]
-#[case(
-    crate::ENUM_UNSIGNED_32_CHECKED_VARIANTS_RELOC_BPF,
-    Some(crate::ENUM_UNSIGNED_32_CHECKED_VARIANTS_RELOC_BTF),
-    None,
+    crate::ENUM_UNSIGNED_32_CHECKED_VARIANTS_RELOC_BTF,
     0xBBBBBBBB
 )]
-#[case(crate::ENUM_UNSIGNED_64_RELOC_BPF, None, None, 0xAAAAAAAABBBBBBBB)]
 #[case(
     crate::ENUM_UNSIGNED_64_RELOC_BPF,
-    Some(crate::ENUM_UNSIGNED_64_RELOC_BTF),
-    None,
+    crate::ENUM_UNSIGNED_64_RELOC_BTF,
     0xCCCCCCCCDDDDDDDD
 )]
 #[case(
     crate::ENUM_UNSIGNED_64_CHECKED_VARIANTS_RELOC_BPF,
-    None,
-    None,
-    0xAAAAAAAABBBBBBBB
-)]
-#[case(
-    crate::ENUM_UNSIGNED_64_CHECKED_VARIANTS_RELOC_BPF,
-    Some(crate::ENUM_UNSIGNED_64_CHECKED_VARIANTS_RELOC_BTF),
-    None,
+    crate::ENUM_UNSIGNED_64_CHECKED_VARIANTS_RELOC_BTF,
     0xCCCCCCCCDDDDDDDD
 )]
-#[case(crate::FIELD_RELOC_BPF, None, None, 2)]
-#[case(crate::FIELD_RELOC_BPF, Some(crate::FIELD_RELOC_BTF), None, 1)]
-#[case(crate::POINTER_RELOC_BPF, None, None, 42)]
-#[case(crate::POINTER_RELOC_BPF, Some(crate::POINTER_RELOC_BTF), None, 21)]
-#[case(crate::STRUCT_FLAVORS_RELOC_BPF, None, None, 1)]
-#[case(
-    crate::STRUCT_FLAVORS_RELOC_BPF,
-    Some(crate::STRUCT_FLAVORS_RELOC_BTF),
-    None,
-    2
-)]
+#[case(crate::FIELD_RELOC_BPF, crate::FIELD_RELOC_BTF, 1)]
+#[case(crate::POINTER_RELOC_BPF, crate::POINTER_RELOC_BTF, 21)]
+#[case(crate::STRUCT_FLAVORS_RELOC_BPF, crate::STRUCT_FLAVORS_RELOC_BTF, 2)]
 #[test_attr(test_log::test)]
-fn relocation_tests(
-    #[case] bpf: &[u8],
-    #[case] btf: Option<&[u8]>,
-    #[case] requirements: Option<Requirements>,
-    #[case] expected: u64,
-) {
-    let features = aya::features();
+fn relocation_tests(#[case] bpf: &[u8], #[case] btf: &[u8], #[case] expected: u64) {
+    let btf = Btf::parse(btf, Endianness::default()).unwrap();
 
-    let btf = btf.map(|btf| Btf::parse(btf, Endianness::default()).unwrap());
-
-    let mut bpf = match EbpfLoader::new().btf(btf.as_ref()).load(bpf) {
-        Ok(bpf) => {
-            if let Some(requirements) = requirements {
-                // We'll want to panic here if we expect some feature we don't have.
-                match requirements {}
-            }
-            bpf
-        }
-        Err(err) => panic!(
-            "err={err:?} requirements={requirements:?} features={:?}",
-            features.btf()
-        ),
-    };
+    let mut bpf = EbpfLoader::new().btf(&btf).load(bpf).unwrap();
 
     let program: &mut UProbe = bpf.program_mut("program").unwrap().try_into().unwrap();
     program.load().unwrap();

--- a/test/integration-test/src/tests/info.rs
+++ b/test/integration-test/src/tests/info.rs
@@ -20,7 +20,7 @@ use aya::{
     util::KernelVersion,
 };
 use aya_obj::generated::bpf_prog_type;
-use libc::EINVAL;
+use libc::{EINVAL, ENOENT};
 
 #[test_log::test]
 fn test_loaded_programs() {
@@ -232,20 +232,34 @@ fn list_loaded_maps() {
     let prog: &mut SocketFilter = bpf.program_mut("simple_prog").unwrap().try_into().unwrap();
     prog.load().unwrap();
 
-    // Ensure the loaded_maps() api doesn't panic
+    // Skip kernels that do not support loaded_maps().
     let mut maps = loaded_maps().peekable();
-    if let Err(err) = maps.peek().unwrap() {
-        if let MapError::SyscallError(err) = &err {
-            if err.io_error.raw_os_error() == Some(EINVAL) {
-                eprintln!("skipping test - `loaded_maps()` not supported");
-                return;
-            }
-        }
-        panic!("{err}");
+    if let Err(MapError::SyscallError(err)) = maps.peek().unwrap()
+        && err.io_error.raw_os_error() == Some(EINVAL)
+    {
+        eprintln!("skipping test - `loaded_maps()` not supported");
+        return;
     }
 
     // Loaded maps should contain our test maps
-    let maps: Vec<_> = maps.filter_map(Result::ok).collect();
+    let maps: Vec<_> = maps
+        .filter_map(|result| match result {
+            Ok(info) => Some(info),
+            // BPF_MAP_GET_NEXT_ID returns an ID without holding a reference, so the map can be
+            // removed before BPF_MAP_GET_FD_BY_ID. The kernel selftests and bpftool both skip the
+            // resulting ENOENT:
+            // https://github.com/torvalds/linux/blob/b15dc417/kernel/bpf/syscall.c#L3184-L3207
+            // https://github.com/torvalds/linux/blob/b95f03f0/tools/testing/selftests/bpf/prog_tests/bpf_obj_id.c#L205-L218
+            // https://github.com/libbpf/bpftool/blob/5730b384/src/map.c#L703-L719
+            Err(MapError::SyscallError(err))
+                if err.call == "bpf_map_get_fd_by_id"
+                    && err.io_error.raw_os_error() == Some(ENOENT) =>
+            {
+                None
+            }
+            Err(err) => panic!("{err:?}"),
+        })
+        .collect();
     if let Ok(info) = &prog.info() {
         if let Some(map_ids) = info.map_ids().unwrap() {
             assert_eq!(2, map_ids.len());

--- a/xtask/public-api/aya-obj.txt
+++ b/xtask/public-api/aya-obj.txt
@@ -4852,13 +4852,15 @@ pub fn aya_obj::Object::parse(&[u8]) -> core::result::Result<Self, aya_obj::Pars
 pub fn aya_obj::Object::patch_map_data(&mut self, std::collections::hash::map::HashMap<&str, (&[u8], bool)>) -> core::result::Result<(), aya_obj::ParseError>
 pub fn aya_obj::Object::sanitize_functions(&mut self, &aya_obj::Features)
 impl aya_obj::Object
+pub fn aya_obj::Object::has_strong_typed_ksyms(&self) -> bool
+pub fn aya_obj::Object::has_typed_ksyms(&self) -> bool
+pub fn aya_obj::Object::resolve_externs(&mut self, core::option::Option<&aya_obj::btf::Btf>) -> core::result::Result<(), aya_obj::KsymsError>
+impl aya_obj::Object
 pub fn aya_obj::Object::relocate_btf(&mut self, &aya_obj::btf::Btf) -> core::result::Result<(), aya_obj::btf::BtfRelocationError>
 impl aya_obj::Object
 pub fn aya_obj::Object::relocate_calls(&mut self, &std::collections::hash::set::HashSet<usize>) -> core::result::Result<(), aya_obj::relocation::EbpfRelocationError>
 pub fn aya_obj::Object::relocate_externs(&mut self) -> core::result::Result<(), aya_obj::relocation::EbpfRelocationError>
 pub fn aya_obj::Object::relocate_maps<'a, I: core::iter::traits::iterator::Iterator<Item = (&'a str, std::os::fd::raw::RawFd, &'a aya_obj::maps::Map)>>(&mut self, I, &std::collections::hash::set::HashSet<usize>) -> core::result::Result<(), aya_obj::relocation::EbpfRelocationError>
-impl aya_obj::Object
-pub fn aya_obj::Object::resolve_externs(&mut self, core::option::Option<&aya_obj::btf::Btf>) -> core::result::Result<(), aya_obj::KsymsError>
 impl core::clone::Clone for aya_obj::Object
 pub fn aya_obj::Object::clone(&self) -> aya_obj::Object
 impl core::fmt::Debug for aya_obj::Object
@@ -5492,13 +5494,15 @@ pub fn aya_obj::Object::parse(&[u8]) -> core::result::Result<Self, aya_obj::Pars
 pub fn aya_obj::Object::patch_map_data(&mut self, std::collections::hash::map::HashMap<&str, (&[u8], bool)>) -> core::result::Result<(), aya_obj::ParseError>
 pub fn aya_obj::Object::sanitize_functions(&mut self, &aya_obj::Features)
 impl aya_obj::Object
+pub fn aya_obj::Object::has_strong_typed_ksyms(&self) -> bool
+pub fn aya_obj::Object::has_typed_ksyms(&self) -> bool
+pub fn aya_obj::Object::resolve_externs(&mut self, core::option::Option<&aya_obj::btf::Btf>) -> core::result::Result<(), aya_obj::KsymsError>
+impl aya_obj::Object
 pub fn aya_obj::Object::relocate_btf(&mut self, &aya_obj::btf::Btf) -> core::result::Result<(), aya_obj::btf::BtfRelocationError>
 impl aya_obj::Object
 pub fn aya_obj::Object::relocate_calls(&mut self, &std::collections::hash::set::HashSet<usize>) -> core::result::Result<(), aya_obj::relocation::EbpfRelocationError>
 pub fn aya_obj::Object::relocate_externs(&mut self) -> core::result::Result<(), aya_obj::relocation::EbpfRelocationError>
 pub fn aya_obj::Object::relocate_maps<'a, I: core::iter::traits::iterator::Iterator<Item = (&'a str, std::os::fd::raw::RawFd, &'a aya_obj::maps::Map)>>(&mut self, I, &std::collections::hash::set::HashSet<usize>) -> core::result::Result<(), aya_obj::relocation::EbpfRelocationError>
-impl aya_obj::Object
-pub fn aya_obj::Object::resolve_externs(&mut self, core::option::Option<&aya_obj::btf::Btf>) -> core::result::Result<(), aya_obj::KsymsError>
 impl core::clone::Clone for aya_obj::Object
 pub fn aya_obj::Object::clone(&self) -> aya_obj::Object
 impl core::fmt::Debug for aya_obj::Object

--- a/xtask/public-api/aya.txt
+++ b/xtask/public-api/aya.txt
@@ -7904,7 +7904,7 @@ impl core::panic::unwind_safe::UnwindSafe for aya::Ebpf
 pub struct aya::EbpfLoader<'a>
 impl<'a> aya::EbpfLoader<'a>
 pub const fn aya::EbpfLoader<'a>::allow_unsupported_maps(&mut self) -> &mut Self
-pub fn aya::EbpfLoader<'a>::btf(&mut self, core::option::Option<&'a aya_obj::btf::btf::Btf>) -> &mut Self
+pub fn aya::EbpfLoader<'a>::btf(&mut self, &'a aya_obj::btf::btf::Btf) -> &mut Self
 pub fn aya::EbpfLoader<'a>::default_map_pin_directory<P: core::convert::AsRef<std::path::Path>>(&mut self, P) -> &mut Self
 pub fn aya::EbpfLoader<'a>::extension(&mut self, &'a str) -> &mut Self
 pub fn aya::EbpfLoader<'a>::load(&mut self, &[u8]) -> core::result::Result<aya::Ebpf, aya::EbpfError>


### PR DESCRIPTION
<!-- markdownlint-disable first-line-heading -->

<!--
    Thank you for your contribution to Aya! 🎉

    For Work In Progress Pull Requests, please use the Draft PR feature.

    Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Aya Contributing Guide: https://github.com/aya-rs/aya/blob/main/CONTRIBUTING.md
     - 📖 Read the Aya Code of Conduct: https://github.com/aya-rs/aya/blob/main/CODE_OF_CONDUCT.md
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages: https://cbea.ms/git-commit/
     - 📗 Update any related documentation.

-->

<!---
      Summarize the changes you're making here. Detailed information belongs in
      the Git commit messages. If your pull request contains just one commit,
      it's best to use its message as a summary. Otherwise, if there are multiple
      atomic commits, write a summary for the entire PR. Feel free to flag
      anything you think needs a reviewer's attention.
-->

<!--
      If your changes address an issue, link it with the *Fixes* tag so
      the issue gets closed when the PR is merged, for example:

      Fixes: #1234

      If you are only referencing an issue without fully addressing it, feel
      free to link it anywhere in the summary.
-->

With some time to kill while waiting for the World Cup final, I browsed through the BTF implementation in Aya and found this issue.

I also thought about removing the BTF load from the new(), but I'm concerned that this could be a behavioral breaking change.

### Added/updated tests?

_We strongly encourage you to add a test for your changes._

- [x] No, and this is why: has been covered by the existed tests.

### Checklist

- [x] Rust code has been formatted with `cargo +nightly fmt`.
- [x] All clippy lints have been fixed.
      You can find failing lints with `cargo xtask clippy`.
- [x] Unit tests are passing locally with `cargo test`.
- [x] The [Integration tests] are passing locally.
- [x] I have blessed any API changes with `cargo xtask public-api --bless`.

[Integration tests]: https://github.com/aya-rs/aya/blob/main/test/README.md

### (Optional) What GIF best describes this PR or how it makes you feel?

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aya-rs/aya/1639)
<!-- Reviewable:end -->
