### PR TITLE
maps/ring_buf: add consume_batch method for batch processing events

### DIFF
--- a/aya/src/maps/ring_buf.rs
+++ b/aya/src/maps/ring_buf.rs
@@ -139,6 +139,9 @@ impl<T> RingBuf<T> {
 
     /// Drains available items up to `max_items` from the ring buffer, invoking `f` for each item.
     ///
+    /// The slice passed to `f` is borrowed from the ring buffer and is only valid for the duration
+    /// of the closure invocation.
+    ///
     /// Returns the number of items processed.
     pub fn consume_batch<F>(&mut self, max_items: usize, mut f: F) -> usize
     where

--- a/aya/src/maps/ring_buf.rs
+++ b/aya/src/maps/ring_buf.rs
@@ -136,6 +136,25 @@ impl<T> RingBuf<T> {
         } = self;
         producer.next(consumer)
     }
+
+    /// Drains available items up to `max_items` from the ring buffer, invoking `f` for each item.
+    ///
+    /// Returns the number of items processed.
+    pub fn consume_batch<F>(&mut self, max_items: usize, mut f: F) -> usize
+    where
+        F: FnMut(&[u8]),
+    {
+        let mut count = 0;
+        while count < max_items {
+            if let Some(item) = self.next() {
+                f(&item);
+                count += 1;
+            } else {
+                break;
+            }
+        }
+        count
+    }
 }
 
 impl<T: Borrow<MapData>> AsFd for RingBuf<T> {

--- a/xtask/public-api/aya.txt
+++ b/xtask/public-api/aya.txt
@@ -559,6 +559,7 @@ impl<T, V> core::panic::unwind_safe::UnwindSafe for aya::maps::queue::Queue<T, V
 pub mod aya::maps::ring_buf
 pub struct aya::maps::ring_buf::RingBuf<T>
 impl<T> aya::maps::ring_buf::RingBuf<T>
+pub fn aya::maps::ring_buf::RingBuf<T>::consume_batch<F>(&mut self, usize, F) -> usize where F: core::ops::function::FnMut(&[u8])
 pub fn aya::maps::ring_buf::RingBuf<T>::next(&mut self) -> core::option::Option<aya::maps::ring_buf::RingBufItem<'_>>
 impl core::convert::TryFrom<aya::maps::Map> for aya::maps::ring_buf::RingBuf<aya::maps::MapData>
 pub type aya::maps::ring_buf::RingBuf<aya::maps::MapData>::Error = aya::maps::MapError

--- a/xtask/public-api/aya.txt
+++ b/xtask/public-api/aya.txt
@@ -1994,6 +1994,7 @@ impl<T> core::panic::unwind_safe::RefUnwindSafe for aya::maps::ReusePortSockArra
 impl<T> core::panic::unwind_safe::UnwindSafe for aya::maps::ReusePortSockArray<T> where T: core::panic::unwind_safe::UnwindSafe
 pub struct aya::maps::RingBuf<T>
 impl<T> aya::maps::ring_buf::RingBuf<T>
+pub fn aya::maps::ring_buf::RingBuf<T>::consume_batch<F>(&mut self, usize, F) -> usize where F: core::ops::function::FnMut(&[u8])
 pub fn aya::maps::ring_buf::RingBuf<T>::next(&mut self) -> core::option::Option<aya::maps::ring_buf::RingBufItem<'_>>
 impl core::convert::TryFrom<aya::maps::Map> for aya::maps::ring_buf::RingBuf<aya::maps::MapData>
 pub type aya::maps::ring_buf::RingBuf<aya::maps::MapData>::Error = aya::maps::MapError


### PR DESCRIPTION
### Summary

This PR introduces `RingBuf::consume_batch`, a helper method allowing userspace applications to drain up to `max_items` available eBPF ring buffer events in a single bounded pass:

```rust
pub fn consume_batch<F>(&mut self, max_items: usize, mut f: F) -> usize
where
    F: FnMut(&[u8])

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aya-rs/aya/1641)
<!-- Reviewable:end -->
