### PR TITLE
feat(aya-tool): Extract the integration test runner from xtask

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -227,10 +227,19 @@ name = "aya-tool"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "ar",
+ "aya-multierror",
  "bindgen",
+ "cargo_metadata",
  "clap",
+ "nix",
+ "tar",
  "tempfile",
  "thiserror",
+ "ureq",
+ "walkdir",
+ "xz2",
+ "zstd",
 ]
 
 [[package]]
@@ -2210,7 +2219,6 @@ name = "xtask"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "ar",
  "aya-multierror",
  "aya-tool",
  "cargo_metadata",
@@ -2218,19 +2226,13 @@ dependencies = [
  "dialoguer",
  "diff",
  "indoc",
- "nix",
  "proc-macro2",
  "public-api",
  "quote",
  "rustdoc-json",
  "rustup-toolchain",
  "syn 3.0.3",
- "tar",
  "tempfile",
- "ureq",
- "walkdir",
- "xz2",
- "zstd",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -207,6 +207,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "aya-multierror"
+version = "0.1.0"
+
+[[package]]
 name = "aya-obj"
 version = "0.3.0"
 dependencies = [
@@ -1580,6 +1584,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "assert_matches",
+ "aya-multierror",
  "clap",
  "glob",
  "nix",
@@ -2206,6 +2211,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "ar",
+ "aya-multierror",
  "aya-tool",
  "cargo_metadata",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -207,6 +207,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "aya-multierror"
+version = "0.1.0"
+
+[[package]]
 name = "aya-obj"
 version = "0.3.0"
 dependencies = [
@@ -1581,6 +1585,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "assert_matches",
+ "aya-multierror",
  "clap",
  "glob",
  "nix",
@@ -2207,6 +2212,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "ar",
+ "aya-multierror",
  "aya-tool",
  "cargo_metadata",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -228,10 +228,19 @@ name = "aya-tool"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "ar",
+ "aya-multierror",
  "bindgen",
+ "cargo_metadata",
  "clap",
+ "nix",
+ "tar",
  "tempfile",
  "thiserror",
+ "ureq",
+ "walkdir",
+ "xz2",
+ "zstd",
 ]
 
 [[package]]
@@ -2211,7 +2220,6 @@ name = "xtask"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "ar",
  "aya-multierror",
  "aya-tool",
  "cargo_metadata",
@@ -2219,19 +2227,13 @@ dependencies = [
  "dialoguer",
  "diff",
  "indoc",
- "nix",
  "proc-macro2",
  "public-api",
  "quote",
  "rustdoc-json",
  "rustup-toolchain",
  "syn 3.0.3",
- "tar",
  "tempfile",
- "ureq",
- "walkdir",
- "xz2",
- "zstd",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
     "aya-log",
     "aya-log-common",
     "aya-log-parser",
+    "aya-multierror",
     "aya-obj",
     "aya-tool",
     "ebpf-panic",

--- a/aya-multierror/BUILD.bazel
+++ b/aya-multierror/BUILD.bazel
@@ -1,0 +1,5 @@
+load("//bazel:rust.bzl", "aya_rust_crate")
+
+aya_rust_crate(
+    name = "aya-multierror",
+)

--- a/aya-multierror/Cargo.toml
+++ b/aya-multierror/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+description = "Aggregate multiple errors with Display formatting"
+name = "aya-multierror"
+version = "0.1.0"
+
+authors.workspace = true
+edition.workspace = true
+homepage.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+
+[lints]
+workspace = true
+
+[dependencies]

--- a/aya-multierror/Cargo.toml
+++ b/aya-multierror/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "aya-multierror"
+version = "0.1.0"
+edition = "2021"
+description = "Aggregate multiple errors with Display formatting"
+
+[dependencies]

--- a/aya-multierror/src/lib.rs
+++ b/aya-multierror/src/lib.rs
@@ -1,0 +1,30 @@
+#[derive(Debug)]
+pub struct Errors<E>(Vec<E>);
+
+impl<E> Errors<E> {
+    pub const fn new(errors: Vec<E>) -> Self {
+        Self(errors)
+    }
+}
+
+impl<E> std::fmt::Display for Errors<E>
+where
+    E: std::fmt::Debug,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let Self(errors) = self;
+        for (i, error) in errors.iter().enumerate() {
+            if i != 0 {
+                writeln!(f)?;
+            }
+            #[expect(
+                clippy::use_debug,
+                reason = "<anyhow::Error as Display> does not show backtrace"
+            )]
+            write!(f, "{error:?}")?;
+        }
+        Ok(())
+    }
+}
+
+impl<E> std::error::Error for Errors<E> where E: std::fmt::Debug {}

--- a/aya-tool/Cargo.toml
+++ b/aya-tool/Cargo.toml
@@ -16,7 +16,16 @@ workspace = true
 
 [dependencies]
 anyhow = { workspace = true, default-features = true }
+ar = { workspace = true }
+aya-multierror = { path = "../aya-multierror", version = "0.1.0", default-features = false }
 bindgen = { workspace = true, default-features = true }
+cargo_metadata = { workspace = true }
 clap = { workspace = true, default-features = true, features = ["derive"] }
+nix = { workspace = true, features = ["fs"] }
+tar = { workspace = true }
 tempfile = { workspace = true }
 thiserror = { workspace = true }
+ureq = { workspace = true, default-features = false, features = ["rustls"] }
+walkdir = { workspace = true }
+xz2 = { workspace = true }
+zstd = { workspace = true }

--- a/aya-tool/src/bin/aya-tool.rs
+++ b/aya-tool/src/bin/aya-tool.rs
@@ -25,26 +25,32 @@ enum Command {
         #[clap(last = true, action)]
         bindgen_args: Vec<String>,
     },
+    /// Run integration tests
+    #[clap(name = "integration-test")]
+    IntegrationTest(aya_tool::integration_test::Options),
 }
 
 fn main() -> Result<(), anyhow::Error> {
     use std::io::Write as _;
 
     let Options { command } = Parser::parse();
-    let bindings = match command {
+    match command {
         Command::Generate {
             btf,
             header,
             names,
             bindgen_args,
         } => {
-            if let Some(header) = header {
+            let bindings = if let Some(header) = header {
                 generate(InputFile::Header(header), &names, &bindgen_args)
             } else {
                 generate(InputFile::Btf(btf), &names, &bindgen_args)
-            }
+            }?;
+            std::io::stdout().write_all(bindings.as_bytes())?;
         }
-    }?;
-    std::io::stdout().write_all(bindings.as_bytes())?;
+        Command::IntegrationTest(opts) => {
+            aya_tool::integration_test::run(opts)?;
+        }
+    }
     Ok(())
 }

--- a/aya-tool/src/integration_test/http.rs
+++ b/aya-tool/src/integration_test/http.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::print_stdout, reason = "xtask is a CLI tool")]
+#![allow(clippy::print_stdout, reason = "aya-tool is a CLI tool")]
 #![allow(clippy::use_debug, reason = "debug output aids troubleshooting")]
 
 use std::{
@@ -12,7 +12,7 @@ use std::{
 use anyhow::{Context as _, Result, anyhow, bail};
 use ureq::http::StatusCode;
 
-const USER_AGENT: &str = "aya-xtask";
+const USER_AGENT: &str = "aya-aya-tool";
 
 pub(crate) struct HttpClient {
     agent: ureq::Agent,

--- a/aya-tool/src/integration_test/mod.rs
+++ b/aya-tool/src/integration_test/mod.rs
@@ -1,0 +1,5 @@
+mod http;
+mod run;
+mod ubuntu_mainline;
+
+pub use run::{Options, run};

--- a/aya-tool/src/integration_test/run.rs
+++ b/aya-tool/src/integration_test/run.rs
@@ -1,5 +1,5 @@
-#![allow(clippy::print_stdout, reason = "xtask is a CLI tool")]
-#![allow(clippy::print_stderr, reason = "xtask is a CLI tool")]
+#![allow(clippy::print_stdout, reason = "aya-tool is a CLI tool")]
+#![allow(clippy::print_stderr, reason = "aya-tool is a CLI tool")]
 #![allow(clippy::use_debug, reason = "debug output aids troubleshooting")]
 
 use std::{
@@ -16,20 +16,21 @@ use std::{
     time::{SystemTime, UNIX_EPOCH},
 };
 
-use anyhow::{Context as _, Result, anyhow, bail};
+use anyhow::{anyhow, bail, Context as _, Result};
 use aya_multierror::Errors;
 use cargo_metadata::{Artifact, CompilerMessage, Message, Target};
 use clap::Parser;
 use nix::sys::stat::{Mode, SFlag};
 use walkdir::WalkDir;
-use xtask::AYA_BUILD_INTEGRATION_BPF;
 
-use crate::{
+use crate::integration_test::{
     http::HttpClient,
     ubuntu_mainline::{
-        KernelArchitecture, KernelPackage, download_ubuntu_mainline_kernel_packages,
+        download_ubuntu_mainline_kernel_packages, KernelArchitecture, KernelPackage,
     },
 };
+
+const AYA_BUILD_INTEGRATION_BPF: &str = "AYA_BUILD_INTEGRATION_BPF";
 
 struct GitHubLogGroup;
 
@@ -77,7 +78,7 @@ enum Environment {
 const INTEGRATION_TEST_PACKAGE: &str = "integration-test";
 
 #[derive(Parser)]
-pub(crate) struct Options {
+pub struct Options {
     #[clap(subcommand)]
     environment: Environment,
 
@@ -331,7 +332,7 @@ impl<W: Write> CpioArchiveBuilder<W> {
 }
 
 /// Build and run the project.
-pub(crate) fn run(opts: Options) -> Result<()> {
+pub fn run(opts: Options) -> Result<()> {
     let Options {
         environment,
         package,

--- a/aya-tool/src/integration_test/ubuntu_mainline.rs
+++ b/aya-tool/src/integration_test/ubuntu_mainline.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::print_stdout, reason = "xtask is a CLI tool")]
+#![allow(clippy::print_stdout, reason = "aya-tool is a CLI tool")]
 #![allow(clippy::use_debug, reason = "debug output aids troubleshooting")]
 
 use std::{
@@ -15,7 +15,7 @@ use std::{
 use anyhow::{Context as _, Result, anyhow, bail};
 use clap::ValueEnum;
 
-use crate::http::{HttpClient, url_file_name};
+use crate::integration_test::http::{HttpClient, url_file_name};
 
 // Ubuntu documents the Mainline archive as per-tag release directories
 // containing generic/lowlatency kernel .deb packages.

--- a/aya-tool/src/lib.rs
+++ b/aya-tool/src/lib.rs
@@ -1,4 +1,3 @@
-#![expect(unused_crate_dependencies, reason = "used in bin")]
-
 pub mod bindgen;
 pub mod generate;
+pub mod integration_test;

--- a/test-distro/Cargo.toml
+++ b/test-distro/Cargo.toml
@@ -24,6 +24,7 @@ path = "src/depmod.rs"
 [dependencies]
 anyhow = { workspace = true, features = ["std"] }
 assert_matches = { workspace = true }
+aya-multierror = { path = "../aya-multierror", version = "0.1.0" }
 clap = { workspace = true, default-features = true, features = ["derive"] }
 glob = { workspace = true }
 nix = { workspace = true, features = [

--- a/test-distro/src/init.rs
+++ b/test-distro/src/init.rs
@@ -4,24 +4,7 @@
 //! in /bin, prints a final message ("init: success|failure"), and powers off the machine.
 
 use anyhow::Context as _;
-
-#[derive(Debug)]
-struct Errors(Vec<anyhow::Error>);
-
-impl std::fmt::Display for Errors {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let Self(errors) = self;
-        for (i, error) in errors.iter().enumerate() {
-            if i != 0 {
-                writeln!(f)?;
-            }
-            write!(f, "{error:?}")?;
-        }
-        Ok(())
-    }
-}
-
-impl std::error::Error for Errors {}
+use aya_multierror::Errors;
 
 fn run() -> anyhow::Result<()> {
     const RXRXRX: nix::sys::stat::Mode = nix::sys::stat::Mode::empty()
@@ -185,7 +168,7 @@ fn run() -> anyhow::Result<()> {
     if errors.is_empty() {
         Ok(())
     } else {
-        Err(Errors(errors).into())
+        Err(Errors::new(errors).into())
     }
 }
 

--- a/test/integration-test/build.rs
+++ b/test/integration-test/build.rs
@@ -31,6 +31,65 @@ use xtask::{AYA_BUILD_INTEGRATION_BPF, LIBBPF_DIR, exec, install_libbpf_headers_
 fn main() -> Result<()> {
     println!("cargo:rerun-if-env-changed={AYA_BUILD_INTEGRATION_BPF}");
 
+    // libbpf-sys cross-compilation workarounds:
+    // - ac_cv_search_* variables skip autoconf checks
+    // - linux-libc-dev provides kernel UAPI headers (installed in CI)
+    // - CFLAGS adds ci/headers for elfutils
+    //
+    // See https://github.com/libbpf/libbpf-sys/issues/137.
+    for name in [
+        "ac_cv_search_argp_parse",
+        "ac_cv_search__obstack_free",
+        "ac_cv_search_gzdirect",
+        "ac_cv_search_fts_close",
+    ] {
+        println!("cargo:rustc-env={name}=none required");
+    }
+
+    const CFLAGS: &str = "CFLAGS";
+    {
+        let headers = env::var("CARGO_MANIFEST_DIR")
+            .map(PathBuf::from)
+            .unwrap()
+            .join("../../../ci/headers");
+        let mut cflags = OsString::new();
+        cflags.push("-I");
+        cflags.push(&headers);
+        if let Some(existing) = env::var_os(CFLAGS) {
+            cflags.push(" ");
+            cflags.push(existing);
+        }
+        println!("cargo:rustc-env={CFLAGS}={}", cflags.to_string_lossy());
+    }
+
+    if cfg!(target_os = "macos") {
+        // Add make wrapper that overrides AR/RANLIB for zlib cross build.
+        const PATH: &str = "PATH";
+        {
+            let bin_dir = env::var("CARGO_MANIFEST_DIR")
+                .map(PathBuf::from)
+                .unwrap()
+                .join("../../../ci/bin");
+            let mut path = OsString::new();
+            path.push(&bin_dir);
+            if let Some(existing) = env::var_os(PATH) {
+                path.push(":");
+                path.push(existing);
+            }
+            println!("cargo:rustc-env={PATH}={}", path.to_string_lossy());
+        }
+
+        for (key, value) in [
+            ("AR_x86_64_unknown_linux_musl", "x86_64-linux-musl-ar"),
+            (
+                "RANLIB_x86_64_unknown_linux_musl",
+                "x86_64-linux-musl-ranlib",
+            ),
+        ] {
+            println!("cargo:rustc-env={key}={value}");
+        }
+    }
+
     // TODO(https://github.com/rust-lang/cargo/issues/4001): generalize this and move it to
     // aya-build if we can determine that we're in a check build.
     let build_integration_bpf = env::var_os(AYA_BUILD_INTEGRATION_BPF)

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -15,7 +15,6 @@ workspace = true
 
 [dependencies]
 anyhow = { workspace = true, features = ["std"] }
-ar = { workspace = true }
 aya-multierror = { path = "../aya-multierror", version = "0.1.0", default-features = false }
 aya-tool = { path = "../aya-tool", version = "0.1.0", default-features = false }
 cargo_metadata = { workspace = true }
@@ -23,16 +22,10 @@ clap = { workspace = true, features = ["derive"] }
 dialoguer = { workspace = true }
 diff = { workspace = true }
 indoc = { workspace = true }
-nix = { workspace = true, features = ["fs"] }
 proc-macro2 = { workspace = true }
 public-api = { workspace = true }
 quote = { workspace = true }
 rustdoc-json = { workspace = true }
 rustup-toolchain = { workspace = true }
 syn = { workspace = true, features = ["full", "parsing", "printing"] }
-tar = { workspace = true }
 tempfile = { workspace = true }
-ureq = { workspace = true }
-walkdir = { workspace = true }
-xz2 = { workspace = true }
-zstd = { workspace = true }

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -16,6 +16,7 @@ workspace = true
 [dependencies]
 anyhow = { workspace = true, features = ["std"] }
 ar = { workspace = true }
+aya-multierror = { path = "../aya-multierror", version = "0.1.0", default-features = false }
 aya-tool = { path = "../aya-tool", version = "0.1.0", default-features = false }
 cargo_metadata = { workspace = true }
 clap = { workspace = true, features = ["derive"] }

--- a/xtask/src/clippy.rs
+++ b/xtask/src/clippy.rs
@@ -1,8 +1,8 @@
-use std::{ffi::OsString, path::Path, process::Command};
+use std::{ffi::OsString, process::Command};
 
 use anyhow::Result;
 use clap::Parser;
-use xtask::{exec, libbpf_sys_env};
+use xtask::exec;
 
 #[derive(Parser)]
 pub(crate) struct Options {
@@ -10,7 +10,7 @@ pub(crate) struct Options {
     args: Vec<OsString>,
 }
 
-pub(crate) fn run(opts: Options, workspace_root: &Path) -> Result<()> {
+pub(crate) fn run(opts: Options) -> Result<()> {
     let Options { args } = opts;
 
     // `-C panic=abort` because "unwinding panics are not supported without
@@ -37,7 +37,6 @@ pub(crate) fn run(opts: Options, workspace_root: &Path) -> Result<()> {
         "panic=abort",
         "-Zpanic_abort_tests",
     ]);
-    libbpf_sys_env(workspace_root, &mut cmd);
     exec(&mut cmd)?;
 
     let base_rustdocflags = "--no-run -Z unstable-options --test-builder clippy-driver";
@@ -45,7 +44,6 @@ pub(crate) fn run(opts: Options, workspace_root: &Path) -> Result<()> {
     cmd.args(["+nightly", "hack", "test", "--doc"]);
     cmd.args(&args);
     cmd.args(["--feature-powerset"]);
-    libbpf_sys_env(workspace_root, &mut cmd);
     cmd.env("CLIPPY_ARGS", "--deny=warnings");
     cmd.env("RUSTDOCFLAGS", base_rustdocflags);
     exec(&mut cmd)?;
@@ -85,7 +83,6 @@ pub(crate) fn run(opts: Options, workspace_root: &Path) -> Result<()> {
                 cmd.args(["--package", package]);
             }
             cmd.args(["--", "--deny", "warnings"]);
-            libbpf_sys_env(workspace_root, &mut cmd);
             cmd.env("CLIPPY_ARGS", "--deny=warnings");
             cmd.env("RUSTFLAGS", &rustflags);
             exec(&mut cmd)?;
@@ -97,7 +94,6 @@ pub(crate) fn run(opts: Options, workspace_root: &Path) -> Result<()> {
         for package in ebpf_packages {
             cmd.args(["--package", package]);
         }
-        libbpf_sys_env(workspace_root, &mut cmd);
         cmd.env("CLIPPY_ARGS", "--deny=warnings");
         cmd.env("RUSTFLAGS", &rustflags);
         cmd.env("RUSTDOCFLAGS", format!("{base_rustdocflags} {rustflags}"));

--- a/xtask/src/lib.rs
+++ b/xtask/src/lib.rs
@@ -1,6 +1,6 @@
 #![expect(unused_crate_dependencies, reason = "used in bin")]
 
-use std::{env, ffi::OsString, path::Path, process::Command};
+use std::{ffi::OsString, path::Path, process::Command};
 
 use anyhow::{Context as _, Result, bail};
 
@@ -15,60 +15,6 @@ pub fn exec(cmd: &mut Command) -> Result<()> {
         bail!("{cmd:?} failed: {status:?}")
     }
     Ok(())
-}
-
-// libbpf-sys cross-compilation workarounds:
-// - ac_cv_search_* variables skip autoconf checks
-// - linux-libc-dev provides kernel UAPI headers (installed in CI)
-// - CFLAGS adds ci/headers for elfutils
-//
-// See https://github.com/libbpf/libbpf-sys/issues/137.
-pub fn libbpf_sys_env(workspace_root: &Path, cmd: &mut Command) {
-    for name in [
-        "ac_cv_search_argp_parse",
-        "ac_cv_search__obstack_free",
-        "ac_cv_search_gzdirect",
-        "ac_cv_search_fts_close",
-    ] {
-        cmd.env(name, "none required");
-    }
-
-    const CFLAGS: &str = "CFLAGS";
-    cmd.env(CFLAGS, {
-        let headers = workspace_root.join("ci").join("headers");
-        let mut cflags = OsString::new();
-        cflags.push("-I");
-        cflags.push(headers.as_os_str());
-        if let Some(existing) = env::var_os(CFLAGS) {
-            cflags.push(" ");
-            cflags.push(existing);
-        }
-        cflags
-    });
-
-    if cfg!(target_os = "macos") {
-        // Add make wrapper that overrides AR/RANLIB for zlib cross build.
-        const PATH: &str = "PATH";
-        cmd.env(PATH, {
-            let mut path = OsString::new();
-            path.push(workspace_root.join("ci").join("bin"));
-            if let Some(existing) = env::var_os(PATH) {
-                path.push(":");
-                path.push(existing);
-            }
-            path
-        });
-
-        for (key, value) in [
-            ("AR_x86_64_unknown_linux_musl", "x86_64-linux-musl-ar"),
-            (
-                "RANLIB_x86_64_unknown_linux_musl",
-                "x86_64-linux-musl-ranlib",
-            ),
-        ] {
-            cmd.env(key, value);
-        }
-    }
 }
 
 /// Returns a [`Command`] that Installs the libbpf headers files from the `source_dir` to the

--- a/xtask/src/lib.rs
+++ b/xtask/src/lib.rs
@@ -34,34 +34,3 @@ pub fn install_libbpf_headers_cmd(
         .arg("install_headers");
     cmd
 }
-
-#[derive(Debug)]
-pub struct Errors<E>(Vec<E>);
-
-impl<E> Errors<E> {
-    pub const fn new(errors: Vec<E>) -> Self {
-        Self(errors)
-    }
-}
-
-impl<E> std::fmt::Display for Errors<E>
-where
-    E: std::fmt::Debug,
-{
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let Self(errors) = self;
-        for (i, error) in errors.iter().enumerate() {
-            if i != 0 {
-                writeln!(f)?;
-            }
-            #[expect(
-                clippy::use_debug,
-                reason = "<anyhow::Error as Display> does not show backtrace"
-            )]
-            write!(f, "{error:?}")?;
-        }
-        Ok(())
-    }
-}
-
-impl<E> std::error::Error for Errors<E> where E: std::fmt::Debug {}

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1,10 +1,7 @@
 mod clippy;
 mod codegen;
 mod docs;
-mod http;
 mod public_api;
-mod run;
-mod ubuntu_mainline;
 
 use std::process::{Command, Output};
 
@@ -24,7 +21,7 @@ enum Subcommand {
     Clippy(clippy::Options),
     Codegen(codegen::Options),
     Docs,
-    IntegrationTest(run::Options),
+    IntegrationTest(aya_tool::integration_test::Options),
     PublicApi(public_api::Options),
 }
 
@@ -67,7 +64,7 @@ fn main() -> Result<()> {
         Subcommand::Clippy(opts) => clippy::run(opts),
         Subcommand::Codegen(opts) => codegen::codegen(opts, libbpf_dir),
         Subcommand::Docs => docs::docs(metadata),
-        Subcommand::IntegrationTest(opts) => run::run(opts),
+        Subcommand::IntegrationTest(opts) => aya_tool::integration_test::run(opts),
         Subcommand::PublicApi(opts) => public_api::public_api(opts, metadata),
     }
 }

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -64,10 +64,10 @@ fn main() -> Result<()> {
     let libbpf_dir = libbpf_dir.as_std_path();
 
     match command {
-        Subcommand::Clippy(opts) => clippy::run(opts, workspace_root.as_std_path()),
+        Subcommand::Clippy(opts) => clippy::run(opts),
         Subcommand::Codegen(opts) => codegen::codegen(opts, libbpf_dir),
         Subcommand::Docs => docs::docs(metadata),
-        Subcommand::IntegrationTest(opts) => run::run(opts, workspace_root.as_std_path()),
+        Subcommand::IntegrationTest(opts) => run::run(opts),
         Subcommand::PublicApi(opts) => public_api::public_api(opts, metadata),
     }
 }

--- a/xtask/src/public_api.rs
+++ b/xtask/src/public_api.rs
@@ -6,11 +6,11 @@ use std::{
 };
 
 use anyhow::{Context as _, Result, bail};
+use aya_multierror::Errors;
 use cargo_metadata::{Metadata, Package, Target};
 use clap::Parser;
 use dialoguer::{Confirm, theme::ColorfulTheme};
 use diff::{Result as Diff, lines};
-use xtask::Errors;
 
 #[derive(Debug, Parser)]
 pub(crate) struct Options {

--- a/xtask/src/run.rs
+++ b/xtask/src/run.rs
@@ -17,11 +17,12 @@ use std::{
 };
 
 use anyhow::{Context as _, Result, anyhow, bail};
+use aya_multierror::Errors;
 use cargo_metadata::{Artifact, CompilerMessage, Message, Target};
 use clap::Parser;
 use nix::sys::stat::{Mode, SFlag};
 use walkdir::WalkDir;
-use xtask::{AYA_BUILD_INTEGRATION_BPF, Errors};
+use xtask::AYA_BUILD_INTEGRATION_BPF;
 
 use crate::{
     http::HttpClient,

--- a/xtask/src/run.rs
+++ b/xtask/src/run.rs
@@ -21,7 +21,7 @@ use cargo_metadata::{Artifact, CompilerMessage, Message, Target};
 use clap::Parser;
 use nix::sys::stat::{Mode, SFlag};
 use walkdir::WalkDir;
-use xtask::{AYA_BUILD_INTEGRATION_BPF, Errors, libbpf_sys_env};
+use xtask::{AYA_BUILD_INTEGRATION_BPF, Errors};
 
 use crate::{
     http::HttpClient,
@@ -330,7 +330,7 @@ impl<W: Write> CpioArchiveBuilder<W> {
 }
 
 /// Build and run the project.
-pub(crate) fn run(opts: Options, workspace_root: &Path) -> Result<()> {
+pub(crate) fn run(opts: Options) -> Result<()> {
     let Options {
         environment,
         package,
@@ -349,7 +349,6 @@ pub(crate) fn run(opts: Options, workspace_root: &Path) -> Result<()> {
                 let binaries = build(target, |cmd| {
                     if package == INTEGRATION_TEST_PACKAGE {
                         cmd.env(AYA_BUILD_INTEGRATION_BPF, "true");
-                        libbpf_sys_env(workspace_root, cmd);
                     }
                     cmd.envs(envs.iter().copied()).args([
                         "--package",


### PR DESCRIPTION
Move the integration test runner from xtask to aya-tool, preserving the original implementation as verbatim as possible with only module path changes for the new crate location.

The motivation behind that move is ability to use the same integration test mechanism in third-party projects using Aya, with https://github.com/anza-xyz/agave planning to use as soon as available.

The integration test functionality is now available in two ways:

1. As a standalone binary subcommand: `aya-tool integration-test`.
2. As a library crate for use in xtask workflows: `use aya_tool::integration_test::{run, Options}`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aya-rs/aya/1648)
<!-- Reviewable:end -->
