### PR TITLE
aya, aya-ebpf, aya-obj: add BPF arena support

### DIFF
--- a/aya-obj/src/btf/btf.rs
+++ b/aya-obj/src/btf/btf.rs
@@ -108,6 +108,13 @@ pub enum BtfError {
         type_id: u32,
     },
 
+    /// Invalid `map_extra` map-definition field.
+    #[error("BTF map `{name}`: invalid `map_extra` field")]
+    InvalidMapExtra {
+        /// Map containing the invalid definition.
+        name: String,
+    },
+
     /// unknown BTF type
     #[error("unknown BTF type `{type_name}`")]
     UnknownBtfTypeName {

--- a/aya-obj/src/extern_types.rs
+++ b/aya-obj/src/extern_types.rs
@@ -506,6 +506,7 @@ mod tests {
             symbol_table: Default::default(),
             symbols_by_section: Default::default(),
             section_infos: Default::default(),
+            pending_arena_data: None,
             symbol_offset_by_name: Default::default(),
         }
     }
@@ -526,6 +527,7 @@ mod tests {
             symbol_table: Default::default(),
             symbols_by_section: Default::default(),
             section_infos: Default::default(),
+            pending_arena_data: None,
             symbol_offset_by_name: Default::default(),
         }
     }

--- a/aya-obj/src/maps.rs
+++ b/aya-obj/src/maps.rs
@@ -144,6 +144,22 @@ pub enum Map {
 }
 
 impl Map {
+    /// Returns the initial arena data associated with this map.
+    pub const fn arena_data(&self) -> Option<&ArenaData> {
+        match self {
+            Self::Legacy(_) => None,
+            Self::Btf(map) => map.arena_data.as_ref(),
+        }
+    }
+
+    /// Returns the initial arena data associated with this map as mutable.
+    pub const fn arena_data_mut(&mut self) -> Option<&mut ArenaData> {
+        match self {
+            Self::Legacy(_) => None,
+            Self::Btf(map) => map.arena_data.as_mut(),
+        }
+    }
+
     /// Returns the map type
     pub const fn map_type(&self) -> u32 {
         match self {
@@ -282,6 +298,7 @@ impl Map {
                     section_index: 0,
                     symbol_index: 0,
                     data: Vec::new(),
+                    arena_data: None,
                 })
             }),
         }
@@ -311,6 +328,38 @@ impl Map {
             symbol_index: None,
             data: Vec::new(),
         })
+    }
+}
+
+/// Initial contents of an arena's `.addr_space.1` section.
+#[derive(Debug, Clone)]
+pub struct ArenaData {
+    pub(crate) section_index: usize,
+    pub(crate) bytes: Vec<u8>,
+    pub(crate) map_offset: u32,
+}
+
+impl ArenaData {
+    /// Returns the ELF section index of `.addr_space.1`.
+    pub const fn section_index(&self) -> usize {
+        self.section_index
+    }
+
+    /// Returns the bytes used to initialize a newly created arena.
+    pub fn data(&self) -> &[u8] {
+        &self.bytes
+    }
+
+    /// Returns the runtime byte offset of the initial data within the arena map.
+    ///
+    /// This is not an ELF file offset or a userspace virtual address.
+    pub const fn map_offset(&self) -> u32 {
+        self.map_offset
+    }
+
+    /// Sets the runtime byte offset of the initial data within the arena map.
+    pub const fn set_map_offset(&mut self, offset: u32) {
+        self.map_offset = offset;
     }
 }
 
@@ -348,4 +397,5 @@ pub struct BtfMap {
     pub(crate) section_index: usize,
     pub(crate) symbol_index: usize,
     pub(crate) data: Vec<u8>,
+    pub(crate) arena_data: Option<ArenaData>,
 }

--- a/aya-obj/src/obj.rs
+++ b/aya-obj/src/obj.rs
@@ -24,9 +24,11 @@ use crate::{
     },
     generated::{
         BPF_CALL, BPF_F_RDONLY_PROG, BPF_JMP, BPF_K, bpf_func_id, bpf_insn, bpf_map_info,
-        bpf_map_type::BPF_MAP_TYPE_ARRAY,
+        bpf_map_type::{BPF_MAP_TYPE_ARENA, BPF_MAP_TYPE_ARRAY},
     },
-    maps::{BtfMap, BtfMapDef, LegacyMap, MINIMUM_MAP_SIZE, Map, PinningType, bpf_map_def},
+    maps::{
+        ArenaData, BtfMap, BtfMapDef, LegacyMap, MINIMUM_MAP_SIZE, Map, PinningType, bpf_map_def,
+    },
     programs::{
         CgroupSkbAttachType, CgroupSockAddrAttachType, CgroupSockAttachType,
         CgroupSockoptAttachType, SkReuseportAttachType, SkSkbKind, XdpAttachType,
@@ -36,6 +38,7 @@ use crate::{
 };
 
 const KERNEL_VERSION_ANY: u32 = 0xFFFF_FFFE;
+const ARENA_DATA_SECTION_NAME: &str = ".addr_space.1";
 
 /// Features implements BPF and BTF feature detection
 #[derive(Default, Debug)]
@@ -47,6 +50,7 @@ pub struct Features {
     bpf_cookie: bool,
     cpumap_prog_id: bool,
     devmap_prog_id: bool,
+    ldimm64_full_range_offset: bool,
     btf: Option<BtfFeatures>,
 }
 
@@ -65,6 +69,7 @@ impl Features {
         bpf_cookie: bool,
         cpumap_prog_id: bool,
         devmap_prog_id: bool,
+        ldimm64_full_range_offset: bool,
         btf: Option<BtfFeatures>,
     ) -> Self {
         Self {
@@ -75,6 +80,7 @@ impl Features {
             bpf_cookie,
             cpumap_prog_id,
             devmap_prog_id,
+            ldimm64_full_range_offset,
             btf,
         }
     }
@@ -117,6 +123,11 @@ impl Features {
         self.devmap_prog_id
     }
 
+    /// Returns whether direct map value offsets can use the full 32-bit range.
+    pub const fn ldimm64_full_range_offset(&self) -> bool {
+        self.ldimm64_full_range_offset
+    }
+
     /// If BTF is supported, returns which BTF features are supported.
     pub const fn btf(&self) -> Option<&BtfFeatures> {
         self.btf.as_ref()
@@ -147,6 +158,7 @@ pub struct Object {
     pub(crate) symbol_table: HashMap<usize, Symbol>,
     pub(crate) symbols_by_section: HashMap<SectionIndex, Vec<usize>>,
     pub(crate) section_infos: HashMap<String, (SectionIndex, u64)>,
+    pub(crate) pending_arena_data: Option<ArenaData>,
     // symbol_offset_by_name caches symbols that could be referenced from a
     // BTF VAR type so the offsets can be fixed up
     pub(crate) symbol_offset_by_name: HashMap<String, u64>,
@@ -566,6 +578,8 @@ impl Object {
             bpf_obj.parse_section(Section::try_from(&s)?)?;
         }
 
+        bpf_obj.resolve_arena_data()?;
+
         Ok(bpf_obj)
     }
 
@@ -583,8 +597,40 @@ impl Object {
             symbol_table: HashMap::new(),
             symbols_by_section: HashMap::new(),
             section_infos: HashMap::new(),
+            pending_arena_data: None,
             symbol_offset_by_name: HashMap::new(),
         }
+    }
+
+    fn resolve_arena_data(&mut self) -> Result<(), ParseError> {
+        let mut arena_maps = self
+            .maps
+            .iter_mut()
+            .filter(|(_, map)| map.map_type() == BPF_MAP_TYPE_ARENA as u32);
+        let arena_map = arena_maps.next();
+
+        if arena_maps.next().is_some() {
+            return Err(ParseError::MultipleArenaMaps);
+        }
+
+        let Some(arena_data) = self.pending_arena_data.take() else {
+            return Ok(());
+        };
+        let Some((name, map)) = arena_map else {
+            return Err(ParseError::ArenaMapNotFound);
+        };
+        let Map::Btf(map) = map else {
+            return Err(ParseError::ArenaMapNotBtfDefined);
+        };
+
+        debug!(
+            "resolved arena data section {} ({} bytes) to map {name}",
+            arena_data.section_index,
+            arena_data.bytes.len(),
+        );
+        map.arena_data = Some(arena_data);
+
+        Ok(())
     }
 
     /// Returns true if this object contains CO-RE relocations.
@@ -833,6 +879,7 @@ impl Object {
                                 section_index: section.index.0,
                                 symbol_index: *symbol_index,
                                 data: Vec::new(),
+                                arena_data: None,
                             }),
                         );
                     }
@@ -897,6 +944,35 @@ impl Object {
             EbpfSectionKind::Data | EbpfSectionKind::Rodata | EbpfSectionKind::Bss => {
                 self.maps
                     .insert(section.name.to_string(), parse_data_map_section(&section));
+            }
+            EbpfSectionKind::ArenaData => {
+                if section.size == 0 {
+                    return Ok(());
+                }
+                // libbpf does not require SHF_WRITE for an SHT_PROGBITS `.addr_space.1`, so
+                // accept both writable and read-only initialized data.
+                // https://github.com/libbpf/libbpf/blob/f7081a6baf3f54949aacb8c2fc11bb30783b83e9/src/libbpf.c#L4027-L4029
+                if !matches!(
+                    section.elf_kind,
+                    SectionKind::Data | SectionKind::ReadOnlyData
+                ) {
+                    return Err(ParseError::InvalidArenaDataSection);
+                }
+                if section.data.len() as u64 != section.size {
+                    return Err(ParseError::InvalidArenaDataSize {
+                        size: section.size,
+                        data_len: section.data.len(),
+                    });
+                }
+                if self.pending_arena_data.is_some() {
+                    return Err(ParseError::DuplicateArenaDataSection);
+                }
+
+                self.pending_arena_data = Some(ArenaData {
+                    section_index: section.index.0,
+                    bytes: section.data.to_vec(),
+                    map_offset: 0,
+                });
             }
             EbpfSectionKind::Text => self.parse_text_section(section)?,
             EbpfSectionKind::Btf => self.parse_btf(&section)?,
@@ -1057,6 +1133,26 @@ pub enum ParseError {
     #[error("no symbols found in the {section_name} section")]
     NoSymbolsForSection { section_name: String },
 
+    #[error("multiple `{ARENA_DATA_SECTION_NAME}` sections are not supported")]
+    DuplicateArenaDataSection,
+
+    #[error("section `{ARENA_DATA_SECTION_NAME}` must be an initialized ELF data section")]
+    InvalidArenaDataSection,
+
+    #[error(
+        "section `{ARENA_DATA_SECTION_NAME}` declares size {size}, but contains {data_len} bytes"
+    )]
+    InvalidArenaDataSize { size: u64, data_len: usize },
+
+    #[error("only one BPF_MAP_TYPE_ARENA map is supported per object")]
+    MultipleArenaMaps,
+
+    #[error("section `{ARENA_DATA_SECTION_NAME}` requires a BPF_MAP_TYPE_ARENA map")]
+    ArenaMapNotFound,
+
+    #[error("the arena associated with `{ARENA_DATA_SECTION_NAME}` must be defined in `.maps`")]
+    ArenaMapNotBtfDefined,
+
     /// No BTF parsed for object
     #[error("no BTF parsed for object")]
     NoBTF,
@@ -1085,6 +1181,8 @@ pub enum EbpfSectionKind {
     Rodata,
     /// `.bss`
     Bss,
+    /// `.addr_space.1`
+    ArenaData,
     /// `.text`
     Text,
     /// `.BTF`
@@ -1099,7 +1197,9 @@ pub enum EbpfSectionKind {
 
 impl EbpfSectionKind {
     fn from_name(name: &str) -> Self {
-        if name.starts_with("license") {
+        if name == ARENA_DATA_SECTION_NAME {
+            Self::ArenaData
+        } else if name.starts_with("license") {
             Self::License
         } else if name.starts_with("version") {
             Self::Version
@@ -1129,6 +1229,7 @@ impl EbpfSectionKind {
 struct Section<'a> {
     index: SectionIndex,
     kind: EbpfSectionKind,
+    elf_kind: SectionKind,
     address: u64,
     name: &'a str,
     data: &'a [u8],
@@ -1146,9 +1247,10 @@ impl<'a> TryFrom<&'a ObjSection<'_, '_>> for Section<'a> {
             error,
         };
         let name = section.name().map_err(map_err)?;
+        let elf_kind = section.kind();
         let kind = match EbpfSectionKind::from_name(name) {
             EbpfSectionKind::Undefined => {
-                if section.kind() == SectionKind::Text && section.size() > 0 {
+                if elf_kind == SectionKind::Text && section.size() > 0 {
                     EbpfSectionKind::Program
                 } else {
                     EbpfSectionKind::Undefined
@@ -1159,6 +1261,7 @@ impl<'a> TryFrom<&'a ObjSection<'_, '_>> for Section<'a> {
         Ok(Section {
             index,
             kind,
+            elf_kind,
             address: section.address(),
             name,
             data: section.data().map_err(map_err)?,
@@ -1237,6 +1340,37 @@ fn get_map_field(btf: &Btf, type_id: u32) -> Result<u32, BtfError> {
         }
     };
     Ok(arr.len)
+}
+
+fn get_map_extra(btf: &Btf, type_id: u32, map_name: &str) -> Result<u64, BtfError> {
+    let type_id = btf.resolve_type(type_id)?;
+
+    let invalid = || BtfError::InvalidMapExtra {
+        name: map_name.to_owned(),
+    };
+
+    match btf.type_by_id(type_id)? {
+        BtfType::Ptr(_) => get_map_field(btf, type_id).map(u64::from),
+        BtfType::Enum(en) => {
+            let [variant] = en.variants.as_slice() else {
+                return Err(invalid());
+            };
+
+            if en.is_signed() {
+                Ok(i64::from(variant.value as i32) as u64)
+            } else {
+                Ok(u64::from(variant.value))
+            }
+        }
+        BtfType::Enum64(en) => {
+            let [variant] = en.variants.as_slice() else {
+                return Err(invalid());
+            };
+
+            Ok((u64::from(variant.value_high) << 32) | u64::from(variant.value_low))
+        }
+        _ => Err(BtfError::UnexpectedBtfType { type_id }),
+    }
 }
 
 // Parse '.bss' '.data' and '.rodata' sections. These sections are arrays of
@@ -1387,7 +1521,7 @@ fn parse_btf_map_struct(
                 map_def.map_flags = get_map_field(btf, m.btf_type)?;
             }
             "map_extra" => {
-                map_def.map_extra = get_map_field(btf, m.btf_type)?.into();
+                map_def.map_extra = get_map_extra(btf, m.btf_type, map_name)?;
             }
             "pinning" => {
                 if is_inner {
@@ -1475,6 +1609,7 @@ pub const fn parse_map_info(info: bpf_map_info, pinned: PinningType) -> Map {
             section_index: 0,
             symbol_index: 0,
             data: Vec::new(),
+            arena_data: None,
         })
     } else {
         Map::Legacy(LegacyMap {
@@ -1558,7 +1693,10 @@ mod tests {
     use rstest::rstest;
 
     use super::*;
-    use crate::generated::{bpf_map_type::BPF_MAP_TYPE_BLOOM_FILTER, btf_ext_header};
+    use crate::{
+        btf::{BtfEnum, BtfEnum64, BtfMember, Enum, Enum64, Ptr},
+        generated::{bpf_map_type::BPF_MAP_TYPE_BLOOM_FILTER, btf_ext_header},
+    };
 
     const FAKE_INS_LEN: u64 = 8;
 
@@ -1572,6 +1710,7 @@ mod tests {
         Section {
             index: SectionIndex(idx),
             kind,
+            elf_kind: SectionKind::Data,
             address: 0,
             name,
             data,
@@ -1616,6 +1755,127 @@ mod tests {
         unsafe { crate::util::bytes_of(val) }
     }
 
+    fn fake_btf_arena_map(section_index: usize, symbol_index: usize) -> Map {
+        Map::Btf(BtfMap {
+            def: BtfMapDef {
+                map_type: BPF_MAP_TYPE_ARENA as u32,
+                ..Default::default()
+            },
+            inner_def: None,
+            section_index,
+            symbol_index,
+            data: Vec::new(),
+            arena_data: None,
+        })
+    }
+
+    #[test]
+    fn test_get_map_extra_from_ptr_to_array() {
+        let mut btf = Btf::new();
+        let array = btf.add_type(BtfType::Array(Array::new(0, 0, 0, u32::MAX)));
+        let ptr = btf.add_type(BtfType::Ptr(Ptr::new(0, array)));
+
+        assert_eq!(
+            get_map_extra(&btf, ptr, "arena").unwrap(),
+            u64::from(u32::MAX)
+        );
+    }
+
+    #[test]
+    fn test_get_map_extra_from_enum() {
+        let mut btf = Btf::new();
+        let en = btf.add_type(BtfType::Enum(Enum::new(
+            0,
+            true,
+            vec![BtfEnum::new(0, u32::MAX)],
+        )));
+
+        assert_eq!(get_map_extra(&btf, en, "arena").unwrap(), u64::MAX);
+    }
+
+    #[test]
+    fn test_get_map_extra_from_enum64() {
+        let mut btf = Btf::new();
+        let value = 1u64 << 44;
+        let en = btf.add_type(BtfType::Enum64(Enum64::new(
+            0,
+            false,
+            vec![BtfEnum64::new(0, value)],
+        )));
+
+        assert_eq!(get_map_extra(&btf, en, "arena").unwrap(), value);
+    }
+
+    #[test]
+    fn test_get_map_extra_rejects_empty_enum() {
+        let mut btf = Btf::new();
+        let en = btf.add_type(BtfType::Enum(Enum::new(0, false, Vec::new())));
+
+        assert_matches!(
+            get_map_extra(&btf, en, "arena"),
+            Err(BtfError::InvalidMapExtra { name }) if name == "arena"
+        );
+    }
+
+    #[test]
+    fn test_get_map_extra_rejects_multiple_enum_variants() {
+        let mut btf = Btf::new();
+        let en = btf.add_type(BtfType::Enum(Enum::new(
+            0,
+            false,
+            vec![BtfEnum::new(0, 1), BtfEnum::new(0, 2)],
+        )));
+        let en64 = btf.add_type(BtfType::Enum64(Enum64::new(
+            0,
+            false,
+            vec![BtfEnum64::new(0, 1), BtfEnum64::new(0, 2)],
+        )));
+
+        for type_id in [en, en64] {
+            assert_matches!(
+                get_map_extra(&btf, type_id, "arena"),
+                Err(BtfError::InvalidMapExtra { name }) if name == "arena"
+            );
+        }
+    }
+
+    #[test]
+    fn test_get_map_extra_rejects_unexpected_type() {
+        let mut btf = Btf::new();
+        let type_id = btf.add_type(BtfType::Struct(Struct::new(0, Vec::new(), 0)));
+
+        assert_matches!(
+            get_map_extra(&btf, type_id, "arena"),
+            Err(BtfError::UnexpectedBtfType { type_id: id }) if id == type_id
+        );
+    }
+
+    #[test]
+    fn test_parse_btf_map_struct_map_extra_enum64() {
+        let mut btf = Btf::new();
+        let map_extra_name = btf.add_string("map_extra");
+        let value = 1u64 << 44;
+        let map_extra = btf.add_type(BtfType::Enum64(Enum64::new(
+            0,
+            false,
+            vec![BtfEnum64::new(0, value)],
+        )));
+        let map = Struct::new(
+            0,
+            vec![BtfMember {
+                name_offset: map_extra_name,
+                btf_type: map_extra,
+                offset: 0,
+            }],
+            8,
+        );
+
+        let (map_def, inner_def) = parse_btf_map_struct(&btf, &map, "arena", false).unwrap();
+
+        assert_eq!(map_def.map_extra, value);
+        assert!(inner_def.is_none());
+    }
+
     #[test]
     fn test_parse_map_info_keyless_btf_map() {
         let mut info = unsafe { mem::zeroed::<bpf_map_info>() };
@@ -1640,6 +1900,220 @@ mod tests {
     #[test]
     fn test_parse_generic_error() {
         assert_matches!(Object::parse(&b"foo"[..]), Err(ParseError::ElfError(_)))
+    }
+
+    #[test]
+    fn test_arena_data_section_kind() {
+        assert_eq!(
+            EbpfSectionKind::from_name(ARENA_DATA_SECTION_NAME),
+            EbpfSectionKind::ArenaData
+        );
+        assert_eq!(
+            EbpfSectionKind::from_name(".addr_space.2"),
+            EbpfSectionKind::Undefined
+        );
+    }
+
+    #[test]
+    fn test_parse_arena_data_section() {
+        let mut obj = fake_obj();
+        let data = [1, 2, 3, 4];
+
+        obj.parse_section(fake_section(
+            EbpfSectionKind::ArenaData,
+            ARENA_DATA_SECTION_NAME,
+            &data,
+            Some(7),
+        ))
+        .unwrap();
+
+        assert!(obj.maps.is_empty());
+        assert_matches!(
+            obj.pending_arena_data.as_ref(),
+            Some(ArenaData {
+                section_index: 7,
+                bytes,
+                map_offset: 0,
+            }) if bytes == &data
+        );
+    }
+
+    #[test]
+    fn test_parse_zero_initialized_arena_data_section() {
+        let mut obj = fake_obj();
+        let data = [0; 4];
+
+        obj.parse_section(fake_section(
+            EbpfSectionKind::ArenaData,
+            ARENA_DATA_SECTION_NAME,
+            &data,
+            Some(7),
+        ))
+        .unwrap();
+
+        assert_eq!(obj.pending_arena_data.unwrap().bytes, data);
+    }
+
+    #[test]
+    fn test_empty_arena_data_section_is_ignored() {
+        let mut obj = fake_obj();
+
+        obj.parse_section(fake_section(
+            EbpfSectionKind::ArenaData,
+            ARENA_DATA_SECTION_NAME,
+            &[],
+            Some(7),
+        ))
+        .unwrap();
+
+        assert!(obj.pending_arena_data.is_none());
+    }
+
+    #[test]
+    fn test_arena_data_section_must_be_initialized_data() {
+        let mut obj = fake_obj();
+
+        assert_matches!(
+            obj.parse_section(Section {
+                index: SectionIndex(7),
+                kind: EbpfSectionKind::ArenaData,
+                elf_kind: SectionKind::UninitializedData,
+                address: 0,
+                name: ARENA_DATA_SECTION_NAME,
+                data: &[],
+                size: 4,
+                relocations: Vec::new(),
+            }),
+            Err(ParseError::InvalidArenaDataSection)
+        );
+    }
+
+    #[test]
+    fn test_read_only_arena_data_section_is_accepted() {
+        let mut obj = fake_obj();
+        let mut section = fake_section(
+            EbpfSectionKind::ArenaData,
+            ARENA_DATA_SECTION_NAME,
+            &[1, 2, 3, 4],
+            Some(7),
+        );
+        section.elf_kind = SectionKind::ReadOnlyData;
+
+        obj.parse_section(section).unwrap();
+
+        assert_eq!(obj.pending_arena_data.unwrap().bytes, [1, 2, 3, 4]);
+    }
+
+    #[test]
+    fn test_arena_data_section_size_must_match_data() {
+        let mut obj = fake_obj();
+
+        assert_matches!(
+            obj.parse_section(Section {
+                index: SectionIndex(7),
+                kind: EbpfSectionKind::ArenaData,
+                elf_kind: SectionKind::Data,
+                address: 0,
+                name: ARENA_DATA_SECTION_NAME,
+                data: &[1, 2],
+                size: 4,
+                relocations: Vec::new(),
+            }),
+            Err(ParseError::InvalidArenaDataSize {
+                size: 4,
+                data_len: 2,
+            })
+        );
+    }
+
+    #[test]
+    fn test_parse_duplicate_arena_data_section() {
+        let mut obj = fake_obj();
+        let section = || {
+            fake_section(
+                EbpfSectionKind::ArenaData,
+                ARENA_DATA_SECTION_NAME,
+                &[0],
+                Some(7),
+            )
+        };
+
+        obj.parse_section(section()).unwrap();
+        assert_matches!(
+            obj.parse_section(section()),
+            Err(ParseError::DuplicateArenaDataSection)
+        );
+    }
+
+    #[test]
+    fn test_arena_data_requires_arena_map() {
+        let mut obj = fake_obj();
+        obj.parse_section(fake_section(
+            EbpfSectionKind::ArenaData,
+            ARENA_DATA_SECTION_NAME,
+            &[0],
+            Some(7),
+        ))
+        .unwrap();
+
+        assert_matches!(obj.resolve_arena_data(), Err(ParseError::ArenaMapNotFound));
+    }
+
+    #[test]
+    fn test_only_one_arena_map_is_supported() {
+        let mut obj = fake_obj();
+        obj.maps
+            .insert("arena_1".to_owned(), fake_btf_arena_map(1, 1));
+        obj.maps
+            .insert("arena_2".to_owned(), fake_btf_arena_map(1, 2));
+
+        assert_matches!(obj.resolve_arena_data(), Err(ParseError::MultipleArenaMaps));
+    }
+
+    #[test]
+    fn test_arena_data_requires_btf_defined_map() {
+        let mut obj = fake_obj();
+        obj.parse_section(fake_section(
+            EbpfSectionKind::ArenaData,
+            ARENA_DATA_SECTION_NAME,
+            &[0],
+            Some(7),
+        ))
+        .unwrap();
+        obj.maps.insert(
+            "arena".to_owned(),
+            Map::new_from_params(BPF_MAP_TYPE_ARENA as u32, 0, 0, 1, 0),
+        );
+
+        assert_matches!(
+            obj.resolve_arena_data(),
+            Err(ParseError::ArenaMapNotBtfDefined)
+        );
+    }
+
+    #[test]
+    fn test_resolve_arena_data() {
+        let mut obj = fake_obj();
+        obj.parse_section(fake_section(
+            EbpfSectionKind::ArenaData,
+            ARENA_DATA_SECTION_NAME,
+            &[1, 2, 3, 4],
+            Some(7),
+        ))
+        .unwrap();
+        obj.maps
+            .insert("arena".to_owned(), fake_btf_arena_map(1, 1));
+
+        obj.resolve_arena_data().unwrap();
+
+        let arena_data = obj.maps["arena"].arena_data().unwrap();
+        assert_eq!(arena_data.section_index(), 7);
+        assert_eq!(arena_data.data(), &[1, 2, 3, 4]);
+        assert_eq!(arena_data.map_offset(), 0);
+
+        let arena_data = obj.maps.get_mut("arena").unwrap().arena_data_mut().unwrap();
+        arena_data.set_map_offset(0xffff_f000);
+        assert_eq!(arena_data.map_offset(), 0xffff_f000);
     }
 
     #[test]

--- a/aya-obj/src/relocation.rs
+++ b/aya-obj/src/relocation.rs
@@ -12,7 +12,7 @@ use crate::{
         BPF_CALL, BPF_DW, BPF_IMM, BPF_JMP, BPF_K, BPF_LD, BPF_PSEUDO_BTF_ID, BPF_PSEUDO_CALL,
         BPF_PSEUDO_FUNC, BPF_PSEUDO_KFUNC_CALL, BPF_PSEUDO_MAP_FD, BPF_PSEUDO_MAP_VALUE, bpf_insn,
     },
-    maps::Map,
+    maps::{ArenaData, Map},
     obj::{Function, Object},
     util::{HashMap, HashSet},
 };
@@ -142,6 +142,9 @@ impl Object {
             maps_by_section.insert(map.section_index(), (name, fd, map));
             if let Some(index) = map.symbol_index() {
                 maps_by_symbol.insert(index, (name, fd, map));
+            }
+            if let Some(arena_data) = map.arena_data() {
+                maps_by_section.insert(arena_data.section_index(), (name, fd, map));
             }
         }
 
@@ -410,7 +413,7 @@ fn relocate_maps<'a, I: Iterator<Item = &'a Relocation>>(
             continue;
         }
 
-        let (_name, fd, map) = if let Some(m) = maps_by_symbol.get(&rel.symbol_index) {
+        let (target, arena_data_offset) = if let Some(m) = maps_by_symbol.get(&rel.symbol_index) {
             let map = &m.2;
             debug!(
                 "relocating map by symbol index {:?}, kind {:?} at insn {ins_index} in section {}",
@@ -419,7 +422,7 @@ fn relocate_maps<'a, I: Iterator<Item = &'a Relocation>>(
                 fun.section_index.0
             );
             debug_assert_eq!(map.symbol_index().unwrap(), rel.symbol_index);
-            m
+            (m, None)
         } else {
             let Some(m) = maps_by_section.get(&section_index) else {
                 debug!("failed relocating map by section index {section_index}");
@@ -430,29 +433,49 @@ fn relocate_maps<'a, I: Iterator<Item = &'a Relocation>>(
                 });
             };
             let map = &m.2;
+            let arena_data_offset = map
+                .arena_data()
+                .filter(|data| data.section_index() == section_index)
+                .map(ArenaData::map_offset);
             debug!(
                 "relocating map by section index {}, kind {:?} at insn {ins_index} in section {}",
-                map.section_index(),
+                section_index,
                 map.section_kind(),
                 fun.section_index.0,
             );
 
-            debug_assert_eq!(map.symbol_index(), None);
-            debug_assert!(matches!(
-                map.section_kind(),
-                EbpfSectionKind::Bss | EbpfSectionKind::Data | EbpfSectionKind::Rodata
-            ));
-            m
+            if arena_data_offset.is_none() {
+                debug_assert_eq!(map.symbol_index(), None);
+                debug_assert!(matches!(
+                    map.section_kind(),
+                    EbpfSectionKind::Bss | EbpfSectionKind::Data | EbpfSectionKind::Rodata
+                ));
+                debug_assert_eq!(map.section_index(), section_index);
+            }
+            (m, arena_data_offset)
         };
-        debug_assert_eq!(map.section_index(), section_index);
+        let (_name, fd, map) = *target;
 
-        if map.data().is_empty() {
+        if arena_data_offset.is_some() && instructions.get(ins_index + 1).is_none() {
+            return Err(RelocationError::InvalidRelocationOffset {
+                offset: rel.offset,
+                relocation_number: rel_n,
+            });
+        }
+
+        if arena_data_offset.is_none() && map.data().is_empty() {
             instructions[ins_index].set_src_reg(BPF_PSEUDO_MAP_FD as u8);
         } else {
+            let addend = instructions[ins_index].imm;
             instructions[ins_index].set_src_reg(BPF_PSEUDO_MAP_VALUE as u8);
-            instructions[ins_index + 1].imm = instructions[ins_index].imm + sym.address as i32;
+            instructions[ins_index + 1].imm = match arena_data_offset {
+                Some(map_offset) => (addend as u32)
+                    .wrapping_add(sym.address as u32)
+                    .wrapping_add(map_offset) as i32,
+                None => addend + sym.address as i32,
+            };
         }
-        instructions[ins_index].imm = *fd;
+        instructions[ins_index].imm = fd;
     }
 
     Ok(())
@@ -685,7 +708,8 @@ mod test {
     use super::*;
     use crate::{
         extern_types::ExternType,
-        maps::{BtfMap, LegacyMap},
+        generated::bpf_map_type::BPF_MAP_TYPE_ARENA,
+        maps::{BtfMap, BtfMapDef, LegacyMap},
     };
 
     fn fake_sym(index: usize, section_index: usize, address: u64, name: &str, size: u64) -> Symbol {
@@ -736,6 +760,25 @@ mod test {
             section_index: 0,
             symbol_index,
             data: Vec::new(),
+            arena_data: None,
+        })
+    }
+
+    fn fake_arena_map(symbol_index: usize, arena_section_index: usize) -> Map {
+        Map::Btf(BtfMap {
+            def: BtfMapDef {
+                map_type: BPF_MAP_TYPE_ARENA as u32,
+                ..Default::default()
+            },
+            inner_def: None,
+            section_index: 5,
+            symbol_index,
+            data: Vec::new(),
+            arena_data: Some(ArenaData {
+                section_index: arena_section_index,
+                bytes: vec![0; 128],
+                map_offset: 0,
+            }),
         })
     }
 
@@ -941,6 +984,124 @@ mod test {
 
         assert_eq!(fun.instructions[1].src_reg(), BPF_PSEUDO_MAP_FD as u8);
         assert_eq!(fun.instructions[1].imm, 2);
+    }
+
+    #[test]
+    fn test_arena_data_relocation() {
+        let mut instruction = ins(&[0x18, 0, 0, 0, 0, 0, 0, 0]);
+        instruction.set_dst_reg(1);
+        instruction.imm = 4;
+        let mut fun = fake_func("test", vec![instruction, ins(&[0; 8])]);
+        let symbol_table = HashMap::from([(2, fake_sym(2, 7, 64, "counter", 8))]);
+        let relocations = [Relocation {
+            offset: 0,
+            symbol_index: 2,
+            size: 64,
+        }];
+        let map = fake_arena_map(1, 7);
+        let maps_by_section = HashMap::from([(7, ("arena", 12, &map))]);
+
+        relocate_maps(
+            &mut fun,
+            relocations.iter(),
+            &maps_by_section,
+            &HashMap::new(),
+            &symbol_table,
+            &HashSet::new(),
+        )
+        .unwrap();
+
+        assert_eq!(fun.instructions[0].src_reg(), BPF_PSEUDO_MAP_VALUE as u8);
+        assert_eq!(fun.instructions[0].imm, 12);
+        assert_eq!(fun.instructions[1].imm, 68);
+    }
+
+    #[test]
+    fn test_arena_data_relocation_uses_full_range_map_offset() {
+        let mut instruction = ins(&[0x18, 0, 0, 0, 0, 0, 0, 0]);
+        instruction.set_dst_reg(1);
+        instruction.imm = 4;
+        let mut fun = fake_func("test", vec![instruction, ins(&[0; 8])]);
+        let symbol_table = HashMap::from([(2, fake_sym(2, 7, 0x2000, "counter", 8))]);
+        let relocations = [Relocation {
+            offset: 0,
+            symbol_index: 2,
+            size: 64,
+        }];
+        let mut map = fake_arena_map(1, 7);
+        map.arena_data_mut().unwrap().set_map_offset(0x7fff_f000);
+        let maps_by_section = HashMap::from([(7, ("arena", 12, &map))]);
+
+        relocate_maps(
+            &mut fun,
+            relocations.iter(),
+            &maps_by_section,
+            &HashMap::new(),
+            &symbol_table,
+            &HashSet::new(),
+        )
+        .unwrap();
+
+        assert_eq!(fun.instructions[0].src_reg(), BPF_PSEUDO_MAP_VALUE as u8);
+        assert_eq!(fun.instructions[0].imm, 12);
+        assert_eq!(fun.instructions[1].imm, 0x8000_1004u32 as i32);
+    }
+
+    #[test]
+    fn test_arena_map_symbol_relocation() {
+        let mut fun = fake_func(
+            "test",
+            vec![ins(&[0x18, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00])],
+        );
+        let symbol_table = HashMap::from([(1, fake_sym(1, 5, 0, "arena", 0))]);
+        let relocations = [Relocation {
+            offset: 0,
+            symbol_index: 1,
+            size: 64,
+        }];
+        let map = fake_arena_map(1, 7);
+        let maps_by_symbol = HashMap::from([(1, ("arena", 12, &map))]);
+
+        relocate_maps(
+            &mut fun,
+            relocations.iter(),
+            &HashMap::new(),
+            &maps_by_symbol,
+            &symbol_table,
+            &HashSet::new(),
+        )
+        .unwrap();
+
+        assert_eq!(fun.instructions[0].src_reg(), BPF_PSEUDO_MAP_FD as u8);
+        assert_eq!(fun.instructions[0].imm, 12);
+    }
+
+    #[test]
+    fn test_arena_data_relocation_requires_second_instruction() {
+        let mut fun = fake_func(
+            "test",
+            vec![ins(&[0x18, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00])],
+        );
+        let symbol_table = HashMap::from([(2, fake_sym(2, 7, 0, "counter", 8))]);
+        let relocations = [Relocation {
+            offset: 0,
+            symbol_index: 2,
+            size: 64,
+        }];
+        let map = fake_arena_map(1, 7);
+        let maps_by_section = HashMap::from([(7, ("arena", 12, &map))]);
+
+        assert_matches::assert_matches!(
+            relocate_maps(
+                &mut fun,
+                relocations.iter(),
+                &maps_by_section,
+                &HashMap::new(),
+                &symbol_table,
+                &HashSet::new(),
+            ),
+            Err(RelocationError::InvalidRelocationOffset { offset: 0, .. })
+        );
     }
 
     #[test]

--- a/aya/src/bpf.rs
+++ b/aya/src/bpf.rs
@@ -29,7 +29,8 @@ use crate::{
         bpf_load_btf, is_bpf_cookie_supported, is_bpf_global_data_supported,
         is_btf_datasec_supported, is_btf_datasec_zero_supported, is_btf_decl_tag_supported,
         is_btf_enum64_supported, is_btf_float_supported, is_btf_func_global_supported,
-        is_btf_func_supported, is_btf_supported, is_btf_type_tag_supported, is_perf_link_supported,
+        is_btf_func_supported, is_btf_supported, is_btf_type_tag_supported,
+        is_ldimm64_full_range_offset_supported, is_perf_link_supported,
         is_probe_read_kernel_supported, is_prog_id_supported, is_prog_name_supported,
         retry_with_verifier_logs,
     },
@@ -82,6 +83,7 @@ fn detect_features() -> Features {
         is_bpf_cookie_supported(),
         is_prog_id_supported(bpf_map_type::BPF_MAP_TYPE_CPUMAP),
         is_prog_id_supported(bpf_map_type::BPF_MAP_TYPE_DEVMAP),
+        is_ldimm64_full_range_offset_supported(),
         btf,
     );
     debug!("BPF Feature Detection: {f:#?}");
@@ -664,6 +666,13 @@ impl<'a> EbpfLoader<'a> {
             if let Some(value_size) = value_size_override(map_type) {
                 map_obj.set_value_size(value_size)
             }
+            if map_type == bpf_map_type::BPF_MAP_TYPE_ARENA {
+                set_arena_data_offset(
+                    &mut map_obj,
+                    page_size(),
+                    FEATURES.ldimm64_full_range_offset(),
+                )?;
+            }
 
             let btf_fd = btf_fd.as_deref().map(|fd| fd.as_fd());
 
@@ -929,6 +938,7 @@ fn parse_map(
     let (name, map) = data;
     let map_type = bpf_map_type::try_from(map.obj().map_type()).map_err(MapError::from)?;
     let map = match map_type {
+        bpf_map_type::BPF_MAP_TYPE_ARENA => Map::Arena(map),
         bpf_map_type::BPF_MAP_TYPE_ARRAY => Map::Array(map),
         bpf_map_type::BPF_MAP_TYPE_PERCPU_ARRAY => Map::PerCpuArray(map),
         bpf_map_type::BPF_MAP_TYPE_PROG_ARRAY => Map::ProgramArray(map),
@@ -1007,6 +1017,68 @@ fn value_size_override(map_type: bpf_map_type) -> Option<u32> {
     }
 }
 
+fn set_arena_data_offset(
+    map: &mut aya_obj::Map,
+    page_size: usize,
+    ldimm64_full_range_offset: bool,
+) -> Result<(), MapError> {
+    let max_entries = map.max_entries();
+    let map_extra = map.map_extra();
+    let Some(data) = map.arena_data_mut() else {
+        return Ok(());
+    };
+
+    let map_offset = arena_data_offset(
+        max_entries,
+        map_extra,
+        data.data().len(),
+        page_size,
+        ldimm64_full_range_offset,
+    )?;
+    data.set_map_offset(map_offset);
+    Ok(())
+}
+
+fn arena_data_offset(
+    max_entries: u32,
+    map_extra: u64,
+    data_size: usize,
+    page_size: usize,
+    ldimm64_full_range_offset: bool,
+) -> Result<u32, MapError> {
+    let arena_size = usize::try_from(max_entries)
+        .ok()
+        .and_then(|pages| pages.checked_mul(page_size))
+        .ok_or(MapError::InvalidArenaMmap {
+            address: map_extra,
+            max_entries,
+            reason: "mapping size overflows usize",
+        })?;
+    if data_size > arena_size {
+        return Err(MapError::ArenaOutOfBounds {
+            offset: 0,
+            size: data_size,
+            arena_size,
+        });
+    }
+
+    // Older kernels restrict direct map-value offsets to less than 1 << 29.
+    // Kernels supporting full-range offsets accept the arena's full 32-bit address range, allowing
+    // globals to be placed at the end of the arena. This mirrors libbpf:
+    // https://github.com/libbpf/libbpf/blob/f7081a6baf3f54949aacb8c2fc11bb30783b83e9/src/libbpf.c#L7444-L7450
+    let map_offset = if ldimm64_full_range_offset {
+        let data_size = data_size.div_ceil(page_size) * page_size;
+        u32::try_from(arena_size - data_size).map_err(|_error| MapError::InvalidArenaMmap {
+            address: map_extra,
+            max_entries,
+            reason: "arena data offset exceeds the 32-bit address range",
+        })?
+    } else {
+        0
+    };
+    Ok(map_offset)
+}
+
 // Adjusts the byte size of a RingBuf map to match a power-of-two multiple of the page size.
 //
 // This mirrors the logic used by libbpf.
@@ -1030,9 +1102,11 @@ const fn adjust_to_page_size(byte_size: u32, page_size: u32) -> u32 {
 
 #[cfg(test)]
 mod tests {
+    use assert_matches::assert_matches;
     use aya_obj::generated::bpf_map_type::*;
 
     use super::{Btf, BtfSource, EbpfLoader, TargetBtf};
+    use crate::maps::MapError;
 
     const PAGE_SIZE: u32 = 4096;
     const NUM_CPUS: u32 = 4;
@@ -1100,6 +1174,44 @@ mod tests {
             Ok(Btf::new())
         })
         .unwrap();
+    }
+
+    #[test]
+    fn test_arena_data_offset() {
+        use super::arena_data_offset;
+
+        assert_eq!(
+            arena_data_offset(4, 0, 1, PAGE_SIZE as usize, false).unwrap(),
+            0
+        );
+        assert_eq!(
+            arena_data_offset(4, 0, 1, PAGE_SIZE as usize, true).unwrap(),
+            3 * PAGE_SIZE
+        );
+        assert_eq!(
+            arena_data_offset(4, 0, PAGE_SIZE as usize + 1, PAGE_SIZE as usize, true).unwrap(),
+            2 * PAGE_SIZE
+        );
+    }
+
+    #[test]
+    fn test_arena_data_offset_rejects_data_larger_than_arena() {
+        use super::arena_data_offset;
+
+        assert_matches!(
+            arena_data_offset(
+                1,
+                0,
+                PAGE_SIZE as usize + 1,
+                PAGE_SIZE as usize,
+                true,
+            ),
+            Err(MapError::ArenaOutOfBounds {
+                offset: 0,
+                size,
+                arena_size,
+            }) if size == PAGE_SIZE as usize + 1 && arena_size == PAGE_SIZE as usize
+        );
     }
 }
 

--- a/aya/src/maps/arena.rs
+++ b/aya/src/maps/arena.rs
@@ -1,0 +1,288 @@
+//! A BPF arena map: memory shared between userspace and BPF programs.
+
+use std::borrow::Borrow;
+#[cfg(target_has_atomic = "32")]
+use std::sync::atomic::AtomicU32;
+#[cfg(target_has_atomic = "64")]
+use std::sync::atomic::AtomicU64;
+
+use crate::{
+    Pod,
+    maps::{MapData, MapError},
+};
+
+/// A BPF arena map (`BPF_MAP_TYPE_ARENA`): a region of memory shared between
+/// userspace and BPF programs.
+///
+/// The arena region is `mmap`ed automatically when the map is created. A
+/// reused arena is mapped when its definition specifies a fixed userspace
+/// address through `map_extra`; otherwise its userspace address cannot be
+/// recovered and conversion to this type returns
+/// [`MapError::ArenaNotMmapped`].
+/// With the default map flags, userspace allocates pages on first touch through
+/// this mapping. BPF programs allocate pages with the arena allocation kfunc;
+/// a BPF load from an unallocated page returns zero and a store is skipped.
+///
+/// Values read from or written to the arena are shared memory concurrently
+/// accessible by BPF programs — reads may observe concurrent updates, and no
+/// synchronization is performed. Pointers stored in the arena by userspace
+/// must be in user-space virtual address form (addresses between
+/// [`Self::user_base`] and `user_base + len`), which is what the BPF-side
+/// `ArenaPtr` expects.
+///
+/// # Minimum kernel version
+///
+/// The minimum kernel version required to use this feature is 6.9.
+///
+/// # Examples
+///
+/// ```no_run
+/// # let mut bpf = aya::Ebpf::load(&[])?;
+/// use aya::maps::Arena;
+///
+/// let arena = Arena::try_from(bpf.map_mut("ARENA").unwrap())?;
+/// // SAFETY: no BPF program or other thread accesses this location while the
+/// // value is written or read.
+/// unsafe {
+///     arena.write_at::<u64>(0, 42)?;
+///     let value = arena.read_at::<u64>(0)?;
+///     assert_eq!(value, 42);
+/// }
+/// # Ok::<(), aya::EbpfError>(())
+/// ```
+#[doc(alias = "BPF_MAP_TYPE_ARENA")]
+#[derive(Debug)]
+pub struct Arena<T> {
+    inner: T,
+}
+
+impl<T: Borrow<MapData>> Arena<T> {
+    pub(crate) fn new(map: T) -> Result<Self, MapError> {
+        map.borrow().arena_mmap().ok_or(MapError::ArenaNotMmapped)?;
+        Ok(Self { inner: map })
+    }
+
+    /// Returns the size of the arena in bytes.
+    pub fn len(&self) -> usize {
+        // Unwrap: checked in `new`.
+        self.inner.borrow().arena_mmap().unwrap().len()
+    }
+
+    /// Returns whether the arena is empty (it never is).
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// Returns the user-space virtual address of the start of the arena.
+    ///
+    /// Add an offset to this to build pointer values that BPF-side
+    /// `ArenaPtr`s and userspace can both dereference.
+    pub fn user_base(&self) -> u64 {
+        self.as_ptr() as u64
+    }
+
+    /// Returns a raw pointer to the start of the arena's userspace mapping.
+    ///
+    /// Creating or inspecting the pointer is safe. Dereferencing it requires
+    /// the caller to uphold the synchronization and validity requirements of
+    /// the operation being performed.
+    pub fn as_ptr(&self) -> *mut u8 {
+        // Unwrap: checked in `new`.
+        self.inner
+            .borrow()
+            .arena_mmap()
+            .unwrap()
+            .ptr()
+            .as_ptr()
+            .cast()
+    }
+
+    /// Reads a value at the given byte offset within the arena.
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure that the bytes are not concurrently written for
+    /// the duration of the read and that any synchronization required to make
+    /// prior writes visible has occurred. In particular, eBPF programs and
+    /// other processes can access the arena independently of Rust borrowing.
+    pub unsafe fn read_at<V: Pod>(&self, offset: usize) -> Result<V, MapError> {
+        let ptr = self.checked_ptr::<V>(offset)?;
+        Ok(unsafe { ptr.read_unaligned() })
+    }
+
+    /// Writes a value at the given byte offset within the arena.
+    ///
+    /// With the default map flags, writing allocates arena pages on first touch.
+    /// An arena created with `BPF_F_SEGV_ON_FAULT` instead faults when the page
+    /// has not already been allocated by BPF.
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure that no conflicting access occurs for the
+    /// duration of the write and must provide any synchronization needed to
+    /// publish the completed value to eBPF or other processes.
+    pub unsafe fn write_at<V: Pod>(&self, offset: usize, value: V) -> Result<(), MapError> {
+        let ptr = self.checked_ptr::<V>(offset)?;
+        unsafe {
+            ptr.write_unaligned(value);
+        }
+        Ok(())
+    }
+
+    /// Returns an atomic 32-bit integer at the given byte offset.
+    ///
+    /// # Safety
+    ///
+    /// For the returned reference's lifetime, every concurrent access to this
+    /// location must be atomic and use the same access width. The underlying
+    /// arena page must not be freed during an access.
+    #[cfg(target_has_atomic = "32")]
+    pub unsafe fn atomic_u32_at(&self, offset: usize) -> Result<&AtomicU32, MapError> {
+        let ptr = self.checked_ptr::<u32>(offset)?;
+        let alignment = align_of::<AtomicU32>();
+        if !ptr.addr().is_multiple_of(alignment) {
+            return Err(MapError::UnalignedArenaAccess { offset, alignment });
+        }
+
+        Ok(unsafe { AtomicU32::from_ptr(ptr) })
+    }
+
+    /// Returns an atomic 64-bit integer at the given byte offset.
+    ///
+    /// # Safety
+    ///
+    /// For the returned reference's lifetime, every concurrent access to this
+    /// location must be atomic and use the same access width. The underlying
+    /// arena page must not be freed during an access.
+    #[cfg(target_has_atomic = "64")]
+    pub unsafe fn atomic_u64_at(&self, offset: usize) -> Result<&AtomicU64, MapError> {
+        let ptr = self.checked_ptr::<u64>(offset)?;
+        let alignment = align_of::<AtomicU64>();
+        if !ptr.addr().is_multiple_of(alignment) {
+            return Err(MapError::UnalignedArenaAccess { offset, alignment });
+        }
+
+        Ok(unsafe { AtomicU64::from_ptr(ptr) })
+    }
+
+    fn checked_ptr<V>(&self, offset: usize) -> Result<*mut V, MapError> {
+        let size = size_of::<V>();
+        let arena_size = self.len();
+        let end = offset.checked_add(size).ok_or(MapError::ArenaOutOfBounds {
+            offset,
+            size,
+            arena_size,
+        })?;
+        if end > arena_size {
+            return Err(MapError::ArenaOutOfBounds {
+                offset,
+                size,
+                arena_size,
+            });
+        }
+
+        Ok(unsafe { self.as_ptr().add(offset).cast() })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::Ordering;
+
+    use assert_matches::assert_matches;
+    use aya_obj::generated::{BPF_F_MMAPABLE, bpf_cmd, bpf_map_type};
+
+    use super::*;
+    use crate::{
+        sys::{Syscall, TEST_MMAP_RET, override_syscall},
+        util::page_size,
+    };
+
+    fn test_arena(backing: &mut [u64]) -> Arena<MapData> {
+        assert_eq!(size_of_val(backing), page_size());
+        override_syscall(|call| match call {
+            Syscall::Ebpf {
+                cmd: bpf_cmd::BPF_MAP_CREATE,
+                ..
+            } => Ok(crate::MockableFd::mock_signed_fd().into()),
+            call => panic!("unexpected syscall {call:?}"),
+        });
+        TEST_MMAP_RET.with(|ret| *ret.borrow_mut() = backing.as_mut_ptr().cast());
+
+        let obj = aya_obj::Map::new_from_params(
+            bpf_map_type::BPF_MAP_TYPE_ARENA as u32,
+            0,
+            0,
+            1,
+            BPF_F_MMAPABLE,
+        );
+        Arena::new(MapData::create(obj, "arena", None).unwrap()).unwrap()
+    }
+
+    #[test]
+    fn read_write_unaligned_value() {
+        let mut backing = vec![0; page_size() / size_of::<u64>()];
+        let arena = test_arena(&mut backing);
+        let value = 0x0102_0304_0506_0708u64;
+
+        unsafe {
+            arena.write_at(1, value).unwrap();
+        }
+        assert_eq!(unsafe { arena.read_at::<u64>(1).unwrap() }, value);
+    }
+
+    #[test]
+    fn read_write_check_bounds_and_overflow() {
+        let mut backing = vec![0; page_size() / size_of::<u64>()];
+        let arena = test_arena(&mut backing);
+
+        assert_matches!(
+            unsafe { arena.read_at::<u64>(page_size() - size_of::<u64>() + 1) },
+            Err(MapError::ArenaOutOfBounds { .. })
+        );
+        assert_matches!(
+            unsafe { arena.write_at::<u64>(usize::MAX, 0) },
+            Err(MapError::ArenaOutOfBounds { .. })
+        );
+    }
+
+    #[test]
+    #[cfg(target_has_atomic = "32")]
+    fn atomic_u32_access() {
+        let mut backing = vec![0; page_size() / size_of::<u64>()];
+        let arena = test_arena(&mut backing);
+        let value = unsafe { arena.atomic_u32_at(0).unwrap() };
+
+        value.store(7, Ordering::Release);
+        assert_eq!(value.fetch_add(5, Ordering::Relaxed), 7);
+        assert_eq!(value.load(Ordering::Acquire), 12);
+    }
+
+    #[test]
+    #[cfg(target_has_atomic = "64")]
+    fn atomic_u64_access() {
+        let mut backing = vec![0; page_size() / size_of::<u64>()];
+        let arena = test_arena(&mut backing);
+        let value = unsafe { arena.atomic_u64_at(0).unwrap() };
+
+        value.store(7, Ordering::Release);
+        assert_eq!(value.fetch_add(5, Ordering::Relaxed), 7);
+        assert_eq!(value.load(Ordering::Acquire), 12);
+    }
+
+    #[test]
+    #[cfg(all(target_has_atomic = "32", target_has_atomic = "64"))]
+    fn atomic_access_checks_bounds_and_alignment() {
+        let mut backing = vec![0; page_size() / size_of::<u64>()];
+        let arena = test_arena(&mut backing);
+
+        assert_matches!(
+            unsafe { arena.atomic_u32_at(1) },
+            Err(MapError::UnalignedArenaAccess { offset: 1, .. })
+        );
+        assert_matches!(
+            unsafe { arena.atomic_u64_at(page_size() - size_of::<u64>() + 1) },
+            Err(MapError::ArenaOutOfBounds { .. })
+        );
+    }
+}

--- a/aya/src/maps/mod.rs
+++ b/aya/src/maps/mod.rs
@@ -68,9 +68,10 @@ use crate::{
         SyscallError, bpf_create_map, bpf_get_object, bpf_map_freeze, bpf_map_get_fd_by_id,
         bpf_map_get_next_key, bpf_map_update_elem_ptr, bpf_pin_object,
     },
-    util::nr_cpus,
+    util::{MMap, nr_cpus, page_size},
 };
 
+pub mod arena;
 pub mod array;
 pub mod bloom_filter;
 pub mod cgroup_storage;
@@ -89,6 +90,7 @@ pub mod stack;
 pub mod stack_trace;
 pub mod xdp;
 
+pub use arena::Arena;
 pub use array::{Array, CgroupArray, PerCpuArray, ProgramArray};
 pub use bloom_filter::BloomFilter;
 #[expect(
@@ -214,6 +216,26 @@ pub enum MapError {
         max_entries: u32,
     },
 
+    /// An arena access exceeds the userspace mapping.
+    #[error("arena access at offset {offset} with size {size} exceeds the arena size {arena_size}")]
+    ArenaOutOfBounds {
+        /// Byte offset within the arena.
+        offset: usize,
+        /// Size of the requested access.
+        size: usize,
+        /// Size of the arena mapping.
+        arena_size: usize,
+    },
+
+    /// An arena access is not correctly aligned.
+    #[error("arena access at offset {offset} requires {alignment}-byte alignment")]
+    UnalignedArenaAccess {
+        /// Byte offset within the arena.
+        offset: usize,
+        /// Required alignment.
+        alignment: usize,
+    },
+
     /// Key not found
     #[error("key not found")]
     KeyNotFound,
@@ -247,6 +269,51 @@ pub enum MapError {
     /// Program IDs are not supported
     #[error("program ids are not supported by the current kernel")]
     ProgIdNotSupported,
+
+    /// The arena map is missing its memory mapping
+    #[error("the arena map has no memory mapping")]
+    ArenaNotMmapped,
+
+    /// Invalid arena memory-mapping parameters.
+    #[error("invalid arena mapping at {address:#x} with {max_entries} pages: {reason}")]
+    InvalidArenaMmap {
+        /// Requested userspace address, or zero for a kernel-selected address.
+        address: u64,
+        /// Number of pages in the arena.
+        max_entries: u32,
+        /// Reason the parameters are invalid.
+        reason: &'static str,
+    },
+
+    /// Failed to map an arena into userspace.
+    #[error("failed to mmap arena at {address:#x} with length {length}")]
+    ArenaMmapError {
+        /// Requested userspace address, or zero for a kernel-selected address.
+        address: u64,
+        /// Mapping length in bytes.
+        length: usize,
+        /// Original [`io::Error`].
+        #[source]
+        io_error: io::Error,
+    },
+
+    /// The arena was not mapped at its requested userspace address.
+    #[error("arena mmap returned address {actual:#x}, expected {requested:#x}")]
+    UnexpectedArenaMmapAddress {
+        /// Requested userspace address.
+        requested: u64,
+        /// Address returned by `mmap`.
+        actual: u64,
+    },
+
+    /// A pinned arena is incompatible with its ELF map definition.
+    #[error("pinned arena map `{name}` is incompatible: {reason}")]
+    IncompatiblePinnedArena {
+        /// Arena map name.
+        name: String,
+        /// Incompatible field.
+        reason: &'static str,
+    },
 
     /// Unsupported Map type
     #[error(
@@ -304,6 +371,8 @@ impl AsFd for MapFd {
 /// eBPF map types.
 #[derive(Debug)]
 pub enum Map {
+    /// An [`Arena`] map.
+    Arena(MapData),
     /// An [`Array`] map.
     Array(MapData),
     /// An [`ArrayOfMaps`] map.
@@ -370,6 +439,7 @@ impl Map {
     /// Returns the low level map type.
     const fn map_type(&self) -> u32 {
         match self {
+            Self::Arena(map) => map.obj.map_type(),
             Self::Array(map) => map.obj.map_type(),
             Self::ArrayOfMaps(map) => map.obj.map_type(),
             Self::BloomFilter(map) => map.obj.map_type(),
@@ -409,6 +479,7 @@ impl Map {
     /// is deleted. All parent directories in the given `path` must already exist.
     pub fn pin<P: AsRef<Path>>(&self, path: P) -> Result<(), PinError> {
         match self {
+            Self::Arena(map) => map.pin(path),
             Self::Array(map) => map.pin(path),
             Self::ArrayOfMaps(map) => map.pin(path),
             Self::BloomFilter(map) => map.pin(path),
@@ -486,7 +557,7 @@ impl Map {
             bpf_map_type::BPF_MAP_TYPE_TASK_STORAGE => Self::Unsupported(map_data),
             bpf_map_type::BPF_MAP_TYPE_USER_RINGBUF => Self::Unsupported(map_data),
             bpf_map_type::BPF_MAP_TYPE_CGRP_STORAGE => Self::CgrpStorage(map_data),
-            bpf_map_type::BPF_MAP_TYPE_ARENA => Self::Unsupported(map_data),
+            bpf_map_type::BPF_MAP_TYPE_ARENA => Self::Arena(map_data),
             bpf_map_type::BPF_MAP_TYPE_PERCPU_CGROUP_STORAGE_DEPRECATED => {
                 Self::PerCpuCgroupStorage(map_data)
             }
@@ -613,6 +684,7 @@ macro_rules! impl_try_from_map {
 }
 
 impl_try_from_map!(() {
+    Arena,
     CgroupArray,
     CpuMap,
     DevMap,
@@ -807,6 +879,142 @@ pub(crate) const fn check_v_size<V>(map: &MapData) -> Result<(), MapError> {
 pub struct MapData {
     obj: aya_obj::Map,
     fd: MapFd,
+    /// For arena maps, the shared mapping of the arena region.
+    ///
+    /// Created eagerly (at map creation / open time) because the kernel fixes
+    /// the arena's user-space base address on first `mmap`, and the verifier
+    /// needs that address when it processes programs using the arena.
+    mmap: Option<MMap>,
+}
+
+#[derive(Clone, Copy)]
+enum ArenaMapOrigin {
+    Created,
+    Reused,
+}
+
+/// Maps an arena into userspace before programs using it are loaded.
+///
+/// A reused arena created without `map_extra` has no discoverable userspace
+/// address, so its fd remains usable by eBPF while userspace access is
+/// unavailable.
+fn mmap_arena(
+    fd: &MapFd,
+    max_entries: u32,
+    map_extra: u64,
+    origin: ArenaMapOrigin,
+) -> Result<Option<MMap>, MapError> {
+    if matches!(origin, ArenaMapOrigin::Reused) && map_extra == 0 {
+        return Ok(None);
+    }
+
+    let invalid = |reason| MapError::InvalidArenaMmap {
+        address: map_extra,
+        max_entries,
+        reason,
+    };
+    let len = usize::try_from(max_entries)
+        .ok()
+        .and_then(|pages| pages.checked_mul(page_size()))
+        .ok_or_else(|| invalid("mapping size overflows usize"))?;
+
+    let address = if map_extra == 0 {
+        None
+    } else {
+        let address = usize::try_from(map_extra)
+            .map_err(|_error| invalid("address does not fit in usize"))?;
+        Some(
+            ptr::NonNull::new(ptr::without_provenance_mut::<libc::c_void>(address))
+                .ok_or_else(|| invalid("address is null"))?,
+        )
+    };
+
+    let flags = libc::MAP_SHARED
+        | if address.is_some() {
+            libc::MAP_FIXED_NOREPLACE
+        } else {
+            0
+        };
+    let mmap = MMap::new(
+        address,
+        fd.as_fd(),
+        len,
+        libc::PROT_READ | libc::PROT_WRITE,
+        flags,
+        0,
+    )
+    .map_err(
+        |SyscallError { call: _, io_error }| MapError::ArenaMmapError {
+            address: map_extra,
+            length: len,
+            io_error,
+        },
+    )?;
+
+    if let Some(address) = address {
+        if mmap.ptr() != address {
+            let actual = mmap.ptr().addr().get() as u64;
+            return Err(MapError::UnexpectedArenaMmapAddress {
+                requested: map_extra,
+                actual,
+            });
+        }
+    }
+
+    Ok(Some(mmap))
+}
+
+fn initialize_arena_data(mmap: &mut MMap, map_offset: u32, data: &[u8]) -> Result<(), MapError> {
+    let offset = map_offset as usize;
+    let size = data.len();
+    let arena_size = mmap.len();
+    let end = offset.checked_add(size).ok_or(MapError::ArenaOutOfBounds {
+        offset,
+        size,
+        arena_size,
+    })?;
+    let destination = mmap
+        .as_mut()
+        .get_mut(offset..end)
+        .ok_or(MapError::ArenaOutOfBounds {
+            offset,
+            size,
+            arena_size,
+        })?;
+    destination.copy_from_slice(data);
+    Ok(())
+}
+
+fn check_pinned_arena_compatibility(
+    obj: &aya_obj::Map,
+    info: &aya_obj::generated::bpf_map_info,
+    name: &str,
+) -> Result<(), MapError> {
+    let incompatible = |reason| MapError::IncompatiblePinnedArena {
+        name: name.to_owned(),
+        reason,
+    };
+
+    if info.type_ != obj.map_type() {
+        return Err(incompatible("map type differs"));
+    }
+    if info.key_size != obj.key_size() {
+        return Err(incompatible("key size differs"));
+    }
+    if info.value_size != obj.value_size() {
+        return Err(incompatible("value size differs"));
+    }
+    if info.max_entries != obj.max_entries() {
+        return Err(incompatible("max entries differs"));
+    }
+    if info.map_flags != obj.map_flags() {
+        return Err(incompatible("map flags differ"));
+    }
+    if info.map_extra != obj.map_extra() {
+        return Err(incompatible("map_extra differs"));
+    }
+
+    Ok(())
 }
 
 impl MapData {
@@ -853,10 +1061,22 @@ impl MapData {
                 io_error,
             }
         })?;
-        Ok(Self {
-            obj,
-            fd: MapFd::from_fd(fd),
-        })
+        let fd = MapFd::from_fd(fd);
+        let mut mmap = if obj.map_type() == bpf_map_type::BPF_MAP_TYPE_ARENA as u32 {
+            mmap_arena(
+                &fd,
+                obj.max_entries(),
+                obj.map_extra(),
+                ArenaMapOrigin::Created,
+            )?
+        } else {
+            None
+        };
+        // Reused arenas contain persistent runtime state, so only initialize a newly created map.
+        if let (Some(mmap), Some(data)) = (mmap.as_mut(), obj.arena_data()) {
+            initialize_arena_data(mmap, data.map_offset(), data.data())?;
+        }
+        Ok(Self { obj, fd, mmap })
     }
 
     pub(crate) fn create_pinned_by_name<P: AsRef<Path>>(
@@ -882,30 +1102,50 @@ impl MapData {
                 });
             }
         };
-        if let Ok(fd) = bpf_get_object(&path_string) {
-            Ok(Self {
-                obj,
-                fd: MapFd::from_fd(fd),
-            })
-        } else {
-            let inner_map;
-            let inner_map_fd = if let Some(inner) = inner_map_obj {
-                inner_map = Self::create(inner, &format!("{name}.inner"), btf_fd)?;
-                Some(inner_map.fd().as_fd())
-            } else {
-                None
-            };
-            let map = Self::create_with_inner_map_fd(obj, name, btf_fd, inner_map_fd)?;
-            map.pin(path).map_err(|error| MapError::PinError {
+        match bpf_get_object(&path_string) {
+            Ok(fd) => {
+                let fd = MapFd::from_fd(fd);
+                let mmap = if obj.map_type() == bpf_map_type::BPF_MAP_TYPE_ARENA as u32 {
+                    let MapInfo(info) = MapInfo::new_from_fd(fd.as_fd())?;
+                    check_pinned_arena_compatibility(&obj, &info, name)?;
+                    mmap_arena(
+                        &fd,
+                        info.max_entries,
+                        info.map_extra,
+                        ArenaMapOrigin::Reused,
+                    )?
+                } else {
+                    None
+                };
+                Ok(Self { obj, fd, mmap })
+            }
+            Err(error) if error.kind() == io::ErrorKind::NotFound => {
+                let inner_map;
+                let inner_map_fd = if let Some(inner) = inner_map_obj {
+                    inner_map = Self::create(inner, &format!("{name}.inner"), btf_fd)?;
+                    Some(inner_map.fd().as_fd())
+                } else {
+                    None
+                };
+                let map = Self::create_with_inner_map_fd(obj, name, btf_fd, inner_map_fd)?;
+                map.pin(path).map_err(|error| MapError::PinError {
+                    name: Some(name.into()),
+                    error,
+                })?;
+                Ok(map)
+            }
+            Err(io_error) => Err(MapError::PinError {
                 name: Some(name.into()),
-                error,
-            })?;
-            Ok(map)
+                error: PinError::SyscallError(SyscallError {
+                    call: "BPF_OBJ_GET",
+                    io_error,
+                }),
+            }),
         }
     }
 
     pub(crate) fn finalize(&mut self) -> Result<(), MapError> {
-        let Self { obj, fd } = self;
+        let Self { obj, fd, mmap: _ } = self;
         if !obj.data().is_empty() {
             bpf_map_update_elem_ptr(fd.as_fd(), &0, obj.data_mut().as_mut_ptr(), 0)
                 .map_err(|io_error| SyscallError {
@@ -923,6 +1163,11 @@ impl MapData {
                 .map_err(MapError::from)?;
         }
         Ok(())
+    }
+
+    /// For arena maps, returns the shared mapping of the arena region.
+    pub(crate) const fn arena_mmap(&self) -> Option<&MMap> {
+        self.mmap.as_ref()
     }
 
     /// Loads a map from a pinned path in bpffs.
@@ -955,10 +1200,17 @@ impl MapData {
 
     fn from_fd_inner(fd: crate::MockableFd) -> Result<Self, MapError> {
         let MapInfo(info) = MapInfo::new_from_fd(fd.as_fd())?;
-        Ok(Self {
-            obj: parse_map_info(info, PinningType::None),
-            fd: MapFd::from_fd(fd),
-        })
+        let arena = (info.type_ == bpf_map_type::BPF_MAP_TYPE_ARENA as u32)
+            .then_some((info.max_entries, info.map_extra));
+        let obj = parse_map_info(info, PinningType::None);
+        let fd = MapFd::from_fd(fd);
+        let mmap = match arena {
+            Some((max_entries, map_extra)) => {
+                mmap_arena(&fd, max_entries, map_extra, ArenaMapOrigin::Reused)?
+            }
+            None => None,
+        };
+        Ok(Self { obj, fd, mmap })
     }
 
     /// Loads a map from a file descriptor.
@@ -998,7 +1250,11 @@ impl MapData {
     pub fn pin<P: AsRef<Path>>(&self, path: P) -> Result<(), PinError> {
         use std::os::unix::ffi::OsStrExt as _;
 
-        let Self { fd, obj: _ } = self;
+        let Self {
+            fd,
+            obj: _,
+            mmap: _,
+        } = self;
         let path = path.as_ref();
         let path_string = CString::new(path.as_os_str().as_bytes()).map_err(|error| {
             PinError::InvalidPinPath {
@@ -1015,12 +1271,20 @@ impl MapData {
 
     /// Returns the file descriptor of the map.
     pub const fn fd(&self) -> &MapFd {
-        let Self { obj: _, fd } = self;
+        let Self {
+            obj: _,
+            fd,
+            mmap: _,
+        } = self;
         fd
     }
 
     pub(crate) const fn obj(&self) -> &aya_obj::Map {
-        let Self { obj, fd: _ } = self;
+        let Self {
+            obj,
+            fd: _,
+            mmap: _,
+        } = self;
         obj
     }
 
@@ -1281,17 +1545,222 @@ mod test_utils {
 
 #[cfg(test)]
 mod tests {
-    use std::{ffi::c_char, os::fd::AsRawFd as _};
+    use std::{
+        ffi::c_char,
+        os::fd::{AsRawFd as _, FromRawFd as _},
+    };
 
     use assert_matches::assert_matches;
     use aya_obj::generated::{bpf_cmd, bpf_map_info};
     use libc::EFAULT;
 
     use super::*;
-    use crate::sys::{Syscall, override_syscall};
+    use crate::sys::{MmapCall, Syscall, TEST_MMAP_CALL, TEST_MMAP_RET, override_syscall};
 
     fn new_obj_map() -> aya_obj::Map {
         test_utils::new_obj_map::<u32>(bpf_map_type::BPF_MAP_TYPE_HASH)
+    }
+
+    fn arena_map_info(map_extra: u64) -> bpf_map_info {
+        bpf_map_info {
+            type_: bpf_map_type::BPF_MAP_TYPE_ARENA as u32,
+            max_entries: 2,
+            map_flags: aya_obj::generated::BPF_F_MMAPABLE,
+            map_extra,
+            // Make `parse_map_info` preserve `map_extra` in a BTF map.
+            btf_value_type_id: 1,
+            ..unsafe { std::mem::zeroed() }
+        }
+    }
+
+    fn new_arena_obj(map_extra: u64) -> aya_obj::Map {
+        parse_map_info(arena_map_info(map_extra), PinningType::None)
+    }
+
+    fn new_test_map_fd() -> MapFd {
+        let fd = unsafe { crate::MockableFd::from_raw_fd(crate::MockableFd::mock_signed_fd()) };
+        MapFd::from_fd(fd)
+    }
+
+    fn set_mmap_return(address: *mut libc::c_void) {
+        TEST_MMAP_RET.with(|ret| *ret.borrow_mut() = address);
+        TEST_MMAP_CALL.with(|call| *call.borrow_mut() = None);
+    }
+
+    fn take_mmap_call() -> Option<MmapCall> {
+        TEST_MMAP_CALL.with(|call| call.borrow_mut().take())
+    }
+
+    fn write_map_info(attr: &mut aya_obj::generated::bpf_attr, info: bpf_map_info) {
+        let info_address = unsafe { attr.info.info } as usize;
+        let info_ptr: *mut bpf_map_info = ptr::with_exposed_provenance_mut(info_address);
+        unsafe { info_ptr.write(info) }
+    }
+
+    #[test]
+    fn test_mmap_created_arena_at_kernel_selected_address() {
+        let fd = new_test_map_fd();
+        let returned = ptr::without_provenance_mut(page_size() * 8);
+        set_mmap_return(returned);
+
+        let mmap = mmap_arena(&fd, 2, 0, ArenaMapOrigin::Created)
+            .unwrap()
+            .unwrap();
+        assert_eq!(mmap.ptr().as_ptr(), returned);
+        assert_eq!(
+            take_mmap_call(),
+            Some(MmapCall {
+                address: ptr::null_mut(),
+                length: page_size() * 2,
+                protection: libc::PROT_READ | libc::PROT_WRITE,
+                flags: libc::MAP_SHARED,
+                fd: crate::MockableFd::mock_signed_fd(),
+                offset: 0,
+            })
+        );
+    }
+
+    #[test]
+    fn test_mmap_created_arena_at_fixed_address() {
+        let fd = new_test_map_fd();
+        let requested = page_size() * 8;
+        let requested_ptr = ptr::without_provenance_mut(requested);
+        set_mmap_return(requested_ptr);
+
+        mmap_arena(&fd, 2, requested as u64, ArenaMapOrigin::Created)
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            take_mmap_call(),
+            Some(MmapCall {
+                address: requested_ptr,
+                length: page_size() * 2,
+                protection: libc::PROT_READ | libc::PROT_WRITE,
+                flags: libc::MAP_SHARED | libc::MAP_FIXED_NOREPLACE,
+                fd: crate::MockableFd::mock_signed_fd(),
+                offset: 0,
+            })
+        );
+    }
+
+    #[test]
+    fn test_initialize_arena_data() {
+        let fd = new_test_map_fd();
+        let mut backing = vec![0u8; page_size() * 2];
+        set_mmap_return(backing.as_mut_ptr().cast());
+        let mut mmap = mmap_arena(&fd, 2, 0, ArenaMapOrigin::Created)
+            .unwrap()
+            .unwrap();
+        let offset = page_size() + 3;
+
+        initialize_arena_data(&mut mmap, offset as u32, &[1, 2, 3, 4]).unwrap();
+
+        assert_eq!(&backing[offset..offset + 4], &[1, 2, 3, 4]);
+    }
+
+    #[test]
+    fn test_initialize_arena_data_checks_bounds() {
+        let fd = new_test_map_fd();
+        let mut backing = vec![0u8; page_size()];
+        set_mmap_return(backing.as_mut_ptr().cast());
+        let mut mmap = mmap_arena(&fd, 1, 0, ArenaMapOrigin::Created)
+            .unwrap()
+            .unwrap();
+        let offset = page_size() - 1;
+
+        assert_matches!(
+            initialize_arena_data(&mut mmap, offset as u32, &[1, 2]),
+            Err(MapError::ArenaOutOfBounds {
+                offset: error_offset,
+                size: 2,
+                arena_size,
+            }) if error_offset == offset && arena_size == page_size()
+        );
+    }
+
+    #[test]
+    fn test_mmap_reused_arena() {
+        let fd = new_test_map_fd();
+        let requested = page_size() * 8;
+        set_mmap_return(ptr::without_provenance_mut(requested));
+
+        assert!(
+            mmap_arena(&fd, 2, requested as u64, ArenaMapOrigin::Reused,)
+                .unwrap()
+                .is_some()
+        );
+        assert!(take_mmap_call().is_some());
+
+        set_mmap_return(ptr::without_provenance_mut(requested));
+        assert!(
+            mmap_arena(&fd, 2, 0, ArenaMapOrigin::Reused)
+                .unwrap()
+                .is_none()
+        );
+        assert_eq!(take_mmap_call(), None);
+    }
+
+    #[test]
+    fn test_mmap_arena_rejects_unexpected_address() {
+        let fd = new_test_map_fd();
+        let requested = page_size() * 8;
+        let actual = requested + page_size();
+        set_mmap_return(ptr::without_provenance_mut(actual));
+
+        assert_matches!(
+            mmap_arena(
+                &fd,
+                2,
+                requested as u64,
+                ArenaMapOrigin::Created,
+            ),
+            Err(MapError::UnexpectedArenaMmapAddress {
+                requested: expected,
+                actual: returned,
+            }) if expected == requested as u64 && returned == actual as u64
+        );
+    }
+
+    #[test]
+    #[cfg(target_os = "linux")]
+    fn test_mmap_arena_preserves_mmap_error() {
+        let fd = new_test_map_fd();
+        let requested = page_size() * 8;
+        set_mmap_return(libc::MAP_FAILED);
+        unsafe {
+            *libc::__errno_location() = libc::EEXIST;
+        }
+
+        assert_matches!(
+            mmap_arena(
+                &fd,
+                2,
+                requested as u64,
+                ArenaMapOrigin::Created,
+            ),
+            Err(MapError::ArenaMmapError {
+                address,
+                length,
+                io_error,
+            }) if address == requested as u64
+                && length == page_size() * 2
+                && io_error.raw_os_error() == Some(libc::EEXIST)
+        );
+    }
+
+    #[test]
+    fn test_pinned_arena_compatibility() {
+        let info = arena_map_info((page_size() * 8) as u64);
+        let obj = parse_map_info(info, PinningType::ByName);
+        check_pinned_arena_compatibility(&obj, &info, "arena").unwrap();
+
+        let mut incompatible = info;
+        incompatible.map_extra += page_size() as u64;
+        assert_matches!(
+            check_pinned_arena_compatibility(&obj, &incompatible, "arena"),
+            Err(MapError::IncompatiblePinnedArena { name, reason: "map_extra differs" })
+                if name == "arena"
+        );
     }
 
     #[test]
@@ -1325,8 +1794,57 @@ mod tests {
             Ok(MapData {
                 obj: _,
                 fd,
+                mmap: _,
             }) => assert_eq!(fd.as_fd().as_raw_fd(), crate::MockableFd::mock_signed_fd())
         );
+    }
+
+    #[test]
+    fn test_from_arena_map_id_uses_map_info_for_mmap() {
+        override_syscall(|call| match call {
+            Syscall::Ebpf {
+                cmd: bpf_cmd::BPF_MAP_GET_FD_BY_ID,
+                ..
+            } => Ok(crate::MockableFd::mock_signed_fd().into()),
+            Syscall::Ebpf {
+                cmd: bpf_cmd::BPF_OBJ_GET_INFO_BY_FD,
+                attr,
+            } => {
+                write_map_info(attr, arena_map_info((page_size() * 8) as u64));
+                Ok(0)
+            }
+            call => panic!("unexpected syscall {call:?}"),
+        });
+        let requested = page_size() * 8;
+        set_mmap_return(ptr::without_provenance_mut(requested));
+
+        let map = MapData::from_id(1234).unwrap();
+        assert!(map.mmap.is_some());
+        assert_eq!(take_mmap_call().unwrap().address.addr(), requested);
+    }
+
+    #[test]
+    fn test_reused_arena_without_fixed_address_is_not_mmapped() {
+        override_syscall(|call| match call {
+            Syscall::Ebpf {
+                cmd: bpf_cmd::BPF_MAP_GET_FD_BY_ID,
+                ..
+            } => Ok(crate::MockableFd::mock_signed_fd().into()),
+            Syscall::Ebpf {
+                cmd: bpf_cmd::BPF_OBJ_GET_INFO_BY_FD,
+                attr,
+            } => {
+                write_map_info(attr, arena_map_info(0));
+                Ok(0)
+            }
+            call => panic!("unexpected syscall {call:?}"),
+        });
+        set_mmap_return(ptr::without_provenance_mut(page_size() * 8));
+
+        let map = MapData::from_id(1234).unwrap();
+        assert!(map.mmap.is_none());
+        assert_eq!(take_mmap_call(), None);
+        assert_matches!(Arena::new(map), Err(MapError::ArenaNotMmapped));
     }
 
     #[test]
@@ -1338,14 +1856,116 @@ mod tests {
             } => Ok(crate::MockableFd::mock_signed_fd().into()),
             _ => Err((-1, io::Error::from_raw_os_error(EFAULT))),
         });
+        set_mmap_return(ptr::null_mut());
 
         assert_matches!(
             MapData::create(new_obj_map(), "foo", None),
             Ok(MapData {
                 obj: _,
                 fd,
+                mmap: _,
             }) => assert_eq!(fd.as_fd().as_raw_fd(), crate::MockableFd::mock_signed_fd())
         );
+        assert_eq!(take_mmap_call(), None);
+    }
+
+    #[test]
+    fn test_create_arena_mmaps_before_returning() {
+        override_syscall(|call| match call {
+            Syscall::Ebpf {
+                cmd: bpf_cmd::BPF_MAP_CREATE,
+                ..
+            } => Ok(crate::MockableFd::mock_signed_fd().into()),
+            call => panic!("unexpected syscall {call:?}"),
+        });
+        let requested = page_size() * 8;
+        set_mmap_return(ptr::without_provenance_mut(requested));
+
+        let map = MapData::create(new_arena_obj(requested as u64), "arena", None).unwrap();
+        assert!(map.mmap.is_some());
+        assert_eq!(take_mmap_call().unwrap().address.addr(), requested);
+    }
+
+    #[test]
+    fn test_create_pinned_map_only_creates_on_not_found() {
+        override_syscall(|call| match call {
+            Syscall::Ebpf {
+                cmd: bpf_cmd::BPF_OBJ_GET,
+                ..
+            } => Err((-1, io::Error::from_raw_os_error(libc::EACCES))),
+            call => panic!("unexpected syscall {call:?}"),
+        });
+
+        assert_matches!(
+            MapData::create_pinned_by_name("/sys/fs/bpf/arena", new_arena_obj(0), "arena", None, None),
+            Err(MapError::PinError {
+                name: Some(name),
+                error: PinError::SyscallError(SyscallError { call: "BPF_OBJ_GET", io_error }),
+            }) if name == "arena" && io_error.raw_os_error() == Some(libc::EACCES)
+        );
+    }
+
+    #[test]
+    fn test_create_pinned_map_creates_on_not_found() {
+        override_syscall(|call| match call {
+            Syscall::Ebpf {
+                cmd: bpf_cmd::BPF_OBJ_GET,
+                ..
+            } => Err((-1, io::Error::from_raw_os_error(libc::ENOENT))),
+            Syscall::Ebpf {
+                cmd: bpf_cmd::BPF_MAP_CREATE,
+                ..
+            } => Ok(crate::MockableFd::mock_signed_fd().into()),
+            Syscall::Ebpf {
+                cmd: bpf_cmd::BPF_OBJ_PIN,
+                ..
+            } => Ok(0),
+            call => panic!("unexpected syscall {call:?}"),
+        });
+        let returned = ptr::without_provenance_mut(page_size() * 8);
+        set_mmap_return(returned);
+
+        let map = MapData::create_pinned_by_name(
+            "/sys/fs/bpf/arena",
+            new_arena_obj(0),
+            "arena",
+            None,
+            None,
+        )
+        .unwrap();
+        assert_eq!(map.mmap.unwrap().ptr().as_ptr(), returned);
+        assert!(take_mmap_call().is_some());
+    }
+
+    #[test]
+    fn test_reused_pinned_arena_uses_actual_map_info() {
+        override_syscall(|call| match call {
+            Syscall::Ebpf {
+                cmd: bpf_cmd::BPF_OBJ_GET,
+                ..
+            } => Ok(crate::MockableFd::mock_signed_fd().into()),
+            Syscall::Ebpf {
+                cmd: bpf_cmd::BPF_OBJ_GET_INFO_BY_FD,
+                attr,
+            } => {
+                write_map_info(attr, arena_map_info((page_size() * 8) as u64));
+                Ok(0)
+            }
+            call => panic!("unexpected syscall {call:?}"),
+        });
+        let requested = page_size() * 8;
+        set_mmap_return(ptr::without_provenance_mut(requested));
+
+        let map = MapData::create_pinned_by_name(
+            "/sys/fs/bpf/arena",
+            new_arena_obj(requested as u64),
+            "arena",
+            None,
+            None,
+        )
+        .unwrap();
+        assert!(map.mmap.is_some());
+        assert_eq!(take_mmap_call().unwrap().address.addr(), requested);
     }
 
     #[test]
@@ -1369,6 +1989,7 @@ mod tests {
             Ok(MapData {
                 obj,
                 fd,
+                mmap: _,
             }) => {
                 assert_eq!(fd.as_fd().as_raw_fd(), crate::MockableFd::mock_signed_fd());
                 assert_eq!(obj.max_entries(), nr_cpus as u32)
@@ -1384,6 +2005,7 @@ mod tests {
             Ok(MapData {
                 obj,
                 fd,
+                mmap: _,
             }) => {
                 assert_eq!(fd.as_fd().as_raw_fd(), crate::MockableFd::mock_signed_fd());
                 assert_eq!(obj.max_entries(), nr_cpus as u32)
@@ -1399,6 +2021,7 @@ mod tests {
             Ok(MapData {
                 obj,
                 fd,
+                mmap: _,
             }) => {
                 assert_eq!(fd.as_fd().as_raw_fd(), crate::MockableFd::mock_signed_fd());
                 assert_eq!(obj.max_entries(), 1)

--- a/aya/src/maps/perf/perf_buffer.rs
+++ b/aya/src/maps/perf/perf_buffer.rs
@@ -123,6 +123,7 @@ impl PerfBuffer {
         .map_err(|io_error| PerfBufferError::OpenError { io_error })?;
         let size = page_size * page_count;
         let mmap = MMap::new(
+            None,
             fd.as_fd(),
             size + page_size,
             PROT_READ | PROT_WRITE,

--- a/aya/src/maps/ring_buf.rs
+++ b/aya/src/maps/ring_buf.rs
@@ -203,6 +203,7 @@ struct ConsumerMetadata {
 impl ConsumerMetadata {
     fn new(fd: BorrowedFd<'_>, offset: usize, page_size: usize) -> Result<Self, MapError> {
         let mmap = MMap::new(
+            None,
             fd,
             page_size,
             PROT_READ | PROT_WRITE,
@@ -305,7 +306,14 @@ impl ProducerData {
         //
         // [0]: https://github.com/torvalds/linux/blob/3f01e9fe/kernel/bpf/ringbuf.c#L108-L124
         let len = page_size + 2 * usize::try_from(byte_size).unwrap();
-        let mmap = MMap::new(fd, len, PROT_READ, MAP_SHARED, offset.try_into().unwrap())?;
+        let mmap = MMap::new(
+            None,
+            fd,
+            len,
+            PROT_READ,
+            MAP_SHARED,
+            offset.try_into().unwrap(),
+        )?;
 
         // The producer position may be non-zero if the map is being loaded from a pin, or the map
         // has been used previously; load the initial value of the producer position from the mmap.

--- a/aya/src/sys/bpf.rs
+++ b/aya/src/sys/bpf.rs
@@ -92,7 +92,8 @@ pub(crate) fn bpf_create_map(
                 | bpf_map_type::BPF_MAP_TYPE_SOCKHASH
                 | bpf_map_type::BPF_MAP_TYPE_QUEUE
                 | bpf_map_type::BPF_MAP_TYPE_STACK
-                | bpf_map_type::BPF_MAP_TYPE_RINGBUF,
+                | bpf_map_type::BPF_MAP_TYPE_RINGBUF
+                | bpf_map_type::BPF_MAP_TYPE_ARENA,
             ) => {
                 u.btf_key_type_id = 0;
                 u.btf_value_type_id = 0;
@@ -809,7 +810,7 @@ fn bpf_obj_get_info_by_fd<T, F: FnOnce(&mut T)>(
     init(&mut info);
 
     attr.info.bpf_fd = fd.as_raw_fd() as u32;
-    attr.info.info = ptr::from_ref(&info) as u64;
+    attr.info.info = ptr::from_mut(&mut info).expose_provenance() as u64;
     attr.info.info_len = size_of_val(&info) as u32;
 
     match unit_sys_bpf(bpf_cmd::BPF_OBJ_GET_INFO_BY_FD, &mut attr) {
@@ -1208,6 +1209,76 @@ pub(crate) fn is_bpf_global_data_supported() -> bool {
 
         bpf_prog_load(&mut attr).is_ok()
     } else {
+        false
+    }
+}
+
+pub(crate) fn is_ldimm64_full_range_offset_supported() -> bool {
+    let map = MapData::create(
+        aya_obj::Map::Legacy(LegacyMap {
+            def: bpf_map_def {
+                map_type: bpf_map_type::BPF_MAP_TYPE_ARRAY as u32,
+                key_size: 4,
+                value_size: 1,
+                max_entries: 1,
+                ..Default::default()
+            },
+            inner_def: None,
+            section_index: 0,
+            section_kind: EbpfSectionKind::Maps,
+            symbol_index: None,
+            data: Vec::new(),
+        }),
+        "aya_ldimm64",
+        None,
+    );
+
+    let Ok(map) = map else {
+        return false;
+    };
+
+    let instructions = [
+        new_insn(
+            (BPF_LD | BPF_DW | BPF_IMM) as u8,
+            1,
+            BPF_PSEUDO_MAP_VALUE as u8,
+            0,
+            map.fd().as_fd().as_raw_fd(),
+        ),
+        new_insn(0, 0, 0, 0, 1 << 30),
+        new_insn((BPF_JMP | BPF_EXIT) as u8, 0, 0, 0, 0),
+    ];
+
+    let (result, verifier_log) = retry_with_verifier_logs(10, |log_buf| {
+        with_prog_insns(ProgramType::SocketFilter, &instructions, |attr| {
+            let u = unsafe { &mut attr.__bindgen_anon_3 };
+
+            if !log_buf.is_empty() {
+                u.log_level = VerifierLogLevel::DEBUG.bits();
+                u.log_buf = log_buf.as_mut_ptr() as u64;
+                u.log_size = log_buf.len() as u32;
+            }
+
+            bpf_prog_load(attr)
+        })
+    });
+
+    let Err(error) = result else {
+        warn!("ldimm64 full-range-offset probe unexpectedly succeeded");
+        return false;
+    };
+
+    let verifier_log = verifier_log.to_string();
+
+    if verifier_log.contains("direct value offset of") {
+        false
+    } else if verifier_log.contains("invalid access to map value pointer") {
+        true
+    } else {
+        warn!(
+            "ldimm64 full-range-offset probe failed unexpectedly: {error}; verifier output: \
+             {verifier_log}"
+        );
         false
     }
 }
@@ -1678,6 +1749,7 @@ bpf_map_type::BPF_MAP_TYPE_DEVMAP_HASH`"]
     #[case::queue(bpf_map_type::BPF_MAP_TYPE_QUEUE)]
     #[case::stack(bpf_map_type::BPF_MAP_TYPE_STACK)]
     #[case::ringbuf(bpf_map_type::BPF_MAP_TYPE_RINGBUF)]
+    #[case::arena(bpf_map_type::BPF_MAP_TYPE_ARENA)]
     fn test_btf_blocklist_strips_type_ids(#[case] map_type: bpf_map_type) {
         const BTF_FD: i32 = 42;
 

--- a/aya/src/sys/fake.rs
+++ b/aya/src/sys/fake.rs
@@ -1,5 +1,7 @@
 use std::{cell::RefCell, ffi::c_void, io, ptr};
 
+use libc::{c_int, off_t};
+
 use super::{SysResult, Syscall};
 
 type SyscallFn = unsafe fn(Syscall<'_>) -> SysResult;
@@ -8,6 +10,17 @@ type SyscallFn = unsafe fn(Syscall<'_>) -> SysResult;
 thread_local! {
     pub(crate) static TEST_SYSCALL: RefCell<SyscallFn> = RefCell::new(test_syscall);
     pub(crate) static TEST_MMAP_RET: RefCell<*mut c_void> = const { RefCell::new(ptr::null_mut()) };
+    pub(crate) static TEST_MMAP_CALL: RefCell<Option<MmapCall>> = const { RefCell::new(None) };
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) struct MmapCall {
+    pub(crate) address: *mut c_void,
+    pub(crate) length: usize,
+    pub(crate) protection: c_int,
+    pub(crate) flags: c_int,
+    pub(crate) fd: i32,
+    pub(crate) offset: off_t,
 }
 
 #[cfg(test)]

--- a/aya/src/sys/mod.rs
+++ b/aya/src/sys/mod.rs
@@ -8,6 +8,8 @@ mod perf_event;
 #[cfg(test)]
 mod fake;
 
+#[cfg(test)]
+use std::os::fd::AsRawFd as _;
 use std::{
     ffi::{c_int, c_void},
     io,
@@ -154,10 +156,6 @@ fn syscall(call: Syscall<'_>) -> SysResult {
     }
 }
 
-#[cfg_attr(
-    test,
-    expect(unused_variables, reason = "TODO: we should validate all arguments")
-)]
 pub(crate) unsafe fn mmap(
     addr: *mut c_void,
     len: usize,
@@ -168,6 +166,16 @@ pub(crate) unsafe fn mmap(
 ) -> *mut c_void {
     #[cfg(test)]
     {
+        TEST_MMAP_CALL.with(|call| {
+            *call.borrow_mut() = Some(MmapCall {
+                address: addr,
+                length: len,
+                protection: prot,
+                flags,
+                fd: fd.as_raw_fd(),
+                offset,
+            })
+        });
         TEST_MMAP_RET.with(|ret| *ret.borrow())
     }
 

--- a/aya/src/util.rs
+++ b/aya/src/util.rs
@@ -438,7 +438,7 @@ pub(crate) fn bytes_of_bpf_name(bpf_name: &[core::ffi::c_char; 16]) -> &[u8] {
 // MMap corresponds to a memory-mapped region.
 //
 // The data is unmapped in Drop.
-#[cfg_attr(test, derive(Debug))]
+#[derive(Debug)]
 pub(crate) struct MMap {
     ptr: ptr::NonNull<c_void>,
     len: usize,
@@ -451,13 +451,15 @@ unsafe impl Sync for MMap {}
 
 impl MMap {
     pub(crate) fn new(
+        address: Option<ptr::NonNull<c_void>>,
         fd: BorrowedFd<'_>,
         len: usize,
         prot: c_int,
         flags: c_int,
         offset: off_t,
     ) -> Result<Self, SyscallError> {
-        match unsafe { mmap(ptr::null_mut(), len, prot, flags, fd, offset) } {
+        let address = address.map_or(ptr::null_mut(), ptr::NonNull::as_ptr);
+        match unsafe { mmap(address, len, prot, flags, fd, offset) } {
             MAP_FAILED => Err(SyscallError {
                 call: "mmap",
                 io_error: io::Error::last_os_error(),
@@ -480,6 +482,7 @@ impl MMap {
     pub(crate) fn map_copy_read_only(path: &Path) -> Result<Self, io::Error> {
         let file = File::open(path)?;
         Self::new(
+            None,
             file.as_fd(),
             file.metadata()?.len().try_into().map_err(|e| {
                 io::Error::new(
@@ -497,12 +500,23 @@ impl MMap {
     pub(crate) const fn ptr(&self) -> ptr::NonNull<c_void> {
         self.ptr
     }
+
+    pub(crate) const fn len(&self) -> usize {
+        self.len
+    }
 }
 
 impl AsRef<[u8]> for MMap {
     fn as_ref(&self) -> &[u8] {
         let Self { ptr, len } = self;
         unsafe { slice::from_raw_parts(ptr.as_ptr().cast(), *len) }
+    }
+}
+
+impl AsMut<[u8]> for MMap {
+    fn as_mut(&mut self) -> &mut [u8] {
+        let Self { ptr, len } = self;
+        unsafe { slice::from_raw_parts_mut(ptr.as_ptr().cast(), *len) }
     }
 }
 

--- a/ebpf/aya-ebpf/src/arena.rs
+++ b/ebpf/aya-ebpf/src/arena.rs
@@ -1,0 +1,186 @@
+//! Types for working with BPF arena memory (`BPF_MAP_TYPE_ARENA`).
+//!
+//! A BPF arena is a sparse region of memory shared between a BPF program and
+//! userspace. Userspace accesses it through `mmap(2)` on the map fd; the BPF
+//! side accesses it through pointers that the verifier tracks as
+//! `PTR_TO_ARENA`. The verifier only accepts a dereference if the pointer's
+//! dataflow goes through a BPF `addr_space_cast` instruction (or an arena
+//! kfunc return); the JIT then sandboxes every access to the arena region
+//! and faults are handled gracefully (loads read 0, stores are skipped).
+//!
+//! [`ArenaPtr`] encapsulates that contract: it stores an arena address in
+//! user-space form (valid on both sides, since only the low 32 bits address
+//! the arena) and re-emits the cast on every dereference, mirroring what
+//! clang does for C's `__arena` address-space-qualified pointers.
+
+use core::marker::PhantomData;
+
+/// Emits a BPF `addr_space_cast` from address space 1 (arena/user view) to 0
+/// (kernel view). The verifier marks the result `PTR_TO_ARENA`, making
+/// dereferences through it legal, runtime-sandboxed arena accesses.
+///
+/// The cast must remain on the dataflow path between the address and the
+/// dereference; inline assembly guarantees that, since LLVM cannot prove the
+/// output equals the input and thus can never substitute the uncast value.
+#[inline(always)]
+pub(crate) fn cast_kern(addr: u64) -> u64 {
+    #[cfg(target_arch = "bpf")]
+    {
+        let out: u64;
+        unsafe {
+            core::arch::asm!(
+                "{dst} = addr_space_cast({src}, 0, 1)",
+                src = in(reg) addr,
+                dst = out(reg) out,
+                options(pure, nomem, nostack),
+            );
+        }
+        out
+    }
+    // We only need this for doc tests which are compiled for the host target
+    #[expect(clippy::unreachable, reason = "only used for doc tests")]
+    #[cfg(not(target_arch = "bpf"))]
+    {
+        unreachable!("addr_space_cast is only available on the bpf target: addr={addr}");
+    }
+}
+
+/// Emits a BPF `addr_space_cast` from address space 0 (kernel view) to 1
+/// (arena/user view). The JIT rewrites this to fold in the arena's user-space
+/// base address, producing a pointer that userspace can dereference through
+/// its mapping of the arena.
+#[expect(
+    dead_code,
+    reason = "needed once BPF-side page allocation (bpf_arena_alloc_pages) lands"
+)]
+#[inline(always)]
+pub(crate) fn cast_user(addr: u64) -> u64 {
+    #[cfg(target_arch = "bpf")]
+    {
+        let out: u64;
+        unsafe {
+            core::arch::asm!(
+                "{dst} = addr_space_cast({src}, 1, 0)",
+                src = in(reg) addr,
+                dst = out(reg) out,
+                options(pure, nomem, nostack),
+            );
+        }
+        out
+    }
+    // We only need this for doc tests which are compiled for the host target
+    #[expect(clippy::unreachable, reason = "only used for doc tests")]
+    #[cfg(not(target_arch = "bpf"))]
+    {
+        unreachable!("addr_space_cast is only available on the bpf target: addr={addr}");
+    }
+}
+
+/// A pointer into BPF arena memory.
+///
+/// The address is stored in user-space form so that pointer-carrying data
+/// structures in the arena are traversable from userspace as well; every
+/// dereference on the BPF side re-establishes verifier provenance via
+/// `cast_kern`. Because of that, `ArenaPtr` fields can be freely embedded
+/// in `#[repr(C)]` structs living in arena memory and loaded back — the Rust
+/// analog of C's `struct foo __arena *`.
+///
+/// # Example
+///
+/// ```ignore
+/// #[repr(C)]
+/// struct Node {
+///     value: u64,
+///     next: ArenaPtr<Node>,
+/// }
+/// ```
+#[repr(transparent)]
+pub struct ArenaPtr<T> {
+    addr: u64,
+    _ty: PhantomData<*mut T>,
+}
+
+// Manual impls: derives would bound on `T: Copy`/`T: Clone`, but the pointer
+// is copyable regardless of the pointee.
+impl<T> Copy for ArenaPtr<T> {}
+
+impl<T> Clone for ArenaPtr<T> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+impl<T> ArenaPtr<T> {
+    /// The null arena pointer.
+    pub const fn null() -> Self {
+        Self::from_user_va(0)
+    }
+
+    /// Creates an arena pointer from a user-space virtual address (or a raw
+    /// arena offset — only the low 32 bits address the arena).
+    pub const fn from_user_va(addr: u64) -> Self {
+        Self {
+            addr,
+            _ty: PhantomData,
+        }
+    }
+
+    /// Returns the user-space form of this pointer.
+    pub const fn as_user_va(self) -> u64 {
+        self.addr
+    }
+
+    /// Returns whether this pointer is null.
+    pub const fn is_null(self) -> bool {
+        self.addr == 0
+    }
+
+    /// Converts to a raw pointer with verifier arena provenance
+    /// (`PTR_TO_ARENA`) established via `addr_space_cast`.
+    ///
+    /// Accesses through the result are runtime-sandboxed by the kernel to the
+    /// arena region: out-of-bounds or unmapped accesses read 0 / are skipped
+    /// rather than faulting.
+    ///
+    /// Verifier provenance is attached to the pointer's dataflow, not its
+    /// numeric address. Converting the result to plain data and later
+    /// reconstructing a pointer from it may lose `PTR_TO_ARENA` provenance.
+    #[inline(always)]
+    pub fn as_ptr(self) -> *mut T {
+        cast_kern(self.addr) as *mut T
+    }
+
+    /// Reads the pointee.
+    ///
+    /// Signed narrow integer reads may produce sign-extending BPF loads, which
+    /// are not supported for arena memory by some kernels.
+    ///
+    /// # Safety
+    ///
+    /// The address must be properly aligned for `T` and valid for reading
+    /// `size_of::<T>()` bytes. Those bytes must represent a valid `T`, and the
+    /// read must not race with a conflicting non-atomic access from userspace
+    /// or another BPF program invocation.
+    #[inline(always)]
+    pub unsafe fn read(self) -> T
+    where
+        T: Copy,
+    {
+        unsafe { self.as_ptr().read() }
+    }
+
+    /// Writes the pointee. Writes to unmapped arena pages are skipped.
+    ///
+    /// # Safety
+    ///
+    /// The address must be properly aligned for `T` and valid for writing
+    /// `size_of::<T>()` bytes. The write must not race with a conflicting
+    /// non-atomic access from userspace or another BPF program invocation.
+    #[inline(always)]
+    pub unsafe fn write(self, value: T)
+    where
+        T: Copy,
+    {
+        unsafe { self.as_ptr().write(value) }
+    }
+}

--- a/ebpf/aya-ebpf/src/btf_maps/arena.rs
+++ b/ebpf/aya-ebpf/src/btf_maps/arena.rs
@@ -1,0 +1,109 @@
+use crate::{
+    arena::ArenaPtr,
+    bindings::{BPF_F_MMAPABLE, bpf_map_type::BPF_MAP_TYPE_ARENA},
+};
+
+/// A BPF arena map (`BPF_MAP_TYPE_ARENA`): a `PAGES`-page region of memory
+/// shared between the BPF program and userspace.
+///
+/// Userspace accesses the region by `mmap`ing the map fd (aya's loader does
+/// this automatically) and can allocate pages simply by touching them; the
+/// BPF side accesses it through [`ArenaPtr`]s anchored via
+/// [`Arena::ptr_from_user_va`].
+///
+/// A program may use at most one arena map.
+///
+/// # Map flags
+///
+/// The default value of `FLAGS` sets the required [`BPF_F_MMAPABLE`] bit.
+/// Callers that override `FLAGS` must keep `BPF_F_MMAPABLE` set or the map
+/// will fail to load with `EINVAL`.
+///
+/// # Minimum kernel version
+///
+/// The minimum kernel version required to use this feature is 6.9.
+///
+/// # Example
+///
+/// ```rust,ignore
+/// use aya_ebpf::{btf_maps::Arena, macros::btf_map};
+///
+/// #[btf_map]
+/// static ARENA: Arena<16> = Arena::new();
+/// ```
+// repr(C) is required to ensure fields maintain their declared order in BTF.
+// Unlike other map definitions, an arena has no `key`/`value` fields: the
+// kernel requires key_size == value_size == 0, which loaders infer from the
+// members' absence. `map_flags` must include BPF_F_MMAPABLE.
+#[repr(C)]
+pub struct Arena<const PAGES: usize, const FLAGS: usize = { BPF_F_MMAPABLE as usize }> {
+    r#type: *const [i32; BPF_MAP_TYPE_ARENA as usize],
+    max_entries: *const [i32; PAGES],
+    map_flags: *const [i32; FLAGS],
+}
+
+// SAFETY: The struct fields are placeholder raw pointers that the BTF loader
+// patches at load time; they are never dereferenced from Rust code, so the
+// wrapper has no aliasable state.
+unsafe impl<const PAGES: usize, const FLAGS: usize> Sync for Arena<PAGES, FLAGS> {}
+
+impl<const PAGES: usize, const FLAGS: usize> Default for Arena<PAGES, FLAGS> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<const PAGES: usize, const FLAGS: usize> Arena<PAGES, FLAGS> {
+    /// Returns a placeholder definition that the BPF loader patches at load time.
+    pub const fn new() -> Self {
+        Self {
+            r#type: ::core::ptr::null(),
+            max_entries: ::core::ptr::null(),
+            map_flags: ::core::ptr::null(),
+        }
+    }
+
+    #[inline(always)]
+    const fn as_ptr(&self) -> *mut ::core::ffi::c_void {
+        ::core::ptr::from_ref(self).cast_mut().cast()
+    }
+
+    /// Returns an [`ArenaPtr`] for a user-space virtual address within this
+    /// arena's mapping.
+    ///
+    /// The kernel places the arena's user mapping at an arbitrary (not
+    /// 4GiB-aligned) base address, so BPF programs cannot address the arena
+    /// by plain offsets: every pointer chain must be anchored at an address
+    /// obtained from userspace (e.g. the arena base or a root object
+    /// address, communicated through a regular map) or, on newer kernels,
+    /// from the arena page allocation kfuncs.
+    ///
+    /// Prefer this method over [`ArenaPtr::from_user_va`] for the anchor
+    /// pointer: it additionally references the arena map so that the
+    /// verifier finds the arena in the program's `used_maps` (required for
+    /// every `addr_space_cast` to be accepted). Pointers *derived* from an
+    /// anchored one (e.g. loaded from arena memory) can use
+    /// [`ArenaPtr::from_user_va`] directly.
+    #[cfg_attr(
+        not(target_arch = "bpf"),
+        expect(
+            clippy::missing_const_for_fn,
+            reason = "contains inline assembly on the bpf target"
+        )
+    )]
+    #[inline(always)]
+    pub fn ptr_from_user_va<T>(&self, user_va: u64) -> ArenaPtr<T> {
+        // The verifier resolves which arena backs an addr_space_cast by
+        // looking at the program's used maps, so the map must be referenced
+        // by at least one surviving instruction. Feeding the map's address
+        // into an empty asm block forces the LD_IMM64 (relocated to the map
+        // fd at load time) to survive optimization.
+        #[cfg(target_arch = "bpf")]
+        unsafe {
+            core::arch::asm!("/* {map} */", map = in(reg) self.as_ptr(), options(nostack));
+        }
+        #[cfg(not(target_arch = "bpf"))]
+        let _: *mut ::core::ffi::c_void = self.as_ptr();
+        ArenaPtr::from_user_va(user_va)
+    }
+}

--- a/ebpf/aya-ebpf/src/btf_maps/mod.rs
+++ b/ebpf/aya-ebpf/src/btf_maps/mod.rs
@@ -1,3 +1,4 @@
+pub mod arena;
 pub mod array;
 pub mod bloom_filter;
 pub mod cgroup_array;
@@ -24,6 +25,7 @@ pub mod stack;
 pub mod stack_trace;
 pub mod xsk_map;
 
+pub use arena::Arena;
 pub use array::Array;
 pub use bloom_filter::BloomFilter;
 pub use cgroup_array::CgroupArray;

--- a/ebpf/aya-ebpf/src/lib.rs
+++ b/ebpf/aya-ebpf/src/lib.rs
@@ -31,6 +31,7 @@
 #![warn(clippy::cast_lossless, clippy::cast_sign_loss)]
 #![no_std]
 
+pub mod arena;
 mod args;
 pub mod bindings;
 #[cfg(generic_const_exprs)]

--- a/test/integration-common/src/lib.rs
+++ b/test/integration-common/src/lib.rs
@@ -1,5 +1,36 @@
 #![no_std]
 
+pub mod arena {
+    /// Lives at offset 0 of the arena; the rendezvous point between the
+    /// userspace test and the BPF program.
+    #[repr(C)]
+    #[derive(Clone, Copy, Debug, Default)]
+    pub struct Root {
+        /// Incremented by the BPF program on every trigger.
+        pub counter: u64,
+        /// Sum of the list nodes' values, computed by the BPF program.
+        pub sum: u64,
+        /// User-space virtual address of the first list node (0 = empty).
+        pub head: u64,
+    }
+
+    /// A linked list node, allocated in the arena by the userspace test.
+    ///
+    /// `next` holds a user-space virtual address; the BPF side re-blesses it
+    /// with an `addr_space_cast` before dereferencing (via `ArenaPtr`).
+    #[repr(C)]
+    #[derive(Clone, Copy, Debug, Default)]
+    pub struct Node {
+        pub value: u64,
+        pub next: u64,
+    }
+
+    #[cfg(feature = "user")]
+    unsafe impl aya::Pod for Root {}
+    #[cfg(feature = "user")]
+    unsafe impl aya::Pod for Node {}
+}
+
 pub mod array {
     pub const GET_INDEX: u32 = 0;
     pub const GET_PTR_INDEX: u32 = 1;

--- a/test/integration-ebpf/Cargo.toml
+++ b/test/integration-ebpf/Cargo.toml
@@ -25,6 +25,10 @@ which = { workspace = true, features = ["real-sys"] }
 xtask = { path = "../../xtask" }
 
 [[bin]]
+name = "arena"
+path = "src/arena.rs"
+
+[[bin]]
 name = "array"
 path = "src/array.rs"
 

--- a/test/integration-ebpf/src/arena.rs
+++ b/test/integration-ebpf/src/arena.rs
@@ -1,0 +1,80 @@
+#![no_std]
+#![no_main]
+#![expect(unused_crate_dependencies, reason = "used in other bins")]
+#![expect(internal_features, reason = "atomic_xadd is unstable")]
+#![expect(unstable_features, reason = "atomic_xadd is unstable")]
+#![feature(core_intrinsics)]
+
+use aya_ebpf::{
+    arena::ArenaPtr,
+    btf_maps::Arena,
+    macros::{btf_map, map, uprobe},
+    maps::Array,
+    programs::ProbeContext,
+};
+use integration_common::arena::{Node, Root};
+
+#[cfg(not(test))]
+extern crate ebpf_panic;
+
+#[btf_map]
+static ARENA: Arena<4> = Arena::new();
+
+/// Bootstrap: userspace stores the root object's user-space address here.
+/// The arena's user mapping lives at an arbitrary base address, so pointer
+/// chains must be anchored at an address provided by userspace.
+#[map]
+static ROOT_PTR: Array<u64> = Array::with_max_entries(1, 0);
+
+const MAX_LIST_NODES: usize = 3;
+
+#[uprobe]
+fn arena_test(_ctx: ProbeContext) {
+    let Some(root_va) = ROOT_PTR.get(0) else {
+        return;
+    };
+    let root: ArenaPtr<Root> = ARENA.ptr_from_user_va(*root_va);
+    // SAFETY: userspace initializes aligned Root and Node values before the
+    // probe runs and does not access them again until the probe returns.
+    let mut r = unsafe { root.read() };
+    r.counter += 1;
+
+    // Walk the linked list built by userspace, summing and doubling each
+    // node's value. Every `next` is loaded from arena memory as a plain
+    // integer and re-blessed by ArenaPtr on the following dereference.
+    let mut sum = 0u64;
+    let mut node = ArenaPtr::<Node>::from_user_va(r.head);
+    for _ in 0..MAX_LIST_NODES {
+        if node.is_null() {
+            break;
+        }
+        // SAFETY: the list consists of initialized, aligned Node values and
+        // userspace does not access it while the probe is running.
+        let mut n = unsafe { node.read() };
+        sum += n.value;
+        n.value *= 2;
+        unsafe {
+            node.write(n);
+        }
+        node = ArenaPtr::from_user_va(n.next);
+    }
+    r.sum = sum;
+    unsafe {
+        root.write(r);
+    }
+}
+
+#[uprobe]
+fn arena_atomic(_ctx: ProbeContext) {
+    let Some(counter_va) = ROOT_PTR.get(0) else {
+        return;
+    };
+    let counter = ARENA.ptr_from_user_va::<u64>(*counter_va);
+
+    unsafe {
+        core::intrinsics::atomic_xadd::<u64, u64, { core::intrinsics::AtomicOrdering::Relaxed }>(
+            counter.as_ptr(),
+            1,
+        );
+    }
+}

--- a/test/integration-test/BUILD.bazel
+++ b/test/integration-test/BUILD.bazel
@@ -7,6 +7,7 @@ load("//bazel:vm.bzl", "aya_qemu_vm_test")
 # Keep this list synchronized with C_BPF in build.rs. The Boolean requests the
 # additional .BTF section used by the corresponding relocation test.
 C_BPF_OBJECTS = [
+    ("bpf/arena-loader.bpf.c", False),
     ("bpf/ext.bpf.c", False),
     ("bpf/iter.bpf.c", True),
     ("bpf/main.bpf.c", False),

--- a/test/integration-test/bpf/arena-loader.bpf.c
+++ b/test/integration-test/bpf/arena-loader.bpf.c
@@ -1,0 +1,160 @@
+// clang-format off
+// SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
+#include <vmlinux.h>
+#include <bpf/bpf_helpers.h>
+// clang-format on
+
+#ifndef __ksym
+#define __ksym __attribute__((section(".ksyms")))
+#endif
+
+extern void *bpf_arena_alloc_pages(void *map, void *addr, __u32 page_cnt,
+                                   int node_id, __u64 flags) __ksym;
+extern void bpf_arena_free_pages(void *map, void *ptr, __u32 page_cnt) __ksym;
+
+struct {
+  __uint(type, BPF_MAP_TYPE_ARENA);
+  __uint(max_entries, 2);
+  __uint(map_flags, BPF_F_MMAPABLE);
+#ifdef __TARGET_ARCH_arm64
+  __ulong(map_extra, 1ULL << 32);
+#else
+  __ulong(map_extra, 1ULL << 44);
+#endif
+} arena SEC(".maps");
+
+struct {
+  __uint(type, BPF_MAP_TYPE_ARRAY);
+  __uint(max_entries, 6);
+  __type(key, __u32);
+  __type(value, __u64);
+} arena_results SEC(".maps");
+
+enum arena_result {
+  COMMAND,
+  ADDRESS,
+  INITIAL_VALUE,
+  VALUE_BEFORE_FREE,
+  VALUE_AFTER_FREE,
+  VALUE_AFTER_WRITE,
+};
+
+enum arena_command {
+  ALLOCATE = 1,
+  FREE = 2,
+  PROBE_ACCESS = 3,
+};
+
+#define ARENA_TEST_VALUE 0x0123456789abcdefULL
+
+// LLVM versions without native BPF address-space lowering still need to
+// produce the canonical addr_space_cast instruction. This is the encoding
+// used by the kernel BPF selftests.
+// clang-format off
+#define bpf_addr_space_cast(var, dst_as, src_as)                              \
+  asm volatile(".byte 0xBF;"                                                 \
+               ".ifc %[reg], r0; .byte 0x00; .endif;"                       \
+               ".ifc %[reg], r1; .byte 0x11; .endif;"                       \
+               ".ifc %[reg], r2; .byte 0x22; .endif;"                       \
+               ".ifc %[reg], r3; .byte 0x33; .endif;"                       \
+               ".ifc %[reg], r4; .byte 0x44; .endif;"                       \
+               ".ifc %[reg], r5; .byte 0x55; .endif;"                       \
+               ".ifc %[reg], r6; .byte 0x66; .endif;"                       \
+               ".ifc %[reg], r7; .byte 0x77; .endif;"                       \
+               ".ifc %[reg], r8; .byte 0x88; .endif;"                       \
+               ".ifc %[reg], r9; .byte 0x99; .endif;"                       \
+               ".short %[off];"                                             \
+               ".long %[as]"                                                \
+               : [reg] "+r"(var)                                            \
+               : [off] "i"(BPF_ADDR_SPACE_CAST),                            \
+                 [as] "i"(((dst_as) << 16) | (src_as)))
+// clang-format on
+
+#define cast_kern(ptr)                                                         \
+  ({                                                                           \
+    typeof(ptr) __ptr = (ptr);                                                 \
+    bpf_addr_space_cast(__ptr, 0, 1);                                          \
+    __ptr;                                                                     \
+  })
+
+#define cast_user(ptr)                                                         \
+  ({                                                                           \
+    typeof(ptr) __ptr = (ptr);                                                 \
+    bpf_addr_space_cast(__ptr, 1, 0);                                          \
+    __ptr;                                                                     \
+  })
+
+struct arena_node {
+  __u64 value;
+  __u64 next;
+};
+
+volatile __u64 arena_counter SEC(".addr_space.1") = 5;
+volatile struct arena_node arena_head SEC(".addr_space.1") = {
+    .value = 10,
+    .next = 0,
+};
+
+SEC("xdp")
+int arena_globals(struct xdp_md *ctx) {
+  volatile struct arena_node *head = cast_kern(&arena_head);
+  volatile __u64 *counter = cast_kern(&arena_counter);
+
+  *counter += head->value;
+  head->value += 1;
+  return XDP_PASS;
+}
+
+static __always_inline __u64 *result(__u32 key) {
+  return bpf_map_lookup_elem(&arena_results, &key);
+}
+
+static __always_inline void set_result(__u32 key, __u64 value) {
+  bpf_map_update_elem(&arena_results, &key, &value, BPF_ANY);
+}
+
+SEC("uprobe.s")
+int arena_pages(struct pt_regs *ctx) {
+  __u64 *command = result(COMMAND);
+
+  if (!command)
+    return 0;
+
+  if (*command == ALLOCATE) {
+    volatile __u64 *page = bpf_arena_alloc_pages(&arena, NULL, 1, -1, 0);
+    if (!page) {
+      set_result(ADDRESS, 0);
+      return 0;
+    }
+
+    // Before 6.15 the kfunc return lacked KF_ARENA_RET and needed an explicit
+    // cast; recasting is also valid on newer kernels.
+    // https://github.com/torvalds/linux/blob/v6.14/kernel/bpf/arena.c#L580
+    page = cast_kern(page);
+    set_result(INITIAL_VALUE, *page);
+    *page = ARENA_TEST_VALUE;
+    set_result(ADDRESS, (__u64)cast_user(page));
+    return 0;
+  }
+
+  __u64 *address = result(ADDRESS);
+  if (!address || !*address)
+    return 0;
+
+  volatile __u64 *page = cast_kern((void *)*address);
+  if (*command == FREE) {
+    set_result(VALUE_BEFORE_FREE, *page);
+    bpf_arena_free_pages(&arena, (void *)page, 1);
+
+    page = cast_kern((void *)*address);
+    set_result(VALUE_AFTER_FREE, *page);
+  } else if (*command == PROBE_ACCESS) {
+    set_result(INITIAL_VALUE, *page);
+    *page = ARENA_TEST_VALUE;
+    set_result(VALUE_AFTER_WRITE, *page);
+  }
+
+  return 0;
+}
+
+char _license[] SEC("license") = "GPL";

--- a/test/integration-test/build.rs
+++ b/test/integration-test/build.rs
@@ -77,6 +77,7 @@ fn main() -> Result<()> {
     // Keep this list synchronized with C_BPF_OBJECTS in BUILD.bazel. The Boolean controls whether
     // to build the additional .BTF section used by the corresponding relocation test.
     const C_BPF: &[(&str, bool)] = &[
+        ("arena-loader.bpf.c", false),
         ("ext.bpf.c", false),
         ("iter.bpf.c", true),
         ("main.bpf.c", false),

--- a/test/integration-test/src/lib.rs
+++ b/test/integration-test/src/lib.rs
@@ -7,6 +7,7 @@ macro_rules! bpf_file {
 }
 
 bpf_file!(
+    ARENA_LOADER => "arena-loader.bpf.o",
     EXT => "ext.bpf.o",
     ITER_TASK => "iter.bpf.o",
     MAIN => "main.bpf.o",
@@ -44,6 +45,7 @@ bpf_file!(
     TEXT_64_64_RELOC => "text_64_64_reloc.o",
     VARIABLES_RELOC => "variables_reloc.bpf.o",
 
+    ARENA => "arena",
     ARRAY => "array",
     BLOOM_FILTER => "bloom_filter",
     BPF_PROBE_READ => "bpf_probe_read",

--- a/test/integration-test/src/tests.rs
+++ b/test/integration-test/src/tests.rs
@@ -22,6 +22,7 @@ where
     runtime.block_on(test())
 }
 
+mod arena;
 mod array;
 mod bloom_filter;
 mod bpf_probe_read;

--- a/test/integration-test/src/tests/arena.rs
+++ b/test/integration-test/src/tests/arena.rs
@@ -1,0 +1,373 @@
+//! Tests for BPF arena maps: memory shared between userspace and BPF.
+
+use std::{path::Path, sync::atomic::Ordering};
+
+use aya::{
+    Ebpf, EbpfLoader, TestRunOptions,
+    maps::{Arena, Array, MapData, MapType},
+    programs::{TestRun as _, UProbe, Xdp, uprobe::UProbeScope},
+    sys::is_map_supported,
+};
+use aya_obj::{
+    Object,
+    generated::{BPF_DW, BPF_IMM, BPF_LD, BPF_PSEUDO_MAP_VALUE},
+};
+use integration_common::arena::{Node, Root};
+use rand::RngExt as _;
+use scopeguard::defer;
+
+#[unsafe(no_mangle)]
+#[inline(never)]
+extern "C" fn arena_trigger_ebpf_program() {
+    std::hint::black_box(());
+}
+
+#[unsafe(no_mangle)]
+#[inline(never)]
+extern "C" fn arena_trigger_atomic_program() {
+    std::hint::black_box(());
+}
+
+#[unsafe(no_mangle)]
+#[inline(never)]
+extern "C" fn arena_trigger_pages_program() {
+    std::hint::black_box(());
+}
+
+#[test]
+fn arena_globals_relocations() {
+    const ARENA_FD: i32 = 12;
+
+    let mut object = Object::parse(crate::ARENA_LOADER).unwrap();
+    object
+        .maps
+        .get_mut("arena")
+        .unwrap()
+        .arena_data_mut()
+        .unwrap()
+        .set_map_offset(0x1000);
+    let maps = object.maps.clone();
+    let text_sections = object
+        .functions
+        .keys()
+        .map(|(section_index, _)| *section_index)
+        .collect();
+
+    object
+        .relocate_maps(
+            maps.iter()
+                .map(|(name, map)| (name.as_str(), ARENA_FD, map)),
+            &text_sections,
+        )
+        .unwrap();
+
+    let program = &object.programs["arena_globals"];
+    let function = &object.functions[&program.function_key()];
+    let mut offsets = function
+        .instructions
+        .windows(2)
+        .filter_map(|instructions| match instructions {
+            [first, second]
+                if first.code == (BPF_LD | BPF_DW | BPF_IMM) as u8
+                    && first.src_reg() == BPF_PSEUDO_MAP_VALUE as u8 =>
+            {
+                assert_eq!(first.imm, ARENA_FD);
+                Some(second.imm)
+            }
+            _ => None,
+        })
+        .collect::<Vec<_>>();
+    offsets.sort_unstable();
+
+    assert_eq!(offsets, [0x1000, 0x1008]);
+}
+
+fn load_arena_loader(pin_path: Option<&Path>) -> Ebpf {
+    let mut loader = EbpfLoader::new();
+    loader.map_max_entries("arena", 4);
+    if let Some(pin_path) = pin_path {
+        loader.map_pin_path("arena", pin_path);
+    }
+    loader.load(crate::ARENA_LOADER).unwrap()
+}
+
+fn page_size() -> usize {
+    let page_size = unsafe { libc::sysconf(libc::_SC_PAGESIZE) };
+    assert!(page_size > 0);
+    page_size as usize
+}
+
+fn arena_globals_data_offset(arena: &Arena<MapData>) -> usize {
+    if aya::features().ldimm64_full_range_offset() {
+        arena.len() - page_size()
+    } else {
+        0
+    }
+}
+
+fn arena_globals_values(arena: &Arena<MapData>) -> (u64, u64) {
+    let offset = arena_globals_data_offset(arena);
+    unsafe {
+        (
+            arena.read_at(offset).unwrap(),
+            arena.read_at(offset + size_of::<u64>()).unwrap(),
+        )
+    }
+}
+
+fn run_arena_globals(bpf: &mut Ebpf) {
+    let prog: &mut Xdp = bpf
+        .program_mut("arena_globals")
+        .unwrap()
+        .try_into()
+        .unwrap();
+    prog.load().unwrap();
+
+    let data_in = [0; 64];
+    let mut data_out = [0; 64];
+    let result = prog
+        .test_run(TestRunOptions {
+            data_in: Some(&data_in),
+            data_out: Some(&mut data_out),
+            ..TestRunOptions::default()
+        })
+        .unwrap();
+    assert_eq!(result.return_value, 2); // XDP_PASS
+}
+
+#[test_log::test]
+fn arena_globals_load_and_initialize() {
+    if !is_map_supported(MapType::Arena).unwrap() {
+        eprintln!("skipping test - arena map not supported");
+        return;
+    }
+
+    let mut bpf = load_arena_loader(None);
+    let arena = Arena::try_from(bpf.take_map("arena").unwrap()).unwrap();
+
+    assert_eq!(arena.len(), 4 * page_size());
+    assert_eq!(arena_globals_values(&arena), (5, 10));
+
+    run_arena_globals(&mut bpf);
+    assert_eq!(arena_globals_values(&arena), (15, 11));
+}
+
+#[test_log::test]
+fn arena_globals_reuse_preserves_contents() {
+    if !is_map_supported(MapType::Arena).unwrap() {
+        eprintln!("skipping test - arena map not supported");
+        return;
+    }
+
+    let pin_path = Path::new("/sys/fs/bpf").join(format!(
+        "aya_arena_globals_{:x}",
+        rand::rng().random::<u64>()
+    ));
+
+    let mut bpf = load_arena_loader(Some(&pin_path));
+    defer! { std::fs::remove_file(&pin_path).unwrap() }
+    let arena = Arena::try_from(bpf.take_map("arena").unwrap()).unwrap();
+    run_arena_globals(&mut bpf);
+    assert_eq!(arena_globals_values(&arena), (15, 11));
+    drop(arena);
+    drop(bpf);
+
+    let mut bpf = load_arena_loader(Some(&pin_path));
+    let arena = Arena::try_from(bpf.take_map("arena").unwrap()).unwrap();
+    assert_eq!(arena_globals_values(&arena), (15, 11));
+
+    run_arena_globals(&mut bpf);
+    assert_eq!(arena_globals_values(&arena), (26, 12));
+}
+
+#[test_log::test]
+fn arena_page_lifecycle_and_faults() {
+    if !is_map_supported(MapType::Arena).unwrap() {
+        eprintln!("skipping test - arena map not supported");
+        return;
+    }
+
+    const COMMAND: u32 = 0;
+    const ADDRESS: u32 = 1;
+    const INITIAL_VALUE: u32 = 2;
+    const VALUE_BEFORE_FREE: u32 = 3;
+    const VALUE_AFTER_FREE: u32 = 4;
+    const VALUE_AFTER_WRITE: u32 = 5;
+
+    const ALLOCATE: u64 = 1;
+    const FREE: u64 = 2;
+    const PROBE_ACCESS: u64 = 3;
+
+    const TEST_VALUE: u64 = 0x0123_4567_89ab_cdef;
+
+    let mut bpf = load_arena_loader(None);
+    let arena = Arena::try_from(bpf.take_map("arena").unwrap()).unwrap();
+    let mut results: Array<_, u64> =
+        Array::try_from(bpf.take_map("arena_results").unwrap()).unwrap();
+
+    let prog: &mut UProbe = bpf.program_mut("arena_pages").unwrap().try_into().unwrap();
+    prog.load().unwrap();
+    prog.attach(
+        ["arena_trigger_pages_program"],
+        "/proc/self/exe",
+        UProbeScope::AllProcesses,
+    )
+    .unwrap();
+
+    results.set(COMMAND, &ALLOCATE, 0).unwrap();
+    arena_trigger_pages_program();
+
+    let address = results.get(&ADDRESS, 0).unwrap();
+    let offset = usize::try_from(address.checked_sub(arena.user_base()).unwrap()).unwrap();
+    assert!(offset < arena.len());
+    assert!(offset.is_multiple_of(page_size()));
+    assert_eq!(results.get(&INITIAL_VALUE, 0).unwrap(), 0);
+    assert_eq!(unsafe { arena.read_at::<u64>(offset).unwrap() }, TEST_VALUE);
+
+    results.set(COMMAND, &FREE, 0).unwrap();
+    arena_trigger_pages_program();
+
+    assert_eq!(results.get(&VALUE_BEFORE_FREE, 0).unwrap(), TEST_VALUE);
+    assert_eq!(results.get(&VALUE_AFTER_FREE, 0).unwrap(), 0);
+
+    // BPF accesses to an unallocated arena page are fault-contained: loads
+    // return zero and stores are skipped.
+    results.set(COMMAND, &PROBE_ACCESS, 0).unwrap();
+    arena_trigger_pages_program();
+    assert_eq!(results.get(&INITIAL_VALUE, 0).unwrap(), 0);
+    assert_eq!(results.get(&VALUE_AFTER_WRITE, 0).unwrap(), 0);
+
+    // The same contract applies just beyond the arena's addressable range.
+    let address = arena.user_base() + arena.len() as u64;
+    results.set(ADDRESS, &address, 0).unwrap();
+    arena_trigger_pages_program();
+    assert_eq!(results.get(&INITIAL_VALUE, 0).unwrap(), 0);
+    assert_eq!(results.get(&VALUE_AFTER_WRITE, 0).unwrap(), 0);
+}
+
+/// Userspace builds a linked list in the arena; the BPF program walks it
+/// (re-blessing every pointer loaded from arena memory with
+/// `addr_space_cast`), sums and doubles the node values, and bumps a counter.
+///
+/// The arena's user mapping lives at an arbitrary base address, so the root
+/// object's address is communicated to the BPF program through a regular
+/// array map.
+#[test_log::test]
+fn arena_shared_list() {
+    if !is_map_supported(MapType::Arena).unwrap() {
+        eprintln!("skipping test - arena map not supported");
+        return;
+    }
+
+    let mut bpf = Ebpf::load(crate::ARENA).unwrap();
+    let map = bpf.take_map("ARENA").unwrap();
+    let arena = Arena::try_from(map).unwrap();
+
+    // Build a 3-node list on the second arena page, linked by user-space
+    // virtual addresses (what the BPF-side ArenaPtr expects).
+    let base = arena.user_base();
+    let (n1, n2, n3) = (0x1000, 0x1040, 0x1080);
+    unsafe {
+        arena.write_at(n3, Node { value: 3, next: 0 }).unwrap();
+        arena
+            .write_at(
+                n2,
+                Node {
+                    value: 2,
+                    next: base + n3 as u64,
+                },
+            )
+            .unwrap();
+        arena
+            .write_at(
+                n1,
+                Node {
+                    value: 1,
+                    next: base + n2 as u64,
+                },
+            )
+            .unwrap();
+        arena
+            .write_at(
+                0,
+                Root {
+                    counter: 0,
+                    sum: 0,
+                    head: base + n1 as u64,
+                },
+            )
+            .unwrap();
+    }
+
+    // Anchor: tell the BPF program where the root object lives.
+    let mut root_ptr: Array<_, u64> = Array::try_from(bpf.map_mut("ROOT_PTR").unwrap()).unwrap();
+    root_ptr.set(0, &base, 0).unwrap();
+
+    let prog: &mut UProbe = bpf.program_mut("arena_test").unwrap().try_into().unwrap();
+    prog.load().unwrap();
+    prog.attach(
+        ["arena_trigger_ebpf_program"],
+        "/proc/self/exe",
+        UProbeScope::AllProcesses,
+    )
+    .unwrap();
+
+    arena_trigger_ebpf_program();
+
+    let root: Root = unsafe { arena.read_at(0).unwrap() };
+    assert_eq!(root.counter, 1);
+    assert_eq!(root.sum, 1 + 2 + 3);
+    assert_eq!(unsafe { arena.read_at::<Node>(n1).unwrap() }.value, 2);
+    assert_eq!(unsafe { arena.read_at::<Node>(n2).unwrap() }.value, 4);
+    assert_eq!(unsafe { arena.read_at::<Node>(n3).unwrap() }.value, 6);
+
+    // Second trigger: the list values double again.
+    arena_trigger_ebpf_program();
+    let root: Root = unsafe { arena.read_at(0).unwrap() };
+    assert_eq!(root.counter, 2);
+    assert_eq!(root.sum, 2 + 4 + 6);
+}
+
+#[test_log::test]
+fn arena_atomic_counter() {
+    if !is_map_supported(MapType::Arena).unwrap() {
+        eprintln!("skipping test - arena map not supported");
+        return;
+    }
+
+    let mut bpf = Ebpf::load(crate::ARENA).unwrap();
+    let map = bpf.take_map("ARENA").unwrap();
+    let arena = Arena::try_from(map).unwrap();
+    let counter = unsafe { arena.atomic_u64_at(0).unwrap() };
+    counter.store(0, Ordering::Relaxed);
+
+    let mut root_ptr: Array<_, u64> = Array::try_from(bpf.map_mut("ROOT_PTR").unwrap()).unwrap();
+    let base = arena.user_base();
+    root_ptr.set(0, &base, 0).unwrap();
+
+    let prog: &mut UProbe = bpf.program_mut("arena_atomic").unwrap().try_into().unwrap();
+    prog.load().unwrap();
+    prog.attach(
+        ["arena_trigger_atomic_program"],
+        "/proc/self/exe",
+        UProbeScope::AllProcesses,
+    )
+    .unwrap();
+
+    const THREADS: u64 = 4;
+    const INCREMENTS: u64 = 100;
+    std::thread::scope(|scope| {
+        for _ in 0..THREADS {
+            scope.spawn(|| {
+                for _ in 0..INCREMENTS {
+                    arena_trigger_atomic_program();
+                }
+            });
+        }
+        for _ in 0..THREADS * INCREMENTS {
+            counter.fetch_add(1, Ordering::Relaxed);
+        }
+    });
+
+    assert_eq!(counter.load(Ordering::Relaxed), THREADS * INCREMENTS * 2);
+}

--- a/xtask/public-api/aya-ebpf.txt
+++ b/xtask/public-api/aya-ebpf.txt
@@ -1,10 +1,44 @@
 pub mod aya_ebpf
 pub use aya_ebpf::cty
 pub use aya_ebpf::macros
+pub mod aya_ebpf::arena
+#[repr(transparent)] pub struct aya_ebpf::arena::ArenaPtr<T>
+impl<T> aya_ebpf::arena::ArenaPtr<T>
+pub fn aya_ebpf::arena::ArenaPtr<T>::as_ptr(self) -> *mut T
+pub const fn aya_ebpf::arena::ArenaPtr<T>::as_user_va(self) -> u64
+pub const fn aya_ebpf::arena::ArenaPtr<T>::from_user_va(u64) -> Self
+pub const fn aya_ebpf::arena::ArenaPtr<T>::is_null(self) -> bool
+pub const fn aya_ebpf::arena::ArenaPtr<T>::null() -> Self
+pub unsafe fn aya_ebpf::arena::ArenaPtr<T>::read(self) -> T where T: core::marker::Copy
+pub unsafe fn aya_ebpf::arena::ArenaPtr<T>::write(self, T) where T: core::marker::Copy
+impl<T> core::clone::Clone for aya_ebpf::arena::ArenaPtr<T>
+pub fn aya_ebpf::arena::ArenaPtr<T>::clone(&self) -> Self
+impl<T> core::marker::Copy for aya_ebpf::arena::ArenaPtr<T>
+impl<T> core::marker::Freeze for aya_ebpf::arena::ArenaPtr<T>
+impl<T> !core::marker::Send for aya_ebpf::arena::ArenaPtr<T>
+impl<T> !core::marker::Sync for aya_ebpf::arena::ArenaPtr<T>
+impl<T> core::marker::Unpin for aya_ebpf::arena::ArenaPtr<T>
+impl<T> core::marker::UnsafeUnpin for aya_ebpf::arena::ArenaPtr<T>
+impl<T> core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::arena::ArenaPtr<T> where T: core::panic::unwind_safe::RefUnwindSafe
+impl<T> core::panic::unwind_safe::UnwindSafe for aya_ebpf::arena::ArenaPtr<T> where T: core::panic::unwind_safe::RefUnwindSafe
 pub mod aya_ebpf::bindings
 pub use aya_ebpf::bindings::<<aya_ebpf_bindings::bindings::*>>
 pub use aya_ebpf::bindings::pt_regs
 pub mod aya_ebpf::btf_maps
+pub mod aya_ebpf::btf_maps::arena
+#[repr(C)] pub struct aya_ebpf::btf_maps::arena::Arena<const PAGES: usize, const FLAGS: usize>
+impl<const PAGES: usize, const FLAGS: usize> aya_ebpf::btf_maps::arena::Arena<PAGES, FLAGS>
+pub const fn aya_ebpf::btf_maps::arena::Arena<PAGES, FLAGS>::new() -> Self
+pub fn aya_ebpf::btf_maps::arena::Arena<PAGES, FLAGS>::ptr_from_user_va<T>(&self, u64) -> aya_ebpf::arena::ArenaPtr<T>
+impl<const PAGES: usize, const FLAGS: usize> core::default::Default for aya_ebpf::btf_maps::arena::Arena<PAGES, FLAGS>
+pub fn aya_ebpf::btf_maps::arena::Arena<PAGES, FLAGS>::default() -> Self
+impl<const PAGES: usize, const FLAGS: usize> core::marker::Sync for aya_ebpf::btf_maps::arena::Arena<PAGES, FLAGS>
+impl<const PAGES: usize, const FLAGS: usize> core::marker::Freeze for aya_ebpf::btf_maps::arena::Arena<PAGES, FLAGS>
+impl<const PAGES: usize, const FLAGS: usize> !core::marker::Send for aya_ebpf::btf_maps::arena::Arena<PAGES, FLAGS>
+impl<const PAGES: usize, const FLAGS: usize> core::marker::Unpin for aya_ebpf::btf_maps::arena::Arena<PAGES, FLAGS>
+impl<const PAGES: usize, const FLAGS: usize> core::marker::UnsafeUnpin for aya_ebpf::btf_maps::arena::Arena<PAGES, FLAGS>
+impl<const PAGES: usize, const FLAGS: usize> core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::btf_maps::arena::Arena<PAGES, FLAGS>
+impl<const PAGES: usize, const FLAGS: usize> core::panic::unwind_safe::UnwindSafe for aya_ebpf::btf_maps::arena::Arena<PAGES, FLAGS>
 pub mod aya_ebpf::btf_maps::array
 #[repr(C)] pub struct aya_ebpf::btf_maps::array::Array<T, const MAX_ENTRIES: usize, const FLAGS: usize>
 impl<T, const MAX_ENTRIES: usize, const FLAGS: usize> aya_ebpf::btf_maps::array::Array<T, MAX_ENTRIES, FLAGS>
@@ -520,6 +554,19 @@ impl<const MAX_ENTRIES: usize, const FLAGS: usize> core::marker::Unpin for aya_e
 impl<const MAX_ENTRIES: usize, const FLAGS: usize> core::marker::UnsafeUnpin for aya_ebpf::btf_maps::xsk_map::XskMap<MAX_ENTRIES, FLAGS>
 impl<const MAX_ENTRIES: usize, const FLAGS: usize> core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::btf_maps::xsk_map::XskMap<MAX_ENTRIES, FLAGS>
 impl<const MAX_ENTRIES: usize, const FLAGS: usize> core::panic::unwind_safe::UnwindSafe for aya_ebpf::btf_maps::xsk_map::XskMap<MAX_ENTRIES, FLAGS>
+#[repr(C)] pub struct aya_ebpf::btf_maps::Arena<const PAGES: usize, const FLAGS: usize>
+impl<const PAGES: usize, const FLAGS: usize> aya_ebpf::btf_maps::arena::Arena<PAGES, FLAGS>
+pub const fn aya_ebpf::btf_maps::arena::Arena<PAGES, FLAGS>::new() -> Self
+pub fn aya_ebpf::btf_maps::arena::Arena<PAGES, FLAGS>::ptr_from_user_va<T>(&self, u64) -> aya_ebpf::arena::ArenaPtr<T>
+impl<const PAGES: usize, const FLAGS: usize> core::default::Default for aya_ebpf::btf_maps::arena::Arena<PAGES, FLAGS>
+pub fn aya_ebpf::btf_maps::arena::Arena<PAGES, FLAGS>::default() -> Self
+impl<const PAGES: usize, const FLAGS: usize> core::marker::Sync for aya_ebpf::btf_maps::arena::Arena<PAGES, FLAGS>
+impl<const PAGES: usize, const FLAGS: usize> core::marker::Freeze for aya_ebpf::btf_maps::arena::Arena<PAGES, FLAGS>
+impl<const PAGES: usize, const FLAGS: usize> !core::marker::Send for aya_ebpf::btf_maps::arena::Arena<PAGES, FLAGS>
+impl<const PAGES: usize, const FLAGS: usize> core::marker::Unpin for aya_ebpf::btf_maps::arena::Arena<PAGES, FLAGS>
+impl<const PAGES: usize, const FLAGS: usize> core::marker::UnsafeUnpin for aya_ebpf::btf_maps::arena::Arena<PAGES, FLAGS>
+impl<const PAGES: usize, const FLAGS: usize> core::panic::unwind_safe::RefUnwindSafe for aya_ebpf::btf_maps::arena::Arena<PAGES, FLAGS>
+impl<const PAGES: usize, const FLAGS: usize> core::panic::unwind_safe::UnwindSafe for aya_ebpf::btf_maps::arena::Arena<PAGES, FLAGS>
 #[repr(C)] pub struct aya_ebpf::btf_maps::Array<T, const MAX_ENTRIES: usize, const FLAGS: usize>
 impl<T, const MAX_ENTRIES: usize, const FLAGS: usize> aya_ebpf::btf_maps::array::Array<T, MAX_ENTRIES, FLAGS>
 pub fn aya_ebpf::btf_maps::array::Array<T, MAX_ENTRIES, FLAGS>::get(&self, u32) -> core::option::Option<&T>

--- a/xtask/public-api/aya-obj.txt
+++ b/xtask/public-api/aya-obj.txt
@@ -16,6 +16,8 @@ pub aya_obj::btf::BtfError::InvalidLineInfo
 pub aya_obj::btf::BtfError::InvalidLineInfo::len: usize
 pub aya_obj::btf::BtfError::InvalidLineInfo::offset: usize
 pub aya_obj::btf::BtfError::InvalidLineInfo::section_len: usize
+pub aya_obj::btf::BtfError::InvalidMapExtra
+pub aya_obj::btf::BtfError::InvalidMapExtra::name: alloc::string::String
 pub aya_obj::btf::BtfError::InvalidRelocationInfo
 pub aya_obj::btf::BtfError::InvalidRelocationKind
 pub aya_obj::btf::BtfError::InvalidRelocationKind::kind: u32
@@ -4496,6 +4498,8 @@ pub enum aya_obj::maps::Map
 pub aya_obj::maps::Map::Btf(aya_obj::maps::BtfMap)
 pub aya_obj::maps::Map::Legacy(aya_obj::maps::LegacyMap)
 impl aya_obj::maps::Map
+pub const fn aya_obj::maps::Map::arena_data(&self) -> core::option::Option<&aya_obj::maps::ArenaData>
+pub const fn aya_obj::maps::Map::arena_data_mut(&mut self) -> core::option::Option<&mut aya_obj::maps::ArenaData>
 pub fn aya_obj::maps::Map::data(&self) -> &[u8]
 pub fn aya_obj::maps::Map::data_mut(&mut self) -> &mut alloc::vec::Vec<u8>
 pub fn aya_obj::maps::Map::inner(&self) -> core::option::Option<Self>
@@ -4562,6 +4566,23 @@ impl core::marker::Unpin for aya_obj::maps::PinningType
 impl core::marker::UnsafeUnpin for aya_obj::maps::PinningType
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::maps::PinningType
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::maps::PinningType
+pub struct aya_obj::maps::ArenaData
+impl aya_obj::maps::ArenaData
+pub fn aya_obj::maps::ArenaData::data(&self) -> &[u8]
+pub const fn aya_obj::maps::ArenaData::map_offset(&self) -> u32
+pub const fn aya_obj::maps::ArenaData::section_index(&self) -> usize
+pub const fn aya_obj::maps::ArenaData::set_map_offset(&mut self, u32)
+impl core::clone::Clone for aya_obj::maps::ArenaData
+pub fn aya_obj::maps::ArenaData::clone(&self) -> aya_obj::maps::ArenaData
+impl core::fmt::Debug for aya_obj::maps::ArenaData
+pub fn aya_obj::maps::ArenaData::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for aya_obj::maps::ArenaData
+impl core::marker::Send for aya_obj::maps::ArenaData
+impl core::marker::Sync for aya_obj::maps::ArenaData
+impl core::marker::Unpin for aya_obj::maps::ArenaData
+impl core::marker::UnsafeUnpin for aya_obj::maps::ArenaData
+impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::maps::ArenaData
+impl core::panic::unwind_safe::UnwindSafe for aya_obj::maps::ArenaData
 pub struct aya_obj::maps::BtfMap
 pub aya_obj::maps::BtfMap::def: aya_obj::maps::BtfMapDef
 impl core::clone::Clone for aya_obj::maps::BtfMap
@@ -4642,6 +4663,7 @@ impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::maps::bpf_map_def
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::maps::bpf_map_def
 pub mod aya_obj::obj
 pub enum aya_obj::obj::EbpfSectionKind
+pub aya_obj::obj::EbpfSectionKind::ArenaData
 pub aya_obj::obj::EbpfSectionKind::Bss
 pub aya_obj::obj::EbpfSectionKind::Btf
 pub aya_obj::obj::EbpfSectionKind::BtfExt
@@ -4671,8 +4693,15 @@ impl core::marker::UnsafeUnpin for aya_obj::EbpfSectionKind
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::EbpfSectionKind
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::EbpfSectionKind
 pub enum aya_obj::obj::ParseError
+pub aya_obj::obj::ParseError::ArenaMapNotBtfDefined
+pub aya_obj::obj::ParseError::ArenaMapNotFound
 pub aya_obj::obj::ParseError::BtfError(aya_obj::btf::BtfError)
+pub aya_obj::obj::ParseError::DuplicateArenaDataSection
 pub aya_obj::obj::ParseError::ElfError(object::read::Error)
+pub aya_obj::obj::ParseError::InvalidArenaDataSection
+pub aya_obj::obj::ParseError::InvalidArenaDataSize
+pub aya_obj::obj::ParseError::InvalidArenaDataSize::data_len: usize
+pub aya_obj::obj::ParseError::InvalidArenaDataSize::size: u64
 pub aya_obj::obj::ParseError::InvalidGlobalData
 pub aya_obj::obj::ParseError::InvalidGlobalData::data_size: usize
 pub aya_obj::obj::ParseError::InvalidGlobalData::name: alloc::string::String
@@ -4695,6 +4724,7 @@ pub aya_obj::obj::ParseError::MapSymbolNameNotFound
 pub aya_obj::obj::ParseError::MapSymbolNameNotFound::i: usize
 pub aya_obj::obj::ParseError::MissingLicenseNullTerminator
 pub aya_obj::obj::ParseError::MissingLicenseNullTerminator::data: alloc::vec::Vec<u8>
+pub aya_obj::obj::ParseError::MultipleArenaMaps
 pub aya_obj::obj::ParseError::NoBTF
 pub aya_obj::obj::ParseError::NoSymbolsForSection
 pub aya_obj::obj::ParseError::NoSymbolsForSection::section_name: alloc::string::String
@@ -4796,6 +4826,7 @@ pub const fn aya_obj::Features::bpf_probe_read_kernel(&self) -> bool
 pub const fn aya_obj::Features::btf(&self) -> core::option::Option<&aya_obj::btf::BtfFeatures>
 pub const fn aya_obj::Features::cpumap_prog_id(&self) -> bool
 pub const fn aya_obj::Features::devmap_prog_id(&self) -> bool
+pub const fn aya_obj::Features::ldimm64_full_range_offset(&self) -> bool
 impl core::default::Default for aya_obj::Features
 pub fn aya_obj::Features::default() -> aya_obj::Features
 impl core::fmt::Debug for aya_obj::Features
@@ -5219,6 +5250,7 @@ impl core::marker::UnsafeUnpin for aya_obj::relocation::EbpfRelocationError
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::relocation::EbpfRelocationError
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::relocation::EbpfRelocationError
 pub enum aya_obj::EbpfSectionKind
+pub aya_obj::EbpfSectionKind::ArenaData
 pub aya_obj::EbpfSectionKind::Bss
 pub aya_obj::EbpfSectionKind::Btf
 pub aya_obj::EbpfSectionKind::BtfExt
@@ -5287,6 +5319,8 @@ pub enum aya_obj::Map
 pub aya_obj::Map::Btf(aya_obj::maps::BtfMap)
 pub aya_obj::Map::Legacy(aya_obj::maps::LegacyMap)
 impl aya_obj::maps::Map
+pub const fn aya_obj::maps::Map::arena_data(&self) -> core::option::Option<&aya_obj::maps::ArenaData>
+pub const fn aya_obj::maps::Map::arena_data_mut(&mut self) -> core::option::Option<&mut aya_obj::maps::ArenaData>
 pub fn aya_obj::maps::Map::data(&self) -> &[u8]
 pub fn aya_obj::maps::Map::data_mut(&mut self) -> &mut alloc::vec::Vec<u8>
 pub fn aya_obj::maps::Map::inner(&self) -> core::option::Option<Self>
@@ -5315,8 +5349,15 @@ impl core::marker::UnsafeUnpin for aya_obj::maps::Map
 impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::maps::Map
 impl core::panic::unwind_safe::UnwindSafe for aya_obj::maps::Map
 pub enum aya_obj::ParseError
+pub aya_obj::ParseError::ArenaMapNotBtfDefined
+pub aya_obj::ParseError::ArenaMapNotFound
 pub aya_obj::ParseError::BtfError(aya_obj::btf::BtfError)
+pub aya_obj::ParseError::DuplicateArenaDataSection
 pub aya_obj::ParseError::ElfError(object::read::Error)
+pub aya_obj::ParseError::InvalidArenaDataSection
+pub aya_obj::ParseError::InvalidArenaDataSize
+pub aya_obj::ParseError::InvalidArenaDataSize::data_len: usize
+pub aya_obj::ParseError::InvalidArenaDataSize::size: u64
 pub aya_obj::ParseError::InvalidGlobalData
 pub aya_obj::ParseError::InvalidGlobalData::data_size: usize
 pub aya_obj::ParseError::InvalidGlobalData::name: alloc::string::String
@@ -5339,6 +5380,7 @@ pub aya_obj::ParseError::MapSymbolNameNotFound
 pub aya_obj::ParseError::MapSymbolNameNotFound::i: usize
 pub aya_obj::ParseError::MissingLicenseNullTerminator
 pub aya_obj::ParseError::MissingLicenseNullTerminator::data: alloc::vec::Vec<u8>
+pub aya_obj::ParseError::MultipleArenaMaps
 pub aya_obj::ParseError::NoBTF
 pub aya_obj::ParseError::NoSymbolsForSection
 pub aya_obj::ParseError::NoSymbolsForSection::section_name: alloc::string::String
@@ -5440,6 +5482,7 @@ pub const fn aya_obj::Features::bpf_probe_read_kernel(&self) -> bool
 pub const fn aya_obj::Features::btf(&self) -> core::option::Option<&aya_obj::btf::BtfFeatures>
 pub const fn aya_obj::Features::cpumap_prog_id(&self) -> bool
 pub const fn aya_obj::Features::devmap_prog_id(&self) -> bool
+pub const fn aya_obj::Features::ldimm64_full_range_offset(&self) -> bool
 impl core::default::Default for aya_obj::Features
 pub fn aya_obj::Features::default() -> aya_obj::Features
 impl core::fmt::Debug for aya_obj::Features

--- a/xtask/public-api/aya.txt
+++ b/xtask/public-api/aya.txt
@@ -5,6 +5,35 @@ pub use aya::Endianness
 pub use aya::PinningType
 pub use aya::bpf_map_def
 pub mod aya::maps
+pub mod aya::maps::arena
+pub struct aya::maps::arena::Arena<T>
+impl<T: core::borrow::Borrow<aya::maps::MapData>> aya::maps::arena::Arena<T>
+pub fn aya::maps::arena::Arena<T>::as_ptr(&self) -> *mut u8
+pub unsafe fn aya::maps::arena::Arena<T>::atomic_u32_at(&self, usize) -> core::result::Result<&core::sync::atomic::AtomicU32, aya::maps::MapError>
+pub unsafe fn aya::maps::arena::Arena<T>::atomic_u64_at(&self, usize) -> core::result::Result<&core::sync::atomic::AtomicU64, aya::maps::MapError>
+pub fn aya::maps::arena::Arena<T>::is_empty(&self) -> bool
+pub fn aya::maps::arena::Arena<T>::len(&self) -> usize
+pub unsafe fn aya::maps::arena::Arena<T>::read_at<V: aya::Pod>(&self, usize) -> core::result::Result<V, aya::maps::MapError>
+pub fn aya::maps::arena::Arena<T>::user_base(&self) -> u64
+pub unsafe fn aya::maps::arena::Arena<T>::write_at<V: aya::Pod>(&self, usize, V) -> core::result::Result<(), aya::maps::MapError>
+impl core::convert::TryFrom<aya::maps::Map> for aya::maps::arena::Arena<aya::maps::MapData>
+pub type aya::maps::arena::Arena<aya::maps::MapData>::Error = aya::maps::MapError
+pub fn aya::maps::arena::Arena<aya::maps::MapData>::try_from(aya::maps::Map) -> core::result::Result<Self, Self::Error>
+impl<'a> core::convert::TryFrom<&'a aya::maps::Map> for aya::maps::arena::Arena<&'a aya::maps::MapData>
+pub type aya::maps::arena::Arena<&'a aya::maps::MapData>::Error = aya::maps::MapError
+pub fn aya::maps::arena::Arena<&'a aya::maps::MapData>::try_from(&'a aya::maps::Map) -> core::result::Result<Self, Self::Error>
+impl<'a> core::convert::TryFrom<&'a mut aya::maps::Map> for aya::maps::arena::Arena<&'a mut aya::maps::MapData>
+pub type aya::maps::arena::Arena<&'a mut aya::maps::MapData>::Error = aya::maps::MapError
+pub fn aya::maps::arena::Arena<&'a mut aya::maps::MapData>::try_from(&'a mut aya::maps::Map) -> core::result::Result<Self, Self::Error>
+impl<T: core::fmt::Debug> core::fmt::Debug for aya::maps::arena::Arena<T>
+pub fn aya::maps::arena::Arena<T>::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl<T> core::marker::Freeze for aya::maps::arena::Arena<T> where T: core::marker::Freeze
+impl<T> core::marker::Send for aya::maps::arena::Arena<T> where T: core::marker::Send
+impl<T> core::marker::Sync for aya::maps::arena::Arena<T> where T: core::marker::Sync
+impl<T> core::marker::Unpin for aya::maps::arena::Arena<T> where T: core::marker::Unpin
+impl<T> core::marker::UnsafeUnpin for aya::maps::arena::Arena<T> where T: core::marker::UnsafeUnpin
+impl<T> core::panic::unwind_safe::RefUnwindSafe for aya::maps::arena::Arena<T> where T: core::panic::unwind_safe::RefUnwindSafe
+impl<T> core::panic::unwind_safe::UnwindSafe for aya::maps::arena::Arena<T> where T: core::panic::unwind_safe::UnwindSafe
 pub mod aya::maps::array
 pub struct aya::maps::array::Array<T, V: aya::Pod>
 impl<T: core::borrow::Borrow<aya::maps::MapData>, V: aya::Pod> aya::maps::array::Array<T, V>
@@ -927,6 +956,7 @@ impl<T> core::marker::UnsafeUnpin for aya::maps::XskMap<T> where T: core::marker
 impl<T> core::panic::unwind_safe::RefUnwindSafe for aya::maps::XskMap<T> where T: core::panic::unwind_safe::RefUnwindSafe
 impl<T> core::panic::unwind_safe::UnwindSafe for aya::maps::XskMap<T> where T: core::panic::unwind_safe::UnwindSafe
 pub enum aya::maps::Map
+pub aya::maps::Map::Arena(aya::maps::MapData)
 pub aya::maps::Map::Array(aya::maps::MapData)
 pub aya::maps::Map::ArrayOfMaps(aya::maps::MapData)
 pub aya::maps::Map::BloomFilter(aya::maps::MapData)
@@ -984,6 +1014,9 @@ pub fn aya::maps::SockMap<aya::maps::MapData>::try_from(aya::maps::Map) -> core:
 impl core::convert::TryFrom<aya::maps::Map> for aya::maps::XskMap<aya::maps::MapData>
 pub type aya::maps::XskMap<aya::maps::MapData>::Error = aya::maps::MapError
 pub fn aya::maps::XskMap<aya::maps::MapData>::try_from(aya::maps::Map) -> core::result::Result<Self, Self::Error>
+impl core::convert::TryFrom<aya::maps::Map> for aya::maps::arena::Arena<aya::maps::MapData>
+pub type aya::maps::arena::Arena<aya::maps::MapData>::Error = aya::maps::MapError
+pub fn aya::maps::arena::Arena<aya::maps::MapData>::try_from(aya::maps::Map) -> core::result::Result<Self, Self::Error>
 impl core::convert::TryFrom<aya::maps::Map> for aya::maps::perf::PerfEventArray<aya::maps::MapData>
 pub type aya::maps::perf::PerfEventArray<aya::maps::MapData>::Error = aya::maps::MapError
 pub fn aya::maps::perf::PerfEventArray<aya::maps::MapData>::try_from(aya::maps::Map) -> core::result::Result<Self, Self::Error>
@@ -1115,6 +1148,9 @@ pub fn aya::maps::SockMap<&'a aya::maps::MapData>::try_from(&'a aya::maps::Map) 
 impl<'a> core::convert::TryFrom<&'a aya::maps::Map> for aya::maps::XskMap<&'a aya::maps::MapData>
 pub type aya::maps::XskMap<&'a aya::maps::MapData>::Error = aya::maps::MapError
 pub fn aya::maps::XskMap<&'a aya::maps::MapData>::try_from(&'a aya::maps::Map) -> core::result::Result<Self, Self::Error>
+impl<'a> core::convert::TryFrom<&'a aya::maps::Map> for aya::maps::arena::Arena<&'a aya::maps::MapData>
+pub type aya::maps::arena::Arena<&'a aya::maps::MapData>::Error = aya::maps::MapError
+pub fn aya::maps::arena::Arena<&'a aya::maps::MapData>::try_from(&'a aya::maps::Map) -> core::result::Result<Self, Self::Error>
 impl<'a> core::convert::TryFrom<&'a aya::maps::Map> for aya::maps::perf::PerfEventArray<&'a aya::maps::MapData>
 pub type aya::maps::perf::PerfEventArray<&'a aya::maps::MapData>::Error = aya::maps::MapError
 pub fn aya::maps::perf::PerfEventArray<&'a aya::maps::MapData>::try_from(&'a aya::maps::Map) -> core::result::Result<Self, Self::Error>
@@ -1148,6 +1184,9 @@ pub fn aya::maps::SockMap<&'a mut aya::maps::MapData>::try_from(&'a mut aya::map
 impl<'a> core::convert::TryFrom<&'a mut aya::maps::Map> for aya::maps::XskMap<&'a mut aya::maps::MapData>
 pub type aya::maps::XskMap<&'a mut aya::maps::MapData>::Error = aya::maps::MapError
 pub fn aya::maps::XskMap<&'a mut aya::maps::MapData>::try_from(&'a mut aya::maps::Map) -> core::result::Result<Self, Self::Error>
+impl<'a> core::convert::TryFrom<&'a mut aya::maps::Map> for aya::maps::arena::Arena<&'a mut aya::maps::MapData>
+pub type aya::maps::arena::Arena<&'a mut aya::maps::MapData>::Error = aya::maps::MapError
+pub fn aya::maps::arena::Arena<&'a mut aya::maps::MapData>::try_from(&'a mut aya::maps::Map) -> core::result::Result<Self, Self::Error>
 impl<'a> core::convert::TryFrom<&'a mut aya::maps::Map> for aya::maps::perf::PerfEventArray<&'a mut aya::maps::MapData>
 pub type aya::maps::perf::PerfEventArray<&'a mut aya::maps::MapData>::Error = aya::maps::MapError
 pub fn aya::maps::perf::PerfEventArray<&'a mut aya::maps::MapData>::try_from(&'a mut aya::maps::Map) -> core::result::Result<Self, Self::Error>
@@ -1213,10 +1252,26 @@ impl core::marker::UnsafeUnpin for aya::maps::Map
 impl core::panic::unwind_safe::RefUnwindSafe for aya::maps::Map
 impl core::panic::unwind_safe::UnwindSafe for aya::maps::Map
 pub enum aya::maps::MapError
+pub aya::maps::MapError::ArenaMmapError
+pub aya::maps::MapError::ArenaMmapError::address: u64
+pub aya::maps::MapError::ArenaMmapError::io_error: core::io::error::Error
+pub aya::maps::MapError::ArenaMmapError::length: usize
+pub aya::maps::MapError::ArenaNotMmapped
+pub aya::maps::MapError::ArenaOutOfBounds
+pub aya::maps::MapError::ArenaOutOfBounds::arena_size: usize
+pub aya::maps::MapError::ArenaOutOfBounds::offset: usize
+pub aya::maps::MapError::ArenaOutOfBounds::size: usize
 pub aya::maps::MapError::CreateError
 pub aya::maps::MapError::CreateError::io_error: core::io::error::Error
 pub aya::maps::MapError::CreateError::name: alloc::string::String
 pub aya::maps::MapError::ElementNotFound
+pub aya::maps::MapError::IncompatiblePinnedArena
+pub aya::maps::MapError::IncompatiblePinnedArena::name: alloc::string::String
+pub aya::maps::MapError::IncompatiblePinnedArena::reason: &'static str
+pub aya::maps::MapError::InvalidArenaMmap
+pub aya::maps::MapError::InvalidArenaMmap::address: u64
+pub aya::maps::MapError::InvalidArenaMmap::max_entries: u32
+pub aya::maps::MapError::InvalidArenaMmap::reason: &'static str
 pub aya::maps::MapError::InvalidKeySize
 pub aya::maps::MapError::InvalidKeySize::expected: usize
 pub aya::maps::MapError::InvalidKeySize::size: usize
@@ -1243,6 +1298,12 @@ pub aya::maps::MapError::PinError::name: core::option::Option<alloc::string::Str
 pub aya::maps::MapError::ProgIdNotSupported
 pub aya::maps::MapError::ProgramNotLoaded
 pub aya::maps::MapError::SyscallError(aya::sys::SyscallError)
+pub aya::maps::MapError::UnalignedArenaAccess
+pub aya::maps::MapError::UnalignedArenaAccess::alignment: usize
+pub aya::maps::MapError::UnalignedArenaAccess::offset: usize
+pub aya::maps::MapError::UnexpectedArenaMmapAddress
+pub aya::maps::MapError::UnexpectedArenaMmapAddress::actual: u64
+pub aya::maps::MapError::UnexpectedArenaMmapAddress::requested: u64
 pub aya::maps::MapError::Unsupported
 pub aya::maps::MapError::Unsupported::map_type: aya_obj::generated::linux_bindings_x86_64::bpf_map_type
 pub aya::maps::MapError::Unsupported::name: alloc::string::String
@@ -1327,6 +1388,34 @@ impl core::marker::Unpin for aya::maps::MapType
 impl core::marker::UnsafeUnpin for aya::maps::MapType
 impl core::panic::unwind_safe::RefUnwindSafe for aya::maps::MapType
 impl core::panic::unwind_safe::UnwindSafe for aya::maps::MapType
+pub struct aya::maps::Arena<T>
+impl<T: core::borrow::Borrow<aya::maps::MapData>> aya::maps::arena::Arena<T>
+pub fn aya::maps::arena::Arena<T>::as_ptr(&self) -> *mut u8
+pub unsafe fn aya::maps::arena::Arena<T>::atomic_u32_at(&self, usize) -> core::result::Result<&core::sync::atomic::AtomicU32, aya::maps::MapError>
+pub unsafe fn aya::maps::arena::Arena<T>::atomic_u64_at(&self, usize) -> core::result::Result<&core::sync::atomic::AtomicU64, aya::maps::MapError>
+pub fn aya::maps::arena::Arena<T>::is_empty(&self) -> bool
+pub fn aya::maps::arena::Arena<T>::len(&self) -> usize
+pub unsafe fn aya::maps::arena::Arena<T>::read_at<V: aya::Pod>(&self, usize) -> core::result::Result<V, aya::maps::MapError>
+pub fn aya::maps::arena::Arena<T>::user_base(&self) -> u64
+pub unsafe fn aya::maps::arena::Arena<T>::write_at<V: aya::Pod>(&self, usize, V) -> core::result::Result<(), aya::maps::MapError>
+impl core::convert::TryFrom<aya::maps::Map> for aya::maps::arena::Arena<aya::maps::MapData>
+pub type aya::maps::arena::Arena<aya::maps::MapData>::Error = aya::maps::MapError
+pub fn aya::maps::arena::Arena<aya::maps::MapData>::try_from(aya::maps::Map) -> core::result::Result<Self, Self::Error>
+impl<'a> core::convert::TryFrom<&'a aya::maps::Map> for aya::maps::arena::Arena<&'a aya::maps::MapData>
+pub type aya::maps::arena::Arena<&'a aya::maps::MapData>::Error = aya::maps::MapError
+pub fn aya::maps::arena::Arena<&'a aya::maps::MapData>::try_from(&'a aya::maps::Map) -> core::result::Result<Self, Self::Error>
+impl<'a> core::convert::TryFrom<&'a mut aya::maps::Map> for aya::maps::arena::Arena<&'a mut aya::maps::MapData>
+pub type aya::maps::arena::Arena<&'a mut aya::maps::MapData>::Error = aya::maps::MapError
+pub fn aya::maps::arena::Arena<&'a mut aya::maps::MapData>::try_from(&'a mut aya::maps::Map) -> core::result::Result<Self, Self::Error>
+impl<T: core::fmt::Debug> core::fmt::Debug for aya::maps::arena::Arena<T>
+pub fn aya::maps::arena::Arena<T>::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl<T> core::marker::Freeze for aya::maps::arena::Arena<T> where T: core::marker::Freeze
+impl<T> core::marker::Send for aya::maps::arena::Arena<T> where T: core::marker::Send
+impl<T> core::marker::Sync for aya::maps::arena::Arena<T> where T: core::marker::Sync
+impl<T> core::marker::Unpin for aya::maps::arena::Arena<T> where T: core::marker::Unpin
+impl<T> core::marker::UnsafeUnpin for aya::maps::arena::Arena<T> where T: core::marker::UnsafeUnpin
+impl<T> core::panic::unwind_safe::RefUnwindSafe for aya::maps::arena::Arena<T> where T: core::panic::unwind_safe::RefUnwindSafe
+impl<T> core::panic::unwind_safe::UnwindSafe for aya::maps::arena::Arena<T> where T: core::panic::unwind_safe::UnwindSafe
 pub struct aya::maps::Array<T, V: aya::Pod>
 impl<T: core::borrow::Borrow<aya::maps::MapData>, V: aya::Pod> aya::maps::array::Array<T, V>
 pub fn aya::maps::array::Array<T, V>::get(&self, &u32, u64) -> core::result::Result<V, aya::maps::MapError>


### PR DESCRIPTION
Add initial end-to-end support for BPF_MAP_TYPE_ARENA.

Teach aya-obj to parse arena map definitions and .addr_space.1 data, and to relocate arena-backed globals. Aya now creates or reuses arena maps, mmaps them before program load, and initializes arena-backed global and static data for newly created maps.

Add the userspace Arena API and the eBPF-side Arena and ArenaPtr APIs. Integration tests cover globals, relocations, map reuse, shared memory, atomics, page allocation/free, and fault-contained accesses.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aya-rs/aya/1680)
<!-- Reviewable:end -->
