### PR TITLE
ci: Rust 1.98.1, nightly-2026-09-10, xtask clippy pass

### DIFF
--- a/aya-ebpf-macros/src/lib.rs
+++ b/aya-ebpf-macros/src/lib.rs
@@ -27,6 +27,8 @@ mod tracepoint;
 mod uprobe;
 mod xdp;
 
+#[cfg(test)]
+use aya_ebpf as _;
 use btf_map::BtfMap;
 use btf_tracepoint::BtfTracePoint;
 use cgroup_device::CgroupDevice;

--- a/aya-log/src/lib.rs
+++ b/aya-log/src/lib.rs
@@ -74,8 +74,12 @@ use aya::{
 };
 pub use aya_log_common::Level;
 use aya_log_common::{ArgumentKind, DisplayHint, LogValueLength, RecordFieldKind};
+#[cfg(test)]
+use env_logger as _;
 use log::{Log, Record, error};
 use thiserror::Error;
+#[cfg(test)]
+use tokio as _;
 
 #[derive(Copy, Clone)]
 #[repr(transparent)]

--- a/aya-obj/src/lib.rs
+++ b/aya-obj/src/lib.rs
@@ -99,6 +99,8 @@ mod util;
 pub use extern_types::KsymsError;
 pub use maps::Map;
 pub use obj::*;
+#[cfg(test)]
+use rbpf as _;
 
 /// An error returned from the verifier.
 ///

--- a/aya-tool/src/bin/aya-tool.rs
+++ b/aya-tool/src/bin/aya-tool.rs
@@ -1,7 +1,10 @@
 use std::path::PathBuf;
 
 use aya_tool::generate::{InputFile, generate};
+use bindgen as _;
 use clap::Parser;
+use tempfile as _;
+use thiserror as _;
 
 #[derive(Parser)]
 pub struct Options {

--- a/aya-tool/src/lib.rs
+++ b/aya-tool/src/lib.rs
@@ -1,2 +1,5 @@
 pub mod bindgen;
 pub mod generate;
+
+use anyhow as _;
+use clap as _;

--- a/aya/src/lib.rs
+++ b/aya/src/lib.rs
@@ -47,6 +47,8 @@ pub mod programs;
 pub mod sys;
 #[cfg(feature = "test-helpers")]
 pub mod test_helpers;
+#[cfg(any(test, feature = "test-helpers"))]
+use nix as _;
 pub mod util;
 
 use std::os::fd::{AsFd, AsRawFd, BorrowedFd, FromRawFd, OwnedFd, RawFd};

--- a/test/integration-ebpf/src/array.rs
+++ b/test/integration-ebpf/src/array.rs
@@ -1,8 +1,20 @@
 #![no_std]
 #![no_main]
+#![allow(
+    unused_crate_dependencies,
+    reason = "ebpf_panic is only required for non-test eBPF builds; importing it unconditionally would register its panic handler during tests and conflict with std"
+)]
 
 #[cfg(not(test))]
 extern crate ebpf_panic;
+
+// Required for satisfying unused-crate-dependencies lint
+#[rustfmt::skip]
+use aya_log_ebpf as _;
+#[rustfmt::skip]
+use integration_ebpf as _;
+#[rustfmt::skip]
+use network_types as _;
 
 use aya_ebpf::{
     btf_maps::Array,

--- a/test/integration-ebpf/src/bloom_filter.rs
+++ b/test/integration-ebpf/src/bloom_filter.rs
@@ -1,8 +1,20 @@
 #![no_std]
 #![no_main]
+#![allow(
+    unused_crate_dependencies,
+    reason = "ebpf_panic is only required for non-test eBPF builds; importing it unconditionally would register its panic handler during tests and conflict with std"
+)]
 
 #[cfg(not(test))]
 extern crate ebpf_panic;
+
+// Required for satisfying unused-crate-dependencies lint
+#[rustfmt::skip]
+use aya_log_ebpf as _;
+#[rustfmt::skip]
+use integration_ebpf as _;
+#[rustfmt::skip]
+use network_types as _;
 
 use aya_ebpf::{
     btf_maps::{Array as BtfArray, BloomFilter as BtfBloomFilter},

--- a/test/integration-ebpf/src/bpf_probe_read.rs
+++ b/test/integration-ebpf/src/bpf_probe_read.rs
@@ -1,5 +1,20 @@
 #![no_std]
 #![no_main]
+#![allow(
+    unused_crate_dependencies,
+    reason = "ebpf_panic is only required for non-test eBPF builds; importing it unconditionally would register its panic handler during tests and conflict with std"
+)]
+
+#[cfg(not(test))]
+extern crate ebpf_panic;
+
+// Required for satisfying unused-crate-dependencies lint
+#[rustfmt::skip]
+use aya_log_ebpf as _;
+#[rustfmt::skip]
+use integration_ebpf as _;
+#[rustfmt::skip]
+use network_types as _;
 
 use aya_ebpf::{
     helpers::{bpf_probe_read_kernel_str_bytes, bpf_probe_read_user_str_bytes},
@@ -8,8 +23,6 @@ use aya_ebpf::{
     programs::ProbeContext,
 };
 use integration_common::bpf_probe_read::{RESULT_BUF_LEN, TestResult};
-#[cfg(not(test))]
-extern crate ebpf_panic;
 
 fn read_str_bytes(
     fun: unsafe fn(*const u8, &mut [u8]) -> Result<&[u8], i32>,

--- a/test/integration-ebpf/src/btf_map_of_maps.rs
+++ b/test/integration-ebpf/src/btf_map_of_maps.rs
@@ -1,9 +1,24 @@
-#![no_std]
-#![no_main]
-
 //! BTF-compatible map-of-maps tests.
 //!
 //! Uses BTF map definitions compatible with both aya and libbpf loaders.
+
+#![no_std]
+#![no_main]
+#![allow(
+    unused_crate_dependencies,
+    reason = "ebpf_panic is only required for non-test eBPF builds; importing it unconditionally would register its panic handler during tests and conflict with std"
+)]
+
+#[cfg(not(test))]
+extern crate ebpf_panic;
+
+// Required for satisfying unused-crate-dependencies lint
+#[rustfmt::skip]
+use aya_log_ebpf as _;
+#[rustfmt::skip]
+use integration_ebpf as _;
+#[rustfmt::skip]
+use network_types as _;
 
 use aya_ebpf::{
     btf_maps::{Array, ArrayOfMaps, HashOfMaps},
@@ -11,9 +26,6 @@ use aya_ebpf::{
     programs::ProbeContext,
 };
 use integration_common::btf_map_of_maps::{INNER_MAX_ENTRIES, TestResult};
-
-#[cfg(not(test))]
-extern crate ebpf_panic;
 
 #[btf_map]
 static ARRAY_OF_MAPS: ArrayOfMaps<Array<u32, { INNER_MAX_ENTRIES as usize }>, 4> =

--- a/test/integration-ebpf/src/btf_maps_plain.rs
+++ b/test/integration-ebpf/src/btf_maps_plain.rs
@@ -5,9 +5,23 @@
 
 #![no_std]
 #![no_main]
+#![allow(
+    unused_crate_dependencies,
+    reason = "ebpf_panic is only required for non-test eBPF builds; importing it unconditionally would register its panic handler during tests and conflict with std"
+)]
 
 #[cfg(not(test))]
 extern crate ebpf_panic;
+
+// Required for satisfying unused-crate-dependencies lint
+#[rustfmt::skip]
+use aya_log_ebpf as _;
+#[rustfmt::skip]
+use integration_ebpf as _;
+#[rustfmt::skip]
+use integration_common as _;
+#[rustfmt::skip]
+use network_types as _;
 
 use aya_ebpf::{
     btf_maps::Array,

--- a/test/integration-ebpf/src/cgroup_array.rs
+++ b/test/integration-ebpf/src/cgroup_array.rs
@@ -1,8 +1,20 @@
 #![no_std]
 #![no_main]
+#![allow(
+    unused_crate_dependencies,
+    reason = "ebpf_panic is only required for non-test eBPF builds; importing it unconditionally would register its panic handler during tests and conflict with std"
+)]
 
 #[cfg(not(test))]
 extern crate ebpf_panic;
+
+// Required for satisfying unused-crate-dependencies lint
+#[rustfmt::skip]
+use aya_log_ebpf as _;
+#[rustfmt::skip]
+use integration_ebpf as _;
+#[rustfmt::skip]
+use network_types as _;
 
 use aya_ebpf::{
     btf_maps::{Array as BtfArray, CgroupArray as BtfCgroupArray},

--- a/test/integration-ebpf/src/cgroup_connect.rs
+++ b/test/integration-ebpf/src/cgroup_connect.rs
@@ -1,8 +1,22 @@
 #![no_std]
 #![no_main]
+#![allow(
+    unused_crate_dependencies,
+    reason = "ebpf_panic is only required for non-test eBPF builds; importing it unconditionally would register its panic handler during tests and conflict with std"
+)]
 
 #[cfg(not(test))]
 extern crate ebpf_panic;
+
+// Required for satisfying unused-crate-dependencies lint
+#[rustfmt::skip]
+use aya_log_ebpf as _;
+#[rustfmt::skip]
+use integration_ebpf as _;
+#[rustfmt::skip]
+use integration_common as _;
+#[rustfmt::skip]
+use network_types as _;
 
 use aya_ebpf::{bindings::sk_action, macros::cgroup_sock_addr, programs::SockAddrContext};
 

--- a/test/integration-ebpf/src/cgroup_storage.rs
+++ b/test/integration-ebpf/src/cgroup_storage.rs
@@ -4,9 +4,23 @@
     deprecated,
     reason = "exercising the deprecated cgroup storage map types"
 )]
+#![allow(
+    unused_crate_dependencies,
+    reason = "ebpf_panic is only required for non-test eBPF builds; importing it unconditionally would register its panic handler during tests and conflict with std"
+)]
 
 #[cfg(not(test))]
 extern crate ebpf_panic;
+
+// Required for satisfying unused-crate-dependencies lint
+#[rustfmt::skip]
+use aya_log_ebpf as _;
+#[rustfmt::skip]
+use integration_ebpf as _;
+#[rustfmt::skip]
+use integration_common as _;
+#[rustfmt::skip]
+use network_types as _;
 
 use aya_ebpf::{
     bindings::sk_action,

--- a/test/integration-ebpf/src/cgrp_storage.rs
+++ b/test/integration-ebpf/src/cgrp_storage.rs
@@ -1,8 +1,20 @@
 #![no_std]
 #![no_main]
+#![allow(
+    unused_crate_dependencies,
+    reason = "ebpf_panic is only required for non-test eBPF builds; importing it unconditionally would register its panic handler during tests and conflict with std"
+)]
 
 #[cfg(not(test))]
 extern crate ebpf_panic;
+
+// Required for satisfying unused-crate-dependencies lint
+#[rustfmt::skip]
+use aya_log_ebpf as _;
+#[rustfmt::skip]
+use integration_ebpf as _;
+#[rustfmt::skip]
+use network_types as _;
 
 use aya_ebpf::{
     bindings::cgroup,

--- a/test/integration-ebpf/src/cpu_map.rs
+++ b/test/integration-ebpf/src/cpu_map.rs
@@ -1,5 +1,22 @@
 #![no_std]
 #![no_main]
+#![allow(
+    unused_crate_dependencies,
+    reason = "ebpf_panic is only required for non-test eBPF builds; importing it unconditionally would register its panic handler during tests and conflict with std"
+)]
+
+#[cfg(not(test))]
+extern crate ebpf_panic;
+
+// Required for satisfying unused-crate-dependencies lint
+#[rustfmt::skip]
+use aya_log_ebpf as _;
+#[rustfmt::skip]
+use integration_ebpf as _;
+#[rustfmt::skip]
+use integration_common as _;
+#[rustfmt::skip]
+use network_types as _;
 
 use aya_ebpf::{
     bindings::xdp_action,
@@ -8,8 +25,6 @@ use aya_ebpf::{
     maps::{Array, CpuMap},
     programs::XdpContext,
 };
-#[cfg(not(test))]
-extern crate ebpf_panic;
 
 #[map]
 static CPUS: CpuMap = CpuMap::with_max_entries(1, 0);

--- a/test/integration-ebpf/src/dev_map.rs
+++ b/test/integration-ebpf/src/dev_map.rs
@@ -1,5 +1,22 @@
 #![no_std]
 #![no_main]
+#![allow(
+    unused_crate_dependencies,
+    reason = "ebpf_panic is only required for non-test eBPF builds; importing it unconditionally would register its panic handler during tests and conflict with std"
+)]
+
+#[cfg(not(test))]
+extern crate ebpf_panic;
+
+// Required for satisfying unused-crate-dependencies lint
+#[rustfmt::skip]
+use aya_log_ebpf as _;
+#[rustfmt::skip]
+use integration_ebpf as _;
+#[rustfmt::skip]
+use integration_common as _;
+#[rustfmt::skip]
+use network_types as _;
 
 use aya_ebpf::{
     bindings::xdp_action,
@@ -8,8 +25,6 @@ use aya_ebpf::{
     maps::{DevMap, DevMapHash, xdp::DevMapValue},
     programs::XdpContext,
 };
-#[cfg(not(test))]
-extern crate ebpf_panic;
 
 #[map]
 static DEVS: DevMap = DevMap::with_max_entries(1, 0);

--- a/test/integration-ebpf/src/fexit.rs
+++ b/test/integration-ebpf/src/fexit.rs
@@ -1,5 +1,20 @@
 #![no_std]
 #![no_main]
+#![allow(
+    unused_crate_dependencies,
+    reason = "ebpf_panic is only required for non-test eBPF builds; importing it unconditionally would register its panic handler during tests and conflict with std"
+)]
+
+#[cfg(not(test))]
+extern crate ebpf_panic;
+
+// Required for satisfying unused-crate-dependencies lint
+#[rustfmt::skip]
+use aya_log_ebpf as _;
+#[rustfmt::skip]
+use integration_ebpf as _;
+#[rustfmt::skip]
+use network_types as _;
 
 use core::ffi::c_void;
 
@@ -14,8 +29,6 @@ use integration_common::fexit::{
     TEST3_INDEX, TEST4_INDEX, TEST5_INDEX, TEST6_INDEX, TEST7_INDEX, TEST8_INDEX, TEST9_INDEX,
     TEST10_INDEX, TestResult,
 };
-#[cfg(not(test))]
-extern crate ebpf_panic;
 
 // FEXIT program return values are ignored by the tracing test-run path.
 const DUMMY_FEXIT_PROG_RETVAL: i32 = 0xa7a;

--- a/test/integration-ebpf/src/hash_map.rs
+++ b/test/integration-ebpf/src/hash_map.rs
@@ -1,8 +1,22 @@
 #![no_std]
 #![no_main]
+#![allow(
+    unused_crate_dependencies,
+    reason = "ebpf_panic is only required for non-test eBPF builds; importing it unconditionally would register its panic handler during tests and conflict with std"
+)]
 
 #[cfg(not(test))]
 extern crate ebpf_panic;
+
+// Required for satisfying unused-crate-dependencies lint
+#[rustfmt::skip]
+use aya_log_ebpf as _;
+#[rustfmt::skip]
+use integration_ebpf as _;
+#[rustfmt::skip]
+use integration_common as _;
+#[rustfmt::skip]
+use network_types as _;
 
 use aya_ebpf::{
     btf_maps::{

--- a/test/integration-ebpf/src/inode_storage.rs
+++ b/test/integration-ebpf/src/inode_storage.rs
@@ -1,8 +1,20 @@
 #![no_std]
 #![no_main]
+#![allow(
+    unused_crate_dependencies,
+    reason = "ebpf_panic is only required for non-test eBPF builds; importing it unconditionally would register its panic handler during tests and conflict with std"
+)]
 
 #[cfg(not(test))]
 extern crate ebpf_panic;
+
+// Required for satisfying unused-crate-dependencies lint
+#[rustfmt::skip]
+use aya_log_ebpf as _;
+#[rustfmt::skip]
+use integration_ebpf as _;
+#[rustfmt::skip]
+use network_types as _;
 
 use aya_ebpf::{
     EbpfContext as _,

--- a/test/integration-ebpf/src/kprobe.rs
+++ b/test/integration-ebpf/src/kprobe.rs
@@ -3,6 +3,23 @@
 #![expect(internal_features, reason = "atomic_xadd is unstable")]
 #![expect(unstable_features, reason = "atomic_xadd is unstable")]
 #![feature(core_intrinsics)]
+#![allow(
+    unused_crate_dependencies,
+    reason = "ebpf_panic is only required for non-test eBPF builds; importing it unconditionally would register its panic handler during tests and conflict with std"
+)]
+
+#[cfg(not(test))]
+extern crate ebpf_panic;
+
+// Required for satisfying unused-crate-dependencies lint
+#[rustfmt::skip]
+use aya_log_ebpf as _;
+#[rustfmt::skip]
+use integration_ebpf as _;
+#[rustfmt::skip]
+use integration_common as _;
+#[rustfmt::skip]
+use network_types as _;
 
 use aya_ebpf::{
     EbpfContext as _, Global,
@@ -10,8 +27,6 @@ use aya_ebpf::{
     maps::Array,
     programs::ProbeContext,
 };
-#[cfg(not(test))]
-extern crate ebpf_panic;
 
 const INDEX: u32 = 0;
 

--- a/test/integration-ebpf/src/lib.rs
+++ b/test/integration-ebpf/src/lib.rs
@@ -1,3 +1,15 @@
 #![no_std]
+#![allow(
+    unused_crate_dependencies,
+    reason = "ebpf_panic is only required for non-test eBPF builds; importing it unconditionally would register its panic handler during tests and conflict with std"
+)]
 
-// This file exists to enable the library target.
+// Required for satisfying unused-crate-dependencies lint
+#[rustfmt::skip]
+use aya_ebpf as _;
+#[rustfmt::skip]
+use aya_log_ebpf as _;
+#[rustfmt::skip]
+use integration_common as _;
+#[rustfmt::skip]
+use network_types as _;

--- a/test/integration-ebpf/src/linear_data_structures.rs
+++ b/test/integration-ebpf/src/linear_data_structures.rs
@@ -1,8 +1,20 @@
 #![no_std]
 #![no_main]
+#![allow(
+    unused_crate_dependencies,
+    reason = "ebpf_panic is only required for non-test eBPF builds; importing it unconditionally would register its panic handler during tests and conflict with std"
+)]
 
 #[cfg(not(test))]
 extern crate ebpf_panic;
+
+// Required for satisfying unused-crate-dependencies lint
+#[rustfmt::skip]
+use aya_log_ebpf as _;
+#[rustfmt::skip]
+use integration_ebpf as _;
+#[rustfmt::skip]
+use network_types as _;
 
 use aya_ebpf::{
     btf_maps::{Array as BtfArray, Queue as BtfQueue, Stack as BtfStack},

--- a/test/integration-ebpf/src/log.rs
+++ b/test/integration-ebpf/src/log.rs
@@ -1,5 +1,18 @@
 #![no_std]
 #![no_main]
+#![allow(
+    unused_crate_dependencies,
+    reason = "ebpf_panic is only required for non-test eBPF builds; importing it unconditionally would register its panic handler during tests and conflict with std"
+)]
+
+#[cfg(not(test))]
+extern crate ebpf_panic;
+
+// Required for satisfying unused-crate-dependencies lint
+#[rustfmt::skip]
+use integration_ebpf as _;
+#[rustfmt::skip]
+use network_types as _;
 
 use core::{
     hint::black_box,
@@ -13,8 +26,6 @@ use aya_ebpf::{
 };
 use aya_log_ebpf::{debug, error, info, trace, warn};
 use integration_common::log::Buffer;
-#[cfg(not(test))]
-extern crate ebpf_panic;
 
 #[map]
 static BUFFER: Array<Buffer> = Array::with_max_entries(1, 0);

--- a/test/integration-ebpf/src/lpm_trie.rs
+++ b/test/integration-ebpf/src/lpm_trie.rs
@@ -1,8 +1,20 @@
 #![no_std]
 #![no_main]
+#![allow(
+    unused_crate_dependencies,
+    reason = "ebpf_panic is only required for non-test eBPF builds; importing it unconditionally would register its panic handler during tests and conflict with std"
+)]
 
 #[cfg(not(test))]
 extern crate ebpf_panic;
+
+// Required for satisfying unused-crate-dependencies lint
+#[rustfmt::skip]
+use aya_log_ebpf as _;
+#[rustfmt::skip]
+use integration_ebpf as _;
+#[rustfmt::skip]
+use network_types as _;
 
 use aya_ebpf::{
     btf_maps::{Array as BtfArray, LpmTrie as BtfLpmTrie, lpm_trie::Key},

--- a/test/integration-ebpf/src/map_test.rs
+++ b/test/integration-ebpf/src/map_test.rs
@@ -1,13 +1,28 @@
 #![no_std]
 #![no_main]
+#![allow(
+    unused_crate_dependencies,
+    reason = "ebpf_panic is only required for non-test eBPF builds; importing it unconditionally would register its panic handler during tests and conflict with std"
+)]
+
+#[cfg(not(test))]
+extern crate ebpf_panic;
+
+// Required for satisfying unused-crate-dependencies lint
+#[rustfmt::skip]
+use aya_log_ebpf as _;
+#[rustfmt::skip]
+use integration_ebpf as _;
+#[rustfmt::skip]
+use integration_common as _;
+#[rustfmt::skip]
+use network_types as _;
 
 use aya_ebpf::{
     macros::{map, socket_filter, uprobe},
     maps::{Array, HashMap},
     programs::{ProbeContext, SkBuffContext},
 };
-#[cfg(not(test))]
-extern crate ebpf_panic;
 
 // Introduced in kernel v3.19.
 #[map]

--- a/test/integration-ebpf/src/memmove_test.rs
+++ b/test/integration-ebpf/src/memmove_test.rs
@@ -1,5 +1,20 @@
 #![no_std]
 #![no_main]
+#![allow(
+    unused_crate_dependencies,
+    reason = "ebpf_panic is only required for non-test eBPF builds; importing it unconditionally would register its panic handler during tests and conflict with std"
+)]
+
+#[cfg(not(test))]
+extern crate ebpf_panic;
+
+// Required for satisfying unused-crate-dependencies lint
+#[rustfmt::skip]
+use aya_log_ebpf as _;
+#[rustfmt::skip]
+use integration_ebpf as _;
+#[rustfmt::skip]
+use integration_common as _;
 
 use core::mem;
 
@@ -9,8 +24,6 @@ use aya_ebpf::{
     maps::HashMap,
     programs::XdpContext,
 };
-#[cfg(not(test))]
-extern crate ebpf_panic;
 use network_types::{
     eth::{EthHdr, EtherType},
     ip::Ipv6Hdr,

--- a/test/integration-ebpf/src/name_test.rs
+++ b/test/integration-ebpf/src/name_test.rs
@@ -1,9 +1,24 @@
 #![no_std]
 #![no_main]
+#![allow(
+    unused_crate_dependencies,
+    reason = "ebpf_panic is only required for non-test eBPF builds; importing it unconditionally would register its panic handler during tests and conflict with std"
+)]
 
-use aya_ebpf::{bindings::xdp_action, macros::xdp, programs::XdpContext};
 #[cfg(not(test))]
 extern crate ebpf_panic;
+
+// Required for satisfying unused-crate-dependencies lint
+#[rustfmt::skip]
+use aya_log_ebpf as _;
+#[rustfmt::skip]
+use integration_ebpf as _;
+#[rustfmt::skip]
+use integration_common as _;
+#[rustfmt::skip]
+use network_types as _;
+
+use aya_ebpf::{bindings::xdp_action, macros::xdp, programs::XdpContext};
 
 #[xdp]
 const fn ihaveaverylongname(_ctx: XdpContext) -> u32 {

--- a/test/integration-ebpf/src/pass.rs
+++ b/test/integration-ebpf/src/pass.rs
@@ -1,9 +1,24 @@
 #![no_std]
 #![no_main]
+#![allow(
+    unused_crate_dependencies,
+    reason = "ebpf_panic is only required for non-test eBPF builds; importing it unconditionally would register its panic handler during tests and conflict with std"
+)]
 
-use aya_ebpf::{bindings::xdp_action, macros::xdp, programs::XdpContext};
 #[cfg(not(test))]
 extern crate ebpf_panic;
+
+// Required for satisfying unused-crate-dependencies lint
+#[rustfmt::skip]
+use aya_log_ebpf as _;
+#[rustfmt::skip]
+use integration_ebpf as _;
+#[rustfmt::skip]
+use integration_common as _;
+#[rustfmt::skip]
+use network_types as _;
+
+use aya_ebpf::{bindings::xdp_action, macros::xdp, programs::XdpContext};
 
 // Note: the `frags` attribute causes this probe to be incompatible with kernel versions < 5.18.0.
 // See https://github.com/torvalds/linux/commit/c2f2cdb.

--- a/test/integration-ebpf/src/per_cpu_array.rs
+++ b/test/integration-ebpf/src/per_cpu_array.rs
@@ -1,8 +1,20 @@
 #![no_std]
 #![no_main]
+#![allow(
+    unused_crate_dependencies,
+    reason = "ebpf_panic is only required for non-test eBPF builds; importing it unconditionally would register its panic handler during tests and conflict with std"
+)]
 
 #[cfg(not(test))]
 extern crate ebpf_panic;
+
+// Required for satisfying unused-crate-dependencies lint
+#[rustfmt::skip]
+use aya_log_ebpf as _;
+#[rustfmt::skip]
+use integration_ebpf as _;
+#[rustfmt::skip]
+use network_types as _;
 
 use aya_ebpf::{
     btf_maps::{Array as BtfArray, PerCpuArray as BtfPerCpuArray},

--- a/test/integration-ebpf/src/perf_event_array.rs
+++ b/test/integration-ebpf/src/perf_event_array.rs
@@ -1,8 +1,22 @@
 #![no_std]
 #![no_main]
+#![allow(
+    unused_crate_dependencies,
+    reason = "ebpf_panic is only required for non-test eBPF builds; importing it unconditionally would register its panic handler during tests and conflict with std"
+)]
 
 #[cfg(not(test))]
 extern crate ebpf_panic;
+
+// Required for satisfying unused-crate-dependencies lint
+#[rustfmt::skip]
+use aya_log_ebpf as _;
+#[rustfmt::skip]
+use integration_ebpf as _;
+#[rustfmt::skip]
+use integration_common as _;
+#[rustfmt::skip]
+use network_types as _;
 
 use aya_ebpf::{
     btf_maps::PerfEventArray as BtfPerfEventArray,

--- a/test/integration-ebpf/src/perf_event_bp.rs
+++ b/test/integration-ebpf/src/perf_event_bp.rs
@@ -1,5 +1,22 @@
 #![no_std]
 #![no_main]
+#![allow(
+    unused_crate_dependencies,
+    reason = "ebpf_panic is only required for non-test eBPF builds; importing it unconditionally would register its panic handler during tests and conflict with std"
+)]
+
+#[cfg(not(test))]
+extern crate ebpf_panic;
+
+// Required for satisfying unused-crate-dependencies lint
+#[rustfmt::skip]
+use aya_log_ebpf as _;
+#[rustfmt::skip]
+use integration_ebpf as _;
+#[rustfmt::skip]
+use integration_common as _;
+#[rustfmt::skip]
+use network_types as _;
 
 use aya_ebpf::{
     EbpfContext as _,
@@ -7,9 +24,6 @@ use aya_ebpf::{
     maps::HashMap,
     programs::PerfEventContext,
 };
-
-#[cfg(not(test))]
-extern crate ebpf_panic;
 
 #[map]
 static READERS: HashMap<u32, u64> = HashMap::with_max_entries(1, 0);

--- a/test/integration-ebpf/src/perf_event_byte_array.rs
+++ b/test/integration-ebpf/src/perf_event_byte_array.rs
@@ -1,8 +1,22 @@
 #![no_std]
 #![no_main]
+#![allow(
+    unused_crate_dependencies,
+    reason = "ebpf_panic is only required for non-test eBPF builds; importing it unconditionally would register its panic handler during tests and conflict with std"
+)]
 
 #[cfg(not(test))]
 extern crate ebpf_panic;
+
+// Required for satisfying unused-crate-dependencies lint
+#[rustfmt::skip]
+use aya_log_ebpf as _;
+#[rustfmt::skip]
+use integration_ebpf as _;
+#[rustfmt::skip]
+use integration_common as _;
+#[rustfmt::skip]
+use network_types as _;
 
 use aya_ebpf::{
     btf_maps::PerfEventByteArray as BtfPerfEventByteArray,

--- a/test/integration-ebpf/src/printk_test.rs
+++ b/test/integration-ebpf/src/printk_test.rs
@@ -2,14 +2,27 @@
 
 #![no_std]
 #![no_main]
+#![allow(
+    unused_crate_dependencies,
+    reason = "ebpf_panic is only required for non-test eBPF builds; importing it unconditionally would register its panic handler during tests and conflict with std"
+)]
+
+#[cfg(not(test))]
+extern crate ebpf_panic;
+
+// Required for satisfying unused-crate-dependencies lint
+#[rustfmt::skip]
+use aya_log_ebpf as _;
+#[rustfmt::skip]
+use integration_ebpf as _;
+#[rustfmt::skip]
+use network_types as _;
 
 use aya_ebpf::{helpers::bpf_printk, macros::uprobe, programs::ProbeContext};
 use integration_common::printk::{
     C_MARKER, TEST_CHAR, TEST_I8, TEST_I16, TEST_I32, TEST_I64, TEST_ISIZE, TEST_U8, TEST_U16,
     TEST_U32, TEST_U64, TEST_USIZE,
 };
-#[cfg(not(test))]
-extern crate ebpf_panic;
 
 #[uprobe]
 fn test_bpf_printk(_ctx: ProbeContext) {

--- a/test/integration-ebpf/src/prog_array.rs
+++ b/test/integration-ebpf/src/prog_array.rs
@@ -1,8 +1,20 @@
 #![no_std]
 #![no_main]
+#![allow(
+    unused_crate_dependencies,
+    reason = "ebpf_panic is only required for non-test eBPF builds; importing it unconditionally would register its panic handler during tests and conflict with std"
+)]
 
 #[cfg(not(test))]
 extern crate ebpf_panic;
+
+// Required for satisfying unused-crate-dependencies lint
+#[rustfmt::skip]
+use aya_log_ebpf as _;
+#[rustfmt::skip]
+use integration_ebpf as _;
+#[rustfmt::skip]
+use network_types as _;
 
 use aya_ebpf::{
     btf_maps::{Array as BtfArray, ProgramArray as BtfProgramArray},

--- a/test/integration-ebpf/src/raw_tracepoint.rs
+++ b/test/integration-ebpf/src/raw_tracepoint.rs
@@ -1,5 +1,20 @@
 #![no_std]
 #![no_main]
+#![allow(
+    unused_crate_dependencies,
+    reason = "ebpf_panic is only required for non-test eBPF builds; importing it unconditionally would register its panic handler during tests and conflict with std"
+)]
+
+#[cfg(not(test))]
+extern crate ebpf_panic;
+
+// Required for satisfying unused-crate-dependencies lint
+#[rustfmt::skip]
+use aya_log_ebpf as _;
+#[rustfmt::skip]
+use integration_ebpf as _;
+#[rustfmt::skip]
+use network_types as _;
 
 use aya_ebpf::{
     EbpfContext as _, Global,
@@ -7,8 +22,6 @@ use aya_ebpf::{
     maps::Array,
     programs::RawTracePointContext,
 };
-#[cfg(not(test))]
-extern crate ebpf_panic;
 use integration_common::raw_tracepoint::{SysEnterEvent, TaskRenameEvent};
 
 #[map]

--- a/test/integration-ebpf/src/relocations.rs
+++ b/test/integration-ebpf/src/relocations.rs
@@ -1,5 +1,22 @@
 #![no_std]
 #![no_main]
+#![allow(
+    unused_crate_dependencies,
+    reason = "ebpf_panic is only required for non-test eBPF builds; importing it unconditionally would register its panic handler during tests and conflict with std"
+)]
+
+#[cfg(not(test))]
+extern crate ebpf_panic;
+
+// Required for satisfying unused-crate-dependencies lint
+#[rustfmt::skip]
+use aya_log_ebpf as _;
+#[rustfmt::skip]
+use integration_ebpf as _;
+#[rustfmt::skip]
+use integration_common as _;
+#[rustfmt::skip]
+use network_types as _;
 
 use core::hint;
 
@@ -8,8 +25,6 @@ use aya_ebpf::{
     maps::Array,
     programs::ProbeContext,
 };
-#[cfg(not(test))]
-extern crate ebpf_panic;
 
 #[map]
 static RESULTS: Array<u64> = Array::with_max_entries(3, 0);

--- a/test/integration-ebpf/src/ring_buf.rs
+++ b/test/integration-ebpf/src/ring_buf.rs
@@ -3,6 +3,21 @@
 #![expect(internal_features, reason = "atomic_xadd is unstable")]
 #![expect(unstable_features, reason = "atomic_xadd is unstable")]
 #![feature(core_intrinsics)]
+#![allow(
+    unused_crate_dependencies,
+    reason = "ebpf_panic is only required for non-test eBPF builds; importing it unconditionally would register its panic handler during tests and conflict with std"
+)]
+
+#[cfg(not(test))]
+extern crate ebpf_panic;
+
+// Required for satisfying unused-crate-dependencies lint
+#[rustfmt::skip]
+use aya_log_ebpf as _;
+#[rustfmt::skip]
+use integration_ebpf as _;
+#[rustfmt::skip]
+use network_types as _;
 
 use aya_ebpf::{
     btf_maps::RingBuf as BtfRingBuf,
@@ -11,8 +26,6 @@ use aya_ebpf::{
     programs::ProbeContext,
 };
 use integration_common::ring_buf::Registers;
-#[cfg(not(test))]
-extern crate ebpf_panic;
 
 #[btf_map]
 static RING_BUF: BtfRingBuf<u64, 0, 0> = BtfRingBuf::new();

--- a/test/integration-ebpf/src/simple_prog.rs
+++ b/test/integration-ebpf/src/simple_prog.rs
@@ -1,9 +1,24 @@
 #![no_std]
 #![no_main]
+#![allow(
+    unused_crate_dependencies,
+    reason = "ebpf_panic is only required for non-test eBPF builds; importing it unconditionally would register its panic handler during tests and conflict with std"
+)]
 
-use aya_ebpf::{macros::socket_filter, programs::SkBuffContext};
 #[cfg(not(test))]
 extern crate ebpf_panic;
+
+// Required for satisfying unused-crate-dependencies lint
+#[rustfmt::skip]
+use aya_log_ebpf as _;
+#[rustfmt::skip]
+use integration_ebpf as _;
+#[rustfmt::skip]
+use integration_common as _;
+#[rustfmt::skip]
+use network_types as _;
+
+use aya_ebpf::{macros::socket_filter, programs::SkBuffContext};
 
 // Introduced in kernel v3.19.
 #[socket_filter]

--- a/test/integration-ebpf/src/sk_reuseport.rs
+++ b/test/integration-ebpf/src/sk_reuseport.rs
@@ -1,5 +1,20 @@
 #![no_std]
 #![no_main]
+#![allow(
+    unused_crate_dependencies,
+    reason = "ebpf_panic is only required for non-test eBPF builds; importing it unconditionally would register its panic handler during tests and conflict with std"
+)]
+
+#[cfg(not(test))]
+extern crate ebpf_panic;
+
+// Required for satisfying unused-crate-dependencies lint
+#[rustfmt::skip]
+use aya_log_ebpf as _;
+#[rustfmt::skip]
+use integration_ebpf as _;
+#[rustfmt::skip]
+use network_types as _;
 
 use aya_ebpf::{
     bindings::sk_action::{SK_DROP, SK_PASS},
@@ -12,8 +27,6 @@ use integration_common::sk_reuseport::{
     CLEAR_FALLBACK_HITS_INDEX, MIGRATE_HITS_INDEX, MIGRATE_SOCKET_INDEX, PATH_HITS_MAX_ENTRIES,
     SELECT_HITS_INDEX, SELECT_SOCKET_INDEX,
 };
-#[cfg(not(test))]
-extern crate ebpf_panic;
 
 const SOCKET_COUNT: u32 = 10;
 const SOCKET_COUNT_USIZE: usize = SOCKET_COUNT as usize;

--- a/test/integration-ebpf/src/sk_storage.rs
+++ b/test/integration-ebpf/src/sk_storage.rs
@@ -1,5 +1,20 @@
 #![no_std]
 #![no_main]
+#![allow(
+    unused_crate_dependencies,
+    reason = "ebpf_panic is only required for non-test eBPF builds; importing it unconditionally would register its panic handler during tests and conflict with std"
+)]
+
+#[cfg(not(test))]
+extern crate ebpf_panic;
+
+// Required for satisfying unused-crate-dependencies lint
+#[rustfmt::skip]
+use aya_log_ebpf as _;
+#[rustfmt::skip]
+use integration_ebpf as _;
+#[rustfmt::skip]
+use network_types as _;
 
 use aya_ebpf::{
     bindings::sk_action,
@@ -8,8 +23,6 @@ use aya_ebpf::{
     programs::SockAddrContext,
 };
 use integration_common::sk_storage::{Ip, Value};
-#[cfg(not(test))]
-extern crate ebpf_panic;
 
 #[btf_map]
 static SOCKET_STORAGE: SkStorage<Value> = SkStorage::new();

--- a/test/integration-ebpf/src/sock_hash.rs
+++ b/test/integration-ebpf/src/sock_hash.rs
@@ -1,5 +1,22 @@
 #![no_std]
 #![no_main]
+#![allow(
+    unused_crate_dependencies,
+    reason = "ebpf_panic is only required for non-test eBPF builds; importing it unconditionally would register its panic handler during tests and conflict with std"
+)]
+
+#[cfg(not(test))]
+extern crate ebpf_panic;
+
+// Required for satisfying unused-crate-dependencies lint
+#[rustfmt::skip]
+use aya_log_ebpf as _;
+#[rustfmt::skip]
+use integration_ebpf as _;
+#[rustfmt::skip]
+use integration_common as _;
+#[rustfmt::skip]
+use network_types as _;
 
 use aya_ebpf::{
     bindings::sk_action::{SK_DROP, SK_PASS},
@@ -8,8 +25,6 @@ use aya_ebpf::{
     maps::SockHash as LegacySockHash,
     programs::SkLookupContext,
 };
-#[cfg(not(test))]
-extern crate ebpf_panic;
 
 #[map(name = "SOCKETS_LEGACY")]
 static SOCKETS_LEGACY: LegacySockHash<u32> = LegacySockHash::with_max_entries(1, 0);

--- a/test/integration-ebpf/src/sock_map.rs
+++ b/test/integration-ebpf/src/sock_map.rs
@@ -1,5 +1,22 @@
 #![no_std]
 #![no_main]
+#![allow(
+    unused_crate_dependencies,
+    reason = "ebpf_panic is only required for non-test eBPF builds; importing it unconditionally would register its panic handler during tests and conflict with std"
+)]
+
+#[cfg(not(test))]
+extern crate ebpf_panic;
+
+// Required for satisfying unused-crate-dependencies lint
+#[rustfmt::skip]
+use aya_log_ebpf as _;
+#[rustfmt::skip]
+use integration_ebpf as _;
+#[rustfmt::skip]
+use integration_common as _;
+#[rustfmt::skip]
+use network_types as _;
 
 use aya_ebpf::{
     bindings::sk_action::{SK_DROP, SK_PASS},
@@ -8,8 +25,6 @@ use aya_ebpf::{
     maps::SockMap as LegacySockMap,
     programs::SkLookupContext,
 };
-#[cfg(not(test))]
-extern crate ebpf_panic;
 
 #[map(name = "SOCKETS_LEGACY")]
 static SOCKETS_LEGACY: LegacySockMap = LegacySockMap::with_max_entries(1, 0);

--- a/test/integration-ebpf/src/socket_filter.rs
+++ b/test/integration-ebpf/src/socket_filter.rs
@@ -1,5 +1,20 @@
 #![no_std]
 #![no_main]
+#![allow(
+    unused_crate_dependencies,
+    reason = "ebpf_panic is only required for non-test eBPF builds; importing it unconditionally would register its panic handler during tests and conflict with std"
+)]
+
+#[cfg(not(test))]
+extern crate ebpf_panic;
+
+// Required for satisfying unused-crate-dependencies lint
+#[rustfmt::skip]
+use aya_log_ebpf as _;
+#[rustfmt::skip]
+use integration_ebpf as _;
+#[rustfmt::skip]
+use network_types as _;
 
 use aya_ebpf::{
     macros::{map, socket_filter},
@@ -11,8 +26,6 @@ use integration_common::socket_filter::{
     REUSEPORT_SECOND_LISTENER_INDEX, REUSEPORT_SELECT_FIRST_HITS_INDEX,
     REUSEPORT_SELECT_SECOND_HITS_INDEX, TRIM_DELTA_BYTES, TRIM_HITS_INDEX,
 };
-#[cfg(not(test))]
-extern crate ebpf_panic;
 
 #[map(name = "path_hits")]
 static PATH_HITS: Array<u64> = Array::with_max_entries(PATH_HITS_MAX_ENTRIES, 0);

--- a/test/integration-ebpf/src/stack_trace.rs
+++ b/test/integration-ebpf/src/stack_trace.rs
@@ -1,8 +1,20 @@
 #![no_std]
 #![no_main]
+#![allow(
+    unused_crate_dependencies,
+    reason = "ebpf_panic is only required for non-test eBPF builds; importing it unconditionally would register its panic handler during tests and conflict with std"
+)]
 
 #[cfg(not(test))]
 extern crate ebpf_panic;
+
+// Required for satisfying unused-crate-dependencies lint
+#[rustfmt::skip]
+use aya_log_ebpf as _;
+#[rustfmt::skip]
+use integration_ebpf as _;
+#[rustfmt::skip]
+use network_types as _;
 
 use aya_ebpf::{
     bindings::BPF_F_USER_STACK,

--- a/test/integration-ebpf/src/stack_trace_lsm.rs
+++ b/test/integration-ebpf/src/stack_trace_lsm.rs
@@ -1,8 +1,20 @@
 #![no_std]
 #![no_main]
+#![allow(
+    unused_crate_dependencies,
+    reason = "ebpf_panic is only required for non-test eBPF builds; importing it unconditionally would register its panic handler during tests and conflict with std"
+)]
 
 #[cfg(not(test))]
 extern crate ebpf_panic;
+
+// Required for satisfying unused-crate-dependencies lint
+#[rustfmt::skip]
+use aya_log_ebpf as _;
+#[rustfmt::skip]
+use integration_ebpf as _;
+#[rustfmt::skip]
+use network_types as _;
 
 use aya_ebpf::{
     EbpfContext as _,

--- a/test/integration-ebpf/src/strncmp.rs
+++ b/test/integration-ebpf/src/strncmp.rs
@@ -1,5 +1,20 @@
 #![no_std]
 #![no_main]
+#![allow(
+    unused_crate_dependencies,
+    reason = "ebpf_panic is only required for non-test eBPF builds; importing it unconditionally would register its panic handler during tests and conflict with std"
+)]
+
+#[cfg(not(test))]
+extern crate ebpf_panic;
+
+// Required for satisfying unused-crate-dependencies lint
+#[rustfmt::skip]
+use aya_log_ebpf as _;
+#[rustfmt::skip]
+use integration_ebpf as _;
+#[rustfmt::skip]
+use network_types as _;
 
 use aya_ebpf::{
     cty::c_long,
@@ -9,8 +24,6 @@ use aya_ebpf::{
     programs::ProbeContext,
 };
 use integration_common::strncmp::TestResult;
-#[cfg(not(test))]
-extern crate ebpf_panic;
 
 #[map]
 static RESULT: Array<TestResult> = Array::with_max_entries(1, 0);

--- a/test/integration-ebpf/src/tcx.rs
+++ b/test/integration-ebpf/src/tcx.rs
@@ -1,9 +1,24 @@
 #![no_std]
 #![no_main]
+#![allow(
+    unused_crate_dependencies,
+    reason = "ebpf_panic is only required for non-test eBPF builds; importing it unconditionally would register its panic handler during tests and conflict with std"
+)]
 
-use aya_ebpf::{bindings::tcx_action_base::TCX_NEXT, macros::classifier, programs::TcContext};
 #[cfg(not(test))]
 extern crate ebpf_panic;
+
+// Required for satisfying unused-crate-dependencies lint
+#[rustfmt::skip]
+use aya_log_ebpf as _;
+#[rustfmt::skip]
+use integration_ebpf as _;
+#[rustfmt::skip]
+use integration_common as _;
+#[rustfmt::skip]
+use network_types as _;
+
+use aya_ebpf::{bindings::tcx_action_base::TCX_NEXT, macros::classifier, programs::TcContext};
 
 #[classifier]
 const fn tcx_next(_ctx: TcContext) -> i32 {

--- a/test/integration-ebpf/src/test.rs
+++ b/test/integration-ebpf/src/test.rs
@@ -1,5 +1,22 @@
 #![no_std]
 #![no_main]
+#![allow(
+    unused_crate_dependencies,
+    reason = "ebpf_panic is only required for non-test eBPF builds; importing it unconditionally would register its panic handler during tests and conflict with std"
+)]
+
+#[cfg(not(test))]
+extern crate ebpf_panic;
+
+// Required for satisfying unused-crate-dependencies lint
+#[rustfmt::skip]
+use aya_log_ebpf as _;
+#[rustfmt::skip]
+use integration_ebpf as _;
+#[rustfmt::skip]
+use integration_common as _;
+#[rustfmt::skip]
+use network_types as _;
 
 use aya_ebpf::{
     bindings::{bpf_ret_code, xdp_action},
@@ -12,8 +29,6 @@ use aya_ebpf::{
         TracePointContext, XdpContext,
     },
 };
-#[cfg(not(test))]
-extern crate ebpf_panic;
 
 #[xdp]
 const fn pass(_ctx: XdpContext) -> u32 {

--- a/test/integration-ebpf/src/test_run.rs
+++ b/test/integration-ebpf/src/test_run.rs
@@ -1,5 +1,20 @@
 #![no_std]
 #![no_main]
+#![allow(
+    unused_crate_dependencies,
+    reason = "ebpf_panic is only required for non-test eBPF builds; importing it unconditionally would register its panic handler during tests and conflict with std"
+)]
+
+#[cfg(not(test))]
+extern crate ebpf_panic;
+
+// Required for satisfying unused-crate-dependencies lint
+#[rustfmt::skip]
+use aya_log_ebpf as _;
+#[rustfmt::skip]
+use integration_ebpf as _;
+#[rustfmt::skip]
+use network_types as _;
 
 use aya_ebpf::{
     bindings::{sk_action::SK_PASS, xdp_action},
@@ -8,8 +23,6 @@ use aya_ebpf::{
     programs::{RawTracePointContext, SkBuffContext, TcContext, XdpContext},
 };
 use integration_common::test_run::{IF_INDEX, XDP_MODIFY_LEN, XDP_MODIFY_VAL};
-#[cfg(not(test))]
-extern crate ebpf_panic;
 
 #[map]
 static EXEC_COUNT: Array<u64> = Array::with_max_entries(1, 0);

--- a/test/integration-ebpf/src/two_progs.rs
+++ b/test/integration-ebpf/src/two_progs.rs
@@ -1,9 +1,24 @@
 #![no_std]
 #![no_main]
+#![allow(
+    unused_crate_dependencies,
+    reason = "ebpf_panic is only required for non-test eBPF builds; importing it unconditionally would register its panic handler during tests and conflict with std"
+)]
 
-use aya_ebpf::{macros::tracepoint, programs::TracePointContext};
 #[cfg(not(test))]
 extern crate ebpf_panic;
+
+// Required for satisfying unused-crate-dependencies lint
+#[rustfmt::skip]
+use aya_log_ebpf as _;
+#[rustfmt::skip]
+use integration_ebpf as _;
+#[rustfmt::skip]
+use integration_common as _;
+#[rustfmt::skip]
+use network_types as _;
+
+use aya_ebpf::{macros::tracepoint, programs::TracePointContext};
 
 #[tracepoint]
 const fn test_tracepoint_one(_ctx: TracePointContext) -> u32 {

--- a/test/integration-ebpf/src/uprobe_cookie.rs
+++ b/test/integration-ebpf/src/uprobe_cookie.rs
@@ -1,5 +1,22 @@
 #![no_std]
 #![no_main]
+#![allow(
+    unused_crate_dependencies,
+    reason = "ebpf_panic is only required for non-test eBPF builds; importing it unconditionally would register its panic handler during tests and conflict with std"
+)]
+
+#[cfg(not(test))]
+extern crate ebpf_panic;
+
+// Required for satisfying unused-crate-dependencies lint
+#[rustfmt::skip]
+use aya_log_ebpf as _;
+#[rustfmt::skip]
+use integration_ebpf as _;
+#[rustfmt::skip]
+use integration_common as _;
+#[rustfmt::skip]
+use network_types as _;
 
 use aya_ebpf::{
     EbpfContext as _, helpers,
@@ -7,8 +24,6 @@ use aya_ebpf::{
     maps::RingBuf,
     programs::ProbeContext,
 };
-#[cfg(not(test))]
-extern crate ebpf_panic;
 
 #[map]
 static RING_BUF: RingBuf = RingBuf::with_byte_size(0, 0);

--- a/test/integration-ebpf/src/uprobe_multi.rs
+++ b/test/integration-ebpf/src/uprobe_multi.rs
@@ -1,14 +1,28 @@
 #![no_std]
 #![no_main]
+#![allow(
+    unused_crate_dependencies,
+    reason = "ebpf_panic is only required for non-test eBPF builds; importing it unconditionally would register its panic handler during tests and conflict with std"
+)]
 
+#[cfg(not(test))]
+extern crate ebpf_panic;
+
+// Required for satisfying unused-crate-dependencies lint
+#[rustfmt::skip]
+use aya_log_ebpf as _;
+#[rustfmt::skip]
+use integration_ebpf as _;
+#[rustfmt::skip]
+use integration_common as _;
+#[rustfmt::skip]
+use network_types as _;
 use aya_ebpf::{
     EbpfContext as _, helpers,
     macros::{map, uprobe},
     maps::RingBuf,
     programs::ProbeContext,
 };
-#[cfg(not(test))]
-extern crate ebpf_panic;
 
 #[map]
 static RING_BUF: RingBuf = RingBuf::with_byte_size(0, 0);

--- a/test/integration-ebpf/src/xdp_sec.rs
+++ b/test/integration-ebpf/src/xdp_sec.rs
@@ -1,9 +1,24 @@
 #![no_std]
 #![no_main]
+#![allow(
+    unused_crate_dependencies,
+    reason = "ebpf_panic is only required for non-test eBPF builds; importing it unconditionally would register its panic handler during tests and conflict with std"
+)]
 
-use aya_ebpf::{bindings::xdp_action::XDP_PASS, macros::xdp, programs::XdpContext};
 #[cfg(not(test))]
 extern crate ebpf_panic;
+
+// Required for satisfying unused-crate-dependencies lint
+#[rustfmt::skip]
+use aya_log_ebpf as _;
+#[rustfmt::skip]
+use integration_ebpf as _;
+#[rustfmt::skip]
+use integration_common as _;
+#[rustfmt::skip]
+use network_types as _;
+
+use aya_ebpf::{bindings::xdp_action::XDP_PASS, macros::xdp, programs::XdpContext};
 
 macro_rules! probe {
     ($name:ident, ($($arg:ident $(= $value:literal)?),*) ) => {

--- a/test/integration-ebpf/src/xsk_map.rs
+++ b/test/integration-ebpf/src/xsk_map.rs
@@ -1,5 +1,22 @@
 #![no_std]
 #![no_main]
+#![allow(
+    unused_crate_dependencies,
+    reason = "ebpf_panic is only required for non-test eBPF builds; importing it unconditionally would register its panic handler during tests and conflict with std"
+)]
+
+#[cfg(not(test))]
+extern crate ebpf_panic;
+
+// Required for satisfying unused-crate-dependencies lint
+#[rustfmt::skip]
+use aya_log_ebpf as _;
+#[rustfmt::skip]
+use integration_ebpf as _;
+#[rustfmt::skip]
+use integration_common as _;
+#[rustfmt::skip]
+use network_types as _;
 
 use aya_ebpf::{
     bindings::xdp_action,
@@ -8,8 +25,6 @@ use aya_ebpf::{
     maps::XskMap,
     programs::XdpContext,
 };
-#[cfg(not(test))]
-extern crate ebpf_panic;
 
 #[map]
 static SOCKS: XskMap = XskMap::with_max_entries(1, 0);

--- a/test/integration-test/build.rs
+++ b/test/integration-test/build.rs
@@ -8,6 +8,7 @@ use std::{
 
 use anyhow::{Context as _, Ok, Result, anyhow};
 use cargo_metadata::{Metadata, MetadataCommand, Package, Target, TargetKind};
+use integration_ebpf as _;
 use xtask::{AYA_BUILD_INTEGRATION_BPF, LIBBPF_DIR, exec, install_libbpf_headers_cmd};
 
 /// This file, along with the xtask crate, allows analysis tools such as `cargo check`, `cargo

--- a/xtask/src/lib.rs
+++ b/xtask/src/lib.rs
@@ -1,6 +1,27 @@
 use std::{env, ffi::OsString, path::Path, process::Command};
 
 use anyhow::{Context as _, Result, bail};
+// Added to satisfy `unused-crate-dependencies` lint
+use ar as _;
+use aya_tool as _;
+use cargo_metadata as _;
+use clap as _;
+use dialoguer as _;
+use diff as _;
+use indoc as _;
+use nix as _;
+use proc_macro2 as _;
+use public_api as _;
+use quote as _;
+use rustdoc_json as _;
+use rustup_toolchain as _;
+use syn as _;
+use tar as _;
+use tempfile as _;
+use ureq as _;
+use walkdir as _;
+use xz2 as _;
+use zstd as _;
 
 pub const AYA_BUILD_INTEGRATION_BPF: &str = "AYA_BUILD_INTEGRATION_BPF";
 pub const LIBBPF_DIR: &str = "xtask/libbpf";


### PR DESCRIPTION
<!-- markdownlint-disable first-line-heading -->

<!--
    Thank you for your contribution to Aya! 🎉

    For Work In Progress Pull Requests, please use the Draft PR feature.

    Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Aya Contributing Guide: https://github.com/aya-rs/aya/blob/main/CONTRIBUTING.md
     - 📖 Read the Aya Code of Conduct: https://github.com/aya-rs/aya/blob/main/CODE_OF_CONDUCT.md
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages: https://cbea.ms/git-commit/
     - 📗 Update any related documentation.

-->

<!---
      Summarize the changes you're making here. Detailed information belongs in
      the Git commit messages. If your pull request contains just one commit,
      it's best to use its message as a summary. Otherwise, if there are multiple
      atomic commits, write a summary for the entire PR. Feel free to flag
      anything you think needs a reviewer's attention.
-->
Changes required to pass `cargo xtask clippy` on latest rust update Rust 1.98.1, nightly-2026-09-10
<!--
      If your changes address an issue, link it with the *Fixes* tag so
      the issue gets closed when the PR is merged, for example:

      Fixes: #1234

      If you are only referencing an issue without fully addressing it, feel
      free to link it anywhere in the summary.
-->

### Added/updated tests?

_We strongly encourage you to add a test for your changes._

- [ ] Yes
- [x] No, and this is why: No new functions added. Changes to pass `cargo xtask clippy`
- [ ] I need help with writing tests

### Checklist

- [x] Rust code has been formatted with `cargo +nightly fmt`.
- [x] All clippy lints have been fixed.
      You can find failing lints with `cargo xtask clippy`.
- [x] Unit tests are passing locally with `cargo test`.
- [ ] The [Integration tests] are passing locally.
- [x] I have blessed any API changes with `cargo xtask public-api --bless`.

[Integration tests]: https://github.com/aya-rs/aya/blob/main/test/README.md

### (Optional) What GIF best describes this PR or how it makes you feel?

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aya-rs/aya/1719)
<!-- Reviewable:end -->
