### PR TITLE
fix(aya-ebpf-macros): change return type of `stream_parser` to `i32`

### DIFF
--- a/aya-ebpf-macros/src/lib.rs
+++ b/aya-ebpf-macros/src/lib.rs
@@ -438,15 +438,15 @@ pub fn btf_tracepoint(attrs: TokenStream, item: TokenStream) -> TokenStream {
 ///
 ///
 ///#[stream_parser]
-///fn stream_parser(ctx: SkBuffContext) -> u32 {
+///fn stream_parser(ctx: SkBuffContext) -> i32 {
 ///    match try_stream_parser(ctx) {
 ///        Ok(ret) => ret,
 ///        Err(ret) => ret,
 ///    }
 ///}
 ///
-///fn try_stream_parser(ctx: SkBuffContext) -> Result<u32, u32> {
-///    Ok(ctx.len())
+///fn try_stream_parser(ctx: SkBuffContext) -> Result<i32, i32> {
+///    Ok(ctx.len() as i32)
 ///}
 /// ```
 #[proc_macro_attribute]

--- a/aya-ebpf-macros/src/sk_skb.rs
+++ b/aya-ebpf-macros/src/sk_skb.rs
@@ -48,10 +48,15 @@ impl SkSkb {
         } = item;
         let section_name: Cow<'_, _> = format!("sk_skb/{kind}").into();
         let fn_name = &sig.ident;
+        let return_type = match kind {
+            SkSkbKind::StreamVerdict => quote! { u32 },
+            SkSkbKind::StreamParser => quote! { i32 },
+        };
+
         quote! {
             #[unsafe(no_mangle)]
             #[unsafe(link_section = #section_name)]
-            #vis fn #fn_name(ctx: *mut ::aya_ebpf::bindings::__sk_buff) -> u32 {
+            #vis fn #fn_name(ctx: *mut ::aya_ebpf::bindings::__sk_buff) -> #return_type {
                 // SAFETY: The `ctx` pointer provided by the kernel should be valid.
                 let ctx = unsafe { ::core::ptr::NonNull::new_unchecked(ctx) };
                 return #fn_name(::aya_ebpf::programs::SkBuffContext::new(ctx));
@@ -74,7 +79,7 @@ mod tests {
             SkSkbKind::StreamParser,
             parse_quote! {},
             parse_quote! {
-                fn prog(ctx: &mut ::aya_ebpf::programs::SkBuffContext) -> u32 {
+                fn prog(ctx: &mut ::aya_ebpf::programs::SkBuffContext) -> i32 {
                     0
                 }
             },
@@ -84,12 +89,12 @@ mod tests {
         let expected = quote! {
             #[unsafe(no_mangle)]
             #[unsafe(link_section = "sk_skb/stream_parser")]
-            fn prog(ctx: *mut ::aya_ebpf::bindings::__sk_buff) -> u32 {
+            fn prog(ctx: *mut ::aya_ebpf::bindings::__sk_buff) -> i32 {
                 // SAFETY: The `ctx` pointer provided by the kernel should be valid.
                 let ctx = unsafe { ::core::ptr::NonNull::new_unchecked(ctx) };
                 return prog(::aya_ebpf::programs::SkBuffContext::new(ctx));
 
-                fn prog(ctx: &mut ::aya_ebpf::programs::SkBuffContext) -> u32 {
+                fn prog(ctx: &mut ::aya_ebpf::programs::SkBuffContext) -> i32 {
                     0
                 }
             }


### PR DESCRIPTION
The `#[stream_parser]` macro currently uses `u32` as the return type. However, the eBPF verifier officially supports negative return values for this program type, which require an `i32` return type: https://docs.ebpf.io/linux/program-type/BPF_PROG_TYPE_SK_SKB

Modified the code generation for `#[stream_parser]` to explicitly use `i32` as the return type.  Updated all related doc examples. Let me know if I need (and how) to add tests since I could not find any for these hooks.

Fixes: #1411 

### Added/updated tests?

_We strongly encourage you to add a test for your changes._

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

### Checklist

- [x] Rust code has been formatted with `cargo +nightly fmt`.
- [x] All clippy lints have been fixed.
      You can find failing lints with `cargo xtask clippy`.
- [x] Unit tests are passing locally with `cargo test`.
- [x] The [Integration tests] are passing locally.
- [x] I have blessed any API changes with `cargo xtask public-api --bless`.

[Integration tests]: https://github.com/aya-rs/aya/blob/main/test/README.md

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aya-rs/aya/1690)
<!-- Reviewable:end -->
