### PR TITLE
ci: increase Bazel heap for macOS runners

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -31,7 +31,8 @@ common:remote --remote_executor=grpcs://remote.buildbuddy.io
 common:remote --remote_cache_compression
 common:remote --remote_download_minimal
 
-# Keep remote backends fed
+# Keep remote backends fed; throttling also waits for remote uploads.
+# https://github.com/bazelbuild/bazel/issues/28734
 common:remote --noexperimental_throttle_remote_action_building
 common:remote --jobs=400
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,8 @@ on:
     - cron: 00 4 * * *
 
 env:
+  # This key is intentionally public so fork pull requests can use BuildBuddy.
+  BUILDBUDDY_API_KEY: 5CeVmFS0jDnutd00x9Xl
   CARGO_TERM_COLOR: always
 
 concurrency:
@@ -36,13 +38,10 @@ jobs:
       - name: Test
         run: |
           set -euo pipefail
-          bazel_args=(
-            --config=remote
-            # This key is intentionally public so fork pull requests can use BuildBuddy.
-            --remote_header=x-buildbuddy-api-key=5CeVmFS0jDnutd00x9Xl
-          )
-
-          bazel test //... "${bazel_args[@]}"
+          # The default JVM heap is under 2 GB on 7 GB macOS runners.
+          bazel --host_jvm_args=-Xmx4g test //... \
+            --config=remote \
+            --remote_header=x-buildbuddy-api-key="$BUILDBUDDY_API_KEY"
 
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
macOS GitHub runners provide 7 GB of memory, leaving Bazel's default JVM heap below 2 GB. Increase the CI heap to 4 GB while retaining the existing 400-job remote execution limit.

Keep remote-action throttling disabled because its semaphore also covers remote input uploads and unnecessarily limits remote throughput [1].

[1]: https://github.com/bazelbuild/bazel/issues/28734

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aya-rs/aya/1655)
<!-- Reviewable:end -->
