### PR TITLE
aya-obj: fix flexible array bounds check in local access specs

### DIFF
--- a/aya-obj/src/btf/relocation.rs
+++ b/aya-obj/src/btf/relocation.rs
@@ -825,7 +825,7 @@ impl<'a> AccessSpec<'a> {
                                 let parent = accessors.last().unwrap();
                                 let parent_ty = btf.type_by_id(parent.type_id)?;
                                 match parent_ty {
-                                    BtfType::Struct(s) => index == s.members.len() - 1,
+                                    BtfType::Struct(s) => parent.index == s.members.len() - 1,
                                     _ => false,
                                 }
                             };
@@ -1294,5 +1294,80 @@ impl ComputedRelocation {
             size: 0,
             type_id: None,
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use assert_matches::assert_matches;
+
+    use super::*;
+    use crate::btf::Int;
+
+    fn flex_array_btf(trailing_members: usize) -> (Btf, u32) {
+        let mut btf = Btf::new();
+        let name_offset = btf.add_string("long unsigned int");
+        let u64_id = btf.add_type(BtfType::Int(Int::new(name_offset, 8, IntEncoding::None, 0)));
+        let array_id = btf.add_type(BtfType::Array(Array::new(0, u64_id, u64_id, 0)));
+
+        let name_offset = btf.add_string("args");
+        let mut members = vec![BtfMember {
+            name_offset,
+            btf_type: array_id,
+            offset: 0,
+        }];
+        for i in 0..trailing_members {
+            let name_offset = btf.add_string(&format!("trailing{i}"));
+            members.push(BtfMember {
+                name_offset,
+                btf_type: u64_id,
+                offset: 0,
+            });
+        }
+
+        let name_offset = btf.add_string("bpf_raw_tracepoint_args");
+        let struct_id = btf.add_type(BtfType::Struct(Struct::new(name_offset, members, 0)));
+        (btf, struct_id)
+    }
+
+    fn field_relocation(type_id: u32) -> Relocation {
+        Relocation {
+            kind: RelocationKind::FieldByteOffset,
+            ins_offset: 0,
+            type_id,
+            access_str_offset: 0,
+            number: 0,
+        }
+    }
+
+    #[test]
+    fn test_access_spec_flex_array_index() {
+        let (btf, struct_id) = flex_array_btf(0);
+        let relocation = field_relocation(struct_id);
+
+        // `args` is the last member of its struct and has zero declared elements, so it is a
+        // flexible array and any element index is in bounds.
+        for (spec, expected_bit_offset) in [("0:0:0", 0), ("0:0:1", 64), ("0:0:7", 448)] {
+            let access_spec = AccessSpec::new(&btf, struct_id, spec, relocation).unwrap();
+            assert_eq!(access_spec.bit_offset, expected_bit_offset);
+        }
+    }
+
+    #[test]
+    fn test_access_spec_zero_length_array_not_last_member() {
+        let (btf, struct_id) = flex_array_btf(1);
+        let relocation = field_relocation(struct_id);
+
+        // `args` is no longer the last member, so it is a zero-length array rather than a
+        // flexible one and every element index is out of bounds.
+        for spec in ["0:0:0", "0:0:1"] {
+            assert_matches!(
+                AccessSpec::new(&btf, struct_id, spec, relocation),
+                Err(RelocationError::InvalidAccessIndex {
+                    error: "array index out of bounds",
+                    ..
+                })
+            );
+        }
     }
 }


### PR DESCRIPTION
When building the local access spec, the flexible-array exemption compares the
array element index against the parent struct's member count, instead of the
array member's own position in the struct.

For `struct bpf_raw_tracepoint_args`, whose single member is `__u64 args[0]`,
`members.len() - 1` is 0, so only `args[0]` was exempted from the bounds check
and any other index failed to relocate with "array index out of bounds". In the
other direction, a zero-length array that is *not* the last member was wrongly
exempted for the one index that made the two counters coincide.

Compare the parent accessor's index, like `match_candidate()` already does for
the target spec, and like libbpf's `is_flex_arr()`:

https://github.com/libbpf/libbpf/blob/master/src/relo_core.c#L70-L82

Fixes: #1662

### Added/updated tests?

- [x] Yes

Two unit tests in `aya-obj/src/btf/relocation.rs`, one per direction. Both fail
on the parent commit: the first panics on `args[1]` with "array index out of
bounds", the second sees `args[1]` wrongly accepted with `bit_offset: 64`.

### Checklist

- [x] Rust code has been formatted with `cargo +nightly fmt`.
- [x] All clippy lints have been fixed. You can find failing lints with
      `cargo xtask clippy`.
- [x] Unit tests are passing locally with `cargo test`.
- [x] The [Integration tests] are passing locally.
- [x] I have blessed any API changes with `cargo xtask public-api --bless`.

On the integration tests: they do not build for me, nor on `aya-rs/aya` main,
where `integration-ebpf` fails to link with `ERROR llvm: Invalid record` from
`bpf-linker` (`main` has been red on those jobs since 2026-08-06). The remaining
jobs are green on this branch: `lint` (which covers nightly fmt, clippy, miri
and public-api), both `bazel` jobs, and `build-test-aya` on all seven targets.

[Integration tests]: https://github.com/aya-rs/aya/blob/main/test/README.md

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aya-rs/aya/1663)
<!-- Reviewable:end -->
