### PR TITLE
maps/lpm_trie: add contains_key method to LpmTrie map

### DIFF
--- a/aya/src/maps/lpm_trie.rs
+++ b/aya/src/maps/lpm_trie.rs
@@ -119,6 +119,15 @@ impl<T: Borrow<MapData>, K: Pod, V: Pod> LpmTrie<T, K, V> {
         hash_map::get(self.inner.borrow(), key, flags)
     }
 
+    /// Returns `true` if the map contains a key matching the longest prefix.
+    pub fn contains_key(&self, key: &Key<K>, flags: u64) -> Result<bool, MapError> {
+        match self.get(key, flags) {
+            Ok(_) => Ok(true),
+            Err(MapError::KeyNotFound) => Ok(false),
+            Err(e) => Err(e),
+        }
+    }
+
     /// An iterator visiting all key-value pairs. The
     /// iterator item type is `Result<(K, V), MapError>`.
     pub fn iter(&self) -> MapIter<'_, Key<K>, V, Self> {

--- a/aya/src/maps/lpm_trie.rs
+++ b/aya/src/maps/lpm_trie.rs
@@ -349,4 +349,41 @@ mod tests {
 
         assert_matches!(trie.get(&key, 0), Err(MapError::KeyNotFound));
     }
+
+    #[test]
+    fn test_contains_key_found() {
+        let map = new_map(new_obj_map());
+        let trie = LpmTrie::<_, u32, u32>::new(&map).unwrap();
+        let ipaddr = Ipv4Addr::new(8, 8, 8, 8);
+        let key = Key::new(16, u32::from(ipaddr).to_be());
+
+        override_syscall(|call| match call {
+            Syscall::Ebpf {
+                cmd: bpf_cmd::BPF_MAP_LOOKUP_ELEM,
+                ..
+            } => Ok(0),
+            _ => sys_error(EFAULT),
+        });
+
+        assert_matches!(trie.contains_key(&key, 0), Ok(true));
+    }
+
+    #[test]
+    fn test_contains_key_not_found() {
+        let map = new_map(new_obj_map());
+        let trie = LpmTrie::<_, u32, u32>::new(&map).unwrap();
+        let ipaddr = Ipv4Addr::new(8, 8, 8, 8);
+        let key = Key::new(16, u32::from(ipaddr).to_be());
+
+        override_syscall(|call| match call {
+            Syscall::Ebpf {
+                cmd: bpf_cmd::BPF_MAP_LOOKUP_ELEM,
+                ..
+            } => sys_error(ENOENT),
+            _ => sys_error(EFAULT),
+        });
+
+        assert_matches!(trie.contains_key(&key, 0), Ok(false));
+    }
 }
+

--- a/aya/src/maps/lpm_trie.rs
+++ b/aya/src/maps/lpm_trie.rs
@@ -386,4 +386,3 @@ mod tests {
         assert_matches!(trie.contains_key(&key, 0), Ok(false));
     }
 }
-

--- a/test/integration-test/src/tests/lpm_trie.rs
+++ b/test/integration-test/src/tests/lpm_trie.rs
@@ -28,6 +28,8 @@ fn lpm_trie_basic(#[case] prog_name: &str, #[case] routes_map: &str, #[case] res
         routes
             .insert(&Key::new(24, [192, 168, 1, 0]), &7u32, 0)
             .unwrap();
+        assert!(routes.contains_key(&Key::new(24, [192, 168, 1, 0]), 0).unwrap());
+        assert!(!routes.contains_key(&Key::new(32, [10, 0, 0, 1]), 0).unwrap());
     }
 
     let prog: &mut UProbe = bpf

--- a/test/integration-test/src/tests/lpm_trie.rs
+++ b/test/integration-test/src/tests/lpm_trie.rs
@@ -28,8 +28,16 @@ fn lpm_trie_basic(#[case] prog_name: &str, #[case] routes_map: &str, #[case] res
         routes
             .insert(&Key::new(24, [192, 168, 1, 0]), &7u32, 0)
             .unwrap();
-        assert!(routes.contains_key(&Key::new(24, [192, 168, 1, 0]), 0).unwrap());
-        assert!(!routes.contains_key(&Key::new(32, [10, 0, 0, 1]), 0).unwrap());
+        assert!(
+            routes
+                .contains_key(&Key::new(24, [192, 168, 1, 0]), 0)
+                .unwrap()
+        );
+        assert!(
+            !routes
+                .contains_key(&Key::new(32, [10, 0, 0, 1]), 0)
+                .unwrap()
+        );
     }
 
     let prog: &mut UProbe = bpf

--- a/xtask/public-api/aya.txt
+++ b/xtask/public-api/aya.txt
@@ -359,6 +359,7 @@ pub struct aya::maps::lpm_trie::LpmTrie<T, K, V>
 impl<K: aya::Pod, V: aya::Pod> aya::maps::lpm_trie::LpmTrie<aya::maps::MapData, K, V>
 pub fn aya::maps::lpm_trie::LpmTrie<aya::maps::MapData, K, V>::create(u32, u32) -> core::result::Result<Self, aya::maps::MapError>
 impl<T: core::borrow::Borrow<aya::maps::MapData>, K: aya::Pod, V: aya::Pod> aya::maps::lpm_trie::LpmTrie<T, K, V>
+pub fn aya::maps::lpm_trie::LpmTrie<T, K, V>::contains_key(&self, &aya::maps::lpm_trie::Key<K>, u64) -> core::result::Result<bool, aya::maps::MapError>
 pub fn aya::maps::lpm_trie::LpmTrie<T, K, V>::get(&self, &aya::maps::lpm_trie::Key<K>, u64) -> core::result::Result<V, aya::maps::MapError>
 pub fn aya::maps::lpm_trie::LpmTrie<T, K, V>::iter(&self) -> aya::maps::MapIter<'_, aya::maps::lpm_trie::Key<K>, V, Self>
 pub fn aya::maps::lpm_trie::LpmTrie<T, K, V>::keys(&self) -> aya::maps::MapKeys<'_, aya::maps::lpm_trie::Key<K>>
@@ -1678,6 +1679,7 @@ pub struct aya::maps::LpmTrie<T, K, V>
 impl<K: aya::Pod, V: aya::Pod> aya::maps::lpm_trie::LpmTrie<aya::maps::MapData, K, V>
 pub fn aya::maps::lpm_trie::LpmTrie<aya::maps::MapData, K, V>::create(u32, u32) -> core::result::Result<Self, aya::maps::MapError>
 impl<T: core::borrow::Borrow<aya::maps::MapData>, K: aya::Pod, V: aya::Pod> aya::maps::lpm_trie::LpmTrie<T, K, V>
+pub fn aya::maps::lpm_trie::LpmTrie<T, K, V>::contains_key(&self, &aya::maps::lpm_trie::Key<K>, u64) -> core::result::Result<bool, aya::maps::MapError>
 pub fn aya::maps::lpm_trie::LpmTrie<T, K, V>::get(&self, &aya::maps::lpm_trie::Key<K>, u64) -> core::result::Result<V, aya::maps::MapError>
 pub fn aya::maps::lpm_trie::LpmTrie<T, K, V>::iter(&self) -> aya::maps::MapIter<'_, aya::maps::lpm_trie::Key<K>, V, Self>
 pub fn aya::maps::lpm_trie::LpmTrie<T, K, V>::keys(&self) -> aya::maps::MapKeys<'_, aya::maps::lpm_trie::Key<K>>


### PR DESCRIPTION
### Summary
Adds a `contains_key` method to `LpmTrie` map to check for key existence matching the longest prefix, providing standard API ergonomics consistent with Rust collection conventions (`std::collections::HashMap::contains_key`).

### Key Changes
* **`LpmTrie::contains_key`**: Checks whether a matching prefix exists in the LPM trie by querying `self.get(key, flags)` and returning `Result<bool, MapError>`.
* **Public API Contract**: Registered `contains_key` in `xtask/public-api/aya.txt` in exact alphabetical order.

### Verification & Testing
- **Unit Tests:** Added `test_contains_key_found` and `test_contains_key_not_found` in `aya/src/maps/lpm_trie.rs`.
- **Integration Tests:** Added `routes.contains_key(...)` assertions in `test/integration-test/src/tests/lpm_trie.rs`.
- **Formatting:** Verified with `cargo fmt`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aya-rs/aya/1642)
<!-- Reviewable:end -->
