### PR TITLE
aya-ebpf: remove Borrow traits from map methods

### DIFF
--- a/ebpf/aya-ebpf/src/btf_maps/array.rs
+++ b/ebpf/aya-ebpf/src/btf_maps/array.rs
@@ -1,4 +1,4 @@
-use core::{borrow::Borrow, ptr::NonNull};
+use core::ptr::NonNull;
 
 use crate::{btf_maps::btf_map_def, insert, lookup};
 
@@ -51,7 +51,7 @@ impl<T, const MAX_ENTRIES: usize, const FLAGS: usize> Array<T, MAX_ENTRIES, FLAG
 
     /// Sets the value of the element at the given index.
     #[inline(always)]
-    pub fn set(&self, index: u32, value: impl Borrow<T>, flags: u64) -> Result<(), i32> {
-        insert(self.as_ptr(), &index, value.borrow(), flags)
+    pub fn set(&self, index: u32, value: &T, flags: u64) -> Result<(), i32> {
+        insert(self.as_ptr(), &index, value, flags)
     }
 }

--- a/ebpf/aya-ebpf/src/btf_maps/bloom_filter.rs
+++ b/ebpf/aya-ebpf/src/btf_maps/bloom_filter.rs
@@ -1,4 +1,4 @@
-use core::{borrow::Borrow, ptr};
+use core::ptr;
 
 use crate::{
     btf_maps::btf_map_def,
@@ -33,8 +33,8 @@ impl<T, const MAX_ENTRIES: usize, const FLAGS: usize, const HASH_FUNCS: usize>
     BloomFilter<T, MAX_ENTRIES, FLAGS, HASH_FUNCS>
 {
     #[inline(always)]
-    pub fn contains(&self, value: impl Borrow<T>) -> Result<(), i32> {
-        let value = ptr::from_ref(value.borrow());
+    pub fn contains(&self, value: &T) -> Result<(), i32> {
+        let value = ptr::from_ref(value);
         match unsafe { bpf_map_peek_elem(self.as_ptr(), value.cast_mut().cast()) } {
             0 => Ok(()),
             ret => Err(ret as i32),
@@ -42,8 +42,8 @@ impl<T, const MAX_ENTRIES: usize, const FLAGS: usize, const HASH_FUNCS: usize>
     }
 
     #[inline(always)]
-    pub fn insert(&self, value: impl Borrow<T>, flags: u64) -> Result<(), i32> {
-        let value = ptr::from_ref(value.borrow());
+    pub fn insert(&self, value: &T, flags: u64) -> Result<(), i32> {
+        let value = ptr::from_ref(value);
         match unsafe { bpf_map_push_elem(self.as_ptr(), value.cast(), flags) } {
             0 => Ok(()),
             ret => Err(ret as i32),

--- a/ebpf/aya-ebpf/src/btf_maps/hash_map.rs
+++ b/ebpf/aya-ebpf/src/btf_maps/hash_map.rs
@@ -2,7 +2,7 @@
 
 #![deny(missing_docs)]
 
-use core::{borrow::Borrow, ptr::NonNull};
+use core::ptr::NonNull;
 
 use aya_ebpf_bindings::bindings::{BPF_F_NO_COMMON_LRU, BPF_F_NO_PREALLOC};
 
@@ -59,10 +59,10 @@ macro_rules! define_btf_hash_map {
 
             $(#[$get_attr])+
             #[inline(always)]
-            pub unsafe fn get(&self, key: impl Borrow<K>) -> Option<&V> {
+            pub unsafe fn get(&self, key: &K) -> Option<&V> {
                 let () = Self::_CHECK;
                 // SAFETY: The caller upholds the aliasing invariants documented above.
-                unsafe { self.lookup(key.borrow()).map(|p| p.as_ref()) }
+                unsafe { self.lookup(key).map(|p| p.as_ref()) }
             }
 
             /// Returns a `*const V` for the value associated with `key`.
@@ -71,9 +71,9 @@ macro_rules! define_btf_hash_map {
             /// caller's responsibility to decide whether dereferencing the
             /// pointer is safe.
             #[inline(always)]
-            pub fn get_ptr(&self, key: impl Borrow<K>) -> Option<*const V> {
+            pub fn get_ptr(&self, key: &K) -> Option<*const V> {
                 let () = Self::_CHECK;
-                unsafe { self.lookup(key.borrow()).map(|p| p.as_ptr().cast_const()) }
+                unsafe { self.lookup(key).map(|p| p.as_ptr().cast_const()) }
             }
 
             /// Returns a `*mut V` for the value associated with `key`.
@@ -81,9 +81,9 @@ macro_rules! define_btf_hash_map {
             /// The same aliasing caveat as [`Self::get`] applies, and the
             /// caller must additionally avoid concurrent writes.
             #[inline(always)]
-            pub fn get_ptr_mut(&self, key: impl Borrow<K>) -> Option<*mut V> {
+            pub fn get_ptr_mut(&self, key: &K) -> Option<*mut V> {
                 let () = Self::_CHECK;
-                unsafe { self.lookup(key.borrow()).map(NonNull::as_ptr) }
+                unsafe { self.lookup(key).map(NonNull::as_ptr) }
             }
 
             #[inline(always)]
@@ -98,19 +98,19 @@ macro_rules! define_btf_hash_map {
             #[inline(always)]
             pub fn insert(
                 &self,
-                key: impl Borrow<K>,
-                value: impl Borrow<V>,
+                key: &K,
+                value: &V,
                 flags: u64,
             ) -> Result<(), i32> {
                 let () = Self::_CHECK;
-                insert(self.as_ptr(), key.borrow(), value.borrow(), flags)
+                insert(self.as_ptr(), key, value, flags)
             }
 
             /// Removes the entry for `key`.
             #[inline(always)]
-            pub fn remove(&self, key: impl Borrow<K>) -> Result<(), i32> {
+            pub fn remove(&self, key: &K) -> Result<(), i32> {
                 let () = Self::_CHECK;
-                remove(self.as_ptr(), key.borrow())
+                remove(self.as_ptr(), key)
             }
         }
     };

--- a/ebpf/aya-ebpf/src/btf_maps/lpm_trie.rs
+++ b/ebpf/aya-ebpf/src/btf_maps/lpm_trie.rs
@@ -1,5 +1,3 @@
-use core::borrow::Borrow;
-
 use aya_ebpf_bindings::bindings::BPF_F_NO_PREALLOC;
 
 pub use crate::maps::lpm_trie::Key;
@@ -100,9 +98,9 @@ impl<K, V, const MAX_ENTRIES: usize, const FLAGS: usize> LpmTrie<K, V, MAX_ENTRI
 
     /// Inserts or updates the value for the exact `(prefix_len, data)` pair.
     #[inline(always)]
-    pub fn insert(&self, key: &Key<K>, value: impl Borrow<V>, flags: u64) -> Result<(), i32> {
+    pub fn insert(&self, key: &Key<K>, value: &V, flags: u64) -> Result<(), i32> {
         let () = Self::_CHECK;
-        insert(self.as_ptr(), key, value.borrow(), flags)
+        insert(self.as_ptr(), key, value, flags)
     }
 
     /// Removes the entry for the exact `(prefix_len, data)` pair.

--- a/ebpf/aya-ebpf/src/btf_maps/per_cpu_array.rs
+++ b/ebpf/aya-ebpf/src/btf_maps/per_cpu_array.rs
@@ -1,4 +1,4 @@
-use core::{borrow::Borrow, ptr::NonNull};
+use core::ptr::NonNull;
 
 use crate::{btf_maps::btf_map_def, insert, lookup};
 
@@ -109,8 +109,8 @@ impl<T, const MAX_ENTRIES: usize, const FLAGS: usize> PerCpuArray<T, MAX_ENTRIES
     /// `flags` is forwarded to `bpf_map_update_elem`; `BPF_NOEXIST` is
     /// rejected by the kernel for arrays.
     #[inline(always)]
-    pub fn set(&self, index: u32, value: impl Borrow<T>, flags: u64) -> Result<(), i32> {
+    pub fn set(&self, index: u32, value: &T, flags: u64) -> Result<(), i32> {
         let () = Self::_CHECK;
-        insert(self.as_ptr(), &index, value.borrow(), flags)
+        insert(self.as_ptr(), &index, value, flags)
     }
 }

--- a/ebpf/aya-ebpf/src/btf_maps/queue.rs
+++ b/ebpf/aya-ebpf/src/btf_maps/queue.rs
@@ -1,4 +1,4 @@
-use core::{borrow::Borrow, mem::MaybeUninit, ptr};
+use core::{mem::MaybeUninit, ptr};
 
 use aya_ebpf_bindings::bindings::BPF_F_NO_PREALLOC;
 
@@ -59,11 +59,9 @@ impl<T, const MAX_ENTRIES: usize, const FLAGS: usize> Queue<T, MAX_ENTRIES, FLAG
     /// `flags` is forwarded to `bpf_map_push_elem`; setting `BPF_EXIST`
     /// evicts the oldest element when the queue is full.
     #[inline(always)]
-    pub fn push(&self, value: impl Borrow<T>, flags: u64) -> Result<(), i32> {
+    pub fn push(&self, value: &T, flags: u64) -> Result<(), i32> {
         let () = Self::_CHECK;
-        let ret = unsafe {
-            bpf_map_push_elem(self.as_ptr(), ptr::from_ref(value.borrow()).cast(), flags)
-        };
+        let ret = unsafe { bpf_map_push_elem(self.as_ptr(), ptr::from_ref(value).cast(), flags) };
         (ret == 0).then_some(()).ok_or(ret as i32)
     }
 

--- a/ebpf/aya-ebpf/src/btf_maps/ring_buf.rs
+++ b/ebpf/aya-ebpf/src/btf_maps/ring_buf.rs
@@ -1,4 +1,4 @@
-use core::{borrow::Borrow, mem::MaybeUninit, ptr};
+use core::{mem::MaybeUninit, ptr};
 
 #[cfg(generic_const_exprs)]
 use crate::const_assert::{Assert, IsTrue};
@@ -89,7 +89,7 @@ impl<T, const MAX_ENTRIES: usize, const FLAGS: usize> RingBuf<T, MAX_ENTRIES, FL
     }
 
     /// Copy `data` to the ring buffer output using the map's `T`.
-    pub fn output(&self, data: impl Borrow<T>, flags: u64) -> Result<(), i32> {
+    pub fn output(&self, data: &T, flags: u64) -> Result<(), i32> {
         self.output_untyped::<T>(data, flags)
     }
 
@@ -108,8 +108,7 @@ impl<T, const MAX_ENTRIES: usize, const FLAGS: usize> RingBuf<T, MAX_ENTRIES, FL
     ///
     /// [`reserve`]: RingBuf::reserve
     /// [`submit`]: RingBufEntry::submit
-    pub fn output_untyped<U: ?Sized>(&self, data: impl Borrow<U>, flags: u64) -> Result<(), i32> {
-        let data = data.borrow();
+    pub fn output_untyped<U: ?Sized>(&self, data: &U, flags: u64) -> Result<(), i32> {
         assert_eq!(8 % align_of_val(data), 0);
         let ret = unsafe {
             bpf_ringbuf_output(

--- a/ebpf/aya-ebpf/src/btf_maps/sock_hash.rs
+++ b/ebpf/aya-ebpf/src/btf_maps/sock_hash.rs
@@ -1,7 +1,4 @@
-use core::{
-    borrow::{Borrow, BorrowMut},
-    ptr,
-};
+use core::ptr;
 
 use crate::{
     ENOENT, EbpfContext as _,
@@ -62,18 +59,13 @@ impl<K, const MAX_ENTRIES: usize, const FLAGS: usize> SockHash<K, MAX_ENTRIES, F
     };
 
     /// Inserts the socket from `sk_ops` into the map under `key`.
-    pub fn update(
-        &self,
-        mut key: impl BorrowMut<K>,
-        mut sk_ops: impl BorrowMut<bpf_sock_ops>,
-        flags: u64,
-    ) -> Result<(), i32> {
+    pub fn update(&self, key: &mut K, sk_ops: &mut bpf_sock_ops, flags: u64) -> Result<(), i32> {
         let () = Self::_CHECK;
         let ret = unsafe {
             bpf_sock_hash_update(
-                ptr::from_mut(sk_ops.borrow_mut()),
+                ptr::from_mut(sk_ops),
                 self.as_ptr().cast(),
-                ptr::from_mut(key.borrow_mut()).cast(),
+                ptr::from_mut(key).cast(),
                 flags,
             )
         };
@@ -81,36 +73,26 @@ impl<K, const MAX_ENTRIES: usize, const FLAGS: usize> SockHash<K, MAX_ENTRIES, F
     }
 
     /// Redirects the message in `ctx` to the socket at `key`.
-    pub fn redirect_msg(
-        &self,
-        ctx: impl Borrow<SkMsgContext>,
-        mut key: impl BorrowMut<K>,
-        flags: u64,
-    ) -> c_long {
+    pub fn redirect_msg(&self, ctx: &SkMsgContext, key: &mut K, flags: u64) -> c_long {
         let () = Self::_CHECK;
         unsafe {
             bpf_msg_redirect_hash(
-                ctx.borrow().msg,
+                ctx.msg,
                 self.as_ptr().cast(),
-                ptr::from_mut(key.borrow_mut()).cast(),
+                ptr::from_mut(key).cast(),
                 flags,
             )
         }
     }
 
     /// Redirects the socket buffer in `ctx` to the socket at `key`.
-    pub fn redirect_skb(
-        &self,
-        ctx: impl Borrow<SkBuffContext>,
-        mut key: impl BorrowMut<K>,
-        flags: u64,
-    ) -> c_long {
+    pub fn redirect_skb(&self, ctx: &SkBuffContext, key: &mut K, flags: u64) -> c_long {
         let () = Self::_CHECK;
         unsafe {
             bpf_sk_redirect_hash(
-                ctx.borrow().skb.as_raw_ptr(),
+                ctx.skb.as_raw_ptr(),
                 self.as_ptr().cast(),
-                ptr::from_mut(key.borrow_mut()).cast(),
+                ptr::from_mut(key).cast(),
                 flags,
             )
         }
@@ -132,13 +114,13 @@ impl<K, const MAX_ENTRIES: usize, const FLAGS: usize> SockHash<K, MAX_ENTRIES, F
     /// [`bpf_sk_assign`]: https://docs.ebpf.io/linux/helper-function/bpf_sk_assign/
     pub fn redirect_sk_lookup(
         &self,
-        ctx: impl Borrow<SkLookupContext>,
-        key: impl Borrow<K>,
+        ctx: &SkLookupContext,
+        key: &K,
         flags: u64,
     ) -> Result<(), i32> {
         let () = Self::_CHECK;
-        let sk = lookup(self.as_ptr(), key.borrow()).ok_or(-ENOENT)?;
-        let ret = unsafe { bpf_sk_assign(ctx.borrow().as_ptr().cast(), sk.as_ptr(), flags) };
+        let sk = lookup(self.as_ptr(), key).ok_or(-ENOENT)?;
+        let ret = unsafe { bpf_sk_assign(ctx.as_ptr().cast(), sk.as_ptr(), flags) };
         let _: c_long = unsafe { bpf_sk_release(sk.as_ptr()) };
         (ret == 0).then_some(()).ok_or(ret as i32)
     }

--- a/ebpf/aya-ebpf/src/btf_maps/stack.rs
+++ b/ebpf/aya-ebpf/src/btf_maps/stack.rs
@@ -1,4 +1,4 @@
-use core::{borrow::Borrow, mem::MaybeUninit, ptr};
+use core::{mem::MaybeUninit, ptr};
 
 use aya_ebpf_bindings::bindings::BPF_F_NO_PREALLOC;
 
@@ -59,11 +59,9 @@ impl<T, const MAX_ENTRIES: usize, const FLAGS: usize> Stack<T, MAX_ENTRIES, FLAG
     /// `flags` is forwarded to `bpf_map_push_elem`; setting `BPF_EXIST`
     /// evicts the bottom element when the stack is full.
     #[inline(always)]
-    pub fn push(&self, value: impl Borrow<T>, flags: u64) -> Result<(), i32> {
+    pub fn push(&self, value: &T, flags: u64) -> Result<(), i32> {
         let () = Self::_CHECK;
-        let ret = unsafe {
-            bpf_map_push_elem(self.as_ptr(), ptr::from_ref(value.borrow()).cast(), flags)
-        };
+        let ret = unsafe { bpf_map_push_elem(self.as_ptr(), ptr::from_ref(value).cast(), flags) };
         (ret == 0).then_some(()).ok_or(ret as i32)
     }
 

--- a/ebpf/aya-ebpf/src/maps/array.rs
+++ b/ebpf/aya-ebpf/src/maps/array.rs
@@ -1,4 +1,4 @@
-use core::{borrow::Borrow, marker::PhantomData, ptr::NonNull};
+use core::{marker::PhantomData, ptr::NonNull};
 
 use crate::{
     bindings::bpf_map_type::BPF_MAP_TYPE_ARRAY,
@@ -42,7 +42,7 @@ impl<T> Array<T> {
 
     /// Sets the value of the element at the given index.
     #[inline(always)]
-    pub fn set(&self, index: u32, value: impl Borrow<T>, flags: u64) -> Result<(), i32> {
-        insert(self.def.as_ptr(), &index, value.borrow(), flags)
+    pub fn set(&self, index: u32, value: &T, flags: u64) -> Result<(), i32> {
+        insert(self.def.as_ptr(), &index, value, flags)
     }
 }

--- a/ebpf/aya-ebpf/src/maps/bloom_filter.rs
+++ b/ebpf/aya-ebpf/src/maps/bloom_filter.rs
@@ -1,4 +1,4 @@
-use core::{borrow::Borrow, marker::PhantomData, ptr};
+use core::{marker::PhantomData, ptr};
 
 use crate::{
     bindings::bpf_map_type::BPF_MAP_TYPE_BLOOM_FILTER,
@@ -21,24 +21,20 @@ impl<T> BloomFilter<T> {
     map_constructors!((), T, BPF_MAP_TYPE_BLOOM_FILTER, phantom _t);
 
     #[inline]
-    pub fn contains(&self, value: impl Borrow<T>) -> Result<(), i32> {
+    pub fn contains(&self, value: &T) -> Result<(), i32> {
         let ret = unsafe {
             bpf_map_peek_elem(
                 self.def.as_ptr().cast(),
-                ptr::from_ref(value.borrow()).cast_mut().cast(),
+                ptr::from_ref(value).cast_mut().cast(),
             )
         };
         (ret == 0).then_some(()).ok_or(ret as i32)
     }
 
     #[inline]
-    pub fn insert(&self, value: impl Borrow<T>, flags: u64) -> Result<(), i32> {
+    pub fn insert(&self, value: &T, flags: u64) -> Result<(), i32> {
         let ret = unsafe {
-            bpf_map_push_elem(
-                self.def.as_ptr().cast(),
-                ptr::from_ref(value.borrow()).cast(),
-                flags,
-            )
+            bpf_map_push_elem(self.def.as_ptr().cast(), ptr::from_ref(value).cast(), flags)
         };
         (ret == 0).then_some(()).ok_or(ret as i32)
     }

--- a/ebpf/aya-ebpf/src/maps/hash_map.rs
+++ b/ebpf/aya-ebpf/src/maps/hash_map.rs
@@ -1,4 +1,4 @@
-use core::{borrow::Borrow, marker::PhantomData};
+use core::marker::PhantomData;
 
 use aya_ebpf_bindings::bindings::bpf_map_type;
 
@@ -46,16 +46,16 @@ macro_rules! define_hash_map {
             /// aliased by another element in the map, causing garbage to be read, or corruption in
             /// case of writes.
             #[inline]
-            pub unsafe fn get(&self, key: impl Borrow<K>) -> Option<&V> {
-                unsafe { get(self.def.as_ptr(), key.borrow()) }
+            pub unsafe fn get(&self, key: &K) -> Option<&V> {
+                unsafe { get(self.def.as_ptr(), key) }
             }
 
             /// Retrieve the value associate with `key` from the map.
             /// The same caveat as `get` applies, but this returns a raw pointer and it's up to the
             /// caller to decide whether it's safe to dereference the pointer or not.
             #[inline]
-            pub fn get_ptr(&self, key: impl Borrow<K>) -> Option<*const V> {
-                get_ptr(self.def.as_ptr(), key.borrow())
+            pub fn get_ptr(&self, key: &K) -> Option<*const V> {
+                get_ptr(self.def.as_ptr(), key)
             }
 
             /// Retrieve the value associate with `key` from the map.
@@ -63,23 +63,18 @@ macro_rules! define_hash_map {
             /// concurrent writes, but it's up to the caller to decide whether it's safe to
             /// dereference the pointer or not.
             #[inline]
-            pub fn get_ptr_mut(&self, key: impl Borrow<K>) -> Option<*mut V> {
-                get_ptr_mut(self.def.as_ptr(), key.borrow())
+            pub fn get_ptr_mut(&self, key: &K) -> Option<*mut V> {
+                get_ptr_mut(self.def.as_ptr(), key)
             }
 
             #[inline]
-            pub fn insert(
-                &self,
-                key: impl Borrow<K>,
-                value: impl Borrow<V>,
-                flags: u64,
-            ) -> Result<(), i32> {
-                insert(self.def.as_ptr(), key.borrow(), value.borrow(), flags)
+            pub fn insert(&self, key: &K, value: &V, flags: u64) -> Result<(), i32> {
+                insert(self.def.as_ptr(), key, value, flags)
             }
 
             #[inline]
-            pub fn remove(&self, key: impl Borrow<K>) -> Result<(), i32> {
-                remove(self.def.as_ptr(), key.borrow())
+            pub fn remove(&self, key: &K) -> Result<(), i32> {
+                remove(self.def.as_ptr(), key)
             }
         }
     };

--- a/ebpf/aya-ebpf/src/maps/lpm_trie.rs
+++ b/ebpf/aya-ebpf/src/maps/lpm_trie.rs
@@ -1,4 +1,4 @@
-use core::{borrow::Borrow, marker::PhantomData};
+use core::marker::PhantomData;
 
 use aya_ebpf_bindings::bindings::BPF_F_NO_PREALLOC;
 
@@ -38,22 +38,17 @@ impl<K, V> LpmTrie<K, V> {
     map_constructors!(Key<K>, V, BPF_MAP_TYPE_LPM_TRIE, extra_flags BPF_F_NO_PREALLOC, phantom _kv);
 
     #[inline]
-    pub fn get(&self, key: impl Borrow<Key<K>>) -> Option<&V> {
-        lookup(self.def.as_ptr(), key.borrow()).map(|p| unsafe { p.as_ref() })
+    pub fn get(&self, key: &Key<K>) -> Option<&V> {
+        lookup(self.def.as_ptr(), key).map(|p| unsafe { p.as_ref() })
     }
 
     #[inline]
-    pub fn insert(
-        &self,
-        key: impl Borrow<Key<K>>,
-        value: impl Borrow<V>,
-        flags: u64,
-    ) -> Result<(), i32> {
-        insert(self.def.as_ptr(), key.borrow(), value.borrow(), flags)
+    pub fn insert(&self, key: &Key<K>, value: &V, flags: u64) -> Result<(), i32> {
+        insert(self.def.as_ptr(), key, value, flags)
     }
 
     #[inline]
-    pub fn remove(&self, key: impl Borrow<Key<K>>) -> Result<(), i32> {
-        remove(self.def.as_ptr(), key.borrow())
+    pub fn remove(&self, key: &Key<K>) -> Result<(), i32> {
+        remove(self.def.as_ptr(), key)
     }
 }

--- a/ebpf/aya-ebpf/src/maps/per_cpu_array.rs
+++ b/ebpf/aya-ebpf/src/maps/per_cpu_array.rs
@@ -1,4 +1,4 @@
-use core::{borrow::Borrow, marker::PhantomData, ptr::NonNull};
+use core::{marker::PhantomData, ptr::NonNull};
 
 use crate::{
     bindings::bpf_map_type::BPF_MAP_TYPE_PERCPU_ARRAY,
@@ -45,7 +45,7 @@ impl<T> PerCpuArray<T> {
 
     /// Sets the value of the current CPU's slot at the given index.
     #[inline(always)]
-    pub fn set(&self, index: u32, value: impl Borrow<T>, flags: u64) -> Result<(), i32> {
-        insert(self.def.as_ptr(), &index, value.borrow(), flags)
+    pub fn set(&self, index: u32, value: &T, flags: u64) -> Result<(), i32> {
+        insert(self.def.as_ptr(), &index, value, flags)
     }
 }

--- a/ebpf/aya-ebpf/src/maps/perf/perf_event_array.rs
+++ b/ebpf/aya-ebpf/src/maps/perf/perf_event_array.rs
@@ -1,4 +1,4 @@
-use core::{borrow::Borrow, marker::PhantomData, ptr};
+use core::{marker::PhantomData, ptr};
 
 use crate::{
     EbpfContext,
@@ -29,18 +29,11 @@ impl<T> PerfEventArray<T> {
         }
     }
 
-    pub fn output<C: EbpfContext>(&self, ctx: &C, data: impl Borrow<T>, flags: u32) {
+    pub fn output<C: EbpfContext>(&self, ctx: &C, data: &T, flags: u32) {
         self.output_at_index(ctx, BPF_F_CURRENT_CPU as u32, data, flags);
     }
 
-    pub fn output_at_index<C: EbpfContext>(
-        &self,
-        ctx: &C,
-        index: u32,
-        data: impl Borrow<T>,
-        flags: u32,
-    ) {
-        let data = data.borrow();
+    pub fn output_at_index<C: EbpfContext>(&self, ctx: &C, index: u32, data: &T, flags: u32) {
         let flags = (u64::from(flags) << 32) | u64::from(index);
         unsafe {
             bpf_perf_event_output(

--- a/ebpf/aya-ebpf/src/maps/queue.rs
+++ b/ebpf/aya-ebpf/src/maps/queue.rs
@@ -1,4 +1,4 @@
-use core::{borrow::Borrow, marker::PhantomData, mem::MaybeUninit, ptr};
+use core::{marker::PhantomData, mem::MaybeUninit, ptr};
 
 use crate::{
     ENOENT,
@@ -21,13 +21,9 @@ impl<T> super::private::Map for Queue<T> {
 impl<T> Queue<T> {
     map_constructors!((), T, BPF_MAP_TYPE_QUEUE, phantom _t);
 
-    pub fn push(&self, value: impl Borrow<T>, flags: u64) -> Result<(), i32> {
+    pub fn push(&self, value: &T, flags: u64) -> Result<(), i32> {
         let ret = unsafe {
-            bpf_map_push_elem(
-                self.def.as_ptr().cast(),
-                ptr::from_ref(value.borrow()).cast(),
-                flags,
-            )
+            bpf_map_push_elem(self.def.as_ptr().cast(), ptr::from_ref(value).cast(), flags)
         };
         (ret == 0).then_some(()).ok_or(ret as i32)
     }

--- a/ebpf/aya-ebpf/src/maps/ring_buf.rs
+++ b/ebpf/aya-ebpf/src/maps/ring_buf.rs
@@ -1,5 +1,4 @@
 use core::{
-    borrow::Borrow,
     mem::MaybeUninit,
     ops::{Deref, DerefMut},
     ptr,
@@ -197,8 +196,7 @@ impl RingBuf {
     ///
     /// [`reserve`]: RingBuf::reserve
     /// [`submit`]: RingBufEntry::submit
-    pub fn output<T: ?Sized>(&self, data: impl Borrow<T>, flags: u64) -> Result<(), i32> {
-        let data = data.borrow();
+    pub fn output<T: ?Sized>(&self, data: &T, flags: u64) -> Result<(), i32> {
         assert_eq!(8 % align_of_val(data), 0);
         let ret = unsafe {
             bpf_ringbuf_output(

--- a/ebpf/aya-ebpf/src/maps/sock_hash.rs
+++ b/ebpf/aya-ebpf/src/maps/sock_hash.rs
@@ -1,8 +1,4 @@
-use core::{
-    borrow::{Borrow, BorrowMut},
-    marker::PhantomData,
-    ptr,
-};
+use core::{marker::PhantomData, ptr};
 
 use crate::{
     ENOENT, EbpfContext as _,
@@ -31,50 +27,35 @@ impl<K> super::private::Map for SockHash<K> {
 impl<K> SockHash<K> {
     map_constructors!(K, u32, BPF_MAP_TYPE_SOCKHASH, phantom _k);
 
-    pub fn update(
-        &self,
-        mut key: impl BorrowMut<K>,
-        mut sk_ops: impl BorrowMut<bpf_sock_ops>,
-        flags: u64,
-    ) -> Result<(), i32> {
+    pub fn update(&self, key: &mut K, sk_ops: &mut bpf_sock_ops, flags: u64) -> Result<(), i32> {
         let ret = unsafe {
             bpf_sock_hash_update(
-                ptr::from_mut(sk_ops.borrow_mut()),
+                ptr::from_mut(sk_ops),
                 self.def.as_ptr().cast(),
-                ptr::from_mut(key.borrow_mut()).cast(),
+                ptr::from_mut(key).cast(),
                 flags,
             )
         };
         (ret == 0).then_some(()).ok_or(ret as i32)
     }
 
-    pub fn redirect_msg(
-        &self,
-        ctx: impl Borrow<SkMsgContext>,
-        mut key: impl BorrowMut<K>,
-        flags: u64,
-    ) -> c_long {
+    pub fn redirect_msg(&self, ctx: &SkMsgContext, key: &mut K, flags: u64) -> c_long {
         unsafe {
             bpf_msg_redirect_hash(
-                ctx.borrow().msg,
+                ctx.msg,
                 self.def.as_ptr().cast(),
-                ptr::from_mut(key.borrow_mut()).cast(),
+                ptr::from_mut(key).cast(),
                 flags,
             )
         }
     }
 
-    pub fn redirect_skb(
-        &self,
-        ctx: impl Borrow<SkBuffContext>,
-        mut key: impl BorrowMut<K>,
-        flags: u64,
-    ) -> c_long {
+    pub fn redirect_skb(&self, ctx: &SkBuffContext, key: &mut K, flags: u64) -> c_long {
         unsafe {
             bpf_sk_redirect_hash(
-                ctx.borrow().skb.as_raw_ptr(),
+                ctx.skb.as_raw_ptr(),
                 self.def.as_ptr().cast(),
-                ptr::from_mut(key.borrow_mut()).cast(),
+                ptr::from_mut(key).cast(),
                 flags,
             )
         }
@@ -82,12 +63,12 @@ impl<K> SockHash<K> {
 
     pub fn redirect_sk_lookup(
         &self,
-        ctx: impl Borrow<SkLookupContext>,
-        key: impl Borrow<K>,
+        ctx: &SkLookupContext,
+        key: &K,
         flags: u64,
     ) -> Result<(), i32> {
-        let sk = lookup(self.def.as_ptr(), key.borrow()).ok_or(-ENOENT)?;
-        let ret = unsafe { bpf_sk_assign(ctx.borrow().as_ptr().cast(), sk.as_ptr(), flags) };
+        let sk = lookup(self.def.as_ptr(), key).ok_or(-ENOENT)?;
+        let ret = unsafe { bpf_sk_assign(ctx.as_ptr().cast(), sk.as_ptr(), flags) };
         let _: c_long = unsafe { bpf_sk_release(sk.as_ptr()) };
         (ret == 0).then_some(()).ok_or(ret as i32)
     }

--- a/ebpf/aya-ebpf/src/maps/stack.rs
+++ b/ebpf/aya-ebpf/src/maps/stack.rs
@@ -1,4 +1,4 @@
-use core::{borrow::Borrow, marker::PhantomData, mem::MaybeUninit, ptr};
+use core::{marker::PhantomData, mem::MaybeUninit, ptr};
 
 use crate::{
     ENOENT,
@@ -21,13 +21,9 @@ impl<T> super::private::Map for Stack<T> {
 impl<T> Stack<T> {
     map_constructors!((), T, BPF_MAP_TYPE_STACK, phantom _t);
 
-    pub fn push(&self, value: impl Borrow<T>, flags: u64) -> Result<(), i32> {
+    pub fn push(&self, value: &T, flags: u64) -> Result<(), i32> {
         let ret = unsafe {
-            bpf_map_push_elem(
-                self.def.as_ptr().cast(),
-                ptr::from_ref(value.borrow()).cast(),
-                flags,
-            )
+            bpf_map_push_elem(self.def.as_ptr().cast(), ptr::from_ref(value).cast(), flags)
         };
         (ret == 0).then_some(()).ok_or(ret as i32)
     }

--- a/test/integration-ebpf/src/bloom_filter.rs
+++ b/test/integration-ebpf/src/bloom_filter.rs
@@ -47,16 +47,16 @@ macro_rules! define_bloom_filter_test {
         fn $insert_prog(ctx: ProbeContext) -> Result<(), i32> {
             let index: u32 = ctx.arg(0).ok_or(-1)?;
             let value: u32 = ctx.arg(1).ok_or(-1)?;
-            let result = map_result($filter_map.insert(value, 0));
-            $result_map.set(index, result, 0)
+            let result = map_result($filter_map.insert(&value, 0));
+            $result_map.set(index, &result, 0)
         }
 
         #[uprobe]
         fn $contains_prog(ctx: ProbeContext) -> Result<(), i32> {
             let index: u32 = ctx.arg(0).ok_or(-1)?;
             let value: u32 = ctx.arg(1).ok_or(-1)?;
-            let result = map_result($filter_map.contains(value));
-            $result_map.set(index, result, 0)
+            let result = map_result($filter_map.contains(&value));
+            $result_map.set(index, &result, 0)
         }
     };
 }

--- a/test/integration-ebpf/src/map_test.rs
+++ b/test/integration-ebpf/src/map_test.rs
@@ -31,7 +31,7 @@ fn simple_prog(_ctx: SkBuffContext) -> i64 {
     // If we use the literal value `0` instead of the local variable `i`, then an additional
     // `.rodata` map will be associated with the program.
     let i = 0;
-    BAZ.get_ptr(i);
+    BAZ.get_ptr(&i);
 
     0
 }
@@ -44,7 +44,7 @@ fn simple_prog_mut(_ctx: ProbeContext) -> i64 {
         }
     }
 
-    if let Some(map_value) = BAZ.get_ptr_mut(0) {
+    if let Some(map_value) = BAZ.get_ptr_mut(&0) {
         unsafe {
             *map_value += 1;
         }

--- a/test/integration-ebpf/src/memmove_test.rs
+++ b/test/integration-ebpf/src/memmove_test.rs
@@ -44,7 +44,7 @@ fn do_dnat(ctx: XdpContext) -> u32 {
 
 fn try_do_dnat(ctx: XdpContext) -> Result<u32, ()> {
     let index = 0;
-    if let Some(nat) = unsafe { RULES.get(index) } {
+    if let Some(nat) = unsafe { RULES.get(&index) } {
         let hproto: *const EtherType = ptr_at(&ctx, mem::offset_of!(EthHdr, ether_type))?;
         match unsafe { *hproto } {
             EtherType::Ipv6 => {

--- a/test/integration-ebpf/src/per_cpu_array.rs
+++ b/test/integration-ebpf/src/per_cpu_array.rs
@@ -73,7 +73,7 @@ macro_rules! define_per_cpu_array_test {
         fn $set_prog(ctx: ProbeContext) -> Result<(), c_long> {
             let index: u32 = ctx.arg(0).ok_or(-1)?;
             let value: u32 = ctx.arg(1).ok_or(-1)?;
-            $array_map.set(index, value, 0).map_err(c_long::from)?;
+            $array_map.set(index, &value, 0).map_err(c_long::from)?;
             Ok(())
         }
     };

--- a/test/integration-ebpf/src/perf_event_bp.rs
+++ b/test/integration-ebpf/src/perf_event_bp.rs
@@ -19,6 +19,6 @@ static READERS: HashMap<u32, u64> = HashMap::with_max_entries(1, 0);
 fn perf_event_bp(ctx: PerfEventContext) -> u32 {
     let tgid = ctx.tgid();
     let addr = unsafe { (*ctx.ctx).addr };
-    let _unused: Result<_, _> = READERS.insert(tgid, addr, 0);
+    let _unused: Result<_, _> = READERS.insert(&tgid, &addr, 0);
     0
 }

--- a/test/integration-ebpf/src/sock_hash.rs
+++ b/test/integration-ebpf/src/sock_hash.rs
@@ -25,9 +25,9 @@ macro_rules! define_sk_lookup {
     ($map:ident, $prog:ident) => {
         #[sk_lookup]
         fn $prog(ctx: SkLookupContext) -> u32 {
-            match $map.redirect_sk_lookup(&ctx, 0u32, 0) {
+            match $map.redirect_sk_lookup(&ctx, &0u32, 0) {
                 Ok(()) => SK_PASS,
-                Err(errno) => match LAST_ERRNO.set(0, errno, 0) {
+                Err(errno) => match LAST_ERRNO.set(0, &errno, 0) {
                     // Single-slot ARRAY set is infallible at runtime.
                     Ok(()) | Err(_) => SK_DROP,
                 },

--- a/test/integration-ebpf/src/sock_map.rs
+++ b/test/integration-ebpf/src/sock_map.rs
@@ -27,7 +27,7 @@ macro_rules! define_sk_lookup {
         fn $prog(ctx: SkLookupContext) -> u32 {
             match $map.redirect_sk_lookup(&ctx, 0, 0) {
                 Ok(()) => SK_PASS,
-                Err(errno) => match LAST_ERRNO.set(0, errno, 0) {
+                Err(errno) => match LAST_ERRNO.set(0, &errno, 0) {
                     // Single-slot ARRAY set is infallible at runtime.
                     Ok(()) | Err(_) => SK_DROP,
                 },

--- a/test/integration-ebpf/src/uprobe_cookie.rs
+++ b/test/integration-ebpf/src/uprobe_cookie.rs
@@ -18,5 +18,5 @@ static RING_BUF: RingBuf = RingBuf::with_byte_size(0, 0);
 fn uprobe_cookie(ctx: ProbeContext) {
     let cookie = unsafe { helpers::bpf_get_attach_cookie(ctx.as_ptr()) };
     let cookie_bytes = cookie.to_ne_bytes();
-    let _res = RING_BUF.output::<[u8]>(cookie_bytes, 0);
+    let _res = RING_BUF.output::<[u8]>(&cookie_bytes, 0);
 }

--- a/test/integration-ebpf/src/uprobe_multi.rs
+++ b/test/integration-ebpf/src/uprobe_multi.rs
@@ -18,7 +18,7 @@ static RING_BUF: RingBuf = RingBuf::with_byte_size(0, 0);
 fn output_cookie(ctx: &ProbeContext) {
     let cookie = unsafe { helpers::bpf_get_attach_cookie(ctx.as_ptr()) };
     let cookie_bytes = cookie.to_ne_bytes();
-    let _res = RING_BUF.output::<[u8]>(cookie_bytes, 0);
+    let _res = RING_BUF.output::<[u8]>(&cookie_bytes, 0);
 }
 
 #[uprobe(multi)]

--- a/xtask/public-api/aya-ebpf.txt
+++ b/xtask/public-api/aya-ebpf.txt
@@ -11,7 +11,7 @@ impl<T, const MAX_ENTRIES: usize, const FLAGS: usize> aya_ebpf::btf_maps::array:
 pub fn aya_ebpf::btf_maps::array::Array<T, MAX_ENTRIES, FLAGS>::get(&self, u32) -> core::option::Option<&T>
 pub fn aya_ebpf::btf_maps::array::Array<T, MAX_ENTRIES, FLAGS>::get_ptr(&self, u32) -> core::option::Option<*const T>
 pub fn aya_ebpf::btf_maps::array::Array<T, MAX_ENTRIES, FLAGS>::get_ptr_mut(&self, u32) -> core::option::Option<*mut T>
-pub fn aya_ebpf::btf_maps::array::Array<T, MAX_ENTRIES, FLAGS>::set(&self, u32, impl core::borrow::Borrow<T>, u64) -> core::result::Result<(), i32>
+pub fn aya_ebpf::btf_maps::array::Array<T, MAX_ENTRIES, FLAGS>::set(&self, u32, &T, u64) -> core::result::Result<(), i32>
 impl<T, const MAX_ENTRIES: usize, const FLAGS: usize> aya_ebpf::btf_maps::array::Array<T, MAX_ENTRIES, FLAGS>
 pub const fn aya_ebpf::btf_maps::array::Array<T, MAX_ENTRIES, FLAGS>::new() -> Self
 impl<T, const MAX_ENTRIES: usize, const FLAGS: usize> core::default::Default for aya_ebpf::btf_maps::array::Array<T, MAX_ENTRIES, FLAGS>
@@ -26,8 +26,8 @@ impl<T, const MAX_ENTRIES: usize, const FLAGS: usize> core::panic::unwind_safe::
 pub mod aya_ebpf::btf_maps::bloom_filter
 #[repr(C)] pub struct aya_ebpf::btf_maps::bloom_filter::BloomFilter<T, const MAX_ENTRIES: usize, const FLAGS: usize, const HASH_FUNCS: usize>
 impl<T, const MAX_ENTRIES: usize, const FLAGS: usize, const HASH_FUNCS: usize> aya_ebpf::btf_maps::bloom_filter::BloomFilter<T, MAX_ENTRIES, FLAGS, HASH_FUNCS>
-pub fn aya_ebpf::btf_maps::bloom_filter::BloomFilter<T, MAX_ENTRIES, FLAGS, HASH_FUNCS>::contains(&self, impl core::borrow::Borrow<T>) -> core::result::Result<(), i32>
-pub fn aya_ebpf::btf_maps::bloom_filter::BloomFilter<T, MAX_ENTRIES, FLAGS, HASH_FUNCS>::insert(&self, impl core::borrow::Borrow<T>, u64) -> core::result::Result<(), i32>
+pub fn aya_ebpf::btf_maps::bloom_filter::BloomFilter<T, MAX_ENTRIES, FLAGS, HASH_FUNCS>::contains(&self, &T) -> core::result::Result<(), i32>
+pub fn aya_ebpf::btf_maps::bloom_filter::BloomFilter<T, MAX_ENTRIES, FLAGS, HASH_FUNCS>::insert(&self, &T, u64) -> core::result::Result<(), i32>
 impl<T, const MAX_ENTRIES: usize, const FLAGS: usize, const HASH_FUNCS: usize> aya_ebpf::btf_maps::bloom_filter::BloomFilter<T, MAX_ENTRIES, FLAGS, HASH_FUNCS>
 pub const fn aya_ebpf::btf_maps::bloom_filter::BloomFilter<T, MAX_ENTRIES, FLAGS, HASH_FUNCS>::new() -> Self
 impl<T, const MAX_ENTRIES: usize, const FLAGS: usize, const HASH_FUNCS: usize> core::default::Default for aya_ebpf::btf_maps::bloom_filter::BloomFilter<T, MAX_ENTRIES, FLAGS, HASH_FUNCS>
@@ -152,11 +152,11 @@ impl<const MAX_ENTRIES: usize, const FLAGS: usize> core::panic::unwind_safe::Unw
 pub mod aya_ebpf::btf_maps::hash_map
 #[repr(C)] pub struct aya_ebpf::btf_maps::hash_map::HashMap<K, V, const MAX_ENTRIES: usize, const FLAGS: usize>
 impl<K, V, const MAX_ENTRIES: usize, const FLAGS: usize> aya_ebpf::btf_maps::hash_map::HashMap<K, V, MAX_ENTRIES, FLAGS>
-pub unsafe fn aya_ebpf::btf_maps::hash_map::HashMap<K, V, MAX_ENTRIES, FLAGS>::get(&self, impl core::borrow::Borrow<K>) -> core::option::Option<&V>
-pub fn aya_ebpf::btf_maps::hash_map::HashMap<K, V, MAX_ENTRIES, FLAGS>::get_ptr(&self, impl core::borrow::Borrow<K>) -> core::option::Option<*const V>
-pub fn aya_ebpf::btf_maps::hash_map::HashMap<K, V, MAX_ENTRIES, FLAGS>::get_ptr_mut(&self, impl core::borrow::Borrow<K>) -> core::option::Option<*mut V>
-pub fn aya_ebpf::btf_maps::hash_map::HashMap<K, V, MAX_ENTRIES, FLAGS>::insert(&self, impl core::borrow::Borrow<K>, impl core::borrow::Borrow<V>, u64) -> core::result::Result<(), i32>
-pub fn aya_ebpf::btf_maps::hash_map::HashMap<K, V, MAX_ENTRIES, FLAGS>::remove(&self, impl core::borrow::Borrow<K>) -> core::result::Result<(), i32>
+pub unsafe fn aya_ebpf::btf_maps::hash_map::HashMap<K, V, MAX_ENTRIES, FLAGS>::get(&self, &K) -> core::option::Option<&V>
+pub fn aya_ebpf::btf_maps::hash_map::HashMap<K, V, MAX_ENTRIES, FLAGS>::get_ptr(&self, &K) -> core::option::Option<*const V>
+pub fn aya_ebpf::btf_maps::hash_map::HashMap<K, V, MAX_ENTRIES, FLAGS>::get_ptr_mut(&self, &K) -> core::option::Option<*mut V>
+pub fn aya_ebpf::btf_maps::hash_map::HashMap<K, V, MAX_ENTRIES, FLAGS>::insert(&self, &K, &V, u64) -> core::result::Result<(), i32>
+pub fn aya_ebpf::btf_maps::hash_map::HashMap<K, V, MAX_ENTRIES, FLAGS>::remove(&self, &K) -> core::result::Result<(), i32>
 impl<K, V, const MAX_ENTRIES: usize, const FLAGS: usize> aya_ebpf::btf_maps::hash_map::HashMap<K, V, MAX_ENTRIES, FLAGS>
 pub const fn aya_ebpf::btf_maps::hash_map::HashMap<K, V, MAX_ENTRIES, FLAGS>::new() -> Self
 impl<K, V, const MAX_ENTRIES: usize, const FLAGS: usize> core::default::Default for aya_ebpf::btf_maps::hash_map::HashMap<K, V, MAX_ENTRIES, FLAGS>
@@ -170,11 +170,11 @@ impl<K, V, const MAX_ENTRIES: usize, const FLAGS: usize> core::panic::unwind_saf
 impl<K, V, const MAX_ENTRIES: usize, const FLAGS: usize> core::panic::unwind_safe::UnwindSafe for aya_ebpf::btf_maps::hash_map::HashMap<K, V, MAX_ENTRIES, FLAGS> where K: core::panic::unwind_safe::RefUnwindSafe, V: core::panic::unwind_safe::RefUnwindSafe
 #[repr(C)] pub struct aya_ebpf::btf_maps::hash_map::LruHashMap<K, V, const MAX_ENTRIES: usize, const FLAGS: usize>
 impl<K, V, const MAX_ENTRIES: usize, const FLAGS: usize> aya_ebpf::btf_maps::hash_map::LruHashMap<K, V, MAX_ENTRIES, FLAGS>
-pub unsafe fn aya_ebpf::btf_maps::hash_map::LruHashMap<K, V, MAX_ENTRIES, FLAGS>::get(&self, impl core::borrow::Borrow<K>) -> core::option::Option<&V>
-pub fn aya_ebpf::btf_maps::hash_map::LruHashMap<K, V, MAX_ENTRIES, FLAGS>::get_ptr(&self, impl core::borrow::Borrow<K>) -> core::option::Option<*const V>
-pub fn aya_ebpf::btf_maps::hash_map::LruHashMap<K, V, MAX_ENTRIES, FLAGS>::get_ptr_mut(&self, impl core::borrow::Borrow<K>) -> core::option::Option<*mut V>
-pub fn aya_ebpf::btf_maps::hash_map::LruHashMap<K, V, MAX_ENTRIES, FLAGS>::insert(&self, impl core::borrow::Borrow<K>, impl core::borrow::Borrow<V>, u64) -> core::result::Result<(), i32>
-pub fn aya_ebpf::btf_maps::hash_map::LruHashMap<K, V, MAX_ENTRIES, FLAGS>::remove(&self, impl core::borrow::Borrow<K>) -> core::result::Result<(), i32>
+pub unsafe fn aya_ebpf::btf_maps::hash_map::LruHashMap<K, V, MAX_ENTRIES, FLAGS>::get(&self, &K) -> core::option::Option<&V>
+pub fn aya_ebpf::btf_maps::hash_map::LruHashMap<K, V, MAX_ENTRIES, FLAGS>::get_ptr(&self, &K) -> core::option::Option<*const V>
+pub fn aya_ebpf::btf_maps::hash_map::LruHashMap<K, V, MAX_ENTRIES, FLAGS>::get_ptr_mut(&self, &K) -> core::option::Option<*mut V>
+pub fn aya_ebpf::btf_maps::hash_map::LruHashMap<K, V, MAX_ENTRIES, FLAGS>::insert(&self, &K, &V, u64) -> core::result::Result<(), i32>
+pub fn aya_ebpf::btf_maps::hash_map::LruHashMap<K, V, MAX_ENTRIES, FLAGS>::remove(&self, &K) -> core::result::Result<(), i32>
 impl<K, V, const MAX_ENTRIES: usize, const FLAGS: usize> aya_ebpf::btf_maps::hash_map::LruHashMap<K, V, MAX_ENTRIES, FLAGS>
 pub const fn aya_ebpf::btf_maps::hash_map::LruHashMap<K, V, MAX_ENTRIES, FLAGS>::new() -> Self
 impl<K, V, const MAX_ENTRIES: usize, const FLAGS: usize> core::default::Default for aya_ebpf::btf_maps::hash_map::LruHashMap<K, V, MAX_ENTRIES, FLAGS>
@@ -188,11 +188,11 @@ impl<K, V, const MAX_ENTRIES: usize, const FLAGS: usize> core::panic::unwind_saf
 impl<K, V, const MAX_ENTRIES: usize, const FLAGS: usize> core::panic::unwind_safe::UnwindSafe for aya_ebpf::btf_maps::hash_map::LruHashMap<K, V, MAX_ENTRIES, FLAGS> where K: core::panic::unwind_safe::RefUnwindSafe, V: core::panic::unwind_safe::RefUnwindSafe
 #[repr(C)] pub struct aya_ebpf::btf_maps::hash_map::LruPerCpuHashMap<K, V, const MAX_ENTRIES: usize, const FLAGS: usize>
 impl<K, V, const MAX_ENTRIES: usize, const FLAGS: usize> aya_ebpf::btf_maps::hash_map::LruPerCpuHashMap<K, V, MAX_ENTRIES, FLAGS>
-pub unsafe fn aya_ebpf::btf_maps::hash_map::LruPerCpuHashMap<K, V, MAX_ENTRIES, FLAGS>::get(&self, impl core::borrow::Borrow<K>) -> core::option::Option<&V>
-pub fn aya_ebpf::btf_maps::hash_map::LruPerCpuHashMap<K, V, MAX_ENTRIES, FLAGS>::get_ptr(&self, impl core::borrow::Borrow<K>) -> core::option::Option<*const V>
-pub fn aya_ebpf::btf_maps::hash_map::LruPerCpuHashMap<K, V, MAX_ENTRIES, FLAGS>::get_ptr_mut(&self, impl core::borrow::Borrow<K>) -> core::option::Option<*mut V>
-pub fn aya_ebpf::btf_maps::hash_map::LruPerCpuHashMap<K, V, MAX_ENTRIES, FLAGS>::insert(&self, impl core::borrow::Borrow<K>, impl core::borrow::Borrow<V>, u64) -> core::result::Result<(), i32>
-pub fn aya_ebpf::btf_maps::hash_map::LruPerCpuHashMap<K, V, MAX_ENTRIES, FLAGS>::remove(&self, impl core::borrow::Borrow<K>) -> core::result::Result<(), i32>
+pub unsafe fn aya_ebpf::btf_maps::hash_map::LruPerCpuHashMap<K, V, MAX_ENTRIES, FLAGS>::get(&self, &K) -> core::option::Option<&V>
+pub fn aya_ebpf::btf_maps::hash_map::LruPerCpuHashMap<K, V, MAX_ENTRIES, FLAGS>::get_ptr(&self, &K) -> core::option::Option<*const V>
+pub fn aya_ebpf::btf_maps::hash_map::LruPerCpuHashMap<K, V, MAX_ENTRIES, FLAGS>::get_ptr_mut(&self, &K) -> core::option::Option<*mut V>
+pub fn aya_ebpf::btf_maps::hash_map::LruPerCpuHashMap<K, V, MAX_ENTRIES, FLAGS>::insert(&self, &K, &V, u64) -> core::result::Result<(), i32>
+pub fn aya_ebpf::btf_maps::hash_map::LruPerCpuHashMap<K, V, MAX_ENTRIES, FLAGS>::remove(&self, &K) -> core::result::Result<(), i32>
 impl<K, V, const MAX_ENTRIES: usize, const FLAGS: usize> aya_ebpf::btf_maps::hash_map::LruPerCpuHashMap<K, V, MAX_ENTRIES, FLAGS>
 pub const fn aya_ebpf::btf_maps::hash_map::LruPerCpuHashMap<K, V, MAX_ENTRIES, FLAGS>::new() -> Self
 impl<K, V, const MAX_ENTRIES: usize, const FLAGS: usize> core::default::Default for aya_ebpf::btf_maps::hash_map::LruPerCpuHashMap<K, V, MAX_ENTRIES, FLAGS>
@@ -206,11 +206,11 @@ impl<K, V, const MAX_ENTRIES: usize, const FLAGS: usize> core::panic::unwind_saf
 impl<K, V, const MAX_ENTRIES: usize, const FLAGS: usize> core::panic::unwind_safe::UnwindSafe for aya_ebpf::btf_maps::hash_map::LruPerCpuHashMap<K, V, MAX_ENTRIES, FLAGS> where K: core::panic::unwind_safe::RefUnwindSafe, V: core::panic::unwind_safe::RefUnwindSafe
 #[repr(C)] pub struct aya_ebpf::btf_maps::hash_map::PerCpuHashMap<K, V, const MAX_ENTRIES: usize, const FLAGS: usize>
 impl<K, V, const MAX_ENTRIES: usize, const FLAGS: usize> aya_ebpf::btf_maps::hash_map::PerCpuHashMap<K, V, MAX_ENTRIES, FLAGS>
-pub unsafe fn aya_ebpf::btf_maps::hash_map::PerCpuHashMap<K, V, MAX_ENTRIES, FLAGS>::get(&self, impl core::borrow::Borrow<K>) -> core::option::Option<&V>
-pub fn aya_ebpf::btf_maps::hash_map::PerCpuHashMap<K, V, MAX_ENTRIES, FLAGS>::get_ptr(&self, impl core::borrow::Borrow<K>) -> core::option::Option<*const V>
-pub fn aya_ebpf::btf_maps::hash_map::PerCpuHashMap<K, V, MAX_ENTRIES, FLAGS>::get_ptr_mut(&self, impl core::borrow::Borrow<K>) -> core::option::Option<*mut V>
-pub fn aya_ebpf::btf_maps::hash_map::PerCpuHashMap<K, V, MAX_ENTRIES, FLAGS>::insert(&self, impl core::borrow::Borrow<K>, impl core::borrow::Borrow<V>, u64) -> core::result::Result<(), i32>
-pub fn aya_ebpf::btf_maps::hash_map::PerCpuHashMap<K, V, MAX_ENTRIES, FLAGS>::remove(&self, impl core::borrow::Borrow<K>) -> core::result::Result<(), i32>
+pub unsafe fn aya_ebpf::btf_maps::hash_map::PerCpuHashMap<K, V, MAX_ENTRIES, FLAGS>::get(&self, &K) -> core::option::Option<&V>
+pub fn aya_ebpf::btf_maps::hash_map::PerCpuHashMap<K, V, MAX_ENTRIES, FLAGS>::get_ptr(&self, &K) -> core::option::Option<*const V>
+pub fn aya_ebpf::btf_maps::hash_map::PerCpuHashMap<K, V, MAX_ENTRIES, FLAGS>::get_ptr_mut(&self, &K) -> core::option::Option<*mut V>
+pub fn aya_ebpf::btf_maps::hash_map::PerCpuHashMap<K, V, MAX_ENTRIES, FLAGS>::insert(&self, &K, &V, u64) -> core::result::Result<(), i32>
+pub fn aya_ebpf::btf_maps::hash_map::PerCpuHashMap<K, V, MAX_ENTRIES, FLAGS>::remove(&self, &K) -> core::result::Result<(), i32>
 impl<K, V, const MAX_ENTRIES: usize, const FLAGS: usize> aya_ebpf::btf_maps::hash_map::PerCpuHashMap<K, V, MAX_ENTRIES, FLAGS>
 pub const fn aya_ebpf::btf_maps::hash_map::PerCpuHashMap<K, V, MAX_ENTRIES, FLAGS>::new() -> Self
 impl<K, V, const MAX_ENTRIES: usize, const FLAGS: usize> core::default::Default for aya_ebpf::btf_maps::hash_map::PerCpuHashMap<K, V, MAX_ENTRIES, FLAGS>
@@ -255,7 +255,7 @@ impl<K> core::panic::unwind_safe::UnwindSafe for aya_ebpf::maps::lpm_trie::Key<K
 #[repr(C)] pub struct aya_ebpf::btf_maps::lpm_trie::LpmTrie<K, V, const MAX_ENTRIES: usize, const FLAGS: usize>
 impl<K, V, const MAX_ENTRIES: usize, const FLAGS: usize> aya_ebpf::btf_maps::lpm_trie::LpmTrie<K, V, MAX_ENTRIES, FLAGS>
 pub fn aya_ebpf::btf_maps::lpm_trie::LpmTrie<K, V, MAX_ENTRIES, FLAGS>::get(&self, &aya_ebpf::maps::lpm_trie::Key<K>) -> core::option::Option<&V>
-pub fn aya_ebpf::btf_maps::lpm_trie::LpmTrie<K, V, MAX_ENTRIES, FLAGS>::insert(&self, &aya_ebpf::maps::lpm_trie::Key<K>, impl core::borrow::Borrow<V>, u64) -> core::result::Result<(), i32>
+pub fn aya_ebpf::btf_maps::lpm_trie::LpmTrie<K, V, MAX_ENTRIES, FLAGS>::insert(&self, &aya_ebpf::maps::lpm_trie::Key<K>, &V, u64) -> core::result::Result<(), i32>
 pub fn aya_ebpf::btf_maps::lpm_trie::LpmTrie<K, V, MAX_ENTRIES, FLAGS>::remove(&self, &aya_ebpf::maps::lpm_trie::Key<K>) -> core::result::Result<(), i32>
 impl<K, V, const MAX_ENTRIES: usize, const FLAGS: usize> aya_ebpf::btf_maps::lpm_trie::LpmTrie<K, V, MAX_ENTRIES, FLAGS>
 pub const fn aya_ebpf::btf_maps::lpm_trie::LpmTrie<K, V, MAX_ENTRIES, FLAGS>::new() -> Self
@@ -310,7 +310,7 @@ impl<T, const MAX_ENTRIES: usize, const FLAGS: usize> aya_ebpf::btf_maps::per_cp
 pub fn aya_ebpf::btf_maps::per_cpu_array::PerCpuArray<T, MAX_ENTRIES, FLAGS>::get(&self, u32) -> core::option::Option<&T>
 pub fn aya_ebpf::btf_maps::per_cpu_array::PerCpuArray<T, MAX_ENTRIES, FLAGS>::get_ptr(&self, u32) -> core::option::Option<*const T>
 pub fn aya_ebpf::btf_maps::per_cpu_array::PerCpuArray<T, MAX_ENTRIES, FLAGS>::get_ptr_mut(&self, u32) -> core::option::Option<*mut T>
-pub fn aya_ebpf::btf_maps::per_cpu_array::PerCpuArray<T, MAX_ENTRIES, FLAGS>::set(&self, u32, impl core::borrow::Borrow<T>, u64) -> core::result::Result<(), i32>
+pub fn aya_ebpf::btf_maps::per_cpu_array::PerCpuArray<T, MAX_ENTRIES, FLAGS>::set(&self, u32, &T, u64) -> core::result::Result<(), i32>
 impl<T, const MAX_ENTRIES: usize, const FLAGS: usize> aya_ebpf::btf_maps::per_cpu_array::PerCpuArray<T, MAX_ENTRIES, FLAGS>
 pub const fn aya_ebpf::btf_maps::per_cpu_array::PerCpuArray<T, MAX_ENTRIES, FLAGS>::new() -> Self
 impl<T, const MAX_ENTRIES: usize, const FLAGS: usize> core::default::Default for aya_ebpf::btf_maps::per_cpu_array::PerCpuArray<T, MAX_ENTRIES, FLAGS>
@@ -376,7 +376,7 @@ pub const fn aya_ebpf::btf_maps::queue::Queue<T, MAX_ENTRIES, FLAGS>::new() -> S
 impl<T, const MAX_ENTRIES: usize, const FLAGS: usize> aya_ebpf::btf_maps::queue::Queue<T, MAX_ENTRIES, FLAGS>
 pub fn aya_ebpf::btf_maps::queue::Queue<T, MAX_ENTRIES, FLAGS>::peek(&self) -> core::result::Result<core::option::Option<T>, i32>
 pub fn aya_ebpf::btf_maps::queue::Queue<T, MAX_ENTRIES, FLAGS>::pop(&self) -> core::result::Result<core::option::Option<T>, i32>
-pub fn aya_ebpf::btf_maps::queue::Queue<T, MAX_ENTRIES, FLAGS>::push(&self, impl core::borrow::Borrow<T>, u64) -> core::result::Result<(), i32>
+pub fn aya_ebpf::btf_maps::queue::Queue<T, MAX_ENTRIES, FLAGS>::push(&self, &T, u64) -> core::result::Result<(), i32>
 impl<T, const MAX_ENTRIES: usize, const FLAGS: usize> core::default::Default for aya_ebpf::btf_maps::queue::Queue<T, MAX_ENTRIES, FLAGS>
 pub fn aya_ebpf::btf_maps::queue::Queue<T, MAX_ENTRIES, FLAGS>::default() -> Self
 impl<T, const MAX_ENTRIES: usize, const FLAGS: usize> core::marker::Sync for aya_ebpf::btf_maps::queue::Queue<T, MAX_ENTRIES, FLAGS>
@@ -407,8 +407,8 @@ pub mod aya_ebpf::btf_maps::ring_buf
 impl<T, const MAX_ENTRIES: usize, const FLAGS: usize> aya_ebpf::btf_maps::ring_buf::RingBuf<T, MAX_ENTRIES, FLAGS>
 pub const fn aya_ebpf::btf_maps::ring_buf::RingBuf<T, MAX_ENTRIES, FLAGS>::new() -> Self
 impl<T, const MAX_ENTRIES: usize, const FLAGS: usize> aya_ebpf::btf_maps::ring_buf::RingBuf<T, MAX_ENTRIES, FLAGS>
-pub fn aya_ebpf::btf_maps::ring_buf::RingBuf<T, MAX_ENTRIES, FLAGS>::output(&self, impl core::borrow::Borrow<T>, u64) -> core::result::Result<(), i32>
-pub fn aya_ebpf::btf_maps::ring_buf::RingBuf<T, MAX_ENTRIES, FLAGS>::output_untyped<U: ?core::marker::Sized>(&self, impl core::borrow::Borrow<U>, u64) -> core::result::Result<(), i32>
+pub fn aya_ebpf::btf_maps::ring_buf::RingBuf<T, MAX_ENTRIES, FLAGS>::output(&self, &T, u64) -> core::result::Result<(), i32>
+pub fn aya_ebpf::btf_maps::ring_buf::RingBuf<T, MAX_ENTRIES, FLAGS>::output_untyped<U: ?core::marker::Sized>(&self, &U, u64) -> core::result::Result<(), i32>
 pub fn aya_ebpf::btf_maps::ring_buf::RingBuf<T, MAX_ENTRIES, FLAGS>::reserve(&self, u64) -> core::option::Option<aya_ebpf::maps::ring_buf::RingBufEntry<T>> where T: 'static
 pub fn aya_ebpf::btf_maps::ring_buf::RingBuf<T, MAX_ENTRIES, FLAGS>::reserve_bytes(&self, usize, u64) -> core::option::Option<aya_ebpf::maps::ring_buf::RingBufBytes<'_>>
 pub fn aya_ebpf::btf_maps::ring_buf::RingBuf<T, MAX_ENTRIES, FLAGS>::reserve_untyped<U: 'static>(&self, u64) -> core::option::Option<aya_ebpf::maps::ring_buf::RingBufEntry<U>>
@@ -443,10 +443,10 @@ pub mod aya_ebpf::btf_maps::sock_hash
 impl<K, const MAX_ENTRIES: usize, const FLAGS: usize> aya_ebpf::btf_maps::sock_hash::SockHash<K, MAX_ENTRIES, FLAGS>
 pub const fn aya_ebpf::btf_maps::sock_hash::SockHash<K, MAX_ENTRIES, FLAGS>::new() -> Self
 impl<K, const MAX_ENTRIES: usize, const FLAGS: usize> aya_ebpf::btf_maps::sock_hash::SockHash<K, MAX_ENTRIES, FLAGS>
-pub fn aya_ebpf::btf_maps::sock_hash::SockHash<K, MAX_ENTRIES, FLAGS>::redirect_msg(&self, impl core::borrow::Borrow<aya_ebpf::programs::sk_msg::SkMsgContext>, impl core::borrow::BorrowMut<K>, u64) -> aya_ebpf_cty::od::c_long
-pub fn aya_ebpf::btf_maps::sock_hash::SockHash<K, MAX_ENTRIES, FLAGS>::redirect_sk_lookup(&self, impl core::borrow::Borrow<aya_ebpf::programs::sk_lookup::SkLookupContext>, impl core::borrow::Borrow<K>, u64) -> core::result::Result<(), i32>
-pub fn aya_ebpf::btf_maps::sock_hash::SockHash<K, MAX_ENTRIES, FLAGS>::redirect_skb(&self, impl core::borrow::Borrow<aya_ebpf::programs::sk_buff::SkBuffContext>, impl core::borrow::BorrowMut<K>, u64) -> aya_ebpf_cty::od::c_long
-pub fn aya_ebpf::btf_maps::sock_hash::SockHash<K, MAX_ENTRIES, FLAGS>::update(&self, impl core::borrow::BorrowMut<K>, impl core::borrow::BorrowMut<aya_ebpf_bindings::x86_64::bindings::bpf_sock_ops>, u64) -> core::result::Result<(), i32>
+pub fn aya_ebpf::btf_maps::sock_hash::SockHash<K, MAX_ENTRIES, FLAGS>::redirect_msg(&self, &aya_ebpf::programs::sk_msg::SkMsgContext, &mut K, u64) -> aya_ebpf_cty::od::c_long
+pub fn aya_ebpf::btf_maps::sock_hash::SockHash<K, MAX_ENTRIES, FLAGS>::redirect_sk_lookup(&self, &aya_ebpf::programs::sk_lookup::SkLookupContext, &K, u64) -> core::result::Result<(), i32>
+pub fn aya_ebpf::btf_maps::sock_hash::SockHash<K, MAX_ENTRIES, FLAGS>::redirect_skb(&self, &aya_ebpf::programs::sk_buff::SkBuffContext, &mut K, u64) -> aya_ebpf_cty::od::c_long
+pub fn aya_ebpf::btf_maps::sock_hash::SockHash<K, MAX_ENTRIES, FLAGS>::update(&self, &mut K, &mut aya_ebpf_bindings::x86_64::bindings::bpf_sock_ops, u64) -> core::result::Result<(), i32>
 impl<K, const MAX_ENTRIES: usize, const FLAGS: usize> core::default::Default for aya_ebpf::btf_maps::sock_hash::SockHash<K, MAX_ENTRIES, FLAGS>
 pub fn aya_ebpf::btf_maps::sock_hash::SockHash<K, MAX_ENTRIES, FLAGS>::default() -> Self
 impl<K, const MAX_ENTRIES: usize, const FLAGS: usize> core::marker::Sync for aya_ebpf::btf_maps::sock_hash::SockHash<K, MAX_ENTRIES, FLAGS>
@@ -481,7 +481,7 @@ pub const fn aya_ebpf::btf_maps::stack::Stack<T, MAX_ENTRIES, FLAGS>::new() -> S
 impl<T, const MAX_ENTRIES: usize, const FLAGS: usize> aya_ebpf::btf_maps::stack::Stack<T, MAX_ENTRIES, FLAGS>
 pub fn aya_ebpf::btf_maps::stack::Stack<T, MAX_ENTRIES, FLAGS>::peek(&self) -> core::result::Result<core::option::Option<T>, i32>
 pub fn aya_ebpf::btf_maps::stack::Stack<T, MAX_ENTRIES, FLAGS>::pop(&self) -> core::result::Result<core::option::Option<T>, i32>
-pub fn aya_ebpf::btf_maps::stack::Stack<T, MAX_ENTRIES, FLAGS>::push(&self, impl core::borrow::Borrow<T>, u64) -> core::result::Result<(), i32>
+pub fn aya_ebpf::btf_maps::stack::Stack<T, MAX_ENTRIES, FLAGS>::push(&self, &T, u64) -> core::result::Result<(), i32>
 impl<T, const MAX_ENTRIES: usize, const FLAGS: usize> core::default::Default for aya_ebpf::btf_maps::stack::Stack<T, MAX_ENTRIES, FLAGS>
 pub fn aya_ebpf::btf_maps::stack::Stack<T, MAX_ENTRIES, FLAGS>::default() -> Self
 impl<T, const MAX_ENTRIES: usize, const FLAGS: usize> core::marker::Sync for aya_ebpf::btf_maps::stack::Stack<T, MAX_ENTRIES, FLAGS>
@@ -525,7 +525,7 @@ impl<T, const MAX_ENTRIES: usize, const FLAGS: usize> aya_ebpf::btf_maps::array:
 pub fn aya_ebpf::btf_maps::array::Array<T, MAX_ENTRIES, FLAGS>::get(&self, u32) -> core::option::Option<&T>
 pub fn aya_ebpf::btf_maps::array::Array<T, MAX_ENTRIES, FLAGS>::get_ptr(&self, u32) -> core::option::Option<*const T>
 pub fn aya_ebpf::btf_maps::array::Array<T, MAX_ENTRIES, FLAGS>::get_ptr_mut(&self, u32) -> core::option::Option<*mut T>
-pub fn aya_ebpf::btf_maps::array::Array<T, MAX_ENTRIES, FLAGS>::set(&self, u32, impl core::borrow::Borrow<T>, u64) -> core::result::Result<(), i32>
+pub fn aya_ebpf::btf_maps::array::Array<T, MAX_ENTRIES, FLAGS>::set(&self, u32, &T, u64) -> core::result::Result<(), i32>
 impl<T, const MAX_ENTRIES: usize, const FLAGS: usize> aya_ebpf::btf_maps::array::Array<T, MAX_ENTRIES, FLAGS>
 pub const fn aya_ebpf::btf_maps::array::Array<T, MAX_ENTRIES, FLAGS>::new() -> Self
 impl<T, const MAX_ENTRIES: usize, const FLAGS: usize> core::default::Default for aya_ebpf::btf_maps::array::Array<T, MAX_ENTRIES, FLAGS>
@@ -557,8 +557,8 @@ impl<V, const MAX_ENTRIES: usize, const FLAGS: usize> core::panic::unwind_safe::
 impl<V, const MAX_ENTRIES: usize, const FLAGS: usize> core::panic::unwind_safe::UnwindSafe for aya_ebpf::btf_maps::ArrayOfMaps<V, MAX_ENTRIES, FLAGS> where V: core::panic::unwind_safe::RefUnwindSafe
 #[repr(C)] pub struct aya_ebpf::btf_maps::BloomFilter<T, const MAX_ENTRIES: usize, const FLAGS: usize, const HASH_FUNCS: usize>
 impl<T, const MAX_ENTRIES: usize, const FLAGS: usize, const HASH_FUNCS: usize> aya_ebpf::btf_maps::bloom_filter::BloomFilter<T, MAX_ENTRIES, FLAGS, HASH_FUNCS>
-pub fn aya_ebpf::btf_maps::bloom_filter::BloomFilter<T, MAX_ENTRIES, FLAGS, HASH_FUNCS>::contains(&self, impl core::borrow::Borrow<T>) -> core::result::Result<(), i32>
-pub fn aya_ebpf::btf_maps::bloom_filter::BloomFilter<T, MAX_ENTRIES, FLAGS, HASH_FUNCS>::insert(&self, impl core::borrow::Borrow<T>, u64) -> core::result::Result<(), i32>
+pub fn aya_ebpf::btf_maps::bloom_filter::BloomFilter<T, MAX_ENTRIES, FLAGS, HASH_FUNCS>::contains(&self, &T) -> core::result::Result<(), i32>
+pub fn aya_ebpf::btf_maps::bloom_filter::BloomFilter<T, MAX_ENTRIES, FLAGS, HASH_FUNCS>::insert(&self, &T, u64) -> core::result::Result<(), i32>
 impl<T, const MAX_ENTRIES: usize, const FLAGS: usize, const HASH_FUNCS: usize> aya_ebpf::btf_maps::bloom_filter::BloomFilter<T, MAX_ENTRIES, FLAGS, HASH_FUNCS>
 pub const fn aya_ebpf::btf_maps::bloom_filter::BloomFilter<T, MAX_ENTRIES, FLAGS, HASH_FUNCS>::new() -> Self
 impl<T, const MAX_ENTRIES: usize, const FLAGS: usize, const HASH_FUNCS: usize> core::default::Default for aya_ebpf::btf_maps::bloom_filter::BloomFilter<T, MAX_ENTRIES, FLAGS, HASH_FUNCS>
@@ -662,11 +662,11 @@ impl<const MAX_ENTRIES: usize, const FLAGS: usize> core::panic::unwind_safe::Ref
 impl<const MAX_ENTRIES: usize, const FLAGS: usize> core::panic::unwind_safe::UnwindSafe for aya_ebpf::btf_maps::dev_map_hash::DevMapHash<MAX_ENTRIES, FLAGS>
 #[repr(C)] pub struct aya_ebpf::btf_maps::HashMap<K, V, const MAX_ENTRIES: usize, const FLAGS: usize>
 impl<K, V, const MAX_ENTRIES: usize, const FLAGS: usize> aya_ebpf::btf_maps::hash_map::HashMap<K, V, MAX_ENTRIES, FLAGS>
-pub unsafe fn aya_ebpf::btf_maps::hash_map::HashMap<K, V, MAX_ENTRIES, FLAGS>::get(&self, impl core::borrow::Borrow<K>) -> core::option::Option<&V>
-pub fn aya_ebpf::btf_maps::hash_map::HashMap<K, V, MAX_ENTRIES, FLAGS>::get_ptr(&self, impl core::borrow::Borrow<K>) -> core::option::Option<*const V>
-pub fn aya_ebpf::btf_maps::hash_map::HashMap<K, V, MAX_ENTRIES, FLAGS>::get_ptr_mut(&self, impl core::borrow::Borrow<K>) -> core::option::Option<*mut V>
-pub fn aya_ebpf::btf_maps::hash_map::HashMap<K, V, MAX_ENTRIES, FLAGS>::insert(&self, impl core::borrow::Borrow<K>, impl core::borrow::Borrow<V>, u64) -> core::result::Result<(), i32>
-pub fn aya_ebpf::btf_maps::hash_map::HashMap<K, V, MAX_ENTRIES, FLAGS>::remove(&self, impl core::borrow::Borrow<K>) -> core::result::Result<(), i32>
+pub unsafe fn aya_ebpf::btf_maps::hash_map::HashMap<K, V, MAX_ENTRIES, FLAGS>::get(&self, &K) -> core::option::Option<&V>
+pub fn aya_ebpf::btf_maps::hash_map::HashMap<K, V, MAX_ENTRIES, FLAGS>::get_ptr(&self, &K) -> core::option::Option<*const V>
+pub fn aya_ebpf::btf_maps::hash_map::HashMap<K, V, MAX_ENTRIES, FLAGS>::get_ptr_mut(&self, &K) -> core::option::Option<*mut V>
+pub fn aya_ebpf::btf_maps::hash_map::HashMap<K, V, MAX_ENTRIES, FLAGS>::insert(&self, &K, &V, u64) -> core::result::Result<(), i32>
+pub fn aya_ebpf::btf_maps::hash_map::HashMap<K, V, MAX_ENTRIES, FLAGS>::remove(&self, &K) -> core::result::Result<(), i32>
 impl<K, V, const MAX_ENTRIES: usize, const FLAGS: usize> aya_ebpf::btf_maps::hash_map::HashMap<K, V, MAX_ENTRIES, FLAGS>
 pub const fn aya_ebpf::btf_maps::hash_map::HashMap<K, V, MAX_ENTRIES, FLAGS>::new() -> Self
 impl<K, V, const MAX_ENTRIES: usize, const FLAGS: usize> core::default::Default for aya_ebpf::btf_maps::hash_map::HashMap<K, V, MAX_ENTRIES, FLAGS>
@@ -714,7 +714,7 @@ impl<T> core::panic::unwind_safe::UnwindSafe for aya_ebpf::btf_maps::inode_stora
 #[repr(C)] pub struct aya_ebpf::btf_maps::LpmTrie<K, V, const MAX_ENTRIES: usize, const FLAGS: usize>
 impl<K, V, const MAX_ENTRIES: usize, const FLAGS: usize> aya_ebpf::btf_maps::lpm_trie::LpmTrie<K, V, MAX_ENTRIES, FLAGS>
 pub fn aya_ebpf::btf_maps::lpm_trie::LpmTrie<K, V, MAX_ENTRIES, FLAGS>::get(&self, &aya_ebpf::maps::lpm_trie::Key<K>) -> core::option::Option<&V>
-pub fn aya_ebpf::btf_maps::lpm_trie::LpmTrie<K, V, MAX_ENTRIES, FLAGS>::insert(&self, &aya_ebpf::maps::lpm_trie::Key<K>, impl core::borrow::Borrow<V>, u64) -> core::result::Result<(), i32>
+pub fn aya_ebpf::btf_maps::lpm_trie::LpmTrie<K, V, MAX_ENTRIES, FLAGS>::insert(&self, &aya_ebpf::maps::lpm_trie::Key<K>, &V, u64) -> core::result::Result<(), i32>
 pub fn aya_ebpf::btf_maps::lpm_trie::LpmTrie<K, V, MAX_ENTRIES, FLAGS>::remove(&self, &aya_ebpf::maps::lpm_trie::Key<K>) -> core::result::Result<(), i32>
 impl<K, V, const MAX_ENTRIES: usize, const FLAGS: usize> aya_ebpf::btf_maps::lpm_trie::LpmTrie<K, V, MAX_ENTRIES, FLAGS>
 pub const fn aya_ebpf::btf_maps::lpm_trie::LpmTrie<K, V, MAX_ENTRIES, FLAGS>::new() -> Self
@@ -729,11 +729,11 @@ impl<K, V, const MAX_ENTRIES: usize, const FLAGS: usize> core::panic::unwind_saf
 impl<K, V, const MAX_ENTRIES: usize, const FLAGS: usize> core::panic::unwind_safe::UnwindSafe for aya_ebpf::btf_maps::lpm_trie::LpmTrie<K, V, MAX_ENTRIES, FLAGS> where V: core::panic::unwind_safe::RefUnwindSafe, K: core::panic::unwind_safe::RefUnwindSafe
 #[repr(C)] pub struct aya_ebpf::btf_maps::LruHashMap<K, V, const MAX_ENTRIES: usize, const FLAGS: usize>
 impl<K, V, const MAX_ENTRIES: usize, const FLAGS: usize> aya_ebpf::btf_maps::hash_map::LruHashMap<K, V, MAX_ENTRIES, FLAGS>
-pub unsafe fn aya_ebpf::btf_maps::hash_map::LruHashMap<K, V, MAX_ENTRIES, FLAGS>::get(&self, impl core::borrow::Borrow<K>) -> core::option::Option<&V>
-pub fn aya_ebpf::btf_maps::hash_map::LruHashMap<K, V, MAX_ENTRIES, FLAGS>::get_ptr(&self, impl core::borrow::Borrow<K>) -> core::option::Option<*const V>
-pub fn aya_ebpf::btf_maps::hash_map::LruHashMap<K, V, MAX_ENTRIES, FLAGS>::get_ptr_mut(&self, impl core::borrow::Borrow<K>) -> core::option::Option<*mut V>
-pub fn aya_ebpf::btf_maps::hash_map::LruHashMap<K, V, MAX_ENTRIES, FLAGS>::insert(&self, impl core::borrow::Borrow<K>, impl core::borrow::Borrow<V>, u64) -> core::result::Result<(), i32>
-pub fn aya_ebpf::btf_maps::hash_map::LruHashMap<K, V, MAX_ENTRIES, FLAGS>::remove(&self, impl core::borrow::Borrow<K>) -> core::result::Result<(), i32>
+pub unsafe fn aya_ebpf::btf_maps::hash_map::LruHashMap<K, V, MAX_ENTRIES, FLAGS>::get(&self, &K) -> core::option::Option<&V>
+pub fn aya_ebpf::btf_maps::hash_map::LruHashMap<K, V, MAX_ENTRIES, FLAGS>::get_ptr(&self, &K) -> core::option::Option<*const V>
+pub fn aya_ebpf::btf_maps::hash_map::LruHashMap<K, V, MAX_ENTRIES, FLAGS>::get_ptr_mut(&self, &K) -> core::option::Option<*mut V>
+pub fn aya_ebpf::btf_maps::hash_map::LruHashMap<K, V, MAX_ENTRIES, FLAGS>::insert(&self, &K, &V, u64) -> core::result::Result<(), i32>
+pub fn aya_ebpf::btf_maps::hash_map::LruHashMap<K, V, MAX_ENTRIES, FLAGS>::remove(&self, &K) -> core::result::Result<(), i32>
 impl<K, V, const MAX_ENTRIES: usize, const FLAGS: usize> aya_ebpf::btf_maps::hash_map::LruHashMap<K, V, MAX_ENTRIES, FLAGS>
 pub const fn aya_ebpf::btf_maps::hash_map::LruHashMap<K, V, MAX_ENTRIES, FLAGS>::new() -> Self
 impl<K, V, const MAX_ENTRIES: usize, const FLAGS: usize> core::default::Default for aya_ebpf::btf_maps::hash_map::LruHashMap<K, V, MAX_ENTRIES, FLAGS>
@@ -747,11 +747,11 @@ impl<K, V, const MAX_ENTRIES: usize, const FLAGS: usize> core::panic::unwind_saf
 impl<K, V, const MAX_ENTRIES: usize, const FLAGS: usize> core::panic::unwind_safe::UnwindSafe for aya_ebpf::btf_maps::hash_map::LruHashMap<K, V, MAX_ENTRIES, FLAGS> where K: core::panic::unwind_safe::RefUnwindSafe, V: core::panic::unwind_safe::RefUnwindSafe
 #[repr(C)] pub struct aya_ebpf::btf_maps::LruPerCpuHashMap<K, V, const MAX_ENTRIES: usize, const FLAGS: usize>
 impl<K, V, const MAX_ENTRIES: usize, const FLAGS: usize> aya_ebpf::btf_maps::hash_map::LruPerCpuHashMap<K, V, MAX_ENTRIES, FLAGS>
-pub unsafe fn aya_ebpf::btf_maps::hash_map::LruPerCpuHashMap<K, V, MAX_ENTRIES, FLAGS>::get(&self, impl core::borrow::Borrow<K>) -> core::option::Option<&V>
-pub fn aya_ebpf::btf_maps::hash_map::LruPerCpuHashMap<K, V, MAX_ENTRIES, FLAGS>::get_ptr(&self, impl core::borrow::Borrow<K>) -> core::option::Option<*const V>
-pub fn aya_ebpf::btf_maps::hash_map::LruPerCpuHashMap<K, V, MAX_ENTRIES, FLAGS>::get_ptr_mut(&self, impl core::borrow::Borrow<K>) -> core::option::Option<*mut V>
-pub fn aya_ebpf::btf_maps::hash_map::LruPerCpuHashMap<K, V, MAX_ENTRIES, FLAGS>::insert(&self, impl core::borrow::Borrow<K>, impl core::borrow::Borrow<V>, u64) -> core::result::Result<(), i32>
-pub fn aya_ebpf::btf_maps::hash_map::LruPerCpuHashMap<K, V, MAX_ENTRIES, FLAGS>::remove(&self, impl core::borrow::Borrow<K>) -> core::result::Result<(), i32>
+pub unsafe fn aya_ebpf::btf_maps::hash_map::LruPerCpuHashMap<K, V, MAX_ENTRIES, FLAGS>::get(&self, &K) -> core::option::Option<&V>
+pub fn aya_ebpf::btf_maps::hash_map::LruPerCpuHashMap<K, V, MAX_ENTRIES, FLAGS>::get_ptr(&self, &K) -> core::option::Option<*const V>
+pub fn aya_ebpf::btf_maps::hash_map::LruPerCpuHashMap<K, V, MAX_ENTRIES, FLAGS>::get_ptr_mut(&self, &K) -> core::option::Option<*mut V>
+pub fn aya_ebpf::btf_maps::hash_map::LruPerCpuHashMap<K, V, MAX_ENTRIES, FLAGS>::insert(&self, &K, &V, u64) -> core::result::Result<(), i32>
+pub fn aya_ebpf::btf_maps::hash_map::LruPerCpuHashMap<K, V, MAX_ENTRIES, FLAGS>::remove(&self, &K) -> core::result::Result<(), i32>
 impl<K, V, const MAX_ENTRIES: usize, const FLAGS: usize> aya_ebpf::btf_maps::hash_map::LruPerCpuHashMap<K, V, MAX_ENTRIES, FLAGS>
 pub const fn aya_ebpf::btf_maps::hash_map::LruPerCpuHashMap<K, V, MAX_ENTRIES, FLAGS>::new() -> Self
 impl<K, V, const MAX_ENTRIES: usize, const FLAGS: usize> core::default::Default for aya_ebpf::btf_maps::hash_map::LruPerCpuHashMap<K, V, MAX_ENTRIES, FLAGS>
@@ -768,7 +768,7 @@ impl<T, const MAX_ENTRIES: usize, const FLAGS: usize> aya_ebpf::btf_maps::per_cp
 pub fn aya_ebpf::btf_maps::per_cpu_array::PerCpuArray<T, MAX_ENTRIES, FLAGS>::get(&self, u32) -> core::option::Option<&T>
 pub fn aya_ebpf::btf_maps::per_cpu_array::PerCpuArray<T, MAX_ENTRIES, FLAGS>::get_ptr(&self, u32) -> core::option::Option<*const T>
 pub fn aya_ebpf::btf_maps::per_cpu_array::PerCpuArray<T, MAX_ENTRIES, FLAGS>::get_ptr_mut(&self, u32) -> core::option::Option<*mut T>
-pub fn aya_ebpf::btf_maps::per_cpu_array::PerCpuArray<T, MAX_ENTRIES, FLAGS>::set(&self, u32, impl core::borrow::Borrow<T>, u64) -> core::result::Result<(), i32>
+pub fn aya_ebpf::btf_maps::per_cpu_array::PerCpuArray<T, MAX_ENTRIES, FLAGS>::set(&self, u32, &T, u64) -> core::result::Result<(), i32>
 impl<T, const MAX_ENTRIES: usize, const FLAGS: usize> aya_ebpf::btf_maps::per_cpu_array::PerCpuArray<T, MAX_ENTRIES, FLAGS>
 pub const fn aya_ebpf::btf_maps::per_cpu_array::PerCpuArray<T, MAX_ENTRIES, FLAGS>::new() -> Self
 impl<T, const MAX_ENTRIES: usize, const FLAGS: usize> core::default::Default for aya_ebpf::btf_maps::per_cpu_array::PerCpuArray<T, MAX_ENTRIES, FLAGS>
@@ -796,11 +796,11 @@ impl<V> core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::btf_maps::cgroup_s
 impl<V> core::panic::unwind_safe::UnwindSafe for aya_ebpf::btf_maps::cgroup_storage::PerCpuCgroupStorage<V> where V: core::panic::unwind_safe::RefUnwindSafe
 #[repr(C)] pub struct aya_ebpf::btf_maps::PerCpuHashMap<K, V, const MAX_ENTRIES: usize, const FLAGS: usize>
 impl<K, V, const MAX_ENTRIES: usize, const FLAGS: usize> aya_ebpf::btf_maps::hash_map::PerCpuHashMap<K, V, MAX_ENTRIES, FLAGS>
-pub unsafe fn aya_ebpf::btf_maps::hash_map::PerCpuHashMap<K, V, MAX_ENTRIES, FLAGS>::get(&self, impl core::borrow::Borrow<K>) -> core::option::Option<&V>
-pub fn aya_ebpf::btf_maps::hash_map::PerCpuHashMap<K, V, MAX_ENTRIES, FLAGS>::get_ptr(&self, impl core::borrow::Borrow<K>) -> core::option::Option<*const V>
-pub fn aya_ebpf::btf_maps::hash_map::PerCpuHashMap<K, V, MAX_ENTRIES, FLAGS>::get_ptr_mut(&self, impl core::borrow::Borrow<K>) -> core::option::Option<*mut V>
-pub fn aya_ebpf::btf_maps::hash_map::PerCpuHashMap<K, V, MAX_ENTRIES, FLAGS>::insert(&self, impl core::borrow::Borrow<K>, impl core::borrow::Borrow<V>, u64) -> core::result::Result<(), i32>
-pub fn aya_ebpf::btf_maps::hash_map::PerCpuHashMap<K, V, MAX_ENTRIES, FLAGS>::remove(&self, impl core::borrow::Borrow<K>) -> core::result::Result<(), i32>
+pub unsafe fn aya_ebpf::btf_maps::hash_map::PerCpuHashMap<K, V, MAX_ENTRIES, FLAGS>::get(&self, &K) -> core::option::Option<&V>
+pub fn aya_ebpf::btf_maps::hash_map::PerCpuHashMap<K, V, MAX_ENTRIES, FLAGS>::get_ptr(&self, &K) -> core::option::Option<*const V>
+pub fn aya_ebpf::btf_maps::hash_map::PerCpuHashMap<K, V, MAX_ENTRIES, FLAGS>::get_ptr_mut(&self, &K) -> core::option::Option<*mut V>
+pub fn aya_ebpf::btf_maps::hash_map::PerCpuHashMap<K, V, MAX_ENTRIES, FLAGS>::insert(&self, &K, &V, u64) -> core::result::Result<(), i32>
+pub fn aya_ebpf::btf_maps::hash_map::PerCpuHashMap<K, V, MAX_ENTRIES, FLAGS>::remove(&self, &K) -> core::result::Result<(), i32>
 impl<K, V, const MAX_ENTRIES: usize, const FLAGS: usize> aya_ebpf::btf_maps::hash_map::PerCpuHashMap<K, V, MAX_ENTRIES, FLAGS>
 pub const fn aya_ebpf::btf_maps::hash_map::PerCpuHashMap<K, V, MAX_ENTRIES, FLAGS>::new() -> Self
 impl<K, V, const MAX_ENTRIES: usize, const FLAGS: usize> core::default::Default for aya_ebpf::btf_maps::hash_map::PerCpuHashMap<K, V, MAX_ENTRIES, FLAGS>
@@ -862,7 +862,7 @@ pub const fn aya_ebpf::btf_maps::queue::Queue<T, MAX_ENTRIES, FLAGS>::new() -> S
 impl<T, const MAX_ENTRIES: usize, const FLAGS: usize> aya_ebpf::btf_maps::queue::Queue<T, MAX_ENTRIES, FLAGS>
 pub fn aya_ebpf::btf_maps::queue::Queue<T, MAX_ENTRIES, FLAGS>::peek(&self) -> core::result::Result<core::option::Option<T>, i32>
 pub fn aya_ebpf::btf_maps::queue::Queue<T, MAX_ENTRIES, FLAGS>::pop(&self) -> core::result::Result<core::option::Option<T>, i32>
-pub fn aya_ebpf::btf_maps::queue::Queue<T, MAX_ENTRIES, FLAGS>::push(&self, impl core::borrow::Borrow<T>, u64) -> core::result::Result<(), i32>
+pub fn aya_ebpf::btf_maps::queue::Queue<T, MAX_ENTRIES, FLAGS>::push(&self, &T, u64) -> core::result::Result<(), i32>
 impl<T, const MAX_ENTRIES: usize, const FLAGS: usize> core::default::Default for aya_ebpf::btf_maps::queue::Queue<T, MAX_ENTRIES, FLAGS>
 pub fn aya_ebpf::btf_maps::queue::Queue<T, MAX_ENTRIES, FLAGS>::default() -> Self
 impl<T, const MAX_ENTRIES: usize, const FLAGS: usize> core::marker::Sync for aya_ebpf::btf_maps::queue::Queue<T, MAX_ENTRIES, FLAGS>
@@ -876,8 +876,8 @@ impl<T, const MAX_ENTRIES: usize, const FLAGS: usize> core::panic::unwind_safe::
 impl<T, const MAX_ENTRIES: usize, const FLAGS: usize> aya_ebpf::btf_maps::ring_buf::RingBuf<T, MAX_ENTRIES, FLAGS>
 pub const fn aya_ebpf::btf_maps::ring_buf::RingBuf<T, MAX_ENTRIES, FLAGS>::new() -> Self
 impl<T, const MAX_ENTRIES: usize, const FLAGS: usize> aya_ebpf::btf_maps::ring_buf::RingBuf<T, MAX_ENTRIES, FLAGS>
-pub fn aya_ebpf::btf_maps::ring_buf::RingBuf<T, MAX_ENTRIES, FLAGS>::output(&self, impl core::borrow::Borrow<T>, u64) -> core::result::Result<(), i32>
-pub fn aya_ebpf::btf_maps::ring_buf::RingBuf<T, MAX_ENTRIES, FLAGS>::output_untyped<U: ?core::marker::Sized>(&self, impl core::borrow::Borrow<U>, u64) -> core::result::Result<(), i32>
+pub fn aya_ebpf::btf_maps::ring_buf::RingBuf<T, MAX_ENTRIES, FLAGS>::output(&self, &T, u64) -> core::result::Result<(), i32>
+pub fn aya_ebpf::btf_maps::ring_buf::RingBuf<T, MAX_ENTRIES, FLAGS>::output_untyped<U: ?core::marker::Sized>(&self, &U, u64) -> core::result::Result<(), i32>
 pub fn aya_ebpf::btf_maps::ring_buf::RingBuf<T, MAX_ENTRIES, FLAGS>::reserve(&self, u64) -> core::option::Option<aya_ebpf::maps::ring_buf::RingBufEntry<T>> where T: 'static
 pub fn aya_ebpf::btf_maps::ring_buf::RingBuf<T, MAX_ENTRIES, FLAGS>::reserve_bytes(&self, usize, u64) -> core::option::Option<aya_ebpf::maps::ring_buf::RingBufBytes<'_>>
 pub fn aya_ebpf::btf_maps::ring_buf::RingBuf<T, MAX_ENTRIES, FLAGS>::reserve_untyped<U: 'static>(&self, u64) -> core::option::Option<aya_ebpf::maps::ring_buf::RingBufEntry<U>>
@@ -910,10 +910,10 @@ impl<T> core::panic::unwind_safe::UnwindSafe for aya_ebpf::btf_maps::sk_storage:
 impl<K, const MAX_ENTRIES: usize, const FLAGS: usize> aya_ebpf::btf_maps::sock_hash::SockHash<K, MAX_ENTRIES, FLAGS>
 pub const fn aya_ebpf::btf_maps::sock_hash::SockHash<K, MAX_ENTRIES, FLAGS>::new() -> Self
 impl<K, const MAX_ENTRIES: usize, const FLAGS: usize> aya_ebpf::btf_maps::sock_hash::SockHash<K, MAX_ENTRIES, FLAGS>
-pub fn aya_ebpf::btf_maps::sock_hash::SockHash<K, MAX_ENTRIES, FLAGS>::redirect_msg(&self, impl core::borrow::Borrow<aya_ebpf::programs::sk_msg::SkMsgContext>, impl core::borrow::BorrowMut<K>, u64) -> aya_ebpf_cty::od::c_long
-pub fn aya_ebpf::btf_maps::sock_hash::SockHash<K, MAX_ENTRIES, FLAGS>::redirect_sk_lookup(&self, impl core::borrow::Borrow<aya_ebpf::programs::sk_lookup::SkLookupContext>, impl core::borrow::Borrow<K>, u64) -> core::result::Result<(), i32>
-pub fn aya_ebpf::btf_maps::sock_hash::SockHash<K, MAX_ENTRIES, FLAGS>::redirect_skb(&self, impl core::borrow::Borrow<aya_ebpf::programs::sk_buff::SkBuffContext>, impl core::borrow::BorrowMut<K>, u64) -> aya_ebpf_cty::od::c_long
-pub fn aya_ebpf::btf_maps::sock_hash::SockHash<K, MAX_ENTRIES, FLAGS>::update(&self, impl core::borrow::BorrowMut<K>, impl core::borrow::BorrowMut<aya_ebpf_bindings::x86_64::bindings::bpf_sock_ops>, u64) -> core::result::Result<(), i32>
+pub fn aya_ebpf::btf_maps::sock_hash::SockHash<K, MAX_ENTRIES, FLAGS>::redirect_msg(&self, &aya_ebpf::programs::sk_msg::SkMsgContext, &mut K, u64) -> aya_ebpf_cty::od::c_long
+pub fn aya_ebpf::btf_maps::sock_hash::SockHash<K, MAX_ENTRIES, FLAGS>::redirect_sk_lookup(&self, &aya_ebpf::programs::sk_lookup::SkLookupContext, &K, u64) -> core::result::Result<(), i32>
+pub fn aya_ebpf::btf_maps::sock_hash::SockHash<K, MAX_ENTRIES, FLAGS>::redirect_skb(&self, &aya_ebpf::programs::sk_buff::SkBuffContext, &mut K, u64) -> aya_ebpf_cty::od::c_long
+pub fn aya_ebpf::btf_maps::sock_hash::SockHash<K, MAX_ENTRIES, FLAGS>::update(&self, &mut K, &mut aya_ebpf_bindings::x86_64::bindings::bpf_sock_ops, u64) -> core::result::Result<(), i32>
 impl<K, const MAX_ENTRIES: usize, const FLAGS: usize> core::default::Default for aya_ebpf::btf_maps::sock_hash::SockHash<K, MAX_ENTRIES, FLAGS>
 pub fn aya_ebpf::btf_maps::sock_hash::SockHash<K, MAX_ENTRIES, FLAGS>::default() -> Self
 impl<K, const MAX_ENTRIES: usize, const FLAGS: usize> core::marker::Sync for aya_ebpf::btf_maps::sock_hash::SockHash<K, MAX_ENTRIES, FLAGS>
@@ -946,7 +946,7 @@ pub const fn aya_ebpf::btf_maps::stack::Stack<T, MAX_ENTRIES, FLAGS>::new() -> S
 impl<T, const MAX_ENTRIES: usize, const FLAGS: usize> aya_ebpf::btf_maps::stack::Stack<T, MAX_ENTRIES, FLAGS>
 pub fn aya_ebpf::btf_maps::stack::Stack<T, MAX_ENTRIES, FLAGS>::peek(&self) -> core::result::Result<core::option::Option<T>, i32>
 pub fn aya_ebpf::btf_maps::stack::Stack<T, MAX_ENTRIES, FLAGS>::pop(&self) -> core::result::Result<core::option::Option<T>, i32>
-pub fn aya_ebpf::btf_maps::stack::Stack<T, MAX_ENTRIES, FLAGS>::push(&self, impl core::borrow::Borrow<T>, u64) -> core::result::Result<(), i32>
+pub fn aya_ebpf::btf_maps::stack::Stack<T, MAX_ENTRIES, FLAGS>::push(&self, &T, u64) -> core::result::Result<(), i32>
 impl<T, const MAX_ENTRIES: usize, const FLAGS: usize> core::default::Default for aya_ebpf::btf_maps::stack::Stack<T, MAX_ENTRIES, FLAGS>
 pub fn aya_ebpf::btf_maps::stack::Stack<T, MAX_ENTRIES, FLAGS>::default() -> Self
 impl<T, const MAX_ENTRIES: usize, const FLAGS: usize> core::marker::Sync for aya_ebpf::btf_maps::stack::Stack<T, MAX_ENTRIES, FLAGS>
@@ -1016,7 +1016,7 @@ pub fn aya_ebpf::maps::array::Array<T>::get(&self, u32) -> core::option::Option<
 pub fn aya_ebpf::maps::array::Array<T>::get_ptr(&self, u32) -> core::option::Option<*const T>
 pub fn aya_ebpf::maps::array::Array<T>::get_ptr_mut(&self, u32) -> core::option::Option<*mut T>
 pub const fn aya_ebpf::maps::array::Array<T>::pinned(u32, u32) -> Self
-pub fn aya_ebpf::maps::array::Array<T>::set(&self, u32, impl core::borrow::Borrow<T>, u64) -> core::result::Result<(), i32>
+pub fn aya_ebpf::maps::array::Array<T>::set(&self, u32, &T, u64) -> core::result::Result<(), i32>
 pub const fn aya_ebpf::maps::array::Array<T>::with_max_entries(u32, u32) -> Self
 impl<T> !core::marker::Freeze for aya_ebpf::maps::array::Array<T>
 impl<T> core::marker::Send for aya_ebpf::maps::array::Array<T> where T: core::marker::Send
@@ -1028,8 +1028,8 @@ impl<T> core::panic::unwind_safe::UnwindSafe for aya_ebpf::maps::array::Array<T>
 pub mod aya_ebpf::maps::bloom_filter
 #[repr(transparent)] pub struct aya_ebpf::maps::bloom_filter::BloomFilter<T>
 impl<T> aya_ebpf::maps::bloom_filter::BloomFilter<T>
-pub fn aya_ebpf::maps::bloom_filter::BloomFilter<T>::contains(&self, impl core::borrow::Borrow<T>) -> core::result::Result<(), i32>
-pub fn aya_ebpf::maps::bloom_filter::BloomFilter<T>::insert(&self, impl core::borrow::Borrow<T>, u64) -> core::result::Result<(), i32>
+pub fn aya_ebpf::maps::bloom_filter::BloomFilter<T>::contains(&self, &T) -> core::result::Result<(), i32>
+pub fn aya_ebpf::maps::bloom_filter::BloomFilter<T>::insert(&self, &T, u64) -> core::result::Result<(), i32>
 pub const fn aya_ebpf::maps::bloom_filter::BloomFilter<T>::pinned(u32, u32) -> Self
 pub const fn aya_ebpf::maps::bloom_filter::BloomFilter<T>::with_max_entries(u32, u32) -> Self
 impl<T> !core::marker::Freeze for aya_ebpf::maps::bloom_filter::BloomFilter<T>
@@ -1084,12 +1084,12 @@ impl<V> core::panic::unwind_safe::UnwindSafe for aya_ebpf::maps::cgroup_storage:
 pub mod aya_ebpf::maps::hash_map
 #[repr(transparent)] pub struct aya_ebpf::maps::hash_map::HashMap<K, V>
 impl<K, V> aya_ebpf::maps::hash_map::HashMap<K, V>
-pub unsafe fn aya_ebpf::maps::hash_map::HashMap<K, V>::get(&self, impl core::borrow::Borrow<K>) -> core::option::Option<&V>
-pub fn aya_ebpf::maps::hash_map::HashMap<K, V>::get_ptr(&self, impl core::borrow::Borrow<K>) -> core::option::Option<*const V>
-pub fn aya_ebpf::maps::hash_map::HashMap<K, V>::get_ptr_mut(&self, impl core::borrow::Borrow<K>) -> core::option::Option<*mut V>
-pub fn aya_ebpf::maps::hash_map::HashMap<K, V>::insert(&self, impl core::borrow::Borrow<K>, impl core::borrow::Borrow<V>, u64) -> core::result::Result<(), i32>
+pub unsafe fn aya_ebpf::maps::hash_map::HashMap<K, V>::get(&self, &K) -> core::option::Option<&V>
+pub fn aya_ebpf::maps::hash_map::HashMap<K, V>::get_ptr(&self, &K) -> core::option::Option<*const V>
+pub fn aya_ebpf::maps::hash_map::HashMap<K, V>::get_ptr_mut(&self, &K) -> core::option::Option<*mut V>
+pub fn aya_ebpf::maps::hash_map::HashMap<K, V>::insert(&self, &K, &V, u64) -> core::result::Result<(), i32>
 pub const fn aya_ebpf::maps::hash_map::HashMap<K, V>::pinned(u32, u32) -> Self
-pub fn aya_ebpf::maps::hash_map::HashMap<K, V>::remove(&self, impl core::borrow::Borrow<K>) -> core::result::Result<(), i32>
+pub fn aya_ebpf::maps::hash_map::HashMap<K, V>::remove(&self, &K) -> core::result::Result<(), i32>
 pub const fn aya_ebpf::maps::hash_map::HashMap<K, V>::with_max_entries(u32, u32) -> Self
 impl<K, V> !core::marker::Freeze for aya_ebpf::maps::hash_map::HashMap<K, V>
 impl<K, V> core::marker::Send for aya_ebpf::maps::hash_map::HashMap<K, V> where K: core::marker::Send, V: core::marker::Send
@@ -1100,12 +1100,12 @@ impl<K, V> !core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::maps::hash_map
 impl<K, V> core::panic::unwind_safe::UnwindSafe for aya_ebpf::maps::hash_map::HashMap<K, V> where K: core::panic::unwind_safe::UnwindSafe, V: core::panic::unwind_safe::UnwindSafe
 #[repr(transparent)] pub struct aya_ebpf::maps::hash_map::LruHashMap<K, V>
 impl<K, V> aya_ebpf::maps::hash_map::LruHashMap<K, V>
-pub unsafe fn aya_ebpf::maps::hash_map::LruHashMap<K, V>::get(&self, impl core::borrow::Borrow<K>) -> core::option::Option<&V>
-pub fn aya_ebpf::maps::hash_map::LruHashMap<K, V>::get_ptr(&self, impl core::borrow::Borrow<K>) -> core::option::Option<*const V>
-pub fn aya_ebpf::maps::hash_map::LruHashMap<K, V>::get_ptr_mut(&self, impl core::borrow::Borrow<K>) -> core::option::Option<*mut V>
-pub fn aya_ebpf::maps::hash_map::LruHashMap<K, V>::insert(&self, impl core::borrow::Borrow<K>, impl core::borrow::Borrow<V>, u64) -> core::result::Result<(), i32>
+pub unsafe fn aya_ebpf::maps::hash_map::LruHashMap<K, V>::get(&self, &K) -> core::option::Option<&V>
+pub fn aya_ebpf::maps::hash_map::LruHashMap<K, V>::get_ptr(&self, &K) -> core::option::Option<*const V>
+pub fn aya_ebpf::maps::hash_map::LruHashMap<K, V>::get_ptr_mut(&self, &K) -> core::option::Option<*mut V>
+pub fn aya_ebpf::maps::hash_map::LruHashMap<K, V>::insert(&self, &K, &V, u64) -> core::result::Result<(), i32>
 pub const fn aya_ebpf::maps::hash_map::LruHashMap<K, V>::pinned(u32, u32) -> Self
-pub fn aya_ebpf::maps::hash_map::LruHashMap<K, V>::remove(&self, impl core::borrow::Borrow<K>) -> core::result::Result<(), i32>
+pub fn aya_ebpf::maps::hash_map::LruHashMap<K, V>::remove(&self, &K) -> core::result::Result<(), i32>
 pub const fn aya_ebpf::maps::hash_map::LruHashMap<K, V>::with_max_entries(u32, u32) -> Self
 impl<K, V> !core::marker::Freeze for aya_ebpf::maps::hash_map::LruHashMap<K, V>
 impl<K, V> core::marker::Send for aya_ebpf::maps::hash_map::LruHashMap<K, V> where K: core::marker::Send, V: core::marker::Send
@@ -1116,12 +1116,12 @@ impl<K, V> !core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::maps::hash_map
 impl<K, V> core::panic::unwind_safe::UnwindSafe for aya_ebpf::maps::hash_map::LruHashMap<K, V> where K: core::panic::unwind_safe::UnwindSafe, V: core::panic::unwind_safe::UnwindSafe
 #[repr(transparent)] pub struct aya_ebpf::maps::hash_map::LruPerCpuHashMap<K, V>
 impl<K, V> aya_ebpf::maps::hash_map::LruPerCpuHashMap<K, V>
-pub unsafe fn aya_ebpf::maps::hash_map::LruPerCpuHashMap<K, V>::get(&self, impl core::borrow::Borrow<K>) -> core::option::Option<&V>
-pub fn aya_ebpf::maps::hash_map::LruPerCpuHashMap<K, V>::get_ptr(&self, impl core::borrow::Borrow<K>) -> core::option::Option<*const V>
-pub fn aya_ebpf::maps::hash_map::LruPerCpuHashMap<K, V>::get_ptr_mut(&self, impl core::borrow::Borrow<K>) -> core::option::Option<*mut V>
-pub fn aya_ebpf::maps::hash_map::LruPerCpuHashMap<K, V>::insert(&self, impl core::borrow::Borrow<K>, impl core::borrow::Borrow<V>, u64) -> core::result::Result<(), i32>
+pub unsafe fn aya_ebpf::maps::hash_map::LruPerCpuHashMap<K, V>::get(&self, &K) -> core::option::Option<&V>
+pub fn aya_ebpf::maps::hash_map::LruPerCpuHashMap<K, V>::get_ptr(&self, &K) -> core::option::Option<*const V>
+pub fn aya_ebpf::maps::hash_map::LruPerCpuHashMap<K, V>::get_ptr_mut(&self, &K) -> core::option::Option<*mut V>
+pub fn aya_ebpf::maps::hash_map::LruPerCpuHashMap<K, V>::insert(&self, &K, &V, u64) -> core::result::Result<(), i32>
 pub const fn aya_ebpf::maps::hash_map::LruPerCpuHashMap<K, V>::pinned(u32, u32) -> Self
-pub fn aya_ebpf::maps::hash_map::LruPerCpuHashMap<K, V>::remove(&self, impl core::borrow::Borrow<K>) -> core::result::Result<(), i32>
+pub fn aya_ebpf::maps::hash_map::LruPerCpuHashMap<K, V>::remove(&self, &K) -> core::result::Result<(), i32>
 pub const fn aya_ebpf::maps::hash_map::LruPerCpuHashMap<K, V>::with_max_entries(u32, u32) -> Self
 impl<K, V> !core::marker::Freeze for aya_ebpf::maps::hash_map::LruPerCpuHashMap<K, V>
 impl<K, V> core::marker::Send for aya_ebpf::maps::hash_map::LruPerCpuHashMap<K, V> where K: core::marker::Send, V: core::marker::Send
@@ -1132,12 +1132,12 @@ impl<K, V> !core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::maps::hash_map
 impl<K, V> core::panic::unwind_safe::UnwindSafe for aya_ebpf::maps::hash_map::LruPerCpuHashMap<K, V> where K: core::panic::unwind_safe::UnwindSafe, V: core::panic::unwind_safe::UnwindSafe
 #[repr(transparent)] pub struct aya_ebpf::maps::hash_map::PerCpuHashMap<K, V>
 impl<K, V> aya_ebpf::maps::hash_map::PerCpuHashMap<K, V>
-pub unsafe fn aya_ebpf::maps::hash_map::PerCpuHashMap<K, V>::get(&self, impl core::borrow::Borrow<K>) -> core::option::Option<&V>
-pub fn aya_ebpf::maps::hash_map::PerCpuHashMap<K, V>::get_ptr(&self, impl core::borrow::Borrow<K>) -> core::option::Option<*const V>
-pub fn aya_ebpf::maps::hash_map::PerCpuHashMap<K, V>::get_ptr_mut(&self, impl core::borrow::Borrow<K>) -> core::option::Option<*mut V>
-pub fn aya_ebpf::maps::hash_map::PerCpuHashMap<K, V>::insert(&self, impl core::borrow::Borrow<K>, impl core::borrow::Borrow<V>, u64) -> core::result::Result<(), i32>
+pub unsafe fn aya_ebpf::maps::hash_map::PerCpuHashMap<K, V>::get(&self, &K) -> core::option::Option<&V>
+pub fn aya_ebpf::maps::hash_map::PerCpuHashMap<K, V>::get_ptr(&self, &K) -> core::option::Option<*const V>
+pub fn aya_ebpf::maps::hash_map::PerCpuHashMap<K, V>::get_ptr_mut(&self, &K) -> core::option::Option<*mut V>
+pub fn aya_ebpf::maps::hash_map::PerCpuHashMap<K, V>::insert(&self, &K, &V, u64) -> core::result::Result<(), i32>
 pub const fn aya_ebpf::maps::hash_map::PerCpuHashMap<K, V>::pinned(u32, u32) -> Self
-pub fn aya_ebpf::maps::hash_map::PerCpuHashMap<K, V>::remove(&self, impl core::borrow::Borrow<K>) -> core::result::Result<(), i32>
+pub fn aya_ebpf::maps::hash_map::PerCpuHashMap<K, V>::remove(&self, &K) -> core::result::Result<(), i32>
 pub const fn aya_ebpf::maps::hash_map::PerCpuHashMap<K, V>::with_max_entries(u32, u32) -> Self
 impl<K, V> !core::marker::Freeze for aya_ebpf::maps::hash_map::PerCpuHashMap<K, V>
 impl<K, V> core::marker::Send for aya_ebpf::maps::hash_map::PerCpuHashMap<K, V> where K: core::marker::Send, V: core::marker::Send
@@ -1161,10 +1161,10 @@ impl<K> core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::maps::lpm_trie::Ke
 impl<K> core::panic::unwind_safe::UnwindSafe for aya_ebpf::maps::lpm_trie::Key<K> where K: core::panic::unwind_safe::UnwindSafe
 #[repr(transparent)] pub struct aya_ebpf::maps::lpm_trie::LpmTrie<K, V>
 impl<K, V> aya_ebpf::maps::lpm_trie::LpmTrie<K, V>
-pub fn aya_ebpf::maps::lpm_trie::LpmTrie<K, V>::get(&self, impl core::borrow::Borrow<aya_ebpf::maps::lpm_trie::Key<K>>) -> core::option::Option<&V>
-pub fn aya_ebpf::maps::lpm_trie::LpmTrie<K, V>::insert(&self, impl core::borrow::Borrow<aya_ebpf::maps::lpm_trie::Key<K>>, impl core::borrow::Borrow<V>, u64) -> core::result::Result<(), i32>
+pub fn aya_ebpf::maps::lpm_trie::LpmTrie<K, V>::get(&self, &aya_ebpf::maps::lpm_trie::Key<K>) -> core::option::Option<&V>
+pub fn aya_ebpf::maps::lpm_trie::LpmTrie<K, V>::insert(&self, &aya_ebpf::maps::lpm_trie::Key<K>, &V, u64) -> core::result::Result<(), i32>
 pub const fn aya_ebpf::maps::lpm_trie::LpmTrie<K, V>::pinned(u32, u32) -> Self
-pub fn aya_ebpf::maps::lpm_trie::LpmTrie<K, V>::remove(&self, impl core::borrow::Borrow<aya_ebpf::maps::lpm_trie::Key<K>>) -> core::result::Result<(), i32>
+pub fn aya_ebpf::maps::lpm_trie::LpmTrie<K, V>::remove(&self, &aya_ebpf::maps::lpm_trie::Key<K>) -> core::result::Result<(), i32>
 pub const fn aya_ebpf::maps::lpm_trie::LpmTrie<K, V>::with_max_entries(u32, u32) -> Self
 impl<K, V> !core::marker::Freeze for aya_ebpf::maps::lpm_trie::LpmTrie<K, V>
 impl<K, V> core::marker::Send for aya_ebpf::maps::lpm_trie::LpmTrie<K, V> where K: core::marker::Send, V: core::marker::Send
@@ -1180,7 +1180,7 @@ pub fn aya_ebpf::maps::per_cpu_array::PerCpuArray<T>::get(&self, u32) -> core::o
 pub fn aya_ebpf::maps::per_cpu_array::PerCpuArray<T>::get_ptr(&self, u32) -> core::option::Option<*const T>
 pub fn aya_ebpf::maps::per_cpu_array::PerCpuArray<T>::get_ptr_mut(&self, u32) -> core::option::Option<*mut T>
 pub const fn aya_ebpf::maps::per_cpu_array::PerCpuArray<T>::pinned(u32, u32) -> Self
-pub fn aya_ebpf::maps::per_cpu_array::PerCpuArray<T>::set(&self, u32, impl core::borrow::Borrow<T>, u64) -> core::result::Result<(), i32>
+pub fn aya_ebpf::maps::per_cpu_array::PerCpuArray<T>::set(&self, u32, &T, u64) -> core::result::Result<(), i32>
 pub const fn aya_ebpf::maps::per_cpu_array::PerCpuArray<T>::with_max_entries(u32, u32) -> Self
 impl<T> !core::marker::Freeze for aya_ebpf::maps::per_cpu_array::PerCpuArray<T>
 impl<T> core::marker::Send for aya_ebpf::maps::per_cpu_array::PerCpuArray<T> where T: core::marker::Send
@@ -1193,8 +1193,8 @@ pub mod aya_ebpf::maps::perf
 #[repr(transparent)] pub struct aya_ebpf::maps::perf::PerfEventArray<T>
 impl<T> aya_ebpf::maps::PerfEventArray<T>
 pub const fn aya_ebpf::maps::PerfEventArray<T>::new(u32) -> Self
-pub fn aya_ebpf::maps::PerfEventArray<T>::output<C: aya_ebpf::EbpfContext>(&self, &C, impl core::borrow::Borrow<T>, u32)
-pub fn aya_ebpf::maps::PerfEventArray<T>::output_at_index<C: aya_ebpf::EbpfContext>(&self, &C, u32, impl core::borrow::Borrow<T>, u32)
+pub fn aya_ebpf::maps::PerfEventArray<T>::output<C: aya_ebpf::EbpfContext>(&self, &C, &T, u32)
+pub fn aya_ebpf::maps::PerfEventArray<T>::output_at_index<C: aya_ebpf::EbpfContext>(&self, &C, u32, &T, u32)
 pub const fn aya_ebpf::maps::PerfEventArray<T>::pinned(u32) -> Self
 impl<T> !core::marker::Freeze for aya_ebpf::maps::PerfEventArray<T>
 impl<T> core::marker::Send for aya_ebpf::maps::PerfEventArray<T> where T: core::marker::Send
@@ -1235,7 +1235,7 @@ impl<T> aya_ebpf::maps::queue::Queue<T>
 pub fn aya_ebpf::maps::queue::Queue<T>::peek(&self) -> core::result::Result<core::option::Option<T>, i32>
 pub const fn aya_ebpf::maps::queue::Queue<T>::pinned(u32, u32) -> Self
 pub fn aya_ebpf::maps::queue::Queue<T>::pop(&self) -> core::result::Result<core::option::Option<T>, i32>
-pub fn aya_ebpf::maps::queue::Queue<T>::push(&self, impl core::borrow::Borrow<T>, u64) -> core::result::Result<(), i32>
+pub fn aya_ebpf::maps::queue::Queue<T>::push(&self, &T, u64) -> core::result::Result<(), i32>
 pub const fn aya_ebpf::maps::queue::Queue<T>::with_max_entries(u32, u32) -> Self
 impl<T> !core::marker::Freeze for aya_ebpf::maps::queue::Queue<T>
 impl<T> core::marker::Send for aya_ebpf::maps::queue::Queue<T> where T: core::marker::Send
@@ -1260,7 +1260,7 @@ impl core::panic::unwind_safe::UnwindSafe for aya_ebpf::maps::reuseport_sock_arr
 pub mod aya_ebpf::maps::ring_buf
 #[repr(transparent)] pub struct aya_ebpf::maps::ring_buf::RingBuf
 impl aya_ebpf::maps::ring_buf::RingBuf
-pub fn aya_ebpf::maps::ring_buf::RingBuf::output<T: ?core::marker::Sized>(&self, impl core::borrow::Borrow<T>, u64) -> core::result::Result<(), i32>
+pub fn aya_ebpf::maps::ring_buf::RingBuf::output<T: ?core::marker::Sized>(&self, &T, u64) -> core::result::Result<(), i32>
 pub const fn aya_ebpf::maps::ring_buf::RingBuf::pinned(u32, u32) -> Self
 pub fn aya_ebpf::maps::ring_buf::RingBuf::query(&self, u64) -> u64
 pub fn aya_ebpf::maps::ring_buf::RingBuf::reserve<T: 'static>(&self, u64) -> core::option::Option<aya_ebpf::maps::ring_buf::RingBufEntry<T>>
@@ -1309,10 +1309,10 @@ pub mod aya_ebpf::maps::sock_hash
 #[repr(transparent)] pub struct aya_ebpf::maps::sock_hash::SockHash<K>
 impl<K> aya_ebpf::maps::sock_hash::SockHash<K>
 pub const fn aya_ebpf::maps::sock_hash::SockHash<K>::pinned(u32, u32) -> Self
-pub fn aya_ebpf::maps::sock_hash::SockHash<K>::redirect_msg(&self, impl core::borrow::Borrow<aya_ebpf::programs::sk_msg::SkMsgContext>, impl core::borrow::BorrowMut<K>, u64) -> aya_ebpf_cty::od::c_long
-pub fn aya_ebpf::maps::sock_hash::SockHash<K>::redirect_sk_lookup(&self, impl core::borrow::Borrow<aya_ebpf::programs::sk_lookup::SkLookupContext>, impl core::borrow::Borrow<K>, u64) -> core::result::Result<(), i32>
-pub fn aya_ebpf::maps::sock_hash::SockHash<K>::redirect_skb(&self, impl core::borrow::Borrow<aya_ebpf::programs::sk_buff::SkBuffContext>, impl core::borrow::BorrowMut<K>, u64) -> aya_ebpf_cty::od::c_long
-pub fn aya_ebpf::maps::sock_hash::SockHash<K>::update(&self, impl core::borrow::BorrowMut<K>, impl core::borrow::BorrowMut<aya_ebpf_bindings::x86_64::bindings::bpf_sock_ops>, u64) -> core::result::Result<(), i32>
+pub fn aya_ebpf::maps::sock_hash::SockHash<K>::redirect_msg(&self, &aya_ebpf::programs::sk_msg::SkMsgContext, &mut K, u64) -> aya_ebpf_cty::od::c_long
+pub fn aya_ebpf::maps::sock_hash::SockHash<K>::redirect_sk_lookup(&self, &aya_ebpf::programs::sk_lookup::SkLookupContext, &K, u64) -> core::result::Result<(), i32>
+pub fn aya_ebpf::maps::sock_hash::SockHash<K>::redirect_skb(&self, &aya_ebpf::programs::sk_buff::SkBuffContext, &mut K, u64) -> aya_ebpf_cty::od::c_long
+pub fn aya_ebpf::maps::sock_hash::SockHash<K>::update(&self, &mut K, &mut aya_ebpf_bindings::x86_64::bindings::bpf_sock_ops, u64) -> core::result::Result<(), i32>
 pub const fn aya_ebpf::maps::sock_hash::SockHash<K>::with_max_entries(u32, u32) -> Self
 impl<K> !core::marker::Freeze for aya_ebpf::maps::sock_hash::SockHash<K>
 impl<K> core::marker::Send for aya_ebpf::maps::sock_hash::SockHash<K> where K: core::marker::Send
@@ -1343,7 +1343,7 @@ impl<T> aya_ebpf::maps::stack::Stack<T>
 pub fn aya_ebpf::maps::stack::Stack<T>::peek(&self) -> core::result::Result<core::option::Option<T>, i32>
 pub const fn aya_ebpf::maps::stack::Stack<T>::pinned(u32, u32) -> Self
 pub fn aya_ebpf::maps::stack::Stack<T>::pop(&self) -> core::result::Result<core::option::Option<T>, i32>
-pub fn aya_ebpf::maps::stack::Stack<T>::push(&self, impl core::borrow::Borrow<T>, u64) -> core::result::Result<(), i32>
+pub fn aya_ebpf::maps::stack::Stack<T>::push(&self, &T, u64) -> core::result::Result<(), i32>
 pub const fn aya_ebpf::maps::stack::Stack<T>::with_max_entries(u32, u32) -> Self
 impl<T> !core::marker::Freeze for aya_ebpf::maps::stack::Stack<T>
 impl<T> core::marker::Send for aya_ebpf::maps::stack::Stack<T> where T: core::marker::Send
@@ -1437,7 +1437,7 @@ pub fn aya_ebpf::maps::array::Array<T>::get(&self, u32) -> core::option::Option<
 pub fn aya_ebpf::maps::array::Array<T>::get_ptr(&self, u32) -> core::option::Option<*const T>
 pub fn aya_ebpf::maps::array::Array<T>::get_ptr_mut(&self, u32) -> core::option::Option<*mut T>
 pub const fn aya_ebpf::maps::array::Array<T>::pinned(u32, u32) -> Self
-pub fn aya_ebpf::maps::array::Array<T>::set(&self, u32, impl core::borrow::Borrow<T>, u64) -> core::result::Result<(), i32>
+pub fn aya_ebpf::maps::array::Array<T>::set(&self, u32, &T, u64) -> core::result::Result<(), i32>
 pub const fn aya_ebpf::maps::array::Array<T>::with_max_entries(u32, u32) -> Self
 impl<T> !core::marker::Freeze for aya_ebpf::maps::array::Array<T>
 impl<T> core::marker::Send for aya_ebpf::maps::array::Array<T> where T: core::marker::Send
@@ -1448,8 +1448,8 @@ impl<T> !core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::maps::array::Arra
 impl<T> core::panic::unwind_safe::UnwindSafe for aya_ebpf::maps::array::Array<T> where T: core::panic::unwind_safe::UnwindSafe
 #[repr(transparent)] pub struct aya_ebpf::maps::BloomFilter<T>
 impl<T> aya_ebpf::maps::bloom_filter::BloomFilter<T>
-pub fn aya_ebpf::maps::bloom_filter::BloomFilter<T>::contains(&self, impl core::borrow::Borrow<T>) -> core::result::Result<(), i32>
-pub fn aya_ebpf::maps::bloom_filter::BloomFilter<T>::insert(&self, impl core::borrow::Borrow<T>, u64) -> core::result::Result<(), i32>
+pub fn aya_ebpf::maps::bloom_filter::BloomFilter<T>::contains(&self, &T) -> core::result::Result<(), i32>
+pub fn aya_ebpf::maps::bloom_filter::BloomFilter<T>::insert(&self, &T, u64) -> core::result::Result<(), i32>
 pub const fn aya_ebpf::maps::bloom_filter::BloomFilter<T>::pinned(u32, u32) -> Self
 pub const fn aya_ebpf::maps::bloom_filter::BloomFilter<T>::with_max_entries(u32, u32) -> Self
 impl<T> !core::marker::Freeze for aya_ebpf::maps::bloom_filter::BloomFilter<T>
@@ -1527,12 +1527,12 @@ impl !core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::maps::DevMapHash
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf::maps::DevMapHash
 #[repr(transparent)] pub struct aya_ebpf::maps::HashMap<K, V>
 impl<K, V> aya_ebpf::maps::hash_map::HashMap<K, V>
-pub unsafe fn aya_ebpf::maps::hash_map::HashMap<K, V>::get(&self, impl core::borrow::Borrow<K>) -> core::option::Option<&V>
-pub fn aya_ebpf::maps::hash_map::HashMap<K, V>::get_ptr(&self, impl core::borrow::Borrow<K>) -> core::option::Option<*const V>
-pub fn aya_ebpf::maps::hash_map::HashMap<K, V>::get_ptr_mut(&self, impl core::borrow::Borrow<K>) -> core::option::Option<*mut V>
-pub fn aya_ebpf::maps::hash_map::HashMap<K, V>::insert(&self, impl core::borrow::Borrow<K>, impl core::borrow::Borrow<V>, u64) -> core::result::Result<(), i32>
+pub unsafe fn aya_ebpf::maps::hash_map::HashMap<K, V>::get(&self, &K) -> core::option::Option<&V>
+pub fn aya_ebpf::maps::hash_map::HashMap<K, V>::get_ptr(&self, &K) -> core::option::Option<*const V>
+pub fn aya_ebpf::maps::hash_map::HashMap<K, V>::get_ptr_mut(&self, &K) -> core::option::Option<*mut V>
+pub fn aya_ebpf::maps::hash_map::HashMap<K, V>::insert(&self, &K, &V, u64) -> core::result::Result<(), i32>
 pub const fn aya_ebpf::maps::hash_map::HashMap<K, V>::pinned(u32, u32) -> Self
-pub fn aya_ebpf::maps::hash_map::HashMap<K, V>::remove(&self, impl core::borrow::Borrow<K>) -> core::result::Result<(), i32>
+pub fn aya_ebpf::maps::hash_map::HashMap<K, V>::remove(&self, &K) -> core::result::Result<(), i32>
 pub const fn aya_ebpf::maps::hash_map::HashMap<K, V>::with_max_entries(u32, u32) -> Self
 impl<K, V> !core::marker::Freeze for aya_ebpf::maps::hash_map::HashMap<K, V>
 impl<K, V> core::marker::Send for aya_ebpf::maps::hash_map::HashMap<K, V> where K: core::marker::Send, V: core::marker::Send
@@ -1543,10 +1543,10 @@ impl<K, V> !core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::maps::hash_map
 impl<K, V> core::panic::unwind_safe::UnwindSafe for aya_ebpf::maps::hash_map::HashMap<K, V> where K: core::panic::unwind_safe::UnwindSafe, V: core::panic::unwind_safe::UnwindSafe
 #[repr(transparent)] pub struct aya_ebpf::maps::LpmTrie<K, V>
 impl<K, V> aya_ebpf::maps::lpm_trie::LpmTrie<K, V>
-pub fn aya_ebpf::maps::lpm_trie::LpmTrie<K, V>::get(&self, impl core::borrow::Borrow<aya_ebpf::maps::lpm_trie::Key<K>>) -> core::option::Option<&V>
-pub fn aya_ebpf::maps::lpm_trie::LpmTrie<K, V>::insert(&self, impl core::borrow::Borrow<aya_ebpf::maps::lpm_trie::Key<K>>, impl core::borrow::Borrow<V>, u64) -> core::result::Result<(), i32>
+pub fn aya_ebpf::maps::lpm_trie::LpmTrie<K, V>::get(&self, &aya_ebpf::maps::lpm_trie::Key<K>) -> core::option::Option<&V>
+pub fn aya_ebpf::maps::lpm_trie::LpmTrie<K, V>::insert(&self, &aya_ebpf::maps::lpm_trie::Key<K>, &V, u64) -> core::result::Result<(), i32>
 pub const fn aya_ebpf::maps::lpm_trie::LpmTrie<K, V>::pinned(u32, u32) -> Self
-pub fn aya_ebpf::maps::lpm_trie::LpmTrie<K, V>::remove(&self, impl core::borrow::Borrow<aya_ebpf::maps::lpm_trie::Key<K>>) -> core::result::Result<(), i32>
+pub fn aya_ebpf::maps::lpm_trie::LpmTrie<K, V>::remove(&self, &aya_ebpf::maps::lpm_trie::Key<K>) -> core::result::Result<(), i32>
 pub const fn aya_ebpf::maps::lpm_trie::LpmTrie<K, V>::with_max_entries(u32, u32) -> Self
 impl<K, V> !core::marker::Freeze for aya_ebpf::maps::lpm_trie::LpmTrie<K, V>
 impl<K, V> core::marker::Send for aya_ebpf::maps::lpm_trie::LpmTrie<K, V> where K: core::marker::Send, V: core::marker::Send
@@ -1557,12 +1557,12 @@ impl<K, V> !core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::maps::lpm_trie
 impl<K, V> core::panic::unwind_safe::UnwindSafe for aya_ebpf::maps::lpm_trie::LpmTrie<K, V> where K: core::panic::unwind_safe::UnwindSafe, V: core::panic::unwind_safe::UnwindSafe
 #[repr(transparent)] pub struct aya_ebpf::maps::LruHashMap<K, V>
 impl<K, V> aya_ebpf::maps::hash_map::LruHashMap<K, V>
-pub unsafe fn aya_ebpf::maps::hash_map::LruHashMap<K, V>::get(&self, impl core::borrow::Borrow<K>) -> core::option::Option<&V>
-pub fn aya_ebpf::maps::hash_map::LruHashMap<K, V>::get_ptr(&self, impl core::borrow::Borrow<K>) -> core::option::Option<*const V>
-pub fn aya_ebpf::maps::hash_map::LruHashMap<K, V>::get_ptr_mut(&self, impl core::borrow::Borrow<K>) -> core::option::Option<*mut V>
-pub fn aya_ebpf::maps::hash_map::LruHashMap<K, V>::insert(&self, impl core::borrow::Borrow<K>, impl core::borrow::Borrow<V>, u64) -> core::result::Result<(), i32>
+pub unsafe fn aya_ebpf::maps::hash_map::LruHashMap<K, V>::get(&self, &K) -> core::option::Option<&V>
+pub fn aya_ebpf::maps::hash_map::LruHashMap<K, V>::get_ptr(&self, &K) -> core::option::Option<*const V>
+pub fn aya_ebpf::maps::hash_map::LruHashMap<K, V>::get_ptr_mut(&self, &K) -> core::option::Option<*mut V>
+pub fn aya_ebpf::maps::hash_map::LruHashMap<K, V>::insert(&self, &K, &V, u64) -> core::result::Result<(), i32>
 pub const fn aya_ebpf::maps::hash_map::LruHashMap<K, V>::pinned(u32, u32) -> Self
-pub fn aya_ebpf::maps::hash_map::LruHashMap<K, V>::remove(&self, impl core::borrow::Borrow<K>) -> core::result::Result<(), i32>
+pub fn aya_ebpf::maps::hash_map::LruHashMap<K, V>::remove(&self, &K) -> core::result::Result<(), i32>
 pub const fn aya_ebpf::maps::hash_map::LruHashMap<K, V>::with_max_entries(u32, u32) -> Self
 impl<K, V> !core::marker::Freeze for aya_ebpf::maps::hash_map::LruHashMap<K, V>
 impl<K, V> core::marker::Send for aya_ebpf::maps::hash_map::LruHashMap<K, V> where K: core::marker::Send, V: core::marker::Send
@@ -1573,12 +1573,12 @@ impl<K, V> !core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::maps::hash_map
 impl<K, V> core::panic::unwind_safe::UnwindSafe for aya_ebpf::maps::hash_map::LruHashMap<K, V> where K: core::panic::unwind_safe::UnwindSafe, V: core::panic::unwind_safe::UnwindSafe
 #[repr(transparent)] pub struct aya_ebpf::maps::LruPerCpuHashMap<K, V>
 impl<K, V> aya_ebpf::maps::hash_map::LruPerCpuHashMap<K, V>
-pub unsafe fn aya_ebpf::maps::hash_map::LruPerCpuHashMap<K, V>::get(&self, impl core::borrow::Borrow<K>) -> core::option::Option<&V>
-pub fn aya_ebpf::maps::hash_map::LruPerCpuHashMap<K, V>::get_ptr(&self, impl core::borrow::Borrow<K>) -> core::option::Option<*const V>
-pub fn aya_ebpf::maps::hash_map::LruPerCpuHashMap<K, V>::get_ptr_mut(&self, impl core::borrow::Borrow<K>) -> core::option::Option<*mut V>
-pub fn aya_ebpf::maps::hash_map::LruPerCpuHashMap<K, V>::insert(&self, impl core::borrow::Borrow<K>, impl core::borrow::Borrow<V>, u64) -> core::result::Result<(), i32>
+pub unsafe fn aya_ebpf::maps::hash_map::LruPerCpuHashMap<K, V>::get(&self, &K) -> core::option::Option<&V>
+pub fn aya_ebpf::maps::hash_map::LruPerCpuHashMap<K, V>::get_ptr(&self, &K) -> core::option::Option<*const V>
+pub fn aya_ebpf::maps::hash_map::LruPerCpuHashMap<K, V>::get_ptr_mut(&self, &K) -> core::option::Option<*mut V>
+pub fn aya_ebpf::maps::hash_map::LruPerCpuHashMap<K, V>::insert(&self, &K, &V, u64) -> core::result::Result<(), i32>
 pub const fn aya_ebpf::maps::hash_map::LruPerCpuHashMap<K, V>::pinned(u32, u32) -> Self
-pub fn aya_ebpf::maps::hash_map::LruPerCpuHashMap<K, V>::remove(&self, impl core::borrow::Borrow<K>) -> core::result::Result<(), i32>
+pub fn aya_ebpf::maps::hash_map::LruPerCpuHashMap<K, V>::remove(&self, &K) -> core::result::Result<(), i32>
 pub const fn aya_ebpf::maps::hash_map::LruPerCpuHashMap<K, V>::with_max_entries(u32, u32) -> Self
 impl<K, V> !core::marker::Freeze for aya_ebpf::maps::hash_map::LruPerCpuHashMap<K, V>
 impl<K, V> core::marker::Send for aya_ebpf::maps::hash_map::LruPerCpuHashMap<K, V> where K: core::marker::Send, V: core::marker::Send
@@ -1593,7 +1593,7 @@ pub fn aya_ebpf::maps::per_cpu_array::PerCpuArray<T>::get(&self, u32) -> core::o
 pub fn aya_ebpf::maps::per_cpu_array::PerCpuArray<T>::get_ptr(&self, u32) -> core::option::Option<*const T>
 pub fn aya_ebpf::maps::per_cpu_array::PerCpuArray<T>::get_ptr_mut(&self, u32) -> core::option::Option<*mut T>
 pub const fn aya_ebpf::maps::per_cpu_array::PerCpuArray<T>::pinned(u32, u32) -> Self
-pub fn aya_ebpf::maps::per_cpu_array::PerCpuArray<T>::set(&self, u32, impl core::borrow::Borrow<T>, u64) -> core::result::Result<(), i32>
+pub fn aya_ebpf::maps::per_cpu_array::PerCpuArray<T>::set(&self, u32, &T, u64) -> core::result::Result<(), i32>
 pub const fn aya_ebpf::maps::per_cpu_array::PerCpuArray<T>::with_max_entries(u32, u32) -> Self
 impl<T> !core::marker::Freeze for aya_ebpf::maps::per_cpu_array::PerCpuArray<T>
 impl<T> core::marker::Send for aya_ebpf::maps::per_cpu_array::PerCpuArray<T> where T: core::marker::Send
@@ -1618,12 +1618,12 @@ impl<V> !core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::maps::cgroup_stor
 impl<V> core::panic::unwind_safe::UnwindSafe for aya_ebpf::maps::cgroup_storage::PerCpuCgroupStorage<V> where V: core::panic::unwind_safe::UnwindSafe
 #[repr(transparent)] pub struct aya_ebpf::maps::PerCpuHashMap<K, V>
 impl<K, V> aya_ebpf::maps::hash_map::PerCpuHashMap<K, V>
-pub unsafe fn aya_ebpf::maps::hash_map::PerCpuHashMap<K, V>::get(&self, impl core::borrow::Borrow<K>) -> core::option::Option<&V>
-pub fn aya_ebpf::maps::hash_map::PerCpuHashMap<K, V>::get_ptr(&self, impl core::borrow::Borrow<K>) -> core::option::Option<*const V>
-pub fn aya_ebpf::maps::hash_map::PerCpuHashMap<K, V>::get_ptr_mut(&self, impl core::borrow::Borrow<K>) -> core::option::Option<*mut V>
-pub fn aya_ebpf::maps::hash_map::PerCpuHashMap<K, V>::insert(&self, impl core::borrow::Borrow<K>, impl core::borrow::Borrow<V>, u64) -> core::result::Result<(), i32>
+pub unsafe fn aya_ebpf::maps::hash_map::PerCpuHashMap<K, V>::get(&self, &K) -> core::option::Option<&V>
+pub fn aya_ebpf::maps::hash_map::PerCpuHashMap<K, V>::get_ptr(&self, &K) -> core::option::Option<*const V>
+pub fn aya_ebpf::maps::hash_map::PerCpuHashMap<K, V>::get_ptr_mut(&self, &K) -> core::option::Option<*mut V>
+pub fn aya_ebpf::maps::hash_map::PerCpuHashMap<K, V>::insert(&self, &K, &V, u64) -> core::result::Result<(), i32>
 pub const fn aya_ebpf::maps::hash_map::PerCpuHashMap<K, V>::pinned(u32, u32) -> Self
-pub fn aya_ebpf::maps::hash_map::PerCpuHashMap<K, V>::remove(&self, impl core::borrow::Borrow<K>) -> core::result::Result<(), i32>
+pub fn aya_ebpf::maps::hash_map::PerCpuHashMap<K, V>::remove(&self, &K) -> core::result::Result<(), i32>
 pub const fn aya_ebpf::maps::hash_map::PerCpuHashMap<K, V>::with_max_entries(u32, u32) -> Self
 impl<K, V> !core::marker::Freeze for aya_ebpf::maps::hash_map::PerCpuHashMap<K, V>
 impl<K, V> core::marker::Send for aya_ebpf::maps::hash_map::PerCpuHashMap<K, V> where K: core::marker::Send, V: core::marker::Send
@@ -1635,8 +1635,8 @@ impl<K, V> core::panic::unwind_safe::UnwindSafe for aya_ebpf::maps::hash_map::Pe
 #[repr(transparent)] pub struct aya_ebpf::maps::PerfEventArray<T>
 impl<T> aya_ebpf::maps::PerfEventArray<T>
 pub const fn aya_ebpf::maps::PerfEventArray<T>::new(u32) -> Self
-pub fn aya_ebpf::maps::PerfEventArray<T>::output<C: aya_ebpf::EbpfContext>(&self, &C, impl core::borrow::Borrow<T>, u32)
-pub fn aya_ebpf::maps::PerfEventArray<T>::output_at_index<C: aya_ebpf::EbpfContext>(&self, &C, u32, impl core::borrow::Borrow<T>, u32)
+pub fn aya_ebpf::maps::PerfEventArray<T>::output<C: aya_ebpf::EbpfContext>(&self, &C, &T, u32)
+pub fn aya_ebpf::maps::PerfEventArray<T>::output_at_index<C: aya_ebpf::EbpfContext>(&self, &C, u32, &T, u32)
 pub const fn aya_ebpf::maps::PerfEventArray<T>::pinned(u32) -> Self
 impl<T> !core::marker::Freeze for aya_ebpf::maps::PerfEventArray<T>
 impl<T> core::marker::Send for aya_ebpf::maps::PerfEventArray<T> where T: core::marker::Send
@@ -1675,7 +1675,7 @@ impl<T> aya_ebpf::maps::queue::Queue<T>
 pub fn aya_ebpf::maps::queue::Queue<T>::peek(&self) -> core::result::Result<core::option::Option<T>, i32>
 pub const fn aya_ebpf::maps::queue::Queue<T>::pinned(u32, u32) -> Self
 pub fn aya_ebpf::maps::queue::Queue<T>::pop(&self) -> core::result::Result<core::option::Option<T>, i32>
-pub fn aya_ebpf::maps::queue::Queue<T>::push(&self, impl core::borrow::Borrow<T>, u64) -> core::result::Result<(), i32>
+pub fn aya_ebpf::maps::queue::Queue<T>::push(&self, &T, u64) -> core::result::Result<(), i32>
 pub const fn aya_ebpf::maps::queue::Queue<T>::with_max_entries(u32, u32) -> Self
 impl<T> !core::marker::Freeze for aya_ebpf::maps::queue::Queue<T>
 impl<T> core::marker::Send for aya_ebpf::maps::queue::Queue<T> where T: core::marker::Send
@@ -1698,7 +1698,7 @@ impl !core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::maps::reuseport_sock
 impl core::panic::unwind_safe::UnwindSafe for aya_ebpf::maps::reuseport_sock_array::ReusePortSockArray
 #[repr(transparent)] pub struct aya_ebpf::maps::RingBuf
 impl aya_ebpf::maps::ring_buf::RingBuf
-pub fn aya_ebpf::maps::ring_buf::RingBuf::output<T: ?core::marker::Sized>(&self, impl core::borrow::Borrow<T>, u64) -> core::result::Result<(), i32>
+pub fn aya_ebpf::maps::ring_buf::RingBuf::output<T: ?core::marker::Sized>(&self, &T, u64) -> core::result::Result<(), i32>
 pub const fn aya_ebpf::maps::ring_buf::RingBuf::pinned(u32, u32) -> Self
 pub fn aya_ebpf::maps::ring_buf::RingBuf::query(&self, u64) -> u64
 pub fn aya_ebpf::maps::ring_buf::RingBuf::reserve<T: 'static>(&self, u64) -> core::option::Option<aya_ebpf::maps::ring_buf::RingBufEntry<T>>
@@ -1714,10 +1714,10 @@ impl core::panic::unwind_safe::UnwindSafe for aya_ebpf::maps::ring_buf::RingBuf
 #[repr(transparent)] pub struct aya_ebpf::maps::SockHash<K>
 impl<K> aya_ebpf::maps::sock_hash::SockHash<K>
 pub const fn aya_ebpf::maps::sock_hash::SockHash<K>::pinned(u32, u32) -> Self
-pub fn aya_ebpf::maps::sock_hash::SockHash<K>::redirect_msg(&self, impl core::borrow::Borrow<aya_ebpf::programs::sk_msg::SkMsgContext>, impl core::borrow::BorrowMut<K>, u64) -> aya_ebpf_cty::od::c_long
-pub fn aya_ebpf::maps::sock_hash::SockHash<K>::redirect_sk_lookup(&self, impl core::borrow::Borrow<aya_ebpf::programs::sk_lookup::SkLookupContext>, impl core::borrow::Borrow<K>, u64) -> core::result::Result<(), i32>
-pub fn aya_ebpf::maps::sock_hash::SockHash<K>::redirect_skb(&self, impl core::borrow::Borrow<aya_ebpf::programs::sk_buff::SkBuffContext>, impl core::borrow::BorrowMut<K>, u64) -> aya_ebpf_cty::od::c_long
-pub fn aya_ebpf::maps::sock_hash::SockHash<K>::update(&self, impl core::borrow::BorrowMut<K>, impl core::borrow::BorrowMut<aya_ebpf_bindings::x86_64::bindings::bpf_sock_ops>, u64) -> core::result::Result<(), i32>
+pub fn aya_ebpf::maps::sock_hash::SockHash<K>::redirect_msg(&self, &aya_ebpf::programs::sk_msg::SkMsgContext, &mut K, u64) -> aya_ebpf_cty::od::c_long
+pub fn aya_ebpf::maps::sock_hash::SockHash<K>::redirect_sk_lookup(&self, &aya_ebpf::programs::sk_lookup::SkLookupContext, &K, u64) -> core::result::Result<(), i32>
+pub fn aya_ebpf::maps::sock_hash::SockHash<K>::redirect_skb(&self, &aya_ebpf::programs::sk_buff::SkBuffContext, &mut K, u64) -> aya_ebpf_cty::od::c_long
+pub fn aya_ebpf::maps::sock_hash::SockHash<K>::update(&self, &mut K, &mut aya_ebpf_bindings::x86_64::bindings::bpf_sock_ops, u64) -> core::result::Result<(), i32>
 pub const fn aya_ebpf::maps::sock_hash::SockHash<K>::with_max_entries(u32, u32) -> Self
 impl<K> !core::marker::Freeze for aya_ebpf::maps::sock_hash::SockHash<K>
 impl<K> core::marker::Send for aya_ebpf::maps::sock_hash::SockHash<K> where K: core::marker::Send
@@ -1746,7 +1746,7 @@ impl<T> aya_ebpf::maps::stack::Stack<T>
 pub fn aya_ebpf::maps::stack::Stack<T>::peek(&self) -> core::result::Result<core::option::Option<T>, i32>
 pub const fn aya_ebpf::maps::stack::Stack<T>::pinned(u32, u32) -> Self
 pub fn aya_ebpf::maps::stack::Stack<T>::pop(&self) -> core::result::Result<core::option::Option<T>, i32>
-pub fn aya_ebpf::maps::stack::Stack<T>::push(&self, impl core::borrow::Borrow<T>, u64) -> core::result::Result<(), i32>
+pub fn aya_ebpf::maps::stack::Stack<T>::push(&self, &T, u64) -> core::result::Result<(), i32>
 pub const fn aya_ebpf::maps::stack::Stack<T>::with_max_entries(u32, u32) -> Self
 impl<T> !core::marker::Freeze for aya_ebpf::maps::stack::Stack<T>
 impl<T> core::marker::Send for aya_ebpf::maps::stack::Stack<T> where T: core::marker::Send


### PR DESCRIPTION
The #1626 has already explains the intent of this PR. Besides this PR, I think the same change should also be applied to the userspace map APIs.

I took a look at #431, which introduced Borrow for preserving existing by-value calls such as key: K. But clippy::needless_borrows_for_generic_args encourages callers to remove explicit borrows. Following that suggestion in userspace map calls could reintroduce the excessive stack usage reported in #427.

If this PR is merged, I plan to submit a follow-up PR applying the same change to the userspace map APIs.


<!-- markdownlint-disable first-line-heading -->

<!--
    Thank you for your contribution to Aya! 🎉

    For Work In Progress Pull Requests, please use the Draft PR feature.

    Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Aya Contributing Guide: https://github.com/aya-rs/aya/blob/main/CONTRIBUTING.md
     - 📖 Read the Aya Code of Conduct: https://github.com/aya-rs/aya/blob/main/CODE_OF_CONDUCT.md
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages: https://cbea.ms/git-commit/
     - 📗 Update any related documentation.

-->

<!---
      Summarize the changes you're making here. Detailed information belongs in
      the Git commit messages. If your pull request contains just one commit,
      it's best to use its message as a summary. Otherwise, if there are multiple
      atomic commits, write a summary for the entire PR. Feel free to flag
      anything you think needs a reviewer's attention.
-->

<!--
      If your changes address an issue, link it with the *Fixes* tag so
      the issue gets closed when the PR is merged, for example:

      Fixes: #1234

      If you are only referencing an issue without fully addressing it, feel
      free to link it anywhere in the summary.
-->

### Added/updated tests?

_We strongly encourage you to add a test for your changes._

- [x] No, and this is why: only change map APIs.

### Checklist

- [x] Rust code has been formatted with `cargo +nightly fmt`.
- [x] All clippy lints have been fixed.
      You can find failing lints with `cargo xtask clippy`.
- [x] Unit tests are passing locally with `cargo test`.
- [x] The [Integration tests] are passing locally.
- [x] I have blessed any API changes with `cargo xtask public-api --bless`.

[Integration tests]: https://github.com/aya-rs/aya/blob/main/test/README.md

### (Optional) What GIF best describes this PR or how it makes you feel?

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aya-rs/aya/1657)
<!-- Reviewable:end -->
