### PR TITLE
build: migrate integration kernels to linux.bzl v0.0.1

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -6,21 +6,18 @@ module(
 bazel_dep(name = "bazel_lib", version = "3.2.2")
 bazel_dep(name = "bazel_skylib", version = "1.9.0")
 
-# The archive_override below supplies the exact unpublished linux.bzl revision.
-bazel_dep(name = "linux.bzl", version = "0.0.0")
+bazel_dep(name = "linux.bzl", version = "0.0.1")
 
 # libbpf supplies headers and libraries for the C BPF integration-test objects.
 bazel_dep(name = "libbpf", version = "1.7.0")
 
 # The LLVM toolchain compiles C BPF objects and the integration VM kernels.
-bazel_dep(name = "llvm", version = "0.8.9")
+bazel_dep(name = "llvm", version = "0.8.14")
 
-# CONFIG_DEBUG_INFO_BTF requires pahole when linking the integration VM kernels.
-bazel_dep(name = "pahole", version = "1.31")
 bazel_dep(name = "platforms", version = "1.1.0")
-bazel_dep(name = "rules_cc", version = "0.2.19")
+bazel_dep(name = "rules_cc", version = "0.2.20")
 bazel_dep(name = "rules_qemu", version = "0.3.0")
-bazel_dep(name = "rules_rs", version = "0.0.93")
+bazel_dep(name = "rules_rs", version = "0.0.98")
 
 # with_cfg.bzl applies the BPF target settings to Rust and C BPF targets.
 bazel_dep(name = "with_cfg.bzl", version = "0.14.6")
@@ -33,12 +30,12 @@ bazel_lib_toolchains = use_extension("@bazel_lib//lib:extensions.bzl", "toolchai
 bazel_lib_toolchains.copy_to_directory()
 use_repo(bazel_lib_toolchains, "copy_to_directory_toolchains")
 
-# Pin the linux.bzl revision that provides the deterministic C initramfs rule.
+# Use the release archive until linux.bzl 0.0.1 is available from the BCR.
 archive_override(
     module_name = "linux.bzl",
-    integrity = "sha256-2gveHVEG4EE5x3N4kDnUftB7ed/6RRFslFwDquObqRg=",
-    strip_prefix = "linux.bzl-e18628f3e177022c2ff0cf93a2e5f2d408f7d2fc",
-    urls = ["https://github.com/hermeticbuild/linux.bzl/archive/e18628f3e177022c2ff0cf93a2e5f2d408f7d2fc.tar.gz"],
+    integrity = "sha256-k/khAfJ1UCTZx9fU/UpCklJ4kT9dIFCAj3DcbJ5Mgtg=",
+    strip_prefix = "linux.bzl-0.0.1",
+    urls = ["https://github.com/hermeticbuild/linux.bzl/releases/download/v0.0.1/linux.bzl-v0.0.1.tar.gz"],
 )
 
 # @rules_rs creates @rules_rust here; generated BUILD files and .bazelrc labels
@@ -125,55 +122,36 @@ use_repo(crate, "crates")
 
 # Use one integrity-pinned Linux source archive for both integration VM
 # architectures.
-linux_kernel = use_extension("@linux.bzl//:linux.bzl", "linux_kernel")
-linux_kernel.archive(
+linux_source_repository = use_repo_rule(
+    "@linux.bzl",
+    "linux_source_repository",
+)
+
+linux_source_repository(
     name = "aya_linux_6_18_2",
     integrity = "sha256-VYxrurdJSSs0+Zgn/oB7ADmnRGk8IdOn4Ds6SO2quWo=",
     strip_prefix = "linux-6.18.2",
     urls = ["https://cdn.kernel.org/pub/linux/kernel/v6.x/linux-6.18.2.tar.xz"],
+    version = "6.18.2",
 )
 
-# Convert each requested Kconfig fragment into a KconfigInfo repository.
-linux_kernel.kconfig(
-    name = "aya_aarch64_kconfig",
-    config = "//test/kernel:aya_aarch64.config",
-)
-linux_kernel.kconfig(
-    name = "aya_x86_64_kconfig",
-    config = "//test/kernel:aya_x86_64.config",
-)
-
-# Generate architecture-specific compact Kbuild metadata from
-# aya_aarch64.config and aya_x86_64.config.
-# linux.bzl encodes pahole 1.31 as "131" for the CONFIG_DEBUG_INFO_BTF probe;
-# keep this value synchronized with bazel_dep(name = "pahole") above.
-# TODO(https://github.com/hermeticbuild/linux.bzl/issues/6): Teach linux.bzl to
-# derive pahole_version from the pahole toolchain.
-linux_kernel.compact(
-    name = "aya_aarch64_compact",
+linux_images = use_extension("@linux.bzl//:extensions.bzl", "linux_images")
+linux_images.image(
+    name = "aya_aarch64_kernel",
     config = "//test/kernel:aya_aarch64.config",
     config_mode = "allnoconfig",
-    config_name = "aarch64",
-    kernel_name = "aya_kernel",
-    kernel_package = "test/kernel",
-    probe_values = {"pahole_version": "131"},
-    source_repo = "aya_linux_6_18_2",
+    platform = "@llvm//platforms:linux_arm64",
+    source = "@aya_linux_6_18_2//:Kconfig",
 )
-linux_kernel.compact(
-    name = "aya_x86_64_compact",
+linux_images.image(
+    name = "aya_x86_64_kernel",
     config = "//test/kernel:aya_x86_64.config",
     config_mode = "allnoconfig",
-    config_name = "x86_64",
-    kernel_name = "aya_kernel",
-    kernel_package = "test/kernel",
-    probe_values = {"pahole_version": "131"},
-    source_repo = "aya_linux_6_18_2",
+    platform = "@llvm//platforms:linux_x86_64",
+    source = "@aya_linux_6_18_2//:Kconfig",
 )
 use_repo(
-    linux_kernel,
-    "aya_aarch64_compact",
-    "aya_aarch64_kconfig",
-    "aya_linux_6_18_2",
-    "aya_x86_64_compact",
-    "aya_x86_64_kconfig",
+    linux_images,
+    "aya_aarch64_kernel",
+    "aya_x86_64_kernel",
 )

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -47,7 +47,8 @@
     "https://bcr.bazel.build/modules/bazel_features/1.43.0/MODULE.bazel": "defa2226f06ba20550d6548c3a2ea2a7929634437a52973869c20c225450eb91",
     "https://bcr.bazel.build/modules/bazel_features/1.45.0/MODULE.bazel": "7daec6d87ab0703417486d4cb948af0b06f55d4d7c08cbb5978c80e79b538edf",
     "https://bcr.bazel.build/modules/bazel_features/1.47.0/MODULE.bazel": "e34df3cb35b1684cfa69923a61ae3803595babd3942cd306a488d51400886b30",
-    "https://bcr.bazel.build/modules/bazel_features/1.47.0/source.json": "4ba0b5138327f2d73352a51547a4e49a0a828ef400e046b15334d8905bf6b7ff",
+    "https://bcr.bazel.build/modules/bazel_features/1.50.0/MODULE.bazel": "2083ef9c7a469f520890483ccf8e0189d6e71e2117e7752e15e6554433d5ae3e",
+    "https://bcr.bazel.build/modules/bazel_features/1.50.0/source.json": "e0ee3debde2789ff56e4452e612d126925ba9ab64d4bde79c67f099d2902df9b",
     "https://bcr.bazel.build/modules/bazel_features/1.9.0/MODULE.bazel": "885151d58d90d8d9c811eb75e3288c11f850e1d6b481a8c9f766adee4712358b",
     "https://bcr.bazel.build/modules/bazel_features/1.9.1/MODULE.bazel": "8f679097876a9b609ad1f60249c49d68bfab783dd9be012faf9d82547b14815a",
     "https://bcr.bazel.build/modules/bazel_lib/3.0.0/MODULE.bazel": "22b70b80ac89ad3f3772526cd9feee2fa412c2b01933fea7ed13238a448d370d",
@@ -83,8 +84,8 @@
     "https://bcr.bazel.build/modules/gazelle/0.33.0/MODULE.bazel": "a13a0f279b462b784fb8dd52a4074526c4a2afe70e114c7d09066097a46b3350",
     "https://bcr.bazel.build/modules/gazelle/0.34.0/MODULE.bazel": "abdd8ce4d70978933209db92e436deb3a8b737859e9354fb5fd11fb5c2004c8a",
     "https://bcr.bazel.build/modules/gazelle/0.36.0/MODULE.bazel": "e375d5d6e9a6ca59b0cb38b0540bc9a05b6aa926d322f2de268ad267a2ee74c0",
-    "https://bcr.bazel.build/modules/gazelle/0.47.0/MODULE.bazel": "b61bb007c4efad134aa30ee7f4a8e2a39b22aa5685f005edaa022fbd1de43ebc",
-    "https://bcr.bazel.build/modules/gazelle/0.47.0/source.json": "aeb2e5df14b7fb298625d75d08b9c65bdb0b56014c5eb89da9e5dd0572280ae6",
+    "https://bcr.bazel.build/modules/gazelle/0.51.3/MODULE.bazel": "618a729142f66de1e2cb776d026413763be5b80d5e3d29ffb9d3d90c5defde90",
+    "https://bcr.bazel.build/modules/gazelle/0.51.3/source.json": "fbe5312a01fb4a2a58caff4a0d40dcf384b6f0bda75e85546663360da1d7538a",
     "https://bcr.bazel.build/modules/google_benchmark/1.8.2/MODULE.bazel": "a70cf1bba851000ba93b58ae2f6d76490a9feb74192e57ab8e8ff13c34ec50cb",
     "https://bcr.bazel.build/modules/googletest/1.11.0/MODULE.bazel": "3a83f095183f66345ca86aa13c58b59f9f94a2f81999c093d4eeaa2d262d12f4",
     "https://bcr.bazel.build/modules/googletest/1.14.0.bcr.1/MODULE.bazel": "22c31a561553727960057361aa33bf20fb2e98584bc4fec007906e27053f80c6",
@@ -101,13 +102,12 @@
     "https://bcr.bazel.build/modules/libbpf/1.7.0/MODULE.bazel": "b8321945253d3a9b511441dc3f4f1aa76535c8a53b081769889cdc0dd37705a0",
     "https://bcr.bazel.build/modules/libbpf/1.7.0/source.json": "0466cf1179fef98a51e1a52a2dc74a4052ad98c6a3aee24298626679235b88b7",
     "https://bcr.bazel.build/modules/libpfm/4.11.0/MODULE.bazel": "45061ff025b301940f1e30d2c16bea596c25b176c8b6b3087e92615adbd52902",
-    "https://bcr.bazel.build/modules/llvm/0.7.1/MODULE.bazel": "74ac75efc6385b8a95d83bfa36ad399500f747c3d0f50287f9b6f9e854ec4814",
+    "https://bcr.bazel.build/modules/llvm/0.8.14/MODULE.bazel": "4e32f919f53cc2127370af20cb9121b0ca082abe43e223de2a058a40d756b813",
+    "https://bcr.bazel.build/modules/llvm/0.8.14/source.json": "38f261d02ef6e44ed0eaee23e69dadd1d7692d14d31feb758d54759605b2a41e",
     "https://bcr.bazel.build/modules/llvm/0.8.9/MODULE.bazel": "9e35ff5bcac996f9edc1b44b8f8baa58c7855e742c5608b07d925dcdbe642100",
-    "https://bcr.bazel.build/modules/llvm/0.8.9/source.json": "424b907b38875f1346b65946e5e482b202b842bd3a570abbe07047d2bc7d667b",
     "https://bcr.bazel.build/modules/lz4/1.10.0.bcr.1/MODULE.bazel": "701a49c6304d1f836604dbfbb1642a0c89320c8bd2fbe5a768ae97b48c8df1d4",
     "https://bcr.bazel.build/modules/lz4/1.10.0.bcr.1/source.json": "33ed2bd01e038792015c2097fdbd4f4ce4f00c2046e9ea62e7fff1ab151754e4",
     "https://bcr.bazel.build/modules/nlohmann_json/3.6.1/MODULE.bazel": "6f7b417dcc794d9add9e556673ad25cb3ba835224290f4f848f8e2db1e1fca74",
-    "https://bcr.bazel.build/modules/package_metadata/0.0.2/MODULE.bazel": "fb8d25550742674d63d7b250063d4580ca530499f045d70748b1b142081ebb92",
     "https://bcr.bazel.build/modules/package_metadata/0.0.3/MODULE.bazel": "77890552ecea9e284b5424c9de827a58099348763a4359e975c359a83d4faa83",
     "https://bcr.bazel.build/modules/package_metadata/0.0.5/MODULE.bazel": "ef4f9439e3270fdd6b9fd4dbc3d2f29d13888e44c529a1b243f7a31dfbc2e8e4",
     "https://bcr.bazel.build/modules/package_metadata/0.0.6/MODULE.bazel": "341dab6f417197494517d54c8e557c0baee1de7aec83543a4fbefe57900acb7e",
@@ -129,6 +129,7 @@
     "https://bcr.bazel.build/modules/protobuf/21.7/MODULE.bazel": "a5a29bb89544f9b97edce05642fac225a808b5b7be74038ea3640fae2f8e66a7",
     "https://bcr.bazel.build/modules/protobuf/27.0/MODULE.bazel": "7873b60be88844a0a1d8f80b9d5d20cfbd8495a689b8763e76c6372998d3f64c",
     "https://bcr.bazel.build/modules/protobuf/27.1/MODULE.bazel": "703a7b614728bb06647f965264967a8ef1c39e09e8f167b3ca0bb1fd80449c0d",
+    "https://bcr.bazel.build/modules/protobuf/29.0-rc2.bcr.1/MODULE.bazel": "52f4126f63a2f0bbf36b99c2a87648f08467a4eaf92ba726bc7d6a500bbf770c",
     "https://bcr.bazel.build/modules/protobuf/29.0-rc2/MODULE.bazel": "6241d35983510143049943fc0d57937937122baf1b287862f9dc8590fc4c37df",
     "https://bcr.bazel.build/modules/protobuf/29.0-rc3/MODULE.bazel": "33c2dfa286578573afc55a7acaea3cada4122b9631007c594bf0729f41c8de92",
     "https://bcr.bazel.build/modules/protobuf/29.0/MODULE.bazel": "319dc8bf4c679ff87e71b1ccfb5a6e90a6dbc4693501d471f48662ac46d04e4e",
@@ -169,19 +170,18 @@
     "https://bcr.bazel.build/modules/rules_cc/0.2.16/MODULE.bazel": "9242fa89f950c6ef7702801ab53922e99c69b02310c39fb6e62b2bd30df2a1d4",
     "https://bcr.bazel.build/modules/rules_cc/0.2.17/MODULE.bazel": "1849602c86cb60da8613d2de887f9566a6d354a6df6d7009f9d04a14402f9a84",
     "https://bcr.bazel.build/modules/rules_cc/0.2.19/MODULE.bazel": "d5e0f05b63273281a16654eb6b1a8742a75ec153ac8b4f0419949d6e401e46f0",
-    "https://bcr.bazel.build/modules/rules_cc/0.2.19/source.json": "1ef48cdbd7aa6238015189b582d3d74ef0cbea3cb3e2cb259d782463f570c14a",
+    "https://bcr.bazel.build/modules/rules_cc/0.2.20/MODULE.bazel": "f5c07bce5ddcb99be21a0812ff5aadb439e688b7449c6542152363b2fd859c1a",
+    "https://bcr.bazel.build/modules/rules_cc/0.2.20/source.json": "1155433dc6b8161bc339ce94095b337ed95feb1f048b014e10b62339d4b4239c",
     "https://bcr.bazel.build/modules/rules_cc/0.2.4/MODULE.bazel": "1ff1223dfd24f3ecf8f028446d4a27608aa43c3f41e346d22838a4223980b8cc",
     "https://bcr.bazel.build/modules/rules_cc/0.2.8/MODULE.bazel": "f1df20f0bf22c28192a794f29b501ee2018fa37a3862a1a2132ae2940a23a642",
-    "https://bcr.bazel.build/modules/rules_devicetree/0.1.3/MODULE.bazel": "ca424ac4d76f137928f2f69eedbaf7cc2ff25487ebb6dccd87f02ab482ab6d43",
-    "https://bcr.bazel.build/modules/rules_devicetree/0.1.3/source.json": "5d6fd1cafe97f128d0257e8edd16d43fb3f83255e6624d22dd996d4e15160689",
     "https://bcr.bazel.build/modules/rules_foreign_cc/0.9.0/MODULE.bazel": "c9e8c682bf75b0e7c704166d79b599f93b72cfca5ad7477df596947891feeef6",
     "https://bcr.bazel.build/modules/rules_fuzzing/0.5.2/MODULE.bazel": "40c97d1144356f52905566c55811f13b299453a14ac7769dfba2ac38192337a8",
     "https://bcr.bazel.build/modules/rules_go/0.41.0/MODULE.bazel": "55861d8e8bb0e62cbd2896f60ff303f62ffcb0eddb74ecb0e5c0cbe36fc292c8",
     "https://bcr.bazel.build/modules/rules_go/0.42.0/MODULE.bazel": "8cfa875b9aa8c6fce2b2e5925e73c1388173ea3c32a0db4d2b4804b453c14270",
     "https://bcr.bazel.build/modules/rules_go/0.46.0/MODULE.bazel": "3477df8bdcc49e698b9d25f734c4f3a9f5931ff34ee48a2c662be168f5f2d3fd",
-    "https://bcr.bazel.build/modules/rules_go/0.53.0/MODULE.bazel": "a4ed760d3ac0dbc0d7b967631a9a3fd9100d28f7d9fcf214b4df87d4bfff5f9a",
-    "https://bcr.bazel.build/modules/rules_go/0.60.0/MODULE.bazel": "4a57ff2ffc2a3570e3c5646575c5a4b07287e91bcdac5d1f72383d51502b48cb",
-    "https://bcr.bazel.build/modules/rules_go/0.60.0/source.json": "1e21368c5e0c3013a110bd79a8fcff8ca46b5bcb2b561713a7273cbfcff7c464",
+    "https://bcr.bazel.build/modules/rules_go/0.59.0/MODULE.bazel": "b7e43e7414a3139a7547d1b4909b29085fbe5182b6c58cbe1ed4c6272815aeae",
+    "https://bcr.bazel.build/modules/rules_go/0.62.0/MODULE.bazel": "8ee616065c3d2b2f7ac0880108316ce8d0c332b3a30aad24e95c0bc124ec853e",
+    "https://bcr.bazel.build/modules/rules_go/0.62.0/source.json": "36d781c558eb7d3bd49dc5e190455714f174232372f15207ab200b4348bda3e6",
     "https://bcr.bazel.build/modules/rules_java/4.0.0/MODULE.bazel": "5a78a7ae82cd1a33cef56dc578c7d2a46ed0dca12643ee45edbb8417899e6f74",
     "https://bcr.bazel.build/modules/rules_java/5.3.5/MODULE.bazel": "a4ec4f2db570171e3e5eb753276ee4b389bae16b96207e9d3230895c99644b86",
     "https://bcr.bazel.build/modules/rules_java/6.5.2/MODULE.bazel": "1d440d262d0e08453fa0c4d8f699ba81609ed0e9a9a0f02cd10b3e7942e61e31",
@@ -217,7 +217,6 @@
     "https://bcr.bazel.build/modules/rules_proto/4.0.0/MODULE.bazel": "a7a7b6ce9bee418c1a760b3d84f83a299ad6952f9903c67f19e4edd964894e06",
     "https://bcr.bazel.build/modules/rules_proto/5.3.0-21.7/MODULE.bazel": "e8dff86b0971688790ae75528fe1813f71809b5afd57facb44dad9e8eca631b7",
     "https://bcr.bazel.build/modules/rules_proto/6.0.0-rc1/MODULE.bazel": "1e5b502e2e1a9e825eef74476a5a1ee524a92297085015a052510b09a1a09483",
-    "https://bcr.bazel.build/modules/rules_proto/6.0.0/MODULE.bazel": "b531d7f09f58dce456cd61b4579ce8c86b38544da75184eadaf0a7cb7966453f",
     "https://bcr.bazel.build/modules/rules_proto/6.0.2/MODULE.bazel": "ce916b775a62b90b61888052a416ccdda405212b6aaeb39522f7dc53431a5e73",
     "https://bcr.bazel.build/modules/rules_proto/7.0.2/MODULE.bazel": "bf81793bd6d2ad89a37a40693e56c61b0ee30f7a7fdbaf3eabbf5f39de47dea2",
     "https://bcr.bazel.build/modules/rules_proto/7.1.0/MODULE.bazel": "002d62d9108f75bb807cd56245d45648f38275cb3a99dcd45dfb864c5d74cb96",
@@ -237,8 +236,8 @@
     "https://bcr.bazel.build/modules/rules_python/1.7.0/source.json": "028a084b65dcf8f4dc4f82f8778dbe65df133f234b316828a82e060d81bdce32",
     "https://bcr.bazel.build/modules/rules_qemu/0.3.0/MODULE.bazel": "2ddd5524b5a8eeee5fb4049018e99111232206c9c37e2cd063a78190cc18f94f",
     "https://bcr.bazel.build/modules/rules_qemu/0.3.0/source.json": "40443bb588205be9bb19455d576579a916f72d3faf5704c9934808581a21da18",
-    "https://bcr.bazel.build/modules/rules_rs/0.0.93/MODULE.bazel": "f7e7525037bd27967a4cfbe7c2fd5ecc780b190f3a48637fe399e114f4d09622",
-    "https://bcr.bazel.build/modules/rules_rs/0.0.93/source.json": "7edc3e1f220a7766865609d17fd0e6f927b9897ef98c5f5f58c3027c2606cfbd",
+    "https://bcr.bazel.build/modules/rules_rs/0.0.98/MODULE.bazel": "f9fd17e0330506efb3c1bf9aa9352fc81013e6d9af9521ccd5a5b3ce3bb81ffa",
+    "https://bcr.bazel.build/modules/rules_rs/0.0.98/source.json": "f8e639ec93ce46084d52466cec576bb67bdbedf42274ed88ca5993078d92fe7a",
     "https://bcr.bazel.build/modules/rules_shell/0.2.0/MODULE.bazel": "fda8a652ab3c7d8fee214de05e7a9916d8b28082234e8d2c0094505c5268ed3c",
     "https://bcr.bazel.build/modules/rules_shell/0.3.0/MODULE.bazel": "de4402cd12f4cc8fda2354fce179fdb068c0b9ca1ec2d2b17b3e21b24c1a937b",
     "https://bcr.bazel.build/modules/rules_shell/0.4.1/MODULE.bazel": "00e501db01bbf4e3e1dd1595959092c2fadf2087b2852d3f553b5370f5633592",
@@ -257,7 +256,6 @@
     "https://bcr.bazel.build/modules/swift_argument_parser/1.3.1.2/MODULE.bazel": "75aab2373a4bbe2a1260b9bf2a1ebbdbf872d3bd36f80bff058dccd82e89422f",
     "https://bcr.bazel.build/modules/tar.bzl/0.10.4/MODULE.bazel": "e8f9ff79199e8d9eaad7f1b0a77ad74b30bb82d794b87d8ca942bead5de83ae9",
     "https://bcr.bazel.build/modules/tar.bzl/0.10.4/source.json": "20143442376c03426f6135292ba02d825cb75308aa47e6bf42dd4cc5a435c2ff",
-    "https://bcr.bazel.build/modules/tar.bzl/0.9.0/MODULE.bazel": "452a22d7f02b1c9d7a22ab25edf20f46f3e1101f0f67dc4bfbf9a474ddf02445",
     "https://bcr.bazel.build/modules/upb/0.0.0-20220923-a547704/MODULE.bazel": "7298990c00040a0e2f121f6c32544bab27d4452f80d9ce51349b1a28f3005c43",
     "https://bcr.bazel.build/modules/with_cfg.bzl/0.12.0/MODULE.bazel": "b573395fe63aef4299ba095173e2f62ccfee5ad9bbf7acaa95dba73af9fc2b38",
     "https://bcr.bazel.build/modules/with_cfg.bzl/0.14.6/MODULE.bazel": "6b6c543e415d2a502954766e50c6a6144a131687f2751b62157a9250e2b04982",
@@ -276,7 +274,7 @@
     "@@aspect_tools_telemetry+//:extension.bzl%telemetry": {
       "general": {
         "bzlTransitiveDigest": "cl5A2O84vDL6Tt+Qga8FCj1DUDGqn+e7ly5rZ+4xvcc=",
-        "usagesDigest": "HTyqOSJVnMu2K3Z0Av//uKNmEOAilOhnN/IEdkaeaJE=",
+        "usagesDigest": "thB5TswUhz1qnY0LcGOE3geqHuGYrGAyYCkQg0r9p6w=",
         "recordedInputs": [
           "REPO_MAPPING:aspect_tools_telemetry+,bazel_lib bazel_lib+",
           "REPO_MAPPING:aspect_tools_telemetry+,bazel_skylib bazel_skylib+"
@@ -286,9 +284,55 @@
             "repoRuleId": "@@aspect_tools_telemetry+//:extension.bzl%tel_repository",
             "attributes": {
               "deps": {
-                "rules_rs": "0.0.93",
+                "rules_rs": "0.0.98",
                 "aspect_tools_telemetry": "0.3.3"
               }
+            }
+          }
+        }
+      }
+    },
+    "@@linux.bzl+//:extensions.bzl%linux_images": {
+      "general": {
+        "bzlTransitiveDigest": "2wze+p/HlP8MYa3yH/96l4VDlJZ3yM5F6BV1T8Ajkr0=",
+        "usagesDigest": "ndu7PCaHoNa+kqjx9C+0FfjiHP3AmgWB+AQKeNgECp0=",
+        "recordedInputs": [
+          "REPO_MAPPING:,aya_linux_6_18_2 +linux_source_repository+aya_linux_6_18_2",
+          "REPO_MAPPING:,llvm llvm+"
+        ],
+        "generatedRepoSpecs": {
+          "aya_aarch64_kernel__linux_graph": {
+            "repoRuleId": "@@linux.bzl+//internal:linux_image_repository.bzl%linux_image",
+            "attributes": {
+              "config": "@@//test/kernel:aya_aarch64.config",
+              "config_mode": "allnoconfig",
+              "overlays": {},
+              "platform": "@@llvm+//platforms:linux_arm64",
+              "source": "@@+linux_source_repository+aya_linux_6_18_2//:Kconfig"
+            }
+          },
+          "aya_aarch64_kernel": {
+            "repoRuleId": "@@linux.bzl+//internal:linux_image_extension.bzl%_linux_image_facade_repository",
+            "attributes": {
+              "graph_repo": "aya_aarch64_kernel__linux_graph",
+              "variants": []
+            }
+          },
+          "aya_x86_64_kernel__linux_graph": {
+            "repoRuleId": "@@linux.bzl+//internal:linux_image_repository.bzl%linux_image",
+            "attributes": {
+              "config": "@@//test/kernel:aya_x86_64.config",
+              "config_mode": "allnoconfig",
+              "overlays": {},
+              "platform": "@@llvm+//platforms:linux_x86_64",
+              "source": "@@+linux_source_repository+aya_linux_6_18_2//:Kconfig"
+            }
+          },
+          "aya_x86_64_kernel": {
+            "repoRuleId": "@@linux.bzl+//internal:linux_image_extension.bzl%_linux_image_facade_repository",
+            "attributes": {
+              "graph_repo": "aya_x86_64_kernel__linux_graph",
+              "variants": []
             }
           }
         }
@@ -1274,6 +1318,7 @@
       "2026-06-24/rust-std-nightly-powerpc64-unknown-linux-gnu.tar.xz": "8564496cf407b7246d8fbbdc1a7d23161a1d5864eea1c1986506ccb96a09519e",
       "2026-06-24/rust-std-nightly-powerpc64le-unknown-linux-gnu.tar.xz": "bf9b3cfd0ce4e50d16022db10e934275320d212412abaf670f40e57e3a94f04f",
       "2026-06-24/rust-std-nightly-powerpc64le-unknown-linux-musl.tar.xz": "74f4f122fba55440c4f9024e6d3766f77117c775ff65fb8eecd023f46389f330",
+      "2026-06-24/rust-std-nightly-riscv32imac-unknown-none-elf.tar.xz": "813bab1669870100dd46743feb37ed88172b6379c42d10bd48da9f1ca6cd4c1f",
       "2026-06-24/rust-std-nightly-riscv32imc-unknown-none-elf.tar.xz": "6a2aec1536c454db8fe5cd850b4b17510805b7f3ee6e67e454755a07a6dbfe2f",
       "2026-06-24/rust-std-nightly-riscv64gc-unknown-linux-gnu.tar.xz": "4b834089211897ca18a2314d943805c2835ff34916b7eb8f00959af6ff5a73e6",
       "2026-06-24/rust-std-nightly-riscv64gc-unknown-linux-musl.tar.xz": "bcee5be92ce25426aae7f05675303e215276a7d5c3541fcd54f38e2b67a470fc",

--- a/test/integration-test/BUILD.bazel
+++ b/test/integration-test/BUILD.bazel
@@ -1,5 +1,5 @@
 load("@bazel_lib//lib:copy_to_directory.bzl", "copy_to_directory")
-load("@linux.bzl//:linux.bzl", "initramfs")
+load("@linux.bzl", "initramfs")
 load("//bazel:bpf.bzl", "aya_c_bpf_objects")
 load("//bazel:rust.bzl", "aya_rust_crate")
 load("//bazel:vm.bzl", "aya_qemu_vm_test")

--- a/test/kernel/BUILD.bazel
+++ b/test/kernel/BUILD.bazel
@@ -1,5 +1,3 @@
-load("@linux.bzl//:linux.bzl", "linux")
-
 package(default_visibility = ["//visibility:public"])
 
 exports_files([
@@ -7,40 +5,26 @@ exports_files([
     "aya_x86_64.config",
 ])
 
-# linux.bzl encodes pahole 1.31 as "131". Keep this synchronized with
-# bazel_dep(name = "pahole", version = "1.31") in MODULE.bazel.
-_PAHOLE_VERSION = "131"
-
-# MODULE.bazel declares this integrity-pinned Linux 6.18.2 repository.
-_LINUX_SOURCE_REPOSITORY = "@aya_linux_6_18_2"
-
-linux(
+alias(
     name = "aya_kernel",
-    compact_repos = {
-        "aarch64": "@aya_aarch64_compact",
-        "x86_64": "@aya_x86_64_compact",
-    },
-    config = {
-        "aarch64": "@aya_aarch64_kconfig//:kconfig",
-        "x86_64": "@aya_x86_64_kconfig//:kconfig",
-    },
-    config_mode = "allnoconfig",
-    pahole = "@pahole//:pahole",
-    probe_values = {"pahole_version": _PAHOLE_VERSION},
-    source_repo = _LINUX_SOURCE_REPOSITORY,
-)
-
-filegroup(
-    name = "aya_kernel_config",
-    srcs = select({
-        "@platforms//cpu:aarch64": [":aya_kernel_aarch64_config"],
-        "@platforms//cpu:x86_64": [":aya_kernel_x86_64_config"],
+    actual = select({
+        "@platforms//cpu:aarch64": "@aya_aarch64_kernel//:kernel",
+        "@platforms//cpu:x86_64": "@aya_x86_64_kernel//:kernel",
     }),
-    output_group = "config",
 )
 
-filegroup(
+alias(
+    name = "aya_kernel_config",
+    actual = select({
+        "@platforms//cpu:aarch64": "@aya_aarch64_kernel//:config",
+        "@platforms//cpu:x86_64": "@aya_x86_64_kernel//:config",
+    }),
+)
+
+alias(
     name = "aya_kernel_system_map",
-    srcs = [":aya_kernel.vm_linux"],
-    output_group = "system_map",
+    actual = select({
+        "@platforms//cpu:aarch64": "@aya_aarch64_kernel//:system_map",
+        "@platforms//cpu:x86_64": "@aya_x86_64_kernel//:system_map",
+    }),
 )

--- a/test/kernel/README.md
+++ b/test/kernel/README.md
@@ -3,7 +3,7 @@
 `aya_aarch64.config` and `aya_x86_64.config` are KCONFIG_ALLCONFIG request
 fragments for the Linux 6.18.2 integration VM kernels declared in
 `MODULE.bazel`. `linux.bzl` resolves each fragment from `allnoconfig` with the
-integrity-pinned Linux source archive and `pahole_version = "131"`.
+integrity-pinned Linux source archive.
 
 The fragments contain requested values, not complete Linux `.config` files.
 Linux Kconfig adds defaults and values derived through dependencies, `select`,
@@ -17,23 +17,15 @@ From the repository root, resolve the aarch64 fragment with:
 
 ```console
 $ bazel build --lockfile_mode=error \
-    --platforms=@rules_rs//rs/platforms:aarch64-unknown-linux-musl \
-    //test/kernel:aya_kernel_aarch64_config
+    @aya_aarch64_kernel//:config
 ```
-
-The resolved configuration is
-`bazel-bin/test/kernel/aya_kernel_aarch64_config.config_tree/.config`.
 
 Resolve the x86_64 fragment with:
 
 ```console
 $ bazel build --lockfile_mode=error \
-    --platforms=@rules_rs//rs/platforms:x86_64-unknown-linux-musl \
-    //test/kernel:aya_kernel_x86_64_config
+    @aya_x86_64_kernel//:config
 ```
-
-The resolved configuration is
-`bazel-bin/test/kernel/aya_kernel_x86_64_config.config_tree/.config`.
 
 After changing either fragment, rebuild both resolved configurations and run:
 


### PR DESCRIPTION
Migrate Aya's Bazel integration kernels to the released linux.bzl v0.0.1
`linux_source_repository` and `linux_images` APIs.

## Changes

- replace the removed `linux_kernel` extension and `linux()` macro
- preserve Aya's kernel, config, and System.map aliases through generated image
  facade repositories
- let linux.bzl own Kconfig/Kbuild evaluation and `pahole` wiring, removing
  Aya's direct `pahole` dependency and manual probe value
- consume the deterministic [linux.bzl v0.0.1 release asset](https://github.com/hermeticbuild/linux.bzl/releases/tag/v0.0.1)
  while Bazel Central Registry publication is pending
- update LLVM, rules_cc, and rules_rs to the versions selected by linux.bzl
- retain the Bazel 9.1.1-generated module lock

The API migration follows
[hermeticbuild/linux.bzl#36](https://github.com/hermeticbuild/linux.bzl/pull/36);
`pahole` ownership is covered by
[hermeticbuild/linux.bzl#10](https://github.com/hermeticbuild/linux.bzl/pull/10).
Aya's workflow and Bazel invocation remain unchanged. The branch is one commit
on current Aya `main`. Rust-for-Linux fixture coverage remains in the merged
[hermeticbuild/linux.bzl#38](https://github.com/hermeticbuild/linux.bzl/pull/38).

### Validation

- `bazel mod deps --lockfile_mode=error`
- both generated kernel config targets build with strict lock mode
- action-graph inspection confirms `LinuxBTFEncode` executes linux.bzl's
  transitive `pahole` binary
- full `bazel test //... --config=remote --lockfile_mode=error`:
  [23/23 tests passed](https://app.buildbuddy.io/invocation/6affec9a-848e-42ac-9ebb-7ddb17da8a44),
  including both VM tests
- refreshed [Aya GitHub Actions run](https://github.com/aya-rs/aya/actions/runs/30678873921)
  passed all 21 jobs

### Added/updated tests?

- [x] Existing Aya VM coverage is retained unchanged
- [x] Fixture-specific Rust module coverage lives in merged
  hermeticbuild/linux.bzl#38

### Checklist

- [x] The branch is rebased onto current Aya `main` as one commit.
- [x] The module lock passes strict mode.
- [x] The refreshed Aya GitHub CI run passed.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aya-rs/aya/1646)
<!-- Reviewable:end -->