### PR TITLE
xtask: avoid response timeouts for kernel downloads

### DIFF
--- a/xtask/src/http.rs
+++ b/xtask/src/http.rs
@@ -23,13 +23,12 @@ impl HttpClient {
         const REQUEST_PHASE_TIMEOUT: Duration = Duration::from_secs(30);
         const REQUEST_GLOBAL_TIMEOUT: Duration = Duration::from_secs(15 * 60);
 
-        // Fail fast when request phases stall, but allow kernel module
-        // packages enough end-to-end time to download on a cold cache.
+        // Keep request setup and metadata responses short. Downloads override
+        // the response limits and use the global limit for the transfer.
         let config = ureq::Agent::config_builder()
             .timeout_resolve(Some(REQUEST_PHASE_TIMEOUT))
             .timeout_connect(Some(REQUEST_PHASE_TIMEOUT))
             .timeout_recv_response(Some(REQUEST_PHASE_TIMEOUT))
-            // This is a body read/progress timeout, not a full download cap.
             .timeout_recv_body(Some(REQUEST_PHASE_TIMEOUT))
             .timeout_global(Some(REQUEST_GLOBAL_TIMEOUT))
             .build();
@@ -91,7 +90,19 @@ impl HttpClient {
                 .with_context(|| format!("failed to create {}", parent.display()))?;
         }
 
-        let mut request = self.agent.get(url).header("User-Agent", USER_AGENT);
+        let mut request = self
+            .agent
+            .get(url)
+            .config()
+            // ureq 3.3 also applies the header timeout while reading the body.
+            // TODO(https://github.com/algesten/ureq/pull/1194): remove this
+            // override once the locked ureq dependency includes the fix.
+            .timeout_recv_response(None)
+            // The body timeout is documented as a total duration, not an idle timeout.
+            // Large packages use the global limit instead of the metadata limit.
+            .timeout_recv_body(None)
+            .build()
+            .header("User-Agent", USER_AGENT);
         if dest_path_exists {
             let etag = fs::read_to_string(etag_path).ok();
             if let Some(etag) = etag
@@ -190,4 +201,72 @@ pub(crate) fn url_file_name(url: &str) -> Result<&str> {
         .next()
         .filter(|file_name| !file_name.is_empty())
         .ok_or_else(|| anyhow!("URL has no filename: {url}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{io::BufRead as _, net::TcpListener, thread, time::Instant};
+
+    use super::*;
+
+    #[test]
+    #[cfg_attr(miri, ignore = "requires networking")]
+    fn download_outlives_metadata_timeouts() -> Result<()> {
+        let listener = TcpListener::bind("127.0.0.1:0")?;
+        listener.set_nonblocking(true)?;
+        let url = format!("http://{}/kernel.deb", listener.local_addr()?);
+        let server = thread::spawn(move || -> Result<()> {
+            let deadline = Instant::now() + Duration::from_secs(5);
+            let (mut stream, _) = loop {
+                match listener.accept() {
+                    Ok(connection) => break connection,
+                    Err(error) if error.kind() == io::ErrorKind::WouldBlock => {
+                        if Instant::now() >= deadline {
+                            bail!("timed out waiting for the download request");
+                        }
+                        thread::sleep(Duration::from_millis(10));
+                    }
+                    Err(error) => return Err(error.into()),
+                }
+            };
+            stream.set_nonblocking(false)?;
+            stream.set_read_timeout(Some(Duration::from_secs(5)))?;
+            {
+                let mut request = io::BufReader::new(&stream);
+                loop {
+                    let mut line = String::new();
+                    if request.read_line(&mut line)? == 0 {
+                        bail!("request ended before its headers");
+                    }
+                    if line == "\r\n" {
+                        break;
+                    }
+                }
+            }
+            stream
+                .write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\na")?;
+            // Headers arrive promptly, but the body takes longer than the
+            // metadata response limits without exceeding the global timeout.
+            thread::sleep(Duration::from_secs(1));
+            stream.write_all(b"b")?;
+            Ok(())
+        });
+
+        let client = HttpClient {
+            agent: ureq::Agent::config_builder()
+                .proxy(None)
+                .timeout_recv_response(Some(Duration::from_millis(250)))
+                .timeout_recv_body(Some(Duration::from_millis(250)))
+                .timeout_global(Some(Duration::from_secs(15)))
+                .build()
+                .into(),
+        };
+        let output = tempfile::tempdir()?;
+        let result = client.download_to_dir(&url, output.path());
+        let server_result = server.join().expect("server panicked");
+        let path = result?;
+        server_result?;
+        assert_eq!(fs::read(path)?, b"ab");
+        Ok(())
+    }
 }


### PR DESCRIPTION
https://docs.rs/ureq/3.3.0/ureq/config/struct.ConfigBuilder.html#method.timeout_recv_response

The `timeout_recv_response` API is pretty weird in the ureq.... 

I need a little more time to understand it fully, maybe I should open an upstream ticket.

<!-- markdownlint-disable first-line-heading -->

<!--
    Thank you for your contribution to Aya! 🎉

    For Work In Progress Pull Requests, please use the Draft PR feature.

    Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Aya Contributing Guide: https://github.com/aya-rs/aya/blob/main/CONTRIBUTING.md
     - 📖 Read the Aya Code of Conduct: https://github.com/aya-rs/aya/blob/main/CODE_OF_CONDUCT.md
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages: https://cbea.ms/git-commit/
     - 📗 Update any related documentation.

-->

<!---
      Summarize the changes you're making here. Detailed information belongs in
      the Git commit messages. If your pull request contains just one commit,
      it's best to use its message as a summary. Otherwise, if there are multiple
      atomic commits, write a summary for the entire PR. Feel free to flag
      anything you think needs a reviewer's attention.
-->

<!--
      If your changes address an issue, link it with the *Fixes* tag so
      the issue gets closed when the PR is merged, for example:

      Fixes: #1234

      If you are only referencing an issue without fully addressing it, feel
      free to link it anywhere in the summary.
-->

### Added/updated tests?

_We strongly encourage you to add a test for your changes._

- [ ] Yes
- [x] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

### Checklist

- [x] Rust code has been formatted with `cargo +nightly fmt`.
- [x] All clippy lints have been fixed.
      You can find failing lints with `cargo xtask clippy`.
- [x] Unit tests are passing locally with `cargo test`.
- [x] The [Integration tests] are passing locally.
- [x] I have blessed any API changes with `cargo xtask public-api --bless`.

[Integration tests]: https://github.com/aya-rs/aya/blob/main/test/README.md

### (Optional) What GIF best describes this PR or how it makes you feel?

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aya-rs/aya/1689)
<!-- Reviewable:end -->
