### PR TITLE
ci: validate Rust toolchain resolution on PRs

### DIFF
--- a/.github/actions/codegen/action.yml
+++ b/.github/actions/codegen/action.yml
@@ -17,7 +17,8 @@ runs:
     - uses: Swatinem/rust-cache@v2
       with:
         shared-key: codegen
-        save-if: ${{ github.event_name != 'pull_request' }}
+        save-if: >-
+          ${{ github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}
 
     - name: Install headers
       shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,11 +116,12 @@ jobs:
           components: clippy,miri,rustfmt,rust-src
 
       # Cache usage approaches GitHub's default 10 GB repository allowance.
-      # PR-scoped entries can only help reruns of one PR, but repeatedly evict
-      # main caches that every PR can restore. Keep PRs restore-only.
+      # Only save default-branch entries, which every branch and PR can
+      # restore, so branch- and PR-scoped entries do not evict shared caches.
       - uses: Swatinem/rust-cache@v2
         with:
-          save-if: ${{ github.event_name != 'pull_request' }}
+          save-if: >-
+            ${{ github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}
 
       - uses: taiki-e/install-action@v2.86.3
         with:
@@ -181,11 +182,12 @@ jobs:
           targets: ${{ matrix.arch }}
 
       # Cache usage approaches GitHub's default 10 GB repository allowance.
-      # PR-scoped entries can only help reruns of one PR, but repeatedly evict
-      # main caches that every PR can restore. Keep PRs restore-only.
+      # Only save default-branch entries, which every branch and PR can
+      # restore, so branch- and PR-scoped entries do not evict shared caches.
       - uses: Swatinem/rust-cache@v2
         with:
-          save-if: ${{ github.event_name != 'pull_request' }}
+          save-if: >-
+            ${{ github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}
 
       - uses: taiki-e/install-action@v2.86.3
         with:
@@ -263,11 +265,12 @@ jobs:
           toolchain: ${{ fromJSON(needs.prepare.outputs.rust-toolchains).stable }}
 
       # Cache usage approaches GitHub's default 10 GB repository allowance.
-      # PR-scoped entries can only help reruns of one PR, but repeatedly evict
-      # main caches that every PR can restore. Keep PRs restore-only.
+      # Only save default-branch entries, which every branch and PR can
+      # restore, so branch- and PR-scoped entries do not evict shared caches.
       - uses: Swatinem/rust-cache@v2
         with:
-          save-if: ${{ github.event_name != 'pull_request' }}
+          save-if: >-
+            ${{ github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}
 
       - uses: taiki-e/install-action@v2.86.3
         with:
@@ -419,11 +422,12 @@ jobs:
           targets: aarch64-unknown-linux-musl,x86_64-unknown-linux-musl
 
       # Cache usage approaches GitHub's default 10 GB repository allowance.
-      # PR-scoped entries can only help reruns of one PR, but repeatedly evict
-      # main caches that every PR can restore. Keep PRs restore-only.
+      # Only save default-branch entries, which every branch and PR can
+      # restore, so branch- and PR-scoped entries do not evict shared caches.
       - uses: Swatinem/rust-cache@v2
         with:
-          save-if: ${{ github.event_name != 'pull_request' }}
+          save-if: >-
+            ${{ github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}
 
       - uses: taiki-e/install-action@v2.86.3
         with:
@@ -462,7 +466,7 @@ jobs:
         if: >-
           matrix.vm-kernels != 'local' &&
           steps.vm-cache.outputs.cache-hit != 'true' &&
-          github.event_name != 'pull_request'
+          github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
         uses: actions/cache/save@v6
         with:
           path: test/.tmp

--- a/.github/workflows/nightly-update.yml
+++ b/.github/workflows/nightly-update.yml
@@ -1,6 +1,12 @@
 name: Update Rust toolchains
 
 on:
+  pull_request:
+    paths:
+      - .github/workflows/nightly-update.yml
+      - .github/workflows/rust-toolchains.yml
+      - scripts/rust_toolchains.py
+
   push:
     branches:
       - main
@@ -16,13 +22,14 @@ jobs:
       contents: read
     uses: ./.github/workflows/rust-toolchains.yml
     with:
-      channels: stable nightly
+      channels: >-
+        ${{ github.ref == format('refs/heads/{0}', github.event.repository.default_branch) &&
+        'stable nightly' || 'stable beta nightly' }}
 
   # Repository-local: regenerate files and publish the update pull request.
   update:
     needs: resolve
     if: >-
-      github.repository == needs.resolve.outputs.provider-repository &&
       github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/rust-toolchains.yml
+++ b/.github/workflows/rust-toolchains.yml
@@ -11,9 +11,6 @@ on:
       rust-toolchains:
         description: Immutable toolchain names and rustc commits by channel
         value: ${{ jobs.resolve.outputs.rust-toolchains }}
-      provider-repository:
-        description: Repository containing this workflow
-        value: ${{ jobs.resolve.outputs.provider-repository }}
 
 permissions:
   contents: read
@@ -23,7 +20,6 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       rust-toolchains: ${{ steps.resolve.outputs.rust-toolchains }}
-      provider-repository: ${{ job.workflow_repository }}
     steps:
       - uses: actions/checkout@v7
         with:


### PR DESCRIPTION
Exercise Rust channel discovery in PRs and reserve promotion and cache writes for the default branch.

— Codex, on behalf of @tamird

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aya-rs/aya/1694)
<!-- Reviewable:end -->
