### PR TITLE
Appease clippy::needless_borrows_for_generic_args

### DIFF
--- a/test/integration-test/src/tests/uprobe_multi.rs
+++ b/test/integration-test/src/tests/uprobe_multi.rs
@@ -87,7 +87,7 @@ fn test_uprobe_attach_multi() {
         },
     ];
     let attach_res = prog.attach(
-        &points,
+        points,
         Path::new("/proc/self/exe"),
         UProbeScope::CallingProcess,
     );
@@ -171,7 +171,7 @@ fn test_uprobe_unknown_program_falls_back_to_multiple_single_points() {
     ];
     let link_id = prog
         .attach(
-            &points,
+            points,
             Path::new("/proc/self/exe"),
             UProbeScope::CallingProcess,
         )
@@ -196,7 +196,7 @@ fn test_uprobe_unknown_program_falls_back_to_multiple_single_points() {
     // second attach verifies the handle remains usable after fallback and detach.
     let link_id = prog
         .attach(
-            &points,
+            points,
             Path::new("/proc/self/exe"),
             UProbeScope::CallingProcess,
         )
@@ -251,7 +251,7 @@ fn test_uprobe_single_program_composite_link_drop_detaches_all_points() {
     ];
     let link_id = prog
         .attach(
-            &points,
+            points,
             Path::new("/proc/self/exe"),
             UProbeScope::AllProcesses,
         )
@@ -302,7 +302,7 @@ fn test_uprobe_attach_multi_invalid_symbol() {
     let points = [PROG_A, PROG_SYMBOL_INVALID];
 
     let attach_res = prog.attach(
-        &points,
+        points,
         Path::new("/proc/self/exe"),
         UProbeScope::AllProcesses,
     );


### PR DESCRIPTION
Before, on nightly-2026-08-22:
```
  error: the borrowed expression implements the required traits
    --> test/integration-test/src/tests/uprobe_multi.rs:90:9
     |
  90 |         &points,
     |         ^^^^^^^ help: change this to: `points`
     |
     = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_borrows_for_generic_args
     = note: `-D clippy::needless-borrows-for-generic-args` implied by `-D warnings`
     = help: to override `-D warnings` add `#[allow(clippy::needless_borrows_for_generic_args)]`

  error: the borrowed expression implements the required traits
     --> test/integration-test/src/tests/uprobe_multi.rs:174:13
      |
  174 |             &points,
      |             ^^^^^^^ help: change this to: `points`
      |
      = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_borrows_for_generic_args

  error: the borrowed expression implements the required traits
     --> test/integration-test/src/tests/uprobe_multi.rs:199:13
      |
  199 |             &points,
      |             ^^^^^^^ help: change this to: `points`
      |
      = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_borrows_for_generic_args

  error: the borrowed expression implements the required traits
     --> test/integration-test/src/tests/uprobe_multi.rs:254:13
      |
  254 |             &points,
      |             ^^^^^^^ help: change this to: `points`
      |
      = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_borrows_for_generic_args

  error: the borrowed expression implements the required traits
     --> test/integration-test/src/tests/uprobe_multi.rs:305:9
      |
  305 |         &points,
      |         ^^^^^^^ help: change this to: `points`
      |
      = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_borrows_for_generic_args
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aya-rs/aya/1693)
<!-- Reviewable:end -->
