### PR TITLE
aya: distinguish probe attachment targets

### DIFF
--- a/aya/src/programs/kprobe.rs
+++ b/aya/src/programs/kprobe.rs
@@ -15,7 +15,7 @@ use crate::{
         ProgramData, ProgramError, ProgramType, define_link_wrapper, impl_try_from_fdlink,
         impl_try_into_fdlink, load_program_without_attach_type,
         perf_attach::{PerfLinkIdInner, PerfLinkInner},
-        probe::{Probe, ProbeKind, attach},
+        probe::{Probe, ProbeEventArgs, ProbeKind, attach},
     },
 };
 
@@ -47,6 +47,11 @@ use crate::{
 pub struct KProbe {
     pub(crate) data: ProgramData<KProbeLink>,
     pub(crate) kind: ProbeKind,
+}
+
+pub(crate) struct KProbeAttachTarget<'a> {
+    function: &'a OsStr,
+    offset: u64,
 }
 
 impl KProbe {
@@ -84,11 +89,14 @@ impl KProbe {
         let Self { data, kind } = self;
         attach::<Self, _>(
             data,
-            *kind,
-            fn_name.as_ref(),
-            offset,
-            None, // pid
-            None, // cookie
+            ProbeEventArgs {
+                target: KProbeAttachTarget {
+                    function: fn_name.as_ref(),
+                    offset,
+                },
+                kind: *kind,
+            },
+            None,
         )
     }
 
@@ -105,9 +113,16 @@ impl KProbe {
 }
 
 impl Probe for KProbe {
+    type AttachTarget<'a> = KProbeAttachTarget<'a>;
+
     const PMU: &'static str = "kprobe";
 
     type Error = KProbeError;
+
+    fn into_common_target(target: Self::AttachTarget<'_>) -> (&OsStr, u64, Option<u32>) {
+        let KProbeAttachTarget { function, offset } = target;
+        (function, offset, None)
+    }
 
     fn file_error(filename: PathBuf, io_error: io::Error) -> Self::Error {
         KProbeError::FileError { filename, io_error }

--- a/aya/src/programs/probe.rs
+++ b/aya/src/programs/probe.rs
@@ -72,22 +72,18 @@ impl ManyProbeLinks {
     pub(crate) fn attach_point<P: Probe>(
         &mut self,
         prog_fd: BorrowedFd<'_>,
-        kind: ProbeKind,
-        fn_name: &OsStr,
-        offset: u64,
-        pid: Option<u32>,
+        args: ProbeEventArgs<P::AttachTarget<'_>>,
         cookie: Option<u64>,
     ) -> Result<(), ProgramError> {
         // The first attached point selected this variant, so subsequent points can use the same
         // fd-backed or perf-backed path directly without repeating backend selection.
         match self {
             Self::Fd(links) => {
-                let link = attach_bpf_probe::<P>(prog_fd, kind, fn_name, offset, pid, cookie)?;
+                let link = attach_bpf_probe::<P>(prog_fd, args, cookie)?;
                 links.push(link);
             }
             Self::PerfLink(links) => {
-                let link =
-                    attach_perf_event_probe::<P>(prog_fd, kind, fn_name, offset, pid, cookie)?;
+                let link = attach_perf_event_probe::<P>(prog_fd, args, cookie)?;
                 links.push(link);
             }
         }
@@ -183,10 +179,20 @@ impl Link for ProbeLinkInner {
 
 id_as_key!(ProbeLinkInner, ProbeLinkIdInner);
 
+/// Arguments used to create a perf event for a probe family's target.
+pub(crate) struct ProbeEventArgs<T> {
+    pub(crate) target: T,
+    pub(crate) kind: ProbeKind,
+}
+
 pub(crate) trait Probe {
+    type AttachTarget<'a>;
+
     const PMU: &'static str;
 
     type Error: Into<ProgramError>;
+
+    fn into_common_target(target: Self::AttachTarget<'_>) -> (&OsStr, u64, Option<u32>);
 
     fn file_error(filename: PathBuf, io_error: io::Error) -> Self::Error;
 
@@ -290,60 +296,41 @@ impl Drop for ProbeEvent {
 
 pub(crate) fn attach<P: Probe, T: Link + From<PerfLinkInner>>(
     program_data: &mut ProgramData<T>,
-    kind: ProbeKind,
-    // NB: the meaning of this argument is different for kprobe/kretprobe and uprobe/uretprobe; in
-    // the kprobe case it is the name of the function to attach to, in the uprobe case it is a path
-    // to the binary or library.
-    //
-    // TODO: consider encoding the type and the argument in the [`ProbeKind`] enum instead of a
-    // separate argument.
-    fn_name: &OsStr,
-    offset: u64,
-    pid: Option<u32>,
+    args: ProbeEventArgs<P::AttachTarget<'_>>,
     cookie: Option<u64>,
 ) -> Result<T::Id, ProgramError> {
     // https://github.com/torvalds/linux/commit/e12f03d7031a977356e3d7b75a68c2185ff8d155
     // Use debugfs to create probe
     let prog_fd = program_data.fd()?;
     let prog_fd = prog_fd.as_fd();
-    let link = attach_impl::<P>(prog_fd, kind, fn_name, offset, pid, cookie)?;
+    let link = attach_impl::<P>(prog_fd, args, cookie)?;
     program_data.links.insert(T::from(link))
 }
 
 pub(crate) fn attach_impl<P: Probe>(
     prog_fd: BorrowedFd<'_>,
-    kind: ProbeKind,
-    fn_name: &OsStr,
-    offset: u64,
-    pid: Option<u32>,
+    args: ProbeEventArgs<P::AttachTarget<'_>>,
     cookie: Option<u64>,
 ) -> Result<PerfLinkInner, ProgramError> {
     if probe_pmu_supported() && FEATURES.bpf_perf_link() {
-        attach_bpf_probe::<P>(prog_fd, kind, fn_name, offset, pid, cookie).map(PerfLinkInner::Fd)
+        attach_bpf_probe::<P>(prog_fd, args, cookie).map(PerfLinkInner::Fd)
     } else {
-        attach_perf_event_probe::<P>(prog_fd, kind, fn_name, offset, pid, cookie)
-            .map(PerfLinkInner::PerfLink)
+        attach_perf_event_probe::<P>(prog_fd, args, cookie).map(PerfLinkInner::PerfLink)
     }
 }
 
 fn attach_bpf_probe<P: Probe>(
     prog_fd: BorrowedFd<'_>,
-    kind: ProbeKind,
-    fn_name: &OsStr,
-    offset: u64,
-    pid: Option<u32>,
+    args: ProbeEventArgs<P::AttachTarget<'_>>,
     cookie: Option<u64>,
 ) -> Result<FdLink, ProgramError> {
-    let perf_fd = create_as_probe::<P>(kind, fn_name, offset, pid)?;
+    let perf_fd = create_as_probe::<P>(args)?;
     attach_bpf_link(prog_fd, perf_fd, cookie)
 }
 
 fn attach_perf_event_probe<P: Probe>(
     prog_fd: BorrowedFd<'_>,
-    kind: ProbeKind,
-    fn_name: &OsStr,
-    offset: u64,
-    pid: Option<u32>,
+    args: ProbeEventArgs<P::AttachTarget<'_>>,
     cookie: Option<u64>,
 ) -> Result<PerfLink, ProgramError> {
     if cookie.is_some() {
@@ -351,9 +338,9 @@ fn attach_perf_event_probe<P: Probe>(
     }
 
     let (perf_fd, event) = if probe_pmu_supported() {
-        (create_as_probe::<P>(kind, fn_name, offset, pid)?, None)
+        (create_as_probe::<P>(args)?, None)
     } else {
-        let (perf_fd, event) = create_as_trace_point::<P>(kind, fn_name, offset, pid)?;
+        let (perf_fd, event) = create_as_trace_point::<P>(args)?;
         (perf_fd, Some(event))
     };
     attach_perf_event(prog_fd, perf_fd, event)
@@ -371,11 +358,9 @@ fn detach_debug_fs<P: Probe>(event_alias: &OsStr) -> Result<(), ProgramError> {
 }
 
 fn create_as_probe<P: Probe>(
-    kind: ProbeKind,
-    fn_name: &OsStr,
-    offset: u64,
-    pid: Option<u32>,
+    ProbeEventArgs { target, kind }: ProbeEventArgs<P::AttachTarget<'_>>,
 ) -> Result<crate::MockableFd, ProgramError> {
+    let (target, offset, pid) = P::into_common_target(target);
     let perf_ty = read_sys_fs_perf_type(P::PMU)
         .map_err(|(filename, io_error)| P::file_error(filename, io_error).into())?;
 
@@ -387,7 +372,7 @@ fn create_as_probe<P: Probe>(
         ProbeKind::Entry => None,
     };
 
-    perf_event_open_probe(perf_ty, ret_bit, fn_name, offset, pid)
+    perf_event_open_probe(perf_ty, ret_bit, target, offset, pid)
         .map_err(|io_error| SyscallError {
             call: "perf_event_open",
             io_error,
@@ -396,14 +381,12 @@ fn create_as_probe<P: Probe>(
 }
 
 fn create_as_trace_point<P: Probe>(
-    kind: ProbeKind,
-    name: &OsStr,
-    offset: u64,
-    pid: Option<u32>,
+    ProbeEventArgs { target, kind }: ProbeEventArgs<P::AttachTarget<'_>>,
 ) -> Result<(crate::MockableFd, ProbeEvent), ProgramError> {
     let tracefs = find_tracefs_path()?;
+    let (target, offset, pid) = P::into_common_target(target);
 
-    let event = create_probe_event::<P>(tracefs, kind, name, offset)
+    let event = create_probe_event::<P>(tracefs, kind, target, offset)
         .map_err(|(filename, io_error)| P::file_error(filename, io_error).into())?;
 
     let ProbeEvent {
@@ -423,7 +406,7 @@ fn create_as_trace_point<P: Probe>(
 fn create_probe_event<P: Probe>(
     tracefs: &Path,
     kind: ProbeKind,
-    fn_name: &OsStr,
+    target: &OsStr,
     offset: u64,
 ) -> Result<ProbeEvent, (PathBuf, io::Error)> {
     use std::os::unix::ffi::OsStrExt as _;
@@ -441,7 +424,7 @@ fn create_probe_event<P: Probe>(
         probe_type_prefix,
     )
     .unwrap();
-    for b in fn_name.as_bytes() {
+    for b in target.as_bytes() {
         let b = match *b {
             b'.' | b'/' | b'-' => b'_',
             b => b,
@@ -460,7 +443,7 @@ fn create_probe_event<P: Probe>(
     write!(&mut probe, "{}:{}s/", probe_type_prefix, P::PMU).unwrap();
     probe.push(&event_alias);
     probe.push(" ");
-    probe.push(fn_name);
+    probe.push(target);
     P::write_offset(&mut probe, kind, offset).unwrap();
     probe.push("\n");
 

--- a/aya/src/programs/uprobe.rs
+++ b/aya/src/programs/uprobe.rs
@@ -31,8 +31,8 @@ use crate::{
         FdLink, LinkError, PerfLinkInner, ProgramData, ProgramError, ProgramType,
         define_link_wrapper, load_program_with_attach_type, load_program_without_attach_type,
         probe::{
-            self, ManyProbeLinks, OsStringExt as _, Probe, ProbeKind, ProbeLinkIdInner,
-            ProbeLinkInner,
+            self, ManyProbeLinks, OsStringExt as _, Probe, ProbeEventArgs, ProbeKind,
+            ProbeLinkIdInner, ProbeLinkInner,
         },
     },
     sys::{SyscallError, bpf_link_create_uprobe_multi},
@@ -59,6 +59,12 @@ pub struct UProbe {
     pub(crate) data: ProgramData<UProbeLink>,
     pub(crate) kind: ProbeKind,
     pub(crate) attach_mode: AttachMode,
+}
+
+pub(crate) struct UProbeAttachTarget<'a> {
+    path: &'a OsStr,
+    offset: u64,
+    pid: Option<u32>,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -528,9 +534,18 @@ impl UProbe {
         } = self;
         let path = path.as_os_str();
         match resolved {
-            ResolvedPoints::One { offset, cookie } => {
-                probe::attach::<Self, UProbeLink>(data, *kind, path, *offset, pid, *cookie)
-            }
+            ResolvedPoints::One { offset, cookie } => probe::attach::<Self, UProbeLink>(
+                data,
+                ProbeEventArgs {
+                    target: UProbeAttachTarget {
+                        path,
+                        offset: *offset,
+                        pid,
+                    },
+                    kind: *kind,
+                },
+                *cookie,
+            ),
             ResolvedPoints::Many { offsets, cookies } => {
                 let prog_fd = data.fd()?;
                 let prog_fd = prog_fd.as_fd();
@@ -554,10 +569,14 @@ impl UProbe {
                     .and_then(|cookies| cookies.first().copied());
                 let first_link = probe::attach_impl::<Self>(
                     prog_fd,
-                    *kind,
-                    path,
-                    first_offset,
-                    pid,
+                    ProbeEventArgs {
+                        target: UProbeAttachTarget {
+                            path,
+                            offset: first_offset,
+                            pid,
+                        },
+                        kind: *kind,
+                    },
                     first_cookie,
                 )
                 .map_err(|error| attach_error(0, first_offset, error))?;
@@ -567,7 +586,14 @@ impl UProbe {
                     let cookie = cookies
                         .as_ref()
                         .and_then(|cookies| cookies.get(index).copied());
-                    match links.attach_point::<Self>(prog_fd, *kind, path, offset, pid, cookie) {
+                    match links.attach_point::<Self>(
+                        prog_fd,
+                        ProbeEventArgs {
+                            target: UProbeAttachTarget { path, offset, pid },
+                            kind: *kind,
+                        },
+                        cookie,
+                    ) {
                         Ok(()) => {}
                         Err(error) => {
                             // Explicitly detach links attached before this failure.
@@ -614,9 +640,16 @@ impl UProbe {
 }
 
 impl Probe for UProbe {
+    type AttachTarget<'a> = UProbeAttachTarget<'a>;
+
     const PMU: &'static str = "uprobe";
 
     type Error = UProbeError;
+
+    fn into_common_target(target: Self::AttachTarget<'_>) -> (&OsStr, u64, Option<u32>) {
+        let UProbeAttachTarget { path, offset, pid } = target;
+        (path, offset, pid)
+    }
 
     fn file_error(filename: PathBuf, io_error: io::Error) -> Self::Error {
         UProbeError::FileError { filename, io_error }


### PR DESCRIPTION
Address this TODO while it's still fresh.

<!-- markdownlint-disable first-line-heading -->

<!--
    Thank you for your contribution to Aya! 🎉

    For Work In Progress Pull Requests, please use the Draft PR feature.

    Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Aya Contributing Guide: https://github.com/aya-rs/aya/blob/main/CONTRIBUTING.md
     - 📖 Read the Aya Code of Conduct: https://github.com/aya-rs/aya/blob/main/CODE_OF_CONDUCT.md
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages: https://cbea.ms/git-commit/
     - 📗 Update any related documentation.

-->

<!---
      Summarize the changes you're making here. Detailed information belongs in
      the Git commit messages. If your pull request contains just one commit,
      it's best to use its message as a summary. Otherwise, if there are multiple
      atomic commits, write a summary for the entire PR. Feel free to flag
      anything you think needs a reviewer's attention.
-->

<!--
      If your changes address an issue, link it with the *Fixes* tag so
      the issue gets closed when the PR is merged, for example:

      Fixes: #1234

      If you are only referencing an issue without fully addressing it, feel
      free to link it anywhere in the summary.
-->

### Added/updated tests?

_We strongly encourage you to add a test for your changes._

- [x] No, and this is why: just a small refactor

### Checklist

- [x] Rust code has been formatted with `cargo +nightly fmt`.
- [x] All clippy lints have been fixed.
      You can find failing lints with `cargo xtask clippy`.
- [x] Unit tests are passing locally with `cargo test`.
- [x] The [Integration tests] are passing locally.
- [x] I have blessed any API changes with `cargo xtask public-api --bless`.

[Integration tests]: https://github.com/aya-rs/aya/blob/main/test/README.md

### (Optional) What GIF best describes this PR or how it makes you feel?

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aya-rs/aya/1659)
<!-- Reviewable:end -->
