### PR TITLE
aya: add attach_to_link for CgroupSockAddr

### DIFF
--- a/aya/src/programs/cgroup_sock_addr.rs
+++ b/aya/src/programs/cgroup_sock_addr.rs
@@ -2,16 +2,17 @@
 
 use std::{hash::Hash, os::fd::AsFd, path::Path};
 
-use aya_obj::generated::bpf_prog_type::BPF_PROG_TYPE_CGROUP_SOCK_ADDR;
+use aya_obj::generated::{bpf_link_type, bpf_prog_type::BPF_PROG_TYPE_CGROUP_SOCK_ADDR};
 pub use aya_obj::programs::CgroupSockAddrAttachType;
 
 use crate::{
     VerifierLogLevel,
     programs::{
-        CgroupAttachMode, FdLink, Link, ProgAttachLink, ProgramData, ProgramError, ProgramType,
-        define_link_wrapper, id_as_key, impl_try_into_fdlink, load_program_with_attach_type,
+        CgroupAttachMode, FdLink, Link, LinkError, ProgAttachLink, ProgramData, ProgramError,
+        ProgramType, define_link_wrapper, id_as_key, impl_try_from_fdlink, impl_try_into_fdlink,
+        load_program_with_attach_type,
     },
-    sys::{LinkTarget, SyscallError, bpf_link_create},
+    sys::{LinkTarget, SyscallError, bpf_link_create, bpf_link_update},
     util::KernelVersion,
 };
 
@@ -105,6 +106,40 @@ impl CgroupSockAddr {
         }
     }
 
+    /// Atomically replaces the program referenced by the provided link.
+    ///
+    /// Ownership of the link will transfer to this program.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`LinkError::InvalidLink`] for a `BPF_PROG_ATTACH` attachment,
+    /// which is what kernels before 5.7 get, as it's currently not supported.
+    pub fn attach_to_link(
+        &mut self,
+        link: CgroupSockAddrLink,
+    ) -> Result<CgroupSockAddrLinkId, ProgramError> {
+        let prog_fd = self.fd()?;
+        let prog_fd = prog_fd.as_fd();
+        match link.into_inner() {
+            CgroupSockAddrLinkInner::Fd(fd_link) => {
+                let link_fd = fd_link.fd;
+                bpf_link_update(link_fd.as_fd(), prog_fd, None, 0).map_err(|io_error| {
+                    SyscallError {
+                        call: "bpf_link_update",
+                        io_error,
+                    }
+                })?;
+
+                self.data
+                    .links
+                    .insert(CgroupSockAddrLink::new(CgroupSockAddrLinkInner::Fd(
+                        FdLink::new(link_fd),
+                    )))
+            }
+            CgroupSockAddrLinkInner::ProgAttach(_) => Err(LinkError::InvalidLink.into()),
+        }
+    }
+
     /// Creates a program from a pinned entry on a bpffs.
     ///
     /// Existing links will not be populated. To work with existing links you should use [`crate::programs::links::PinnedLink`].
@@ -162,3 +197,9 @@ define_link_wrapper!(
 );
 
 impl_try_into_fdlink!(CgroupSockAddrLink, CgroupSockAddrLinkInner);
+
+impl_try_from_fdlink!(
+    CgroupSockAddrLink,
+    CgroupSockAddrLinkInner,
+    bpf_link_type::BPF_LINK_TYPE_CGROUP
+);

--- a/aya/src/programs/mod.rs
+++ b/aya/src/programs/mod.rs
@@ -183,6 +183,10 @@ pub enum ProgramError {
     #[error(transparent)]
     SyscallError(#[from] SyscallError),
 
+    /// An error occurred while working with a link.
+    #[error(transparent)]
+    LinkError(#[from] LinkError),
+
     /// The network interface does not exist.
     #[error("unknown network interface {name}")]
     UnknownInterface {

--- a/test/integration-ebpf/Cargo.toml
+++ b/test/integration-ebpf/Cargo.toml
@@ -201,6 +201,10 @@ name = "cgroup_array"
 path = "src/cgroup_array.rs"
 
 [[bin]]
+name = "cgroup_connect"
+path = "src/cgroup_connect.rs"
+
+[[bin]]
 name = "cgroup_storage"
 path = "src/cgroup_storage.rs"
 

--- a/test/integration-ebpf/src/cgroup_connect.rs
+++ b/test/integration-ebpf/src/cgroup_connect.rs
@@ -1,0 +1,13 @@
+#![no_std]
+#![no_main]
+#![expect(unused_crate_dependencies, reason = "used in other bins")]
+
+#[cfg(not(test))]
+extern crate ebpf_panic;
+
+use aya_ebpf::{bindings::sk_action, macros::cgroup_sock_addr, programs::SockAddrContext};
+
+#[cgroup_sock_addr(connect4)]
+const fn cgroup_connect(_ctx: SockAddrContext) -> i32 {
+    sk_action::SK_PASS as i32
+}

--- a/test/integration-test/src/lib.rs
+++ b/test/integration-test/src/lib.rs
@@ -49,6 +49,7 @@ bpf_file!(
     BPF_PROBE_READ => "bpf_probe_read",
     BTF_MAPS_PLAIN => "btf_maps_plain",
     CGROUP_ARRAY => "cgroup_array",
+    CGROUP_CONNECT => "cgroup_connect",
     CGROUP_STORAGE => "cgroup_storage",
     CPU_MAP => "cpu_map",
     DEV_MAP => "dev_map",

--- a/test/integration-test/src/tests/load.rs
+++ b/test/integration-test/src/tests/load.rs
@@ -8,8 +8,8 @@ use aya::{
     maps::{Array, RingBuf},
     pin::PinError,
     programs::{
-        FlowDissector, KProbe, LinkOrder, ProbeKind, Program, ProgramError, SchedClassifier,
-        TcAttachType, TracePoint, UProbe, Xdp, XdpMode,
+        CgroupAttachMode, CgroupSockAddr, FlowDissector, KProbe, LinkOrder, ProbeKind, Program,
+        ProgramError, SchedClassifier, TcAttachType, TracePoint, UProbe, Xdp, XdpMode,
         flow_dissector::{FlowDissectorLink, FlowDissectorLinkId},
         kprobe::{KProbeLink, KProbeLinkId},
         links::{FdLink, LinkError, PinnedLink},
@@ -476,6 +476,58 @@ fn pin_tcx_link() {
     // Load a new program and atomically replace the old one using attach_to_link
     let mut bpf = Ebpf::load(crate::TCX).unwrap();
     let prog: &mut SchedClassifier = bpf.program_mut(program_name).unwrap().try_into().unwrap();
+    prog.load().unwrap();
+
+    let old_link = PinnedLink::from_pin(pin_path).unwrap();
+    let link = FdLink::from(old_link).try_into().unwrap();
+    let _link_id = prog.attach_to_link(link).unwrap();
+
+    assert_loaded(program_name);
+
+    // Clean up: remove the stale pin file and drop the bpf instance (which drops the program and link)
+    remove_file(pin_path).unwrap();
+    drop(bpf);
+    assert_unloaded(program_name);
+}
+
+#[test_log::test]
+fn pin_cgroup_link() {
+    // bpf_link for cgroup programs requires kernel >= 5.7; below that `attach`
+    // produces a BPF_PROG_ATTACH link, which cannot be pinned or updated.
+    let kernel_version = KernelVersion::current().unwrap();
+    if kernel_version < KernelVersion::new(5, 7, 0) {
+        eprintln!("skipping pin_cgroup_link test on kernel {kernel_version:?}");
+        return;
+    }
+
+    use aya::test_helpers::{Cgroup, NetNsGuard};
+    let _netns = NetNsGuard::new().unwrap();
+    let root_cgroup = Cgroup::root().unwrap();
+    let cgroup = root_cgroup
+        .create_child("aya-test-pin-cgroup-link")
+        .unwrap();
+    let cgroup_fd = cgroup.fd().unwrap();
+
+    let program_name = "cgroup_connect";
+    let pin_path = "/sys/fs/bpf/aya-cgroup-test-connect4";
+    let mut bpf = Ebpf::load(crate::CGROUP_CONNECT).unwrap();
+    let prog: &mut CgroupSockAddr = bpf.program_mut(program_name).unwrap().try_into().unwrap();
+    prog.load().unwrap();
+
+    let link_id = prog.attach(&cgroup_fd, CgroupAttachMode::Single).unwrap();
+    let link = prog.take_link(link_id).unwrap();
+    assert_loaded(program_name);
+
+    let fd_link: FdLink = link.try_into().unwrap();
+    fd_link.pin(pin_path).unwrap();
+
+    // Because of the pin, the program is still attached
+    prog.unload().unwrap();
+    assert_loaded(program_name);
+
+    // Load a new program and atomically replace the old one using attach_to_link
+    let mut bpf = Ebpf::load(crate::CGROUP_CONNECT).unwrap();
+    let prog: &mut CgroupSockAddr = bpf.program_mut(program_name).unwrap().try_into().unwrap();
     prog.load().unwrap();
 
     let old_link = PinnedLink::from_pin(pin_path).unwrap();

--- a/xtask/public-api/aya.txt
+++ b/xtask/public-api/aya.txt
@@ -2502,6 +2502,7 @@ pub struct aya::programs::cgroup_sock_addr::CgroupSockAddr
 impl aya::programs::cgroup_sock_addr::CgroupSockAddr
 pub const aya::programs::cgroup_sock_addr::CgroupSockAddr::PROGRAM_TYPE: aya::programs::ProgramType
 pub fn aya::programs::cgroup_sock_addr::CgroupSockAddr::attach<T: std::os::fd::owned::AsFd>(&mut self, T, aya::programs::links::CgroupAttachMode) -> core::result::Result<aya::programs::cgroup_sock_addr::CgroupSockAddrLinkId, aya::programs::ProgramError>
+pub fn aya::programs::cgroup_sock_addr::CgroupSockAddr::attach_to_link(&mut self, aya::programs::cgroup_sock_addr::CgroupSockAddrLink) -> core::result::Result<aya::programs::cgroup_sock_addr::CgroupSockAddrLinkId, aya::programs::ProgramError>
 pub fn aya::programs::cgroup_sock_addr::CgroupSockAddr::from_pin<P: core::convert::AsRef<std::path::Path>>(P, aya_obj::programs::cgroup_sock_addr::CgroupSockAddrAttachType) -> core::result::Result<Self, aya::programs::ProgramError>
 pub fn aya::programs::cgroup_sock_addr::CgroupSockAddr::load(&mut self) -> core::result::Result<(), aya::programs::ProgramError>
 impl aya::programs::cgroup_sock_addr::CgroupSockAddr
@@ -2545,6 +2546,9 @@ pub fn aya::programs::cgroup_sock_addr::CgroupSockAddrLink::eq(&self, &Self) -> 
 impl core::convert::TryFrom<aya::programs::cgroup_sock_addr::CgroupSockAddrLink> for aya::programs::links::FdLink
 pub type aya::programs::links::FdLink::Error = aya::programs::links::LinkError
 pub fn aya::programs::links::FdLink::try_from(aya::programs::cgroup_sock_addr::CgroupSockAddrLink) -> core::result::Result<Self, Self::Error>
+impl core::convert::TryFrom<aya::programs::links::FdLink> for aya::programs::cgroup_sock_addr::CgroupSockAddrLink
+pub type aya::programs::cgroup_sock_addr::CgroupSockAddrLink::Error = aya::programs::links::LinkError
+pub fn aya::programs::cgroup_sock_addr::CgroupSockAddrLink::try_from(aya::programs::links::FdLink) -> core::result::Result<Self, Self::Error>
 impl core::fmt::Debug for aya::programs::cgroup_sock_addr::CgroupSockAddrLink
 pub fn aya::programs::cgroup_sock_addr::CgroupSockAddrLink::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::hash::Hash for aya::programs::cgroup_sock_addr::CgroupSockAddrLink
@@ -3334,6 +3338,8 @@ pub enum aya::programs::links::LinkError
 pub aya::programs::links::LinkError::InvalidLink
 pub aya::programs::links::LinkError::SyscallError(aya::sys::SyscallError)
 pub aya::programs::links::LinkError::UnknownLinkType(u32)
+impl core::convert::From<aya::programs::links::LinkError> for aya::programs::ProgramError
+pub fn aya::programs::ProgramError::from(aya::programs::links::LinkError) -> Self
 impl core::convert::From<aya::sys::SyscallError> for aya::programs::links::LinkError
 pub fn aya::programs::links::LinkError::from(aya::sys::SyscallError) -> Self
 impl core::error::Error for aya::programs::links::LinkError
@@ -3446,6 +3452,9 @@ pub fn aya::programs::links::FdLink::try_from(aya::programs::iter::IterLink) -> 
 impl core::convert::TryFrom<aya::programs::kprobe::KProbeLink> for aya::programs::links::FdLink
 pub type aya::programs::links::FdLink::Error = aya::programs::links::LinkError
 pub fn aya::programs::links::FdLink::try_from(aya::programs::kprobe::KProbeLink) -> core::result::Result<Self, Self::Error>
+impl core::convert::TryFrom<aya::programs::links::FdLink> for aya::programs::cgroup_sock_addr::CgroupSockAddrLink
+pub type aya::programs::cgroup_sock_addr::CgroupSockAddrLink::Error = aya::programs::links::LinkError
+pub fn aya::programs::cgroup_sock_addr::CgroupSockAddrLink::try_from(aya::programs::links::FdLink) -> core::result::Result<Self, Self::Error>
 impl core::convert::TryFrom<aya::programs::links::FdLink> for aya::programs::iter::IterLink
 pub type aya::programs::iter::IterLink::Error = aya::programs::links::LinkError
 pub fn aya::programs::iter::IterLink::try_from(aya::programs::links::FdLink) -> core::result::Result<Self, Self::Error>
@@ -5996,6 +6005,7 @@ pub aya::programs::ProgramError::IOError(core::io::error::Error)
 pub aya::programs::ProgramError::InvalidName
 pub aya::programs::ProgramError::InvalidName::name: alloc::string::String
 pub aya::programs::ProgramError::KProbeError(aya::programs::kprobe::KProbeError)
+pub aya::programs::ProgramError::LinkError(aya::programs::links::LinkError)
 pub aya::programs::ProgramError::LoadError
 pub aya::programs::ProgramError::LoadError::io_error: core::io::error::Error
 pub aya::programs::ProgramError::LoadError::verifier_log: aya_obj::VerifierLog
@@ -6021,6 +6031,8 @@ impl core::convert::From<aya::programs::extension::ExtensionError> for aya::prog
 pub fn aya::programs::ProgramError::from(aya::programs::extension::ExtensionError) -> Self
 impl core::convert::From<aya::programs::kprobe::KProbeError> for aya::programs::ProgramError
 pub fn aya::programs::ProgramError::from(aya::programs::kprobe::KProbeError) -> Self
+impl core::convert::From<aya::programs::links::LinkError> for aya::programs::ProgramError
+pub fn aya::programs::ProgramError::from(aya::programs::links::LinkError) -> Self
 impl core::convert::From<aya::programs::sk_reuseport::SkReuseportError> for aya::programs::ProgramError
 pub fn aya::programs::ProgramError::from(aya::programs::sk_reuseport::SkReuseportError) -> Self
 impl core::convert::From<aya::programs::socket_filter::SocketFilterError> for aya::programs::ProgramError
@@ -6455,6 +6467,7 @@ pub struct aya::programs::CgroupSockAddr
 impl aya::programs::cgroup_sock_addr::CgroupSockAddr
 pub const aya::programs::cgroup_sock_addr::CgroupSockAddr::PROGRAM_TYPE: aya::programs::ProgramType
 pub fn aya::programs::cgroup_sock_addr::CgroupSockAddr::attach<T: std::os::fd::owned::AsFd>(&mut self, T, aya::programs::links::CgroupAttachMode) -> core::result::Result<aya::programs::cgroup_sock_addr::CgroupSockAddrLinkId, aya::programs::ProgramError>
+pub fn aya::programs::cgroup_sock_addr::CgroupSockAddr::attach_to_link(&mut self, aya::programs::cgroup_sock_addr::CgroupSockAddrLink) -> core::result::Result<aya::programs::cgroup_sock_addr::CgroupSockAddrLinkId, aya::programs::ProgramError>
 pub fn aya::programs::cgroup_sock_addr::CgroupSockAddr::from_pin<P: core::convert::AsRef<std::path::Path>>(P, aya_obj::programs::cgroup_sock_addr::CgroupSockAddrAttachType) -> core::result::Result<Self, aya::programs::ProgramError>
 pub fn aya::programs::cgroup_sock_addr::CgroupSockAddr::load(&mut self) -> core::result::Result<(), aya::programs::ProgramError>
 impl aya::programs::cgroup_sock_addr::CgroupSockAddr


### PR DESCRIPTION
Add `CgroupSockAddr::attach_to_link`, which atomically swaps the program behind an already attached cgroup link, as `Xdp` and `SchedClassifier` already do.

Together with `TryFrom<FdLink> for CgroupSockAddrLink`, added here too, a link recovered from a bpffs pin can be pointed at a newly loaded program without the cgroup ever going unattached:

    let prog: &mut CgroupSockAddr = bpf.program_mut("myprog").unwrap().try_into()?;
    prog.load()?;

    let pinned = PinnedLink::from_pin("/sys/fs/bpf/myprog_link")?;
    let link = FdLink::from(pinned).try_into()?;

    prog.attach_to_link(link)?;

Neither existed before: `CgroupSockAddr` could return a link to be pinned but would not take one back, so the only option was to unpin the old link and attach a new one, leaving a window where no cgroup program is attached.

Only `BPF_LINK_CREATE` attachments are supported: those made with `BPF_PROG_ATTACH` (kernels < 5.7) return `LinkError::InvalidLink` because, unlike XDP and TC, a cgroup configured with `BPF_F_ALLOW_MULTI` (exposed in aya as `CgroupAttachMode::AllowMultiple`) can hold several programs of one attach type, and a reattach would append the new program instead of replacing the existing one. Supporting that would mean passing `BPF_F_REPLACE` and the fd of the program to replace, which would need an extra param on `bpf_prog_attach` and all its callers. Not worth it for an outdated syscall command superseded by `BPF_LINK_CREATE`.

**Few remarks for the review**
- as stated already in the commit message, this does not support `BPF_PROG_ATTACH` attachments: deliberate choice, but happy to add support for that as well (I have the patch ready, it's ~100 lines, just wasn't sure it was worth the extra churn for an outdated bpf command)
- this touches only `CgroupSockAddr`. Implementing the same for `CgroupSkb`, `CgroupSock` and `SockOps` should be mostly a copypaste chore, while `CgroupDevice`, `CgroupSockopt` and `CgroupSysctl` would need `impl_try_into_fdlink!` first (I left them out as I wanted to get one program right first, could be a follow up in case)

### Added/updated tests?

_We strongly encourage you to add a test for your changes._

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

### Checklist

- [x] Rust code has been formatted with `cargo +nightly fmt`.
- [x] All clippy lints have been fixed.
      You can find failing lints with `cargo xtask clippy`.
- [x] Unit tests are passing locally with `cargo test`.
- [x] The [Integration tests] are passing locally.
- [x] I have blessed any API changes with `cargo xtask public-api --bless`.

[Integration tests]: https://github.com/aya-rs/aya/blob/main/test/README.md

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aya-rs/aya/1687)
<!-- Reviewable:end -->
