### PR TITLE
refactor(xtask/run): Add buffered writer for initramfs generation

### DIFF
--- a/xtask/src/run.rs
+++ b/xtask/src/run.rs
@@ -7,7 +7,7 @@ use std::{
     ffi::{OsStr, OsString},
     fmt::{Arguments, Write as _},
     fs::{self, File, OpenOptions},
-    io::{BufRead as _, BufReader, Write},
+    io::{BufRead as _, BufReader, BufWriter, Write},
     os::unix::ffi::OsStrExt as _,
     path::{Path, PathBuf},
     process::{Child, ChildStdin, Command, Output, Stdio},
@@ -535,7 +535,8 @@ pub(crate) fn run(opts: Options, workspace_root: &Path) -> Result<()> {
                     .with_context(|| {
                         format!("failed to create {} for writing", initrd_image.display())
                     })?;
-                let mut initrd_archive = CpioArchiveBuilder::new(initrd_image_file);
+                let buffered_file = BufWriter::new(initrd_image_file);
+                let mut initrd_archive = CpioArchiveBuilder::new(buffered_file);
                 let mtime_secs = SystemTime::now().duration_since(UNIX_EPOCH)?.as_secs();
                 let mtime = u32::try_from(mtime_secs).with_context(|| {
                     format!("cpio supports only `u32` mtimes, got {mtime_secs}")
@@ -643,6 +644,7 @@ pub(crate) fn run(opts: Options, workspace_root: &Path) -> Result<()> {
                 // Append the required trailer entry as the last one, then
                 // write the initramfs to the output file.
                 initrd_archive.append_trailer()?;
+                initrd_archive.inner.flush()?;
                 drop(initrd_archive);
 
                 let mut qemu = Command::new(format!("qemu-system-{guest_arch}"));


### PR DESCRIPTION
Use `BufWriter` between the file handle and `CpioArchiveBuilder` to improve performance by reducing system calls when writing small entries to the initramfs image.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aya-rs/aya/1652)
<!-- Reviewable:end -->
