### PR TITLE
refactor(xtask/run): Simplify initramfs file path logic

### DIFF
--- a/xtask/src/run.rs
+++ b/xtask/src/run.rs
@@ -567,22 +567,13 @@ pub(crate) fn run(opts: Options, workspace_root: &Path) -> Result<()> {
                         mtime,
                     )?;
                 }
-                for (name, path) in &test_distro {
-                    if name == "init" {
-                        initrd_archive.append_file(
-                            PathBuf::from("init"),
-                            path,
-                            executable_mode,
-                            mtime,
-                        )?;
+                for (name, source) in &test_distro {
+                    let path = if name == "init" {
+                        PathBuf::from("init")
                     } else {
-                        initrd_archive.append_file(
-                            Path::new("sbin").join(name),
-                            path,
-                            executable_mode,
-                            mtime,
-                        )?;
-                    }
+                        Path::new("sbin").join(name)
+                    };
+                    initrd_archive.append_file(path, source, executable_mode, mtime)?;
                 }
 
                 // At this point we need to make a slight detour!


### PR DESCRIPTION
Consolidate the conditional path construction for initramfs files into a single path variable before calling `append_file`, reducing code duplication.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aya-rs/aya/1651)
<!-- Reviewable:end -->
